### PR TITLE
docs: add internal link validation and fix 58 broken links

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,6 +3,49 @@ import starlight from "@astrojs/starlight";
 import starlightLinksValidator from "starlight-links-validator";
 import mermaid from "astro-mermaid";
 
+// Auto-injects locale prefix into internal links for translated content files.
+// ES files write links as /gitlab-mcp-server/path/ (same as EN); this plugin
+// transforms them to /gitlab-mcp-server/es/path/ at build time, preventing
+// locale-stripping bugs and keeping MDX source DRY across languages.
+function remarkLocaleLinks() {
+	return (tree, file) => {
+		const filePath = file.history?.[0] || "";
+		if (!filePath.includes("/docs/es/")) return;
+
+		const prefix = `${basePath}/`;
+		const esPrefix = `${basePath}/es/`;
+
+		(function visitNode(node) {
+			// Markdown links: [text](/gitlab-mcp-server/path/)
+			if (
+				node.type === "link" &&
+				node.url?.startsWith(prefix) &&
+				!node.url?.startsWith(esPrefix)
+			) {
+				node.url = node.url.replace(prefix, esPrefix);
+			}
+			// MDX JSX elements: <LinkCard href="/gitlab-mcp-server/path/" />
+			if (
+				(node.type === "mdxJsxFlowElement" ||
+					node.type === "mdxJsxTextElement") &&
+				node.attributes
+			) {
+				for (const attr of node.attributes) {
+					if (
+						attr.name === "href" &&
+						typeof attr.value === "string" &&
+						attr.value.startsWith(prefix) &&
+						!attr.value.startsWith(esPrefix)
+					) {
+						attr.value = attr.value.replace(prefix, esPrefix);
+					}
+				}
+			}
+			if (node.children) node.children.forEach(visitNode);
+		})(tree);
+	};
+}
+
 // Converts deprecated HTML align attributes to CSS text-align (WCAG2AA compliance)
 function rehypeTableAlign() {
 	return (tree) => {
@@ -395,6 +438,7 @@ export default defineConfig({
 		}),
 	],
 	markdown: {
+		remarkPlugins: [remarkLocaleLinks],
 		rehypePlugins: [rehypeTableAlign],
 	},
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import starlightLinksValidator from "starlight-links-validator";
 import mermaid from "astro-mermaid";
 
 // Converts deprecated HTML align attributes to CSS text-align (WCAG2AA compliance)
@@ -85,6 +86,12 @@ export default defineConfig({
 		}),
 		starlight({
 			title: "GitLab MCP Server",
+			plugins: [
+				starlightLinksValidator({
+					errorOnRelativeLinks: false,
+					errorOnFallbackPages: false,
+				}),
+			],
 			description:
 				"A Model Context Protocol (MCP) server exposing 1000+ GitLab operations as AI-accessible tools. Written in Go.",
 			logo: {

--- a/site/package.json
+++ b/site/package.json
@@ -25,7 +25,8 @@
     "astro": "^6.1.8",
     "astro-mermaid": "^2.0.1",
     "mermaid": "^11.14.0",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "starlight-links-validator": "^0.23.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/site/package.json
+++ b/site/package.json
@@ -25,10 +25,10 @@
     "astro": "^6.1.8",
     "astro-mermaid": "^2.0.1",
     "mermaid": "^11.14.0",
-    "sharp": "^0.34.5",
-    "starlight-links-validator": "^0.23.0"
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "starlight-links-validator": "^0.23.0",
     "@astrojs/check": "^0.9.8",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+      starlight-links-validator:
+        specifier: ^0.23.0
+        version: 0.23.0(@astrojs/starlight@0.38.3(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)))(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3))
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.8
@@ -998,6 +1001,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
+
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
@@ -1152,6 +1158,10 @@ packages:
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1832,6 +1842,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -2136,6 +2150,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -2310,6 +2328,10 @@ packages:
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-absolute-url@5.0.0:
+    resolution: {integrity: sha512-sdJyNpBnQHuVnBunfzjAecOhZr2+A30ywfFvu3EnxtKLUWfwGgyWUmqHbGZiU6vTfHpCPm5GvLe4BAvlU9n8VQ==}
+    engines: {node: '>=20'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3264,6 +3286,13 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  starlight-links-validator@0.23.0:
+    resolution: {integrity: sha512-dpKJdNv170+jyw8HDgPKGIW/MnXUxa3v8RqJrER47jx4fbxvLsITIw0/Y76xzTTrDv8LhQ7t/ExFutUDQqm3FQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.38.0'
+      astro: '>=6.0.0'
+
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
@@ -3310,9 +3339,17 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -3331,6 +3368,10 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  terminal-link@5.0.0:
+    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
+    engines: {node: '>=20'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -4713,6 +4754,8 @@ snapshots:
       undici-types: 7.19.2
     optional: true
 
+  '@types/picomatch@4.0.3': {}
+
   '@types/sarif@2.1.7': {}
 
   '@types/sax@1.2.7':
@@ -4922,6 +4965,10 @@ snapshots:
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
@@ -5668,6 +5715,8 @@ snapshots:
 
   envinfo@7.21.0: {}
 
+  environment@1.1.0: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -6061,6 +6110,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -6348,6 +6399,8 @@ snapshots:
   ip-address@10.1.0: {}
 
   iron-webcrypto@1.2.1: {}
+
+  is-absolute-url@5.0.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -7772,6 +7825,23 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  starlight-links-validator@0.23.0(@astrojs/starlight@0.38.3(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)))(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)):
+    dependencies:
+      '@astrojs/starlight': 0.38.3(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3))
+      '@types/picomatch': 4.0.3
+      astro: 6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      is-absolute-url: 5.0.0
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-to-hast: 13.2.1
+      picomatch: 4.0.4
+      terminal-link: 5.0.0
+      unist-util-visit: 5.1.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   stream-replace-string@2.0.0: {}
 
   streamx@2.25.0:
@@ -7824,9 +7894,16 @@ snapshots:
 
   stylis@4.3.6: {}
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
 
   svgo@4.0.1:
     dependencies:
@@ -7871,6 +7948,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  terminal-link@5.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 4.4.0
 
   text-decoder@1.2.7:
     dependencies:

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
-      starlight-links-validator:
-        specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.38.3(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)))(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3))
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.8
@@ -64,6 +61,9 @@ importers:
       serve:
         specifier: ^14.2.6
         version: 14.2.6
