### PR TITLE
fix: stabilize flaky TestBranchUnprotect_APIError by fixing ContainsAny port match

### DIFF
--- a/internal/tools/branches/branches.go
+++ b/internal/tools/branches/branches.go
@@ -175,8 +175,7 @@ func Unprotect(ctx context.Context, client *gitlabclient.Client, input Unprotect
 	_, err := client.GL().ProtectedBranches.UnprotectRepositoryBranches(string(input.ProjectID), input.BranchName, gl.WithContext(ctx))
 	if err != nil {
 		// 404 means the branch is not protected — idempotent success.
-		// client-go may return *ErrorResponse (with status code) or plain error "404 Not Found".
-		if toolutil.IsHTTPStatus(err, http.StatusNotFound) || toolutil.ContainsAny(err, "404") {
+		if toolutil.IsNotFound(err) {
 			return UnprotectOutput{
 				Status:  "already_unprotected",
 				Message: fmt.Sprintf("Branch %q in project %s is not protected — no action needed.", input.BranchName, input.ProjectID),

--- a/internal/tools/mrapprovals/mrapprovals.go
+++ b/internal/tools/mrapprovals/mrapprovals.go
@@ -225,7 +225,7 @@ func State(ctx context.Context, client *gitlabclient.Client, input StateInput) (
 	}
 	state, _, err := client.GL().MergeRequestApprovals.GetApprovalState(string(input.ProjectID), input.MRIID, gl.WithContext(ctx))
 	if err != nil {
-		if toolutil.IsHTTPStatus(err, 404) || toolutil.ContainsAny(err, "404") {
+		if toolutil.IsNotFound(err) {
 			return StateOutput{}, fmt.Errorf("mrApprovalState: merge request approval features require GitLab Premium or higher. This instance appears to be running Community Edition: %w", err)
 		}
 		return StateOutput{}, toolutil.WrapErrWithMessage("mrApprovalState", err)
@@ -252,7 +252,7 @@ func Rules(ctx context.Context, client *gitlabclient.Client, input RulesInput) (
 	}
 	rules, _, err := client.GL().MergeRequestApprovals.GetApprovalRules(string(input.ProjectID), input.MRIID, gl.WithContext(ctx))
 	if err != nil {
-		if toolutil.IsHTTPStatus(err, 404) || toolutil.ContainsAny(err, "404") {
+		if toolutil.IsNotFound(err) {
 			return RulesOutput{}, fmt.Errorf("mrApprovalRules: merge request approval rules require GitLab Premium or higher. This instance appears to be running Community Edition: %w", err)
 		}
 		return RulesOutput{}, toolutil.WrapErrWithMessage("mrApprovalRules", err)
@@ -278,7 +278,7 @@ func Config(ctx context.Context, client *gitlabclient.Client, input ConfigInput)
 	}
 	cfg, _, err := client.GL().MergeRequestApprovals.GetConfiguration(string(input.ProjectID), input.MRIID, gl.WithContext(ctx))
 	if err != nil {
-		if toolutil.IsHTTPStatus(err, 404) || toolutil.ContainsAny(err, "404") {
+		if toolutil.IsNotFound(err) {
 			return ConfigOutput{}, fmt.Errorf("mrApprovalConfig: merge request approval configuration requires GitLab Premium or higher. This instance appears to be running Community Edition: %w", err)
 		}
 		return ConfigOutput{}, toolutil.WrapErrWithMessage("mrApprovalConfig", err)

--- a/internal/toolutil/errors.go
+++ b/internal/toolutil/errors.go
@@ -246,6 +246,19 @@ func IsHTTPStatus(err error, code int) bool {
 	return errors.As(err, &glErr) && glErr.Response != nil && glErr.Response.StatusCode == code
 }
 
+// IsNotFound reports whether err represents a 404 Not Found, either via a
+// structured GitLab ErrorResponse status code or via a plain-text error
+// message from client-go (which may contain "404 Not Found" as text).
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsHTTPStatus(err, http.StatusNotFound) {
+		return true
+	}
+	return ContainsAny(err, "404 Not Found")
+}
+
 // ExtractGitLabMessage extracts the specific error message from a GitLab
 // ErrorResponse in the error chain. Returns empty string if not found or if
 // the message only repeats the HTTP status text (e.g., "405 Method Not Allowed").

--- a/internal/toolutil/errors_test.go
+++ b/internal/toolutil/errors_test.go
@@ -708,3 +708,66 @@ func TestIsHTTPStatus_WrappedErrNotFound(t *testing.T) {
 		t.Error("expected true for wrapped gl.ErrNotFound with 404")
 	}
 }
+
+// TestIsNotFound verifies that IsNotFound detects 404 via structured ErrorResponse,
+// plain-text error messages, and rejects non-404 errors including port numbers
+// that happen to contain "404".
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "structured 404 ErrorResponse",
+			err: &gl.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			want: true,
+		},
+		{
+			name: "sentinel gl.ErrNotFound",
+			err:  gl.ErrNotFound,
+			want: true,
+		},
+		{
+			name: "plain text 404 Not Found",
+			err:  fmt.Errorf("404 Not Found"),
+			want: true,
+		},
+		{
+			name: "wrapped plain text 404 Not Found",
+			err:  fmt.Errorf("GET http://example.com/api: 404 Not Found"),
+			want: true,
+		},
+		{
+			name: "403 error should not match",
+			err:  fmt.Errorf("GET http://example.com/api: 403 Forbidden"),
+			want: false,
+		},
+		{
+			name: "port containing 404 should not match",
+			err:  fmt.Errorf("GET http://127.0.0.1:40456/api/v4/projects: 403 Forbidden"),
+			want: false,
+		},
+		{
+			name: "port 40400 should not match",
+			err:  fmt.Errorf("GET http://127.0.0.1:40400/api/v4/projects: 500 Internal Server Error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsNotFound(tt.err)
+			if got != tt.want {
+				t.Errorf("IsNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`TestBranchUnprotect_APIError` was flaky in CI — it would intermittently fail with:

```
branches_test.go:902: expected error for API failure
```

## Root Cause

`ContainsAny(err, "404")` searches for the substring `"404"` anywhere in the error message. In tests using `httptest`, the server is assigned a **random port**. When that port happens to contain `404` (e.g., `http://127.0.0.1:40456/...`), the check falsely matches a 403 Forbidden error as a 404 Not Found, causing the handler to return idempotent success instead of an error.

This is a classic **non-deterministic test failure** — it only triggers when the OS assigns a port containing the digit sequence `404`.

## Fix

Changed all 4 occurrences of `ContainsAny(err, "404")` to `ContainsAny(err, "404 Not Found")`:

- `internal/tools/branches/branches.go` — `Unprotect()` handler
- `internal/tools/mrapprovals/mrapprovals.go` — `State()`, `Rules()`, and `Config()` handlers

The string `"404 Not Found"` will never appear inside a port number, eliminating the false positive while still matching the plain-text error format from client-go.

## Verification

- All branch tests pass: `go test ./internal/tools/branches/ -count=1`
- All mrapprovals tests pass: `go test ./internal/tools/mrapprovals/ -count=1`
- `go vet` clean on both packages

## Summary by Sourcery

Stabilize error handling around 404 responses for branch unprotect and merge request approvals to eliminate flaky behavior in tests and runtime.

Bug Fixes:
- Tighten string matching for 404 errors to avoid false positives from random ports in error messages when unprotecting branches.
- Ensure merge request approvals state, rules, and config handlers correctly distinguish real 404 Not Found errors from other failures.