### PR TITLE
chore: add glama.json for Glama MCP directory listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "jmrplens"
+  ]
+}


### PR DESCRIPTION
Add `glama.json` metadata file required by the [Glama MCP directory](https://glama.ai/mcp/servers) for server listing and discovery.\n\nThe file contains:\n- Schema reference (`https://glama.ai/mcp/schemas/server.json`)\n- Maintainer information\n\nGlama automatically extracts the rest of the server metadata (description, categories, security/quality scores, platforms, etc.) from the GitHub repository.

## Summary by Sourcery

Add metadata configuration for Glama MCP server directory listing and discovery.

Build:
- Add glama.json metadata file required for Glama MCP directory integration.

Chores:
- Introduce repository-level metadata file to support external MCP server discovery services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->