+      starlight-links-validator:
+        specifier: ^0.23.0
+        version: 0.23.0(@astrojs/starlight@0.38.3(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3)))(astro@6.1.8(@types/node@25.6.0)(rollup@4.60.1)(typescript@6.0.3)(yaml@2.8.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -99,7 +99,7 @@ Start HTTP mode with:
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-See [HTTP Server Mode](/en/guides/http-mode/) for detailed configuration.
+See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for detailed configuration.
 
 ## Tool architecture
 

--- a/site/src/content/docs/capabilities/overview.mdx
+++ b/site/src/content/docs/capabilities/overview.mdx
@@ -9,13 +9,13 @@ GitLab MCP Server implements 7 MCP protocol capabilities that enhance how AI ass
 
 | Capability                                  | Direction       | What It Enables                                                             |
 | ------------------------------------------- | --------------- | --------------------------------------------------------------------------- |
-| [Logging](/en/capabilities/logging)         | Server → Client | Structured log messages sent to the MCP client for visibility               |
-| [Progress](/en/capabilities/progress)       | Server → Client | Real-time progress updates for long-running operations                      |
-| [Roots](/en/capabilities/roots)             | Client → Server | Workspace context — auto-detect GitLab project from local git repo          |
-| [Sampling](/en/capabilities/sampling)       | Server → Client | AI-powered analysis — server sends GitLab data to client's LLM for analysis |
-| [Elicitation](/en/capabilities/elicitation) | Server → Client | Interactive wizards — step-by-step forms for creating complex resources     |
-| [Completions](/en/capabilities/completions) | Client → Server | Argument autocompletion for project names, branches, users, and more        |
-| [Icons](/en/capabilities/icons)             | Server → Client | SVG icons for every tool, resource, and prompt                              |
+| [Logging](/gitlab-mcp-server/capabilities/logging/)         | Server → Client | Structured log messages sent to the MCP client for visibility               |
+| [Progress](/gitlab-mcp-server/capabilities/progress/)       | Server → Client | Real-time progress updates for long-running operations                      |
+| [Roots](/gitlab-mcp-server/capabilities/roots/)             | Client → Server | Workspace context — auto-detect GitLab project from local git repo          |
+| [Sampling](/gitlab-mcp-server/capabilities/sampling/)       | Server → Client | AI-powered analysis — server sends GitLab data to client's LLM for analysis |
+| [Elicitation](/gitlab-mcp-server/capabilities/elicitation/) | Server → Client | Interactive wizards — step-by-step forms for creating complex resources     |
+| [Completions](/gitlab-mcp-server/capabilities/completions/) | Client → Server | Argument autocompletion for project names, branches, users, and more        |
+| [Icons](/gitlab-mcp-server/capabilities/icons/)             | Server → Client | SVG icons for every tool, resource, and prompt                              |
 
 ## How capabilities work
 

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -99,7 +99,7 @@ Inicia el modo HTTP con:
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para la configuración detallada.
+Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para la configuración detallada.
 
 ## Arquitectura de herramientas
 

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -99,7 +99,7 @@ Inicia el modo HTTP con:
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para la configuración detallada.
+Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para la configuración detallada.
 
 ## Arquitectura de herramientas
 

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -99,7 +99,7 @@ Inicia el modo HTTP con:
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Consulta [Modo servidor HTTP](/es/guides/http-mode/) para la configuración detallada.
+Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para la configuración detallada.
 
 ## Arquitectura de herramientas
 

--- a/site/src/content/docs/es/capabilities/overview.mdx
+++ b/site/src/content/docs/es/capabilities/overview.mdx
@@ -9,13 +9,13 @@ GitLab MCP Server implementa 7 capacidades del protocolo MCP que mejoran la form
 
 | Capacidad                                                   | Dirección          | Qué Habilita                                                                                   |
 | ----------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| [Logging](/gitlab-mcp-server/es/capabilities/logging/)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
-| [Progress](/gitlab-mcp-server/es/capabilities/progress/)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
-| [Roots](/gitlab-mcp-server/es/capabilities/roots/)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
-| [Sampling](/gitlab-mcp-server/es/capabilities/sampling/)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
-| [Elicitation](/gitlab-mcp-server/es/capabilities/elicitation/) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
-| [Completions](/gitlab-mcp-server/es/capabilities/completions/) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
-| [Icons](/gitlab-mcp-server/es/capabilities/icons/)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
+| [Logging](/gitlab-mcp-server/capabilities/logging/)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
+| [Progress](/gitlab-mcp-server/capabilities/progress/)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
+| [Roots](/gitlab-mcp-server/capabilities/roots/)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
+| [Sampling](/gitlab-mcp-server/capabilities/sampling/)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
+| [Elicitation](/gitlab-mcp-server/capabilities/elicitation/) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
+| [Completions](/gitlab-mcp-server/capabilities/completions/) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
+| [Icons](/gitlab-mcp-server/capabilities/icons/)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
 
 ## Cómo funcionan las capacidades
 

--- a/site/src/content/docs/es/capabilities/overview.mdx
+++ b/site/src/content/docs/es/capabilities/overview.mdx
@@ -9,13 +9,13 @@ GitLab MCP Server implementa 7 capacidades del protocolo MCP que mejoran la form
 
 | Capacidad                                   | Dirección          | Qué Habilita                                                                                   |
 | ------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| [Logging](/es/capabilities/logging)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
-| [Progress](/es/capabilities/progress)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
-| [Roots](/es/capabilities/roots)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
-| [Sampling](/es/capabilities/sampling)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
-| [Elicitation](/es/capabilities/elicitation) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
-| [Completions](/es/capabilities/completions) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
-| [Icons](/es/capabilities/icons)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
+| [Logging](/gitlab-mcp-server/capabilities/logging/)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
+| [Progress](/gitlab-mcp-server/capabilities/progress/)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
+| [Roots](/gitlab-mcp-server/capabilities/roots/)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
+| [Sampling](/gitlab-mcp-server/capabilities/sampling/)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
+| [Elicitation](/gitlab-mcp-server/capabilities/elicitation/) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
+| [Completions](/gitlab-mcp-server/capabilities/completions/) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
+| [Icons](/gitlab-mcp-server/capabilities/icons/)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
 
 ## Cómo funcionan las capacidades
 

--- a/site/src/content/docs/es/capabilities/overview.mdx
+++ b/site/src/content/docs/es/capabilities/overview.mdx
@@ -7,15 +7,15 @@ GitLab MCP Server implementa 7 capacidades del protocolo MCP que mejoran la form
 
 ## Resumen de capacidades
 
-| Capacidad                                   | Dirección          | Qué Habilita                                                                                   |
-| ------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
-| [Logging](/gitlab-mcp-server/capabilities/logging/)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
-| [Progress](/gitlab-mcp-server/capabilities/progress/)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
-| [Roots](/gitlab-mcp-server/capabilities/roots/)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
-| [Sampling](/gitlab-mcp-server/capabilities/sampling/)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
-| [Elicitation](/gitlab-mcp-server/capabilities/elicitation/) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
-| [Completions](/gitlab-mcp-server/capabilities/completions/) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
-| [Icons](/gitlab-mcp-server/capabilities/icons/)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
+| Capacidad                                                   | Dirección          | Qué Habilita                                                                                   |
+| ----------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| [Logging](/gitlab-mcp-server/es/capabilities/logging/)         | Servidor → Cliente | Mensajes de log estructurados enviados al cliente MCP para visibilidad                         |
+| [Progress](/gitlab-mcp-server/es/capabilities/progress/)       | Servidor → Cliente | Actualizaciones de progreso en tiempo real para operaciones de larga duración                  |
+| [Roots](/gitlab-mcp-server/es/capabilities/roots/)             | Cliente → Servidor | Contexto del workspace — auto-detectar proyecto de GitLab desde el repositorio git local       |
+| [Sampling](/gitlab-mcp-server/es/capabilities/sampling/)       | Servidor → Cliente | Análisis impulsado por IA — el servidor envía datos de GitLab al LLM del cliente para análisis |
+| [Elicitation](/gitlab-mcp-server/es/capabilities/elicitation/) | Servidor → Cliente | Asistentes interactivos — formularios paso a paso para crear recursos complejos                |
+| [Completions](/gitlab-mcp-server/es/capabilities/completions/) | Cliente → Servidor | Autocompletado de argumentos para nombres de proyectos, ramas, usuarios y más                  |
+| [Icons](/gitlab-mcp-server/es/capabilities/icons/)             | Servidor → Cliente | Iconos SVG para cada herramienta, recurso y prompt                                             |
 
 ## Cómo funcionan las capacidades
 

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -307,7 +307,7 @@ GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
-El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/es/configuration/) para el orden de carga completo.
+El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/configuration/) para el orden de carga completo.
 
 ## Modo HTTP
 
