### PR TITLE
feat: Open Plugins compatibility (.plugin/plugin.json + .mcp.json)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,35 +115,37 @@ jobs:
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
 
-      - name: Commit updated server.json to main
+      - name: Commit updated server.json and plugin.json to main
         env:
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/server.json" -q '.sha')
-          gh api "repos/${GITHUB_REPOSITORY}/contents/server.json" \
-            -X PUT \
-            -f message="chore: update server.json SHA256 hashes for v${VERSION}" \
-            -f content="$(base64 -w0 server.json)" \
-            -f sha="$FILE_SHA" \
-            -f branch="main"
 
-      - name: Commit updated .plugin/plugin.json to main
-        env:
-          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          if [ ! -f .plugin/plugin.json ]; then
-            echo "::notice::.plugin/plugin.json not found, skipping"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git fetch origin main
+          git checkout main
+
+          # Re-apply updates on top of latest main (the script is idempotent
+          # and reads checksums.txt + version, so re-running produces the
+          # same result as the artifact built earlier in this job).
+          bash scripts/update-server-json-sha.sh dist/checksums.txt "${VERSION}"
+
+          git add server.json
+          [ -f .plugin/plugin.json ] && git add .plugin/plugin.json
+
+          if git diff --cached --quiet; then
+            echo "::notice::No manifest changes to commit"
             exit 0
           fi
-          FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.plugin/plugin.json" -q '.sha')
-          gh api "repos/${GITHUB_REPOSITORY}/contents/.plugin/plugin.json" \
-            -X PUT \
-            -f message="chore: update .plugin/plugin.json version for v${VERSION}" \
-            -f content="$(base64 -w0 .plugin/plugin.json)" \
-            -f sha="$FILE_SHA" \
-            -f branch="main"
+
+          git commit -m "chore: update manifests for v${VERSION}
+
+          Updates server.json (MCP Registry) and .plugin/plugin.json
+          (Open Plugins) with version ${VERSION} and pinned SHA256 hashes."
+          git push origin main
 
   docker:
     name: Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,23 @@ jobs:
             -f sha="$FILE_SHA" \
             -f branch="main"
 
+      - name: Commit updated .plugin/plugin.json to main
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ ! -f .plugin/plugin.json ]; then
+            echo "::notice::.plugin/plugin.json not found, skipping"
+            exit 0
+          fi
+          FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/.plugin/plugin.json" -q '.sha')
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.plugin/plugin.json" \
+            -X PUT \
+            -f message="chore: update .plugin/plugin.json version for v${VERSION}" \
+            -f content="$(base64 -w0 .plugin/plugin.json)" \
+            -f sha="$FILE_SHA" \
+            -f branch="main"
+
   docker:
     name: Docker
     runs-on: ubuntu-latest

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,39 @@
+{
+    "mcpServers": {
+        "gitlab": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "GITLAB_URL",
+                "-e",
+                "GITLAB_TOKEN",
+                "-e",
+                "GITLAB_SKIP_TLS_VERIFY",
+                "-e",
+                "META_TOOLS",
+                "-e",
+                "GITLAB_ENTERPRISE",
+                "-e",
+                "GITLAB_READ_ONLY",
+                "-e",
+                "GITLAB_SAFE_MODE",
+                "-e",
+                "LOG_LEVEL",
+                "ghcr.io/jmrplens/gitlab-mcp-server:latest"
+            ],
+            "env": {
+                "GITLAB_URL": "${GITLAB_URL}",
+                "GITLAB_TOKEN": "${GITLAB_TOKEN}",
+                "GITLAB_SKIP_TLS_VERIFY": "${GITLAB_SKIP_TLS_VERIFY:-false}",
+                "META_TOOLS": "${META_TOOLS:-true}",
+                "GITLAB_ENTERPRISE": "${GITLAB_ENTERPRISE:-false}",
+                "GITLAB_READ_ONLY": "${GITLAB_READ_ONLY:-false}",
+                "GITLAB_SAFE_MODE": "${GITLAB_SAFE_MODE:-false}",
+                "LOG_LEVEL": "${LOG_LEVEL:-info}"
+            }
+        }
+    }
+}

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://open-plugins.com/schemas/plugin.schema.json",
+    "name": "gitlab-mcp-server",
+    "version": "1.2.1",
+    "description": "GitLab MCP server exposing 1000 GitLab REST API and GraphQL operations as MCP tools for AI assistants. Includes 32 base / 47 enterprise meta-tools, 24 resources, 38 prompts, 17 completion types and 6 MCP capabilities (logging, progress, roots, sampling, elicitation, completions).",
+    "author": {
+        "name": "Jose M. Requena Plens",
+        "url": "https://github.com/jmrplens"
+    },
+    "homepage": "https://jmrplens.github.io/gitlab-mcp-server/",
+    "repository": "https://github.com/jmrplens/gitlab-mcp-server",
+    "license": "MIT",
+    "logo": "https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/site/src/assets/logo-light.svg",
+    "keywords": [
+        "mcp",
+        "gitlab",
+        "model-context-protocol",
+        "ai",
+        "llm",
+        "devops",
+        "ci-cd",
+        "merge-requests",
+        "issues",
+        "pipelines",
+        "code-review",
+        "graphql",
+        "rest-api"
+    ],
+    "mcpServers": "./.mcp.json"
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,31 @@ See [Meta-Tools](meta-tools.md) for the full reference.
 
 ---
 
