### PR TITLE
docs(site): fix version drift and capability classification in user docs

### DIFF
--- a/site/src/content/docs/capabilities/icons.mdx
+++ b/site/src/content/docs/capabilities/icons.mdx
@@ -5,7 +5,7 @@ description: SVG icon gallery for all tools, resources, and prompts
 
 import { Badge } from "@astrojs/starlight/components";
 
-GitLab MCP Server assigns **50 unique SVG icons** to all ~1,050 individual tools, 36 meta-tools, 4 resources, and 38 prompts. Icons are stored as base64-encoded SVG data URIs (`data:image/svg+xml;base64,...`) with `Sizes: ["any"]` for scalability, and help MCP clients render recognizable UI elements for each GitLab domain.
+GitLab MCP Server assigns **50 unique SVG icons** to all 1006 individual tools, 32 meta-tools (47 with enterprise), 44 resources, and 38 prompts. Icons are stored as base64-encoded SVG data URIs (`data:image/svg+xml;base64,...`) with `Sizes: ["any"]` for scalability, and help MCP clients render recognizable UI elements for each GitLab domain.
 
 ## Design principles
 

--- a/site/src/content/docs/capabilities/overview.mdx
+++ b/site/src/content/docs/capabilities/overview.mdx
@@ -3,7 +3,7 @@ title: MCP Capabilities
 description: Protocol capabilities implemented by GitLab MCP Server
 ---
 
-GitLab MCP Server implements 7 MCP protocol capabilities that enhance how AI assistants interact with GitLab. These capabilities go beyond basic tool calling to provide richer, more intelligent interactions.
+GitLab MCP Server implements **6 MCP protocol capabilities** that enhance how AI assistants interact with GitLab, plus **icon metadata** on every tool, resource, and prompt. These go beyond basic tool calling to provide richer, more intelligent interactions.
 
 ## Capabilities overview
 

--- a/site/src/content/docs/es/capabilities/icons.mdx
+++ b/site/src/content/docs/es/capabilities/icons.mdx
@@ -5,7 +5,7 @@ description: Galería de iconos SVG para todas las herramientas, recursos y prom
 
 import { Badge } from "@astrojs/starlight/components";
 
-GitLab MCP Server asigna **50 iconos SVG únicos** a las ~1.050 herramientas individuales, 36 meta-herramientas, 4 recursos y 38 prompts. Los iconos se almacenan como SVG codificados en base64 (`data:image/svg+xml;base64,...`) con `Sizes: ["any"]` para escalabilidad, y ayudan a los clientes MCP a mostrar elementos de interfaz reconocibles para cada dominio de GitLab.
+GitLab MCP Server asigna **50 iconos SVG únicos** a las 1006 herramientas individuales, 32 meta-herramientas (47 con enterprise), 44 recursos y 38 prompts. Los iconos se almacenan como SVG codificados en base64 (`data:image/svg+xml;base64,...`) con `Sizes: ["any"]` para escalabilidad, y ayudan a los clientes MCP a mostrar elementos de interfaz reconocibles para cada dominio de GitLab.
 
 ## Principios de diseño
 

--- a/site/src/content/docs/es/capabilities/overview.mdx
+++ b/site/src/content/docs/es/capabilities/overview.mdx
@@ -3,7 +3,7 @@ title: Capacidades MCP
 description: Capacidades del protocolo implementadas por GitLab MCP Server
 ---
 
-GitLab MCP Server implementa 7 capacidades del protocolo MCP que mejoran la forma en que los asistentes de IA interactúan con GitLab. Estas capacidades van más allá de las llamadas básicas a herramientas para proporcionar interacciones más ricas e inteligentes.
+GitLab MCP Server implementa **6 capacidades del protocolo MCP** que mejoran la forma en que los asistentes de IA interactúan con GitLab, más **metadatos de iconos** en cada herramienta, recurso y prompt. Van más allá de las llamadas básicas a herramientas para proporcionar interacciones más ricas e inteligentes.
 
 ## Resumen de capacidades
 

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -48,9 +48,9 @@ El servidor traduce estas solicitudes en llamadas a la API de GitLab, las ejecut
 
 | Característica                  | Detalles                                                                                                                                       |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **28+ Meta-herramientas**       | Herramientas agrupadas por dominio que cubren proyectos, issues, merge requests, pipelines, CI/CD, wikis, releases y más                       |
+| **32 Meta-herramientas**       | Herramientas agrupadas por dominio que cubren proyectos, issues, merge requests, pipelines, CI/CD, wikis, releases y más                       |
 | **11 Herramientas de análisis** | Análisis impulsado por IA mediante MCP sampling — diagnóstico de fallos en pipelines, revisión de seguridad de MRs, detección de deuda técnica |