@@ -317,7 +317,7 @@ Para despliegues en equipo, puedes ejecutar el servidor en modo HTTP donde cada 
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para más detalles.
+Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para más detalles.
 
 ### Modo OAuth (recomendado para producción)
 
@@ -330,7 +330,7 @@ Para gestión de tokens sin configuración manual, usa el modo OAuth. Los usuari
 Los clientes MCP que soportan OAuth 2.1 (VS Code, Claude Code) descubren el servidor de autorización automáticamente vía `/.well-known/oauth-protected-resource`. Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida.
 
 :::caution
-Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para ejemplos por cliente.
+Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para ejemplos por cliente.
 :::
 
 ## GitLab autoalojado
@@ -396,7 +396,7 @@ GITLAB_SKIP_TLS_VERIFY=true
 </TabItem>
 </Tabs>
 
-Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/gitlab-mcp-server/es/configuration/) para todas las opciones disponibles.
+Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/gitlab-mcp-server/configuration/) para todas las opciones disponibles.
 
 ## Verificar la configuración
 
@@ -446,12 +446,12 @@ Por ejemplo, en lugar de herramientas separadas `gitlab_list_issues`, `gitlab_cr
 Esto es transparente para ti — tu cliente de IA maneja el enrutamiento automáticamente. Solo pregunta de forma natural: _"crea un issue para el bug del login"_ y el LLM selecciona la meta-herramienta y acción correctas.
 
 :::tip
-Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) para la referencia completa.
+Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) para la referencia completa.
 :::
 
 ## Próximos pasos
 
-- [Configuración](/gitlab-mcp-server/es/configuration/) — Ajusta las variables de entorno y funciones opcionales
-- [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
-- [Arquitectura](/gitlab-mcp-server/es/architecture/) — Comprende cómo funciona el servidor internamente
-- [Referencia de herramientas](/gitlab-mcp-server/es/tools/overview/) — Explora todas las herramientas disponibles por dominio
+- [Configuración](/gitlab-mcp-server/configuration/) — Ajusta las variables de entorno y funciones opcionales
+- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
+- [Arquitectura](/gitlab-mcp-server/architecture/) — Comprende cómo funciona el servidor internamente
+- [Referencia de herramientas](/gitlab-mcp-server/tools/overview/) — Explora todas las herramientas disponibles por dominio

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -307,7 +307,7 @@ GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
-El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/es/configuration/) para el orden de carga completo.
+El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/configuration/) para el orden de carga completo.
 
 ## Modo HTTP
 
@@ -317,7 +317,7 @@ Para despliegues en equipo, puedes ejecutar el servidor en modo HTTP donde cada 
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/es/operations/http-server/) para más detalles.
+Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para más detalles.
 
 ### Modo OAuth (recomendado para producción)
 
@@ -330,7 +330,7 @@ Para gestión de tokens sin configuración manual, usa el modo OAuth. Los usuari
 Los clientes MCP que soportan OAuth 2.1 (VS Code, Claude Code) descubren el servidor de autorización automáticamente vía `/.well-known/oauth-protected-resource`. Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida.
 
 :::caution
-Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/es/operations/http-server/) para ejemplos por cliente.
+Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para ejemplos por cliente.
 :::
 
 ## GitLab autoalojado
@@ -396,7 +396,7 @@ GITLAB_SKIP_TLS_VERIFY=true
 </TabItem>
 </Tabs>
 
-Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/es/configuration/) para todas las opciones disponibles.
+Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/gitlab-mcp-server/configuration/) para todas las opciones disponibles.
 
 ## Verificar la configuración
 
@@ -446,12 +446,12 @@ Por ejemplo, en lugar de herramientas separadas `gitlab_list_issues`, `gitlab_cr
 Esto es transparente para ti — tu cliente de IA maneja el enrutamiento automáticamente. Solo pregunta de forma natural: _"crea un issue para el bug del login"_ y el LLM selecciona la meta-herramienta y acción correctas.
 
 :::tip
-Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/es/tools/meta-tools/) para la referencia completa.
+Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) para la referencia completa.
 :::
 
 ## Próximos pasos
 
-- [Configuración](/es/configuration/) — Ajusta las variables de entorno y funciones opcionales
-- [Meta-herramientas](/es/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
-- [Arquitectura](/es/architecture/) — Comprende cómo funciona el servidor internamente
-- [Referencia de herramientas](/es/tools/) — Explora todas las herramientas disponibles por dominio
+- [Configuración](/gitlab-mcp-server/configuration/) — Ajusta las variables de entorno y funciones opcionales
+- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
+- [Arquitectura](/gitlab-mcp-server/architecture/) — Comprende cómo funciona el servidor internamente
+- [Referencia de herramientas](/gitlab-mcp-server/tools/overview/) — Explora todas las herramientas disponibles por dominio

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -307,7 +307,7 @@ GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
-El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/configuration/) para el orden de carga completo.
+El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/es/configuration/) para el orden de carga completo.
 
 ## Modo HTTP
 
@@ -317,7 +317,7 @@ Para despliegues en equipo, puedes ejecutar el servidor en modo HTTP donde cada 
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para más detalles.
+Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para más detalles.
 
 ### Modo OAuth (recomendado para producción)
 
@@ -330,7 +330,7 @@ Para gestión de tokens sin configuración manual, usa el modo OAuth. Los usuari
 Los clientes MCP que soportan OAuth 2.1 (VS Code, Claude Code) descubren el servidor de autorización automáticamente vía `/.well-known/oauth-protected-resource`. Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida.
 
 :::caution
-Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para ejemplos por cliente.
+Los clientes deben configurarse con el `clientId` de la Aplicación OAuth de GitLab y el scope `api`. Sin `clientId`, los clientes recurren al Registro Dinámico de Clientes (DCR) que asigna el scope `mcp` en lugar de `api`, causando que la mayoría de las operaciones fallen. Consulta [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para ejemplos por cliente.
 :::
 
 ## GitLab autoalojado
@@ -396,7 +396,7 @@ GITLAB_SKIP_TLS_VERIFY=true
 </TabItem>
 </Tabs>
 
-Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/gitlab-mcp-server/configuration/) para todas las opciones disponibles.
+Tanto GitLab CE (gratuito) como EE (Premium/Ultimate) son totalmente compatibles. Para funciones exclusivas de EE como métricas DORA, épicas y gestión de vulnerabilidades, habilita el modo enterprise con `GITLAB_ENTERPRISE=true`. Consulta [Configuración](/gitlab-mcp-server/es/configuration/) para todas las opciones disponibles.
 
 ## Verificar la configuración
 
@@ -446,12 +446,12 @@ Por ejemplo, en lugar de herramientas separadas `gitlab_list_issues`, `gitlab_cr
 Esto es transparente para ti — tu cliente de IA maneja el enrutamiento automáticamente. Solo pregunta de forma natural: _"crea un issue para el bug del login"_ y el LLM selecciona la meta-herramienta y acción correctas.
 
 :::tip
-Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) para la referencia completa.
+Las meta-herramientas reducen el overhead de tokens en un **96%** mientras preservan la funcionalidad completa. Consulta [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) para la referencia completa.
 :::
 
 ## Próximos pasos
 
-- [Configuración](/gitlab-mcp-server/configuration/) — Ajusta las variables de entorno y funciones opcionales
-- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
-- [Arquitectura](/gitlab-mcp-server/architecture/) — Comprende cómo funciona el servidor internamente
-- [Referencia de herramientas](/gitlab-mcp-server/tools/overview/) — Explora todas las herramientas disponibles por dominio
+- [Configuración](/gitlab-mcp-server/es/configuration/) — Ajusta las variables de entorno y funciones opcionales
+- [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) — Entiende cómo se organizan las herramientas y descubre todas las operaciones disponibles
+- [Arquitectura](/gitlab-mcp-server/es/architecture/) — Comprende cómo funciona el servidor internamente
+- [Referencia de herramientas](/gitlab-mcp-server/es/tools/overview/) — Explora todas las herramientas disponibles por dominio

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -107,22 +107,22 @@ Prueba estos con tu asistente de IA una vez conectado GitLab MCP Server:
 <CardGrid>
 	<LinkCard
 		title="Primeros pasos"
-		href="/gitlab-mcp-server/es/getting-started/"
+		href="/gitlab-mcp-server/getting-started/"
 		description="Instala el binario y conéctalo a tu primer cliente de IA en minutos"
 	/>
 	<LinkCard
 		title="Arquitectura"
-		href="/gitlab-mcp-server/es/architecture/"
+		href="/gitlab-mcp-server/architecture/"
 		description="Comprende cómo el servidor conecta los asistentes de IA con GitLab"
 	/>
 	<LinkCard
 		title="Configuración"
-		href="/gitlab-mcp-server/es/configuration/"
+		href="/gitlab-mcp-server/configuration/"
 		description="Variables de entorno, configuraciones de clientes y opciones de despliegue"
 	/>
 	<LinkCard
 		title="Referencia de herramientas"
-		href="/gitlab-mcp-server/es/tools/overview/"
+		href="/gitlab-mcp-server/tools/overview/"
 		description="Explora todas las herramientas MCP disponibles por dominio"
 	/>
 </CardGrid>

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -107,22 +107,22 @@ Prueba estos con tu asistente de IA una vez conectado GitLab MCP Server:
 <CardGrid>
 	<LinkCard
 		title="Primeros pasos"
-		href="/es/getting-started/"
+		href="/gitlab-mcp-server/getting-started/"
 		description="Instala el binario y conéctalo a tu primer cliente de IA en minutos"
 	/>
 	<LinkCard
 		title="Arquitectura"
-		href="/es/architecture/"
+		href="/gitlab-mcp-server/architecture/"
 		description="Comprende cómo el servidor conecta los asistentes de IA con GitLab"
 	/>
 	<LinkCard
 		title="Configuración"
-		href="/es/configuration/"
+		href="/gitlab-mcp-server/configuration/"
 		description="Variables de entorno, configuraciones de clientes y opciones de despliegue"
 	/>
 	<LinkCard
 		title="Referencia de herramientas"
-		href="/es/tools/"
+		href="/gitlab-mcp-server/tools/overview/"
 		description="Explora todas las herramientas MCP disponibles por dominio"
 	/>
 </CardGrid>

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -107,22 +107,22 @@ Prueba estos con tu asistente de IA una vez conectado GitLab MCP Server:
 <CardGrid>
 	<LinkCard
 		title="Primeros pasos"
-		href="/gitlab-mcp-server/getting-started/"
+		href="/gitlab-mcp-server/es/getting-started/"
 		description="Instala el binario y conéctalo a tu primer cliente de IA en minutos"
 	/>
 	<LinkCard
 		title="Arquitectura"
-		href="/gitlab-mcp-server/architecture/"
+		href="/gitlab-mcp-server/es/architecture/"
 		description="Comprende cómo el servidor conecta los asistentes de IA con GitLab"
 	/>
 	<LinkCard
 		title="Configuración"
-		href="/gitlab-mcp-server/configuration/"
+		href="/gitlab-mcp-server/es/configuration/"
 		description="Variables de entorno, configuraciones de clientes y opciones de despliegue"
 	/>
 	<LinkCard
 		title="Referencia de herramientas"
-		href="/gitlab-mcp-server/tools/overview/"
+		href="/gitlab-mcp-server/es/tools/overview/"
 		description="Explora todas las herramientas MCP disponibles por dominio"
 	/>
 </CardGrid>

--- a/site/src/content/docs/es/operations/ci-cd.mdx
+++ b/site/src/content/docs/es/operations/ci-cd.mdx
@@ -200,7 +200,7 @@ http-mode-pipeline:
         | jq '.result.content[0].text'
 ```
 
