### PR TITLE
feat(config): make auto-update timeout configurable (default 60s)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,6 +191,7 @@ When creating a new release and uploading binaries to GitHub Releases:
 | `AUTO_UPDATE`            | Enable auto-update: `true` (default), `check`, `false` | `true` (default)   |
 | `AUTO_UPDATE_REPO`       | GitHub repository slug for release assets (owner/repo) | `jmrplens/gitlab-mcp-server` |
 | `AUTO_UPDATE_INTERVAL`   | Periodic check interval, HTTP mode | `1h` (default)     |
+| `AUTO_UPDATE_TIMEOUT`    | Pre-start download timeout (range 5s–10m) | `60s` (default)    |
 | `GITLAB_ENTERPRISE`      | Enable Enterprise/Premium tools: gates 35 individual tool sub-packages and 15 dedicated meta-tools | `false` (default) |
 | `MAX_HTTP_CLIENTS`       | Max client sessions, HTTP mode (also `--max-http-clients` flag) | `100` (default)    |
 | `SESSION_TIMEOUT`        | Idle session timeout, HTTP mode (also `--session-timeout` flag) | `30m` (default)  |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ make analyze-report                        # generate LLM-consumable report
 | `AUTO_UPDATE`            | No       | Enable auto-update: `true` (default), `check`, `false`  |
 | `AUTO_UPDATE_REPO`       | No       | GitHub repository slug for release assets (`jmrplens/gitlab-mcp-server`) |
 | `AUTO_UPDATE_INTERVAL`   | No       | Periodic check interval (`1h` default, HTTP mode)        |
+| `AUTO_UPDATE_TIMEOUT`    | No       | Pre-start download timeout (`60s` default, range 5s–10m) |
 | `GITLAB_ENTERPRISE`      | No       | Enable Enterprise/Premium tools: gates 35 individual tool sub-packages and 15 dedicated meta-tools for GitLab Premium/Ultimate (`false` default) |
 | `AUTH_MODE`              | No       | HTTP mode auth: `legacy` (default) or `oauth` (RFC 9728 Bearer verification) |
 | `OAUTH_CACHE_TTL`        | No       | OAuth token identity cache TTL (`15m` default, range 1m–2h) |
@@ -265,6 +266,7 @@ In **HTTP mode**, configuration comes from CLI flags instead of environment vari
 | `--auto-update`       | `true`  | Enable auto-update (`true`, `check`, `false`)            |
 | `--auto-update-repo`  | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets |
 | `--auto-update-interval` | `1h` | Periodic update check interval                           |
