### PR TITLE
fix: set annotations.Title on all meta-tools for smithery scoring

### DIFF
--- a/internal/tools/accessrequests/register.go
+++ b/internal/tools/accessrequests/register.go
@@ -159,7 +159,7 @@ Actions:
 - approve_group: Approve group access request. Params: group_id (required), user_id (required, int), access_level (optional, int)
 - deny_project: Deny project access request. Params: project_id (required), user_id (required, int)
 - deny_group: Deny group access request. Params: group_id (required), user_id (required, int)`,
-		Annotations: toolutil.DeriveAnnotations(routes),
+		Annotations: toolutil.DeriveAnnotationsWithTitle("gitlab_access_request", routes),
 		Icons:       toolutil.IconUser,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, toolutil.MakeMetaHandler("gitlab_access_request", routes, nil))

--- a/internal/tools/metatool.go
+++ b/internal/tools/metatool.go
@@ -74,9 +74,6 @@ func destructiveVoidAction[T any](client *gitlabclient.Client, fn func(ctx conte
 	return toolutil.DestructiveVoidAction(client, fn)
 }
 
-// readOnlyMetaAnnotations are for meta-tools with only list/get/search actions.
-var readOnlyMetaAnnotations = toolutil.ReadOnlyMetaAnnotations
-
 // makeMetaHandler creates a meta-tool handler using markdownForResult as the formatter.
 func makeMetaHandler(toolName string, routes actionMap) func(ctx context.Context, req *mcp.CallToolRequest, input MetaToolInput) (*mcp.CallToolResult, any, error) {
 	return toolutil.MakeMetaHandler(toolName, routes, markdownForResult)
@@ -90,7 +87,7 @@ func addMetaTool(server *mcp.Server, name, desc string, routes actionMap, icons 
 		Name:        name,
 		Title:       toolutil.TitleFromName(name),
 		Description: desc,
-		Annotations: toolutil.DeriveAnnotations(routes),
+		Annotations: toolutil.DeriveAnnotationsWithTitle(name, routes),
 		Icons:       icons,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, makeMetaHandler(name, routes))
@@ -103,7 +100,7 @@ func addReadOnlyMetaTool(server *mcp.Server, name, desc string, routes actionMap
 		Name:        name,
 		Title:       toolutil.TitleFromName(name),
 		Description: desc,
-		Annotations: readOnlyMetaAnnotations,
+		Annotations: toolutil.ReadOnlyMetaAnnotationsWithTitle(name),
 		Icons:       icons,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, makeMetaHandler(name, routes))

--- a/internal/tools/packages/register.go
+++ b/internal/tools/packages/register.go
@@ -210,7 +210,7 @@ Delete actions:
 - file_delete: Delete a single file from a package (irreversible). Params: project_id (required), package_id (required), package_file_id (required)
 
 Common workflow: list → publish_directory → publish_and_link (for release binaries)`,
-		Annotations: toolutil.DeriveAnnotations(routes),
+		Annotations: toolutil.DeriveAnnotationsWithTitle("gitlab_package", routes),
 		Icons:       toolutil.IconPackage,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, toolutil.MakeMetaHandler("gitlab_package", routes, nil))

--- a/internal/tools/runners/register.go
+++ b/internal/tools/runners/register.go
@@ -387,7 +387,7 @@ Controller tokens:
 - controller_token_create: controller_id*, description
 
 See also: gitlab_pipeline, gitlab_job`,
-		Annotations: toolutil.DeriveAnnotations(routes),
+		Annotations: toolutil.DeriveAnnotationsWithTitle("gitlab_runner", routes),
 		Icons:       toolutil.IconRunner,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, toolutil.MakeMetaHandler("gitlab_runner", routes, nil))

--- a/internal/tools/samplingtools/register.go
+++ b/internal/tools/samplingtools/register.go
@@ -331,7 +331,7 @@ All actions need project_id*. Additional params per action:
 
 NOT for raw data retrieval — use gitlab_merge_request, gitlab_issue, gitlab_pipeline.
 See also: gitlab_merge_request, gitlab_issue, gitlab_pipeline, gitlab_release`,