+## Alternative: Open Plugins (Cursor / Claude Code)
+
+The repository ships an [Open Plugins](https://open-plugins.com/) v1.0.0 manifest (`.plugin/plugin.json` + `.mcp.json`) so the server can be installed in a single step on conformant hosts:
+
+```bash
+/plugin install jmrplens/gitlab-mcp-server
+```
+
+The bundled `.mcp.json` runs the published Docker image `ghcr.io/jmrplens/gitlab-mcp-server:latest`, so [Docker](https://docs.docker.com/get-docker/) must be installed. The host passes these environment variables through to the container:
+
+| Variable                 | Required | Description                                              |
+| ------------------------ | -------- | -------------------------------------------------------- |
+| `GITLAB_URL`             | Yes      | GitLab instance URL                                      |
+| `GITLAB_TOKEN`           | Yes      | Personal Access Token                                    |
+| `GITLAB_SKIP_TLS_VERIFY` | No       | `true` for self-signed certs (default `false`)           |
+| `META_TOOLS`             | No       | Group tools per domain (default `true`)                  |
+| `GITLAB_ENTERPRISE`      | No       | Enable Premium/Ultimate tools (default `false`)          |
+| `GITLAB_READ_ONLY`       | No       | Disable mutating tools (default `false`)                 |
+| `GITLAB_SAFE_MODE`       | No       | Preview mutating tool inputs (default `false`)           |
+| `LOG_LEVEL`              | No       | `debug`, `info`, `warn`, `error` (default `info`)        |
+
+The Open Plugins spec starts every entry in `.mcp.json` automatically and does not support runtime variants, so the manifest ships with a single Docker entry. To use the native binary instead, edit the local copy of `.mcp.json` (typically under `.agents/plugins/gitlab-mcp-server/`) after installation and replace `command` / `args` with the path to the binary downloaded from [GitHub Releases](https://github.com/jmrplens/gitlab-mcp-server/releases/latest).
+
+---
+
 ## Alternative: Manual Configuration
 
 If you prefer not to use the wizard, create a `.env` file next to the binary:

--- a/scripts/update-server-json-sha.sh
+++ b/scripts/update-server-json-sha.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
-# Update server.json with version, version-pinned download URLs,
-# and SHA256 hashes from GoReleaser's checksums.txt.
+# Update server.json (MCP Registry manifest) and .plugin/plugin.json
+# (Open Plugins manifest) with the release version, version-pinned download
+# URLs, and SHA256 hashes from GoReleaser's checksums.txt.
 #
 # Usage: update-server-json-sha.sh <checksums-file> <version>
 #
-# Steps:
+# Steps for server.json:
 #   1. Sets top-level .version to the given version
 #   2. Sets .packages[].version to the given version
 #   3. Pins .packages[].identifier URLs to /releases/download/v<version>/,
 #      handling both /releases/latest/download/ and prior /releases/download/vX.Y.Z/
 #   4. Sets .fileSha256 for each package matching a checksum entry
+#
+# Steps for .plugin/plugin.json:
+#   5. Sets top-level .version to the given version (if file exists)
 
 set -euo pipefail
 
 CHECKSUMS_FILE="${1:?Usage: $0 <checksums-file> <version>}"
 VERSION="${2:?Usage: $0 <checksums-file> <version>}"
 SERVER_JSON="server.json"
+PLUGIN_JSON=".plugin/plugin.json"
 
 if [[ ! -f "$CHECKSUMS_FILE" ]]; then
   echo "ERROR: checksums file not found: $CHECKSUMS_FILE" >&2
@@ -75,4 +80,12 @@ echo "Updated $updated of $total package entries"
 if [[ "$updated" -eq 0 ]]; then
   echo "WARNING: no checksums matched any package identifier" >&2
   exit 1
+fi
+
+# 5. Update Open Plugins manifest version (if present)
+if [[ -f "$PLUGIN_JSON" ]]; then
+  jq --arg v "$VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.$$.json && mv tmp.$$.json "$PLUGIN_JSON"
+  echo "$PLUGIN_JSON version set to $VERSION"
+else
+  echo "NOTE: $PLUGIN_JSON not found, skipping Open Plugins manifest update"
 fi

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -73,6 +73,50 @@ El asistente:
 El asistente de configuración es compatible con VS Code, Claude Desktop, Cursor y Claude Code. Para otros clientes, usa la configuración manual a continuación.
 :::
 
+## Instalar como Open Plugin (Cursor / Claude Code)
+
+Este repositorio incluye un manifest [Open Plugins](https://open-plugins.com/) v1.0.0 (`.plugin/plugin.json`) para que el servidor se pueda instalar en un solo paso en cualquier host compatible (Cursor, Claude Code, OpenCode):
+
+```bash
+# Cursor / Claude Code (cuando lo soporte tu versión)
+/plugin install jmrplens/gitlab-mcp-server
+```
+
+El plugin usa la imagen Docker publicada `ghcr.io/jmrplens/gitlab-mcp-server:latest` mediante `docker run -i --rm`, por lo que necesitas [Docker](https://docs.docker.com/get-docker/) instalado y en ejecución.
+
+### Variables de entorno requeridas
+
+El host debe proporcionar estas variables antes de habilitar el plugin:
+
+| Variable | Obligatoria | Descripción |
+|---|---|---|
+| `GITLAB_URL` | Sí | URL de la instancia GitLab (p. ej. `https://gitlab.example.com`) |
+| `GITLAB_TOKEN` | Sí | Personal Access Token (`glpat-...`) |
+| `GITLAB_SKIP_TLS_VERIFY` | No | `true` para certificados autofirmados (por defecto `false`) |
+| `META_TOOLS` | No | `true` para herramientas agrupadas, `false` individuales (por defecto `true`) |
+| `GITLAB_ENTERPRISE` | No | `true` para habilitar herramientas Premium/Ultimate (por defecto `false`) |
+| `GITLAB_READ_ONLY` | No | `true` para deshabilitar herramientas de escritura (por defecto `false`) |
+| `GITLAB_SAFE_MODE` | No | `true` para previsualizar entradas de herramientas mutantes (por defecto `false`) |
+| `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (por defecto `info`) |
+
+### ¿Prefieres binario nativo en lugar de Docker?
+
+La spec de Open Plugins arranca automáticamente cada entrada de `.mcp.json`, así que la configuración incluida usa Docker por portabilidad. Si prefieres el binario nativo, instala el plugin y después edita la copia local de `.mcp.json` (normalmente en `.agents/plugins/gitlab-mcp-server/`) para sustituir el `command` / `args` de Docker por la ruta al binario que hayas descargado desde [GitHub Releases](https://github.com/jmrplens/gitlab-mcp-server/releases/latest):
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "/usr/local/bin/gitlab-mcp-server",
+      "env": {
+        "GITLAB_URL": "${GITLAB_URL}",
+        "GITLAB_TOKEN": "${GITLAB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
 ## Configuración manual
 
 Si prefieres configurar manualmente, elige tu cliente de IA:

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -73,6 +73,50 @@ The wizard will:
 The setup wizard supports VS Code, Claude Desktop, Cursor, and Claude Code. For other clients, use the manual configuration below.
 :::
 
+## Install as an Open Plugin (Cursor / Claude Code)
+
+This repository ships an [Open Plugins](https://open-plugins.com/) v1.0.0 manifest (`.plugin/plugin.json`) so the server can be installed in a single step on any conformant host (Cursor, Claude Code, OpenCode):
+
+```bash
+# Cursor / Claude Code (when supported by your version)
+/plugin install jmrplens/gitlab-mcp-server
+```
+
+The plugin uses the published Docker image `ghcr.io/jmrplens/gitlab-mcp-server:latest` via `docker run -i --rm`, so you need [Docker](https://docs.docker.com/get-docker/) installed and running.
+
+### Required environment
+
+The host must provide these variables before enabling the plugin:
+
+| Variable | Required | Description |
+|---|---|---|
+| `GITLAB_URL` | Yes | GitLab instance URL (e.g. `https://gitlab.example.com`) |
+| `GITLAB_TOKEN` | Yes | Personal Access Token (`glpat-...`) |
+| `GITLAB_SKIP_TLS_VERIFY` | No | `true` for self-signed certs (default `false`) |
+| `META_TOOLS` | No | `true` for grouped tools, `false` for individual (default `true`) |
+| `GITLAB_ENTERPRISE` | No | `true` to enable Premium/Ultimate tools (default `false`) |
+| `GITLAB_READ_ONLY` | No | `true` to disable mutating tools (default `false`) |
+| `GITLAB_SAFE_MODE` | No | `true` to preview mutating tool inputs (default `false`) |
+| `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error` (default `info`) |
+
+### Prefer a native binary instead of Docker?
+
+The Open Plugins spec runs every entry in `.mcp.json` automatically, so the bundled config uses Docker for portability. If you prefer the native binary, install the plugin and then edit the local copy of `.mcp.json` after installation (typically under `.agents/plugins/gitlab-mcp-server/`) to replace the Docker `command` / `args` with a path to the platform binary you downloaded from [GitHub Releases](https://github.com/jmrplens/gitlab-mcp-server/releases/latest):
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "/usr/local/bin/gitlab-mcp-server",
+      "env": {
+        "GITLAB_URL": "${GITLAB_URL}",
+        "GITLAB_TOKEN": "${GITLAB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
 ## Manual configuration
 
 If you prefer to configure manually, choose your AI client:


### PR DESCRIPTION
Adds Open Plugins (open-plugins.com) v1.0.0 compatibility so the MCP server can be installed in one step on conformant hosts (Cursor, Claude Code, OpenCode) and listed via Cursor Directory's fast-track plugin submission.

## Changes

### New files
- `.plugin/plugin.json` — Open Plugins manifest with name, version, description, author, repository, license, logo, keywords, and pointer to `.mcp.json`
- `.mcp.json` — single MCP server entry running `ghcr.io/jmrplens/gitlab-mcp-server:latest` via `docker run -i --rm` with passthrough of all 8 standard configuration env vars

### Release pipeline
- `scripts/update-server-json-sha.sh`: extended to also bump `.plugin/plugin.json` version on release
- `.github/workflows/release.yml`: replaced two separate Contents-API commits with a single git CLI commit that updates `server.json` and `.plugin/plugin.json` together (one commit per release on main, instead of two)

### Documentation
- `docs/getting-started.md`, `site/src/content/docs/getting-started.mdx` (EN), `site/src/content/docs/es/getting-started.mdx` (ES): added 'Open Plugins' install section with the `/plugin install jmrplens/gitlab-mcp-server` one-liner, environment variable table, Docker requirement note, and instructions for swapping the bundled Docker entry for a native binary after installation.

## Why Docker?

The Open Plugins spec runs every entry in `.mcp.json` automatically and does not support runtime variants — so the manifest ships with a single Docker entry for portability. Users who prefer the native binary can edit the local copy of `.mcp.json` after installation (documented in getting-started).

## Validation
- `pnpm install` + `pnpm run format:check` + `pnpm run eslint` + `pnpm run build` + `pnpm run html-validate` all pass
- JSON validated with python json.tool
- YAML validated with python yaml.safe_load
- bash -n on the release script

No skills, agents, rules or hooks are bundled — this plugin distributes the MCP server only.

## Summary by Sourcery

Add Open Plugins compatibility and align release automation to update both MCP and Open Plugins manifests together.

New Features:
- Provide an Open Plugins v1.0.0 manifest and bundled .mcp.json so the MCP server can be installed as a one-step plugin on compatible hosts.

Enhancements:
- Extend the release script to bump the Open Plugins manifest version alongside server.json using checksums from GoReleaser.
- Update the release workflow to commit and push manifest changes to main in a single git commit instead of multiple Contents API updates.

Documentation:
- Document Open Plugins installation, configuration, and Docker vs native binary usage in English and Spanish getting-started guides and the main getting-started documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Open Plugins support for GitLab integration with Cursor/Claude Code, enabling streamlined plugin installation.

* **Documentation**
  * Updated installation guides with new Open Plugins setup instructions and environment variable configuration details.
  * Added Docker runtime documentation and native binary installation alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->