+| `--auto-update-timeout` | `60s` | Pre-start download timeout (range 5s–10m)                |
 
 **General flags** (both stdio and HTTP modes):
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -105,7 +105,7 @@ func main() {
 	flag.StringVar(&hcfg.autoUpdate, "auto-update", "true", "Auto-update mode: true (auto-apply), check (log-only), false (disabled)")
 	flag.StringVar(&hcfg.autoUpdateRepo, "auto-update-repo", config.DefaultAutoUpdateRepo, "GitHub repository for update checks")
 	flag.DurationVar(&hcfg.autoUpdateInterval, "auto-update-interval", config.DefaultAutoUpdateInterval, "How often to check for updates")
-	flag.DurationVar(&hcfg.autoUpdateTimeout, "auto-update-timeout", config.DefaultAutoUpdateTimeout, "Timeout for pre-start update download (default 60s)")
+	flag.DurationVar(&hcfg.autoUpdateTimeout, "auto-update-timeout", config.DefaultAutoUpdateTimeout, "Timeout for pre-start update download (range 5s\u201310m)")
 	flag.DurationVar(&hcfg.revalidateInterval, "revalidate-interval", config.DefaultRevalidateInterval, "Token re-validation interval (0 to disable)")
 	flag.StringVar(&hcfg.authMode, "auth-mode", "legacy", "Authentication mode: legacy (default) or oauth")
 	flag.DurationVar(&hcfg.oauthCacheTTL, "oauth-cache-ttl", config.DefaultOAuthCacheTTL, "OAuth token cache TTL")
@@ -333,6 +333,14 @@ func runHTTP(ctx context.Context, hcfg *httpConfig) error {
 	}
 	if cfg.RevalidateInterval > config.MaxRevalidateInterval {
 		return fmt.Errorf("--revalidate-interval %s exceeds maximum of %s", cfg.RevalidateInterval, config.MaxRevalidateInterval)
+	}
+	if cfg.AutoUpdateTimeout > 0 {
+		if cfg.AutoUpdateTimeout < config.MinAutoUpdateTimeout {
+			return fmt.Errorf("--auto-update-timeout %s is below minimum of %s", cfg.AutoUpdateTimeout, config.MinAutoUpdateTimeout)
+		}
+		if cfg.AutoUpdateTimeout > config.MaxAutoUpdateTimeout {
+			return fmt.Errorf("--auto-update-timeout %s exceeds maximum of %s", cfg.AutoUpdateTimeout, config.MaxAutoUpdateTimeout)
+		}
 	}
 
 	toolutil.SetUploadConfig(cfg.UploadMaxFileSize)
@@ -826,6 +834,7 @@ func startAutoUpdate(ctx context.Context, cfg *config.Config) {
 		Mode:           mode,
 		Repository:     cfg.AutoUpdateRepo,
 		Interval:       cfg.AutoUpdateInterval,
+		Timeout:        cfg.AutoUpdateTimeout,
 		CurrentVersion: version,
 	})
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -334,13 +334,11 @@ func runHTTP(ctx context.Context, hcfg *httpConfig) error {
 	if cfg.RevalidateInterval > config.MaxRevalidateInterval {
 		return fmt.Errorf("--revalidate-interval %s exceeds maximum of %s", cfg.RevalidateInterval, config.MaxRevalidateInterval)
 	}
-	if cfg.AutoUpdateTimeout > 0 {
-		if cfg.AutoUpdateTimeout < config.MinAutoUpdateTimeout {
-			return fmt.Errorf("--auto-update-timeout %s is below minimum of %s", cfg.AutoUpdateTimeout, config.MinAutoUpdateTimeout)
-		}
-		if cfg.AutoUpdateTimeout > config.MaxAutoUpdateTimeout {
-			return fmt.Errorf("--auto-update-timeout %s exceeds maximum of %s", cfg.AutoUpdateTimeout, config.MaxAutoUpdateTimeout)
-		}
+	if cfg.AutoUpdateTimeout < config.MinAutoUpdateTimeout {
+		return fmt.Errorf("--auto-update-timeout %s is below minimum of %s", cfg.AutoUpdateTimeout, config.MinAutoUpdateTimeout)
+	}
+	if cfg.AutoUpdateTimeout > config.MaxAutoUpdateTimeout {
+		return fmt.Errorf("--auto-update-timeout %s exceeds maximum of %s", cfg.AutoUpdateTimeout, config.MaxAutoUpdateTimeout)
 	}
 
 	toolutil.SetUploadConfig(cfg.UploadMaxFileSize)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -71,6 +71,7 @@ type httpConfig struct {
 	autoUpdate         string
 	autoUpdateRepo     string
 	autoUpdateInterval time.Duration
+	autoUpdateTimeout  time.Duration
 	revalidateInterval time.Duration
 	authMode           string
 	oauthCacheTTL      time.Duration
@@ -104,6 +105,7 @@ func main() {
 	flag.StringVar(&hcfg.autoUpdate, "auto-update", "true", "Auto-update mode: true (auto-apply), check (log-only), false (disabled)")
 	flag.StringVar(&hcfg.autoUpdateRepo, "auto-update-repo", config.DefaultAutoUpdateRepo, "GitHub repository for update checks")
 	flag.DurationVar(&hcfg.autoUpdateInterval, "auto-update-interval", config.DefaultAutoUpdateInterval, "How often to check for updates")
+	flag.DurationVar(&hcfg.autoUpdateTimeout, "auto-update-timeout", config.DefaultAutoUpdateTimeout, "Timeout for pre-start update download (default 60s)")
 	flag.DurationVar(&hcfg.revalidateInterval, "revalidate-interval", config.DefaultRevalidateInterval, "Token re-validation interval (0 to disable)")
 	flag.StringVar(&hcfg.authMode, "auth-mode", "legacy", "Authentication mode: legacy (default) or oauth")
 	flag.DurationVar(&hcfg.oauthCacheTTL, "oauth-cache-ttl", config.DefaultOAuthCacheTTL, "OAuth token cache TTL")
@@ -195,6 +197,7 @@ FLAGS
   -auto-update string       Auto-update mode: true|check|false (default "true")
   -auto-update-repo string  GitLab project path for updates (default "%s")
   -auto-update-interval dur How often to check for updates (default %s)
+  -auto-update-timeout dur  Timeout for pre-start update download (default %s)
   -auth-mode string         Authentication mode: legacy|oauth (default "legacy")
   -oauth-cache-ttl duration OAuth token cache TTL (default %s, min %s, max %s)
 
@@ -208,6 +211,7 @@ ENVIRONMENT VARIABLES (stdio mode)
   AUTO_UPDATE               Auto-update mode: true/check/false (default true)
   AUTO_UPDATE_REPO          GitLab project for updates (default %s)
   AUTO_UPDATE_INTERVAL      Periodic check interval (default 1h, HTTP mode)
+  AUTO_UPDATE_TIMEOUT       Pre-start download timeout (default 60s, range 5s–10m)
   LOG_LEVEL                 Logging: debug/info/warn/error (default info)
 
 JSON CONFIGURATION EXAMPLES
@@ -247,6 +251,7 @@ JSON CONFIGURATION EXAMPLES
 		projectAuthor, projectDepartment, projectRepository,
 		config.DefaultMaxHTTPClients, config.DefaultSessionTimeout,
 		config.DefaultAutoUpdateRepo, config.DefaultAutoUpdateInterval,
+		config.DefaultAutoUpdateTimeout,
 		config.DefaultOAuthCacheTTL, config.MinOAuthCacheTTL, config.MaxOAuthCacheTTL,
 		config.DefaultAutoUpdateRepo)
 }
@@ -303,6 +308,7 @@ func runHTTP(ctx context.Context, hcfg *httpConfig) error {
 		AutoUpdate:         hcfg.autoUpdate,
 		AutoUpdateRepo:     hcfg.autoUpdateRepo,
 		AutoUpdateInterval: hcfg.autoUpdateInterval,
+		AutoUpdateTimeout:  hcfg.autoUpdateTimeout,
 		AuthMode:           hcfg.authMode,
 		OAuthCacheTTL:      hcfg.oauthCacheTTL,
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -371,7 +371,7 @@ func TestRunWithContext_SuccessHTTPIndividualTools(t *testing.T) {
 			addr:           ":0",
 			gitlabURL:      srv.URL,
 			metaTools:      false,
-			maxHTTPClients: config.DefaultMaxHTTPClients,
+			maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 			sessionTimeout: config.DefaultSessionTimeout,
 		})
 	}()
@@ -403,7 +403,7 @@ func TestRunWithContext_SuccessHTTPMetaTools(t *testing.T) {
 			addr:           ":0",
 			gitlabURL:      srv.URL,
 			metaTools:      true,
-			maxHTTPClients: config.DefaultMaxHTTPClients,
+			maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 			sessionTimeout: config.DefaultSessionTimeout,
 		})
 	}()