-| **24 Recursos MCP**             | Endpoints de datos de solo lectura para información de proyectos, perfiles de usuario, configuración del servidor                              |
+| **44 Recursos MCP**             | Endpoints de datos de solo lectura para información de proyectos, perfiles de usuario, configuración del servidor                              |
 | **38 Prompts MCP**              | Plantillas de prompts predefinidas para informes, auditorías, análisis entre proyectos y flujos de trabajo en equipo                           |
 | **Modo HTTP multiusuario**      | Despliega como servidor compartido con aislamiento por token para entornos de equipo                                                           |
 | **GitLab CE y EE**              | Compatible con Community Edition y Enterprise Edition, incluyendo instancias autoalojadas                                                      |

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -48,9 +48,9 @@ The server translates these requests into GitLab API calls, executes them, and r
 
 | Feature                  | Details                                                                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| **28+ Meta-Tools**       | Domain-grouped tools covering projects, issues, merge requests, pipelines, CI/CD, wikis, releases, and more     |
+| **32 Meta-Tools**       | Domain-grouped tools covering projects, issues, merge requests, pipelines, CI/CD, wikis, releases, and more     |
 | **11 Analysis Tools**    | AI-powered analysis via MCP sampling — pipeline failure diagnosis, MR security review, technical debt detection |
-| **24 MCP Resources**     | Read-only data endpoints for project info, user profiles, server configuration                                  |
+| **44 MCP Resources**     | Read-only data endpoints for project info, user profiles, server configuration                                  |
 | **38 MCP Prompts**       | Pre-built prompt templates for reports, audits, cross-project analysis, and team workflows                      |
 | **Multi-User HTTP Mode** | Deploy as a shared server with per-token isolation for team environments                                        |
 | **GitLab CE & EE**       | Compatible with both Community Edition and Enterprise Edition, including self-hosted instances                  |


### PR DESCRIPTION
## Summary

Audited all 54 user-facing Astro Starlight docs (`site/src/content/docs/`, EN+ES) against canonical project facts in `CLAUDE.md` and `.github/copilot-instructions.md`. This PR fixes the **factual inaccuracies** identified — the larger feature-coverage gaps (Phase 3) are tracked in a follow-up plan.

## Changes

### Phase 1 — Version drift

| File | Before | After |
| ---- | ------ | ----- |
| `index.mdx` (EN+ES) | `28+ Meta-Tools` | `32 Meta-Tools` |
| `index.mdx` (EN+ES) | `24 MCP Resources` | `44 MCP Resources` |
| `capabilities/icons.mdx` (EN+ES) | `~1,050 tools, 36 meta-tools, 4 resources` | `1006 tools, 32 meta-tools (47 enterprise), 44 resources` |

### Phase 2 — Capability classification

| File | Before | After |
| ---- | ------ | ----- |
| `capabilities/overview.mdx` (EN+ES) | `7 MCP protocol capabilities` | `6 MCP protocol capabilities, plus icon metadata` |

Per MCP spec and `CLAUDE.md`, icons are metadata on tools/resources/prompts — not a 7th protocol capability. The `/capabilities/icons/` page remains for user discoverability.

## Validation

- `pnpm run build` (Astro): ✅ 57 pages built successfully, all internal links valid
- `markdownlint-cli2` on all 6 changed files: ✅ no new lint errors introduced (pre-existing issues unrelated to this PR)

## Out of scope

Phase 3 (new content pages — Docker/fly.io deployment, signed binary verification, OAuth user guide, multi-instance `GITLAB-URL` header, IDE-specific setup expansion, safe-mode usage, rate-limiting strategy) requires substantial new content with EN+ES mirrors. Tracked in local audit plan; recommend a separate PR per topic.

## Summary by Sourcery

Align user-facing documentation with current GitLab MCP Server capabilities and counts across English and Spanish sites.

Documentation:
- Update EN/ES landing pages to reflect the current numbers of meta-tools and MCP resources.
- Revise EN/ES icon capability docs to reflect up-to-date counts of tools, meta-tools (including enterprise variants), resources, and prompts.
- Clarify EN/ES MCP capabilities overview to describe six protocol capabilities plus icon metadata rather than treating icons as a separate capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated inventory counts**: Meta-tools increased to 32, MCP Resources expanded to 44
* **Clarified icon metadata**: Documentation now explicitly states that icon metadata is provided for every tool, resource, and prompt
* **Capability count revised**: Reduced from 7 to 6 capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->