-Consulta [Servidor HTTP](/es/operations/http-server/) para detalles completos.
+Consulta [Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para detalles completos.
 
 ## Herramientas CI/CD disponibles
 
@@ -272,7 +272,7 @@ Disparar un pipeline con variables personalizadas usando JSON-RPC:
 }
 ```
 
-Para la referencia completa de herramientas, consulta [Resumen de herramientas](/es/tools/).
+Para la referencia completa de herramientas, consulta [Resumen de herramientas](/gitlab-mcp-server/tools/overview/).
 
 ## Mejores prácticas de seguridad
 

--- a/site/src/content/docs/es/operations/ci-cd.mdx
+++ b/site/src/content/docs/es/operations/ci-cd.mdx
@@ -200,7 +200,7 @@ http-mode-pipeline:
         | jq '.result.content[0].text'
 ```
 
-Consulta [Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para detalles completos.
+Consulta [Servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para detalles completos.
 
 ## Herramientas CI/CD disponibles
 
@@ -272,7 +272,7 @@ Disparar un pipeline con variables personalizadas usando JSON-RPC:
 }
 ```
 
-Para la referencia completa de herramientas, consulta [Resumen de herramientas](/gitlab-mcp-server/tools/overview/).
+Para la referencia completa de herramientas, consulta [Resumen de herramientas](/gitlab-mcp-server/es/tools/overview/).
 
 ## Mejores prácticas de seguridad
 

--- a/site/src/content/docs/es/operations/ci-cd.mdx
+++ b/site/src/content/docs/es/operations/ci-cd.mdx
@@ -200,7 +200,7 @@ http-mode-pipeline:
         | jq '.result.content[0].text'
 ```
 
-Consulta [Servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para detalles completos.
+Consulta [Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para detalles completos.
 
 ## Herramientas CI/CD disponibles
 
@@ -272,7 +272,7 @@ Disparar un pipeline con variables personalizadas usando JSON-RPC:
 }
 ```
 
-Para la referencia completa de herramientas, consulta [Resumen de herramientas](/gitlab-mcp-server/es/tools/overview/).
+Para la referencia completa de herramientas, consulta [Resumen de herramientas](/gitlab-mcp-server/tools/overview/).
 
 ## Mejores prácticas de seguridad
 

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -198,7 +198,7 @@ Para despliegues HTTP en producción, considera usar el modo OAuth (`--auth-mode
 - La identidad del token se cachea durante `--oauth-cache-ttl` (por defecto: 15 minutos, rango: 1m–2h)
 - La cabecera `PRIVATE-TOKEN` sigue siendo compatible para retrocompatibilidad
 
-Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/es/operations/http-server/) para los detalles completos de configuración.
+Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para los detalles completos de configuración.
 
 ## Lista de verificación de mejores prácticas
 

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -198,7 +198,7 @@ Para despliegues HTTP en producción, considera usar el modo OAuth (`--auth-mode
 - La identidad del token se cachea durante `--oauth-cache-ttl` (por defecto: 15 minutos, rango: 1m–2h)
 - La cabecera `PRIVATE-TOKEN` sigue siendo compatible para retrocompatibilidad
 
-Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para los detalles completos de configuración.
+Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para los detalles completos de configuración.
 
 ## Lista de verificación de mejores prácticas
 

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -198,7 +198,7 @@ Para despliegues HTTP en producción, considera usar el modo OAuth (`--auth-mode
 - La identidad del token se cachea durante `--oauth-cache-ttl` (por defecto: 15 minutos, rango: 1m–2h)
 - La cabecera `PRIVATE-TOKEN` sigue siendo compatible para retrocompatibilidad
 
-Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) para los detalles completos de configuración.
+Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida, y [Modo Servidor HTTP](/gitlab-mcp-server/operations/http-server/) para los detalles completos de configuración.
 
 ## Lista de verificación de mejores prácticas
 

--- a/site/src/content/docs/es/operations/troubleshooting.mdx
+++ b/site/src/content/docs/es/operations/troubleshooting.mdx
@@ -34,7 +34,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | ------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | El cliente MCP muestra 1006 herramientas en lugar de 42 | Meta-herramientas desactivadas          | Establece `META_TOOLS=true` (por defecto) para consolidar en meta-herramientas de dominio          |
 | Herramienta no encontrada en `tools/list`               | Desajuste del modo de meta-herramientas | El modo individual usa `gitlab_create_issue`, el modo meta usa `gitlab_issue` con `action: create` |
-| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/gitlab-mcp-server/es/tools/overview/)                     |
+| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/gitlab-mcp-server/tools/overview/)                     |
 | Herramientas enterprise faltantes                       | Modo enterprise desactivado             | Establece `GITLAB_ENTERPRISE=true` para habilitar 15 meta-herramientas enterprise adicionales      |
 
 ## Actualización automática
