### PR TITLE
feat(release): publish images to Docker Hub + add Cline/Roo Code to README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   GO_VERSION: "1.26.2"
   REGISTRY: ghcr.io
   IMAGE_NAME: jmrplens/gitlab-mcp-server
+  DOCKERHUB_IMAGE: jmrplens/gitlab-mcp-server
 
 jobs:
   e2e:
@@ -166,6 +167,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        id: dockerhub-login
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN not set — skipping Docker Hub publish."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.dockerhub-login.outputs.skip == 'false'
+        uses: docker/login-action@v4
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: docker/build-push-action@v7
         id: docker-push
         with:
@@ -177,11 +198,19 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ steps.dockerhub-login.outputs.skip == 'false' && format('docker.io/{0}:{1}', env.DOCKERHUB_IMAGE, steps.version.outputs.version) || '' }}
+            ${{ steps.dockerhub-login.outputs.skip == 'false' && format('docker.io/{0}:latest', env.DOCKERHUB_IMAGE) || '' }}
 
-      - name: Sign Docker image
+      - name: Sign Docker image (ghcr.io)
         run: |
           cosign sign --yes \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.docker-push.outputs.digest }}
+
+      - name: Sign Docker image (Docker Hub)
+        if: steps.dockerhub-login.outputs.skip == 'false'
+        run: |
+          cosign sign --yes \
+            docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
 
   fly-deploy:
     name: Fly.io Deploy

--- a/README.md
+++ b/README.md
@@ -239,6 +239,52 @@ Add to `.kiro/settings/mcp.json`:
 
 </details>
 
+<details>
+<summary><strong>Cline</strong></summary>
+
+Open the Cline sidebar in VS Code → click the MCP servers icon → **Edit Global MCP**, or edit `cline_mcp_settings.json` directly:
+
+- **macOS**: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- **Linux**: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- **Windows**: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "/path/to/gitlab-mcp-server",
+      "env": {
+        "GITLAB_URL": "https://gitlab.example.com",
+        "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Roo Code</strong></summary>
+
+Open the Roo Code sidebar in VS Code → MCP servers icon → **Edit Global MCP** (or **Edit Project MCP** to create `.roo/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "/path/to/gitlab-mcp-server",
+      "env": {
+        "GITLAB_URL": "https://gitlab.example.com",
+        "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 ### 3. Verify
 
 Open your AI client and try:
@@ -324,7 +370,7 @@ Meta-tool summary:
 | **Elicitation** | 4 interactive creation wizards |
 | **Roots** | Workspace root tracking |
 
-Tested with: VS Code + GitHub Copilot, Claude Desktop, Claude Code, Cursor, Windsurf, JetBrains IDEs, Zed, Kiro.
+Tested with: VS Code + GitHub Copilot, Claude Desktop, Claude Code, Cursor, Windsurf, JetBrains IDEs, Zed, Kiro, Cline, Roo Code.
 
 See the full [Compatibility Matrix](https://jmrplens.github.io/gitlab-mcp-server/compatibility/) for detailed client support.
 


### PR DESCRIPTION
## Docker Hub publish

The `docker` release job now pushes the **same image digest** to both `ghcr.io` and `docker.io/jmrplens/gitlab-mcp-server`:

- Tags published per registry: `<version>` and `latest`.
- Cosign signs the image on both registries.
- Logs in to Docker Hub only when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets are set; otherwise skips with a warning (no failure on forks or after token rotation).

Secrets `DOCKERHUB_USERNAME=jmrplens` and `DOCKERHUB_TOKEN` are already configured on the repository.

## Cline / Roo Code in README

Added <details> configuration blocks for Cline and Roo Code mirroring the existing client entries (these were already documented in `docs/ide-configuration.md` and the Astro site, just not in the README quick-start). Updated the 'Tested with' line accordingly.

## Summary by Sourcery

Publish release Docker images to both GitHub Container Registry and Docker Hub while expanding IDE quick-start documentation for additional MCP clients.

New Features:
- Publish release images to Docker Hub under the jmrplens/gitlab-mcp-server repository with versioned and latest tags.
- Document configuration steps for using the GitLab MCP server with Cline and Roo Code clients in the README.

Enhancements:
- Ensure the same image digest is pushed and cosign-signed on both ghcr.io and Docker Hub, with Docker Hub publishing made optional based on available secrets.
- Update the README supported-clients list to include Cline and Roo Code.