-		Annotations: toolutil.ReadOnlyMetaAnnotations,
+		Annotations: toolutil.ReadOnlyMetaAnnotationsWithTitle("gitlab_analyze"),
 		Icons:       toolutil.IconAnalytics,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, toolutil.MakeMetaHandler("gitlab_analyze", routes, metaMarkdownForResult))

--- a/internal/tools/search/register.go
+++ b/internal/tools/search/register.go
@@ -204,7 +204,7 @@ Returns: JSON with resource data. Lists include pagination (page, per_page, tota
 - snippets: query* (global only)
 
 See also: gitlab_project, gitlab_merge_request, gitlab_issue`,
-		Annotations: toolutil.ReadOnlyMetaAnnotations,
+		Annotations: toolutil.ReadOnlyMetaAnnotationsWithTitle("gitlab_search"),
 		Icons:       toolutil.IconSearch,
 		InputSchema: toolutil.MetaToolSchema(routes),
 	}, toolutil.MakeMetaHandler("gitlab_search", routes, markdownForResult))

--- a/internal/tools/testdata/tools_meta.json
+++ b/internal/tools/testdata/tools_meta.json
@@ -72,7 +72,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Access"
     }
   },
   {
@@ -182,7 +183,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Admin"
     }
   },
   {
@@ -223,7 +225,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Analyze"
     }
   },
   {
@@ -255,7 +258,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Attestation"
     }
   },
   {
@@ -289,7 +293,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Audit Event"
     }
   },
   {
@@ -328,7 +333,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Branch"
     }
   },
   {
@@ -360,7 +366,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "CI Catalog"
     }
   },
   {
@@ -403,7 +410,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "CI Variable"
     }
   },
   {
@@ -433,7 +441,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Compliance Policy"
     }
   },
   {
@@ -464,7 +473,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Custom Emoji"
     }
   },
   {
@@ -496,7 +506,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Dependency"
     }
   },
   {
@@ -608,7 +619,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Dora Metrics"
     }
   },
   {
@@ -640,7 +652,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Enterprise User"
     }
   },
   {
@@ -691,7 +704,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Environment"
     }
   },
   {
@@ -733,7 +747,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "External Status Check"
     }
   },
   {
@@ -771,7 +786,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Feature Flags"
     }
   },
   {
@@ -807,7 +823,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Geo"
     }
   },
   {
@@ -965,7 +982,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Group"
     }
   },
   {
@@ -997,7 +1015,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Group Scim"
     }
   },
   {
@@ -1088,7 +1107,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Issue"
     }
   },
   {
@@ -1141,7 +1161,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Job"
     }
   },
   {
@@ -1175,7 +1196,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Member Role"
     }
   },
   {
@@ -1256,7 +1278,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Merge Request"
     }
   },
   {
@@ -1288,7 +1311,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Merge Train"
     }
   },
   {
@@ -1319,7 +1343,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Model Registry"
     }
   },
   {
@@ -1369,7 +1394,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "MR Review"
     }
   },
   {
@@ -1421,7 +1447,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Package"
     }
   },
   {
@@ -1482,7 +1509,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Pipeline"
     }
   },
   {
@@ -1632,7 +1660,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Project"
     }
   },
   {
@@ -1664,7 +1693,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Project Alias"
     }
   },
   {
@@ -1704,7 +1734,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Release"
     }
   },
   {
@@ -1772,7 +1803,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Repository"
     }
   },
   {
@@ -1834,7 +1866,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Runner"
     }
   },
   {
@@ -1874,7 +1907,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Search"
     }
   },
   {
@@ -1905,7 +1939,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Security Finding"
     }
   },
   {
@@ -1967,7 +2002,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Snippet"
     }
   },
   {
@@ -2013,7 +2049,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Storage Move"
     }
   },
   {
@@ -2050,7 +2087,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Tag"
     }
   },
   {
@@ -2092,7 +2130,8 @@
       "destructiveHint": false,
       "idempotentHint": true,
       "openWorldHint": true,
-      "readOnlyHint": true
+      "readOnlyHint": true,
+      "title": "Template"
     }
   },
   {
@@ -2194,7 +2233,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "User"
     }
   },
   {
@@ -2230,7 +2270,8 @@
     },
     "annotations": {
       "destructiveHint": false,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Vulnerability"
     }
   },
   {
@@ -2264,7 +2305,8 @@
     },
     "annotations": {
       "destructiveHint": true,
-      "openWorldHint": true
+      "openWorldHint": true,
+      "title": "Wiki"
     }
   }
 ]

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -356,3 +356,17 @@ func DeriveAnnotations(routes ActionMap) *mcp.ToolAnnotations {
 	cp := *NonDestructiveMetaAnnotations
 	return &cp
 }
+
+// DeriveAnnotationsWithTitle returns route-derived annotations with Title set from the tool name.
+func DeriveAnnotationsWithTitle(name string, routes ActionMap) *mcp.ToolAnnotations {
+	a := DeriveAnnotations(routes)
+	a.Title = TitleFromName(name)
+	return a
+}
+
+// ReadOnlyMetaAnnotationsWithTitle returns a copy of ReadOnlyMetaAnnotations with Title set.
+func ReadOnlyMetaAnnotationsWithTitle(name string) *mcp.ToolAnnotations {
+	a := *ReadOnlyMetaAnnotations
+	a.Title = TitleFromName(name)
+	return &a
+}

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -755,6 +755,63 @@ func TestDeriveAnnotations_EmptyMap(t *testing.T) {
 	}
 }
 
+// TestDeriveAnnotationsWithTitle verifies that DeriveAnnotationsWithTitle
+// delegates to DeriveAnnotations and sets Title from the tool name.
+// Covers both destructive and non-destructive route maps.
+func TestDeriveAnnotationsWithTitle(t *testing.T) {
+	noop := func(_ context.Context, _ map[string]any) (any, error) { return nil, nil }
+
+	t.Run("non-destructive routes set title and DestructiveHint=false", func(t *testing.T) {
+		routes := ActionMap{"list": Route(noop), "get": Route(noop)}
+		ann := DeriveAnnotationsWithTitle("gitlab_branch", routes)
+		if ann.Title != "Branch" {
+			t.Errorf("Title = %q, want %q", ann.Title, "Branch")
+		}
+		if ann.DestructiveHint == nil || *ann.DestructiveHint != false {
+			t.Error("non-destructive routes should produce DestructiveHint=false")
+		}
+	})
+
+	t.Run("destructive routes set title and DestructiveHint=true", func(t *testing.T) {
+		routes := ActionMap{"list": Route(noop), "delete": DestructiveRoute(noop)}
+		ann := DeriveAnnotationsWithTitle("gitlab_merge_request", routes)
+		if ann.Title != "Merge Request" {
+			t.Errorf("Title = %q, want %q", ann.Title, "Merge Request")
+		}
+		if ann.DestructiveHint == nil || *ann.DestructiveHint != true {
+			t.Error("destructive routes should produce DestructiveHint=true")
+		}
+	})
+}
+
+// TestReadOnlyMetaAnnotationsWithTitle verifies that ReadOnlyMetaAnnotationsWithTitle
+// returns a copy of ReadOnlyMetaAnnotations with the Title set and all read-only
+// fields preserved. Also verifies the shared singleton is not mutated.
+func TestReadOnlyMetaAnnotationsWithTitle(t *testing.T) {
+	ann := ReadOnlyMetaAnnotationsWithTitle("gitlab_search")
+
+	if ann.Title != "Search" {
+		t.Errorf("Title = %q, want %q", ann.Title, "Search")
+	}
+	if !ann.ReadOnlyHint {
+		t.Error("ReadOnlyHint should be true")
+	}
+	if !ann.IdempotentHint {
+		t.Error("IdempotentHint should be true")
+	}
+	if ann.DestructiveHint == nil || *ann.DestructiveHint != false {
+		t.Error("DestructiveHint should be false")
+	}
+	if ann.OpenWorldHint == nil || *ann.OpenWorldHint != true {
+		t.Error("OpenWorldHint should be true")
+	}
+
+	// Verify the shared singleton was not mutated.
+	if ReadOnlyMetaAnnotations.Title != "" {
+		t.Errorf("singleton Title mutated to %q, want empty", ReadOnlyMetaAnnotations.Title)
+	}
+}
+
 // TestMakeMetaHandler_MetadataDestructive_TriggersConfirm verifies that
 // MakeMetaHandler reads route.Destructive to determine confirmation requirement.
 func TestMakeMetaHandler_MetadataDestructive_TriggersConfirm(t *testing.T) {

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -759,7 +759,7 @@ func TestDeriveAnnotations_EmptyMap(t *testing.T) {
 // delegates to DeriveAnnotations and sets Title from the tool name.
 // Covers both destructive and non-destructive route maps.
 func TestDeriveAnnotationsWithTitle(t *testing.T) {
-	noop := func(_ context.Context, _ map[string]any) (any, error) { return nil, nil }
+	noop := func(_ context.Context, _ map[string]any) (any, error) { return struct{}{}, nil }
 
 	t.Run("non-destructive routes set title and DestructiveHint=false", func(t *testing.T) {
 		routes := ActionMap{"list": Route(noop), "get": Route(noop)}


### PR DESCRIPTION
## Summary

All 29 meta-tools now include `ToolAnnotations.Title` matching the top-level `Tool.Title`. Previously, only `Tool.Title` was set but `Annotations.Title` was empty, which smithery.ai quality scoring penalizes under the **Naming** category.

## Changes

### `internal/tools/metatool.go`
- `addMetaTool()`: now sets `annotations.Title = toolutil.TitleFromName(name)` on the derived annotations
- `addReadOnlyMetaTool()`: copies `readOnlyMetaAnnotations`, sets `Title`, passes pointer to copy (avoids mutating the shared preset)

### 5 delegated `RegisterMeta()` sub-packages
Each now has a local helper that copies the base annotations and sets `Title`:
- `internal/tools/samplingtools/register.go` → `analyzeAnnotations()` for `gitlab_analyze`
- `internal/tools/search/register.go` → `searchAnnotations()` for `gitlab_search`
- `internal/tools/runners/register.go` → `runnerAnnotations()` for `gitlab_runner`
- `internal/tools/accessrequests/register.go` → `accessRequestAnnotations()` for `gitlab_access_request`
- `internal/tools/packages/register.go` → `packageAnnotations()` for `gitlab_package`

## Verification

- `go build ./...` ✅
- `go test -count=1` on all affected packages ✅
- `TestRegisterAll_ToolAnnotations` ✅
- `TestAllSubPackagesRegistered` ✅
- `make analyze-fix` ✅
- Deployed to Fly.io ✅

## Summary by Sourcery

Ensure all meta-tools propagate their display titles into tool annotations for consistent naming and external scoring.

Enhancements:
- Set ToolAnnotations.Title for all generic and read-only meta-tools to match their Tool.Title values.
- Introduce per-subpackage helpers to derive annotations with titles for access request, package, runner, sampling, and search meta-tools, avoiding mutation of shared base annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tool metadata annotations now include explicit, title-aware information so tools display consistent titles in metadata.
* **Chores**
  * Tool metadata JSON entries updated to include title fields for many tools.
* **Tests**
  * Added unit tests validating the new title-aware annotation helpers behave correctly and preserve prior hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->