@@ -63,7 +63,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | `404` en `/.well-known/oauth-protected-resource`            | Modo OAuth no habilitado                          | Inicia el servidor con `--auth-mode=oauth`                                                                                     |
 | El cliente no inicia el flujo OAuth                         | El cliente no soporta OAuth 2.1                   | Usa la cabecera `PRIVATE-TOKEN` en su lugar — funciona en modo OAuth mediante normalización automática                         |
 | La cabecera `PRIVATE-TOKEN` no funciona en modo OAuth       | Debería funcionar                                 | El middleware normaliza `PRIVATE-TOKEN` a Bearer — verifica la validez del token                                               |
-| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) |
+| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) |
 
 ## Paginación
 

--- a/site/src/content/docs/es/operations/troubleshooting.mdx
+++ b/site/src/content/docs/es/operations/troubleshooting.mdx
@@ -34,7 +34,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | ------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | El cliente MCP muestra 1006 herramientas en lugar de 42 | Meta-herramientas desactivadas          | Establece `META_TOOLS=true` (por defecto) para consolidar en meta-herramientas de dominio          |
 | Herramienta no encontrada en `tools/list`               | Desajuste del modo de meta-herramientas | El modo individual usa `gitlab_create_issue`, el modo meta usa `gitlab_issue` con `action: create` |
-| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/es/tools/overview)                     |
+| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/gitlab-mcp-server/tools/overview/)                     |
 | Herramientas enterprise faltantes                       | Modo enterprise desactivado             | Establece `GITLAB_ENTERPRISE=true` para habilitar 15 meta-herramientas enterprise adicionales      |
 
 ## Actualización automática
@@ -63,7 +63,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | `404` en `/.well-known/oauth-protected-resource`            | Modo OAuth no habilitado                          | Inicia el servidor con `--auth-mode=oauth`                                                                                     |
 | El cliente no inicia el flujo OAuth                         | El cliente no soporta OAuth 2.1                   | Usa la cabecera `PRIVATE-TOKEN` en su lugar — funciona en modo OAuth mediante normalización automática                         |
 | La cabecera `PRIVATE-TOKEN` no funciona en modo OAuth       | Debería funcionar                                 | El middleware normaliza `PRIVATE-TOKEN` a Bearer — verifica la validez del token                                               |
-| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/es/operations/http-server/) |
+| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) |
 
 ## Paginación
 

--- a/site/src/content/docs/es/operations/troubleshooting.mdx
+++ b/site/src/content/docs/es/operations/troubleshooting.mdx
@@ -34,7 +34,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | ------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | El cliente MCP muestra 1006 herramientas en lugar de 42 | Meta-herramientas desactivadas          | Establece `META_TOOLS=true` (por defecto) para consolidar en meta-herramientas de dominio          |
 | Herramienta no encontrada en `tools/list`               | Desajuste del modo de meta-herramientas | El modo individual usa `gitlab_create_issue`, el modo meta usa `gitlab_issue` con `action: create` |
-| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/gitlab-mcp-server/tools/overview/)                     |
+| `unknown action` en llamada a meta-herramienta          | Parámetro de acción inválido            | Verifica las acciones válidas en [Resumen de Herramientas](/gitlab-mcp-server/es/tools/overview/)                     |
 | Herramientas enterprise faltantes                       | Modo enterprise desactivado             | Establece `GITLAB_ENTERPRISE=true` para habilitar 15 meta-herramientas enterprise adicionales      |
 
 ## Actualización automática
@@ -63,7 +63,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 | `404` en `/.well-known/oauth-protected-resource`            | Modo OAuth no habilitado                          | Inicia el servidor con `--auth-mode=oauth`                                                                                     |
 | El cliente no inicia el flujo OAuth                         | El cliente no soporta OAuth 2.1                   | Usa la cabecera `PRIVATE-TOKEN` en su lugar — funciona en modo OAuth mediante normalización automática                         |
 | La cabecera `PRIVATE-TOKEN` no funciona en modo OAuth       | Debería funcionar                                 | El middleware normaliza `PRIVATE-TOKEN` a Bearer — verifica la validez del token                                               |
-| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) |
+| Operaciones fallan con scope `mcp` insuficiente             | DCR fallback asignó scope `mcp` en lugar de `api` | Configura `clientId` explícitamente en la configuración del cliente MCP. Ver [Modo servidor HTTP](/gitlab-mcp-server/es/operations/http-server/) |
 
 ## Paginación
 

--- a/site/src/content/docs/es/tools/overview.mdx
+++ b/site/src/content/docs/es/tools/overview.mdx
@@ -128,6 +128,6 @@ Las herramientas Enterprise requieren una licencia de GitLab Premium o Ultimate 
 
 ## Lectura adicional
 