@@ -486,7 +486,7 @@ func TestRunWithContext_HTTPMissingURL(t *testing.T) {
 	err := runWithContext(context.Background(), &httpConfig{
 		addr:           ":0",
 		gitlabURL:      "",
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {
@@ -512,7 +512,7 @@ func TestRunWithContext_HTTPInvalidURL(t *testing.T) {
 			err := runWithContext(context.Background(), &httpConfig{
 				addr:           ":0",
 				gitlabURL:      tt.url,
-				maxHTTPClients: config.DefaultMaxHTTPClients,
+				maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 				sessionTimeout: config.DefaultSessionTimeout,
 			})
 			if err == nil {
@@ -909,7 +909,7 @@ func TestRunHTTP_AutoUpdateDisabled(t *testing.T) {
 			addr:           ":0",
 			gitlabURL:      srv.URL,
 			metaTools:      false,
-			maxHTTPClients: config.DefaultMaxHTTPClients,
+			maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 			sessionTimeout: config.DefaultSessionTimeout,
 			autoUpdate:     "false",
 		})
@@ -1000,7 +1000,7 @@ func TestRunHTTP_AutoUpdateInvalid(t *testing.T) {
 			addr:           ":0",
 			gitlabURL:      srv.URL,
 			metaTools:      false,
-			maxHTTPClients: config.DefaultMaxHTTPClients,
+			maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 			sessionTimeout: config.DefaultSessionTimeout,
 			autoUpdate:     "bogus",
 		})
@@ -1492,7 +1492,7 @@ func TestRunHTTP_InvalidAuthMode(t *testing.T) {
 	err := runHTTP(context.Background(), &httpConfig{
 		gitlabURL:      "https://gitlab.example.com",
 		authMode:       "saml",
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {
@@ -1510,7 +1510,7 @@ func TestRunHTTP_OAuthCacheTTL_BelowMin(t *testing.T) {
 		gitlabURL:      "https://gitlab.example.com",
 		authMode:       "oauth",
 		oauthCacheTTL:  10 * time.Second,
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {
@@ -1528,7 +1528,7 @@ func TestRunHTTP_OAuthCacheTTL_AboveMax(t *testing.T) {
 		gitlabURL:      "https://gitlab.example.com",
 		authMode:       "oauth",
 		oauthCacheTTL:  5 * time.Hour,
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {
@@ -1544,7 +1544,7 @@ func TestRunHTTP_OAuthCacheTTL_AboveMax(t *testing.T) {
 func TestRunHTTP_SessionTimeoutExceedsMax(t *testing.T) {
 	err := runHTTP(context.Background(), &httpConfig{
 		gitlabURL:      "https://gitlab.example.com",
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: 48 * time.Hour,
 	})
 	if err == nil {
@@ -1577,7 +1577,7 @@ func TestRunHTTP_RevalidateIntervalExceedsMax(t *testing.T) {
 func TestRunHTTP_MissingGitLabURL(t *testing.T) {
 	err := runHTTP(context.Background(), &httpConfig{
 		gitlabURL:      "",
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {
@@ -1585,11 +1585,62 @@ func TestRunHTTP_MissingGitLabURL(t *testing.T) {
 	}
 }
 
+// TestRunHTTP_AutoUpdateTimeoutBelowMin verifies that runHTTP rejects an
+// auto-update-timeout below the minimum threshold.
+func TestRunHTTP_AutoUpdateTimeoutBelowMin(t *testing.T) {
+	err := runHTTP(context.Background(), &httpConfig{
+		gitlabURL:         "https://gitlab.example.com",
+		maxHTTPClients:    config.DefaultMaxHTTPClients,
+		sessionTimeout:    config.DefaultSessionTimeout,
+		autoUpdateTimeout: 1 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected error for auto-update-timeout below minimum")
+	}
+	if !strings.Contains(err.Error(), "auto-update-timeout") {
+		t.Errorf("error should mention auto-update-timeout, got: %v", err)
+	}
+}
+
+// TestRunHTTP_AutoUpdateTimeoutAboveMax verifies that runHTTP rejects an
+// auto-update-timeout above the maximum threshold.
+func TestRunHTTP_AutoUpdateTimeoutAboveMax(t *testing.T) {
+	err := runHTTP(context.Background(), &httpConfig{
+		gitlabURL:         "https://gitlab.example.com",
+		maxHTTPClients:    config.DefaultMaxHTTPClients,
+		sessionTimeout:    config.DefaultSessionTimeout,
+		autoUpdateTimeout: 15 * time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected error for auto-update-timeout above maximum")
+	}
+	if !strings.Contains(err.Error(), "auto-update-timeout") {
+		t.Errorf("error should mention auto-update-timeout, got: %v", err)
+	}
+}
+
+// TestRunHTTP_AutoUpdateTimeoutZero verifies that runHTTP rejects an
+// explicit zero timeout instead of silently falling back to a default.
+func TestRunHTTP_AutoUpdateTimeoutZero(t *testing.T) {
+	err := runHTTP(context.Background(), &httpConfig{
+		gitlabURL:         "https://gitlab.example.com",
+		maxHTTPClients:    config.DefaultMaxHTTPClients,
+		sessionTimeout:    config.DefaultSessionTimeout,
+		autoUpdateTimeout: 0,
+	})
+	if err == nil {
+		t.Fatal("expected error for zero auto-update-timeout")
+	}
+	if !strings.Contains(err.Error(), "auto-update-timeout") {
+		t.Errorf("error should mention auto-update-timeout, got: %v", err)
+	}
+}
+
 // TestRunHTTP_InvalidGitLabURL verifies that runHTTP rejects a non-HTTP(S) URL.
 func TestRunHTTP_InvalidGitLabURL(t *testing.T) {
 	err := runHTTP(context.Background(), &httpConfig{
 		gitlabURL:      "ftp://gitlab.example.com",
-		maxHTTPClients: config.DefaultMaxHTTPClients,
+		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
 	if err == nil {

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -341,7 +341,7 @@ The Makefile `release` target generates all of these automatically.
 | `autoupdate: repository is required` | `AUTO_UPDATE_REPO` is empty | Set `AUTO_UPDATE_REPO` or use the default |
 | `autoupdate: creating GitHub source` | Network error reaching GitHub API | Verify network connectivity to `github.com` |
 | `autoupdate: detecting latest release` | No releases in repository, or token lacks permissions | Create a release or check token permissions |
-| `autoupdate: startup check failed` | Network timeout (10s limit at startup) | Check network connectivity; the server starts anyway |
+| `autoupdate: startup check failed` | Network timeout (`AUTO_UPDATE_TIMEOUT`, default 60s) | Check network connectivity or increase `AUTO_UPDATE_TIMEOUT`; the server starts anyway |
 | `autoupdate: could not initialize periodic updater` | Missing required config in HTTP mode | Verify `--auto-update-repo` flag and network connectivity |
 | Update detected but not applied | Mode is `check` | Set `AUTO_UPDATE=true` to enable automatic application |
 | Server still runs old version after update (Windows) | Binary replaced but process not restarted | Restart the server process (Windows only — Unix re-execs automatically) |

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -67,7 +67,7 @@ Accepted aliases: `1`/`yes` for true, `0`/`no` for false. The value is case-inse
 
 ### Stdio Mode
 
-When running as a stdio server (the default), auto-update runs as a **pre-start update** with a 15-second timeout, **before** the MCP server logic begins:
+When running as a stdio server (the default), auto-update runs as a **pre-start update** with a configurable timeout (default: 60 seconds), **before** the MCP server logic begins:
 
 1. `CleanupOldBinary()` — remove leftover `.old` file from a previous update.
 2. Parse `AUTO_UPDATE` mode from environment variables.
@@ -129,6 +129,7 @@ When running as an HTTP server (`--http`), auto-update runs as a **background pe
 | `AUTO_UPDATE` | `true` | Update mode: `true`, `check`, or `false` |
 | `AUTO_UPDATE_REPO` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
 | `AUTO_UPDATE_INTERVAL` | `1h` | Check interval (used by HTTP mode periodic checks) |
+| `AUTO_UPDATE_TIMEOUT` | `60s` | Timeout for pre-start update download (range: 5s–10m) |
 
 Auto-update uses the GitHub Releases API via `AUTO_UPDATE_REPO`. It does **not** use the user's `GITLAB_URL`, `GITLAB_TOKEN`, or `GITLAB_SKIP_TLS_VERIFY`.
 
@@ -139,6 +140,7 @@ Auto-update uses the GitHub Releases API via `AUTO_UPDATE_REPO`. It does **not**
 | `--auto-update` | `true` | Update mode: `true`, `check`, or `false` |
 | `--auto-update-repo` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
 | `--auto-update-interval` | `1h` | Interval between periodic update checks |
+| `--auto-update-timeout` | `60s` | Timeout for pre-start update download (range: 5s–10m) |
 
 Auto-update uses the GitHub Releases API, so `--gitlab-url` and `--skip-tls-verify` do **not** affect auto-update behaviour.
 
@@ -162,6 +164,12 @@ Custom repository and fast check interval:
 AUTO_UPDATE=true
 AUTO_UPDATE_REPO=my-group/my-project
 AUTO_UPDATE_INTERVAL=15m
+```
+
+Increase the download timeout for slow connections:
+
+```env
+AUTO_UPDATE_TIMEOUT=120s
 ```
 
 HTTP mode with custom settings:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -55,6 +55,7 @@ When run without flags and a `GITLAB_TOKEN` is set, the server starts in **stdio
 | `-auto-update` | string | `true` | Auto-update mode: `true` (auto-apply), `check` (log-only), `false` (disabled) |
 | `-auto-update-repo` | string | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for update release assets |
 | `-auto-update-interval` | duration | `1h` | How often to check for new releases (HTTP mode periodic checks) |
+| `-auto-update-timeout` | duration | `60s` | Timeout for pre-start update download (range: 5s–10m) |
 
 ---
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -77,6 +77,7 @@ These variables configure the HTTP server pool when running in HTTP mode. In std
 | `AUTO_UPDATE` | `true` | Update mode: `true` (download and apply), `check` (log only), `false` (disabled) |
 | `AUTO_UPDATE_REPO` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
 | `AUTO_UPDATE_INTERVAL` | `1h` | Periodic update check interval (HTTP mode background checks) |
+| `AUTO_UPDATE_TIMEOUT` | `60s` | Pre-start download timeout (range: 5s–10m) |
 
 > **Note**: Auto-update uses the GitHub Releases API via `AUTO_UPDATE_REPO`. See [Auto-Update](auto-update.md) for details.
 
@@ -131,6 +132,7 @@ In HTTP mode, configuration comes from CLI flags instead of environment variable
 | `AUTO_UPDATE` | `--auto-update` | |
 | `AUTO_UPDATE_REPO` | `--auto-update-repo` | |
 | `AUTO_UPDATE_INTERVAL` | `--auto-update-interval` | |
+| `AUTO_UPDATE_TIMEOUT` | `--auto-update-timeout` | |
 
 ---
 

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -67,14 +67,15 @@ type Config struct {
 	Mode           Mode          // Update behavior (auto, check, disabled)
 	Repository     string        // GitHub repository slug (e.g. "jmrplens/gitlab-mcp-server")
 	Interval       time.Duration // Check interval for HTTP mode periodic checks
+	Timeout        time.Duration // Timeout for individual update checks (default 30s if zero)
 	CurrentVersion string        // Running binary version (semver without "v" prefix)
 }
 
 // String returns a redacted representation of Config to prevent accidental
 // token leakage via fmt.Print, log, or %v formatting.
 func (c Config) String() string {
-	return fmt.Sprintf("Config{Mode:%s Repository:%s Interval:%s CurrentVersion:%s}",
-		c.Mode, c.Repository, c.Interval, c.CurrentVersion)
+	return fmt.Sprintf("Config{Mode:%s Repository:%s Interval:%s Timeout:%s CurrentVersion:%s}",
+		c.Mode, c.Repository, c.Interval, c.Timeout, c.CurrentVersion)
 }
 
 // GoString implements [fmt.GoStringer] to prevent token leakage via %#v formatting.
@@ -273,7 +274,11 @@ func (u *Updater) safePeriodicCheckOnce(ctx context.Context) {
 
 // periodicCheckOnce performs a single update check cycle, logging the result.
 func (u *Updater) periodicCheckOnce(ctx context.Context) {
-	checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	timeout := u.cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	info, available, err := u.CheckForUpdate(checkCtx)

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -601,6 +601,24 @@ func TestPeriodicCheckOnce_Error(t *testing.T) {
 	// No panic — the "check failed" log branch was exercised.
 }
 
+// TestPeriodicCheckOnce_ExplicitTimeout verifies that when Config.Timeout
+// is set explicitly, periodicCheckOnce uses it instead of the 30s default.
+func TestPeriodicCheckOnce_ExplicitTimeout(t *testing.T) {
+	src := &mockSource{releases: nil}
+	u := NewUpdaterWithSource(Config{
+		Mode:           ModeAuto,
+		Repository:     "group/project",
+		CurrentVersion: "1.0.0",
+		Interval:       50 * time.Millisecond,
+		Timeout:        90 * time.Second,
+	}, src)
+
+	ctx := t.Context()
+
+	u.periodicCheckOnce(ctx)
+	// No panic — the explicit timeout path was exercised.
+}
+
 // TestPeriodicCheckOnce_ModeCheck verifies that in check-only mode,
 // an available update is logged but not applied.
 func TestPeriodicCheckOnce_ModeCheck(t *testing.T) {
@@ -1209,6 +1227,7 @@ func TestConfig_String(t *testing.T) {
 		Mode:           ModeAuto,
 		Repository:     "group/project",
 		Interval:       1 * time.Hour,
+		Timeout:        90 * time.Second,
 		CurrentVersion: "1.0.0",
 	}
 	s := cfg.String()
@@ -1220,6 +1239,9 @@ func TestConfig_String(t *testing.T) {
 	}
 	if !strings.Contains(s, "1.0.0") {
 		t.Errorf("String() = %q, want to contain version", s)
+	}
+	if !strings.Contains(s, "1m30s") {
+		t.Errorf("String() = %q, want to contain timeout value", s)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,9 @@ const (
 const (
 	DefaultAutoUpdateRepo     = "jmrplens/gitlab-mcp-server"
 	DefaultAutoUpdateInterval = 1 * time.Hour
-	DefaultAutoUpdateTimeout  = 15 * time.Second
+	DefaultAutoUpdateTimeout  = 60 * time.Second
+	MinAutoUpdateTimeout      = 5 * time.Second
+	MaxAutoUpdateTimeout      = 10 * time.Minute
 )
 
 // Config holds all configuration values for the MCP server.
@@ -150,6 +152,12 @@ func Load() (*Config, error) {
 	autoUpdateTimeout, err := parseDuration(os.Getenv("AUTO_UPDATE_TIMEOUT"), DefaultAutoUpdateTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("invalid AUTO_UPDATE_TIMEOUT value: %w", err)
+	}
+	if autoUpdateTimeout < MinAutoUpdateTimeout {
+		return nil, fmt.Errorf("AUTO_UPDATE_TIMEOUT %s is below minimum of %s", autoUpdateTimeout, MinAutoUpdateTimeout)
+	}
+	if autoUpdateTimeout > MaxAutoUpdateTimeout {
+		return nil, fmt.Errorf("AUTO_UPDATE_TIMEOUT %s exceeds maximum of %s", autoUpdateTimeout, MaxAutoUpdateTimeout)
 	}
 
 	autoUpdate := os.Getenv("AUTO_UPDATE")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,12 +153,6 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid AUTO_UPDATE_TIMEOUT value: %w", err)
 	}
-	if autoUpdateTimeout < MinAutoUpdateTimeout {
-		return nil, fmt.Errorf("AUTO_UPDATE_TIMEOUT %s is below minimum of %s", autoUpdateTimeout, MinAutoUpdateTimeout)
-	}
-	if autoUpdateTimeout > MaxAutoUpdateTimeout {
-		return nil, fmt.Errorf("AUTO_UPDATE_TIMEOUT %s exceeds maximum of %s", autoUpdateTimeout, MaxAutoUpdateTimeout)
-	}
 
 	autoUpdate := os.Getenv("AUTO_UPDATE")
 	if autoUpdate == "" {
@@ -238,6 +232,14 @@ func (c *Config) validate() error {
 		}
 		if c.OAuthCacheTTL > MaxOAuthCacheTTL {
 			return fmt.Errorf("OAUTH_CACHE_TTL %s exceeds maximum of %s", c.OAuthCacheTTL, MaxOAuthCacheTTL)
+		}
+	}
+	if c.AutoUpdateTimeout != 0 {
+		if c.AutoUpdateTimeout < MinAutoUpdateTimeout {
+			return fmt.Errorf("AUTO_UPDATE_TIMEOUT %s is below minimum of %s", c.AutoUpdateTimeout, MinAutoUpdateTimeout)
+		}
+		if c.AutoUpdateTimeout > MaxAutoUpdateTimeout {
+			return fmt.Errorf("AUTO_UPDATE_TIMEOUT %s exceeds maximum of %s", c.AutoUpdateTimeout, MaxAutoUpdateTimeout)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -762,6 +762,41 @@ func TestValidate_OAuthCacheTTL(t *testing.T) {
 	}
 }
 
+// TestValidate_AutoUpdateTimeout verifies that validate enforces min/max bounds
+// on AutoUpdateTimeout when it is non-zero (covers HTTP-mode direct construction).
+func TestValidate_AutoUpdateTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		wantErr bool
+	}{
+		{name: "zero is valid (uses default)", timeout: 0, wantErr: false},
+		{name: "at minimum", timeout: MinAutoUpdateTimeout, wantErr: false},
+		{name: "at maximum", timeout: MaxAutoUpdateTimeout, wantErr: false},
+		{name: "between bounds", timeout: 2 * time.Minute, wantErr: false},
+		{name: "below minimum", timeout: 1 * time.Second, wantErr: true},
+		{name: "above maximum", timeout: 15 * time.Minute, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				GitLabURL:         "https://gitlab.example.com",
+				GitLabToken:       "test-token",
+				MaxHTTPClients:    1,
+				AutoUpdateTimeout: tt.timeout,
+			}
+			err := cfg.validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("validate() for AutoUpdateTimeout %v expected error, got nil", tt.timeout)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validate() for AutoUpdateTimeout %v unexpected error: %v", tt.timeout, err)
+			}
+		})
+	}
+}
+
 // TestLoad_AuthMode verifies AUTH_MODE env var parsing and defaults.
 func TestLoad_AuthMode(t *testing.T) {
 	t.Setenv("GITLAB_URL", testHTTPExampleURL)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -430,6 +430,58 @@ func TestLoad_AutoUpdateInterval(t *testing.T) {
 	})
 }
 
+// TestLoad_AutoUpdateTimeout verifies AUTO_UPDATE_TIMEOUT env var parsing, default, and bounds.
+func TestLoad_AutoUpdateTimeout(t *testing.T) {
+	t.Setenv("GITLAB_URL", testHTTPExampleURL)
+	t.Setenv("GITLAB_TOKEN", "test")
+
+	t.Run(subtestDefault, func(t *testing.T) {
+		t.Setenv("AUTO_UPDATE_TIMEOUT", "")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf(fmtLoadErr, err)
+		}
+		if cfg.AutoUpdateTimeout != DefaultAutoUpdateTimeout {
+			t.Errorf("AutoUpdateTimeout = %v, want %v", cfg.AutoUpdateTimeout, DefaultAutoUpdateTimeout)
+		}
+	})
+
+	t.Run(subtestCustom, func(t *testing.T) {
+		t.Setenv("AUTO_UPDATE_TIMEOUT", "90s")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf(fmtLoadErr, err)
+		}
+		if cfg.AutoUpdateTimeout != 90*time.Second {
+			t.Errorf("AutoUpdateTimeout = %v, want 90s", cfg.AutoUpdateTimeout)
+		}
+	})
+
+	t.Run(subtestInvalid, func(t *testing.T) {
+		t.Setenv("AUTO_UPDATE_TIMEOUT", "not-a-duration")
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected error for invalid AUTO_UPDATE_TIMEOUT")
+		}
+	})
+
+	t.Run("below_minimum", func(t *testing.T) {
+		t.Setenv("AUTO_UPDATE_TIMEOUT", "1s")
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected error for AUTO_UPDATE_TIMEOUT below minimum")
+		}
+	})
+
+	t.Run("above_maximum", func(t *testing.T) {
+		t.Setenv("AUTO_UPDATE_TIMEOUT", "15m")
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected error for AUTO_UPDATE_TIMEOUT above maximum")
+		}
+	})
+}
+
 // TestValidate_URLFormat verifies that GITLAB_URL must have a valid scheme and host.
 func TestValidate_URLFormat(t *testing.T) {
 	tests := []struct {

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -217,6 +217,7 @@ When running in HTTP mode (`--http`), configuration uses CLI flags instead of en
 | `--auto-update`          | `true`                       | Auto-update mode                         |
 | `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | GitHub release repository                |
 | `--auto-update-interval` | `1h`                         | Periodic update check interval           |
+| `--auto-update-timeout`  | `60s`                        | Pre-start download timeout (5s–10m)      |
 | `--auth-mode`            | `legacy`                     | Authentication mode: `legacy` or `oauth` |
 | `--oauth-cache-ttl`      | `15m`                        | OAuth token identity cache TTL (1m–2h)   |
 

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -53,6 +53,7 @@ These control which MCP capabilities are enabled:
 | `AUTO_UPDATE`          | `true`                       | Auto-update behavior: `true` (apply on start), `check` (notify only), `false` (disabled) |
 | `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets                                                     |
 | `AUTO_UPDATE_INTERVAL` | `1h`                         | Periodic check interval (HTTP mode only)                                                 |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Pre-start download timeout (range: 5s–10m)                                               |
 
 ## Admin options
 

--- a/site/src/content/docs/es/configuration.mdx
+++ b/site/src/content/docs/es/configuration.mdx
@@ -217,6 +217,7 @@ Al ejecutar en modo HTTP (`--http`), la configuración usa flags de CLI en lugar
 | `--auto-update`          | `true`                       | Modo de autoactualización                              |
 | `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | Repositorio de GitHub para releases                    |
 | `--auto-update-interval` | `1h`                         | Intervalo de comprobación periódica de actualizaciones |
+| `--auto-update-timeout`  | `60s`                        | Tiempo de espera de descarga pre-inicio (5s–10m)      |
 | `--auth-mode`            | `legacy`                     | Modo de autenticación: `legacy` u `oauth`              |
 | `--oauth-cache-ttl`      | `15m`                        | TTL de caché de identidad OAuth (1m–2h)                |
 

--- a/site/src/content/docs/es/configuration.mdx
+++ b/site/src/content/docs/es/configuration.mdx
@@ -53,6 +53,7 @@ Estos controlan qué capacidades MCP están habilitadas:
 | `AUTO_UPDATE`          | `true`                       | Comportamiento de autoactualización: `true` (aplicar al iniciar), `check` (solo notificar), `false` (deshabilitado) |
 | `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | Repositorio de GitHub para los assets de release                                                                    |
 | `AUTO_UPDATE_INTERVAL` | `1h`                         | Intervalo de comprobación periódica (solo modo HTTP)                                                                |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Timeout de descarga pre-inicio (rango: 5s–10m)                                                                     |
 
 ## Opciones de administración
 

--- a/site/src/content/docs/es/operations/auto-update.mdx
+++ b/site/src/content/docs/es/operations/auto-update.mdx
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ### Verificación al inicio (modo stdio)
 
-En modo stdio (el predeterminado), la actualización automática se ejecuta como una **verificación previa al inicio** con un timeout de 15 segundos antes de que el servidor MCP comience a aceptar conexiones:
+En modo stdio (el predeterminado), la actualización automática se ejecuta como una **verificación previa al inicio** con un timeout configurable (por defecto: 60 segundos) antes de que el servidor MCP comience a aceptar conexiones:
 
 1. `CleanupOldBinary()` elimina cualquier archivo `.old` sobrante de una actualización anterior
 2. Verifica si hay una versión más nueva en GitHub
@@ -77,6 +77,7 @@ En modo HTTP, la actualización automática se ejecuta como una **verificación 
 | `AUTO_UPDATE`          | `true`                       | Modo de actualización: `true`, `check` o `false`                                  |
 | `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | Slug del repositorio de GitHub (`propietario/repo`) para assets del release       |
 | `AUTO_UPDATE_INTERVAL` | `1h`                         | Intervalo de verificación (usado por las verificaciones periódicas del modo HTTP) |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Timeout de descarga pre-inicio (rango: 5s–10m)                                   |
 
 ### Flags de CLI (modo http)
 
@@ -85,6 +86,7 @@ En modo HTTP, la actualización automática se ejecuta como una **verificación 
 | `--auto-update`          | `true`                       | Modo de actualización: `true`, `check` o `false`                            |
 | `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | Slug del repositorio de GitHub (`propietario/repo`) para assets del release |
 | `--auto-update-interval` | `1h`                         | Intervalo entre verificaciones periódicas de actualización                  |
+| `--auto-update-timeout`  | `60s`                        | Timeout de descarga pre-inicio (rango: 5s–10m)                             |
 
 :::note
 La actualización automática usa la **API de GitHub Releases** — es completamente independiente de tu configuración de GitLab. Tus ajustes de `GITLAB_URL`, `GITLAB_TOKEN` y `GITLAB_SKIP_TLS_VERIFY` no afectan a la actualización automática.

--- a/site/src/content/docs/operations/auto-update.mdx
+++ b/site/src/content/docs/operations/auto-update.mdx
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ### Startup check (stdio mode)
 
-In stdio mode (the default), auto-update runs as a **pre-start check** with a 15-second timeout before the MCP server begins accepting connections:
+In stdio mode (the default), auto-update runs as a **pre-start check** with a configurable timeout (default: 60 seconds) before the MCP server begins accepting connections:
 
 1. `CleanupOldBinary()` removes any leftover `.old` file from a previous update
 2. Checks for a newer release on GitHub
@@ -77,6 +77,7 @@ In HTTP mode, auto-update runs as a **background periodic check**:
 | `AUTO_UPDATE`          | `true`                       | Update mode: `true`, `check`, or `false`                 |
 | `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | GitHub repository slug (`owner/repo`) for release assets |
 | `AUTO_UPDATE_INTERVAL` | `1h`                         | Check interval (used by HTTP mode periodic checks)       |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Pre-start download timeout (range: 5s–10m)              |
 
 ### CLI flags (HTTP mode)
 
@@ -85,6 +86,7 @@ In HTTP mode, auto-update runs as a **background periodic check**:
 | `--auto-update`          | `true`                       | Update mode: `true`, `check`, or `false`                 |
 | `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | GitHub repository slug (`owner/repo`) for release assets |
 | `--auto-update-interval` | `1h`                         | Interval between periodic update checks                  |
+| `--auto-update-timeout`  | `60s`                        | Pre-start download timeout (range: 5s–10m)              |
 
 :::note
 Auto-update uses the **GitHub Releases API** — it is completely independent of your GitLab configuration. Your `GITLAB_URL`, `GITLAB_TOKEN`, and `GITLAB_SKIP_TLS_VERIFY` settings do not affect auto-update.


### PR DESCRIPTION
## Summary

Change `AUTO_UPDATE_TIMEOUT` default from **15s to 60s** and add min/max validation (5s–10m) to prevent download timeouts on slower connections when auto-updating the binary from GitHub Releases (~15 MB).

## Problem

The previous 15-second hard-coded timeout was insufficient for downloading the binary on slower or high-latency connections, causing `context deadline exceeded` errors during the pre-start auto-update check in stdio mode.

## Changes

### Code
- **`internal/config/config.go`** — Default changed to 60s, new `MinAutoUpdateTimeout` (5s) and `MaxAutoUpdateTimeout` (10m) constants, range validation
- **`cmd/server/main.go`** — New `autoUpdateTimeout` field in `httpConfig`, `--auto-update-timeout` CLI flag for HTTP mode, wired into config, `printHelp` updated
- **`internal/config/config_test.go`** — New `TestLoad_AutoUpdateTimeout` with 5 subtests (default, custom, invalid, below_minimum, above_maximum)

### Documentation (Markdown)
- `docs/auto-update.md` — Updated env/CLI tables, "15-second" → "60-second", added config example
- `docs/env-reference.md` — New `AUTO_UPDATE_TIMEOUT` row in both tables
- `docs/cli-reference.md` — New `-auto-update-timeout` row
- `CLAUDE.md` and `.github/copilot-instructions.md` — Env var and flag tables updated

### Documentation (Astro Starlight EN+ES)
- `site/src/content/docs/operations/auto-update.mdx` + ES variant
- `site/src/content/docs/configuration.mdx` + ES variant

## Verification

- `go vet` ✅
- `go test ./internal/config/ -count=1` ✅ (all tests pass including 5 new subtests)
- `golangci-lint run` ✅
- `markdownlint-cli2` ✅

## Summary by Sourcery

Make the auto-update timeout configurable with sensible defaults and bounds, and document the new configuration surfaces across code and docs.

New Features:
- Introduce configurable AUTO_UPDATE_TIMEOUT via env var and --auto-update-timeout CLI flag for HTTP mode, defaulting to 60 seconds.

Enhancements:
- Adjust the default auto-update timeout from 15 seconds to 60 seconds and enforce minimum/maximum bounds (5s–10m) during configuration loading.

Documentation:
- Update markdown and Astro Starlight (EN/ES) documentation, including env/CLI references and configuration guides, to describe the new auto-update timeout option and its default/range.

Tests:
- Add configuration tests for AUTO_UPDATE_TIMEOUT covering default, custom value, invalid format, and out-of-range values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-update timeouts are now configurable via AUTO_UPDATE_TIMEOUT or --auto-update-timeout (default 60s, range 5s–10m).
  * Periodic update checks now respect the configured timeout.

* **Documentation**
  * Updated configuration, CLI reference, and auto-update docs (including Spanish) to document the new timeout setting and examples.

* **Tests**
  * Added unit tests covering timeout parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->