### PR TITLE
chore(deps): bump actions/download-artifact from 7 to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: coverage
       - name: SonarCloud Scan


### PR DESCRIPTION
Supersedes #45 (dependabot).

Bumps the only `actions/download-artifact` reference (`.github/workflows/ci.yml` line 59, sonarcloud job) from `@v7` to `@v8`.

### v8 release notes (relevant)

- **ESM migration** — transparent to callers.
- **digest-mismatch defaults to `error`** (secure-by-default; previously warning).
- Skips decompression for non-zipped downloads based on `Content-Type` header. New `skip-decompress` opt-in.

### Why no other changes are needed

The sonarcloud job downloads a single `coverage.out` file uploaded by `actions/upload-artifact@v7`. Per the v8 release notes, v8 is forward-compatible with artifacts produced by v7 uploads, and our payload is a plain text file (no zip handling involved on our side).

Closes #45.

## Summary by Sourcery

CI:
- Bump actions/download-artifact from v7 to v8 in the CI workflow used for SonarCloud coverage analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to use the latest version of the artifact download tool for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->