-- [Meta-herramientas](/es/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
-- [Herramientas de análisis](/es/tools/analysis/) — herramientas de sampling impulsadas por IA
-- [Recursos y prompts](/es/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts
+- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
+- [Herramientas de análisis](/gitlab-mcp-server/tools/analysis/) — herramientas de sampling impulsadas por IA
+- [Recursos y prompts](/gitlab-mcp-server/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts

--- a/site/src/content/docs/es/tools/overview.mdx
+++ b/site/src/content/docs/es/tools/overview.mdx
@@ -128,6 +128,6 @@ Las herramientas Enterprise requieren una licencia de GitLab Premium o Ultimate 
 
 ## Lectura adicional
 
-- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
-- [Herramientas de análisis](/gitlab-mcp-server/tools/analysis/) — herramientas de sampling impulsadas por IA
-- [Recursos y prompts](/gitlab-mcp-server/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts
+- [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
+- [Herramientas de análisis](/gitlab-mcp-server/es/tools/analysis/) — herramientas de sampling impulsadas por IA
+- [Recursos y prompts](/gitlab-mcp-server/es/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts

--- a/site/src/content/docs/es/tools/overview.mdx
+++ b/site/src/content/docs/es/tools/overview.mdx
@@ -128,6 +128,6 @@ Las herramientas Enterprise requieren una licencia de GitLab Premium o Ultimate 
 
 ## Lectura adicional
 
-- [Meta-herramientas](/gitlab-mcp-server/es/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
-- [Herramientas de análisis](/gitlab-mcp-server/es/tools/analysis/) — herramientas de sampling impulsadas por IA
-- [Recursos y prompts](/gitlab-mcp-server/es/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts
+- [Meta-herramientas](/gitlab-mcp-server/tools/meta-tools/) — arquitectura detallada de meta-herramientas y uso
+- [Herramientas de análisis](/gitlab-mcp-server/tools/analysis/) — herramientas de sampling impulsadas por IA
+- [Recursos y prompts](/gitlab-mcp-server/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -307,7 +307,7 @@ GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
-The server loads `.env` from the current working directory automatically. See [Configuration](/en/configuration/) for the full load order.
+The server loads `.env` from the current working directory automatically. See [Configuration](/gitlab-mcp-server/configuration/) for the full load order.
 
 ## HTTP mode
 
@@ -317,7 +317,7 @@ For team deployments, you can run the server in HTTP mode where each user authen
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
 ```
 
-Each client connects via HTTP and provides their own GitLab token. See [HTTP Server Mode](/en/operations/http-server/) for details.
+Each client connects via HTTP and provides their own GitLab token. See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for details.
 
 ### OAuth mode (recommended for production)
 
@@ -330,7 +330,7 @@ For zero-config token management, use OAuth mode. Users authorize through the br
 MCP clients that support OAuth 2.1 (VS Code, Claude Code) discover the authorization server automatically via `/.well-known/oauth-protected-resource`. See [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) for creating the required GitLab OAuth Application.
 
 :::caution
-Clients must be configured with the `clientId` from the GitLab OAuth Application and `api` scope. Without `clientId`, clients fall back to Dynamic Client Registration (DCR) which assigns the `mcp` scope instead of `api`, causing most operations to fail. See [HTTP Server Mode](/en/operations/http-server/) for per-client examples.
+Clients must be configured with the `clientId` from the GitLab OAuth Application and `api` scope. Without `clientId`, clients fall back to Dynamic Client Registration (DCR) which assigns the `mcp` scope instead of `api`, causing most operations to fail. See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for per-client examples.
 :::
 
 ## Self-hosted GitLab
@@ -396,7 +396,7 @@ GITLAB_SKIP_TLS_VERIFY=true
 </TabItem>
 </Tabs>
 
-Both GitLab CE (free) and EE (Premium/Ultimate) are fully supported. For EE-exclusive features like DORA metrics, epics, and vulnerability management, enable enterprise mode with `GITLAB_ENTERPRISE=true`. See [Configuration](/en/configuration/) for all available options.
+Both GitLab CE (free) and EE (Premium/Ultimate) are fully supported. For EE-exclusive features like DORA metrics, epics, and vulnerability management, enable enterprise mode with `GITLAB_ENTERPRISE=true`. See [Configuration](/gitlab-mcp-server/configuration/) for all available options.
 
 ## Verify the setup
 
@@ -446,12 +446,12 @@ For example, instead of separate `gitlab_list_issues`, `gitlab_create_issue`, `g
 This is transparent to you — your AI client handles the routing automatically. You just ask naturally: _"create an issue for the login bug"_ and the LLM selects the right meta-tool and action.
 
 :::tip
-Meta-tools reduce token overhead by **96%** while preserving full functionality. See [Meta-tools](/en/tools/meta-tools/) for the complete reference.
+Meta-tools reduce token overhead by **96%** while preserving full functionality. See [Meta-tools](/gitlab-mcp-server/tools/meta-tools/) for the complete reference.
 :::
 
 ## Next steps
 
-- [Configuration](/en/configuration/) — Fine-tune environment variables and optional features
-- [Meta-tools](/en/tools/meta-tools/) — Understand how tools are organized and discover all available operations
-- [Architecture](/en/architecture/) — Understand how the server works under the hood
-- [Tools Reference](/en/tools/) — Explore all available tools by domain
+- [Configuration](/gitlab-mcp-server/configuration/) — Fine-tune environment variables and optional features
+- [Meta-tools](/gitlab-mcp-server/tools/meta-tools/) — Understand how tools are organized and discover all available operations
+- [Architecture](/gitlab-mcp-server/architecture/) — Understand how the server works under the hood
+- [Tools Reference](/gitlab-mcp-server/tools/overview/) — Explore all available tools by domain

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -117,22 +117,22 @@ Try these with your AI assistant once GitLab MCP Server is connected:
 <CardGrid>
 	<LinkCard
 		title="Getting Started"
-		href="/en/getting-started/"
+		href="/gitlab-mcp-server/getting-started/"
 		description="Install the binary and connect to your first AI client in minutes"
 	/>
 	<LinkCard
 		title="Architecture"
-		href="/en/architecture/"
+		href="/gitlab-mcp-server/architecture/"
 		description="Understand how the server connects AI assistants to GitLab"
 	/>
 	<LinkCard
 		title="Configuration"
-		href="/en/configuration/"
+		href="/gitlab-mcp-server/configuration/"
 		description="Environment variables, client configs, and deployment options"
 	/>
 	<LinkCard
 		title="Tools Reference"
-		href="/en/tools/"
+		href="/gitlab-mcp-server/tools/overview/"
 		description="Browse all available MCP tools by domain"
 	/>
 </CardGrid>

--- a/site/src/content/docs/operations/ci-cd.mdx
+++ b/site/src/content/docs/operations/ci-cd.mdx
@@ -200,7 +200,7 @@ http-mode-pipeline:
         | jq '.result.content[0].text'
 ```
 
-See [HTTP Server Mode](/operations/http-server/) for full details.
+See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for full details.
 
 ## CI/CD tools available
 
@@ -272,7 +272,7 @@ Trigger a pipeline with custom variables using JSON-RPC:
 }
 ```
 
-For the complete tool reference, see [Tools Overview](/en/tools/).
+For the complete tool reference, see [Tools Overview](/gitlab-mcp-server/tools/overview/).
 
 ## Security best practices
 

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -198,7 +198,7 @@ For production HTTP deployments, consider using OAuth mode (`--auth-mode=oauth`)
 - Token identity is cached for `--oauth-cache-ttl` (default: 15 minutes, range: 1m–2h)
 - The `PRIVATE-TOKEN` header remains supported for backward compatibility
 
-See [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) for creating the required GitLab OAuth Application, and [HTTP Server Mode](/en/operations/http-server/) for full configuration details.
+See [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) for creating the required GitLab OAuth Application, and [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for full configuration details.
 
 ## Best practices checklist
 

--- a/site/src/content/docs/operations/troubleshooting.mdx
+++ b/site/src/content/docs/operations/troubleshooting.mdx
@@ -34,7 +34,7 @@ For the complete technical reference, see [`docs/troubleshooting.md`](https://gi
 | ----------------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
 | MCP client shows 1006 tools instead of 42 | Meta-tools disabled      | Set `META_TOOLS=true` (default) to consolidate into domain meta-tools                           |
 | Tool not found in `tools/list`            | Meta-tool mode mismatch  | Individual mode uses `gitlab_create_issue`, meta mode uses `gitlab_issue` with `action: create` |
-| `unknown action` in meta-tool call        | Invalid action parameter | Check valid actions in the [Tools Overview](/en/tools/overview)                                 |
+| `unknown action` in meta-tool call        | Invalid action parameter | Check valid actions in the [Tools Overview](/gitlab-mcp-server/tools/overview/)                                  |
 | Enterprise tools missing                  | Enterprise mode disabled | Set `GITLAB_ENTERPRISE=true` to enable 15 additional enterprise meta-tools                      |
 
 ## Auto-update
@@ -63,7 +63,7 @@ For the complete technical reference, see [`docs/troubleshooting.md`](https://gi
 | `404` on `/.well-known/oauth-protected-resource` | OAuth mode not enabled                       | Start the server with `--auth-mode=oauth`                                                                     |
 | Client doesn't start OAuth flow                  | Client lacks OAuth 2.1 support               | Use `PRIVATE-TOKEN` header instead — it works in OAuth mode via automatic normalization                       |
 | `PRIVATE-TOKEN` header not working in OAuth mode | Should still work                            | The middleware normalizes `PRIVATE-TOKEN` to Bearer — check token validity                                    |
-| Operations fail with insufficient `mcp` scope    | DCR fallback assigned `mcp` instead of `api` | Configure `clientId` explicitly in the MCP client config. See [HTTP Server Mode](/en/operations/http-server/) |
+| Operations fail with insufficient `mcp` scope    | DCR fallback assigned `mcp` instead of `api` | Configure `clientId` explicitly in the MCP client config. See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) |
 
 ## Pagination
 

--- a/site/src/content/docs/tools/overview.mdx
+++ b/site/src/content/docs/tools/overview.mdx
@@ -128,6 +128,6 @@ Enterprise tools require a GitLab Premium or Ultimate license on your instance. 
 
 ## Further reading
 
-- [Meta-tools](/en/tools/meta-tools/) — detailed meta-tool architecture and usage
-- [Analysis Tools](/en/tools/analysis/) — AI-powered sampling tools
-- [Resources & Prompts](/en/tools/resources-prompts/) — read-only context and prompt templates
+- [Meta-tools](/gitlab-mcp-server/tools/meta-tools/) — detailed meta-tool architecture and usage
+- [Analysis Tools](/gitlab-mcp-server/tools/analysis/) — AI-powered sampling tools
+- [Resources & Prompts](/gitlab-mcp-server/tools/resources-prompts/) — read-only context and prompt templates


### PR DESCRIPTION
## Summary

Add build-time internal link validation to Astro Starlight docs and fix all 58 broken internal links across 16 MDX files.

## Changes

### Link Validator Plugin
- Install `starlight-links-validator` v0.23.0 as Starlight plugin
- Configure with `errorOnRelativeLinks: false` (project uses absolute paths)
- Configure with `errorOnFallbackPages: false` (ES translations are incomplete — fallback pages are expected)
- Build now **fails** if any internal link points to a non-existent page

### Broken Link Fixes
All 58 broken links were caused by missing `/gitlab-mcp-server` base path prefix. Astro's `base` config does not auto-rewrite links in markdown content — only sidebar/navigation is handled automatically.

**16 files fixed** (EN + ES):

| Page | Links Fixed |
|------|:-----------:|
| `index.mdx` | 4 |
| `architecture.mdx` | 1 |
| `capabilities/overview.mdx` | 7 |
| `getting-started.mdx` | 9 |
| `operations/ci-cd.mdx` | 2 |
| `operations/security.mdx` | 1 |
| `operations/troubleshooting.mdx` | 2 |
| `tools/overview.mdx` | 3 |

_(× 2 for EN + ES versions = 58 total)_

## Verification

```
 validating links

╭─                             ─╮
· All internal links are valid. ·
╰─                             ─╯
```

Build passes with 0 link errors.

## Summary by Sourcery

Add build-time validation for internal documentation links and update docs to use the correct base-prefixed URLs.

Enhancements:
- Integrate the starlight links validator plugin into the Astro Starlight site configuration to fail builds on invalid internal links.

Build:
- Add starlight-links-validator as a site dependency for link checking during builds.

Documentation:
- Fix broken internal links across English and Spanish documentation pages to use the correct /gitlab-mcp-server/ URL paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation link validation to detect broken references within the site.

* **Documentation**
  * Updated documentation URL structure across all pages and language translations to use a unified `/gitlab-mcp-server/` base path, consolidating navigation routes for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->