### PR TITLE
test: improve test quality with shared helpers and request assertions

### DIFF
--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/creativeprojects/go-selfupdate"
+
 	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/creativeprojects/go-selfupdate"
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // Mock types for selfupdate.Source, SourceRelease, SourceAsset.
@@ -279,8 +280,7 @@ func TestCheckForUpdate_CancelledContext(t *testing.T) {
 		CurrentVersion: "1.0.0",
 	}, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, _, err := u.CheckForUpdate(ctx)
 	if err == nil {
@@ -295,8 +295,7 @@ func TestApplyUpdate_CancelledContext(t *testing.T) {
 		CurrentVersion: "1.0.0",
 	}, nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := u.ApplyUpdate(ctx)
 	if err == nil {

--- a/internal/autoupdate/prestart_test.go
+++ b/internal/autoupdate/prestart_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/creativeprojects/go-selfupdate"
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // TestJustUpdated_Default verifies JustUpdated returns false when the
@@ -430,8 +431,7 @@ func TestDownloadAndReplace_FullSuccess(t *testing.T) {
 // indirectly since PreStartUpdate creates its own Updater with a real GitHub
 // source; we use a cancelled context to trigger the error path.
 func TestPreStartUpdate_CheckForUpdateFails(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	result := PreStartUpdate(ctx, Config{
 		Mode:           ModeAuto,

--- a/internal/autoupdate/prestart_test.go
+++ b/internal/autoupdate/prestart_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/creativeprojects/go-selfupdate"
+
 	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 

--- a/internal/completions/completions_test.go
+++ b/internal/completions/completions_test.go
@@ -9,8 +9,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // Shared test assertion messages and endpoint paths.

--- a/internal/completions/completions_test.go
+++ b/internal/completions/completions_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -306,8 +307,7 @@ func TestComplete_APIErrorReturnsEmpty(t *testing.T) {
 func TestComplete_ContextCancelled(t *testing.T) {
 	h := NewHandler(newTestClient(t, http.NotFoundHandler()))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	req := &mcp.CompleteRequest{}
 	req.Params = &mcp.CompleteParams{

--- a/internal/completions/search_test.go
+++ b/internal/completions/search_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // Shared test assertion messages and subtest names for search tests.
@@ -353,8 +355,7 @@ func TestSearchTags_APIError(t *testing.T) {
 // context.
 func TestSearch_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.NotFoundHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	tests := []struct {
 		name string
@@ -632,8 +633,7 @@ func TestSearchJobs_APIError(t *testing.T) {
 // the new search functions return a context cancellation error.
 func TestSearchNew_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.NotFoundHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	tests := []struct {
 		name string

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // testImpl is a shared MCP implementation descriptor used across tests.

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -114,8 +115,7 @@ func TestSelectOne_EmptyOptions(t *testing.T) {
 // TestElicit_ContextCancelled verifies that the internal elicit method
 // returns [context.Canceled] when the context is already canceled.
 func TestElicit_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	c := Client{session: &mcp.ServerSession{}}
 	_, err := c.elicit(ctx, "test", map[string]any{"type": "object"})

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -94,7 +94,7 @@ func TestPing_ContextCancelled(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
+	cancel()
 
 	if _, err = client.Ping(ctx); err == nil {
 		t.Error("Ping() expected error for canceled context, got nil")

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -95,8 +96,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 		session: &mcp.ServerSession{},
 		token:   "test-token",
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	// Should silently return without sending
 	tracker.Update(ctx, 1, 3, "test")
 }

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 const testProgressMessage = "Working..."

--- a/internal/roots/roots_test.go
+++ b/internal/roots/roots_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -313,8 +314,7 @@ func TestRefresh_WithCancelledContext(t *testing.T) {
 	ss := setupInMemorySession(t, []*mcp.Root{{URI: "file:///tmp"}})
 
 	m := NewManager()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
+	ctx := testutil.CancelledCtx(t) // cancel immediately
 
 	err := m.Refresh(ctx, ss)
 	if err == nil {
@@ -359,8 +359,7 @@ func TestListClientRoots_WithSession(t *testing.T) {
 func TestListClientRoots_CancelledContext(t *testing.T) {
 	ss := setupInMemorySession(t, []*mcp.Root{{URI: "file:///tmp"}})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListClientRoots(ctx, ss)
 	if err == nil {

--- a/internal/roots/roots_test.go
+++ b/internal/roots/roots_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // TestNewManager verifies that [NewManager] returns a non-nil [Manager] with

--- a/internal/sampling/sampling_test.go
+++ b/internal/sampling/sampling_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -79,8 +80,7 @@ func TestAnalyze_UnsupportedClient(t *testing.T) {
 func TestAnalyze_CancelledContext(t *testing.T) {
 	// Even with a session, canceled context should return immediately.
 	// We can only test the unsupported path cleanly without a real session.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	var c Client
 	_, err := c.Analyze(ctx, "prompt", "data")
@@ -932,8 +932,7 @@ func TestAnalyzeWithTools_UnsupportedClient(t *testing.T) {
 // returns a context error when the context is already cancelled and the client
 // is supported.
 func TestAnalyzeWithTools_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	var c Client
 	executor := &mockToolExecutor{}

--- a/internal/sampling/sampling_test.go
+++ b/internal/sampling/sampling_test.go
@@ -15,8 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 const (

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // testFactory returns a ServerFactory that creates minimal *mcp.Server instances.
@@ -588,8 +589,7 @@ func TestRevalidateAll_CancelledContext(t *testing.T) {
 
 	_, _ = pool.GetOrCreate("tok-1")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	// Should return quickly without panicking.
 	pool.revalidateAll(ctx)

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -9,11 +9,16 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 )
+
+// captureSlogMu serializes CaptureSlog calls to prevent concurrent tests
+// from overwriting each other's global slog default.
+var captureSlogMu sync.Mutex
 
 // CancelledCtx returns a pre-cancelled context for testing cancellation handling.
 func CancelledCtx(t *testing.T) context.Context {
@@ -25,12 +30,17 @@ func CancelledCtx(t *testing.T) context.Context {
 
 // CaptureSlog redirects slog output to a buffer for the duration of the test.
 // The original default logger is restored via t.Cleanup.
+// NOT safe for t.Parallel — acquires captureSlogMu for the test lifetime.
 func CaptureSlog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
+	captureSlogMu.Lock()
 	original := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
-	t.Cleanup(func() { slog.SetDefault(original) })
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+		captureSlogMu.Unlock()
+	})
 	return &buf
 }
 

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -4,7 +4,9 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,6 +21,17 @@ func CancelledCtx(t *testing.T) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	return ctx
+}
+
+// CaptureSlog redirects slog output to a buffer for the duration of the test.
+// The original default logger is restored via t.Cleanup.
+func CaptureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
 }
 
 // MsgErrEmptyProjectID is the shared assertion message for tests that expect

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -4,6 +4,7 @@
 package testutil
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,14 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 )
+
+// CancelledCtx returns a pre-cancelled context for testing cancellation handling.
+func CancelledCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
 
 // MsgErrEmptyProjectID is the shared assertion message for tests that expect
 // an error when project_id is empty.

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -5,8 +5,10 @@ package testutil
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +18,19 @@ func TestCancelledCtx(t *testing.T) {
 	ctx := CancelledCtx(t)
 	if ctx.Err() != context.Canceled {
 		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.Canceled)
+	}
+}
+
+// TestCaptureSlog verifies that CaptureSlog captures slog output into a
+// buffer and that the output contains the expected JSON fields.
+func TestCaptureSlog(t *testing.T) {
+	buf := CaptureSlog(t)
+	slog.Info("test message", "key", "val")
+	out := buf.String()
+	for _, want := range []string{`"msg":"test message"`, `"key":"val"`, `"level":"INFO"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("slog output missing %q, got: %s", want, out)
+		}
 	}
 }
 

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -4,10 +4,20 @@
 package testutil
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+// TestCancelledCtx verifies that CancelledCtx returns a context that is
+// already cancelled with context.Canceled error.
+func TestCancelledCtx(t *testing.T) {
+	ctx := CancelledCtx(t)
+	if ctx.Err() != context.Canceled {
+		t.Errorf("ctx.Err() = %v, want %v", ctx.Err(), context.Canceled)
+	}
+}
 
 // TestAssertRequestMethod verifies AssertRequestMethod does not fail the test
 // when the expected method matches.

--- a/internal/tools/accesstokens/accesstokens_test.go
+++ b/internal/tools/accesstokens/accesstokens_test.go
@@ -747,8 +747,7 @@ func TestCancelled_Context(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	tests := []struct {
 		name string

--- a/internal/tools/attestations/attestations_test.go
+++ b/internal/tools/attestations/attestations_test.go
@@ -371,8 +371,7 @@ func TestList_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{
 		ProjectID:     toolutil.StringOrInt("10"),
@@ -485,8 +484,7 @@ func TestDownload_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Download(ctx, client, DownloadInput{
 		ProjectID:      toolutil.StringOrInt("10"),

--- a/internal/tools/auditevents/auditevents_extra_test.go
+++ b/internal/tools/auditevents/auditevents_extra_test.go
@@ -18,8 +18,7 @@ func TestListInstance_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called on cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListInstance(ctx, client, ListInstanceInput{})
 	if err == nil {
@@ -33,8 +32,7 @@ func TestGetInstance_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetInstance(ctx, client, GetInstanceInput{EventID: 1})
 	if err == nil {
@@ -48,8 +46,7 @@ func TestListGroup_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "5"})
 	if err == nil {
@@ -63,8 +60,7 @@ func TestGetGroup_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetGroup(ctx, client, GetGroupInput{GroupID: "5", EventID: 1})
 	if err == nil {
@@ -78,8 +74,7 @@ func TestListProject_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "42"})
 	if err == nil {
@@ -93,8 +88,7 @@ func TestGetProject_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetProject(ctx, client, GetProjectInput{ProjectID: "42", EventID: 1})
 	if err == nil {

--- a/internal/tools/boards/boards_test.go
+++ b/internal/tools/boards/boards_test.go
@@ -599,8 +599,7 @@ func TestListBoards_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListBoards(ctx, client, ListBoardsInput{ProjectID: "10"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -644,8 +643,7 @@ func TestGetBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetBoard(ctx, client, GetBoardInput{ProjectID: "10", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -668,8 +666,7 @@ func TestCreateBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateBoard(ctx, client, CreateBoardInput{ProjectID: "10", Name: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -718,8 +715,7 @@ func TestUpdateBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateBoard(ctx, client, UpdateBoardInput{ProjectID: "10", BoardID: 1, Name: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -742,8 +738,7 @@ func TestDeleteBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteBoard(ctx, client, DeleteBoardInput{ProjectID: "10", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -770,8 +765,7 @@ func TestListBoardLists_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListBoardLists(ctx, client, ListBoardListsInput{ProjectID: "10", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -794,8 +788,7 @@ func TestGetBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetBoardList(ctx, client, GetBoardListInput{ProjectID: "10", BoardID: 1, ListID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -838,8 +831,7 @@ func TestCreateBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateBoardList(ctx, client, CreateBoardListInput{ProjectID: "10", BoardID: 1, LabelID: 20})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -862,8 +854,7 @@ func TestUpdateBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateBoardList(ctx, client, UpdateBoardListInput{ProjectID: "10", BoardID: 1, ListID: 100, Position: 2})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -886,8 +877,7 @@ func TestDeleteBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteBoardList(ctx, client, DeleteBoardListInput{ProjectID: "10", BoardID: 1, ListID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/branches/branches_test.go
+++ b/internal/tools/branches/branches_test.go
@@ -523,8 +523,7 @@ func TestProtectedBranchGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ProtectedGet(ctx, client, ProtectedGetInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
@@ -599,8 +598,7 @@ func TestProtectedBranchUpdate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ProtectedUpdate(ctx, client, ProtectedUpdateInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
@@ -658,8 +656,7 @@ func TestDeleteMerged_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := DeleteMerged(ctx, client, DeleteMergedInput{ProjectID: "42"})
 	if err == nil {
@@ -676,8 +673,7 @@ func TestBranchCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", BranchName: "x", Ref: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -689,8 +685,7 @@ func TestBranchList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -702,8 +697,7 @@ func TestBranchGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -715,8 +709,7 @@ func TestBranchDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", BranchName: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -728,8 +721,7 @@ func TestBranchProtect_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Protect(ctx, client, ProtectInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -741,8 +733,7 @@ func TestBranchUnprotect_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Unprotect(ctx, client, UnprotectInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -754,8 +745,7 @@ func TestProtectedList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ProtectedList(ctx, client, ProtectedListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/broadcastmessages/broadcastmessages_test.go
+++ b/internal/tools/broadcastmessages/broadcastmessages_test.go
@@ -5,6 +5,7 @@ package broadcastmessages
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -332,8 +333,11 @@ func TestCreate_InvalidEndsAt(t *testing.T) {
 
 // TestCreate_WithAllOptionalFields verifies the behavior of create with all optional fields.
 func TestCreate_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":2,"message":"Full test","starts_at":"2026-01-01T00:00:00Z","ends_at":"2026-01-02T00:00:00Z","font":"serif","active":true,"target_access_levels":[30],"target_path":"/dashboard","broadcast_type":"notification","dismissable":true,"theme":"blue"}`)
 			return
 		}
@@ -357,6 +361,11 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 	}
 	if out.Message.BroadcastType != "notification" {
 		t.Errorf("expected notification, got %s", out.Message.BroadcastType)
+	}
+	for _, want := range []string{"starts_at", "ends_at", "font", "target_access_levels", "target_path", "broadcast_type", "dismissable", "theme"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/broadcastmessages/broadcastmessages_test.go
+++ b/internal/tools/broadcastmessages/broadcastmessages_test.go
@@ -336,7 +336,10 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":2,"message":"Full test","starts_at":"2026-01-01T00:00:00Z","ends_at":"2026-01-02T00:00:00Z","font":"serif","active":true,"target_access_levels":[30],"target_path":"/dashboard","broadcast_type":"notification","dismissable":true,"theme":"blue"}`)
 			return

--- a/internal/tools/cilint/cilint_test.go
+++ b/internal/tools/cilint/cilint_test.go
@@ -127,8 +127,7 @@ func TestCILintProject_MissingProjectID(t *testing.T) {
 // TestCILintProject_CancelledContext verifies the behavior of c i lint project cancelled context.
 func TestCILintProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := LintProject(ctx, client, ProjectInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal("expected error for canceled context")
@@ -228,8 +227,7 @@ func TestCILint_EmptyContent(t *testing.T) {
 // TestCILint_CancelledContext verifies the behavior of c i lint cancelled context.
 func TestCILint_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := LintContent(ctx, client, ContentInput{ProjectID: "1", Content: "stages: []"})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/civariables/civariables_test.go
+++ b/internal/tools/civariables/civariables_test.go
@@ -67,8 +67,7 @@ func TestCIVariableList_MissingProjectID(t *testing.T) {
 // TestCIVariableList_CancelledContext verifies the behavior of c i variable list cancelled context.
 func TestCIVariableList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -127,8 +126,7 @@ func TestCIVariableGet_MissingFields(t *testing.T) {
 // TestCIVariableGet_CancelledContext verifies the behavior of c i variable get cancelled context.
 func TestCIVariableGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "1", Key: "K"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -186,8 +184,7 @@ func TestCIVariableCreate_MissingFields(t *testing.T) {
 // TestCIVariableCreate_CancelledContext verifies the behavior of c i variable create cancelled context.
 func TestCIVariableCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID: "1", Key: "K", Value: "V",
 	})
@@ -246,8 +243,7 @@ func TestCIVariableUpdate_MissingFields(t *testing.T) {
 // TestCIVariableUpdate_CancelledContext verifies the behavior of c i variable update cancelled context.
 func TestCIVariableUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{
 		ProjectID: "1", Key: "K",
 	})
@@ -301,8 +297,7 @@ func TestCIVariableDelete_MissingFields(t *testing.T) {
 // TestCIVariableDelete_CancelledContext verifies the behavior of c i variable delete cancelled context.
 func TestCIVariableDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{
 		ProjectID: "1", Key: "K",
 	})

--- a/internal/tools/ciyamltemplates/ciyamltemplates_test.go
+++ b/internal/tools/ciyamltemplates/ciyamltemplates_test.go
@@ -120,8 +120,7 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
 		t.Fatal("expected error for canceled context")
@@ -176,8 +175,7 @@ func TestList_EmptyResult(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{Key: "Go"})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/commitdiscussions/commitdiscussions_test.go
+++ b/internal/tools/commitdiscussions/commitdiscussions_test.go
@@ -260,8 +260,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID, CommitSHA: testCommitSHA})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -273,8 +272,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: testProjectID, CommitSHA: testCommitSHA, DiscussionID: testDiscussionID})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -286,8 +284,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: testProjectID, CommitSHA: testCommitSHA, Body: "t"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -299,8 +296,7 @@ func TestAddNote_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddNote(ctx, client, AddNoteInput{ProjectID: testProjectID, CommitSHA: testCommitSHA, DiscussionID: testDiscussionID, Body: "t"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -312,8 +308,7 @@ func TestUpdateNote_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateNote(ctx, client, UpdateNoteInput{ProjectID: testProjectID, CommitSHA: testCommitSHA, DiscussionID: testDiscussionID, NoteID: 1, Body: "t"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -325,8 +320,7 @@ func TestDeleteNote_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteNote(ctx, client, DeleteNoteInput{ProjectID: testProjectID, CommitSHA: testCommitSHA, DiscussionID: testDiscussionID, NoteID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -1093,7 +1093,10 @@ func TestCommitCreate_WithAllOptions(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathRepoCommits {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":"opt1","short_id":"opt1","title":"t"}`)
 			return
@@ -1295,7 +1298,10 @@ func TestSetStatus_WithAllOptions(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/42/statuses/abc" {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{
 				"id":3,"sha":"abc","ref":"main","status":"success","name":"deploy",

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -5,6 +5,7 @@ package commits
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -1089,8 +1090,11 @@ func TestGetGPGSignature_APIError(t *testing.T) {
 
 // TestCommitCreate_WithAllOptions verifies the behavior of commit create with all options.
 func TestCommitCreate_WithAllOptions(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathRepoCommits {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":"opt1","short_id":"opt1","title":"t"}`)
 			return
 		}
@@ -1114,6 +1118,11 @@ func TestCommitCreate_WithAllOptions(t *testing.T) {
 	}
 	if out.ShortID != "opt1" {
 		t.Errorf(fmtOutShortIDWant, out.ShortID, "opt1")
+	}
+	for _, want := range []string{"start_sha", "author_email", "author_name", "force", "actions"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 
@@ -1283,8 +1292,11 @@ func TestGetStatuses_WithFilters(t *testing.T) {
 
 // TestSetStatus_WithAllOptions verifies the behavior of set status with all options.
 func TestSetStatus_WithAllOptions(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/42/statuses/abc" {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{
 				"id":3,"sha":"abc","ref":"main","status":"success","name":"deploy",
 				"target_url":"https://ci.example.com","description":"OK","coverage":95.5,
@@ -1320,6 +1332,11 @@ func TestSetStatus_WithAllOptions(t *testing.T) {
 	}
 	if out.CreatedAt == "" {
 		t.Error("CreatedAt is empty")
+	}
+	for _, want := range []string{"ref", "name", "context", "target_url", "description", "coverage", "pipeline_id"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -279,8 +279,7 @@ func TestCommitList_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -820,8 +819,7 @@ func TestCommitCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Branch: "main", CommitMessage: "t", Actions: []Action{{Action: actionCreate, FilePath: "f"}}})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -833,8 +831,7 @@ func TestCommitGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -846,8 +843,7 @@ func TestCommitDiff_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Diff(ctx, client, DiffInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -859,8 +855,7 @@ func TestGetRefs_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetRefs(ctx, client, RefsInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -872,8 +867,7 @@ func TestGetComments_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetComments(ctx, client, CommentsInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -885,8 +879,7 @@ func TestPostComment_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := PostComment(ctx, client, PostCommentInput{ProjectID: "42", SHA: "abc", Note: "t"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -898,8 +891,7 @@ func TestGetStatuses_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetStatuses(ctx, client, StatusesInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -911,8 +903,7 @@ func TestSetStatus_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := SetStatus(ctx, client, SetStatusInput{ProjectID: "42", SHA: "abc", State: "success"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -924,8 +915,7 @@ func TestListMRsByCommit_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListMRsByCommit(ctx, client, MRsByCommitInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -937,8 +927,7 @@ func TestCherryPick_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CherryPick(ctx, client, CherryPickInput{ProjectID: "42", SHA: "abc", Branch: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -950,8 +939,7 @@ func TestRevert_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Revert(ctx, client, RevertInput{ProjectID: "42", SHA: "abc", Branch: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -963,8 +951,7 @@ func TestGetGPGSignature_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGPGSignature(ctx, client, GPGSignatureInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/compliancepolicy/compliance_policy_test.go
+++ b/internal/tools/compliancepolicy/compliance_policy_test.go
@@ -67,8 +67,7 @@ func TestGet(t *testing.T) {
 			name:    "returns error when context is cancelled",
 			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
 			ctx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
+				ctx := testutil.CancelledCtx(t)
 				return ctx
 			},
 			wantErr: true,
@@ -173,8 +172,7 @@ func TestUpdate(t *testing.T) {
 			input:   UpdateInput{CSPNamespaceID: &nsID},
 			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
 			ctx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
+				ctx := testutil.CancelledCtx(t)
 				return ctx
 			},
 			wantErr: true,

--- a/internal/tools/context_error_test.go
+++ b/internal/tools/context_error_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/branches"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/commits"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/files"
@@ -42,8 +43,7 @@ func TestBranchProtect_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := branches.Protect(ctx, client, branches.ProtectInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
@@ -87,8 +87,7 @@ func TestBranchUnprotect_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := branches.Unprotect(ctx, client, branches.UnprotectInput{ProjectID: "42", BranchName: "main"})
 	if err == nil {
@@ -101,8 +100,7 @@ func TestBranchCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := branches.Create(ctx, client, branches.CreateInput{ProjectID: "42", BranchName: "dev", Ref: "main"})
 	if err == nil {
@@ -115,8 +113,7 @@ func TestBranchList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := branches.List(ctx, client, branches.ListInput{ProjectID: "42"})
 	if err == nil {
@@ -129,8 +126,7 @@ func TestProtectedBranchesList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := branches.ProtectedList(ctx, client, branches.ProtectedListInput{ProjectID: "42"})
 	if err == nil {
@@ -169,8 +165,7 @@ func TestTagCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := tags.Create(ctx, client, tags.CreateInput{ProjectID: "42", TagName: "v1.0", Ref: "main"})
 	if err == nil {
@@ -183,8 +178,7 @@ func TestTagDelete_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := tags.Delete(ctx, client, tags.DeleteInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -197,8 +191,7 @@ func TestTagList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := tags.List(ctx, client, tags.ListInput{ProjectID: "42"})
 	if err == nil {
@@ -225,8 +218,7 @@ func TestReleaseCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releases.Create(ctx, client, releases.CreateInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -239,8 +231,7 @@ func TestReleaseGet_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releases.Get(ctx, client, releases.GetInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -253,8 +244,7 @@ func TestReleaseUpdate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releases.Update(ctx, client, releases.UpdateInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -267,8 +257,7 @@ func TestReleaseDelete_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releases.Delete(ctx, client, releases.DeleteInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -281,8 +270,7 @@ func TestReleaseList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releases.List(ctx, client, releases.ListInput{ProjectID: "42"})
 	if err == nil {
@@ -345,8 +333,7 @@ func TestReleaseLinkCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releaselinks.Create(ctx, client, releaselinks.CreateInput{ProjectID: "42", TagName: "v1.0", Name: "bin", URL: "https://example.com"})
 	if err == nil {
@@ -359,8 +346,7 @@ func TestReleaseLinkDelete_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releaselinks.Delete(ctx, client, releaselinks.DeleteInput{ProjectID: "42", TagName: "v1.0", LinkID: 1})
 	if err == nil {
@@ -373,8 +359,7 @@ func TestReleaseLinkList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := releaselinks.List(ctx, client, releaselinks.ListInput{ProjectID: "42", TagName: "v1.0"})
 	if err == nil {
@@ -413,8 +398,7 @@ func TestMRCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.Create(ctx, client, mergerequests.CreateInput{ProjectID: "42", SourceBranch: "dev", TargetBranch: "main", Title: "test"})
 	if err == nil {
@@ -427,8 +411,7 @@ func TestMRGet_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.Get(ctx, client, mergerequests.GetInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -441,8 +424,7 @@ func TestMRList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.List(ctx, client, mergerequests.ListInput{ProjectID: "42"})
 	if err == nil {
@@ -455,8 +437,7 @@ func TestMRUpdate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.Update(ctx, client, mergerequests.UpdateInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -469,8 +450,7 @@ func TestMRMerge_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.Merge(ctx, client, mergerequests.MergeInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -483,8 +463,7 @@ func TestMRApprove_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mergerequests.Approve(ctx, client, mergerequests.ApproveInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -497,8 +476,7 @@ func TestMRUnapprove_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := mergerequests.Unapprove(ctx, client, mergerequests.ApproveInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -573,8 +551,7 @@ func TestMRNoteCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrnotes.Create(ctx, client, mrnotes.CreateInput{ProjectID: "42", MRIID: 1, Body: "test"})
 	if err == nil {
@@ -587,8 +564,7 @@ func TestMRNotesList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrnotes.List(ctx, client, mrnotes.ListInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -601,8 +577,7 @@ func TestMRNoteUpdate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrnotes.Update(ctx, client, mrnotes.UpdateInput{ProjectID: "42", MRIID: 1, NoteID: 1, Body: "new"})
 	if err == nil {
@@ -615,8 +590,7 @@ func TestMRNoteDelete_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := mrnotes.Delete(ctx, client, mrnotes.DeleteInput{ProjectID: "42", MRIID: 1, NoteID: 1})
 	if err == nil {
@@ -667,8 +641,7 @@ func TestMRDiscussionCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrdiscussions.Create(ctx, client, mrdiscussions.CreateInput{ProjectID: "42", MRIID: 1, Body: "test"})
 	if err == nil {
@@ -681,8 +654,7 @@ func TestMRDiscussionResolve_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrdiscussions.Resolve(ctx, client, mrdiscussions.ResolveInput{ProjectID: "42", MRIID: 1, DiscussionID: "abc", Resolved: true})
 	if err == nil {
@@ -695,8 +667,7 @@ func TestMRDiscussionReply_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrdiscussions.Reply(ctx, client, mrdiscussions.ReplyInput{ProjectID: "42", MRIID: 1, DiscussionID: "abc", Body: "test"})
 	if err == nil {
@@ -709,8 +680,7 @@ func TestMRDiscussionList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrdiscussions.List(ctx, client, mrdiscussions.ListInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -773,8 +743,7 @@ func TestMRChangesGet_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := mrchanges.Get(ctx, client, mrchanges.GetInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -789,8 +758,7 @@ func TestCommitCreate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := commits.Create(ctx, client, commits.CreateInput{ProjectID: "42", Branch: "main", CommitMessage: "test", Actions: []commits.Action{{Action: "create", FilePath: "f.txt", Content: "x"}}})
 	if err == nil {
@@ -805,8 +773,7 @@ func TestFileGet_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := files.Get(ctx, client, files.GetInput{ProjectID: "42", FilePath: "README.md", Ref: "main"})
 	if err == nil {
@@ -821,8 +788,7 @@ func TestProjectGet_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := projects.Get(ctx, client, projects.GetInput{ProjectID: "42"})
 	if err == nil {
@@ -835,8 +801,7 @@ func TestProjectList_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := projects.List(ctx, client, projects.ListInput{})
 	if err == nil {
@@ -849,8 +814,7 @@ func TestProjectDelete_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := projects.Delete(ctx, client, projects.DeleteInput{ProjectID: "42"})
 	if err == nil {
@@ -863,8 +827,7 @@ func TestProjectUpdate_ContextCancelled(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := projects.Update(ctx, client, projects.UpdateInput{ProjectID: "42"})
 	if err == nil {

--- a/internal/tools/dependencies/dependencies_test.go
+++ b/internal/tools/dependencies/dependencies_test.go
@@ -172,8 +172,7 @@ func TestListDeps_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListDeps(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -270,8 +269,7 @@ func TestCreateExport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateExport(ctx, client, CreateExportInput{PipelineID: 100})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -367,8 +365,7 @@ func TestGetExport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetExport(ctx, client, GetExportInput{ExportID: 1})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -460,8 +457,7 @@ func TestDownloadExport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadExport(ctx, client, DownloadExportInput{ExportID: 1})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")

--- a/internal/tools/deploykeys/deploykeys_test.go
+++ b/internal/tools/deploykeys/deploykeys_test.go
@@ -399,8 +399,7 @@ func TestListProject_APIError(t *testing.T) {
 // TestListProject_CancelledContext verifies the behavior of list project cancelled context.
 func TestListProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -434,8 +433,7 @@ func TestGet_MissingProjectID(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "1", DeployKeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -504,8 +502,7 @@ func TestAdd_WithInvalidExpiresAt(t *testing.T) {
 // TestAdd_CancelledContext verifies the behavior of add cancelled context.
 func TestAdd_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Add(ctx, client, AddInput{ProjectID: "1", Title: "k", Key: "ssh-rsa AAAA"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -539,8 +536,7 @@ func TestUpdate_MissingProjectID(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "1", DeployKeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -594,8 +590,7 @@ func TestDelete_MissingDeployKeyID(t *testing.T) {
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "1", DeployKeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -629,8 +624,7 @@ func TestEnable_MissingProjectID(t *testing.T) {
 // TestEnable_CancelledContext verifies the behavior of enable cancelled context.
 func TestEnable_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Enable(ctx, client, EnableInput{ProjectID: "1", DeployKeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -680,8 +674,7 @@ func TestListAll_WithPublicFilter(t *testing.T) {
 // TestListAll_CancelledContext verifies the behavior of list all cancelled context.
 func TestListAll_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListAll(ctx, client, ListAllInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -738,8 +731,7 @@ func TestAddInstance_WithInvalidExpiresAt(t *testing.T) {
 // TestAddInstance_CancelledContext verifies the behavior of add instance cancelled context.
 func TestAddInstance_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddInstance(ctx, client, AddInstanceInput{Title: "k", Key: "ssh-rsa AAAA"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -764,8 +756,7 @@ func TestListUserProject_APIError(t *testing.T) {
 // TestListUserProject_CancelledContext verifies the behavior of list user project cancelled context.
 func TestListUserProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListUserProject(ctx, client, ListUserProjectInput{UserID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
+++ b/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
@@ -212,8 +212,7 @@ func TestList_APIError404(t *testing.T) {
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42", DeploymentID: 7})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/deployments/deployments_test.go
+++ b/internal/tools/deployments/deployments_test.go
@@ -98,8 +98,7 @@ func TestDeploymentList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -148,8 +147,7 @@ func TestDeploymentGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", DeploymentID: 1})
 	if err == nil {
@@ -217,8 +215,7 @@ func TestDeploymentCreate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Environment: "e", Ref: "r", SHA: "s"})
 	if err == nil {
@@ -283,8 +280,7 @@ func TestDeploymentUpdate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", DeploymentID: 1, Status: "success"})
 	if err == nil {
@@ -330,8 +326,7 @@ func TestDeploymentDelete_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", DeploymentID: 1})
 	if err == nil {
@@ -606,8 +601,7 @@ func TestDeploymentDelete_MissingProjectID(t *testing.T) {
 // TestDeploymentApproveOrReject_CancelledContext verifies the behavior of deployment approve or reject cancelled context.
 func TestDeploymentApproveOrReject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ApproveOrReject(ctx, client, ApproveOrRejectInput{
 		ProjectID: "42", DeploymentID: 10, Status: "approved",

--- a/internal/tools/deploytokens/deploytokens_test.go
+++ b/internal/tools/deploytokens/deploytokens_test.go
@@ -360,8 +360,7 @@ func TestListAll_APIError(t *testing.T) {
 // TestListAll_CancelledContext verifies the behavior of list all cancelled context.
 func TestListAll_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListAll(ctx, client, ListAllInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -400,8 +399,7 @@ func TestListProject_APIError(t *testing.T) {
 // TestListProject_CancelledContext verifies the behavior of list project cancelled context.
 func TestListProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -469,8 +467,7 @@ func TestListGroup_APIError(t *testing.T) {
 // TestListGroup_CancelledContext verifies the behavior of list group cancelled context.
 func TestListGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -547,8 +544,7 @@ func TestGetProject_MissingProjectID(t *testing.T) {
 // TestGetProject_CancelledContext verifies the behavior of get project cancelled context.
 func TestGetProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetProject(ctx, client, GetProjectInput{ProjectID: "1", DeployTokenID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -582,8 +578,7 @@ func TestGetGroup_MissingGroupID(t *testing.T) {
 // TestGetGroup_CancelledContext verifies the behavior of get group cancelled context.
 func TestGetGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroup(ctx, client, GetGroupInput{GroupID: "1", DeployTokenID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -671,8 +666,7 @@ func TestCreateProject_InvalidExpiresAt(t *testing.T) {
 // TestCreateProject_CancelledContext verifies the behavior of create project cancelled context.
 func TestCreateProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateProject(ctx, client, CreateProjectInput{
 		ProjectID: "1", Name: "tok", Scopes: []string{"read_repository"},
 	})
@@ -770,8 +764,7 @@ func TestCreateGroup_InvalidExpiresAt(t *testing.T) {
 // TestCreateGroup_CancelledContext verifies the behavior of create group cancelled context.
 func TestCreateGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateGroup(ctx, client, CreateGroupInput{
 		GroupID: "1", Name: "tok", Scopes: []string{"read_repository"},
 	})
@@ -807,8 +800,7 @@ func TestDeleteProject_MissingProjectID(t *testing.T) {
 // TestDeleteProject_CancelledContext verifies the behavior of delete project cancelled context.
 func TestDeleteProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteProject(ctx, client, DeleteProjectInput{ProjectID: "1", DeployTokenID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -842,8 +834,7 @@ func TestDeleteGroup_MissingGroupID(t *testing.T) {
 // TestDeleteGroup_CancelledContext verifies the behavior of delete group cancelled context.
 func TestDeleteGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteGroup(ctx, client, DeleteGroupInput{GroupID: "1", DeployTokenID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/dorametrics/dorametrics_test.go
+++ b/internal/tools/dorametrics/dorametrics_test.go
@@ -202,8 +202,7 @@ func TestGetProjectMetrics_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetProjectMetrics(ctx, client, ProjectInput{ProjectID: "42", Metric: "deployment_frequency"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -353,8 +352,7 @@ func TestGetGroupMetrics_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroupMetrics(ctx, client, GroupInput{GroupID: "5", Metric: "deployment_frequency"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")

--- a/internal/tools/enterpriseusers/enterprise_users_test.go
+++ b/internal/tools/enterpriseusers/enterprise_users_test.go
@@ -87,8 +87,7 @@ func TestList_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{GroupID: toolutil.StringOrInt("42")})
 	if err == nil {
@@ -286,8 +285,7 @@ func TestGet_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{GroupID: toolutil.StringOrInt("42"), UserID: 10})
 	if err == nil {
@@ -360,8 +358,7 @@ func TestDisable2FA_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Disable2FA(ctx, client, Disable2FAInput{
 		GroupID: toolutil.StringOrInt("42"),
@@ -458,8 +455,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{
 		GroupID: toolutil.StringOrInt("42"),

--- a/internal/tools/environments/environments_test.go
+++ b/internal/tools/environments/environments_test.go
@@ -97,8 +97,7 @@ func TestEnvironmentList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -153,8 +152,7 @@ func TestEnvironmentGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", EnvironmentID: 1})
 	if err == nil {
@@ -211,8 +209,7 @@ func TestEnvironmentCreate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Name: "qa"})
 	if err == nil {
@@ -270,8 +267,7 @@ func TestEnvironmentUpdate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", EnvironmentID: 1, Name: "x"})
 	if err == nil {
@@ -323,8 +319,7 @@ func TestEnvironmentDelete_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", EnvironmentID: 1})
 	if err == nil {
@@ -403,8 +398,7 @@ func TestEnvironmentStop_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Stop(ctx, client, StopInput{ProjectID: "42", EnvironmentID: 1})
 	if err == nil {

--- a/internal/tools/epicissues/epic_issues_test.go
+++ b/internal/tools/epicissues/epic_issues_test.go
@@ -344,8 +344,7 @@ func TestList(t *testing.T) {
 
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
 		t.Fatal("List() expected context error, got nil")
@@ -466,8 +465,7 @@ func TestAssign(t *testing.T) {
 
 func TestAssign_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Assign(ctx, client, AssignInput{FullPath: testFullPath, IID: 1, ChildProjectPath: testChildProject, ChildIID: 10})
 	if err == nil {
 		t.Fatal("Assign() expected context error, got nil")
@@ -585,8 +583,7 @@ func TestRemove(t *testing.T) {
 
 func TestRemove_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Remove(ctx, client, RemoveInput{FullPath: testFullPath, IID: 1, ChildProjectPath: testChildProject, ChildIID: 10})
 	if err == nil {
 		t.Fatal("Remove() expected context error, got nil")
@@ -766,8 +763,7 @@ func TestUpdateOrder(t *testing.T) {
 
 func TestUpdateOrder_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateOrder(ctx, client, UpdateInput{
 		FullPath: testFullPath, IID: 1,
 		ChildID: "gid://gitlab/WorkItem/10", AdjacentID: "gid://gitlab/WorkItem/20",

--- a/internal/tools/epics/epics_test.go
+++ b/internal/tools/epics/epics_test.go
@@ -650,7 +650,7 @@ func TestCreate_WithAllOptions(t *testing.T) {
 			t.Fatal("GraphQL variables missing 'input' object")
 		}
 		for _, key := range []string{"title", "confidential", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "assigneesWidget", "labelsWidget", "weightWidget", "healthStatusWidget"} {
-			if _, ok := input[key]; !ok {
+			if _, exists := input[key]; !exists {
 				t.Errorf("GraphQL input missing %q", key)
 			}
 		}
@@ -713,7 +713,7 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 				t.Fatal("GraphQL variables missing 'input' object")
 			}
 			for _, key := range []string{"title", "stateEvent", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "labelsWidget", "assigneesWidget", "weightWidget", "healthStatusWidget", "statusWidget"} {
-				if _, ok := input[key]; !ok {
+				if _, exists := input[key]; !exists {
 					t.Errorf("GraphQL input missing %q", key)
 				}
 			}

--- a/internal/tools/epics/epics_test.go
+++ b/internal/tools/epics/epics_test.go
@@ -158,8 +158,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("List() expected context error, got nil")
@@ -663,8 +662,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{FullPath: testFullPath, Title: "X"})
 	if err == nil {
 		t.Fatal("expected context error, got nil")
@@ -719,8 +717,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{FullPath: testFullPath, IID: 1, Title: "X"})
 	if err == nil {
 		t.Fatal("expected context error, got nil")
@@ -734,8 +731,7 @@ func TestGetLinks_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetLinks(ctx, client, GetLinksInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
 		t.Fatal("expected context error, got nil")
@@ -758,8 +754,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
 		t.Fatal("expected context error, got nil")
@@ -771,8 +766,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not reach API")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
 		t.Fatal("expected context error, got nil")

--- a/internal/tools/epics/epics_test.go
+++ b/internal/tools/epics/epics_test.go
@@ -599,7 +599,16 @@ func TestToLinkItem_NilAuthorAndCreatedAt(t *testing.T) {
 // TestList_WithAllFilters verifies that List passes all filter parameters to
 // the GraphQL API without errors when every optional field is populated.
 func TestList_WithAllFilters(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars, err := testutil.ParseGraphQLVariables(r)
+		if err != nil {
+			t.Fatalf("ParseGraphQLVariables: %v", err)
+		}
+		for _, key := range []string{"fullPath", "state", "search", "authorUsername", "labelName", "confidential", "sort", "first", "after", "includeAncestors", "includeDescendants"} {
+			if _, ok := vars[key]; !ok {
+				t.Errorf("GraphQL variables missing %q", key)
+			}
+		}
 		testutil.RespondJSON(w, http.StatusOK, listResponseJSON)
 	}))
 	boolTrue := true
@@ -631,7 +640,20 @@ func TestList_WithAllFilters(t *testing.T) {
 // (description, confidential, color, dates, assignees, labels, weight, health)
 // without errors.
 func TestCreate_WithAllOptions(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars, err := testutil.ParseGraphQLVariables(r)
+		if err != nil {
+			t.Fatalf("ParseGraphQLVariables: %v", err)
+		}
+		input, ok := vars["input"].(map[string]any)
+		if !ok {
+			t.Fatal("GraphQL variables missing 'input' object")
+		}
+		for _, key := range []string{"title", "confidential", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "assigneesWidget", "labelsWidget", "weightWidget", "healthStatusWidget"} {
+			if _, ok := input[key]; !ok {
+				t.Errorf("GraphQL input missing %q", key)
+			}
+		}
 		testutil.RespondJSON(w, http.StatusOK, createResponseJSON)
 	}))
 	boolTrue := true
@@ -676,12 +698,25 @@ func TestCreate_CancelledContext(t *testing.T) {
 // weight, health, status) without errors.
 func TestUpdate_WithAllOptions(t *testing.T) {
 	call := 0
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		call++
 		switch call {
 		case 1:
 			testutil.RespondJSON(w, http.StatusOK, deleteGIDResponseJSON)
 		default:
+			vars, err := testutil.ParseGraphQLVariables(r)
+			if err != nil {
+				t.Fatalf("ParseGraphQLVariables: %v", err)
+			}
+			input, ok := vars["input"].(map[string]any)
+			if !ok {
+				t.Fatal("GraphQL variables missing 'input' object")
+			}
+			for _, key := range []string{"title", "stateEvent", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "labelsWidget", "assigneesWidget", "weightWidget", "healthStatusWidget", "statusWidget"} {
+				if _, ok := input[key]; !ok {
+					t.Errorf("GraphQL input missing %q", key)
+				}
+			}
 			testutil.RespondJSON(w, http.StatusOK, updateResponseJSON)
 		}
 	}))

--- a/internal/tools/externalstatuschecks/external_status_checks_test.go
+++ b/internal/tools/externalstatuschecks/external_status_checks_test.go
@@ -5,7 +5,9 @@ package externalstatuschecks
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
@@ -540,8 +542,11 @@ func TestUpdateProjectExternalStatusCheck_Success(t *testing.T) {
 
 // TestUpdateProjectExternalStatusCheck_WithAllFields verifies update with all optional fields.
 func TestUpdateProjectExternalStatusCheck_WithAllFields(t *testing.T) {
+	var capturedBody string
 	mux := http.NewServeMux()
-	mux.HandleFunc("PUT /api/v4/projects/1/external_status_checks/42", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("PUT /api/v4/projects/1/external_status_checks/42", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, projectStatusCheckJSON)
 	})
 	client := testutil.NewTestClient(t, mux)
@@ -559,6 +564,11 @@ func TestUpdateProjectExternalStatusCheck_WithAllFields(t *testing.T) {
 	}
 	if out.Name != "Security Scan" {
 		t.Errorf("expected name 'Security Scan', got %q", out.Name)
+	}
+	for _, want := range []string{"name", "external_url", "shared_secret", "protected_branch_ids"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/externalstatuschecks/external_status_checks_test.go
+++ b/internal/tools/externalstatuschecks/external_status_checks_test.go
@@ -545,7 +545,10 @@ func TestUpdateProjectExternalStatusCheck_WithAllFields(t *testing.T) {
 	var capturedBody string
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/v4/projects/1/external_status_checks/42", func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, projectStatusCheckJSON)
 	})

--- a/internal/tools/externalstatuschecks/external_status_checks_test.go
+++ b/internal/tools/externalstatuschecks/external_status_checks_test.go
@@ -724,8 +724,7 @@ func TestToProjectStatusCheckOutput_NoBranches(t *testing.T) {
 // returns an error before making an API call.
 func TestListMergeStatusChecks_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListMergeStatusChecks(ctx, client, ListMergeStatusChecksInput{ProjectID: "1", MRIID: 10})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -774,8 +773,7 @@ func TestListMergeStatusChecks_WithPagination(t *testing.T) {
 // context returns an error before making an API call.
 func TestSetExternalStatusCheckStatus_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := SetExternalStatusCheckStatus(ctx, client, SetStatusInput{
 		ProjectID: "1", MRIID: 10, SHA: "abc", ExternalStatusCheckID: 1, Status: "passed",
 	})
@@ -803,8 +801,7 @@ func TestSetExternalStatusCheckStatus_APIError(t *testing.T) {
 // returns an error for ListProjectStatusChecks.
 func TestListProjectStatusChecks_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProjectStatusChecks(ctx, client, ListProjectStatusChecksInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -852,8 +849,7 @@ func TestListProjectStatusChecks_WithPagination(t *testing.T) {
 // context returns an error for legacy create.
 func TestCreateExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := CreateExternalStatusCheck(ctx, client, CreateLegacyInput{
 		ProjectID: "1", Name: "x", ExternalURL: "https://x.com",
 	})
@@ -900,8 +896,7 @@ func TestCreateExternalStatusCheck_WithProtectedBranches(t *testing.T) {
 // context returns an error for legacy delete.
 func TestDeleteExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteExternalStatusCheck(ctx, client, DeleteLegacyInput{ProjectID: "1", CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -925,8 +920,7 @@ func TestDeleteExternalStatusCheck_APIError(t *testing.T) {
 // context returns an error for legacy update.
 func TestUpdateExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := UpdateExternalStatusCheck(ctx, client, UpdateLegacyInput{ProjectID: "1", CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -970,8 +964,7 @@ func TestUpdateExternalStatusCheck_AllOptionalFields(t *testing.T) {
 // context returns an error for legacy retry.
 func TestRetryFailedStatusCheckForMR_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := RetryFailedStatusCheckForMR(ctx, client, RetryLegacyInput{ProjectID: "1", MRIID: 10, CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -995,8 +988,7 @@ func TestRetryFailedStatusCheckForMR_APIError(t *testing.T) {
 // cancelled context returns an error.
 func TestListProjectMRExternalStatusChecks_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProjectMRExternalStatusChecks(ctx, client, ListProjectMRInput{ProjectID: "1", MRIID: 10})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -1045,8 +1037,7 @@ func TestListProjectMRExternalStatusChecks_WithPagination(t *testing.T) {
 // cancelled context returns an error.
 func TestListProjectExternalStatusChecks_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProjectExternalStatusChecks(ctx, client, ListProjectInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -1094,8 +1085,7 @@ func TestListProjectExternalStatusChecks_WithPagination(t *testing.T) {
 // cancelled context returns an error.
 func TestCreateProjectExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateProjectExternalStatusCheck(ctx, client, CreateProjectInput{
 		ProjectID: "1", Name: "x", ExternalURL: "https://x.com",
 	})
@@ -1123,8 +1113,7 @@ func TestCreateProjectExternalStatusCheck_APIError(t *testing.T) {
 // cancelled context returns an error.
 func TestDeleteProjectExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteProjectExternalStatusCheck(ctx, client, DeleteProjectInput{ProjectID: "1", CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -1148,8 +1137,7 @@ func TestDeleteProjectExternalStatusCheck_APIError(t *testing.T) {
 // cancelled context returns an error.
 func TestUpdateProjectExternalStatusCheck_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateProjectExternalStatusCheck(ctx, client, UpdateProjectInput{ProjectID: "1", CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -1173,8 +1161,7 @@ func TestUpdateProjectExternalStatusCheck_APIError(t *testing.T) {
 // that a cancelled context returns an error.
 func TestRetryFailedExternalStatusCheckForProjectMR_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := RetryFailedExternalStatusCheckForProjectMR(ctx, client, RetryProjectInput{ProjectID: "1", MRIID: 10, CheckID: 42})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -1199,8 +1186,7 @@ func TestRetryFailedExternalStatusCheckForProjectMR_APIError(t *testing.T) {
 // cancelled context returns an error.
 func TestSetProjectMRExternalStatusCheckStatus_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := SetProjectMRExternalStatusCheckStatus(ctx, client, SetProjectStatusInput{
 		ProjectID: "1", MRIID: 10, SHA: "abc", ExternalStatusCheckID: 1, Status: "passed",
 	})

--- a/internal/tools/files/files_test.go
+++ b/internal/tools/files/files_test.go
@@ -604,8 +604,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", FilePath: testFileMainGo})
 	if err == nil {
@@ -618,8 +617,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", FilePath: "f.txt", Branch: "main", CommitMessage: "m"})
 	if err == nil {
@@ -632,8 +630,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", FilePath: "f.txt", Branch: "main", CommitMessage: "m"})
 	if err == nil {
@@ -646,8 +643,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", FilePath: "f.txt", Branch: "main", CommitMessage: "m"})
 	if err == nil {
@@ -660,8 +656,7 @@ func TestBlame_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Blame(ctx, client, BlameInput{ProjectID: "42", FilePath: testFileMainGo})
 	if err == nil {
@@ -674,8 +669,7 @@ func TestGetMetaData_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetMetaData(ctx, client, MetaDataInput{ProjectID: "42", FilePath: testFileMainGo})
 	if err == nil {
@@ -688,8 +682,7 @@ func TestGetRaw_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetRaw(ctx, client, RawInput{ProjectID: "42", FilePath: testFileMainGo})
 	if err == nil {
@@ -702,8 +695,7 @@ func TestGetRawFileMetaData_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetRawFileMetaData(ctx, client, RawMetaDataInput{ProjectID: "42", FilePath: testFileMainGo})
 	if err == nil {

--- a/internal/tools/geo/geo_test.go
+++ b/internal/tools/geo/geo_test.go
@@ -399,8 +399,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{})
 	if err == nil {
@@ -413,8 +412,7 @@ func TestList_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
@@ -433,8 +431,7 @@ func TestGet_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -449,8 +446,7 @@ func TestEdit_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Edit(ctx, client, EditInput{ID: 1})
 	if err == nil {
@@ -465,8 +461,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -481,8 +476,7 @@ func TestRepair_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Repair(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -497,8 +491,7 @@ func TestListStatus_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListStatus(ctx, client, ListStatusInput{})
 	if err == nil {
@@ -513,8 +506,7 @@ func TestGetStatus_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetStatus(ctx, client, IDInput{ID: 1})
 	if err == nil {

--- a/internal/tools/groupboards/groupboards_test.go
+++ b/internal/tools/groupboards/groupboards_test.go
@@ -498,8 +498,7 @@ func TestListGroupBoards_APIError(t *testing.T) {
 // TestListGroupBoards_CancelledContext verifies the behavior of list group boards cancelled context.
 func TestListGroupBoards_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroupBoards(ctx, client, ListGroupBoardsInput{GroupID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -524,8 +523,7 @@ func TestGetGroupBoard_APIError(t *testing.T) {
 // TestGetGroupBoard_CancelledContext verifies the behavior of get group board cancelled context.
 func TestGetGroupBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroupBoard(ctx, client, GetGroupBoardInput{GroupID: "42", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -550,8 +548,7 @@ func TestCreateGroupBoard_APIError(t *testing.T) {
 // TestCreateGroupBoard_CancelledContext verifies the behavior of create group board cancelled context.
 func TestCreateGroupBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateGroupBoard(ctx, client, CreateGroupBoardInput{GroupID: "42", Name: "board"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -576,8 +573,7 @@ func TestUpdateGroupBoard_APIError(t *testing.T) {
 // TestUpdateGroupBoard_CancelledContext verifies the behavior of update group board cancelled context.
 func TestUpdateGroupBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateGroupBoard(ctx, client, UpdateGroupBoardInput{GroupID: "42", BoardID: 1, Name: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -602,8 +598,7 @@ func TestDeleteGroupBoard_APIError(t *testing.T) {
 // TestDeleteGroupBoard_CancelledContext verifies the behavior of delete group board cancelled context.
 func TestDeleteGroupBoard_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteGroupBoard(ctx, client, DeleteGroupBoardInput{GroupID: "42", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -628,8 +623,7 @@ func TestListGroupBoardLists_APIError(t *testing.T) {
 // TestListGroupBoardLists_CancelledContext verifies the behavior of list group board lists cancelled context.
 func TestListGroupBoardLists_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroupBoardLists(ctx, client, ListGroupBoardListsInput{GroupID: "42", BoardID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -654,8 +648,7 @@ func TestGetGroupBoardList_APIError(t *testing.T) {
 // TestGetGroupBoardList_CancelledContext verifies the behavior of get group board list cancelled context.
 func TestGetGroupBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroupBoardList(ctx, client, GetGroupBoardListInput{GroupID: "42", BoardID: 1, ListID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -680,8 +673,7 @@ func TestCreateGroupBoardList_APIError(t *testing.T) {
 // TestCreateGroupBoardList_CancelledContext verifies the behavior of create group board list cancelled context.
 func TestCreateGroupBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateGroupBoardList(ctx, client, CreateGroupBoardListInput{GroupID: "42", BoardID: 1, LabelID: 5})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -706,8 +698,7 @@ func TestUpdateGroupBoardList_APIError(t *testing.T) {
 // TestUpdateGroupBoardList_CancelledContext verifies the behavior of update group board list cancelled context.
 func TestUpdateGroupBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateGroupBoardList(ctx, client, UpdateGroupBoardListInput{GroupID: "42", BoardID: 1, ListID: 10, Position: 2})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -773,8 +764,7 @@ func TestDeleteGroupBoardList_APIError(t *testing.T) {
 // TestDeleteGroupBoardList_CancelledContext verifies the behavior of delete group board list cancelled context.
 func TestDeleteGroupBoardList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteGroupBoardList(ctx, client, DeleteGroupBoardListInput{GroupID: "42", BoardID: 1, ListID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/groupcredentials/group_credentials_test.go
+++ b/internal/tools/groupcredentials/group_credentials_test.go
@@ -98,8 +98,7 @@ func TestListPATs_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListPATs(ctx, client, ListPATsInput{GroupID: toolutil.StringOrInt("mygroup")})
 	if err == nil {
@@ -166,8 +165,7 @@ func TestListSSHKeys_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListSSHKeys(ctx, client, ListSSHKeysInput{GroupID: toolutil.StringOrInt("mygroup")})
 	if err == nil {
@@ -239,8 +237,7 @@ func TestRevokePAT_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := RevokePAT(ctx, client, RevokePATInput{
 		GroupID: toolutil.StringOrInt("mygroup"),
@@ -320,8 +317,7 @@ func TestDeleteSSHKey_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := DeleteSSHKey(ctx, client, DeleteSSHKeyInput{
 		GroupID: toolutil.StringOrInt("mygroup"),

--- a/internal/tools/groupepicboards/group_epic_boards_test.go
+++ b/internal/tools/groupepicboards/group_epic_boards_test.go
@@ -142,8 +142,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: testGroupID})
 	if err == nil {
 		t.Fatal("List() expected context error, got nil")
@@ -309,8 +308,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("handler should not be called for cancelled context")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: testGroupID, BoardID: 1})
 	if err == nil {
 		t.Fatal("Get() expected context error, got nil")

--- a/internal/tools/groupimportexport/groupimportexport_test.go
+++ b/internal/tools/groupimportexport/groupimportexport_test.go
@@ -198,8 +198,7 @@ const errExpCancelledCtx = "expected error for canceled context"
 // TestScheduleExport_CancelledContext verifies the behavior of schedule export cancelled context.
 func TestScheduleExport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ScheduleExport(ctx, client, ScheduleExportInput{GroupID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -243,8 +242,7 @@ func TestExportDownload_ReadAllError(t *testing.T) {
 // TestExportDownload_CancelledContext verifies the behavior of export download cancelled context.
 func TestExportDownload_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ExportDownload(ctx, client, ExportDownloadInput{GroupID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -258,8 +256,7 @@ func TestExportDownload_CancelledContext(t *testing.T) {
 // TestImportFile_CancelledContext verifies the behavior of import file cancelled context.
 func TestImportFile_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	tmpFile := filepath.Join(t.TempDir(), "export.tar.gz")
 	if err := os.WriteFile(tmpFile, []byte("fake"), 0644); err != nil {

--- a/internal/tools/groupiterations/group_iterations_test.go
+++ b/internal/tools/groupiterations/group_iterations_test.go
@@ -178,8 +178,7 @@ func TestList_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{GroupID: "10"})
 	if err == nil {

--- a/internal/tools/grouplabels/grouplabels_test.go
+++ b/internal/tools/grouplabels/grouplabels_test.go
@@ -357,8 +357,7 @@ func TestList_APIError(t *testing.T) {
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "10"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -413,8 +412,7 @@ func TestGet_APIError(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: "10", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -441,8 +439,7 @@ func TestCreate_APIError(t *testing.T) {
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{
 		GroupID: "10", Name: "bug", Color: "#d9534f",
 	})
@@ -498,8 +495,7 @@ func TestUpdate_APIError(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{GroupID: "10", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -554,8 +550,7 @@ func TestDelete_APIError(t *testing.T) {
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{GroupID: "10", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -580,8 +575,7 @@ func TestSubscribe_APIError(t *testing.T) {
 // TestSubscribe_CancelledContext verifies the behavior of subscribe cancelled context.
 func TestSubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Subscribe(ctx, client, SubscribeInput{GroupID: "10", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -606,8 +600,7 @@ func TestUnsubscribe_APIError(t *testing.T) {
 // TestUnsubscribe_CancelledContext verifies the behavior of unsubscribe cancelled context.
 func TestUnsubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Unsubscribe(ctx, client, SubscribeInput{GroupID: "10", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
+++ b/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
@@ -163,8 +163,7 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "5"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -277,8 +276,7 @@ func TestList_APIErrorInternalServer(t *testing.T) {
 // TestDeleteByID_CancelledContext verifies the behavior of delete by i d cancelled context.
 func TestDeleteByID_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteByID(ctx, client, DeleteByIDInput{GroupID: "5", UploadID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -314,8 +312,7 @@ func TestDeleteByID_InternalServerError(t *testing.T) {
 // TestDeleteBySecretAndFilename_CancelledContext verifies the behavior of delete by secret and filename cancelled context.
 func TestDeleteBySecretAndFilename_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteBySecretAndFilename(ctx, client, DeleteBySecretAndFilenameInput{
 		GroupID: "5", Secret: "abc", Filename: "image.png",
 	})

--- a/internal/tools/groupmembers/groupmembers_test.go
+++ b/internal/tools/groupmembers/groupmembers_test.go
@@ -307,8 +307,7 @@ func TestGetMember_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"id":10}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetMember(ctx, client, GetInput{GroupID: "5", UserID: 10})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -353,8 +352,7 @@ func TestGetInheritedMember_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"id":10}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetInheritedMember(ctx, client, GetInput{GroupID: "5", UserID: 10})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -390,8 +388,7 @@ func TestAddMember_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{"id":1}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddMember(ctx, client, AddInput{GroupID: "5", UserID: 1, AccessLevel: 30})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -470,8 +467,7 @@ func TestEditMember_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"id":10}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := EditMember(ctx, client, EditInput{GroupID: "5", UserID: 10, AccessLevel: 40})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -528,8 +524,7 @@ func TestRemoveMember_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := RemoveMember(ctx, client, RemoveInput{GroupID: "5", UserID: 10})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -584,8 +579,7 @@ func TestShareGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{"id":5}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ShareGroup(ctx, client, ShareInput{GroupID: "5", ShareGroupID: 10, GroupAccess: 30})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")
@@ -646,8 +640,7 @@ func TestUnshareGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := UnshareGroup(ctx, client, UnshareInput{GroupID: "5", ShareGroupID: 10})
 	if err == nil {
 		t.Fatal("expected canceled context error, got nil")

--- a/internal/tools/groupmilestones/groupmilestones_test.go
+++ b/internal/tools/groupmilestones/groupmilestones_test.go
@@ -560,8 +560,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "10"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -680,8 +679,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -708,8 +706,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{GroupID: "10", Title: "v2.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -769,8 +766,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -849,8 +845,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -888,8 +883,7 @@ func TestGetIssues_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetIssues(ctx, client, GetIssuesInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -961,8 +955,7 @@ func TestGetMergeRequests_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetMergeRequests(ctx, client, GetMergeRequestsInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1034,8 +1027,7 @@ func TestGetBurndownChartEvents_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetBurndownChartEvents(ctx, client, GetBurndownChartEventsInput{GroupID: "10", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/groupprotectedbranches/groupprotectedbranches_test.go
+++ b/internal/tools/groupprotectedbranches/groupprotectedbranches_test.go
@@ -134,8 +134,7 @@ func TestList_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "mygroup"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -231,8 +230,7 @@ func TestGet_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, branchJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: "mygroup", Branch: "main"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -369,8 +367,7 @@ func TestProtect_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Protect(ctx, client, ProtectInput{GroupID: "mygroup", Name: "main"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -488,8 +485,7 @@ func TestUpdate_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{GroupID: "mygroup", Branch: "main"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
@@ -554,8 +550,7 @@ func TestUnprotect_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Unprotect(ctx, client, UnprotectInput{GroupID: "mygroup", Branch: "main"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")

--- a/internal/tools/grouprelationsexport/grouprelationsexport_test.go
+++ b/internal/tools/grouprelationsexport/grouprelationsexport_test.go
@@ -105,8 +105,7 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestScheduleExport_CancelledContext verifies the behavior of schedule export cancelled context.
 func TestScheduleExport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := ScheduleExport(ctx, client, ScheduleExportInput{GroupID: "10"})
 	if err == nil {
 		t.Fatal("expected error for canceled context, got nil")
@@ -147,8 +146,7 @@ func TestScheduleExport_EmptyGroupID(t *testing.T) {
 // TestListExportStatus_CancelledContext verifies the behavior of list export status cancelled context.
 func TestListExportStatus_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListExportStatus(ctx, client, ListExportStatusInput{GroupID: "10"})
 	if err == nil {
 		t.Fatal("expected error for canceled context, got nil")

--- a/internal/tools/groupreleases/groupreleases_test.go
+++ b/internal/tools/groupreleases/groupreleases_test.go
@@ -99,8 +99,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "mygroup"})
 	if err == nil {
 		t.Fatal("List() expected error for canceled context, got nil")

--- a/internal/tools/groups/groups_test.go
+++ b/internal/tools/groups/groups_test.go
@@ -157,8 +157,7 @@ func TestGroupList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
@@ -212,8 +211,7 @@ func TestGroupGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, groupDetailJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{GroupID: "99"})
 	if err == nil {
@@ -318,8 +316,7 @@ func TestGroupMembersList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := MembersList(ctx, client, MembersListInput{GroupID: "99"})
 	if err == nil {
@@ -417,8 +414,7 @@ func TestSubgroupsList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := SubgroupsList(ctx, client, SubgroupsListInput{GroupID: "99"})
 	if err == nil {
@@ -1061,8 +1057,7 @@ func TestSubgroupsList_WithPagination(t *testing.T) {
 // TestCreate_CancelledContext verifies the behavior of cov create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{Name: "g"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1109,8 +1104,7 @@ func TestCreate_AllOptionalFields(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of cov update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{GroupID: "99", Name: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1154,8 +1148,7 @@ func TestUpdate_AllOptionalFields(t *testing.T) {
 // TestDelete_CancelledContext verifies the behavior of cov delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1189,8 +1182,7 @@ func TestDelete_PermanentlyRemove(t *testing.T) {
 // TestRestore_CancelledContext verifies the behavior of cov restore cancelled context.
 func TestRestore_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Restore(ctx, client, RestoreInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1231,8 +1223,7 @@ func TestArchive_Success(t *testing.T) {
 // TestArchive_CancelledContext verifies archive respects context cancellation.
 func TestArchive_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Archive(ctx, client, ArchiveInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1282,8 +1273,7 @@ func TestUnarchive_Success(t *testing.T) {
 // TestUnarchive_CancelledContext verifies unarchive respects context cancellation.
 func TestUnarchive_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Unarchive(ctx, client, ArchiveInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1317,8 +1307,7 @@ func TestUnarchive_EmptyGroupID(t *testing.T) {
 // TestSearch_CancelledContext verifies the behavior of cov search cancelled context.
 func TestSearch_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Search(ctx, client, SearchInput{Query: "q"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1343,8 +1332,7 @@ func TestSearch_ServerError(t *testing.T) {
 // TestTransferProject_CancelledContext verifies the behavior of cov transfer project cancelled context.
 func TestTransferProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := TransferProject(ctx, client, TransferInput{GroupID: "99", ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1369,8 +1357,7 @@ func TestTransferProject_ServerError(t *testing.T) {
 // TestListProjects_CancelledContext verifies the behavior of cov list projects cancelled context.
 func TestListProjects_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProjects(ctx, client, ListProjectsInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1440,8 +1427,7 @@ func TestListProjects_AllOptionalFilters(t *testing.T) {
 // TestListHooks_CancelledContext verifies the behavior of cov list hooks cancelled context.
 func TestListHooks_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListHooks(ctx, client, ListHooksInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1499,8 +1485,7 @@ func TestListHooks_WithPagination(t *testing.T) {
 // TestGetHook_CancelledContext verifies the behavior of cov get hook cancelled context.
 func TestGetHook_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetHook(ctx, client, GetHookInput{GroupID: "99", HookID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1523,8 +1508,7 @@ func TestGetHook_MissingGroupID(t *testing.T) {
 // TestAddHook_CancelledContext verifies the behavior of cov add hook cancelled context.
 func TestAddHook_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddHook(ctx, client, AddHookInput{
 		GroupID:   "99",
 		HookInput: HookInput{URL: "https://example.com"},
@@ -1616,8 +1600,7 @@ func TestAddHook_AllOptionalFields(t *testing.T) {
 // TestEditHook_CancelledContext verifies the behavior of cov edit hook cancelled context.
 func TestEditHook_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := EditHook(ctx, client, EditHookInput{
 		GroupID:   "99",
 		HookID:    10,
@@ -1695,8 +1678,7 @@ func TestEditHook_AllOptionalFields(t *testing.T) {
 // TestDeleteHook_CancelledContext verifies the behavior of cov delete hook cancelled context.
 func TestDeleteHook_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteHook(ctx, client, DeleteHookInput{GroupID: "99", HookID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/groupscim/group_scim_test.go
+++ b/internal/tools/groupscim/group_scim_test.go
@@ -54,8 +54,7 @@ func TestList_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{GroupID: toolutil.StringOrInt("mygroup")})
 	if err == nil {
@@ -131,8 +130,7 @@ func TestGet_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{
 		GroupID: toolutil.StringOrInt("mygroup"),
@@ -224,8 +222,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Update(ctx, client, UpdateInput{
 		GroupID:   toolutil.StringOrInt("mygroup"),
@@ -301,8 +298,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{
 		GroupID: toolutil.StringOrInt("mygroup"),

--- a/internal/tools/groupsshcerts/group_ssh_certs_test.go
+++ b/internal/tools/groupsshcerts/group_ssh_certs_test.go
@@ -110,8 +110,7 @@ func TestList_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{GroupID: toolutil.StringOrInt("mygroup")})
 	if err == nil {
@@ -205,8 +204,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{
 		GroupID: toolutil.StringOrInt("mygroup"),
@@ -282,8 +280,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{
 		GroupID:       toolutil.StringOrInt("mygroup"),

--- a/internal/tools/groupstoragemoves/group_storage_moves_test.go
+++ b/internal/tools/groupstoragemoves/group_storage_moves_test.go
@@ -253,8 +253,7 @@ func TestRetrieveAll_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveAll(ctx, client, ListInput{})
 	if err == nil {
@@ -317,8 +316,7 @@ func TestRetrieveForGroup_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveForGroup(ctx, client, ListForGroupInput{GroupID: 10})
 	if err == nil {
@@ -375,8 +373,7 @@ func TestGet_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -404,8 +401,7 @@ func TestGetForGroup_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetForGroup(ctx, client, GroupMoveInput{GroupID: 10, ID: 1})
 	if err == nil {
@@ -433,8 +429,7 @@ func TestSchedule_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Schedule(ctx, client, ScheduleInput{GroupID: 10})
 	if err == nil {
@@ -467,8 +462,7 @@ func TestScheduleAll_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ScheduleAll(ctx, client, ScheduleAllInput{})
 	if err == nil {

--- a/internal/tools/groupvariables/groupvariables_test.go
+++ b/internal/tools/groupvariables/groupvariables_test.go
@@ -309,8 +309,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "10"})
 	if err == nil {
 		t.Fatal(errExpectedCtxCancelled)
@@ -393,8 +392,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: "10", Key: "K"})
 	if err == nil {
 		t.Fatal(errExpectedCtxCancelled)
@@ -432,8 +430,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{GroupID: "10", Key: "K", Value: "V"})
 	if err == nil {
 		t.Fatal(errExpectedCtxCancelled)
@@ -518,8 +515,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{GroupID: "10", Key: "K"})
 	if err == nil {
 		t.Fatal(errExpectedCtxCancelled)
@@ -594,8 +590,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{GroupID: "10", Key: "K"})
 	if err == nil {
 		t.Fatal(errExpectedCtxCancelled)

--- a/internal/tools/groupwikis/groupwikis_test.go
+++ b/internal/tools/groupwikis/groupwikis_test.go
@@ -77,8 +77,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{GroupID: "mygroup"})
 	if err == nil {
 		t.Fatal("List() expected error for canceled context, got nil")
@@ -309,8 +308,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{GroupID: "mygroup", Slug: "home"})
 	if err == nil {
 		t.Fatal("Get() expected error for cancelled context, got nil")
@@ -362,8 +360,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{GroupID: "mygroup", Title: "T", Content: "C"})
 	if err == nil {
 		t.Fatal("Create() expected error for cancelled context, got nil")
@@ -439,8 +436,7 @@ func TestEdit_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Edit(ctx, client, EditInput{GroupID: "mygroup", Slug: "home", Title: "T"})
 	if err == nil {
 		t.Fatal("Edit() expected error for cancelled context, got nil")
@@ -464,8 +460,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{GroupID: "mygroup", Slug: "home"})
 	if err == nil {
 		t.Fatal("Delete() expected error for cancelled context, got nil")

--- a/internal/tools/health/health_test.go
+++ b/internal/tools/health/health_test.go
@@ -215,8 +215,7 @@ func TestCheck_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Check(ctx, client, Input{})
 	if err == nil {

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -5,6 +5,7 @@ package importservice
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -253,8 +254,11 @@ const fmtUnexpErr = "unexpected error: %v"
 
 // TestImportFromGitHub_WithAllOptionalFields verifies the behavior of import from git hub with all optional fields.
 func TestImportFromGitHub_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/import/github" {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"name":"imported","full_path":"ns/imported","full_name":"ns / imported","import_source":"github.com/user/repo","import_status":"scheduled"}`)
 			return
 		}
@@ -273,6 +277,11 @@ func TestImportFromGitHub_WithAllOptionalFields(t *testing.T) {
 	}
 	if out.Name != "imported" {
 		t.Errorf("expected name 'imported', got %q", out.Name)
+	}
+	for _, want := range []string{"personal_access_token", "repo_id", "target_namespace", "new_name", "github_hostname", "timeout_strategy"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -257,7 +257,10 @@ func TestImportFromGitHub_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/import/github" {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"name":"imported","full_path":"ns/imported","full_name":"ns / imported","import_source":"github.com/user/repo","import_status":"scheduled"}`)
 			return

--- a/internal/tools/instancevariables/instancevariables_test.go
+++ b/internal/tools/instancevariables/instancevariables_test.go
@@ -354,8 +354,7 @@ func TestInstanceVariableList_WithPagination(t *testing.T) {
 // TestInstanceVariableList_CancelledContext verifies the behavior of instance variable list cancelled context.
 func TestInstanceVariableList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -380,8 +379,7 @@ func TestInstanceVariableGet_APIError(t *testing.T) {
 // TestInstanceVariableGet_CancelledContext verifies the behavior of instance variable get cancelled context.
 func TestInstanceVariableGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{Key: "MY_VAR"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -446,8 +444,7 @@ func TestInstanceVariableCreate_AllOptionalFields(t *testing.T) {
 // TestInstanceVariableCreate_CancelledContext verifies the behavior of instance variable create cancelled context.
 func TestInstanceVariableCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{Key: "K", Value: "V"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -506,8 +503,7 @@ func TestInstanceVariableUpdate_AllOptionalFields(t *testing.T) {
 // TestInstanceVariableUpdate_CancelledContext verifies the behavior of instance variable update cancelled context.
 func TestInstanceVariableUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{Key: "K"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -532,8 +528,7 @@ func TestInstanceVariableDelete_APIError(t *testing.T) {
 // TestInstanceVariableDelete_CancelledContext verifies the behavior of instance variable delete cancelled context.
 func TestInstanceVariableDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{Key: "K"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/integrations/integrations_test.go
+++ b/internal/tools/integrations/integrations_test.go
@@ -5,6 +5,7 @@ package integrations
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -402,8 +403,11 @@ func TestDelete_APIError400(t *testing.T) {
 
 // TestSetJira_WithAllOptionalFields verifies the behavior of set jira with all optional fields.
 func TestSetJira_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"title":"Jira","slug":"jira","active":true}`)
 			return
 		}
@@ -441,6 +445,11 @@ func TestSetJira_WithAllOptionalFields(t *testing.T) {
 	}
 	if out.Integration.Slug != "jira" {
 		t.Errorf("expected slug 'jira', got %q", out.Integration.Slug)
+	}
+	for _, want := range []string{"api_url", "jira_issue_prefix", "jira_issue_regex", "project_keys", "comment_on_event_enabled", "jira_issue_transition_automatic"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/integrations/integrations_test.go
+++ b/internal/tools/integrations/integrations_test.go
@@ -406,7 +406,10 @@ func TestSetJira_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"title":"Jira","slug":"jira","active":true}`)
 			return

--- a/internal/tools/issuediscussions/issuediscussions_test.go
+++ b/internal/tools/issuediscussions/issuediscussions_test.go
@@ -637,8 +637,7 @@ func TestToListOutput_EmptyList(t *testing.T) {
 
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -651,8 +650,7 @@ func TestList_CancelledContext(t *testing.T) {
 
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -665,8 +663,7 @@ func TestGet_CancelledContext(t *testing.T) {
 
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -679,8 +676,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 
 // TestAddNote_CancelledContext verifies the behavior of add note cancelled context.
 func TestAddNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -693,8 +689,7 @@ func TestAddNote_CancelledContext(t *testing.T) {
 
 // TestUpdateNote_CancelledContext verifies the behavior of update note cancelled context.
 func TestUpdateNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -707,8 +702,7 @@ func TestUpdateNote_CancelledContext(t *testing.T) {
 
 // TestDeleteNote_CancelledContext verifies the behavior of delete note cancelled context.
 func TestDeleteNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/tools/issuelinks/issuelinks_test.go
+++ b/internal/tools/issuelinks/issuelinks_test.go
@@ -124,8 +124,7 @@ func TestIssueLinkList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID, IssueIID: 5})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -211,8 +210,7 @@ func TestIssueLinkGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: testProjectID, IssueIID: 5, IssueLinkID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -340,8 +338,7 @@ func TestIssueLinkCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: testProjectID, IssueIID: 5, TargetProjectID: "20", TargetIssueIID: "12"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -415,8 +412,7 @@ func TestIssueLinkDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// no response needed: validation fails before reaching API
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, IssueIID: 5, IssueLinkID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/issuenotes/issue_notes_test.go
+++ b/internal/tools/issuenotes/issue_notes_test.go
@@ -113,8 +113,7 @@ func TestIssueNoteCreate_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID: testProjectID,
@@ -677,8 +676,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42", IssueIID: 10})
 	if err == nil {
 		t.Fatal("List() expected error for canceled context, got nil")
@@ -690,8 +688,7 @@ func TestGetNote_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, noteJSONSimple)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetNote(ctx, client, GetInput{ProjectID: "42", IssueIID: 10, NoteID: 100})
 	if err == nil {
 		t.Fatal("GetNote() expected error for canceled context, got nil")
@@ -703,8 +700,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, noteJSONSimple)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", IssueIID: 10, NoteID: 100, Body: "test"})
 	if err == nil {
 		t.Fatal("Update() expected error for canceled context, got nil")
@@ -716,8 +712,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", IssueIID: 10, NoteID: 100})
 	if err == nil {
 		t.Fatal("Delete() expected error for canceled context, got nil")

--- a/internal/tools/issues/issues_test.go
+++ b/internal/tools/issues/issues_test.go
@@ -2012,13 +2012,6 @@ func TestBasicMRToOutput_NilAuthor(t *testing.T) {
 // Context cancellation tests for ALL 21 handlers
 // ---------------------------------------------------------------------------.
 
-// cancelledCtx is an internal helper for the issues package.
-func cancelledCtx() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	return ctx
-}
-
 // nopClient is an internal helper for the issues package.
 func nopClient(t *testing.T) *gitlabclient.Client {
 	t.Helper()
@@ -2029,119 +2022,119 @@ func nopClient(t *testing.T) *gitlabclient.Client {
 
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
-	if _, err := Get(cancelledCtx(), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := Get(testutil.CancelledCtx(t), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("Get: expected error for canceled context")
 	}
 }
 
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
-	if _, err := List(cancelledCtx(), nopClient(t), ListInput{ProjectID: testProjectID}); err == nil {
+	if _, err := List(testutil.CancelledCtx(t), nopClient(t), ListInput{ProjectID: testProjectID}); err == nil {
 		t.Fatal("List: expected error for canceled context")
 	}
 }
 
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
-	if _, err := Update(cancelledCtx(), nopClient(t), UpdateInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := Update(testutil.CancelledCtx(t), nopClient(t), UpdateInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("Update: expected error for canceled context")
 	}
 }
 
 // TestGetByID_CancelledContext verifies the behavior of get by i d cancelled context.
 func TestGetByID_CancelledContext(t *testing.T) {
-	if _, err := GetByID(cancelledCtx(), nopClient(t), GetByIDInput{IssueID: 10}); err == nil {
+	if _, err := GetByID(testutil.CancelledCtx(t), nopClient(t), GetByIDInput{IssueID: 10}); err == nil {
 		t.Fatal("GetByID: expected error for canceled context")
 	}
 }
 
 // TestReorder_CancelledContext verifies the behavior of reorder cancelled context.
 func TestReorder_CancelledContext(t *testing.T) {
-	if _, err := Reorder(cancelledCtx(), nopClient(t), ReorderInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := Reorder(testutil.CancelledCtx(t), nopClient(t), ReorderInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("Reorder: expected error for canceled context")
 	}
 }
 
 // TestMove_CancelledContext verifies the behavior of move cancelled context.
 func TestMove_CancelledContext(t *testing.T) {
-	if _, err := Move(cancelledCtx(), nopClient(t), MoveInput{ProjectID: testProjectID, IssueIID: 10, ToProjectID: 99}); err == nil {
+	if _, err := Move(testutil.CancelledCtx(t), nopClient(t), MoveInput{ProjectID: testProjectID, IssueIID: 10, ToProjectID: 99}); err == nil {
 		t.Fatal("Move: expected error for canceled context")
 	}
 }
 
 // TestSubscribe_CancelledContext verifies the behavior of subscribe cancelled context.
 func TestSubscribe_CancelledContext(t *testing.T) {
-	if _, err := Subscribe(cancelledCtx(), nopClient(t), SubscribeInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := Subscribe(testutil.CancelledCtx(t), nopClient(t), SubscribeInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("Subscribe: expected error for canceled context")
 	}
 }
 
 // TestUnsubscribe_CancelledContext verifies the behavior of unsubscribe cancelled context.
 func TestUnsubscribe_CancelledContext(t *testing.T) {
-	if _, err := Unsubscribe(cancelledCtx(), nopClient(t), UnsubscribeInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := Unsubscribe(testutil.CancelledCtx(t), nopClient(t), UnsubscribeInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("Unsubscribe: expected error for canceled context")
 	}
 }
 
 // TestCreateTodo_CancelledContext verifies the behavior of create todo cancelled context.
 func TestCreateTodo_CancelledContext(t *testing.T) {
-	if _, err := CreateTodo(cancelledCtx(), nopClient(t), CreateTodoInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := CreateTodo(testutil.CancelledCtx(t), nopClient(t), CreateTodoInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("CreateTodo: expected error for canceled context")
 	}
 }
 
 // TestSetTimeEstimate_CancelledContext verifies the behavior of set time estimate cancelled context.
 func TestSetTimeEstimate_CancelledContext(t *testing.T) {
-	if _, err := SetTimeEstimate(cancelledCtx(), nopClient(t), SetTimeEstimateInput{ProjectID: testProjectID, IssueIID: 10, Duration: "3h"}); err == nil {
+	if _, err := SetTimeEstimate(testutil.CancelledCtx(t), nopClient(t), SetTimeEstimateInput{ProjectID: testProjectID, IssueIID: 10, Duration: "3h"}); err == nil {
 		t.Fatal("SetTimeEstimate: expected error for canceled context")
 	}
 }
 
 // TestResetTimeEstimate_CancelledContext verifies the behavior of reset time estimate cancelled context.
 func TestResetTimeEstimate_CancelledContext(t *testing.T) {
-	if _, err := ResetTimeEstimate(cancelledCtx(), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := ResetTimeEstimate(testutil.CancelledCtx(t), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("ResetTimeEstimate: expected error for canceled context")
 	}
 }
 
 // TestAddSpentTime_CancelledContext verifies the behavior of add spent time cancelled context.
 func TestAddSpentTime_CancelledContext(t *testing.T) {
-	if _, err := AddSpentTime(cancelledCtx(), nopClient(t), AddSpentTimeInput{ProjectID: testProjectID, IssueIID: 10, Duration: "1h"}); err == nil {
+	if _, err := AddSpentTime(testutil.CancelledCtx(t), nopClient(t), AddSpentTimeInput{ProjectID: testProjectID, IssueIID: 10, Duration: "1h"}); err == nil {
 		t.Fatal("AddSpentTime: expected error for canceled context")
 	}
 }
 
 // TestResetSpentTime_CancelledContext verifies the behavior of reset spent time cancelled context.
 func TestResetSpentTime_CancelledContext(t *testing.T) {
-	if _, err := ResetSpentTime(cancelledCtx(), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := ResetSpentTime(testutil.CancelledCtx(t), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("ResetSpentTime: expected error for canceled context")
 	}
 }
 
 // TestGetTimeStats_CancelledContext verifies the behavior of get time stats cancelled context.
 func TestGetTimeStats_CancelledContext(t *testing.T) {
-	if _, err := GetTimeStats(cancelledCtx(), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := GetTimeStats(testutil.CancelledCtx(t), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("GetTimeStats: expected error for canceled context")
 	}
 }
 
 // TestGetParticipants_CancelledContext verifies the behavior of get participants cancelled context.
 func TestGetParticipants_CancelledContext(t *testing.T) {
-	if _, err := GetParticipants(cancelledCtx(), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := GetParticipants(testutil.CancelledCtx(t), nopClient(t), GetInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("GetParticipants: expected error for canceled context")
 	}
 }
 
 // TestListMRsClosing_CancelledContext verifies the behavior of list m rs closing cancelled context.
 func TestListMRsClosing_CancelledContext(t *testing.T) {
-	if _, err := ListMRsClosing(cancelledCtx(), nopClient(t), ListMRsClosingInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := ListMRsClosing(testutil.CancelledCtx(t), nopClient(t), ListMRsClosingInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("ListMRsClosing: expected error for canceled context")
 	}
 }
 
 // TestListMRsRelated_CancelledContext verifies the behavior of list m rs related cancelled context.
 func TestListMRsRelated_CancelledContext(t *testing.T) {
-	if _, err := ListMRsRelated(cancelledCtx(), nopClient(t), ListMRsRelatedInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
+	if _, err := ListMRsRelated(testutil.CancelledCtx(t), nopClient(t), ListMRsRelatedInput{ProjectID: testProjectID, IssueIID: 10}); err == nil {
 		t.Fatal("ListMRsRelated: expected error for canceled context")
 	}
 }

--- a/internal/tools/issues/issues_test.go
+++ b/internal/tools/issues/issues_test.go
@@ -181,8 +181,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ProjectID: testProjectID, Title: "test"})
 	if err == nil {
@@ -456,8 +455,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, IssueIID: 10})
 	if err == nil {
@@ -532,8 +530,7 @@ func TestListGroup_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "10"})
 	if err == nil {
@@ -866,8 +863,7 @@ func TestListAll_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListAll(ctx, client, ListAllInput{})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/issuestatistics/issuestatistics_test.go
+++ b/internal/tools/issuestatistics/issuestatistics_test.go
@@ -336,8 +336,7 @@ func TestGet_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":0,"closed":0,"opened":0}}}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -461,8 +460,7 @@ func TestGetGroup_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":0,"closed":0,"opened":0}}}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroup(ctx, client, GetGroupInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -589,8 +587,7 @@ func TestGetProject_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":0,"closed":0,"opened":0}}}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetProject(ctx, client, GetProjectInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -297,8 +297,7 @@ func TestJobList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -854,8 +853,7 @@ func TestJobGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -882,8 +880,7 @@ func TestJobTrace_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Trace(ctx, client, TraceInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -910,8 +907,7 @@ func TestJobCancel_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Cancel(ctx, client, ActionInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -938,8 +934,7 @@ func TestJobRetry_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Retry(ctx, client, ActionInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -966,8 +961,7 @@ func TestListProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1024,8 +1018,7 @@ func TestListBridges_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListBridges(ctx, client, BridgeListInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1084,8 +1077,7 @@ func TestGetArtifacts_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("PK"))
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetArtifacts(ctx, client, GetInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1114,8 +1106,7 @@ func TestDownloadArtifacts_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadArtifacts(ctx, client, DownloadArtifactsInput{
 		ProjectID: "42", RefName: "main",
 	})
@@ -1157,8 +1148,7 @@ func TestDownloadSingleArtifact_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadSingleArtifact(ctx, client, SingleArtifactInput{
 		ProjectID: "42", JobID: 100, ArtifactPath: "report.txt",
 	})
@@ -1202,8 +1192,7 @@ func TestDownloadSingleArtifactByRef_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadSingleArtifactByRef(ctx, client, SingleArtifactRefInput{
 		ProjectID: "42", RefName: "main", ArtifactPath: "report.txt", JobName: "build",
 	})
@@ -1258,8 +1247,7 @@ func TestErase_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Erase(ctx, client, ActionInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1286,8 +1274,7 @@ func TestKeepArtifacts_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := KeepArtifacts(ctx, client, ActionInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1314,8 +1301,7 @@ func TestPlay_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, jobJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Play(ctx, client, PlayInput{ProjectID: "42", JobID: 100})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/jobs/wait_test.go
+++ b/internal/tools/jobs/wait_test.go
@@ -187,8 +187,7 @@ func TestJobWait_CanceledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, jobWithStatus("running"))
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Wait(ctx, nil, client, WaitInput{
 		ProjectID:       "42",

--- a/internal/tools/jobtokenscope/jobtokenscope_test.go
+++ b/internal/tools/jobtokenscope/jobtokenscope_test.go
@@ -263,8 +263,7 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestGetAccessSettings_CancelledContext verifies the behavior of get access settings cancelled context.
 func TestGetAccessSettings_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetAccessSettings(ctx, client, GetAccessSettingsInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -289,8 +288,7 @@ func TestPatchAccessSettings_APIError(t *testing.T) {
 // TestPatchAccessSettings_CancelledContext verifies the behavior of patch access settings cancelled context.
 func TestPatchAccessSettings_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := PatchAccessSettings(ctx, client, PatchAccessSettingsInput{ProjectID: "42", Enabled: false})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -315,8 +313,7 @@ func TestListInboundAllowlist_APIError(t *testing.T) {
 // TestListInboundAllowlist_CancelledContext verifies the behavior of list inbound allowlist cancelled context.
 func TestListInboundAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListInboundAllowlist(ctx, client, ListInboundAllowlistInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -378,8 +375,7 @@ func TestAddProjectAllowlist_APIError(t *testing.T) {
 // TestAddProjectAllowlist_CancelledContext verifies the behavior of add project allowlist cancelled context.
 func TestAddProjectAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddProjectAllowlist(ctx, client, AddProjectAllowlistInput{ProjectID: "42", TargetProjectID: 99})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -393,8 +389,7 @@ func TestAddProjectAllowlist_CancelledContext(t *testing.T) {
 // TestRemoveProjectAllowlist_CancelledContext verifies the behavior of remove project allowlist cancelled context.
 func TestRemoveProjectAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := RemoveProjectAllowlist(ctx, client, RemoveProjectAllowlistInput{ProjectID: "42", TargetProjectID: 99})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -419,8 +414,7 @@ func TestListGroupAllowlist_APIError(t *testing.T) {
 // TestListGroupAllowlist_CancelledContext verifies the behavior of list group allowlist cancelled context.
 func TestListGroupAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroupAllowlist(ctx, client, ListGroupAllowlistInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -482,8 +476,7 @@ func TestAddGroupAllowlist_APIError(t *testing.T) {
 // TestAddGroupAllowlist_CancelledContext verifies the behavior of add group allowlist cancelled context.
 func TestAddGroupAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddGroupAllowlist(ctx, client, AddGroupAllowlistInput{ProjectID: "42", TargetGroupID: 5})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -508,8 +501,7 @@ func TestRemoveGroupAllowlist_APIError(t *testing.T) {
 // TestRemoveGroupAllowlist_CancelledContext verifies the behavior of remove group allowlist cancelled context.
 func TestRemoveGroupAllowlist_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := RemoveGroupAllowlist(ctx, client, RemoveGroupAllowlistInput{ProjectID: "42", TargetGroupID: 5})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/labels/labels_test.go
+++ b/internal/tools/labels/labels_test.go
@@ -134,8 +134,7 @@ func TestLabelList_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -449,8 +448,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", LabelID: "bug"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -519,8 +517,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Name: "x", Color: "#000"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -578,8 +575,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", LabelID: "bug", NewName: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -617,8 +613,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", LabelID: "bug"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -645,8 +640,7 @@ func TestSubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Subscribe(ctx, client, SubscribeInput{ProjectID: "42", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -673,8 +667,7 @@ func TestUnsubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Unsubscribe(ctx, client, SubscribeInput{ProjectID: "42", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -701,8 +694,7 @@ func TestPromote_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Promote(ctx, client, PromoteInput{ProjectID: "42", LabelID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/markdown/markdown_test.go
+++ b/internal/tools/markdown/markdown_test.go
@@ -94,8 +94,7 @@ func TestRender_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"html":"<p>x</p>"}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Render(ctx, client, RenderInput{Text: "test"})
 	if err == nil {
 		t.Fatal("expected error for canceled context, got nil")

--- a/internal/tools/memberroles/member_roles_test.go
+++ b/internal/tools/memberroles/member_roles_test.go
@@ -2,7 +2,9 @@ package memberroles
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
@@ -455,10 +457,13 @@ func TestToOutput_Nil(t *testing.T) {
 // forwards all permission flags to the GitLab API. This exercises every branch
 // in buildCreateOpts that handles optional permission fields.
 func TestCreateInstance_WithAllPermissions(t *testing.T) {
+	var capturedBody string
 	trueVal := true
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.AssertRequestPath(t, r, "/api/v4/member_roles")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, `{
 			"id":10,"name":"full-perms","description":"All permissions",
 			"base_access_level":30,
@@ -515,6 +520,11 @@ func TestCreateInstance_WithAllPermissions(t *testing.T) {
 	}
 	if out.RemoveProject == nil || !*out.RemoveProject {
 		t.Error("expected RemoveProject to be true")
+	}
+	for _, want := range []string{"admin_cicd_variables", "admin_merge_request", "read_code", "remove_project", "manage_deploy_tokens", "admin_vulnerability"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/memberroles/member_roles_test.go
+++ b/internal/tools/memberroles/member_roles_test.go
@@ -462,7 +462,10 @@ func TestCreateInstance_WithAllPermissions(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.AssertRequestPath(t, r, "/api/v4/member_roles")
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, `{
 			"id":10,"name":"full-perms","description":"All permissions",

--- a/internal/tools/memberroles/member_roles_test.go
+++ b/internal/tools/memberroles/member_roles_test.go
@@ -40,8 +40,7 @@ func TestListInstance_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListInstance(ctx, client, ListInstanceInput{})
 	if err == nil {
@@ -100,8 +99,7 @@ func TestListGroup_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: toolutil.StringOrInt("mygroup")})
 	if err == nil {
@@ -182,8 +180,7 @@ func TestCreateInstance_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := CreateInstance(ctx, client, CreateInstanceInput{
 		Name:            "custom-dev",
@@ -281,8 +278,7 @@ func TestCreateGroup_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := CreateGroup(ctx, client, CreateGroupInput{
 		GroupID:         toolutil.StringOrInt("mygroup"),
@@ -344,8 +340,7 @@ func TestDeleteInstance_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := DeleteInstance(ctx, client, DeleteInstanceInput{MemberRoleID: 1})
 	if err == nil {
@@ -415,8 +410,7 @@ func TestDeleteGroup_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := DeleteGroup(ctx, client, DeleteGroupInput{
 		GroupID:      toolutil.StringOrInt("mygroup"),

--- a/internal/tools/members/members_test.go
+++ b/internal/tools/members/members_test.go
@@ -141,8 +141,7 @@ func TestProjectMembersList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID})
 	if err == nil {

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -1913,8 +1913,7 @@ func TestRelatedIssues_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := RelatedIssues(ctx, client, RelatedIssuesInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("RelatedIssues() expected error for canceled context, got nil")
@@ -1996,8 +1995,7 @@ func TestCreateTodo_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateTodo(ctx, client, CreateTodoInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("CreateTodo() expected error for canceled context, got nil")
@@ -2077,8 +2075,7 @@ func TestCreateDependency_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateDependency(ctx, client, DependencyInput{ProjectID: testProjectID, MRIID: 1, BlockingMergeRequestID: 100})
 	if err == nil {
 		t.Fatal("CreateDependency() expected error for canceled context, got nil")
@@ -2134,8 +2131,7 @@ func TestDeleteDependency_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteDependency(ctx, client, DeleteDependencyInput{ProjectID: testProjectID, MRIID: 1, BlockingMergeRequestID: 100})
 	if err == nil {
 		t.Fatal("DeleteDependency() expected error for canceled context, got nil")
@@ -2210,8 +2206,7 @@ func TestGetDependencies_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetDependencies(ctx, client, GetDependenciesInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("GetDependencies() expected error for canceled context, got nil")
@@ -2238,8 +2233,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: testProjectID, SourceBranch: "a", TargetBranch: "b", Title: "t"})
 	if err == nil {
 		t.Fatal("Create() expected error for canceled context, got nil")
@@ -2251,8 +2245,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Get() expected error for canceled context, got nil")
@@ -2264,8 +2257,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID})
 	if err == nil {
 		t.Fatal("List() expected error for canceled context, got nil")
@@ -2277,8 +2269,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Update() expected error for canceled context, got nil")
@@ -2290,8 +2281,7 @@ func TestMerge_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Merge(ctx, client, MergeInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Merge() expected error for canceled context, got nil")
@@ -2303,8 +2293,7 @@ func TestApprove_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Approve(ctx, client, ApproveInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Approve() expected error for canceled context, got nil")
@@ -2316,8 +2305,7 @@ func TestUnapprove_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Unapprove(ctx, client, ApproveInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Unapprove() expected error for canceled context, got nil")
@@ -2329,8 +2317,7 @@ func TestCommits_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Commits(ctx, client, CommitsInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Commits() expected error for canceled context, got nil")
@@ -2342,8 +2329,7 @@ func TestPipelines_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Pipelines(ctx, client, PipelinesInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Pipelines() expected error for canceled context, got nil")
@@ -2355,8 +2341,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Delete() expected error for canceled context, got nil")
@@ -2368,8 +2353,7 @@ func TestRebase_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Rebase(ctx, client, RebaseInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Rebase() expected error for canceled context, got nil")
@@ -2381,8 +2365,7 @@ func TestListGlobal_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGlobal(ctx, client, ListGlobalInput{})
 	if err == nil {
 		t.Fatal("ListGlobal() expected error for canceled context, got nil")
@@ -2394,8 +2377,7 @@ func TestListGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "99"})
 	if err == nil {
 		t.Fatal("ListGroup() expected error for canceled context, got nil")
@@ -2407,8 +2389,7 @@ func TestParticipants_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Participants(ctx, client, ParticipantsInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Participants() expected error for canceled context, got nil")
@@ -2420,8 +2401,7 @@ func TestReviewers_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Reviewers(ctx, client, ParticipantsInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Reviewers() expected error for canceled context, got nil")
@@ -2433,8 +2413,7 @@ func TestCreatePipeline_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreatePipeline(ctx, client, CreatePipelineInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("CreatePipeline() expected error for canceled context, got nil")
@@ -2446,8 +2425,7 @@ func TestIssuesClosed_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := IssuesClosed(ctx, client, IssuesClosedInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("IssuesClosed() expected error for canceled context, got nil")
@@ -2459,8 +2437,7 @@ func TestCancelAutoMerge_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CancelAutoMerge(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("CancelAutoMerge() expected error for canceled context, got nil")
@@ -2472,8 +2449,7 @@ func TestSubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Subscribe(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Subscribe() expected error for canceled context, got nil")
@@ -2485,8 +2461,7 @@ func TestUnsubscribe_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Unsubscribe(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("Unsubscribe() expected error for canceled context, got nil")
@@ -2498,8 +2473,7 @@ func TestSetTimeEstimate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := SetTimeEstimate(ctx, client, SetTimeEstimateInput{ProjectID: testProjectID, MRIID: 1, Duration: "3h"})
 	if err == nil {
 		t.Fatal("SetTimeEstimate() expected error for canceled context, got nil")
@@ -2511,8 +2485,7 @@ func TestResetTimeEstimate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetTimeEstimate(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("ResetTimeEstimate() expected error for canceled context, got nil")
@@ -2524,8 +2497,7 @@ func TestAddSpentTime_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddSpentTime(ctx, client, AddSpentTimeInput{ProjectID: testProjectID, MRIID: 1, Duration: "1h"})
 	if err == nil {
 		t.Fatal("AddSpentTime() expected error for canceled context, got nil")
@@ -2537,8 +2509,7 @@ func TestResetSpentTime_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetSpentTime(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("ResetSpentTime() expected error for canceled context, got nil")
@@ -2550,8 +2521,7 @@ func TestGetTimeStats_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetTimeStats(ctx, client, GetInput{ProjectID: testProjectID, MRIID: 1})
 	if err == nil {
 		t.Fatal("GetTimeStats() expected error for canceled context, got nil")

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -3078,7 +3078,10 @@ func TestCreate_AllOptionalFields(t *testing.T) {
 func TestCreate_AssigneeIDSingular(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathMRs {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			bodyStr := string(body)
 			if !strings.Contains(bodyStr, `"assignee_id":28`) {
 				t.Errorf("request body missing assignee_id: %s", bodyStr)
@@ -3109,7 +3112,10 @@ func TestCreate_AssigneeIDSingular(t *testing.T) {
 func TestUpdate_AssigneeIDSingular(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == pathMR1 {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			bodyStr := string(body)
 			if !strings.Contains(bodyStr, `"assignee_id":28`) {
 				t.Errorf("request body missing assignee_id: %s", bodyStr)
@@ -3417,7 +3423,10 @@ func TestMerge_AutoDetectsSquashOnMerge(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathMR1:
 			testutil.RespondJSON(w, http.StatusOK, mrWithSquashOnMerge)
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
 		default:
@@ -3452,7 +3461,10 @@ func TestMerge_AutoDetectsForceRemoveSourceBranch(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathMR1:
 			testutil.RespondJSON(w, http.StatusOK, mrWithForceRemove)
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
 		default:
@@ -3487,7 +3499,10 @@ func TestMerge_EnforcedSquashOverridesExplicitFalse(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathMR1:
 			testutil.RespondJSON(w, http.StatusOK, mrWithSquashOnMerge)
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
 		default:
@@ -3525,7 +3540,10 @@ func TestMerge_ExplicitSquashRespectedWhenNotEnforced(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == pathMR1:
 			testutil.RespondJSON(w, http.StatusOK, mrNoSquash)
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
 		default:

--- a/internal/tools/milestones/milestones_test.go
+++ b/internal/tools/milestones/milestones_test.go
@@ -619,8 +619,7 @@ func TestMilestoneList_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -731,8 +730,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -759,8 +757,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Title: "v1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -804,8 +801,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", MilestoneIID: 1, Title: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -821,8 +817,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -838,8 +833,7 @@ func TestGetIssues_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetIssues(ctx, client, GetIssuesInput{ProjectID: "42", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -899,8 +893,7 @@ func TestGetMergeRequests_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetMergeRequests(ctx, client, GetMergeRequestsInput{ProjectID: "42", MilestoneIID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/mrapprovals/debug_test.go
+++ b/internal/tools/mrapprovals/debug_test.go
@@ -54,8 +54,7 @@ func TestConfig_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Config(ctx, client, ConfigInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -84,8 +83,7 @@ func TestReset_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Reset(ctx, client, ResetInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -114,8 +112,7 @@ func TestCreateRule_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := CreateRule(ctx, client, CreateRuleInput{ProjectID: "42", MRIID: 1, Name: "R"})
 	if err == nil {
@@ -176,8 +173,7 @@ func TestUpdateRule_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := UpdateRule(ctx, client, UpdateRuleInput{ProjectID: "42", MRIID: 1, ApprovalRuleID: 5})
 	if err == nil {
@@ -250,8 +246,7 @@ func TestDeleteRule_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := DeleteRule(ctx, client, DeleteRuleInput{ProjectID: "42", MRIID: 1, ApprovalRuleID: 5})
 	if err == nil {

--- a/internal/tools/mrapprovals/mrapprovals_test.go
+++ b/internal/tools/mrapprovals/mrapprovals_test.go
@@ -144,8 +144,7 @@ func TestMRApprovalState_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := State(ctx, client, StateInput{
 		ProjectID: "42",
@@ -310,8 +309,7 @@ func TestMRApprovalRules_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Rules(ctx, client, RulesInput{
 		ProjectID: "42",

--- a/internal/tools/mrchanges/mrchanges_test.go
+++ b/internal/tools/mrchanges/mrchanges_test.go
@@ -579,8 +579,7 @@ func TestRawDiffs_APIError(t *testing.T) {
 
 // TestRawDiffs_CancelledContext verifies the behavior of raw diffs cancelled context.
 func TestRawDiffs_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -642,8 +641,7 @@ func TestFormatRawDiffsMarkdown_NoTrailingNewline(t *testing.T) {
 
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -667,8 +665,7 @@ func TestGet_MissingProjectID(t *testing.T) {
 
 // TestListDiffVersions_CancelledContext verifies the behavior of list diff versions cancelled context.
 func TestListDiffVersions_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -681,8 +678,7 @@ func TestListDiffVersions_CancelledContext(t *testing.T) {
 
 // TestGetDiffVersion_CancelledContext verifies the behavior of get diff version cancelled context.
 func TestGetDiffVersion_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/tools/mrcontextcommits/mrcontextcommits_test.go
+++ b/internal/tools/mrcontextcommits/mrcontextcommits_test.go
@@ -270,8 +270,7 @@ func TestList_WithCreatedAt(t *testing.T) {
 
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -312,8 +311,7 @@ func TestCreate_WithCreatedAt(t *testing.T) {
 
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -334,8 +332,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/tools/mrdiscussions/mr_discussions_test.go
+++ b/internal/tools/mrdiscussions/mr_discussions_test.go
@@ -452,8 +452,7 @@ func TestCreate_MissingProjectID(t *testing.T) {
 
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -528,8 +527,7 @@ func TestResolve_MissingProjectID(t *testing.T) {
 
 // TestResolve_CancelledContext verifies the behavior of resolve cancelled context.
 func TestResolve_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -568,8 +566,7 @@ func TestReply_MissingProjectID(t *testing.T) {
 
 // TestReply_CancelledContext verifies the behavior of reply cancelled context.
 func TestReply_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -608,8 +605,7 @@ func TestList_MissingProjectID(t *testing.T) {
 
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -637,8 +633,7 @@ func TestList_APIError(t *testing.T) {
 
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -666,8 +661,7 @@ func TestGet_APIError(t *testing.T) {
 
 // TestUpdateNote_CancelledContext verifies the behavior of update note cancelled context.
 func TestUpdateNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -695,8 +689,7 @@ func TestUpdateNote_APIError(t *testing.T) {
 
 // TestDeleteNote_CancelledContext verifies the behavior of delete note cancelled context.
 func TestDeleteNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/tools/mrdraftnotes/mr_draft_notes_test.go
+++ b/internal/tools/mrdraftnotes/mr_draft_notes_test.go
@@ -105,8 +105,7 @@ func TestDraftNoteList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -163,8 +162,7 @@ func TestDraftNoteGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", MRIID: 1, NoteID: 10})
 	if err == nil {
@@ -291,8 +289,7 @@ func TestDraftNoteCreate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", MRIID: 1, Note: "x"})
 	if err == nil {
@@ -351,8 +348,7 @@ func TestDraftNoteUpdate_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", MRIID: 1, NoteID: 10, Note: "x"})
 	if err == nil {
@@ -406,8 +402,7 @@ func TestDraftNoteDelete_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", MRIID: 1, NoteID: 10})
 	if err == nil {
@@ -477,8 +472,7 @@ func TestDraftNotePublish_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Publish(ctx, client, PublishInput{ProjectID: "42", MRIID: 1, NoteID: 10})
 	if err == nil {
@@ -545,8 +539,7 @@ func TestDraftNotePublishAll_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := PublishAll(ctx, client, PublishAllInput{ProjectID: "42", MRIID: 1})
 	if err == nil {
@@ -995,8 +988,7 @@ func TestPublish_MissingProjectID(t *testing.T) {
 
 // TestPublishAll_CancelledContext verifies the behavior of publish all cancelled context.
 func TestPublishAll_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/tools/mrnotes/mr_notes_test.go
+++ b/internal/tools/mrnotes/mr_notes_test.go
@@ -418,8 +418,7 @@ func TestCreate_MissingProjectID(t *testing.T) {
 
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -447,8 +446,7 @@ func TestList_MissingProjectID(t *testing.T) {
 
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -510,8 +508,7 @@ func TestUpdate_MissingProjectID(t *testing.T) {
 
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -539,8 +536,7 @@ func TestUpdate_APIError(t *testing.T) {
 
 // TestGetNote_CancelledContext verifies the behavior of get note cancelled context.
 func TestGetNote_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
@@ -579,8 +575,7 @@ func TestDelete_MissingProjectID(t *testing.T) {
 
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/tools/packages/markdown_test.go
+++ b/internal/tools/packages/markdown_test.go
@@ -468,8 +468,7 @@ func TestList_APIError(t *testing.T) {
 
 // TestList_ContextCancelled verifies the behavior of list context cancelled.
 func TestList_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))
@@ -553,8 +552,7 @@ func TestFileList_APIError(t *testing.T) {
 
 // TestFileList_ContextCancelled verifies the behavior of file list context cancelled.
 func TestFileList_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))
@@ -616,8 +614,7 @@ func TestDelete_APIError(t *testing.T) {
 
 // TestDelete_ContextCancelled verifies the behavior of delete context cancelled.
 func TestDelete_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))
@@ -644,8 +641,7 @@ func TestFileDelete_APIError(t *testing.T) {
 
 // TestFileDelete_ContextCancelled verifies the behavior of file delete context cancelled.
 func TestFileDelete_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))
@@ -749,8 +745,7 @@ func TestPublishDirectory_NonexistentDir(t *testing.T) {
 
 // TestStreamDownload_ContextCancelled verifies the behavior of stream download context cancelled.
 func TestStreamDownload_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))
@@ -1264,8 +1259,7 @@ func TestPublish_APIError(t *testing.T) {
 
 // TestPublish_ContextCancelled verifies the behavior of publish context cancelled.
 func TestPublish_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal(errNoReachAPI)
 	}))

--- a/internal/tools/packages/packages_composite_test.go
+++ b/internal/tools/packages/packages_composite_test.go
@@ -222,8 +222,7 @@ func TestPackagePublishAndLink_ContextCancelled(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := PublishAndLink(ctx, nil, client, PublishAndLinkInput{
 		ProjectID:      "42",
@@ -487,8 +486,7 @@ func TestPackagePublishDirectory_ContextCancelled(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := PublishDirectory(ctx, nil, client, PublishDirInput{
 		ProjectID:      "42",

--- a/internal/tools/packages/packages_stream_test.go
+++ b/internal/tools/packages/packages_stream_test.go
@@ -96,8 +96,7 @@ func TestStreamDownloadPackageFile_CreatesDirectory(t *testing.T) {
 func TestStreamDownloadPackageFile_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, testStreamServer(t, "data", http.StatusOK))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Download(ctx, nil, client, DownloadInput{
 		ProjectID:      "42",

--- a/internal/tools/packages/packages_test.go
+++ b/internal/tools/packages/packages_test.go
@@ -210,8 +210,7 @@ func TestPackagePublish_MissingProjectID(t *testing.T) {
 
 // TestPackagePublish_ContextCancelled verifies the behavior of package publish context cancelled.
 func TestPackagePublish_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal(errNoReachAPI)
@@ -294,8 +293,7 @@ func TestPackageDownload_MissingOutputPath(t *testing.T) {
 
 // TestPackageDownload_ContextCancelled verifies the behavior of package download context cancelled.
 func TestPackageDownload_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal(errNoReachAPI)

--- a/internal/tools/pipelines/pipelines_test.go
+++ b/internal/tools/pipelines/pipelines_test.go
@@ -142,8 +142,7 @@ func TestPipelineList_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -921,8 +920,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -934,8 +932,7 @@ func TestCancel_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Cancel(ctx, client, ActionInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -947,8 +944,7 @@ func TestRetry_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Retry(ctx, client, ActionInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -960,8 +956,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -973,8 +968,7 @@ func TestGetVariables_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetVariables(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -986,8 +980,7 @@ func TestGetTestReport_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetTestReport(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -999,8 +992,7 @@ func TestGetTestReportSummary_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetTestReportSummary(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1012,8 +1004,7 @@ func TestGetLatest_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetLatest(ctx, client, GetLatestInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1025,8 +1016,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Ref: "main"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -1038,8 +1028,7 @@ func TestUpdateMetadata_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("should not be called")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateMetadata(ctx, client, UpdateMetadataInput{ProjectID: "42", PipelineID: 10, Name: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/pipelines/wait_test.go
+++ b/internal/tools/pipelines/wait_test.go
@@ -180,8 +180,7 @@ func TestWait_CanceledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, pipelineJSON("running"))
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Wait(ctx, nil, client, WaitInput{
 		ProjectID:       "42",

--- a/internal/tools/pipelineschedules/pipelineschedules_test.go
+++ b/internal/tools/pipelineschedules/pipelineschedules_test.go
@@ -94,8 +94,7 @@ func TestPipelineScheduleList_MissingProjectID(t *testing.T) {
 // TestPipelineScheduleList_CancelledContext verifies the behavior of pipeline schedule list cancelled context.
 func TestPipelineScheduleList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -147,8 +146,7 @@ func TestPipelineSchedule_GetZeroID(t *testing.T) {
 // TestPipelineScheduleGet_CancelledContext verifies the behavior of pipeline schedule get cancelled context.
 func TestPipelineScheduleGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "1", ScheduleID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -210,8 +208,7 @@ func TestPipelineScheduleCreate_MissingFields(t *testing.T) {
 // TestPipelineScheduleCreate_CancelledContext verifies the behavior of pipeline schedule create cancelled context.
 func TestPipelineScheduleCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID: "1", Description: "d", Ref: "r", Cron: "c",
 	})
@@ -263,8 +260,7 @@ func TestPipelineSchedule_UpdateZeroID(t *testing.T) {
 // TestPipelineScheduleUpdate_CancelledContext verifies the behavior of pipeline schedule update cancelled context.
 func TestPipelineScheduleUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{
 		ProjectID: "1", ScheduleID: 1,
 	})
@@ -309,8 +305,7 @@ func TestPipelineSchedule_DeleteZeroID(t *testing.T) {
 // TestPipelineScheduleDelete_CancelledContext verifies the behavior of pipeline schedule delete cancelled context.
 func TestPipelineScheduleDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{
 		ProjectID: "1", ScheduleID: 1,
 	})
@@ -363,8 +358,7 @@ func TestPipelineSchedule_RunZeroID(t *testing.T) {
 // TestPipelineScheduleRun_CancelledContext verifies the behavior of pipeline schedule run cancelled context.
 func TestPipelineScheduleRun_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { /* no response body needed */ }))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Run(ctx, client, RunInput{
 		ProjectID: "1", ScheduleID: 1,
 	})
@@ -908,8 +902,7 @@ func TestTakeOwnership_APIError(t *testing.T) {
 // TestTakeOwnership_CancelledContext verifies the behavior of take ownership cancelled context.
 func TestTakeOwnership_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := TakeOwnership(ctx, client, TakeOwnershipInput{ProjectID: "1", ScheduleID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -958,8 +951,7 @@ func TestCreateVariable_ZeroScheduleID(t *testing.T) {
 // TestCreateVariable_CancelledContext verifies the behavior of create variable cancelled context.
 func TestCreateVariable_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateVariable(ctx, client, CreateVariableInput{
 		ProjectID: "1", ScheduleID: 1, Key: "K", Value: "V",
 	})
@@ -1041,8 +1033,7 @@ func TestEditVariable_MissingValue(t *testing.T) {
 // TestEditVariable_CancelledContext verifies the behavior of edit variable cancelled context.
 func TestEditVariable_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := EditVariable(ctx, client, EditVariableInput{
 		ProjectID: "1", ScheduleID: 1, Key: "K", Value: "V",
 	})
@@ -1100,8 +1091,7 @@ func TestDeleteVariable_ZeroScheduleID(t *testing.T) {
 // TestDeleteVariable_CancelledContext verifies the behavior of delete variable cancelled context.
 func TestDeleteVariable_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteVariable(ctx, client, DeleteVariableInput{
 		ProjectID: "1", ScheduleID: 1, Key: "K",
 	})
@@ -1130,8 +1120,7 @@ func TestListTriggeredPipelines_APIError(t *testing.T) {
 // TestListTriggeredPipelines_CancelledContext verifies the behavior of list triggered pipelines cancelled context.
 func TestListTriggeredPipelines_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListTriggeredPipelines(ctx, client, ListTriggeredPipelinesInput{
 		ProjectID: "1", ScheduleID: 1,
 	})

--- a/internal/tools/pipelinetriggers/pipelinetriggers_test.go
+++ b/internal/tools/pipelinetriggers/pipelinetriggers_test.go
@@ -369,8 +369,7 @@ func TestListTriggers_APIError(t *testing.T) {
 // TestListTriggers_CancelledContext verifies the behavior of list triggers cancelled context.
 func TestListTriggers_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListTriggers(ctx, client, ListInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -422,8 +421,7 @@ func TestGetTrigger_APIError(t *testing.T) {
 // TestGetTrigger_CancelledContext verifies the behavior of get trigger cancelled context.
 func TestGetTrigger_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetTrigger(ctx, client, GetInput{ProjectID: "1", TriggerID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -459,8 +457,7 @@ func TestCreateTrigger_MissingProjectID(t *testing.T) {
 // TestCreateTrigger_CancelledContext verifies the behavior of create trigger cancelled context.
 func TestCreateTrigger_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateTrigger(ctx, client, CreateInput{ProjectID: "1", Description: "test"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -496,8 +493,7 @@ func TestUpdateTrigger_MissingProjectID(t *testing.T) {
 // TestUpdateTrigger_CancelledContext verifies the behavior of update trigger cancelled context.
 func TestUpdateTrigger_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateTrigger(ctx, client, UpdateInput{ProjectID: "1", TriggerID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -551,8 +547,7 @@ func TestDeleteTrigger_MissingTriggerID(t *testing.T) {
 // TestDeleteTrigger_CancelledContext verifies the behavior of delete trigger cancelled context.
 func TestDeleteTrigger_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteTrigger(ctx, client, DeleteInput{ProjectID: "1", TriggerID: 10})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -588,8 +583,7 @@ func TestRunTrigger_MissingProjectID(t *testing.T) {
 // TestRunTrigger_CancelledContext verifies the behavior of run trigger cancelled context.
 func TestRunTrigger_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := RunTrigger(ctx, client, RunInput{
 		ProjectID: "1", Ref: "main", Token: "tok",
 	})

--- a/internal/tools/projectaliases/project_aliases_test.go
+++ b/internal/tools/projectaliases/project_aliases_test.go
@@ -78,8 +78,7 @@ func TestList_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
@@ -146,8 +145,7 @@ func TestGet_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{Name: "test"})
 	if err == nil {
@@ -228,8 +226,7 @@ func TestCreate_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{Name: "test", ProjectID: 1})
 	if err == nil {
@@ -288,8 +285,7 @@ func TestDelete_ContextCancelled(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{Name: "test"})
 	if err == nil {

--- a/internal/tools/projectdiscovery/projectdiscovery_test.go
+++ b/internal/tools/projectdiscovery/projectdiscovery_test.go
@@ -276,8 +276,7 @@ func TestResolve_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, testProjectJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Resolve(ctx, client, ResolveInput{
 		RemoteURL: "https://gitlab.example.com/group/project.git",

--- a/internal/tools/projectiterations/project_iterations_test.go
+++ b/internal/tools/projectiterations/project_iterations_test.go
@@ -182,8 +182,7 @@ func TestList_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "10"})
 	if err == nil {

--- a/internal/tools/projectmirrors/project_mirrors_test.go
+++ b/internal/tools/projectmirrors/project_mirrors_test.go
@@ -94,8 +94,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -195,8 +194,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: testProjectID, MirrorID: 42})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -246,8 +244,7 @@ func TestGetPublicKey_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetPublicKey(ctx, client, GetPublicKeyInput{ProjectID: testProjectID, MirrorID: 42})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -355,8 +352,7 @@ func TestAdd_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Add(ctx, client, AddInput{ProjectID: testProjectID, URL: "https://example.com/repo.git"})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -413,8 +409,7 @@ func TestEdit_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Edit(ctx, client, EditInput{ProjectID: testProjectID, MirrorID: 42})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -461,8 +456,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, MirrorID: 42})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -509,8 +503,7 @@ func TestForcePushUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := ForcePushUpdate(ctx, client, ForcePushInput{ProjectID: testProjectID, MirrorID: 42})
 	if err == nil {
 		t.Fatal("expected context error")

--- a/internal/tools/projects/approvals_test.go
+++ b/internal/tools/projects/approvals_test.go
@@ -90,8 +90,7 @@ func TestGetApprovalConfig_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetApprovalConfig(ctx, client, GetApprovalConfigInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -299,8 +298,7 @@ func TestCreateApprovalRule_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateApprovalRule(ctx, client, CreateApprovalRuleInput{
 		ProjectID: "42", Name: "rule", ApprovalsRequired: 1,
 	})

--- a/internal/tools/projects/mirroring_test.go
+++ b/internal/tools/projects/mirroring_test.go
@@ -118,8 +118,7 @@ func TestConfigurePullMirror_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ConfigurePullMirror(ctx, client, ConfigurePullMirrorInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -2420,7 +2420,10 @@ func TestFork_WithAllOptions(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Fork {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":100,"name":"my-fork","path_with_namespace":"user/my-fork","visibility":"private","web_url":"https://gitlab.example.com/user/my-fork"}`)
 			return
@@ -2483,7 +2486,10 @@ func TestAddHook_WithAllEvents(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Hooks {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"url":"https://example.com/hook","project_id":42,"push_events":true,"issues_events":true,"merge_requests_events":true,"tag_push_events":true,"note_events":true,"confidential_note_events":true,"job_events":true,"pipeline_events":true,"wiki_page_events":true,"deployment_events":true,"releases_events":true,"emoji_events":true,"resource_access_token_events":true}`)
 			return
@@ -2534,7 +2540,10 @@ func TestEditHook_WithAllEvents(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProject42Hook1 {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"url":"https://example.com/hook-updated","project_id":42,"push_events":true}`)
 			return
@@ -5552,7 +5561,10 @@ func TestFormatRepositoryStorageMarkdown_NonEmpty(t *testing.T) {
 func TestCreateForUser_AllOptionalFields(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjectForUser5 {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			s := string(body)
 			for _, want := range []string{
 				`"path":"custom-path"`,

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -2417,8 +2417,11 @@ func TestFormatListStarrersMarkdown(t *testing.T) {
 
 // TestFork_WithAllOptions verifies the behavior of fork with all options.
 func TestFork_WithAllOptions(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Fork {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":100,"name":"my-fork","path_with_namespace":"user/my-fork","visibility":"private","web_url":"https://gitlab.example.com/user/my-fork"}`)
 			return
 		}
@@ -2441,6 +2444,11 @@ func TestFork_WithAllOptions(t *testing.T) {
 	}
 	if out.Name != testMyFork {
 		t.Errorf(fmtNameWantQ, out.Name, testMyFork)
+	}
+	for _, want := range []string{"name", "path", "namespace_id", "namespace_path", "description", "visibility", "branches", "mr_default_target_self"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 
@@ -2472,8 +2480,11 @@ func TestListForks_WithFilters(t *testing.T) {
 
 // TestAddHook_WithAllEvents verifies the behavior of add hook with all events.
 func TestAddHook_WithAllEvents(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Hooks {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"url":"https://example.com/hook","project_id":42,"push_events":true,"issues_events":true,"merge_requests_events":true,"tag_push_events":true,"note_events":true,"confidential_note_events":true,"job_events":true,"pipeline_events":true,"wiki_page_events":true,"deployment_events":true,"releases_events":true,"emoji_events":true,"resource_access_token_events":true}`)
 			return
 		}
@@ -2511,12 +2522,20 @@ func TestAddHook_WithAllEvents(t *testing.T) {
 	if out.ID != 1 {
 		t.Errorf(fmtIDWant1, out.ID)
 	}
+	for _, want := range []string{"url", "token", "push_events_branch_filter", "custom_webhook_template", "branch_filter_strategy", "emoji_events", "resource_access_token_events"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
+	}
 }
 
 // TestEditHook_WithAllEvents verifies the behavior of edit hook with all events.
 func TestEditHook_WithAllEvents(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProject42Hook1 {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"url":"https://example.com/hook-updated","project_id":42,"push_events":true}`)
 			return
 		}
@@ -2554,6 +2573,11 @@ func TestEditHook_WithAllEvents(t *testing.T) {
 	}
 	if out.URL != "https://example.com/hook-updated" {
 		t.Errorf("URL = %q, want updated URL", out.URL)
+	}
+	for _, want := range []string{"url", "token", "push_events_branch_filter", "custom_webhook_template", "branch_filter_strategy", "emoji_events"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -586,8 +586,7 @@ func TestProjectCreate_ContextCancelled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{Name: "ignored"})
 	if err == nil {
@@ -4853,8 +4852,7 @@ func TestSetCustomHeader_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := SetCustomHeader(ctx, client, SetCustomHeaderInput{
 		ProjectID: "42", HookID: 1, Key: testKeyXCustom, Value: testValueHdr,
 	})
@@ -5021,8 +5019,7 @@ func TestDeleteWebhookURLVariable_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteWebhookURLVariable(ctx, client, DeleteWebhookURLVariableInput{
 		ProjectID: "42", HookID: 1, Key: testKeyMyVar,
 	})
@@ -5126,8 +5123,7 @@ func TestDeleteForkRelation_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteForkRelation(ctx, client, DeleteForkRelationInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -5266,8 +5262,7 @@ func TestUploadAvatar_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	content := base64.StdEncoding.EncodeToString([]byte("data"))
 	_, err := UploadAvatar(ctx, client, UploadAvatarInput{
 		ProjectID: "42", Filename: "a.png", ContentBase64: content,
@@ -5359,8 +5354,7 @@ func TestStartHousekeeping_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := StartHousekeeping(ctx, client, StartHousekeepingInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -5417,8 +5411,7 @@ func TestGetRepositoryStorage_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetRepositoryStorage(ctx, client, GetRepositoryStorageInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -5483,8 +5476,7 @@ func TestCreateForUser_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateForUser(ctx, client, CreateForUserInput{
 		UserID: 5, Name: "repo",
 	})
@@ -5582,8 +5574,7 @@ func TestDownloadAvatar_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadAvatar(ctx, client, DownloadAvatarInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -5595,8 +5586,7 @@ func TestDeleteCustomHeader_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteCustomHeader(ctx, client, DeleteCustomHeaderInput{ProjectID: "42", HookID: 1, Key: "X-Custom"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6139,8 +6129,7 @@ func TestAddHook_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddHook(ctx, client, AddHookInput{ProjectID: "42", URL: "https://example.com"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6152,8 +6141,7 @@ func TestEditHook_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := EditHook(ctx, client, EditHookInput{ProjectID: "42", HookID: 1})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6165,8 +6153,7 @@ func TestGetPullMirror_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetPullMirror(ctx, client, GetPullMirrorInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6178,8 +6165,7 @@ func TestStartMirroring_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := StartMirroring(ctx, client, StartMirroringInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6191,8 +6177,7 @@ func TestRestore_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Restore(ctx, client, RestoreInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6270,8 +6255,7 @@ func TestListApprovalRules_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListApprovalRules(ctx, client, ListApprovalRulesInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)
@@ -6283,8 +6267,7 @@ func TestChangeApprovalConfig_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ChangeApprovalConfig(ctx, client, ChangeApprovalConfigInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpectedCtxErr)

--- a/internal/tools/projectstoragemoves/project_storage_moves_test.go
+++ b/internal/tools/projectstoragemoves/project_storage_moves_test.go
@@ -156,8 +156,7 @@ func TestRetrieveAll_ContextCanceled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveAll(ctx, client, ListInput{})
 	if err == nil {
@@ -247,8 +246,7 @@ func TestRetrieveForProject_ContextCanceled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveForProject(ctx, client, ListForProjectInput{ProjectID: 42})
 	if err == nil {
@@ -351,8 +349,7 @@ func TestGet_ContextCanceled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, storageMoveJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -434,8 +431,7 @@ func TestGetForProject_ContextCanceled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, storageMoveJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetForProject(ctx, client, ProjectMoveInput{ProjectID: 42, ID: 1})
 	if err == nil {
@@ -530,8 +526,7 @@ func TestSchedule_ContextCanceled(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, storageMoveJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Schedule(ctx, client, ScheduleInput{ProjectID: 42})
 	if err == nil {
@@ -621,8 +616,7 @@ func TestScheduleAll_ContextCanceled(t *testing.T) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ScheduleAll(ctx, client, ScheduleAllInput{})
 	if err == nil {

--- a/internal/tools/protectedenvs/protectedenvs_test.go
+++ b/internal/tools/protectedenvs/protectedenvs_test.go
@@ -5,6 +5,7 @@ package protectedenvs
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -181,8 +182,11 @@ func TestProtect_WithAccessLevels(t *testing.T) {
 // optional field branches: UserID, GroupID, GroupInheritanceType in both
 // DeployAccessLevels and ApprovalRules.
 func TestProtect_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedEnvs {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, envJSON)
 			return
 		}
@@ -206,6 +210,11 @@ func TestProtect_WithAllOptionalFields(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Protect() unexpected error: %v", err)
+	}
+	for _, want := range []string{"deploy_access_levels", "user_id", "group_id", "group_inheritance_type", "approval_rules", "required_approvals"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 
@@ -489,8 +498,11 @@ func boolPtr(v bool) *bool { return new(v) }
 // TestUpdate_WithAllFields verifies Update maps all optional fields including
 // DeployAccessLevels and ApprovalRules with all sub-fields populated.
 func TestUpdate_WithAllFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProtectedEnv1 {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, envJSON)
 			return
 		}
@@ -530,6 +542,11 @@ func TestUpdate_WithAllFields(t *testing.T) {
 	}
 	if out.Name != "production" {
 		t.Errorf("Name = %q, want %q", out.Name, "production")
+	}
+	for _, want := range []string{"deploy_access_levels", "user_id", "group_id", "group_inheritance_type", "approval_rules", "required_approvals", "_destroy"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/protectedenvs/protectedenvs_test.go
+++ b/internal/tools/protectedenvs/protectedenvs_test.go
@@ -216,8 +216,7 @@ func TestGet_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, envJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", Environment: "prod"})
 	if err == nil {
@@ -232,8 +231,7 @@ func TestProtect_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, envJSON)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Protect(ctx, client, ProtectInput{ProjectID: "42", Name: "prod"})
 	if err == nil {
@@ -248,8 +246,7 @@ func TestUnprotect_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Unprotect(ctx, client, UnprotectInput{ProjectID: "42", Environment: "prod"})
 	if err == nil {
@@ -555,8 +552,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, envJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{
 		ProjectID:   "42",
 		Environment: "production",
@@ -582,8 +578,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")

--- a/internal/tools/protectedenvs/protectedenvs_test.go
+++ b/internal/tools/protectedenvs/protectedenvs_test.go
@@ -185,7 +185,10 @@ func TestProtect_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedEnvs {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, envJSON)
 			return
@@ -501,7 +504,10 @@ func TestUpdate_WithAllFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProtectedEnv1 {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, envJSON)
 			return

--- a/internal/tools/protectedpackages/protected_packages_test.go
+++ b/internal/tools/protectedpackages/protected_packages_test.go
@@ -77,8 +77,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -182,8 +181,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID:          testProjectID,
 		PackageNamePattern: "@scope/pkg*",
@@ -271,8 +269,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: testProjectID, RuleID: 1})
 	if err == nil {
 		t.Fatal("expected context error")
@@ -341,8 +338,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, RuleID: 1})
 	if err == nil {
 		t.Fatal("expected context error")

--- a/internal/tools/releaselinks/release_links_test.go
+++ b/internal/tools/releaselinks/release_links_test.go
@@ -465,8 +465,7 @@ func TestReleaseLinkCreateBatch_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := CreateBatch(ctx, client, CreateBatchInput{
 		ProjectID: "42",
 		TagName:   testTagV120,
@@ -516,8 +515,7 @@ func TestCreate_MissingProjectID(t *testing.T) {
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID: "42", TagName: "v1.0.0", Name: "link", URL: "https://example.com",
 	})
@@ -577,8 +575,7 @@ func TestDelete_MissingProjectID(t *testing.T) {
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Delete(ctx, client, DeleteInput{
 		ProjectID: "42", TagName: "v1.0.0", LinkID: 1,
 	})
@@ -618,8 +615,7 @@ func TestGet_MissingProjectID(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{
 		ProjectID: "42", TagName: "v1.0.0", LinkID: 1,
 	})
@@ -659,8 +655,7 @@ func TestUpdate_MissingProjectID(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{
 		ProjectID: "42", TagName: "v1.0.0", LinkID: 1, Name: "x",
 	})
@@ -729,8 +724,7 @@ func TestList_MissingProjectID(t *testing.T) {
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42", TagName: "v1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/releases/releases_test.go
+++ b/internal/tools/releases/releases_test.go
@@ -383,8 +383,7 @@ func TestCreate_MissingProjectID(t *testing.T) {
 // TestCreate_CancelledContext verifies the behavior of create cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", TagName: "v1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -443,8 +442,7 @@ func TestUpdate_MissingProjectID(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", TagName: "v1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -478,8 +476,7 @@ func TestDelete_MissingProjectID(t *testing.T) {
 // TestDelete_CancelledContext verifies the behavior of delete cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Delete(ctx, client, DeleteInput{ProjectID: "42", TagName: "v1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -513,8 +510,7 @@ func TestGet_MissingProjectID(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", TagName: "v1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -548,8 +544,7 @@ func TestGetLatest_MissingProjectID(t *testing.T) {
 // TestGetLatest_CancelledContext verifies the behavior of get latest cancelled context.
 func TestGetLatest_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetLatest(ctx, client, GetLatestInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -583,8 +578,7 @@ func TestList_MissingProjectID(t *testing.T) {
 // TestList_CancelledContext verifies the behavior of list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/repository/repository_test.go
+++ b/internal/tools/repository/repository_test.go
@@ -203,8 +203,7 @@ func TestRepositoryTree_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Tree(ctx, client, TreeInput{ProjectID: "42"})
 	if err == nil {
@@ -218,8 +217,7 @@ func TestRepositoryCompare_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Compare(ctx, client, CompareInput{
 		ProjectID: "42",
@@ -582,8 +580,7 @@ func TestRepositoryContributors_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Contributors(ctx, client, ContributorsInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -595,8 +592,7 @@ func TestRepositoryMergeBase_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := MergeBase(ctx, client, MergeBaseInput{ProjectID: "42", Refs: []string{"main", "dev"}})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -608,8 +604,7 @@ func TestRepositoryBlob_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Blob(ctx, client, BlobInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -621,8 +616,7 @@ func TestRepositoryRawBlobContent_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := RawBlobContent(ctx, client, BlobInput{ProjectID: "42", SHA: "abc"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -634,8 +628,7 @@ func TestRepositoryArchive_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Archive(ctx, client, ArchiveInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -647,8 +640,7 @@ func TestRepositoryAddChangelog_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddChangelog(ctx, client, AddChangelogInput{ProjectID: "42", Version: "1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -660,8 +652,7 @@ func TestRepositoryGenerateChangelogData_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{"notes":""}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GenerateChangelogData(ctx, client, GenerateChangelogInput{ProjectID: "42", Version: "1.0.0"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)

--- a/internal/tools/repositorysubmodules/list_test.go
+++ b/internal/tools/repositorysubmodules/list_test.go
@@ -261,8 +261,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected error for canceled context")
@@ -495,8 +494,7 @@ func TestEnrichSubmoduleCommitSHAs_CancelledContext(t *testing.T) {
 		{Name: "b", Path: "dir2/b"},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	enrichSubmoduleCommitSHAs(ctx, client, "42", "main", entries)
 

--- a/internal/tools/repositorysubmodules/read_test.go
+++ b/internal/tools/repositorysubmodules/read_test.go
@@ -169,8 +169,7 @@ func TestRead_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Read(ctx, client, ReadInput{ProjectID: "42", SubmodulePath: "lib", FilePath: "f.txt"})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/repositorysubmodules/repositorysubmodules_test.go
+++ b/internal/tools/repositorysubmodules/repositorysubmodules_test.go
@@ -146,8 +146,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: "42", Submodule: "lib", Branch: "main", CommitSHA: "abc"})
 	if err == nil {
 		t.Fatal("expected error for canceled context, got nil")

--- a/internal/tools/runnercontrollers/runnercontrollers_test.go
+++ b/internal/tools/runnercontrollers/runnercontrollers_test.go
@@ -108,8 +108,7 @@ func TestList_APIError(t *testing.T) {
 // TestList_ContextCancelled verifies that List respects context cancellation.
 func TestList_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
@@ -163,8 +162,7 @@ func TestGet_APIError(t *testing.T) {
 // TestGet_ContextCancelled verifies that Get respects context cancellation.
 func TestGet_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ControllerID: 1})
 	if err == nil {
@@ -220,8 +218,7 @@ func TestCreate_APIError(t *testing.T) {
 // TestCreate_ContextCancelled verifies that Create respects context cancellation.
 func TestCreate_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{Description: "x"})
 	if err == nil {
@@ -275,8 +272,7 @@ func TestUpdate_APIError(t *testing.T) {
 // TestUpdate_ContextCancelled verifies that Update respects context cancellation.
 func TestUpdate_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{ControllerID: 1})
 	if err == nil {
@@ -324,8 +320,7 @@ func TestDelete_APIError(t *testing.T) {
 // TestDelete_ContextCancelled verifies that Delete respects context cancellation.
 func TestDelete_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ControllerID: 1})
 	if err == nil {

--- a/internal/tools/runnercontrollerscopes/runnercontrollerscopes_test.go
+++ b/internal/tools/runnercontrollerscopes/runnercontrollerscopes_test.go
@@ -77,8 +77,7 @@ func TestList_APIError(t *testing.T) {
 // TestList_ContextCancelled verifies that List respects context cancellation.
 func TestList_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ControllerID: 1})
 	if err == nil {
@@ -129,8 +128,7 @@ func TestAddInstanceScope_APIError(t *testing.T) {
 // TestAddInstanceScope_ContextCancelled verifies context cancellation.
 func TestAddInstanceScope_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := AddInstanceScope(ctx, client, AddInstanceScopeInput{ControllerID: 1})
 	if err == nil {
@@ -178,8 +176,7 @@ func TestRemoveInstanceScope_APIError(t *testing.T) {
 // TestRemoveInstanceScope_ContextCancelled verifies context cancellation.
 func TestRemoveInstanceScope_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := RemoveInstanceScope(ctx, client, RemoveInstanceScopeInput{ControllerID: 1})
 	if err == nil {
@@ -243,8 +240,7 @@ func TestAddRunnerScope_APIError(t *testing.T) {
 // TestAddRunnerScope_ContextCancelled verifies context cancellation.
 func TestAddRunnerScope_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := AddRunnerScope(ctx, client, AddRunnerScopeInput{ControllerID: 1, RunnerID: 42})
 	if err == nil {
@@ -305,8 +301,7 @@ func TestRemoveRunnerScope_APIError(t *testing.T) {
 // TestRemoveRunnerScope_ContextCancelled verifies context cancellation.
 func TestRemoveRunnerScope_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := RemoveRunnerScope(ctx, client, RemoveRunnerScopeInput{ControllerID: 1, RunnerID: 42})
 	if err == nil {

--- a/internal/tools/runnercontrollertokens/runnercontrollertokens_test.go
+++ b/internal/tools/runnercontrollertokens/runnercontrollertokens_test.go
@@ -110,8 +110,7 @@ func TestList_APIError(t *testing.T) {
 // TestList_ContextCancelled verifies that List respects context cancellation.
 func TestList_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ControllerID: 1})
 	if err == nil {
@@ -178,8 +177,7 @@ func TestGet_APIError(t *testing.T) {
 // TestGet_ContextCancelled verifies that Get respects context cancellation.
 func TestGet_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ControllerID: 1, TokenID: 10})
 	if err == nil {
@@ -248,8 +246,7 @@ func TestCreate_APIError(t *testing.T) {
 // TestCreate_ContextCancelled verifies that Create respects context cancellation.
 func TestCreate_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{ControllerID: 1})
 	if err == nil {
@@ -313,8 +310,7 @@ func TestRotate_APIError(t *testing.T) {
 // TestRotate_ContextCancelled verifies that Rotate respects context cancellation.
 func TestRotate_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Rotate(ctx, client, RotateInput{ControllerID: 1, TokenID: 10})
 	if err == nil {
@@ -375,8 +371,7 @@ func TestRevoke_APIError(t *testing.T) {
 // TestRevoke_ContextCancelled verifies that Revoke respects context cancellation.
 func TestRevoke_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, nopHandler())
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Revoke(ctx, client, RevokeInput{ControllerID: 1, TokenID: 10})
 	if err == nil {

--- a/internal/tools/runners/runners_test.go
+++ b/internal/tools/runners/runners_test.go
@@ -910,8 +910,7 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestList_CancelledContext verifies the behavior of cov list cancelled context.
 func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -960,8 +959,7 @@ func TestList_WithAllFilters(t *testing.T) {
 // TestGet_CancelledContext verifies the behavior of cov get cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -975,8 +973,7 @@ func TestGet_CancelledContext(t *testing.T) {
 // TestUpdate_CancelledContext verifies the behavior of cov update cancelled context.
 func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1043,8 +1040,7 @@ func TestUpdate_AllOptionalFields(t *testing.T) {
 // TestRemove_CancelledContext verifies the behavior of cov remove cancelled context.
 func TestRemove_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Remove(ctx, client, RemoveInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1069,8 +1065,7 @@ func TestRemove_APIError(t *testing.T) {
 // TestListJobs_CancelledContext verifies the behavior of cov list jobs cancelled context.
 func TestListJobs_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListJobs(ctx, client, ListJobsInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1128,8 +1123,7 @@ func TestListJobs_WithAllFilters(t *testing.T) {
 // TestListProject_CancelledContext verifies the behavior of cov list project cancelled context.
 func TestListProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1177,8 +1171,7 @@ func TestListProject_AllFilters(t *testing.T) {
 // TestEnableProject_CancelledContext verifies the behavior of cov enable project cancelled context.
 func TestEnableProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := EnableProject(ctx, client, EnableProjectInput{ProjectID: "1", RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1203,8 +1196,7 @@ func TestEnableProject_APIError(t *testing.T) {
 // TestDisableProject_CancelledContext verifies the behavior of cov disable project cancelled context.
 func TestDisableProject_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DisableProject(ctx, client, DisableProjectInput{ProjectID: "1", RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1229,8 +1221,7 @@ func TestDisableProject_APIError(t *testing.T) {
 // TestListGroup_CancelledContext verifies the behavior of cov list group cancelled context.
 func TestListGroup_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1278,8 +1269,7 @@ func TestListGroup_AllFilters(t *testing.T) {
 // TestRegister_CancelledContext verifies the behavior of cov register cancelled context.
 func TestRegister_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Register(ctx, client, RegisterInput{Token: "tok"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1340,8 +1330,7 @@ func TestRegister_AllOptionalFields(t *testing.T) {
 // TestDeleteByID_CancelledContext verifies the behavior of cov delete by i d cancelled context.
 func TestDeleteByID_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteByID(ctx, client, DeleteByIDInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1366,8 +1355,7 @@ func TestDeleteByID_APIError(t *testing.T) {
 // TestVerify_CancelledContext verifies the behavior of cov verify cancelled context.
 func TestVerify_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Verify(ctx, client, VerifyInput{Token: "tok"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1381,8 +1369,7 @@ func TestVerify_CancelledContext(t *testing.T) {
 // TestResetAuthToken_CancelledContext verifies the behavior of cov reset auth token cancelled context.
 func TestResetAuthToken_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetAuthToken(ctx, client, ResetAuthTokenInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1429,8 +1416,7 @@ func TestResetAuthToken_NilFields(t *testing.T) {
 // TestListAll_CancelledContext verifies the behavior of cov list all cancelled context.
 func TestListAll_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListAll(ctx, client, ListAllInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1468,8 +1454,7 @@ func TestListAll_AllFilters(t *testing.T) {
 // TestDeleteByToken_CancelledContext verifies the behavior of cov delete by token cancelled context.
 func TestDeleteByToken_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := DeleteByToken(ctx, client, DeleteByTokenInput{Token: "tok"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1483,8 +1468,7 @@ func TestDeleteByToken_CancelledContext(t *testing.T) {
 // TestResetInstanceRegToken_CancelledContext verifies the behavior of cov reset instance reg token cancelled context.
 func TestResetInstanceRegToken_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetInstanceRegToken(ctx, client, ResetInstanceRegTokenInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1498,8 +1482,7 @@ func TestResetInstanceRegToken_CancelledContext(t *testing.T) {
 // TestResetGroupRegToken_CancelledContext verifies the behavior of cov reset group reg token cancelled context.
 func TestResetGroupRegToken_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetGroupRegToken(ctx, client, ResetGroupRegTokenInput{GroupID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -1513,8 +1496,7 @@ func TestResetGroupRegToken_CancelledContext(t *testing.T) {
 // TestResetProjectRegToken_CancelledContext verifies the behavior of cov reset project reg token cancelled context.
 func TestResetProjectRegToken_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ResetProjectRegToken(ctx, client, ResetProjectRegTokenInput{ProjectID: "1"})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/search/search_test.go
+++ b/internal/tools/search/search_test.go
@@ -198,8 +198,7 @@ func TestSearchCode_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Code(ctx, client, CodeInput{ProjectID: "42", Query: "test"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -282,8 +281,7 @@ func TestSearchIssues_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Issues(ctx, client, IssuesInput{Query: "bug"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -361,8 +359,7 @@ func TestSearchCommits_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Commits(ctx, client, CommitsInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -718,8 +715,7 @@ func TestSearchWiki_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Wiki(ctx, client, WikiInput{Query: "test"})
 	if err == nil {
 		t.Fatal(errExpCancelledNil)
@@ -977,8 +973,7 @@ func TestSearchMergeRequests_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := MergeRequests(ctx, client, MergeRequestsInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)
@@ -990,8 +985,7 @@ func TestSearchMilestones_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Milestones(ctx, client, MilestonesInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)
@@ -1003,8 +997,7 @@ func TestSearchNotes_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Notes(ctx, client, NotesInput{ProjectID: "42", Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)
@@ -1016,8 +1009,7 @@ func TestSearchProjects_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Projects(ctx, client, ProjectsInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)
@@ -1029,8 +1021,7 @@ func TestSearchSnippets_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Snippets(ctx, client, SnippetsInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)
@@ -1042,8 +1033,7 @@ func TestSearchUsers_CancelledCtx(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Users(ctx, client, UsersInput{Query: "x"})
 	if err == nil {
 		t.Fatal(errExpected)

--- a/internal/tools/securitysettings/security_settings_test.go
+++ b/internal/tools/securitysettings/security_settings_test.go
@@ -64,8 +64,7 @@ func TestGetProject_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetProject(ctx, client, GetProjectInput{ProjectID: toolutil.StringOrInt("42")})
 	if err == nil {
@@ -129,8 +128,7 @@ func TestUpdateProject_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := UpdateProject(ctx, client, UpdateProjectInput{
 		ProjectID:                   toolutil.StringOrInt("42"),
@@ -220,8 +218,7 @@ func TestUpdateGroup_CancelledContext(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := UpdateGroup(ctx, client, UpdateGroupInput{
 		GroupID:                     toolutil.StringOrInt("mygroup"),

--- a/internal/tools/serverupdate/serverupdate_test.go
+++ b/internal/tools/serverupdate/serverupdate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/autoupdate"
+	"github.com/jmrplens/gitlab-mcp-server/internal/testutil"
 )
 
 // TestFormatCheckMarkdownString_UpdateAvailable verifies Markdown output
@@ -306,8 +307,7 @@ func TestCheck_NoUpdate(t *testing.T) {
 // TestCheck_CancelledContext verifies Check respects context cancellation.
 func TestCheck_CancelledContext(t *testing.T) {
 	updater := newTestUpdater(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Check(ctx, updater, CheckInput{})
 	if err == nil {
@@ -318,8 +318,7 @@ func TestCheck_CancelledContext(t *testing.T) {
 // TestApply_CancelledContext verifies Apply respects context cancellation.
 func TestApply_CancelledContext(t *testing.T) {
 	updater := newTestUpdater(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Apply(ctx, updater, ApplyInput{})
 	if err == nil {

--- a/internal/tools/snippetnotes/snippet_notes_test.go
+++ b/internal/tools/snippetnotes/snippet_notes_test.go
@@ -96,8 +96,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: testProjectID, SnippetID: 1})
 	if err == nil {
 		t.Fatal("List() expected context error, got nil")
@@ -225,8 +224,7 @@ func TestGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: testProjectID, SnippetID: 1, NoteID: 100})
 	if err == nil {
 		t.Fatal("Get() expected context error, got nil")
@@ -301,8 +299,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: testProjectID, SnippetID: 1, Body: "hello"})
 	if err == nil {
 		t.Fatal("Create() expected context error, got nil")
@@ -378,8 +375,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{ProjectID: testProjectID, SnippetID: 1, NoteID: 100, Body: "x"})
 	if err == nil {
 		t.Fatal("Update() expected context error, got nil")
@@ -447,8 +443,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: testProjectID, SnippetID: 1, NoteID: 100})
 	if err == nil {
 		t.Fatal("Delete() expected context error, got nil")

--- a/internal/tools/snippets/project_snippets_test.go
+++ b/internal/tools/snippets/project_snippets_test.go
@@ -422,7 +422,10 @@ func TestExplore_APIError(t *testing.T) {
 func TestCreate_WithAllOptions(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, covSnippetJSON)
 	}))
@@ -451,7 +454,10 @@ func TestCreate_WithAllOptions(t *testing.T) {
 func TestUpdate_WithAllOptions(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, covSnippetJSON)
 	}))

--- a/internal/tools/snippets/project_snippets_test.go
+++ b/internal/tools/snippets/project_snippets_test.go
@@ -5,6 +5,7 @@ package snippets
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -419,7 +420,10 @@ func TestExplore_APIError(t *testing.T) {
 
 // TestCreate_WithAllOptions verifies the behavior of create with all options.
 func TestCreate_WithAllOptions(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var capturedBody string
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, covSnippetJSON)
 	}))
 	out, err := Create(context.Background(), client, CreateInput{
@@ -436,11 +440,19 @@ func TestCreate_WithAllOptions(t *testing.T) {
 	if out.ID != 1 {
 		t.Errorf(fmtIDEquals, out.ID)
 	}
+	for _, want := range []string{"title", "description", "visibility", "files"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
+	}
 }
 
 // TestUpdate_WithAllOptions verifies the behavior of update with all options.
 func TestUpdate_WithAllOptions(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var capturedBody string
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, covSnippetJSON)
 	}))
 	out, err := Update(context.Background(), client, UpdateInput{
@@ -457,6 +469,11 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 	}
 	if out.ID != 1 {
 		t.Errorf(fmtIDEquals, out.ID)
+	}
+	for _, want := range []string{"title", "description", "visibility", "files"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/snippetstoragemoves/snippet_storage_moves_extra_test.go
+++ b/internal/tools/snippetstoragemoves/snippet_storage_moves_extra_test.go
@@ -48,8 +48,7 @@ func TestRetrieveForSnippet_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveForSnippet(ctx, client, ListForSnippetInput{SnippetID: 55})
 	if err == nil {
@@ -145,8 +144,7 @@ func TestGet_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, IDInput{ID: 1})
 	if err == nil {
@@ -177,8 +175,7 @@ func TestGetForSnippet_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetForSnippet(ctx, client, SnippetMoveInput{SnippetID: 55, ID: 1})
 	if err == nil {
@@ -209,8 +206,7 @@ func TestSchedule_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Schedule(ctx, client, ScheduleInput{SnippetID: 55})
 	if err == nil {
@@ -247,8 +243,7 @@ func TestScheduleAll_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ScheduleAll(ctx, client, ScheduleAllInput{})
 	if err == nil {

--- a/internal/tools/snippetstoragemoves/snippet_storage_moves_test.go
+++ b/internal/tools/snippetstoragemoves/snippet_storage_moves_test.go
@@ -250,8 +250,7 @@ func TestRetrieveAll_ContextCanceled(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := RetrieveAll(ctx, client, ListInput{})
 	if err == nil {

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -762,7 +762,10 @@ func TestTagProtect_WithAllowedToCreate(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedTags {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"name":"v*","create_access_levels":[{"id":1,"access_level":30,"access_level_description":"Developers + Maintainers","user_id":5}]}`)
 			return

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -5,6 +5,7 @@ package tags
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -758,8 +759,11 @@ func TestTagUnprotect_APIError(t *testing.T) {
 
 // TestTagProtect_WithAllowedToCreate verifies the behavior of tag protect with allowed to create.
 func TestTagProtect_WithAllowedToCreate(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedTags {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"name":"v*","create_access_levels":[{"id":1,"access_level":30,"access_level_description":"Developers + Maintainers","user_id":5}]}`)
 			return
 		}
@@ -780,6 +784,11 @@ func TestTagProtect_WithAllowedToCreate(t *testing.T) {
 	}
 	if out.Name != "v*" {
 		t.Errorf(fmtNameWant, out.Name, "v*")
+	}
+	for _, want := range []string{"allowed_to_create", "user_id", "group_id", "deploy_key_id"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -553,8 +553,7 @@ func TestTagCreate_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", TagName: "v0", Ref: "main"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -566,8 +565,7 @@ func TestTagDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", TagName: "v0"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -579,8 +577,7 @@ func TestTagList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -592,8 +589,7 @@ func TestTagGet_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", TagName: "v0"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -605,8 +601,7 @@ func TestTagGetSignature_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetSignature(ctx, client, SignatureInput{ProjectID: "42", TagName: "v0"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -618,8 +613,7 @@ func TestTagListProtected_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListProtectedTags(ctx, client, ListProtectedTagsInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -631,8 +625,7 @@ func TestTagGetProtected_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetProtectedTag(ctx, client, GetProtectedTagInput{ProjectID: "42", TagName: "v*"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -644,8 +637,7 @@ func TestTagProtect_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ProtectTag(ctx, client, ProtectTagInput{ProjectID: "42", TagName: "v*"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)
@@ -657,8 +649,7 @@ func TestTagUnprotect_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := UnprotectTag(ctx, client, UnprotectTagInput{ProjectID: "42", TagName: "v*"})
 	if err == nil {
 		t.Fatal(errCancelledCtx)

--- a/internal/tools/todos/todos_test.go
+++ b/internal/tools/todos/todos_test.go
@@ -137,8 +137,7 @@ func TestTodoList_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -201,8 +200,7 @@ func TestTodoMarkDone_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := MarkDone(ctx, client, MarkDoneInput{ID: 1})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)
@@ -250,8 +248,7 @@ func TestTodoMarkAllDone_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := MarkAllDone(ctx, client, MarkAllDoneInput{})
 	if err == nil {
 		t.Fatal(errExpCancelledCtx)

--- a/internal/tools/topics/topics_test.go
+++ b/internal/tools/topics/topics_test.go
@@ -328,7 +328,10 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, topicJSON)
 			return
@@ -371,7 +374,10 @@ func TestUpdate_WithAllOptionalFields(t *testing.T) {
 	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
-			body, _ := io.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, topicJSON)
 			return

--- a/internal/tools/topics/topics_test.go
+++ b/internal/tools/topics/topics_test.go
@@ -5,6 +5,7 @@ package topics
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -324,8 +325,11 @@ func TestCreate_APIError400(t *testing.T) {
 
 // TestCreate_WithAllOptionalFields verifies the behavior of create with all optional fields.
 func TestCreate_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, topicJSON)
 			return
 		}
@@ -339,6 +343,11 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 	}
 	if out.Topic.Name != "go" {
 		t.Errorf("expected name 'go', got %q", out.Topic.Name)
+	}
+	for _, want := range []string{"title", "description"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 
@@ -359,8 +368,11 @@ func TestUpdate_APIError400(t *testing.T) {
 
 // TestUpdate_WithAllOptionalFields verifies the behavior of update with all optional fields.
 func TestUpdate_WithAllOptionalFields(t *testing.T) {
+	var capturedBody string
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, topicJSON)
 			return
 		}
@@ -374,6 +386,11 @@ func TestUpdate_WithAllOptionalFields(t *testing.T) {
 	}
 	if out.Topic.ID != 1 {
 		t.Errorf("expected topic ID 1, got %d", out.Topic.ID)
+	}
+	for _, want := range []string{"title", "description"} {
+		if !strings.Contains(capturedBody, want) {
+			t.Errorf("request body missing field %q", want)
+		}
 	}
 }
 

--- a/internal/tools/uploads/uploads_test.go
+++ b/internal/tools/uploads/uploads_test.go
@@ -762,8 +762,7 @@ func TestUpload_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("API should not be called")
 	}))
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Upload(ctx, nil, client, UploadInput{
 		ProjectID:     "p",
 		ContentBase64: base64.StdEncoding.EncodeToString([]byte("data")),

--- a/internal/tools/uploads/uploads_test.go
+++ b/internal/tools/uploads/uploads_test.go
@@ -126,8 +126,7 @@ func TestProjectUpload_CancelledContext(t *testing.T) {
 		t.Fatal("API should not be called with canceled context")
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Upload(ctx, nil, client, UploadInput{
 		ProjectID:     "42",
@@ -528,8 +527,7 @@ func TestList_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
@@ -608,8 +606,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", UploadID: 5})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")

--- a/internal/tools/usergpgkeys/usergpgkeys_test.go
+++ b/internal/tools/usergpgkeys/usergpgkeys_test.go
@@ -241,8 +241,7 @@ func TestList_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -253,8 +252,7 @@ func TestListForUser_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, "[]")
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := ListForUser(ctx, client, ListForUserInput{UserID: 42})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -265,8 +263,7 @@ func TestGet_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, gpgKeyJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{KeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -277,8 +274,7 @@ func TestGetForUser_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusOK, gpgKeyJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := GetForUser(ctx, client, GetForUserInput{UserID: 42, KeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -289,8 +285,7 @@ func TestAdd_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, gpgKeyJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Add(ctx, client, AddInput{Key: "-----BEGIN PGP PUBLIC KEY BLOCK-----"})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -301,8 +296,7 @@ func TestAddForUser_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondJSON(w, http.StatusCreated, gpgKeyJSON)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := AddForUser(ctx, client, AddForUserInput{UserID: 42, Key: "-----BEGIN PGP PUBLIC KEY BLOCK-----"})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -313,8 +307,7 @@ func TestDelete_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := Delete(ctx, client, DeleteInput{KeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)
@@ -325,8 +318,7 @@ func TestDeleteForUser_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 	_, err := DeleteForUser(ctx, client, DeleteForUserInput{UserID: 42, KeyID: 1})
 	if err == nil {
 		t.Fatal(errExpCtxCancel)

--- a/internal/tools/users/user_admin_extra_test.go
+++ b/internal/tools/users/user_admin_extra_test.go
@@ -88,8 +88,7 @@ func TestAdminActions_TableDriven(t *testing.T) {
 				w.WriteHeader(http.StatusCreated)
 			}))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
+			ctx := testutil.CancelledCtx(t)
 
 			_, err := action.fn(ctx, client, AdminActionInput{UserID: 42})
 			if err == nil {

--- a/internal/tools/users/user_crud_extra_test.go
+++ b/internal/tools/users/user_crud_extra_test.go
@@ -111,8 +111,7 @@ func TestCreateUser_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{
 		Email: "a@b.com", Name: "User", Username: "user",
@@ -185,8 +184,7 @@ func TestModifyUser_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Modify(ctx, client, ModifyInput{UserID: 42})
 	if err == nil {
@@ -224,8 +222,7 @@ func TestDeleteUser_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Delete(ctx, client, DeleteInput{UserID: 42})
 	if err == nil {

--- a/internal/tools/users/user_misc_extra_test.go
+++ b/internal/tools/users/user_misc_extra_test.go
@@ -66,8 +66,7 @@ func TestCurrentUserStatus_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := CurrentUserStatus(ctx, client, CurrentInput{})
 	if err == nil {
@@ -174,8 +173,7 @@ func TestCreateUserRunner_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := CreateUserRunner(ctx, client, CreateUserRunnerInput{RunnerType: "instance_type"})
 	if err == nil {
@@ -225,8 +223,7 @@ func TestDeleteUserIdentity_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := DeleteUserIdentity(ctx, client, DeleteUserIdentityInput{UserID: 42, Provider: "ldap"})
 	if err == nil {
@@ -274,8 +271,7 @@ func TestGetUserActivities_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetUserActivities(ctx, client, GetUserActivitiesInput{})
 	if err == nil {
@@ -323,8 +319,7 @@ func TestGetUserMemberships_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetUserMemberships(ctx, client, GetUserMembershipsInput{UserID: 42})
 	if err == nil {

--- a/internal/tools/users/user_ssh_keys_extra_test.go
+++ b/internal/tools/users/user_ssh_keys_extra_test.go
@@ -82,8 +82,7 @@ func TestGetSSHKeyForUser_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetSSHKeyForUser(ctx, client, GetSSHKeyForUserInput{UserID: 42, KeyID: 1})
 	if err == nil {
@@ -172,8 +171,7 @@ func TestAddSSHKeyForUser_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := AddSSHKeyForUser(ctx, client, AddSSHKeyForUserInput{
 		UserID: 42, Title: "k", Key: "ssh-rsa X",
@@ -247,8 +245,7 @@ func TestDeleteSSHKeyForUser_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := DeleteSSHKeyForUser(ctx, client, DeleteSSHKeyForUserInput{UserID: 42, KeyID: 1})
 	if err == nil {
@@ -286,8 +283,7 @@ func TestListSSHKeysForUser_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListSSHKeysForUser(ctx, client, ListSSHKeysForUserInput{UserID: 42})
 	if err == nil {
@@ -325,8 +321,7 @@ func TestGetSSHKey_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetSSHKey(ctx, client, GetSSHKeyInput{KeyID: 1})
 	if err == nil {
@@ -391,8 +386,7 @@ func TestAddSSHKey_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusCreated, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := AddSSHKey(ctx, client, AddSSHKeyInput{Title: "k", Key: "ssh-rsa X"})
 	if err == nil {
@@ -430,8 +424,7 @@ func TestDeleteSSHKey_CancelledContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := DeleteSSHKey(ctx, client, DeleteSSHKeyInput{KeyID: 1})
 	if err == nil {

--- a/internal/tools/users/users_test.go
+++ b/internal/tools/users/users_test.go
@@ -88,8 +88,7 @@ func TestCurrent_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Current(ctx, client, CurrentInput{})
 	if err == nil {
@@ -576,8 +575,7 @@ func TestList_UsersCancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{})
 	if err == nil {
@@ -688,8 +686,7 @@ func TestGet_UserCancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{UserID: 42})
 	if err == nil {
@@ -719,8 +716,7 @@ func TestGet_UserStatusCancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetStatus(ctx, client, GetStatusInput{UserID: 42})
 	if err == nil {
@@ -766,8 +762,7 @@ func TestSetUserStatus_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := SetStatus(ctx, client, SetStatusInput{Emoji: "coffee"})
 	if err == nil {
@@ -833,8 +828,7 @@ func TestListSSHKeys_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListSSHKeys(ctx, client, ListSSHKeysInput{})
 	if err == nil {
@@ -900,8 +894,7 @@ func TestListEmails_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListEmails(ctx, client, ListEmailsInput{})
 	if err == nil {
@@ -938,8 +931,7 @@ func TestListContributionEvents_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListContributionEvents(ctx, client, ListContributionEventsInput{UserID: 42})
 	if err == nil {
@@ -1040,8 +1032,7 @@ func TestGetAssociationsCount_CancelledContext(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetAssociationsCount(ctx, client, GetAssociationsCountInput{UserID: 42})
 	if err == nil {

--- a/internal/tools/wikis/wikis_test.go
+++ b/internal/tools/wikis/wikis_test.go
@@ -111,8 +111,7 @@ func TestWikiList_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -230,8 +229,7 @@ func TestWikiGet_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", Slug: "my-page"})
 	if err == nil {
@@ -352,8 +350,7 @@ func TestWikiCreate_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{
 		ProjectID: "42",
@@ -432,8 +429,7 @@ func TestWikiUpdate_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{
 		ProjectID: "42",
@@ -511,8 +507,7 @@ func TestWikiDelete_CancelledContext(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", Slug: "my-page"})
 	if err == nil {

--- a/internal/tools/workitems/workitems_test.go
+++ b/internal/tools/workitems/workitems_test.go
@@ -817,8 +817,7 @@ func TestGet_ContextCancelled(t *testing.T) {
 	})
 	client := testutil.NewTestClient(t, handler)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Get(ctx, client, GetInput{FullPath: testProjectPath, IID: 1})
 	if err == nil {
@@ -833,8 +832,7 @@ func TestList_ContextCancelled(t *testing.T) {
 	})
 	client := testutil.NewTestClient(t, handler)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := List(ctx, client, ListInput{FullPath: testProjectPath})
 	if err == nil {
@@ -849,8 +847,7 @@ func TestCreate_ContextCancelled(t *testing.T) {
 	})
 	client := testutil.NewTestClient(t, handler)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Create(ctx, client, CreateInput{
 		FullPath:       testProjectPath,
@@ -1098,8 +1095,7 @@ func TestUpdate_ContextCancelled(t *testing.T) {
 	})
 	client := testutil.NewTestClient(t, handler)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := testutil.CancelledCtx(t)
 
 	_, err := Update(ctx, client, UpdateInput{FullPath: testProjectPath, IID: 1, Title: "x"})
 	if err == nil {

--- a/internal/toolutil/logging_test.go
+++ b/internal/toolutil/logging_test.go
@@ -1,70 +1,149 @@
-// logging_test.go contains unit tests for the LogToolCall and LogToolCallAll
-// helpers. Tests verify that logging does not panic for success, error, nil
-// request, and non-nil request scenarios.
+// logging_test.go contains unit tests for the LogToolCall, LogToolCallAll,
+// and logToolCallWithUser helpers. Tests capture slog output and assert that
+// the correct log level, tool name, and structured fields are present.
 package toolutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// TestLogToolCall_Success verifies that LogToolCall does not panic for a
-// successful tool invocation (nil error).
-func TestLogToolCall_Success(t *testing.T) {
-	LogToolCall("test_tool", time.Now(), nil)
+// captureSlog redirects slog to a buffer for the duration of the test.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
 }
 
-// TestLogToolCall_Error verifies that LogToolCall does not panic when
-// logging a failed tool invocation.
+// assertContains fails if the output does not contain the expected substring.
+func assertContains(t *testing.T, output, want string) {
+	t.Helper()
+	if !strings.Contains(output, want) {
+		t.Errorf("output missing %q, got:\n%s", want, output)
+	}
+}
+
+// assertNotContains fails if the output unexpectedly contains the substring.
+func assertNotContains(t *testing.T, output, unwanted string) {
+	t.Helper()
+	if strings.Contains(output, unwanted) {
+		t.Errorf("output should not contain %q, got:\n%s", unwanted, output)
+	}
+}
+
+// TestLogToolCall_Success verifies that LogToolCall logs an INFO message
+// with the tool name and duration for a successful call (nil error).
+func TestLogToolCall_Success(t *testing.T) {
+	buf := captureSlog(t)
+	LogToolCall("test_tool", time.Now(), nil)
+	out := buf.String()
+	assertContains(t, out, `"level":"INFO"`)
+	assertContains(t, out, `"msg":"tool call completed"`)
+	assertContains(t, out, `"tool":"test_tool"`)
+	assertContains(t, out, `"duration"`)
+	assertNotContains(t, out, `"error"`)
+}
+
+// TestLogToolCall_Error verifies that LogToolCall logs an ERROR message
+// with the tool name, duration, and error details for a failed call.
 func TestLogToolCall_Error(t *testing.T) {
+	buf := captureSlog(t)
 	LogToolCall("test_tool", time.Now(), errors.New("something failed"))
+	out := buf.String()
+	assertContains(t, out, `"level":"ERROR"`)
+	assertContains(t, out, `"msg":"tool call failed"`)
+	assertContains(t, out, `"tool":"test_tool"`)
+	assertContains(t, out, `"error":"something failed"`)
 }
 
 // TestLogToolCallAll_NilRequest verifies that LogToolCallAll handles a nil
-// CallToolRequest without panicking, for both success and error paths.
+// CallToolRequest for both success and error paths, logging the correct level.
 func TestLogToolCallAll_NilRequest(t *testing.T) {
+	buf := captureSlog(t)
 	ctx := context.Background()
-	LogToolCallAll(ctx, nil, "test_tool", time.Now(), nil)
-	LogToolCallAll(ctx, nil, "test_tool", time.Now(), errors.New("err"))
+
+	LogToolCallAll(ctx, nil, "nil_req_tool", time.Now(), nil)
+	LogToolCallAll(ctx, nil, "nil_req_tool", time.Now(), errors.New("err"))
+
+	out := buf.String()
+	assertContains(t, out, `"level":"INFO"`)
+	assertContains(t, out, `"level":"ERROR"`)
+	assertContains(t, out, `"tool":"nil_req_tool"`)
 }
 
 // TestLogToolCallAll_WithRequest verifies that LogToolCallAll handles
-// a non-nil request without a session, silently skipping MCP logging.
+// a non-nil request without a session, logging the correct fields.
 func TestLogToolCallAll_WithRequest(t *testing.T) {
-	// CallToolRequest without session — MCP logging is silently skipped
+	buf := captureSlog(t)
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
-	LogToolCallAll(ctx, req, "test_tool", time.Now(), nil)
-	LogToolCallAll(ctx, req, "test_tool", time.Now(), errors.New("err"))
+
+	LogToolCallAll(ctx, req, "req_tool", time.Now(), nil)
+	LogToolCallAll(ctx, req, "req_tool", time.Now(), errors.New("err"))
+
+	out := buf.String()
+	assertContains(t, out, `"tool":"req_tool"`)
+	assertContains(t, out, `"level":"INFO"`)
+	assertContains(t, out, `"level":"ERROR"`)
 }
 
 // TestLogToolCallAll_WithAuthenticatedUser verifies that LogToolCallAll
-// routes to logToolCallWithUser when an authenticated identity is present
-// in the context. Covers both success and error paths with user info.
+// routes to logToolCallWithUser when an authenticated identity is present,
+// including user and user_id fields in the log output.
 func TestLogToolCallAll_WithAuthenticatedUser(t *testing.T) {
+	buf := captureSlog(t)
 	identity := UserIdentity{UserID: "123", Username: "testuser"}
 	ctx := IdentityToContext(context.Background(), identity)
 
-	// Success path with authenticated user
-	LogToolCallAll(ctx, nil, "test_tool", time.Now(), nil)
-	// Error path with authenticated user
-	LogToolCallAll(ctx, nil, "test_tool", time.Now(), errors.New("test error"))
+	LogToolCallAll(ctx, nil, "user_tool", time.Now(), nil)
+	LogToolCallAll(ctx, nil, "user_tool", time.Now(), errors.New("test error"))
+
+	out := buf.String()
+	assertContains(t, out, `"tool":"user_tool"`)
+	assertContains(t, out, `"user":"testuser"`)
+	assertContains(t, out, `"user_id":"123"`)
+	assertContains(t, out, `"level":"INFO"`)
+	assertContains(t, out, `"level":"ERROR"`)
 }
 
-// TestLogToolCallWithUser_Success verifies that logToolCallWithUser does not
-// panic when logging a successful tool call with user identity.
+// TestLogToolCallWithUser_Success verifies that logToolCallWithUser logs
+// an INFO message with user and user_id fields for a successful call.
 func TestLogToolCallWithUser_Success(t *testing.T) {
+	buf := captureSlog(t)
 	user := UserIdentity{UserID: "42", Username: "admin"}
-	logToolCallWithUser("test_tool", time.Now(), nil, user)
+	logToolCallWithUser("user_success_tool", time.Now(), nil, user)
+
+	out := buf.String()
+	assertContains(t, out, `"level":"INFO"`)
+	assertContains(t, out, `"msg":"tool call completed"`)
+	assertContains(t, out, `"tool":"user_success_tool"`)
+	assertContains(t, out, `"user":"admin"`)
+	assertContains(t, out, `"user_id":"42"`)
+	assertNotContains(t, out, `"error"`)
 }
 
-// TestLogToolCallWithUser_Error verifies that logToolCallWithUser does not
-// panic when logging a failed tool call with user identity.
+// TestLogToolCallWithUser_Error verifies that logToolCallWithUser logs
+// an ERROR message with user, user_id, and error fields for a failed call.
 func TestLogToolCallWithUser_Error(t *testing.T) {
+	buf := captureSlog(t)
 	user := UserIdentity{UserID: "42", Username: "admin"}
-	logToolCallWithUser("test_tool", time.Now(), errors.New("api failure"), user)
+	logToolCallWithUser("user_error_tool", time.Now(), errors.New("api failure"), user)
+
+	out := buf.String()
+	assertContains(t, out, `"level":"ERROR"`)
+	assertContains(t, out, `"msg":"tool call failed"`)
+	assertContains(t, out, `"tool":"user_error_tool"`)
+	assertContains(t, out, `"user":"admin"`)
+	assertContains(t, out, `"user_id":"42"`)
+	assertContains(t, out, `"error":"api failure"`)
 }


### PR DESCRIPTION
## Summary

Three targeted improvements to test quality across the project, reducing boilerplate and eliminating false-pass risks.

### Phase 1: `CancelledCtx` helper (`testutil.CancelledCtx`)

Introduces a reusable helper that returns a pre-cancelled context, replacing 657 inline `context.WithCancel` + immediate `cancel()` patterns across 121 test files. Reduces 4–5 lines per call site to 1.

**Before:**
```go
ctx, cancel := context.WithCancel(context.Background())
cancel()
_, err := SomeFunc(ctx, client, input)
```

**After:**
```go
_, err := SomeFunc(testutil.CancelledCtx(t), client, input)
```

### Phase 2: `CaptureSlog` helper (`testutil.CaptureSlog`)

Introduces a helper that captures `slog` log output and returns it as a string for assertion. Rewrites 3 test files (`toolutil/logging_test.go`) to use structured assertions instead of visual inspection.

### Phase 3: WithAll* request body/variable assertions

Adds request body capture and field assertions to 21 `WithAll*` test functions across 12 packages. Previously these tests sent all optional fields but never verified the request payload reached the mock server — a classic false-pass pattern.

- **18 REST tests**: capture body with `io.ReadAll`, assert key fields via `strings.Contains`
- **3 GraphQL tests**: capture variables via `testutil.ParseGraphQLVariables`, assert nested input widget fields

### Stats

- **129 files changed**, +1,006 / -1,337 lines (net reduction of 331 lines)
- All 179 packages pass with `-race`
- All 9 static analysis tools pass (zero findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure by consolidating context-cancellation patterns across test suites, reducing code duplication and enhancing test maintainability through shared test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->