### PR TITLE
Fix MCP publisher asset download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           MCP_PUBLISHER_SHA256: ""  # If empty, signature verification is skipped; populate to enforce.
         run: |
           set -euo pipefail
-          TARBALL="mcp-publisher_${MCP_PUBLISHER_VERSION#v}_linux_amd64.tar.gz"
+          TARBALL="mcp-publisher_linux_amd64.tar.gz"
           URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${TARBALL}"
           echo "Downloading ${URL}"
           curl -fsSL --retry 3 -o "${TARBALL}" "${URL}"


### PR DESCRIPTION
## Summary
- Correct the MCP publisher tarball name used by the release workflow
- Keep the pinned publisher version while matching the actual registry release asset naming

## Validation
- Ran `git diff --check`
- Downloaded `https://github.com/modelcontextprotocol/registry/releases/download/v1.7.2/mcp-publisher_linux_amd64.tar.gz`
- Verified the tarball contains `mcp-publisher`

## Summary by Sourcery

Build:
- Update the release workflow tarball name to match the MCP publisher asset naming convention in the registry.