### PR TITLE
Refactor E2E suite foundations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,7 +130,7 @@ E2E tests run against a real GitLab instance via in-memory MCP transport (build 
 go test -v -tags e2e -timeout 300s ./test/e2e/suite/
 make test-e2e
 
-# Docker mode (ephemeral GitLab CE with CI runner)
+# Docker mode (ephemeral GitLab CE with CI runner and fixture service)
 docker compose -f test/e2e/docker-compose.yml up -d
 ./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh
 set -a && source test/e2e/.env.docker && set +a
@@ -148,6 +148,7 @@ go test -tags e2e -c -o /dev/null ./test/e2e/suite/  # Linux
 - Requires `.env` with `GITLAB_URL`, `GITLAB_TOKEN` (user needs create/delete project permissions)
 - Two sequential workflows: `TestFullWorkflow` (~174 subtests, individual tools) and `TestMetaToolWorkflow` (~151 subtests, meta-tools)
 - Covers: user, project CRUD, commits, branches, tags, releases, issues, labels, milestones, members, upload, MR lifecycle, notes, discussions, search, groups, pipelines, packages, wikis, CI variables, environments, issue links, deploy keys, snippets, pipeline schedules, badges, access tokens, award emoji, sampling, elicitation
+- Docker mode also writes `E2E_FIXTURE_URL` and `E2E_GITLAB_INTERNAL_URL` for deterministic webhook, custom emoji, and push mirror tests without public Internet dependencies
 - Not covered (needs Docker mode): pipeline CRUD (CI runner), job tools
 
 ### Build & Cross-Compilation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ gitlab-mcp-server/
 │   ├── oauth-app-setup.md       # Creating GitLab OAuth applications for MCP clients
 │   └── ide-configuration.md     # Per-IDE MCP JSON configuration (stdio, HTTP legacy, OAuth)
 ├── test/e2e/                    # End-to-end integration tests
-│   ├── docker-compose.yml       # Ephemeral GitLab CE + Runner for Docker mode
+│   ├── docker-compose.yml       # Ephemeral GitLab CE + Runner + fixture service for Docker mode
 │   ├── .env.docker              # Docker mode environment variables
 │   ├── README.md                # E2E documentation
 │   ├── scripts/                 # E2E provisioning scripts (setup, runner, wait)
@@ -190,7 +190,7 @@ go vet ./...                             # Static analysis
 # End-to-end tests (requires .env with GITLAB_URL, GITLAB_TOKEN)
 go test -v -tags e2e -timeout 300s ./test/e2e/suite/   # Run all e2e tests
 make test-e2e                                          # Same via Makefile
-make test-e2e-docker                                   # Ephemeral GitLab CE container (Docker, ~4 GB RAM)
+make test-e2e-docker                                   # Ephemeral GitLab CE + runner + fixture service (Docker, ~4 GB RAM)
 go test -tags e2e -c -o NUL ./test/e2e/suite/           # Compile-only check (Windows)
 go test -tags e2e -c -o /dev/null ./test/e2e/suite/     # Compile-only check (Linux)
 ```
@@ -530,7 +530,7 @@ go test -tags e2e -c -o NUL ./test/e2e/suite/       # Windows
 go test -tags e2e -c -o /dev/null ./test/e2e/suite/  # Linux
 ```
 
-**Docker mode** — ephemeral GitLab CE container with CI runner (enables pipeline/job tests):
+**Docker mode** — ephemeral GitLab CE container with CI runner and fixture service (enables pipeline/job tests and deterministic webhook/custom-emoji/mirror endpoints):
 
 ```bash
 docker compose -f test/e2e/docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,13 @@ test-e2e-docker:
 	  -- -tags e2e -timeout 1800s ./test/e2e/suite/ 2>&1 | tee $(E2E_REPORT_DIR)/e2e-docker-output.txt'; \
 	  echo $$? > $(E2E_REPORT_DIR)/e2e-docker-status
 	@echo "=== Tearing down ==="
-	docker compose -f test/e2e/docker-compose.yml down -v
-	@echo "=== E2E reports saved to $(E2E_REPORT_DIR)/ ==="
 	@status=$$(cat $(E2E_REPORT_DIR)/e2e-docker-status); \
+	  teardown_status=0; \
+	  docker compose -f test/e2e/docker-compose.yml down -v || teardown_status=$$?; \
+	  echo "=== E2E reports saved to $(E2E_REPORT_DIR)/ ==="; \
 	  rm -f $(E2E_REPORT_DIR)/e2e-docker-status; \
-	  if [ "$$status" -ne 0 ]; then exit "$$status"; fi
+	  if [ "$$status" -ne 0 ]; then exit "$$status"; fi; \
+	  if [ "$$teardown_status" -ne 0 ]; then exit "$$teardown_status"; fi
 
 ## coverage: run tests and generate HTML coverage report
 coverage: test

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ test-e2e:
 	@echo "         Tests create and delete projects, groups, users, and other resources."
 	@read -p "Are you sure you want to continue? [y/N] " confirm && [ "$$confirm" = "y" ] || { echo "Aborted."; exit 1; }
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
-	gotestsum \
+	bash -o pipefail -c 'gotestsum \
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-junit.xml \
 	  --jsonfile $(E2E_REPORT_DIR)/e2e-log.json \
-	  -- -tags e2e -timeout 120s ./test/e2e/suite/ 2>&1 | tee $(E2E_REPORT_DIR)/e2e-output.txt
+	  -- -tags e2e -timeout 120s ./test/e2e/suite/ 2>&1 | tee $(E2E_REPORT_DIR)/e2e-output.txt'
 
 ## test-e2e-docker: start ephemeral GitLab CE, run E2E tests, tear down
 test-e2e-docker:
@@ -131,14 +131,19 @@ test-e2e-docker:
 	./test/e2e/scripts/register-runner.sh http://localhost:8929
 	@echo "=== Running E2E tests ==="
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
-	set -a && . test/e2e/.env.docker && set +a && E2E_MODE=docker gotestsum \
+	@set +e; \
+	  bash -o pipefail -c 'set -a && . test/e2e/.env.docker && set +a && E2E_MODE=docker gotestsum \
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-docker-junit.xml \
 	  --jsonfile $(E2E_REPORT_DIR)/e2e-docker-log.json \
-	  -- -tags e2e -timeout 1800s ./test/e2e/suite/ 2>&1 | tee $(E2E_REPORT_DIR)/e2e-docker-output.txt || true
+	  -- -tags e2e -timeout 1800s ./test/e2e/suite/ 2>&1 | tee $(E2E_REPORT_DIR)/e2e-docker-output.txt'; \
+	  echo $$? > $(E2E_REPORT_DIR)/e2e-docker-status
 	@echo "=== Tearing down ==="
 	docker compose -f test/e2e/docker-compose.yml down -v
 	@echo "=== E2E reports saved to $(E2E_REPORT_DIR)/ ==="
+	@status=$$(cat $(E2E_REPORT_DIR)/e2e-docker-status); \
+	  rm -f $(E2E_REPORT_DIR)/e2e-docker-status; \
+	  if [ "$$status" -ne 0 ]; then exit "$$status"; fi
 
 ## coverage: run tests and generate HTML coverage report
 coverage: test

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -566,9 +566,7 @@ Or use the Makefile target that automates the full lifecycle:
 make test-e2e-docker
 ```
 
-Docker mode enables pipeline and job tests that require a CI runner.
-
-Tests that require GitLab to fetch public URLs or contact public Git remotes are gated behind the `external-network` capability. Set `E2E_EXTERNAL_NETWORK=true` only in environments with deterministic outbound access. Without that variable, Docker mode skips project webhook, push mirror, and custom emoji tests that depend on public network access.
+Docker mode enables pipeline and job tests that require a CI runner. It also starts an internal `e2e-fixture` HTTP service and configures GitLab to allow local outbound requests, so project webhook, push mirror, and custom emoji tests use deterministic in-network endpoints instead of public Internet access.
 
 #### Test Reports
 
@@ -607,7 +605,7 @@ The suite uses five MCP server/client pairs via `mcp.NewInMemoryTransports()`:
 | MCP capabilities     | Verifies logging, progress, roots, completions, sampling, elicitation, and safe mode |
 | Docker-only runner   | Exercises CI pipeline and job behavior with a registered runner |
 
-Latest Docker validation snapshot: `make test-e2e-docker` completed 1,142 tests with 4 external-network skips in 335.761 seconds on 2026-04-30. Test function counts and package coverage values above are unchanged by the external-network gating change.
+Latest Docker validation snapshot: `make test-e2e-docker` completed 1,166 tests with 0 skips, 0 failures, and 0 errors in 389.057 seconds on 2026-04-30. Test function counts and package coverage values above are unchanged by the fixture change.
 
 **Lifecycle covered:** user → project CRUD → commits → branches → tags → releases → issues → labels → milestones → members → upload → MR lifecycle → notes → discussions → search → groups → pipelines → packages → wikis → CI variables → environments → issue links → deploy keys → snippets → pipeline schedules → badges → access tokens → award emoji → sampling → elicitation → cleanup
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -568,6 +568,8 @@ make test-e2e-docker
 
 Docker mode enables pipeline and job tests that require a CI runner.
 
+Tests that require GitLab to fetch public URLs or contact public Git remotes are gated behind the `external-network` capability. Set `E2E_EXTERNAL_NETWORK=true` only in environments with deterministic outbound access. Without that variable, Docker mode skips project webhook, push mirror, and custom emoji tests that depend on public network access.
+
 #### Test Reports
 
 Both `make test-e2e` and `make test-e2e-docker` use [gotestsum](https://github.com/gotestyourself/gotestsum) to produce structured test reports in `dist/e2e-reports/`:
@@ -580,25 +582,32 @@ Both `make test-e2e` and `make test-e2e-docker` use [gotestsum](https://github.c
 
 Docker mode files use the `e2e-docker-` prefix. Reports are written to `dist/e2e-reports/` (gitignored via `dist/`).
 
+The Makefile targets run `gotestsum` through `tee` with `pipefail` so test failures propagate to the target exit code. `make test-e2e-docker` still tears down Docker containers and volumes before returning a non-zero status on failure.
+
 Install gotestsum via `make install-tools` or `go install gotest.tools/gotestsum@latest`.
 
 #### Test Architecture
 
-The suite uses 4 MCP server/client pairs via `mcp.NewInMemoryTransports()`:
+The suite uses five MCP server/client pairs via `mcp.NewInMemoryTransports()`:
 
-| Session            | Purpose                                    |
-| ------------------ | ------------------------------------------ |
-| `session`          | Individual tools (TestFullWorkflow)         |
-| `metaSession`      | Meta-tools (TestMetaToolWorkflow)           |
-| `samplingSession`  | Sampling tools with mock LLM handler       |
-| `elicitSession`    | Elicitation tools with mock user handler   |
+| Session       | Purpose                                    |
+| ------------- | ------------------------------------------ |
+| `individual`  | Individual GitLab tools                    |
+| `meta`        | Domain meta-tools and action dispatch      |
+| `sampling`    | Sampling tools with mock LLM handler       |
+| `elicitation` | Elicitation tools with mock user handler   |
+| `safeMode`    | Mutating tools wrapped as safe-mode previews |
 
 **Workflows:**
 
-| Workflow               | Subtests | Functions | Description                                         |
-| ---------------------- | -------: | --------: | --------------------------------------------------- |
-| TestFullWorkflow       |     ~174 |       191 | Individual tools through complete project lifecycle  |
-| TestMetaToolWorkflow   |     ~151 |       156 | Same operations via meta-tools (domain dispatch)     |
+| Area                 | Description                                               |
+| -------------------- | --------------------------------------------------------- |
+| Individual tools     | Exercises domain tools directly against real GitLab       |
+| Meta-tools           | Exercises domain action dispatch through meta-tools       |
+| MCP capabilities     | Verifies logging, progress, roots, completions, sampling, elicitation, and safe mode |
+| Docker-only runner   | Exercises CI pipeline and job behavior with a registered runner |
+
+Latest Docker validation snapshot: `make test-e2e-docker` completed 1,142 tests with 4 external-network skips in 335.761 seconds on 2026-04-30. Test function counts and package coverage values above are unchanged by the external-network gating change.
 
 **Lifecycle covered:** user → project CRUD → commits → branches → tags → releases → issues → labels → milestones → members → upload → MR lifecycle → notes → discussions → search → groups → pipelines → packages → wikis → CI variables → environments → issue links → deploy keys → snippets → pipeline schedules → badges → access tokens → award emoji → sampling → elicitation → cleanup
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -4,7 +4,7 @@
 > **Audience**: 🔧 Developers, contributors
 > **Prerequisites**: Go testing basics, understanding of httptest
 >
-> Comprehensive test documentation for gitlab-mcp-server. Updated: 2026-04-30.
+> Comprehensive test documentation for gitlab-mcp-server.
 >
 > **Maintenance Rule**: Whenever tests are added, modified, or removed, this document must be updated with the new counts and coverage values.
 
@@ -605,7 +605,7 @@ The suite uses five MCP server/client pairs via `mcp.NewInMemoryTransports()`:
 | MCP capabilities     | Verifies logging, progress, roots, completions, sampling, elicitation, and safe mode |
 | Docker-only runner   | Exercises CI pipeline and job behavior with a registered runner |
 
-Latest Docker validation snapshot: `make test-e2e-docker` completed 1,166 tests with 0 skips, 0 failures, and 0 errors in 389.057 seconds on 2026-04-30. Test function counts and package coverage values above are unchanged by the fixture change.
+Latest Docker validation snapshot: `make test-e2e-docker` completed 1,166 tests with 0 skips, 0 failures, and 0 errors in 389.057 seconds. Test function counts and package coverage values above are unchanged by the fixture change.
 
 **Lifecycle covered:** user → project CRUD → commits → branches → tags → releases → issues → labels → milestones → members → upload → MR lifecycle → notes → discussions → search → groups → pipelines → packages → wikis → CI variables → environments → issue links → deploy keys → snippets → pipeline schedules → badges → access tokens → award emoji → sampling → elicitation → cleanup
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -540,7 +540,7 @@ Uses an ephemeral GitLab CE container provisioned by Docker Compose. Requires Do
 
 All E2E Docker infrastructure is version-controlled under `test/e2e/`:
 
-- `test/e2e/docker-compose.yml` — GitLab CE + Runner compose definition
+- `test/e2e/docker-compose.yml` — GitLab CE + Runner + fixture service compose definition
 - `test/e2e/scripts/setup-gitlab.sh` — Creates test user, PAT, writes `.env.docker`
 - `test/e2e/scripts/register-runner.sh` — Registers CI runner in GitLab
 - `test/e2e/scripts/wait-for-gitlab.sh` — Polls GitLab readiness endpoint
@@ -793,7 +793,7 @@ internal/tools/samplingtools/
 
 ```text
 test/e2e/
-├── docker-compose.yml        # Ephemeral GitLab CE + Runner
+├── docker-compose.yml        # Ephemeral GitLab CE + Runner + fixture service
 ├── .env.docker               # Docker mode environment variables
 ├── README.md                 # E2E documentation
 ├── scripts/                  # Provisioning scripts

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -94,6 +94,7 @@ E2E tests are grouped by the resource scope they touch. New tests that mutate re
 | `instance-global` | Instance-wide resources such as settings, topics, broadcast messages, feature flags, system hooks, OAuth applications, Sidekiq, and metadata | Must be admin-gated and serialized when mutating global state |
 | `runner` | Pipeline and job tests that depend on the Docker CI runner | Requires Docker mode with a registered runner; avoid concurrent runner-heavy lifecycles |
 | `enterprise` | Premium or Ultimate features enabled through `GITLAB_ENTERPRISE=true` | Skip cleanly when the instance does not expose the feature |
+| `external-network` | Tests that require GitLab to fetch public URLs or contact public Git remotes, such as custom emoji image imports, webhooks, and push mirrors | Disabled by default; set `E2E_EXTERNAL_NETWORK=true` only when outbound access is deterministic |
 | `safe-mode` | Safe-mode session where mutating tools return previews instead of changing GitLab state | Parallel when assertions are read-only and no shared resources are mutated |
 | `sampling` | Sampling-enabled session with a mock LLM handler | Parallel when each test owns any GitLab resources it creates |
 | `elicitation` | Elicitation-enabled session with a mock user handler | Parallel when each test owns any GitLab resources it creates |

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -61,7 +61,7 @@ All Go test files live in the `suite/` subdirectory (package `suite`):
 
 | File                       | Purpose                                              |
 | -------------------------- | ---------------------------------------------------- |
-| `suite/setup_test.go`      | TestMain, 4 MCP sessions, helpers, shared state      |
+| `suite/setup_test.go`      | TestMain, 5 MCP sessions, helpers, shared state      |
 | `suite/fixture_test.go`    | Self-contained GitLab resource builders               |
 | `suite/*_test.go`          | 91 domain-specific test files                         |
 
@@ -69,16 +69,34 @@ All Go test files live in the `suite/` subdirectory (package `suite`):
 
 | Session            | Purpose                                  |
 | ------------------ | ---------------------------------------- |
-| `session`          | Individual tools (TestFullWorkflow)       |
-| `metaSession`      | Meta-tools (TestMetaToolWorkflow)         |
-| `samplingSession`  | Sampling tools with mock LLM handler     |
-| `elicitSession`    | Elicitation tools with mock user handler |
+| `individual`       | Individual tools                          |
+| `meta`             | Meta-tools                                |
+| `sampling`         | Sampling tools with mock LLM handler      |
+| `elicitation`      | Elicitation tools with mock user handler  |
+| `safeMode`         | Mutating tools wrapped to return previews |
 
 ### Safety Guardrails
 
 - **Snapshot-based cleanup**: `TestMain` captures pre-test project/group/label/variable state and restores it on exit
 - **Unique names**: All test resources use timestamped names to avoid conflicts
-- **Sequential execution**: All subtests run sequentially sharing state via `testState`/`metaState`
+- **Scoped parallelism**: Most top-level tests call `t.Parallel()`; lifecycle subtests usually stay sequential inside each top-level test when they share IDs or mutable state
+
+### Isolation and capabilities
+
+E2E tests are grouped by the resource scope they touch. New tests that mutate resources must use an existing fixture helper or explicitly register cleanup for every resource they create. See `suite/CAPABILITIES.md` for the current inventory and future gating plan.
+
+| Scope | Meaning | Parallelism guidance |
+| ----- | ------- | -------------------- |
+| `project` | Project-owned resources such as files, branches, issues, merge requests, packages, releases, and project settings | Parallel by default when each test creates its own project and cleanup is registered |
+| `group` | Group-owned resources such as group projects, members, labels, wikis, epics, and group settings | Parallel by default when each test creates its own group and cleanup is registered |
+| `user` | Admin-created or test-created user resources | Requires explicit cleanup and, for admin user lifecycle tests, admin capability checks |
+| `current-user` | State attached to the authenticated test user, including status, todos, SSH keys, personal access tokens, and notification preferences | Must be serialized or restored before more parallelism is added |
+| `instance-global` | Instance-wide resources such as settings, topics, broadcast messages, feature flags, system hooks, OAuth applications, Sidekiq, and metadata | Must be admin-gated and serialized when mutating global state |
+| `runner` | Pipeline and job tests that depend on the Docker CI runner | Requires Docker mode with a registered runner; avoid concurrent runner-heavy lifecycles |
+| `enterprise` | Premium or Ultimate features enabled through `GITLAB_ENTERPRISE=true` | Skip cleanly when the instance does not expose the feature |
+| `safe-mode` | Safe-mode session where mutating tools return previews instead of changing GitLab state | Parallel when assertions are read-only and no shared resources are mutated |
+| `sampling` | Sampling-enabled session with a mock LLM handler | Parallel when each test owns any GitLab resources it creates |
+| `elicitation` | Elicitation-enabled session with a mock user handler | Parallel when each test owns any GitLab resources it creates |
 
 ## Running Individual Workflows
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -13,6 +13,11 @@ Requires a running GitLab instance with a Personal Access Token that has create/
 cat > .env <<EOF
 GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-...
+# Required when running webhook/custom-emoji tests outside Docker mode.
+# Must be reachable from the GitLab instance, not just from the test process.
+E2E_FIXTURE_URL=https://fixture.example.com
+# Optional when GitLab must reach itself through a different URL for push mirror tests.
+E2E_GITLAB_INTERNAL_URL=https://gitlab.example.com
 EOF
 
 # Run
@@ -25,7 +30,7 @@ Uses an ephemeral GitLab CE container. Requires Docker and ~4 GB RAM.
 
 All Docker infrastructure is version-controlled in this directory:
 
-- `docker-compose.yml` — GitLab CE + Runner definition
+- `docker-compose.yml` — GitLab CE + Runner + fixture service definition
 - `scripts/setup-gitlab.sh` — Creates test user, PAT, generates `test/e2e/.env.docker`
 - `scripts/register-runner.sh` — Registers CI runner
 - `scripts/wait-for-gitlab.sh` — Polls readiness endpoint
@@ -51,7 +56,7 @@ Or use the Makefile target:
 make test-e2e-docker
 ```
 
-Docker mode enables pipeline and job tests that require a CI runner.
+Docker mode enables pipeline and job tests that require a CI runner, and starts an internal fixture service used by webhook and custom emoji tests. The setup script also writes `E2E_FIXTURE_URL` and `E2E_GITLAB_INTERNAL_URL` into `.env.docker` so CI runs all non-EE tests without public Internet dependencies.
 
 ## Architecture
 
@@ -94,7 +99,7 @@ E2E tests are grouped by the resource scope they touch. New tests that mutate re
 | `instance-global` | Instance-wide resources such as settings, topics, broadcast messages, feature flags, system hooks, OAuth applications, Sidekiq, and metadata | Must be admin-gated and serialized when mutating global state |
 | `runner` | Pipeline and job tests that depend on the Docker CI runner | Requires Docker mode with a registered runner; avoid concurrent runner-heavy lifecycles |
 | `enterprise` | Premium or Ultimate features enabled through `GITLAB_ENTERPRISE=true` | Skip cleanly when the instance does not expose the feature |
-| `external-network` | Tests that require GitLab to fetch public URLs or contact public Git remotes, such as custom emoji image imports, webhooks, and push mirrors | Disabled by default; set `E2E_EXTERNAL_NETWORK=true` only when outbound access is deterministic |
+| `external-network` | Reserved for tests that truly require public Internet access | Prefer Docker fixture endpoints or test-owned GitLab projects so CI can execute non-EE tests without skips |
 | `safe-mode` | Safe-mode session where mutating tools return previews instead of changing GitLab state | Parallel when assertions are read-only and no shared resources are mutated |
 | `sampling` | Sampling-enabled session with a mock LLM handler | Parallel when each test owns any GitLab resources it creates |
 | `elicitation` | Elicitation-enabled session with a mock user handler | Parallel when each test owns any GitLab resources it creates |

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -48,6 +48,28 @@ services:
       - runner-config:/etc/gitlab-runner
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
+  e2e-fixture:
+    image: nginx:alpine
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cat > /etc/nginx/conf.d/default.conf <<'NGINX'
+        server {
+          listen 8080;
+          location = /hook { add_header Content-Type application/json; return 200 '{"ok":true,"endpoint":"hook"}\n'; }
+          location = /hook-updated { add_header Content-Type application/json; return 200 '{"ok":true,"endpoint":"hook-updated"}\n'; }
+          location = /emoji.png { root /usr/share/nginx/html; add_header Content-Type image/png; }
+        }
+        NGINX
+        printf '%s' 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' | base64 -d > /usr/share/nginx/html/emoji.png
+        nginx -g 'daemon off;'
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/emoji.png"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
 volumes:
   gitlab-config:
   gitlab-logs:

--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -90,6 +90,8 @@ curl -sf "${GITLAB_URL}/api/v4/application/settings" \
     -H "Authorization: Bearer ${ROOT_TOKEN}" \
     -d "default_branch_protection=0" \
     -d "deletion_adjourned_period=1" \
+    -d "allow_local_requests_from_web_hooks_and_services=true" \
+    -d "allow_local_requests_from_system_hooks=true" \
     -d "throttle_authenticated_api_enabled=false" \
     -d "throttle_authenticated_web_enabled=false" \
     -d "throttle_unauthenticated_api_enabled=false" \
@@ -100,7 +102,7 @@ curl -sf "${GITLAB_URL}/api/v4/application/settings" \
     -d "throttle_unauthenticated_files_api_enabled=false" \
     -d "throttle_authenticated_deprecated_api_enabled=false" \
     -d "throttle_unauthenticated_deprecated_api_enabled=false" > /dev/null 2>&1
-echo "    Default branch protection disabled, deletion_adjourned_period=1, rate limiting disabled"
+echo "    Default branch protection disabled, local outbound requests enabled, deletion_adjourned_period=1, rate limiting disabled"
 
 # 2. Create test user
 echo "  [2/4] Creating test user '${TEST_USER}'..."
@@ -185,6 +187,8 @@ GITLAB_URL=${GITLAB_URL}
 GITLAB_TOKEN=${PAT}
 GITLAB_SKIP_TLS_VERIFY=true
 E2E_MODE=docker
+E2E_FIXTURE_URL=http://e2e-fixture:8080
+E2E_GITLAB_INTERNAL_URL=http://gitlab-e2e
 EOF
 
 echo ""

--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Provision a test user and Personal Access Token on the ephemeral GitLab instance.
-# Writes credentials to test/e2e/.env.docker.
+# Writes credentials and Docker fixture endpoints to test/e2e/.env.docker.
 # Usage: ./test/e2e/scripts/setup-gitlab.sh [GITLAB_URL]
 
 GITLAB_URL="${1:-http://localhost:8929}"

--- a/test/e2e/suite/CAPABILITIES.md
+++ b/test/e2e/suite/CAPABILITIES.md
@@ -19,6 +19,9 @@ This inventory records the highest-risk E2E test patterns and the capability gat
 | `users_meta_test.go::TestMeta_UserSSHKeyLifecycle` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Creates and deletes SSH keys for the authenticated user. |
 | `users_meta_test.go::TestMeta_UserAdmin` | `user`, `instance-global` | Yes | No, serialize admin user lifecycle | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Creates, updates, blocks, deactivates, bans, and deletes users. |
 | `users_meta_test.go::TestMeta_UserServiceAccounts` | `current-user`, `user`, `enterprise` | Yes | No, serialize PAT/service-account creation | `CapabilityCurrentUserState`, `CapabilityEnterprise` | Service accounts are EE-only; current-user PAT creation needs cleanup or documented limitations. |
+| `projects_meta_test.go::TestMeta_ProjectHooks` | `external-network`, `project` | Yes | Yes, when public webhook URLs are reachable | `CapabilityExternalNetwork` | Creates project webhooks against an external endpoint and expects GitLab URL validation to accept the endpoint. |
+| `projectmirrors_test.go::TestMeta_ProjectRemoteMirrors` | `external-network`, `project` | Yes | Yes, when public Git remotes are reachable | `CapabilityExternalNetwork` | Creates push mirror configuration against an external Git remote. |
+| `customemoji_test.go::TestIndividual_CustomEmoji` / `TestMeta_CustomEmoji` | `external-network`, `group` | Yes | Yes, when public image URLs are reachable | `CapabilityExternalNetwork` | Creates custom emoji from a public image URL fetched by GitLab. |
 | `notifications_test.go::TestMeta_Notifications` | `current-user`, `project` | No | Yes | None | Read-only notification retrieval today; mutation tests belong behind current-user gates. |
 | `todos_test.go::TestIndividual_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through individual tools. |
 | `todos_test.go::TestMeta_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through meta-tools. |
@@ -40,5 +43,6 @@ This inventory records the highest-risk E2E test patterns and the capability gat
 - `CapabilityCurrentUserState` should guard tests that mutate the authenticated user's status, todos, notification preferences, SSH keys, or personal access tokens.
 - `CapabilityRunner` should guard tests that need a registered CI runner or can consume shared runner capacity.
 - `CapabilityEnterprise` should guard Premium or Ultimate features and skip cleanly on Community Edition.
+- `CapabilityExternalNetwork` should guard tests that require GitLab to fetch public URLs or contact public Git remotes. Set `E2E_EXTERNAL_NETWORK=true` only in environments with deterministic outbound access.
 - Project-scoped and group-scoped tests can remain parallel when every created resource is test-owned and cleanup is registered.
 - Read-only metadata and MCP capability tests can remain parallel unless they create shared GitLab state.

--- a/test/e2e/suite/CAPABILITIES.md
+++ b/test/e2e/suite/CAPABILITIES.md
@@ -1,0 +1,44 @@
+# E2E Capability Inventory
+
+This inventory records the highest-risk E2E test patterns and the capability gates that should protect them during the E2E refactor. It is intentionally focused on tests that touch shared state, runner capacity, or MCP capability infrastructure.
+
+| Test Pattern | Resource Scope | Mutates Shared State | Can Run In Parallel | Required Gate | Notes |
+| ------------ | -------------- | -------------------- | ------------------- | ------------- | ----- |
+| `admin_meta_test.go::TestMeta_AdminTopics` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Creates, updates, and deletes instance topic metadata. |
+| `admin_meta_test.go::TestMeta_AdminSettingsAppearance` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Updates global appearance/settings and needs snapshot/restore. |
+| `admin_meta_test.go::TestMeta_AdminBroadcast` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Broadcast messages are visible instance-wide. |
+| `admin_meta_test.go::TestMeta_AdminFeatures` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Feature flag changes can affect unrelated tests. |
+| `admin_meta_test.go::TestMeta_AdminSystemHooks` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | System hooks are instance-level webhooks. |
+| `admin_meta_test.go::TestMeta_AdminSidekiqMetrics` | `instance-global` | No | Yes | `CapabilityAdmin` | Read-only admin metrics. |
+| `admin_meta_test.go::TestMeta_AdminPlanLimitsMetadata` | `instance-global` | No | Yes | `CapabilityAdmin` | Read-only plan limits, metadata, and statistics checks. |
+| `admin_meta_test.go::TestMeta_AdminApplications` | `instance-global` | Yes | No, serialize global mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | OAuth application lifecycle affects instance-global app registry. |
+| `admin_meta_test.go::TestMeta_AdminCustomAttributes` | `user`, `instance-global` | Yes | No, serialize admin mutations | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Mutates custom attributes on admin-scoped resources. |
+| `users_meta_test.go::TestMeta_UserSelf` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Sets authenticated user status and must restore prior state. |
+| `users_meta_test.go::TestMeta_UserTodosEvents` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done. |
+| `users_meta_test.go::TestMeta_UserNamespacesNotifications` | `current-user`, `project`, `group` | Yes | No, serialize current-user notification changes | `CapabilityCurrentUserState` | Updates global and scoped notification settings; group fixture cleanup is required. |
+| `users_meta_test.go::TestMeta_UserSSHKeyLifecycle` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Creates and deletes SSH keys for the authenticated user. |
+| `users_meta_test.go::TestMeta_UserAdmin` | `user`, `instance-global` | Yes | No, serialize admin user lifecycle | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Creates, updates, blocks, deactivates, bans, and deletes users. |
+| `users_meta_test.go::TestMeta_UserServiceAccounts` | `current-user`, `user`, `enterprise` | Yes | No, serialize PAT/service-account creation | `CapabilityCurrentUserState`, `CapabilityEnterprise` | Service accounts are EE-only; current-user PAT creation needs cleanup or documented limitations. |
+| `notifications_test.go::TestMeta_Notifications` | `current-user`, `project` | No | Yes | None | Read-only notification retrieval today; mutation tests belong behind current-user gates. |
+| `todos_test.go::TestIndividual_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through individual tools. |
+| `todos_test.go::TestMeta_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through meta-tools. |
+| `pipelines_test.go::TestPipelines` | `project`, `runner` | No | No, keep runner lifecycle serial | `CapabilityRunner` | Intentionally not parallelized because Docker mode uses a shared runner. |
+| `wait_test.go::TestWaitTools` | `project`, `runner` | No | Yes, with runner availability | `CapabilityRunner` | Exercises pipeline/job wait tools and can time out on slow runner hosts. |
+| `capabilities_test.go::TestCapability_Logging` | `metadata` | No | Yes | None | Read-only MCP logging capability test. |
+| `capabilities_test.go::TestCapability_Progress` | `project` | No | Yes | None | Creates a project and verifies progress notifications during upload. |
+| `capabilities_test.go::TestCapability_Roots` | `metadata` | No | Yes | None | Verifies roots discovery through MCP resource reads. |
+| `capabilities_test.go::TestCapability_RootsListChanged` | `metadata` | No | Yes | None | Verifies roots/list_changed notification handling. |
+| `capabilities_test.go::TestCapability_Completions` | `project`, `metadata` | No | Yes | None | Creates a project to provide completion data, then runs parallel read-only subtests. |
+| `meta_schema_resource_test.go::TestMetaSchemaResource_ListsTemplate` | `metadata` | No | Yes | None | Verifies meta-schema resource templates. |
+| `meta_schema_resource_test.go::TestMetaSchemaResource_ReadMergeRequestCreate` | `metadata` | No | Yes | None | Reads and validates merge-request create schema. |
+| `meta_schema_resource_test.go::TestMetaSchemaResource_NotFound` | `metadata` | No | Yes | None | Verifies invalid schema resources fail cleanly. |
+| `meta_schema_resource_test.go::TestMetaSchemaResource_IndexEnumeratesMetaTools` | `metadata` | No | Yes | None | Verifies the schema index includes meta-tools. |
+
+## Capability Rules
+
+- `CapabilityInstanceGlobal` should guard tests that create, update, or delete instance-wide resources.
+- `CapabilityCurrentUserState` should guard tests that mutate the authenticated user's status, todos, notification preferences, SSH keys, or personal access tokens.
+- `CapabilityRunner` should guard tests that need a registered CI runner or can consume shared runner capacity.
+- `CapabilityEnterprise` should guard Premium or Ultimate features and skip cleanly on Community Edition.
+- Project-scoped and group-scoped tests can remain parallel when every created resource is test-owned and cleanup is registered.
+- Read-only metadata and MCP capability tests can remain parallel unless they create shared GitLab state.

--- a/test/e2e/suite/CAPABILITIES.md
+++ b/test/e2e/suite/CAPABILITIES.md
@@ -19,9 +19,9 @@ This inventory records the highest-risk E2E test patterns and the capability gat
 | `users_meta_test.go::TestMeta_UserSSHKeyLifecycle` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Creates and deletes SSH keys for the authenticated user. |
 | `users_meta_test.go::TestMeta_UserAdmin` | `user`, `instance-global` | Yes | No, serialize admin user lifecycle | `CapabilityAdmin`, `CapabilityInstanceGlobal` | Creates, updates, blocks, deactivates, bans, and deletes users. |
 | `users_meta_test.go::TestMeta_UserServiceAccounts` | `current-user`, `user`, `enterprise` | Yes | No, serialize PAT/service-account creation | `CapabilityCurrentUserState`, `CapabilityEnterprise` | Service accounts are EE-only; current-user PAT creation needs cleanup or documented limitations. |
-| `projects_meta_test.go::TestMeta_ProjectHooks` | `external-network`, `project` | Yes | Yes, when public webhook URLs are reachable | `CapabilityExternalNetwork` | Creates project webhooks against an external endpoint and expects GitLab URL validation to accept the endpoint. |
-| `projectmirrors_test.go::TestMeta_ProjectRemoteMirrors` | `external-network`, `project` | Yes | Yes, when public Git remotes are reachable | `CapabilityExternalNetwork` | Creates push mirror configuration against an external Git remote. |
-| `customemoji_test.go::TestIndividual_CustomEmoji` / `TestMeta_CustomEmoji` | `external-network`, `group` | Yes | Yes, when public image URLs are reachable | `CapabilityExternalNetwork` | Creates custom emoji from a public image URL fetched by GitLab. |
+| `projects_meta_test.go::TestMeta_ProjectHooks` | `project` | Yes | Yes | None | Creates project webhooks against the Docker fixture service (`E2E_FIXTURE_URL`) so GitLab URL validation and delivery do not require public Internet access. |
+| `projectmirrors_test.go::TestMeta_ProjectRemoteMirrors` | `project` | Yes | Yes | None | Creates push mirror configuration against a second test-owned GitLab project via `E2E_GITLAB_INTERNAL_URL`. |
+| `customemoji_test.go::TestIndividual_CustomEmoji` / `TestMeta_CustomEmoji` | `group` | Yes | Yes | None | Creates custom emoji from the Docker fixture PNG (`E2E_FIXTURE_URL`) instead of a public image URL. |
 | `notifications_test.go::TestMeta_Notifications` | `current-user`, `project` | No | Yes | None | Read-only notification retrieval today; mutation tests belong behind current-user gates. |
 | `todos_test.go::TestIndividual_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through individual tools. |
 | `todos_test.go::TestMeta_Todos` | `current-user` | Yes | No, serialize current-user state | `CapabilityCurrentUserState` | Marks all current-user todos done through meta-tools. |
@@ -43,6 +43,6 @@ This inventory records the highest-risk E2E test patterns and the capability gat
 - `CapabilityCurrentUserState` should guard tests that mutate the authenticated user's status, todos, notification preferences, SSH keys, or personal access tokens.
 - `CapabilityRunner` should guard tests that need a registered CI runner or can consume shared runner capacity.
 - `CapabilityEnterprise` should guard Premium or Ultimate features and skip cleanly on Community Edition.
-- `CapabilityExternalNetwork` should guard tests that require GitLab to fetch public URLs or contact public Git remotes. Set `E2E_EXTERNAL_NETWORK=true` only in environments with deterministic outbound access.
+- `CapabilityExternalNetwork` is reserved for future tests that truly require public Internet access. Prefer Docker fixture endpoints or test-owned GitLab projects so CI can execute all non-EE tests without skips.
 - Project-scoped and group-scoped tests can remain parallel when every created resource is test-owned and cleanup is registered.
 - Read-only metadata and MCP capability tests can remain parallel unless they create shared GitLab state.

--- a/test/e2e/suite/admin_meta_test.go
+++ b/test/e2e/suite/admin_meta_test.go
@@ -33,7 +33,6 @@ func TestMeta_AdminTopics(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -95,7 +94,6 @@ func TestMeta_AdminSettingsAppearance(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -140,7 +138,6 @@ func TestMeta_AdminBroadcast(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -208,7 +205,6 @@ func TestMeta_AdminFeatures(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -262,7 +258,6 @@ func TestMeta_AdminSystemHooks(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -327,7 +322,6 @@ func TestMeta_AdminSidekiqMetrics(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -373,7 +367,6 @@ func TestMeta_AdminPlanLimitsMetadata(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -421,7 +414,6 @@ func TestMeta_AdminApplications(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -468,7 +460,6 @@ func TestMeta_AdminCustomAttributes(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 

--- a/test/e2e/suite/admin_meta_test.go
+++ b/test/e2e/suite/admin_meta_test.go
@@ -32,57 +32,59 @@ func TestMeta_AdminTopics(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	topicName := uniqueName("topic")
-	var topicID int64
+		topicName := uniqueName("topic")
+		var topicID int64
 
-	t.Run("TopicCreate", func(t *testing.T) {
-		out, err := callToolOn[topics.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "topic_create",
-			"params": map[string]any{
-				"name":  topicName,
-				"title": "E2E " + topicName,
-			},
+		t.Run("TopicCreate", func(t *testing.T) {
+			out, err := callToolOn[topics.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "topic_create",
+				"params": map[string]any{
+					"name":  topicName,
+					"title": "E2E " + topicName,
+				},
+			})
+			requireNoError(t, err, "topic_create")
+			requireTruef(t, out.Topic.ID > 0, "topic_create: expected ID > 0")
+			topicID = out.Topic.ID
+			t.Logf("Created topic %d: %s", topicID, topicName)
 		})
-		requireNoError(t, err, "topic_create")
-		requireTruef(t, out.Topic.ID > 0, "topic_create: expected ID > 0")
-		topicID = out.Topic.ID
-		t.Logf("Created topic %d: %s", topicID, topicName)
-	})
-	defer func() {
-		if topicID > 0 {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-				"action": "topic_delete",
+		defer func() {
+			if topicID > 0 {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+					"action": "topic_delete",
+					"params": map[string]any{"topic_id": topicID},
+				})
+			}
+		}()
+
+		t.Run("TopicGet", func(t *testing.T) {
+			requireTruef(t, topicID > 0, "topicID not set")
+			out, err := callToolOn[topics.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "topic_get",
 				"params": map[string]any{"topic_id": topicID},
 			})
-		}
-	}()
-
-	t.Run("TopicGet", func(t *testing.T) {
-		requireTruef(t, topicID > 0, "topicID not set")
-		out, err := callToolOn[topics.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "topic_get",
-			"params": map[string]any{"topic_id": topicID},
+			requireNoError(t, err, "topic_get")
+			requireTruef(t, out.Topic.ID == topicID, "topic_get: ID mismatch")
+			t.Logf("Got topic %d: %s", out.Topic.ID, out.Topic.Name)
 		})
-		requireNoError(t, err, "topic_get")
-		requireTruef(t, out.Topic.ID == topicID, "topic_get: ID mismatch")
-		t.Logf("Got topic %d: %s", out.Topic.ID, out.Topic.Name)
-	})
 
-	t.Run("TopicUpdate", func(t *testing.T) {
-		requireTruef(t, topicID > 0, "topicID not set")
-		out, err := callToolOn[topics.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "topic_update",
-			"params": map[string]any{
-				"topic_id":    topicID,
-				"description": "Updated by E2E test",
-			},
+		t.Run("TopicUpdate", func(t *testing.T) {
+			requireTruef(t, topicID > 0, "topicID not set")
+			out, err := callToolOn[topics.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "topic_update",
+				"params": map[string]any{
+					"topic_id":    topicID,
+					"description": "Updated by E2E test",
+				},
+			})
+			requireNoError(t, err, "topic_update")
+			requireTruef(t, out.Topic.ID == topicID, "topic_update: ID mismatch")
 		})
-		requireNoError(t, err, "topic_update")
-		requireTruef(t, out.Topic.ID == topicID, "topic_update: ID mismatch")
 	})
 }
 
@@ -92,40 +94,42 @@ func TestMeta_AdminSettingsAppearance(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("SettingsUpdate", func(t *testing.T) {
-		out, err := callToolOn[settings.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "settings_update",
-			"params": map[string]any{
-				"settings": map[string]any{"default_branch_name": "main"},
-			},
+		t.Run("SettingsUpdate", func(t *testing.T) {
+			out, err := callToolOn[settings.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "settings_update",
+				"params": map[string]any{
+					"settings": map[string]any{"default_branch_name": "main"},
+				},
+			})
+			requireNoError(t, err, "settings_update")
+			requireTruef(t, len(out.Settings) > 0, "settings_update: expected settings map")
+			t.Logf("Settings updated (%d keys)", len(out.Settings))
 		})
-		requireNoError(t, err, "settings_update")
-		requireTruef(t, len(out.Settings) > 0, "settings_update: expected settings map")
-		t.Logf("Settings updated (%d keys)", len(out.Settings))
-	})
 
-	t.Run("AppearanceGet", func(t *testing.T) {
-		out, err := callToolOn[appearance.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "appearance_get",
-			"params": map[string]any{},
+		t.Run("AppearanceGet", func(t *testing.T) {
+			out, err := callToolOn[appearance.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "appearance_get",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "appearance_get")
+			t.Logf("Appearance: title=%s", out.Appearance.Title)
 		})
-		requireNoError(t, err, "appearance_get")
-		t.Logf("Appearance: title=%s", out.Appearance.Title)
-	})
 
-	t.Run("AppearanceUpdate", func(t *testing.T) {
-		out, err := callToolOn[appearance.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "appearance_update",
-			"params": map[string]any{
-				"title": "E2E GitLab",
-			},
+		t.Run("AppearanceUpdate", func(t *testing.T) {
+			out, err := callToolOn[appearance.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "appearance_update",
+				"params": map[string]any{
+					"title": "E2E GitLab",
+				},
+			})
+			requireNoError(t, err, "appearance_update")
+			t.Logf("Updated appearance: title=%s", out.Appearance.Title)
 		})
-		requireNoError(t, err, "appearance_update")
-		t.Logf("Updated appearance: title=%s", out.Appearance.Title)
 	})
 }
 
@@ -135,63 +139,65 @@ func TestMeta_AdminBroadcast(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	var msgID int64
+		var msgID int64
 
-	t.Run("BroadcastList", func(t *testing.T) {
-		out, err := callToolOn[broadcastmessages.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "broadcast_message_list",
-			"params": map[string]any{},
+		t.Run("BroadcastList", func(t *testing.T) {
+			out, err := callToolOn[broadcastmessages.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "broadcast_message_list",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "broadcast_message_list")
+			t.Logf("Broadcast messages: %d", len(out.Messages))
 		})
-		requireNoError(t, err, "broadcast_message_list")
-		t.Logf("Broadcast messages: %d", len(out.Messages))
-	})
 
-	t.Run("BroadcastCreate", func(t *testing.T) {
-		out, err := callToolOn[broadcastmessages.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "broadcast_message_create",
-			"params": map[string]any{
-				"message": "E2E test broadcast " + uniqueName(""),
-			},
+		t.Run("BroadcastCreate", func(t *testing.T) {
+			out, err := callToolOn[broadcastmessages.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "broadcast_message_create",
+				"params": map[string]any{
+					"message": "E2E test broadcast " + uniqueName(""),
+				},
+			})
+			requireNoError(t, err, "broadcast_message_create")
+			requireTruef(t, out.Message.ID > 0, "broadcast_message_create: expected ID > 0")
+			msgID = out.Message.ID
+			t.Logf("Created broadcast %d", msgID)
 		})
-		requireNoError(t, err, "broadcast_message_create")
-		requireTruef(t, out.Message.ID > 0, "broadcast_message_create: expected ID > 0")
-		msgID = out.Message.ID
-		t.Logf("Created broadcast %d", msgID)
-	})
-	defer func() {
-		if msgID > 0 {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-				"action": "broadcast_message_delete",
+		defer func() {
+			if msgID > 0 {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+					"action": "broadcast_message_delete",
+					"params": map[string]any{"id": msgID},
+				})
+			}
+		}()
+
+		t.Run("BroadcastGet", func(t *testing.T) {
+			requireTruef(t, msgID > 0, "msgID not set")
+			out, err := callToolOn[broadcastmessages.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "broadcast_message_get",
 				"params": map[string]any{"id": msgID},
 			})
-		}
-	}()
-
-	t.Run("BroadcastGet", func(t *testing.T) {
-		requireTruef(t, msgID > 0, "msgID not set")
-		out, err := callToolOn[broadcastmessages.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "broadcast_message_get",
-			"params": map[string]any{"id": msgID},
+			requireNoError(t, err, "broadcast_message_get")
+			requireTruef(t, out.Message.ID == msgID, "broadcast_message_get: ID mismatch")
 		})
-		requireNoError(t, err, "broadcast_message_get")
-		requireTruef(t, out.Message.ID == msgID, "broadcast_message_get: ID mismatch")
-	})
 
-	t.Run("BroadcastUpdate", func(t *testing.T) {
-		requireTruef(t, msgID > 0, "msgID not set")
-		out, err := callToolOn[broadcastmessages.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "broadcast_message_update",
-			"params": map[string]any{
-				"id":      msgID,
-				"message": "Updated E2E broadcast",
-			},
+		t.Run("BroadcastUpdate", func(t *testing.T) {
+			requireTruef(t, msgID > 0, "msgID not set")
+			out, err := callToolOn[broadcastmessages.UpdateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "broadcast_message_update",
+				"params": map[string]any{
+					"id":      msgID,
+					"message": "Updated E2E broadcast",
+				},
+			})
+			requireNoError(t, err, "broadcast_message_update")
+			requireTruef(t, out.Message.ID == msgID, "broadcast_message_update: ID mismatch")
 		})
-		requireNoError(t, err, "broadcast_message_update")
-		requireTruef(t, out.Message.ID == msgID, "broadcast_message_update: ID mismatch")
 	})
 }
 
@@ -201,49 +207,51 @@ func TestMeta_AdminFeatures(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	featureName := fmt.Sprintf("e2e_test_feature_%d", time.Now().UnixMilli())
+		featureName := fmt.Sprintf("e2e_test_feature_%d", time.Now().UnixMilli())
 
-	t.Run("FeatureList", func(t *testing.T) {
-		out, err := callToolOn[features.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "feature_list",
-			"params": map[string]any{},
+		t.Run("FeatureList", func(t *testing.T) {
+			out, err := callToolOn[features.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "feature_list",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "feature_list")
+			t.Logf("Features: %d", len(out.Features))
 		})
-		requireNoError(t, err, "feature_list")
-		t.Logf("Features: %d", len(out.Features))
-	})
 
-	t.Run("FeatureListDefinitions", func(t *testing.T) {
-		out, err := callToolOn[features.ListDefinitionsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "feature_list_definitions",
-			"params": map[string]any{},
+		t.Run("FeatureListDefinitions", func(t *testing.T) {
+			out, err := callToolOn[features.ListDefinitionsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "feature_list_definitions",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "feature_list_definitions")
+			t.Logf("Feature definitions: %d", len(out.Definitions))
 		})
-		requireNoError(t, err, "feature_list_definitions")
-		t.Logf("Feature definitions: %d", len(out.Definitions))
-	})
 
-	t.Run("FeatureSet", func(t *testing.T) {
-		out, err := callToolOn[features.SetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "feature_set",
-			"params": map[string]any{
-				"name":  featureName,
-				"value": true,
-			},
+		t.Run("FeatureSet", func(t *testing.T) {
+			out, err := callToolOn[features.SetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "feature_set",
+				"params": map[string]any{
+					"name":  featureName,
+					"value": true,
+				},
+			})
+			requireNoError(t, err, "feature_set")
+			requireTruef(t, out.Feature.Name == featureName, "feature name mismatch")
+			t.Logf("Set feature: %s", out.Feature.Name)
 		})
-		requireNoError(t, err, "feature_set")
-		requireTruef(t, out.Feature.Name == featureName, "feature name mismatch")
-		t.Logf("Set feature: %s", out.Feature.Name)
-	})
 
-	t.Run("FeatureDelete", func(t *testing.T) {
-		err := callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "feature_delete",
-			"params": map[string]any{"name": featureName},
+		t.Run("FeatureDelete", func(t *testing.T) {
+			err := callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "feature_delete",
+				"params": map[string]any{"name": featureName},
+			})
+			requireNoError(t, err, "feature_delete")
 		})
-		requireNoError(t, err, "feature_delete")
 	})
 }
 
@@ -253,60 +261,62 @@ func TestMeta_AdminSystemHooks(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	var hookID int64
+		var hookID int64
 
-	t.Run("SystemHookList", func(t *testing.T) {
-		out, err := callToolOn[systemhooks.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "system_hook_list",
-			"params": map[string]any{},
+		t.Run("SystemHookList", func(t *testing.T) {
+			out, err := callToolOn[systemhooks.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "system_hook_list",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "system_hook_list")
+			t.Logf("System hooks: %d", len(out.Hooks))
 		})
-		requireNoError(t, err, "system_hook_list")
-		t.Logf("System hooks: %d", len(out.Hooks))
-	})
 
-	t.Run("SystemHookAdd", func(t *testing.T) {
-		out, err := callToolOn[systemhooks.AddOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "system_hook_add",
-			"params": map[string]any{
-				"url":  "https://e2e-test.example.com/hook",
-				"name": "e2e-test-hook",
-			},
+		t.Run("SystemHookAdd", func(t *testing.T) {
+			out, err := callToolOn[systemhooks.AddOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "system_hook_add",
+				"params": map[string]any{
+					"url":  "https://e2e-test.example.com/hook",
+					"name": "e2e-test-hook",
+				},
+			})
+			requireNoError(t, err, "system_hook_add")
+			requireTruef(t, out.Hook.ID > 0, "system_hook_add: expected ID > 0")
+			hookID = out.Hook.ID
+			t.Logf("Added system hook %d (name=%s)", hookID, out.Hook.Name)
 		})
-		requireNoError(t, err, "system_hook_add")
-		requireTruef(t, out.Hook.ID > 0, "system_hook_add: expected ID > 0")
-		hookID = out.Hook.ID
-		t.Logf("Added system hook %d (name=%s)", hookID, out.Hook.Name)
-	})
-	defer func() {
-		if hookID > 0 {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-				"action": "system_hook_delete",
+		defer func() {
+			if hookID > 0 {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+					"action": "system_hook_delete",
+					"params": map[string]any{"id": hookID},
+				})
+			}
+		}()
+
+		t.Run("SystemHookGet", func(t *testing.T) {
+			requireTruef(t, hookID > 0, "hookID not set")
+			out, err := callToolOn[systemhooks.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "system_hook_get",
 				"params": map[string]any{"id": hookID},
 			})
-		}
-	}()
-
-	t.Run("SystemHookGet", func(t *testing.T) {
-		requireTruef(t, hookID > 0, "hookID not set")
-		out, err := callToolOn[systemhooks.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "system_hook_get",
-			"params": map[string]any{"id": hookID},
+			requireNoError(t, err, "system_hook_get")
+			requireTruef(t, out.Hook.ID == hookID, "system_hook_get: ID mismatch")
 		})
-		requireNoError(t, err, "system_hook_get")
-		requireTruef(t, out.Hook.ID == hookID, "system_hook_get: ID mismatch")
-	})
 
-	t.Run("SystemHookTest", func(t *testing.T) {
-		requireTruef(t, hookID > 0, "hookID not set")
-		_, err := callToolOn[systemhooks.TestOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "system_hook_test",
-			"params": map[string]any{"id": hookID},
+		t.Run("SystemHookTest", func(t *testing.T) {
+			requireTruef(t, hookID > 0, "hookID not set")
+			_, err := callToolOn[systemhooks.TestOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "system_hook_test",
+				"params": map[string]any{"id": hookID},
+			})
+			requireNoError(t, err, "system_hook_test")
 		})
-		requireNoError(t, err, "system_hook_test")
 	})
 }
 
@@ -316,41 +326,43 @@ func TestMeta_AdminSidekiqMetrics(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("QueueMetrics", func(t *testing.T) {
-		out, err := callToolOn[sidekiq.GetQueueMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "sidekiq_queue_metrics",
-			"params": map[string]any{},
+		t.Run("QueueMetrics", func(t *testing.T) {
+			out, err := callToolOn[sidekiq.GetQueueMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "sidekiq_queue_metrics",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "sidekiq_queue_metrics")
+			t.Logf("Sidekiq queues: %d", len(out.Queues))
 		})
-		requireNoError(t, err, "sidekiq_queue_metrics")
-		t.Logf("Sidekiq queues: %d", len(out.Queues))
-	})
 
-	t.Run("ProcessMetrics", func(t *testing.T) {
-		_, err := callToolOn[sidekiq.GetProcessMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "sidekiq_process_metrics",
-			"params": map[string]any{},
+		t.Run("ProcessMetrics", func(t *testing.T) {
+			_, err := callToolOn[sidekiq.GetProcessMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "sidekiq_process_metrics",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "sidekiq_process_metrics")
 		})
-		requireNoError(t, err, "sidekiq_process_metrics")
-	})
 
-	t.Run("JobStats", func(t *testing.T) {
-		_, err := callToolOn[sidekiq.GetJobStatsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "sidekiq_job_stats",
-			"params": map[string]any{},
+		t.Run("JobStats", func(t *testing.T) {
+			_, err := callToolOn[sidekiq.GetJobStatsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "sidekiq_job_stats",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "sidekiq_job_stats")
 		})
-		requireNoError(t, err, "sidekiq_job_stats")
-	})
 
-	t.Run("CompoundMetrics", func(t *testing.T) {
-		_, err := callToolOn[sidekiq.GetCompoundMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "sidekiq_compound_metrics",
-			"params": map[string]any{},
+		t.Run("CompoundMetrics", func(t *testing.T) {
+			_, err := callToolOn[sidekiq.GetCompoundMetricsOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "sidekiq_compound_metrics",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "sidekiq_compound_metrics")
 		})
-		requireNoError(t, err, "sidekiq_compound_metrics")
 	})
 }
 
@@ -360,43 +372,45 @@ func TestMeta_AdminPlanLimitsMetadata(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("PlanLimitsGet", func(t *testing.T) {
-		const maxRetries = 3
-		var lastErr error
-		for attempt := range maxRetries {
-			_, lastErr = callToolOn[planlimits.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-				"action": "plan_limits_get",
-				"params": map[string]any{"plan_name": "default"},
-			})
-			if lastErr == nil || !isTransientNetworkError(lastErr) {
-				break
+		t.Run("PlanLimitsGet", func(t *testing.T) {
+			const maxRetries = 3
+			var lastErr error
+			for attempt := range maxRetries {
+				_, lastErr = callToolOn[planlimits.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+					"action": "plan_limits_get",
+					"params": map[string]any{"plan_name": "default"},
+				})
+				if lastErr == nil || !isTransientNetworkError(lastErr) {
+					break
+				}
+				t.Logf("plan_limits_get: transient error (attempt %d/%d): %v", attempt+1, maxRetries, lastErr)
+				time.Sleep(time.Duration(attempt+1) * time.Second)
 			}
-			t.Logf("plan_limits_get: transient error (attempt %d/%d): %v", attempt+1, maxRetries, lastErr)
-			time.Sleep(time.Duration(attempt+1) * time.Second)
-		}
-		requireNoError(t, lastErr, "plan_limits_get")
-	})
-
-	t.Run("MetadataGet", func(t *testing.T) {
-		out, err := callToolOn[metadata.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "metadata_get",
-			"params": map[string]any{},
+			requireNoError(t, lastErr, "plan_limits_get")
 		})
-		requireNoError(t, err, "metadata_get")
-		requireTruef(t, out.Version != "", "metadata_get: expected non-empty version")
-		t.Logf("GitLab version: %s revision: %s", out.Version, out.Revision)
-	})
 
-	t.Run("AppStatisticsGet", func(t *testing.T) {
-		_, err := callToolOn[appstatistics.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "app_statistics_get",
-			"params": map[string]any{},
+		t.Run("MetadataGet", func(t *testing.T) {
+			out, err := callToolOn[metadata.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "metadata_get",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "metadata_get")
+			requireTruef(t, out.Version != "", "metadata_get: expected non-empty version")
+			t.Logf("GitLab version: %s revision: %s", out.Version, out.Revision)
 		})
-		requireNoError(t, err, "app_statistics_get")
+
+		t.Run("AppStatisticsGet", func(t *testing.T) {
+			_, err := callToolOn[appstatistics.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "app_statistics_get",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "app_statistics_get")
+		})
 	})
 }
 
@@ -406,43 +420,45 @@ func TestMeta_AdminApplications(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	var appID int64
+		var appID int64
 
-	t.Run("ApplicationList", func(t *testing.T) {
-		out, err := callToolOn[applications.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "application_list",
-			"params": map[string]any{},
-		})
-		requireNoError(t, err, "application_list")
-		t.Logf("Applications: %d", len(out.Applications))
-	})
-
-	t.Run("ApplicationCreate", func(t *testing.T) {
-		out, err := callToolOn[applications.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "application_create",
-			"params": map[string]any{
-				"name":         "e2e-app-" + uniqueName(""),
-				"redirect_uri": "https://e2e-test.example.com/callback",
-				"scopes":       "api",
-			},
-		})
-		requireNoError(t, err, "application_create")
-		requireTruef(t, out.ID > 0, "application_create: expected ID > 0")
-		appID = out.ID
-		t.Logf("Created application %d", appID)
-	})
-	defer func() {
-		if appID > 0 {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-				"action": "application_delete",
-				"params": map[string]any{"id": appID},
+		t.Run("ApplicationList", func(t *testing.T) {
+			out, err := callToolOn[applications.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "application_list",
+				"params": map[string]any{},
 			})
-		}
-	}()
+			requireNoError(t, err, "application_list")
+			t.Logf("Applications: %d", len(out.Applications))
+		})
+
+		t.Run("ApplicationCreate", func(t *testing.T) {
+			out, err := callToolOn[applications.CreateOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "application_create",
+				"params": map[string]any{
+					"name":         "e2e-app-" + uniqueName(""),
+					"redirect_uri": "https://e2e-test.example.com/callback",
+					"scopes":       "api",
+				},
+			})
+			requireNoError(t, err, "application_create")
+			requireTruef(t, out.ID > 0, "application_create: expected ID > 0")
+			appID = out.ID
+			t.Logf("Created application %d", appID)
+		})
+		defer func() {
+			if appID > 0 {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+					"action": "application_delete",
+					"params": map[string]any{"id": appID},
+				})
+			}
+		}()
+	})
 }
 
 // TestMeta_AdminCustomAttributes exercises custom attribute CRUD on the current user.
@@ -451,65 +467,67 @@ func TestMeta_AdminCustomAttributes(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	// Get current user ID for custom attributes
-	usr, usrErr := callToolOn[struct{ ID int64 }](ctx, sess.meta, "gitlab_user", map[string]any{
-		"action": "current",
-		"params": map[string]any{},
-	})
-	requireNoError(t, usrErr, "get current user")
-	attrKey := "e2e_test_attr"
-
-	t.Run("CustomAttrSet", func(t *testing.T) {
-		out, err := callToolOn[customattributes.SetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "custom_attr_set",
-			"params": map[string]any{
-				"resource_type": "user",
-				"resource_id":   usr.ID,
-				"key":           attrKey,
-				"value":         "test-value",
-			},
+		// Get current user ID for custom attributes
+		usr, usrErr := callToolOn[struct{ ID int64 }](ctx, sess.meta, "gitlab_user", map[string]any{
+			"action": "current",
+			"params": map[string]any{},
 		})
-		requireNoError(t, err, "custom_attr_set")
-		t.Logf("Set custom attr: key=%s", out.Key)
-	})
-	defer func() {
-		_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "custom_attr_delete",
-			"params": map[string]any{
-				"resource_type": "user",
-				"resource_id":   usr.ID,
-				"key":           attrKey,
-			},
-		})
-	}()
+		requireNoError(t, usrErr, "get current user")
+		attrKey := "e2e_test_attr"
 
-	t.Run("CustomAttrGet", func(t *testing.T) {
-		out, err := callToolOn[customattributes.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "custom_attr_get",
-			"params": map[string]any{
-				"resource_type": "user",
-				"resource_id":   usr.ID,
-				"key":           attrKey,
-			},
+		t.Run("CustomAttrSet", func(t *testing.T) {
+			out, err := callToolOn[customattributes.SetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "custom_attr_set",
+				"params": map[string]any{
+					"resource_type": "user",
+					"resource_id":   usr.ID,
+					"key":           attrKey,
+					"value":         "test-value",
+				},
+			})
+			requireNoError(t, err, "custom_attr_set")
+			t.Logf("Set custom attr: key=%s", out.Key)
 		})
-		requireNoError(t, err, "custom_attr_get")
-		t.Logf("Got custom attr: key=%s value=%s", out.Key, out.Value)
-	})
+		defer func() {
+			_ = callToolVoidOn(ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "custom_attr_delete",
+				"params": map[string]any{
+					"resource_type": "user",
+					"resource_id":   usr.ID,
+					"key":           attrKey,
+				},
+			})
+		}()
 
-	t.Run("CustomAttrList", func(t *testing.T) {
-		out, err := callToolOn[customattributes.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
-			"action": "custom_attr_list",
-			"params": map[string]any{
-				"resource_type": "user",
-				"resource_id":   usr.ID,
-			},
+		t.Run("CustomAttrGet", func(t *testing.T) {
+			out, err := callToolOn[customattributes.GetOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "custom_attr_get",
+				"params": map[string]any{
+					"resource_type": "user",
+					"resource_id":   usr.ID,
+					"key":           attrKey,
+				},
+			})
+			requireNoError(t, err, "custom_attr_get")
+			t.Logf("Got custom attr: key=%s value=%s", out.Key, out.Value)
 		})
-		requireNoError(t, err, "custom_attr_list")
-		requireTruef(t, len(out.Attributes) > 0, "custom_attr_list: expected at least 1 attribute")
-		t.Logf("Custom attributes: %d", len(out.Attributes))
+
+		t.Run("CustomAttrList", func(t *testing.T) {
+			out, err := callToolOn[customattributes.ListOutput](ctx, sess.meta, "gitlab_admin", map[string]any{
+				"action": "custom_attr_list",
+				"params": map[string]any{
+					"resource_type": "user",
+					"resource_id":   usr.ID,
+				},
+			})
+			requireNoError(t, err, "custom_attr_list")
+			requireTruef(t, len(out.Attributes) > 0, "custom_attr_list: expected at least 1 attribute")
+			t.Logf("Custom attributes: %d", len(out.Attributes))
+		})
 	})
 }

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -128,7 +128,7 @@ func lockedCapabilities(caps []Capability) []Capability {
 	seen := make(map[Capability]struct{}, len(caps))
 	for _, cap := range caps {
 		switch cap {
-		case CapabilityInstanceGlobal, CapabilityCurrentUserState:
+		case CapabilityRunner, CapabilityInstanceGlobal, CapabilityCurrentUserState:
 			seen[cap] = struct{}{}
 		}
 	}

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -1,0 +1,158 @@
+//go:build e2e
+
+package suite
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// Capability identifies an E2E environment requirement or shared-state scope.
+type Capability string
+
+// Capability values describe the resource scopes that need explicit gates.
+const (
+	CapabilityAdmin            Capability = "admin"
+	CapabilityEnterprise       Capability = "enterprise"
+	CapabilityRunner           Capability = "runner"
+	CapabilityInstanceGlobal   Capability = "instance-global"
+	CapabilityCurrentUserState Capability = "current-user-state"
+	CapabilitySafeMode         Capability = "safe-mode"
+	CapabilitySampling         Capability = "sampling"
+	CapabilityElicitation      Capability = "elicitation"
+)
+
+var adminCapability = struct {
+	once sync.Once
+	ok   bool
+	err  error
+}{}
+
+var capabilityLocks = struct {
+	mu    sync.Mutex
+	locks map[Capability]*sync.Mutex
+}{locks: map[Capability]*sync.Mutex{}}
+
+// RequireCapabilities skips the test when required E2E capabilities are absent.
+func RequireCapabilities(t *testing.T, caps ...Capability) {
+	t.Helper()
+
+	for _, cap := range caps {
+		switch cap {
+		case CapabilityAdmin:
+			if !hasAdminCapability() {
+				if adminCapability.err != nil {
+					t.Skipf("admin capability unavailable: %v", adminCapability.err)
+				}
+				t.Skip("admin capability unavailable")
+			}
+		case CapabilityEnterprise:
+			if !sess.enterprise {
+				t.Skip("enterprise capability unavailable")
+			}
+		case CapabilityRunner:
+			if !hasRunner(sess.glClient) {
+				t.Skip("runner capability unavailable")
+			}
+		case CapabilitySafeMode:
+			if sess.safeMode == nil {
+				t.Skip("safe-mode MCP session not configured")
+			}
+		case CapabilitySampling:
+			if sess.sampling == nil {
+				t.Skip("sampling MCP session not configured")
+			}
+		case CapabilityElicitation:
+			if sess.elicitation == nil {
+				t.Skip("elicitation MCP session not configured")
+			}
+		case CapabilityInstanceGlobal, CapabilityCurrentUserState:
+			// These capabilities represent shared mutable state and are enforced by locks.
+		default:
+			t.Fatalf("unknown E2E capability %q", cap)
+		}
+	}
+}
+
+// RunWithCapabilities centralizes capability checks, locks, and E2E context setup.
+func RunWithCapabilities(t *testing.T, caps []Capability, fn func(t *testing.T, e2e *E2EContext)) {
+	t.Helper()
+
+	RequireCapabilities(t, caps...)
+	unlock := acquireCapabilityLocks(caps)
+	t.Cleanup(unlock)
+
+	e2e := NewE2EContext(t)
+	fn(t, e2e)
+}
+
+func hasAdminCapability() bool {
+	adminCapability.once.Do(func() {
+		if sess.glClient == nil {
+			adminCapability.err = errGitLabClientUnavailable{}
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		user, _, err := sess.glClient.GL().Users.CurrentUser(gl.WithContext(ctx))
+		if err != nil {
+			adminCapability.err = err
+			return
+		}
+		adminCapability.ok = user.IsAdmin
+	})
+	return adminCapability.ok
+}
+
+func acquireCapabilityLocks(caps []Capability) func() {
+	lockCaps := lockedCapabilities(caps)
+	for _, cap := range lockCaps {
+		lockForCapability(cap).Lock()
+	}
+
+	return func() {
+		for i := len(lockCaps) - 1; i >= 0; i-- {
+			lockForCapability(lockCaps[i]).Unlock()
+		}
+	}
+}
+
+func lockedCapabilities(caps []Capability) []Capability {
+	seen := make(map[Capability]struct{}, len(caps))
+	for _, cap := range caps {
+		switch cap {
+		case CapabilityInstanceGlobal, CapabilityCurrentUserState:
+			seen[cap] = struct{}{}
+		}
+	}
+
+	lockCaps := make([]Capability, 0, len(seen))
+	for cap := range seen {
+		lockCaps = append(lockCaps, cap)
+	}
+	sort.Slice(lockCaps, func(i, j int) bool { return lockCaps[i] < lockCaps[j] })
+	return lockCaps
+}
+
+func lockForCapability(cap Capability) *sync.Mutex {
+	capabilityLocks.mu.Lock()
+	defer capabilityLocks.mu.Unlock()
+
+	lock := capabilityLocks.locks[cap]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		capabilityLocks.locks[cap] = lock
+	}
+	return lock
+}
+
+type errGitLabClientUnavailable struct{}
+
+func (errGitLabClientUnavailable) Error() string { return "gitlab client unavailable" }

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -32,12 +32,12 @@ const (
 	CapabilityExternalNetwork  Capability = "external-network"
 )
 
-// adminCapability caches whether the configured GitLab token has administrator
-// privileges so admin-only tests do not probe the API repeatedly.
+// adminCapability caches a successful administrator probe so admin-only tests
+// do not repeatedly verify a token that is already known to be privileged.
 var adminCapability = struct {
-	once sync.Once
-	ok   bool
-	err  error
+	mu     sync.Mutex
+	cached bool
+	ok     bool
 }{}
 
 // capabilityLocks stores process-local mutexes for capabilities that mutate
@@ -54,9 +54,9 @@ func RequireCapabilities(t *testing.T, caps ...Capability) {
 	for _, capability := range caps {
 		switch capability {
 		case CapabilityAdmin:
-			if !hasAdminCapability() {
-				if adminCapability.err != nil {
-					t.Skipf("admin capability unavailable: %v", adminCapability.err)
+			if ok, err := hasAdminCapability(); !ok {
+				if err != nil {
+					t.Skipf("admin capability unavailable: %v", err)
 				}
 				t.Skip("admin capability unavailable")
 			}
@@ -111,25 +111,38 @@ func RunWithCapabilities(t *testing.T, caps []Capability, fn func(t *testing.T, 
 }
 
 // hasAdminCapability reports whether the configured GitLab user is an
-// administrator, caching the first API probe for the duration of the test run.
-func hasAdminCapability() bool {
-	adminCapability.once.Do(func() {
-		if sess.glClient == nil {
-			adminCapability.err = gitLabClientUnavailableError{}
-			return
-		}
+// administrator, caching only successful admin probes so transient failures can
+// be retried by later tests.
+func hasAdminCapability() (bool, error) {
+	adminCapability.mu.Lock()
+	if adminCapability.cached {
+		ok := adminCapability.ok
+		adminCapability.mu.Unlock()
+		return ok, nil
+	}
+	adminCapability.mu.Unlock()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+	if sess.glClient == nil {
+		return false, gitLabClientUnavailableError{}
+	}
 
-		user, _, err := sess.glClient.GL().Users.CurrentUser(gl.WithContext(ctx))
-		if err != nil {
-			adminCapability.err = err
-			return
-		}
-		adminCapability.ok = user.IsAdmin
-	})
-	return adminCapability.ok
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	user, _, err := sess.glClient.GL().Users.CurrentUser(gl.WithContext(ctx))
+	if err != nil {
+		return false, err
+	}
+	if !user.IsAdmin {
+		return false, nil
+	}
+
+	adminCapability.mu.Lock()
+	adminCapability.ok = true
+	adminCapability.cached = true
+	adminCapability.mu.Unlock()
+
+	return true, nil
 }
 
 // acquireCapabilityLocks locks all serialized capabilities in deterministic

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -5,7 +5,7 @@ package suite
 import (
 	"context"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -45,8 +45,8 @@ var capabilityLocks = struct {
 func RequireCapabilities(t *testing.T, caps ...Capability) {
 	t.Helper()
 
-	for _, cap := range caps {
-		switch cap {
+	for _, capability := range caps {
+		switch capability {
 		case CapabilityAdmin:
 			if !hasAdminCapability() {
 				if adminCapability.err != nil {
@@ -76,12 +76,12 @@ func RequireCapabilities(t *testing.T, caps ...Capability) {
 			}
 		case CapabilityExternalNetwork:
 			if !hasExternalNetworkCapability() {
-				t.Skip("external-network capability unavailable; set E2E_EXTERNAL_NETWORK=true to run tests that call public URLs")
+				t.Skip("external-network capability unavailable; prefer Docker fixture endpoints; set E2E_EXTERNAL_NETWORK=true only for tests that must call public URLs")
 			}
 		case CapabilityInstanceGlobal, CapabilityCurrentUserState:
 			// These capabilities represent shared mutable state and are enforced by locks.
 		default:
-			t.Fatalf("unknown E2E capability %q", cap)
+			t.Fatalf("unknown E2E capability %q", capability)
 		}
 	}
 }
@@ -105,7 +105,7 @@ func RunWithCapabilities(t *testing.T, caps []Capability, fn func(t *testing.T, 
 func hasAdminCapability() bool {
 	adminCapability.once.Do(func() {
 		if sess.glClient == nil {
-			adminCapability.err = errGitLabClientUnavailable{}
+			adminCapability.err = gitLabClientUnavailableError{}
 			return
 		}
 
@@ -124,8 +124,8 @@ func hasAdminCapability() bool {
 
 func acquireCapabilityLocks(caps []Capability) func() {
 	lockCaps := lockedCapabilities(caps)
-	for _, cap := range lockCaps {
-		lockForCapability(cap).Lock()
+	for _, capability := range lockCaps {
+		lockForCapability(capability).Lock()
 	}
 
 	return func() {
@@ -137,33 +137,33 @@ func acquireCapabilityLocks(caps []Capability) func() {
 
 func lockedCapabilities(caps []Capability) []Capability {
 	seen := make(map[Capability]struct{}, len(caps))
-	for _, cap := range caps {
-		switch cap {
+	for _, capability := range caps {
+		switch capability {
 		case CapabilityRunner, CapabilityInstanceGlobal, CapabilityCurrentUserState:
-			seen[cap] = struct{}{}
+			seen[capability] = struct{}{}
 		}
 	}
 
 	lockCaps := make([]Capability, 0, len(seen))
-	for cap := range seen {
-		lockCaps = append(lockCaps, cap)
+	for capability := range seen {
+		lockCaps = append(lockCaps, capability)
 	}
-	sort.Slice(lockCaps, func(i, j int) bool { return lockCaps[i] < lockCaps[j] })
+	slices.Sort(lockCaps)
 	return lockCaps
 }
 
-func lockForCapability(cap Capability) *sync.Mutex {
+func lockForCapability(capability Capability) *sync.Mutex {
 	capabilityLocks.mu.Lock()
 	defer capabilityLocks.mu.Unlock()
 
-	lock := capabilityLocks.locks[cap]
+	lock := capabilityLocks.locks[capability]
 	if lock == nil {
 		lock = &sync.Mutex{}
-		capabilityLocks.locks[cap] = lock
+		capabilityLocks.locks[capability] = lock
 	}
 	return lock
 }
 
-type errGitLabClientUnavailable struct{}
+type gitLabClientUnavailableError struct{}
 
-func (errGitLabClientUnavailable) Error() string { return "gitlab client unavailable" }
+func (gitLabClientUnavailableError) Error() string { return "gitlab client unavailable" }

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// capabilities_helper_test.go defines capability gates and locks used by E2E
+// tests that require optional GitLab features or shared mutable instance state.
 package suite
 
 import (
@@ -30,12 +32,16 @@ const (
 	CapabilityExternalNetwork  Capability = "external-network"
 )
 
+// adminCapability caches whether the configured GitLab token has administrator
+// privileges so admin-only tests do not probe the API repeatedly.
 var adminCapability = struct {
 	once sync.Once
 	ok   bool
 	err  error
 }{}
 
+// capabilityLocks stores process-local mutexes for capabilities that mutate
+// shared GitLab state and therefore must not run concurrently.
 var capabilityLocks = struct {
 	mu    sync.Mutex
 	locks map[Capability]*sync.Mutex
@@ -86,6 +92,8 @@ func RequireCapabilities(t *testing.T, caps ...Capability) {
 	}
 }
 
+// hasExternalNetworkCapability reports whether tests that must call public
+// Internet endpoints are explicitly enabled for the current E2E run.
 func hasExternalNetworkCapability() bool {
 	return strings.EqualFold(os.Getenv("E2E_EXTERNAL_NETWORK"), "true")
 }
@@ -102,6 +110,8 @@ func RunWithCapabilities(t *testing.T, caps []Capability, fn func(t *testing.T, 
 	fn(t, e2e)
 }
 
+// hasAdminCapability reports whether the configured GitLab user is an
+// administrator, caching the first API probe for the duration of the test run.
 func hasAdminCapability() bool {
 	adminCapability.once.Do(func() {
 		if sess.glClient == nil {
@@ -122,6 +132,8 @@ func hasAdminCapability() bool {
 	return adminCapability.ok
 }
 
+// acquireCapabilityLocks locks all serialized capabilities in deterministic
+// order and returns a cleanup function that releases them in reverse order.
 func acquireCapabilityLocks(caps []Capability) func() {
 	lockCaps := lockedCapabilities(caps)
 	for _, capability := range lockCaps {
@@ -135,6 +147,8 @@ func acquireCapabilityLocks(caps []Capability) func() {
 	}
 }
 
+// lockedCapabilities returns the subset of capabilities that require serialized
+// execution because they mutate instance-wide or current-user state.
 func lockedCapabilities(caps []Capability) []Capability {
 	seen := make(map[Capability]struct{}, len(caps))
 	for _, capability := range caps {
@@ -152,6 +166,8 @@ func lockedCapabilities(caps []Capability) []Capability {
 	return lockCaps
 }
 
+// lockForCapability returns the mutex associated with capability, creating it
+// lazily while protecting the shared lock map.
 func lockForCapability(capability Capability) *sync.Mutex {
 	capabilityLocks.mu.Lock()
 	defer capabilityLocks.mu.Unlock()
@@ -164,6 +180,9 @@ func lockForCapability(capability Capability) *sync.Mutex {
 	return lock
 }
 
+// gitLabClientUnavailableError indicates that an admin capability probe could
+// not run because the E2E GitLab client was not configured.
 type gitLabClientUnavailableError struct{}
 
+// Error returns the human-readable reason for the unavailable GitLab client.
 func (gitLabClientUnavailableError) Error() string { return "gitlab client unavailable" }

--- a/test/e2e/suite/capabilities_helper_test.go
+++ b/test/e2e/suite/capabilities_helper_test.go
@@ -4,7 +4,9 @@ package suite
 
 import (
 	"context"
+	"os"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +27,7 @@ const (
 	CapabilitySafeMode         Capability = "safe-mode"
 	CapabilitySampling         Capability = "sampling"
 	CapabilityElicitation      Capability = "elicitation"
+	CapabilityExternalNetwork  Capability = "external-network"
 )
 
 var adminCapability = struct {
@@ -71,12 +74,20 @@ func RequireCapabilities(t *testing.T, caps ...Capability) {
 			if sess.elicitation == nil {
 				t.Skip("elicitation MCP session not configured")
 			}
+		case CapabilityExternalNetwork:
+			if !hasExternalNetworkCapability() {
+				t.Skip("external-network capability unavailable; set E2E_EXTERNAL_NETWORK=true to run tests that call public URLs")
+			}
 		case CapabilityInstanceGlobal, CapabilityCurrentUserState:
 			// These capabilities represent shared mutable state and are enforced by locks.
 		default:
 			t.Fatalf("unknown E2E capability %q", cap)
 		}
 	}
+}
+
+func hasExternalNetworkCapability() bool {
+	return strings.EqualFold(os.Getenv("E2E_EXTERNAL_NETWORK"), "true")
 }
 
 // RunWithCapabilities centralizes capability checks, locks, and E2E context setup.

--- a/test/e2e/suite/capabilities_test.go
+++ b/test/e2e/suite/capabilities_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/completions"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/internal/prompts"
 	"github.com/jmrplens/gitlab-mcp-server/internal/resources"
 	"github.com/jmrplens/gitlab-mcp-server/internal/roots"
@@ -63,10 +64,10 @@ type logEntry struct {
 //     so the server's InitializedHandler can fetch them via ListRoots.
 //
 // The session is closed in t.Cleanup.
-func newCapabilitiesSession(t *testing.T, withLogging, withProgress bool, withRoots []*mcp.Root) *capabilitiesSession {
+func newCapabilitiesSession(t *testing.T, client *gitlabclient.Client, enterprise bool, withLogging, withProgress bool, withRoots []*mcp.Root) *capabilitiesSession {
 	t.Helper()
 
-	completionHandler := completions.NewHandler(sess.glClient)
+	completionHandler := completions.NewHandler(client)
 	rootsManager := roots.NewManager()
 
 	server := mcp.NewServer(&mcp.Implementation{
@@ -88,11 +89,11 @@ func newCapabilitiesSession(t *testing.T, withLogging, withProgress bool, withRo
 		},
 	})
 
-	tools.RegisterAll(server, sess.glClient, sess.enterprise)
-	resources.Register(server, sess.glClient)
+	tools.RegisterAll(server, client, enterprise)
+	resources.Register(server, client)
 	resources.RegisterWorkspaceRoots(server, rootsManager)
 	resources.RegisterWorkflowGuides(server)
-	prompts.Register(server, sess.glClient)
+	prompts.Register(server, client)
 
 	st, ct := mcp.NewInMemoryTransports()
 	serverCtx, serverCancel := context.WithCancel(context.Background())
@@ -207,7 +208,7 @@ func TestCapability_Logging(t *testing.T) {
 		t.Skip("gitlab client not configured")
 	}
 
-	cs := newCapabilitiesSession(t, true, false, nil)
+	cs := newCapabilitiesSession(t, sess.glClient, sess.enterprise, true, false, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -258,7 +259,7 @@ func TestCapability_Progress(t *testing.T) {
 		t.Skip("gitlab client or individual session not configured")
 	}
 
-	cs := newCapabilitiesSession(t, false, true, nil)
+	cs := newCapabilitiesSession(t, sess.glClient, sess.enterprise, false, true, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -328,7 +329,7 @@ func TestCapability_Roots(t *testing.T) {
 	advertised := []*mcp.Root{
 		{URI: "file:///tmp/e2e-capabilities-root", Name: "e2e-capabilities-root"},
 	}
-	cs := newCapabilitiesSession(t, false, false, advertised)
+	cs := newCapabilitiesSession(t, sess.glClient, sess.enterprise, false, false, advertised)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -367,7 +368,7 @@ func TestCapability_RootsListChanged(t *testing.T) {
 		t.Skip("gitlab client not configured")
 	}
 
-	cs := newCapabilitiesSession(t, false, false, nil)
+	cs := newCapabilitiesSession(t, sess.glClient, sess.enterprise, false, false, nil)
 	cs.mcpClient.AddRoots(&mcp.Root{
 		URI:  "file:///tmp/e2e-capabilities-late-root",
 		Name: "e2e-capabilities-late-root",
@@ -418,7 +419,7 @@ func TestCapability_Completions(t *testing.T) {
 		t.Skip("gitlab client not configured")
 	}
 
-	cs := newCapabilitiesSession(t, false, false, nil)
+	cs := newCapabilitiesSession(t, sess.glClient, sess.enterprise, false, false, nil)
 
 	// Ensure at least one project exists so completions have something to
 	// return. Use the shared session to avoid duplicating cleanup logic.

--- a/test/e2e/suite/cirunner_test.go
+++ b/test/e2e/suite/cirunner_test.go
@@ -38,143 +38,142 @@ fast-pass:
 // NOT parallelized: pipeline-heavy tests share a single CI runner. Running
 // them concurrently causes pipelines to queue, leading to spurious timeouts.
 func TestIndividual_CIRunner(t *testing.T) {
-	if !hasRunner(sess.glClient) {
-		t.Skip("CI runner not available — skipping pipeline/job tests")
-	}
+	RunWithCapabilities(t, []Capability{CapabilityRunner, CapabilitySampling}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
+		defer cancel()
 
-	proj := createProject(ctx, t, sess.individual)
-	unprotectMain(ctx, t, proj)
+		proj := createProject(ctx, t, sess.individual)
+		unprotectMain(ctx, t, proj)
 
-	var pipelineID int64
-	var jobID int64
+		var pipelineID int64
+		var jobID int64
 
-	t.Run("CommitCIConfig", func(t *testing.T) {
-		_, err := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
-			ProjectID:     proj.pidOf(),
-			Branch:        defaultBranch,
-			CommitMessage: "ci: add .gitlab-ci.yml for E2E pipeline tests",
-			Actions: []commits.Action{{
-				Action:   "create",
-				FilePath: ".gitlab-ci.yml",
-				Content:  ciYAML,
-			}},
+		t.Run("CommitCIConfig", func(t *testing.T) {
+			_, err := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
+				ProjectID:     proj.pidOf(),
+				Branch:        defaultBranch,
+				CommitMessage: "ci: add .gitlab-ci.yml for E2E pipeline tests",
+				Actions: []commits.Action{{
+					Action:   "create",
+					FilePath: ".gitlab-ci.yml",
+					Content:  ciYAML,
+				}},
+			})
+			requireNoError(t, err, "commit CI config")
+			t.Logf("Committed .gitlab-ci.yml to %s", defaultBranch)
 		})
-		requireNoError(t, err, "commit CI config")
-		t.Logf("Committed .gitlab-ci.yml to %s", defaultBranch)
-	})
 
-	pidStr := strconv.FormatInt(proj.ID, 10)
+		pidStr := strconv.FormatInt(proj.ID, 10)
 
-	t.Run("PipelineCreate", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
-			ProjectID: toolutil.StringOrInt(pidStr),
-			Ref:       defaultBranch,
+		t.Run("PipelineCreate", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
+				ProjectID: toolutil.StringOrInt(pidStr),
+				Ref:       defaultBranch,
+			})
+			requireNoError(t, err, "pipeline create")
+			requireTruef(t, out.ID > 0, "pipeline ID should be positive")
+			pipelineID = out.ID
+			t.Logf("Created pipeline: ID=%d status=%s ref=%s", out.ID, out.Status, out.Ref)
 		})
-		requireNoError(t, err, "pipeline create")
-		requireTruef(t, out.ID > 0, "pipeline ID should be positive")
-		pipelineID = out.ID
-		t.Logf("Created pipeline: ID=%d status=%s ref=%s", out.ID, out.Status, out.Ref)
-	})
 
-	t.Run("PipelineGet", func(t *testing.T) {
-		requireTruef(t, pipelineID > 0, "pipeline ID not set")
+		t.Run("PipelineGet", func(t *testing.T) {
+			requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_get", pipelines.GetInput{
-			ProjectID:  toolutil.StringOrInt(pidStr),
-			PipelineID: pipelineID,
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_get", pipelines.GetInput{
+				ProjectID:  toolutil.StringOrInt(pidStr),
+				PipelineID: pipelineID,
+			})
+			requireNoError(t, err, "pipeline get")
+			requireTruef(t, out.ID == pipelineID, "expected pipeline ID %d, got %d", pipelineID, out.ID)
+			t.Logf("Got pipeline: ID=%d status=%s", out.ID, out.Status)
 		})
-		requireNoError(t, err, "pipeline get")
-		requireTruef(t, out.ID == pipelineID, "expected pipeline ID %d, got %d", pipelineID, out.ID)
-		t.Logf("Got pipeline: ID=%d status=%s", out.ID, out.Status)
-	})
 
-	t.Run("PipelineList", func(t *testing.T) {
-		out, err := callToolOn[pipelines.ListOutput](ctx, sess.individual, "gitlab_pipeline_list", pipelines.ListInput{
-			ProjectID: toolutil.StringOrInt(pidStr),
+		t.Run("PipelineList", func(t *testing.T) {
+			out, err := callToolOn[pipelines.ListOutput](ctx, sess.individual, "gitlab_pipeline_list", pipelines.ListInput{
+				ProjectID: toolutil.StringOrInt(pidStr),
+			})
+			requireNoError(t, err, "pipeline list")
+			requireTruef(t, len(out.Pipelines) >= 1, "expected at least 1 pipeline, got %d", len(out.Pipelines))
+			t.Logf("Listed %d pipelines", len(out.Pipelines))
 		})
-		requireNoError(t, err, "pipeline list")
-		requireTruef(t, len(out.Pipelines) >= 1, "expected at least 1 pipeline, got %d", len(out.Pipelines))
-		t.Logf("Listed %d pipelines", len(out.Pipelines))
-	})
 
-	t.Run("WaitAndJobList", func(t *testing.T) {
-		requireTruef(t, pipelineID > 0, "pipeline ID not set")
+		t.Run("WaitAndJobList", func(t *testing.T) {
+			requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-		status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
-		t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
+			status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
+			t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
 
-		out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
-			ProjectID:  toolutil.StringOrInt(pidStr),
-			PipelineID: pipelineID,
+			out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
+				ProjectID:  toolutil.StringOrInt(pidStr),
+				PipelineID: pipelineID,
+			})
+			requireNoError(t, err, "job list")
+			requireTruef(t, len(out.Jobs) >= 1, "expected at least 1 job, got %d", len(out.Jobs))
+			jobID = out.Jobs[0].ID
+			t.Logf("Listed %d jobs; first job: ID=%d name=%s status=%s", len(out.Jobs), out.Jobs[0].ID, out.Jobs[0].Name, out.Jobs[0].Status)
 		})
-		requireNoError(t, err, "job list")
-		requireTruef(t, len(out.Jobs) >= 1, "expected at least 1 job, got %d", len(out.Jobs))
-		jobID = out.Jobs[0].ID
-		t.Logf("Listed %d jobs; first job: ID=%d name=%s status=%s", len(out.Jobs), out.Jobs[0].ID, out.Jobs[0].Name, out.Jobs[0].Status)
-	})
 
-	t.Run("JobGet", func(t *testing.T) {
-		requireTruef(t, jobID > 0, "job ID not set")
+		t.Run("JobGet", func(t *testing.T) {
+			requireTruef(t, jobID > 0, "job ID not set")
 
-		out, err := callToolOn[jobs.Output](ctx, sess.individual, "gitlab_job_get", jobs.GetInput{
-			ProjectID: toolutil.StringOrInt(pidStr),
-			JobID:     jobID,
+			out, err := callToolOn[jobs.Output](ctx, sess.individual, "gitlab_job_get", jobs.GetInput{
+				ProjectID: toolutil.StringOrInt(pidStr),
+				JobID:     jobID,
+			})
+			requireNoError(t, err, "job get")
+			requireTruef(t, out.ID == jobID, "expected job ID %d, got %d", jobID, out.ID)
+			t.Logf("Got job: ID=%d name=%s status=%s", out.ID, out.Name, out.Status)
 		})
-		requireNoError(t, err, "job get")
-		requireTruef(t, out.ID == jobID, "expected job ID %d, got %d", jobID, out.ID)
-		t.Logf("Got job: ID=%d name=%s status=%s", out.ID, out.Name, out.Status)
-	})
 
-	t.Run("JobTrace", func(t *testing.T) {
-		requireTruef(t, jobID > 0, "job ID not set")
+		t.Run("JobTrace", func(t *testing.T) {
+			requireTruef(t, jobID > 0, "job ID not set")
 
-		out, err := callToolOn[jobs.TraceOutput](ctx, sess.individual, "gitlab_job_trace", jobs.TraceInput{
-			ProjectID: toolutil.StringOrInt(pidStr),
-			JobID:     jobID,
+			out, err := callToolOn[jobs.TraceOutput](ctx, sess.individual, "gitlab_job_trace", jobs.TraceInput{
+				ProjectID: toolutil.StringOrInt(pidStr),
+				JobID:     jobID,
+			})
+			requireNoError(t, err, "job trace")
+			requireTruef(t, len(out.Trace) > 0, "expected non-empty job trace")
+			t.Logf("Got job trace: %d chars (truncated=%v)", len(out.Trace), out.Truncated)
 		})
-		requireNoError(t, err, "job trace")
-		requireTruef(t, len(out.Trace) > 0, "expected non-empty job trace")
-		t.Logf("Got job trace: %d chars (truncated=%v)", len(out.Trace), out.Truncated)
-	})
 
-	t.Run("SamplingAnalyzePipelineFailure", func(t *testing.T) {
-		requireTruef(t, pipelineID > 0, "pipeline ID not set")
+		t.Run("SamplingAnalyzePipelineFailure", func(t *testing.T) {
+			requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-		out, err := callToolOn[samplingtools.AnalyzePipelineFailureOutput](ctx, sess.sampling, "gitlab_analyze_pipeline_failure", samplingtools.AnalyzePipelineFailureInput{
-			ProjectID:  toolutil.StringOrInt(pidStr),
-			PipelineID: pipelineID,
+			out, err := callToolOn[samplingtools.AnalyzePipelineFailureOutput](ctx, sess.sampling, "gitlab_analyze_pipeline_failure", samplingtools.AnalyzePipelineFailureInput{
+				ProjectID:  toolutil.StringOrInt(pidStr),
+				PipelineID: pipelineID,
+			})
+			requireNoError(t, err, "sampling analyze pipeline failure")
+			requireTruef(t, out.Analysis != "", "expected non-empty analysis")
+			requireTruef(t, out.Model == "e2e-mock-model", "expected mock model, got %q", out.Model)
+			t.Logf("Analyzed pipeline failure: model=%s, analysis_len=%d", out.Model, len(out.Analysis))
 		})
-		requireNoError(t, err, "sampling analyze pipeline failure")
-		requireTruef(t, out.Analysis != "", "expected non-empty analysis")
-		requireTruef(t, out.Model == "e2e-mock-model", "expected mock model, got %q", out.Model)
-		t.Logf("Analyzed pipeline failure: model=%s, analysis_len=%d", out.Model, len(out.Analysis))
-	})
 
-	t.Run("PipelineRetry", func(t *testing.T) {
-		requireTruef(t, pipelineID > 0, "pipeline ID not set")
+		t.Run("PipelineRetry", func(t *testing.T) {
+			requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_retry", pipelines.ActionInput{
-			ProjectID:  toolutil.StringOrInt(pidStr),
-			PipelineID: pipelineID,
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_retry", pipelines.ActionInput{
+				ProjectID:  toolutil.StringOrInt(pidStr),
+				PipelineID: pipelineID,
+			})
+			requireNoError(t, err, "pipeline retry")
+			t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
+
+			waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
 		})
-		requireNoError(t, err, "pipeline retry")
-		t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
 
-		waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
-	})
+		t.Run("PipelineDelete", func(t *testing.T) {
+			requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-	t.Run("PipelineDelete", func(t *testing.T) {
-		requireTruef(t, pipelineID > 0, "pipeline ID not set")
-
-		err := callToolVoidOn(ctx, sess.individual, "gitlab_pipeline_delete", pipelines.DeleteInput{
-			ProjectID:  toolutil.StringOrInt(pidStr),
-			PipelineID: pipelineID,
+			err := callToolVoidOn(ctx, sess.individual, "gitlab_pipeline_delete", pipelines.DeleteInput{
+				ProjectID:  toolutil.StringOrInt(pidStr),
+				PipelineID: pipelineID,
+			})
+			requireNoError(t, err, "pipeline delete")
+			pipelineID = 0
+			t.Logf("Deleted pipeline")
 		})
-		requireNoError(t, err, "pipeline delete")
-		pipelineID = 0
-		t.Logf("Deleted pipeline")
 	})
 }

--- a/test/e2e/suite/cirunner_test.go
+++ b/test/e2e/suite/cirunner_test.go
@@ -39,7 +39,6 @@ fast-pass:
 // them concurrently causes pipelines to queue, leading to spurious timeouts.
 func TestIndividual_CIRunner(t *testing.T) {
 	RunWithCapabilities(t, []Capability{CapabilityRunner, CapabilitySampling}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
 		defer cancel()
 

--- a/test/e2e/suite/cirunner_test.go
+++ b/test/e2e/suite/cirunner_test.go
@@ -38,7 +38,7 @@ fast-pass:
 // NOT parallelized: pipeline-heavy tests share a single CI runner. Running
 // them concurrently causes pipelines to queue, leading to spurious timeouts.
 func TestIndividual_CIRunner(t *testing.T) {
-	if !hasRunner() {
+	if !hasRunner(sess.glClient) {
 		t.Skip("CI runner not available — skipping pipeline/job tests")
 	}
 
@@ -103,7 +103,7 @@ func TestIndividual_CIRunner(t *testing.T) {
 	t.Run("WaitAndJobList", func(t *testing.T) {
 		requireTruef(t, pipelineID > 0, "pipeline ID not set")
 
-		status := waitForPipeline(t, proj.ID, pipelineID, 900*time.Second)
+		status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
 		t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
 
 		out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
@@ -163,7 +163,7 @@ func TestIndividual_CIRunner(t *testing.T) {
 		requireNoError(t, err, "pipeline retry")
 		t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
 
-		waitForPipeline(t, proj.ID, pipelineID, 900*time.Second)
+		waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
 	})
 
 	t.Run("PipelineDelete", func(t *testing.T) {

--- a/test/e2e/suite/context_test.go
+++ b/test/e2e/suite/context_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// context_test.go defines the per-test E2E context object that bundles MCP
+// sessions, GitLab client access, and cleanup ownership for resource fixtures.
 package suite
 
 import (
@@ -12,6 +14,7 @@ import (
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 )
 
+// defaultCleanupTimeout bounds per-test resource cleanup during t.Cleanup.
 const defaultCleanupTimeout = 60 * time.Second
 
 // E2EContext carries per-test E2E sessions, identity, and cleanup ownership.
@@ -46,6 +49,7 @@ func NewE2EContext(t *testing.T) *E2EContext {
 	return e2e
 }
 
+// cleanupContext creates the bounded background context used by cleanup hooks.
 func cleanupContext(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)
 }
@@ -75,6 +79,8 @@ func (e2e *E2EContext) SafeMode() *mcp.ClientSession {
 	return e2e.requiredSession("safe mode", e2e.Sessions.safeMode)
 }
 
+// requiredSession returns session or skips the test with name when it is not
+// configured for the current E2E mode.
 func (e2e *E2EContext) requiredSession(name string, session *mcp.ClientSession) *mcp.ClientSession {
 	e2e.T.Helper()
 	if session == nil {

--- a/test/e2e/suite/context_test.go
+++ b/test/e2e/suite/context_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 )
 
 const defaultCleanupTimeout = 60 * time.Second

--- a/test/e2e/suite/context_test.go
+++ b/test/e2e/suite/context_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package suite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const defaultCleanupTimeout = 60 * time.Second
+
+// E2EContext carries per-test E2E sessions, identity, and cleanup ownership.
+type E2EContext struct {
+	T        *testing.T
+	RunID    string
+	Name     string
+	Sessions sessions
+	GitLab   *gitlabclient.Client
+	Ledger   *ResourceLedger
+}
+
+// NewE2EContext creates per-test E2E context and registers ledger cleanup.
+func NewE2EContext(t *testing.T) *E2EContext {
+	t.Helper()
+
+	e2e := &E2EContext{
+		T:        t,
+		RunID:    e2eRunID,
+		Name:     t.Name(),
+		Sessions: sess,
+		GitLab:   sess.glClient,
+		Ledger:   &ResourceLedger{},
+	}
+
+	t.Cleanup(func() {
+		ctx, cancel := cleanupContext(defaultCleanupTimeout)
+		defer cancel()
+		e2e.Ledger.CleanupAll(ctx, t)
+	})
+
+	return e2e
+}
+
+func cleanupContext(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+// Individual returns the individual-tool MCP session or skips the test.
+func (e2e *E2EContext) Individual() *mcp.ClientSession {
+	return e2e.requiredSession("individual", e2e.Sessions.individual)
+}
+
+// Meta returns the meta-tool MCP session or skips the test.
+func (e2e *E2EContext) Meta() *mcp.ClientSession {
+	return e2e.requiredSession("meta", e2e.Sessions.meta)
+}
+
+// Sampling returns the sampling-enabled MCP session or skips the test.
+func (e2e *E2EContext) Sampling() *mcp.ClientSession {
+	return e2e.requiredSession("sampling", e2e.Sessions.sampling)
+}
+
+// Elicitation returns the elicitation-enabled MCP session or skips the test.
+func (e2e *E2EContext) Elicitation() *mcp.ClientSession {
+	return e2e.requiredSession("elicitation", e2e.Sessions.elicitation)
+}
+
+// SafeMode returns the safe-mode MCP session or skips the test.
+func (e2e *E2EContext) SafeMode() *mcp.ClientSession {
+	return e2e.requiredSession("safe mode", e2e.Sessions.safeMode)
+}
+
+func (e2e *E2EContext) requiredSession(name string, session *mcp.ClientSession) *mcp.ClientSession {
+	e2e.T.Helper()
+	if session == nil {
+		e2e.T.Skipf("%s MCP session not configured", name)
+	}
+	return session
+}

--- a/test/e2e/suite/customemoji_test.go
+++ b/test/e2e/suite/customemoji_test.go
@@ -18,14 +18,15 @@ import (
 // create → list → delete.
 func TestIndividual_CustomEmoji(t *testing.T) {
 	t.Parallel()
-	RequireCapabilities(t, CapabilityExternalNetwork)
 
 	ctx := context.Background()
+	groupName := uniqueName("e2e-custom-emoji-ind")
+	emojiURL := e2eFixtureServiceURL("/emoji.png")
 
 	// Create a temporary group for custom emoji.
 	groupOut, groupErr := callToolOn[groups.Output](ctx, sess.individual, "gitlab_group_create", groups.CreateInput{
-		Name: "e2e-custom-emoji-ind",
-		Path: "e2e-custom-emoji-ind",
+		Name: groupName,
+		Path: groupName,
 	})
 	requireNoError(t, groupErr, "create group for custom emoji")
 	t.Cleanup(func() {
@@ -40,7 +41,7 @@ func TestIndividual_CustomEmoji(t *testing.T) {
 		out, err := callToolOn[customemoji.CreateOutput](ctx, sess.individual, "gitlab_create_custom_emoji", customemoji.CreateInput{
 			GroupPath: groupOut.Path,
 			Name:      "e2e_test_emoji",
-			URL:       "https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png",
+			URL:       emojiURL,
 		})
 		requireNoError(t, err, "create custom emoji")
 		requireTruef(t, out.Emoji.ID != "", "expected non-empty emoji GID")
@@ -71,15 +72,16 @@ func TestIndividual_CustomEmoji(t *testing.T) {
 // create → list → delete.
 func TestMeta_CustomEmoji(t *testing.T) {
 	t.Parallel()
-	RequireCapabilities(t, CapabilityExternalNetwork)
 
 	ctx := context.Background()
+	groupName := uniqueName("e2e-custom-emoji-meta")
+	emojiURL := e2eFixtureServiceURL("/emoji.png")
 
 	groupOut, groupErr := callToolOn[groups.Output](ctx, sess.meta, "gitlab_group", map[string]any{
 		"action": "create",
 		"params": map[string]any{
-			"name": "e2e-custom-emoji-meta",
-			"path": "e2e-custom-emoji-meta",
+			"name": groupName,
+			"path": groupName,
 		},
 	})
 	requireNoError(t, groupErr, "create group for custom emoji (meta)")
@@ -97,7 +99,7 @@ func TestMeta_CustomEmoji(t *testing.T) {
 			"params": map[string]any{
 				"group_path": groupOut.Path,
 				"name":       "e2e_test_emoji_meta",
-				"url":        "https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png",
+				"url":        emojiURL,
 			},
 		})
 		requireNoError(t, err, "meta custom emoji create")

--- a/test/e2e/suite/customemoji_test.go
+++ b/test/e2e/suite/customemoji_test.go
@@ -18,6 +18,8 @@ import (
 // create → list → delete.
 func TestIndividual_CustomEmoji(t *testing.T) {
 	t.Parallel()
+	RequireCapabilities(t, CapabilityExternalNetwork)
+
 	ctx := context.Background()
 
 	// Create a temporary group for custom emoji.
@@ -69,6 +71,8 @@ func TestIndividual_CustomEmoji(t *testing.T) {
 // create → list → delete.
 func TestMeta_CustomEmoji(t *testing.T) {
 	t.Parallel()
+	RequireCapabilities(t, CapabilityExternalNetwork)
+
 	ctx := context.Background()
 
 	groupOut, groupErr := callToolOn[groups.Output](ctx, sess.meta, "gitlab_group", map[string]any{

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -171,7 +171,7 @@ func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSess
 	})
 	requireNoError(t, err, "create project fixture")
 
-	e2e.Ledger.Register(ResourceRecord{
+	requireNoError(t, e2e.Ledger.Register(ResourceRecord{
 		Kind:      ResourceKindProject,
 		ID:        strconv.FormatInt(out.ID, 10),
 		Path:      out.PathWithNamespace,
@@ -186,7 +186,7 @@ func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSess
 				FullPath:          out.PathWithNamespace,
 			})
 		},
-	})
+	}), "register project fixture cleanup")
 
 	// Wait for the default branch to be available.
 	waitForBranchOn(ctx, t, e2e.GitLab, out.ID, defaultBranch)
@@ -228,7 +228,7 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 	})
 	requireNoError(t, err, "create project fixture (meta)")
 
-	e2e.Ledger.Register(ResourceRecord{
+	requireNoError(t, e2e.Ledger.Register(ResourceRecord{
 		Kind:      ResourceKindProject,
 		ID:        strconv.FormatInt(out.ID, 10),
 		Path:      out.PathWithNamespace,
@@ -246,7 +246,7 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 				},
 			})
 		},
-	})
+	}), "register meta project fixture cleanup")
 
 	// Wait for the default branch to be available.
 	waitForBranchOn(ctx, t, e2e.GitLab, out.ID, defaultBranch)
@@ -279,7 +279,7 @@ func CreateGroupMeta(ctx context.Context, e2e *E2EContext, session *mcp.ClientSe
 	requireNoError(t, err, "create group fixture (meta)")
 
 	id := strconv.FormatInt(out.ID, 10)
-	e2e.Ledger.Register(ResourceRecord{
+	requireNoError(t, e2e.Ledger.Register(ResourceRecord{
 		Kind:      ResourceKindGroup,
 		ID:        id,
 		Path:      out.FullPath,
@@ -293,7 +293,7 @@ func CreateGroupMeta(ctx context.Context, e2e *E2EContext, session *mcp.ClientSe
 				"params": map[string]any{"group_id": id},
 			})
 		},
-	})
+	}), "register meta group fixture cleanup")
 
 	return GroupFixture{ID: out.ID, Path: out.FullPath}
 }
@@ -540,7 +540,7 @@ func waitForMRReadyState(ctx context.Context, client *gitlabclient.Client, proje
 	defer cancel()
 
 	return Poll(pollCtx, 500*time.Millisecond, maxWait, func() (bool, string, error) {
-		mr, _, err := client.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(pollCtx))
+		mr, resp, err := client.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(pollCtx))
 		if err == nil {
 			switch mr.DetailedMergeStatus {
 			case "preparing", "checking", "unchecked", "":
@@ -552,6 +552,23 @@ func waitForMRReadyState(ctx context.Context, client *gitlabclient.Client, proje
 		if pollCtx.Err() != nil {
 			return false, "", pollCtx.Err()
 		}
-		return false, fmt.Sprintf("error polling MR !%d in project %d: %v", mrIID, projectID, err), nil
+
+		state := fmt.Sprintf("error polling MR !%d in project %d: %v", mrIID, projectID, err)
+		if resp != nil {
+			state = fmt.Sprintf("MR !%d in project %d: HTTP %d", mrIID, projectID, resp.StatusCode)
+		}
+		if resp == nil && !isTransientNetworkError(err) {
+			return false, state, fmt.Errorf("get MR !%d in project %d: %w", mrIID, projectID, err)
+		}
+		if resp != nil && !retryableMergeRequestResponse(resp) {
+			return false, state, fmt.Errorf("get MR !%d in project %d: %w", mrIID, projectID, err)
+		}
+		return false, state, nil
 	})
+}
+
+// retryableMergeRequestResponse reports whether an MR readiness lookup can be
+// retried after GitLab returns an HTTP response.
+func retryableMergeRequestResponse(resp *gl.Response) bool {
+	return resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
 }

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -63,30 +62,6 @@ type MRFixture struct {
 type CommitFixture struct {
 	SHA     string
 	ShortID string
-}
-
-// ---------------------------------------------------------------------------
-// sanitizeTestName converts a test name like
-// "TestIndividual_Branches/Create" into a slug safe for GitLab project names.
-// ---------------------------------------------------------------------------
-
-// unsafeChars matches any character that is not lowercase alphanumeric or hyphen,
-// used by [sanitizeTestName] to strip characters unsafe for GitLab project names.
-var unsafeChars = regexp.MustCompile(`[^a-z0-9-]`)
-
-// sanitizeTestName converts a Go test name like
-// "TestIndividual_Branches/Create" into a slug safe for GitLab project
-// names by lowercasing, replacing separators with hyphens, stripping
-// unsafe characters, and truncating to 40 characters.
-func sanitizeTestName(name string) string {
-	s := strings.ToLower(name)
-	s = strings.ReplaceAll(s, "/", "-")
-	s = strings.ReplaceAll(s, "_", "-")
-	s = unsafeChars.ReplaceAllString(s, "")
-	if len(s) > 40 {
-		s = s[:40]
-	}
-	return s
 }
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -496,56 +496,47 @@ func createMRMeta(ctx context.Context, t *testing.T, session *mcp.ClientSession,
 // waitForBranchOn polls the GitLab API until the named branch exists in the
 // given project or the context is canceled. Under parallel load (~60 projects)
 // branch creation can take well over 30s, so we allow up to 90s with
-// progressive backoff. Transient errors (429, 5xx, network) are retried silently.
+// bounded polling. Transient errors (429, 5xx, network) are retried silently.
 func waitForBranchOn(ctx context.Context, t *testing.T, client *gitlabclient.Client, projectID int64, branch string) {
 	t.Helper()
 	drainSidekiq(ctx, t, client)
+	requireNoError(t, waitForBranch(ctx, client, projectID, branch), fmt.Sprintf("wait for branch %s in project %d", branch, projectID))
+}
+
+func waitForBranch(ctx context.Context, client *gitlabclient.Client, projectID int64, branch string) error {
+	if client == nil {
+		return fmt.Errorf("gitlab client not configured")
+	}
 	pid := int(projectID)
 
 	const maxWait = 90 * time.Second
-	deadline := time.Now().Add(maxWait)
-	delay := 500 * time.Millisecond
+	pollCtx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
 
-	for time.Now().Before(deadline) {
-		_, resp, err := client.GL().Branches.GetBranch(pid, branch)
+	return Poll(pollCtx, 500*time.Millisecond, maxWait, func() (bool, string, error) {
+		_, resp, err := client.GL().Branches.GetBranch(pid, branch, gl.WithContext(pollCtx))
 		if err == nil {
-			t.Logf("Branch %q ready in project %d", branch, projectID)
-			return
+			return true, fmt.Sprintf("branch %q ready in project %d", branch, projectID), nil
 		}
 
-		retryable := false
-		if resp == nil {
-			// Network-level error (EOF, connection reset) — always retryable.
-			retryable = true
-		} else {
-			switch {
-			case resp.StatusCode == http.StatusNotFound:
-				retryable = true
-			case resp.StatusCode == http.StatusTooManyRequests:
-				retryable = true
-			case resp.StatusCode >= 500:
-				retryable = true
-			}
+		state := fmt.Sprintf("branch %q in project %d: %v", branch, projectID, err)
+		if resp != nil {
+			state = fmt.Sprintf("branch %q in project %d: HTTP %d", branch, projectID, resp.StatusCode)
 		}
-		if !retryable {
-			requireNoError(t, err, fmt.Sprintf("get branch %s in project %d", branch, projectID))
+		if !retryableBranchResponse(resp) {
+			return false, state, fmt.Errorf("get branch %q in project %d: %w", branch, projectID, err)
 		}
-
-		select {
-		case <-ctx.Done():
-			t.Fatalf("context canceled waiting for branch %q: %v", branch, ctx.Err())
-		case <-time.After(delay):
-		}
-
-		// Progressive backoff: 500ms → 1s → 2s (capped)
-		if delay < 2*time.Second {
-			delay *= 2
-		}
-	}
-	t.Fatalf("branch %q not available in project %d after %s", branch, projectID, maxWait)
+		return false, state, nil
+	})
 }
 
-// waitForMRReady polls the MR until the GitLab DetailedMergeStatus leaves the
+func retryableBranchResponse(resp *gl.Response) bool {
+	if resp == nil {
+		return true
+	}
+	return resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+}
+
 // waitForMRReady polls the MR until the GitLab DetailedMergeStatus leaves the
 // transitional values ("preparing", "checking", "unchecked", "") that GitLab
 // CE reports while still computing the diff and merge ref. Downstream
@@ -558,32 +549,33 @@ func waitForBranchOn(ctx context.Context, t *testing.T, client *gitlabclient.Cli
 // that the test's own assertion produces the actionable failure message.
 func waitForMRReady(ctx context.Context, t *testing.T, client *gitlabclient.Client, projectID, mrIID int64) {
 	t.Helper()
-	if client == nil {
-		return
-	}
 	drainSidekiq(ctx, t, client)
+	if err := waitForMRReadyState(ctx, client, projectID, mrIID); err != nil {
+		t.Logf("MR !%d readiness wait in project %d ended: %v", mrIID, projectID, err)
+	}
+}
+
+func waitForMRReadyState(ctx context.Context, client *gitlabclient.Client, projectID, mrIID int64) error {
+	if client == nil {
+		return nil
+	}
 	const maxWait = 120 * time.Second
-	deadline := time.Now().Add(maxWait)
-	delay := 500 * time.Millisecond
-	for time.Now().Before(deadline) {
-		mr, _, err := client.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(ctx))
+	pollCtx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
+
+	return Poll(pollCtx, 500*time.Millisecond, maxWait, func() (bool, string, error) {
+		mr, _, err := client.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(pollCtx))
 		if err == nil {
 			switch mr.DetailedMergeStatus {
 			case "preparing", "checking", "unchecked", "":
-			// still computing; continue polling
+				return false, fmt.Sprintf("detailed_merge_status=%q", mr.DetailedMergeStatus), nil
 			default:
-				t.Logf("MR !%d ready in project %d: detailed_merge_status=%s", mrIID, projectID, mr.DetailedMergeStatus)
-				return
+				return true, fmt.Sprintf("detailed_merge_status=%q", mr.DetailedMergeStatus), nil
 			}
 		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(delay):
+		if pollCtx.Err() != nil {
+			return false, "", nil
 		}
-		if delay < 2*time.Second {
-			delay *= 2
-		}
-	}
-	t.Logf("MR !%d not ready after %s (continuing; final assertion will report state)", mrIID, maxWait)
+		return false, fmt.Sprintf("error polling MR !%d in project %d: %v", mrIID, projectID, err), nil
+	})
 }

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -145,10 +145,14 @@ func retryOnTransient[O any](ctx context.Context, t *testing.T, label string, ma
 // spurious "already been taken" errors and transient connection resets.
 const projectCreateRetries = 5
 
-// createProject creates a private project via individual MCP tools and
-// registers deletion in t.Cleanup.
-func createProject(ctx context.Context, t *testing.T, session *mcp.ClientSession) ProjectFixture {
-	t.Helper()
+// CreateProject creates a private project via individual MCP tools and
+// registers deletion in the per-test resource ledger.
+func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSession) ProjectFixture {
+	e2e.T.Helper()
+	if session == nil {
+		e2e.T.Skip("project fixture MCP session not configured")
+	}
+	t := e2e.T
 	var out projects.Output
 	var err error
 	for attempt := range projectCreateRetries {
@@ -172,26 +176,43 @@ func createProject(ctx context.Context, t *testing.T, session *mcp.ClientSession
 	}
 	requireNoError(t, err, "create project fixture")
 
-	t.Cleanup(func() {
-		delCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = callToolVoidOn(delCtx, session, "gitlab_project_delete", projects.DeleteInput{
-			ProjectID:         toolutil.StringOrInt(strconv.FormatInt(out.ID, 10)),
-			PermanentlyRemove: true,
-			FullPath:          out.PathWithNamespace,
-		})
+	e2e.Ledger.Register(ResourceRecord{
+		Kind:      ResourceKindProject,
+		ID:        strconv.FormatInt(out.ID, 10),
+		Path:      out.PathWithNamespace,
+		Name:      out.Name,
+		OwnerTest: e2e.Name,
+		RunID:     e2e.RunID,
+		CreatedAt: time.Now(),
+		Cleanup: func(cleanupCtx context.Context) error {
+			return callToolVoidOn(cleanupCtx, session, "gitlab_project_delete", projects.DeleteInput{
+				ProjectID:         toolutil.StringOrInt(strconv.FormatInt(out.ID, 10)),
+				PermanentlyRemove: true,
+				FullPath:          out.PathWithNamespace,
+			})
+		},
 	})
 
 	// Wait for the default branch to be available.
-	waitForBranchOn(ctx, t, sess.glClient, out.ID, defaultBranch)
+	waitForBranchOn(ctx, t, e2e.GitLab, out.ID, defaultBranch)
 
 	return ProjectFixture{ID: out.ID, Path: out.PathWithNamespace}
 }
 
-// createProjectMeta creates a private project via the gitlab_project meta-tool
-// and registers deletion in t.Cleanup.
-func createProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSession) ProjectFixture {
+// createProject keeps legacy call sites working while they migrate to E2EContext.
+func createProject(ctx context.Context, t *testing.T, session *mcp.ClientSession) ProjectFixture {
 	t.Helper()
+	return CreateProject(ctx, NewE2EContext(t), session)
+}
+
+// CreateProjectMeta creates a private project via the gitlab_project meta-tool
+// and registers deletion in the per-test resource ledger.
+func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.ClientSession) ProjectFixture {
+	e2e.T.Helper()
+	if session == nil {
+		e2e.T.Skip("project fixture MCP session not configured")
+	}
+	t := e2e.T
 	var out projects.Output
 	var err error
 	for attempt := range projectCreateRetries {
@@ -218,23 +239,36 @@ func createProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSes
 	}
 	requireNoError(t, err, "create project fixture (meta)")
 
-	t.Cleanup(func() {
-		delCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = callToolVoidOn(delCtx, session, "gitlab_project", map[string]any{
-			"action": "delete",
-			"params": map[string]any{
-				"project_id":         strconv.FormatInt(out.ID, 10),
-				"permanently_remove": true,
-				"full_path":          out.PathWithNamespace,
-			},
-		})
+	e2e.Ledger.Register(ResourceRecord{
+		Kind:      ResourceKindProject,
+		ID:        strconv.FormatInt(out.ID, 10),
+		Path:      out.PathWithNamespace,
+		Name:      out.Name,
+		OwnerTest: e2e.Name,
+		RunID:     e2e.RunID,
+		CreatedAt: time.Now(),
+		Cleanup: func(cleanupCtx context.Context) error {
+			return callToolVoidOn(cleanupCtx, session, "gitlab_project", map[string]any{
+				"action": "delete",
+				"params": map[string]any{
+					"project_id":         strconv.FormatInt(out.ID, 10),
+					"permanently_remove": true,
+					"full_path":          out.PathWithNamespace,
+				},
+			})
+		},
 	})
 
 	// Wait for the default branch to be available.
-	waitForBranchOn(ctx, t, sess.glClient, out.ID, defaultBranch)
+	waitForBranchOn(ctx, t, e2e.GitLab, out.ID, defaultBranch)
 
 	return ProjectFixture{ID: out.ID, Path: out.PathWithNamespace}
+}
+
+// createProjectMeta keeps legacy call sites working while they migrate to E2EContext.
+func createProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSession) ProjectFixture {
+	t.Helper()
+	return CreateProjectMeta(ctx, NewE2EContext(t), session)
 }
 
 // unprotectMain removes protection from the main branch so commits can

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -470,6 +470,8 @@ func waitForBranchOn(ctx context.Context, t *testing.T, client *gitlabclient.Cli
 	requireNoError(t, waitForBranch(ctx, client, projectID, branch), fmt.Sprintf("wait for branch %s in project %d", branch, projectID))
 }
 
+// waitForBranch polls GitLab until branch is visible in projectID or returns a
+// non-retryable branch lookup error.
 func waitForBranch(ctx context.Context, client *gitlabclient.Client, projectID int64, branch string) error {
 	if client == nil {
 		return fmt.Errorf("gitlab client not configured")
@@ -497,6 +499,8 @@ func waitForBranch(ctx context.Context, client *gitlabclient.Client, projectID i
 	})
 }
 
+// retryableBranchResponse reports whether a branch lookup response can be
+// retried while GitLab converges after branch creation.
 func retryableBranchResponse(resp *gl.Response) bool {
 	if resp == nil {
 		return true
@@ -522,6 +526,8 @@ func waitForMRReady(ctx context.Context, t *testing.T, client *gitlabclient.Clie
 	}
 }
 
+// waitForMRReadyState polls GitLab until the merge request leaves transitional
+// detailed merge states or the polling context expires.
 func waitForMRReadyState(ctx context.Context, client *gitlabclient.Client, projectID, mrIID int64) error {
 	if client == nil {
 		return nil

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -154,8 +154,8 @@ func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSess
 		e2e.T.Skip("project fixture MCP session not configured")
 	}
 	t := e2e.T
+	name := uniqueName(e2eProjectPrefix + sanitizeTestName(t.Name()))
 	out, err := retryWithBackoff(ctx, t, "create project fixture", projectCreateRetries, func(int) (projects.Output, bool, string, error) {
-		name := uniqueName(e2eProjectPrefix + sanitizeTestName(t.Name()))
 		out, err := callToolOn[projects.Output](ctx, session, "gitlab_project_create", projects.CreateInput{
 			Name:                 name,
 			Description:          "E2E: " + t.Name(),
@@ -208,8 +208,8 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 		e2e.T.Skip("project fixture MCP session not configured")
 	}
 	t := e2e.T
+	name := uniqueName(e2eProjectPrefix + "meta-" + sanitizeTestName(t.Name()))
 	out, err := retryWithBackoff(ctx, t, "create project fixture (meta)", projectCreateRetries, func(int) (projects.Output, bool, string, error) {
-		name := uniqueName(e2eProjectPrefix + "meta-" + sanitizeTestName(t.Name()))
 		out, err := callToolOn[projects.Output](ctx, session, "gitlab_project", map[string]any{
 			"action": "create",
 			"params": map[string]any{
@@ -492,7 +492,10 @@ func waitForBranch(ctx context.Context, client *gitlabclient.Client, projectID i
 		if resp != nil {
 			state = fmt.Sprintf("branch %q in project %d: HTTP %d", branch, projectID, resp.StatusCode)
 		}
-		if !retryableBranchResponse(resp) {
+		if resp == nil && !isTransientNetworkError(err) {
+			return false, state, fmt.Errorf("get branch %q in project %d: %w", branch, projectID, err)
+		}
+		if resp != nil && !retryableBranchResponse(resp) {
 			return false, state, fmt.Errorf("get branch %q in project %d: %w", branch, projectID, err)
 		}
 		return false, state, nil

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/branches"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/commits"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/issues"
@@ -182,7 +183,7 @@ func createProject(ctx context.Context, t *testing.T, session *mcp.ClientSession
 	})
 
 	// Wait for the default branch to be available.
-	waitForBranchOn(ctx, t, session, out.ID, defaultBranch)
+	waitForBranchOn(ctx, t, sess.glClient, out.ID, defaultBranch)
 
 	return ProjectFixture{ID: out.ID, Path: out.PathWithNamespace}
 }
@@ -231,7 +232,7 @@ func createProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSes
 	})
 
 	// Wait for the default branch to be available.
-	waitForBranchOn(ctx, t, session, out.ID, defaultBranch)
+	waitForBranchOn(ctx, t, sess.glClient, out.ID, defaultBranch)
 
 	return ProjectFixture{ID: out.ID, Path: out.PathWithNamespace}
 }
@@ -412,9 +413,9 @@ func createMRMeta(ctx context.Context, t *testing.T, session *mcp.ClientSession,
 // given project or the context is canceled. Under parallel load (~60 projects)
 // branch creation can take well over 30s, so we allow up to 90s with
 // progressive backoff. Transient errors (429, 5xx, network) are retried silently.
-func waitForBranchOn(ctx context.Context, t *testing.T, _ *mcp.ClientSession, projectID int64, branch string) {
+func waitForBranchOn(ctx context.Context, t *testing.T, client *gitlabclient.Client, projectID int64, branch string) {
 	t.Helper()
-	drainSidekiq(ctx, t)
+	drainSidekiq(ctx, t, client)
 	pid := int(projectID)
 
 	const maxWait = 90 * time.Second
@@ -422,7 +423,7 @@ func waitForBranchOn(ctx context.Context, t *testing.T, _ *mcp.ClientSession, pr
 	delay := 500 * time.Millisecond
 
 	for time.Now().Before(deadline) {
-		_, resp, err := sess.glClient.GL().Branches.GetBranch(pid, branch)
+		_, resp, err := client.GL().Branches.GetBranch(pid, branch)
 		if err == nil {
 			t.Logf("Branch %q ready in project %d", branch, projectID)
 			return
@@ -471,17 +472,17 @@ func waitForBranchOn(ctx context.Context, t *testing.T, _ *mcp.ClientSession, pr
 // The helper is best-effort: it never fails the test on its own. If the MR
 // never leaves the transitional state within maxWait, it logs and returns so
 // that the test's own assertion produces the actionable failure message.
-func waitForMRReady(ctx context.Context, t *testing.T, projectID, mrIID int64) {
+func waitForMRReady(ctx context.Context, t *testing.T, client *gitlabclient.Client, projectID, mrIID int64) {
 	t.Helper()
-	if sess.glClient == nil {
+	if client == nil {
 		return
 	}
-	drainSidekiq(ctx, t)
+	drainSidekiq(ctx, t, client)
 	const maxWait = 120 * time.Second
 	deadline := time.Now().Add(maxWait)
 	delay := 500 * time.Millisecond
 	for time.Now().Before(deadline) {
-		mr, _, err := sess.glClient.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(ctx))
+		mr, _, err := client.GL().MergeRequests.GetMergeRequest(int(projectID), mrIID, nil, gl.WithContext(ctx))
 		if err == nil {
 			switch mr.DetailedMergeStatus {
 			case "preparing", "checking", "unchecked", "":

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -18,6 +18,7 @@ import (
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/branches"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/commits"
+	"github.com/jmrplens/gitlab-mcp-server/internal/tools/groups"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/issues"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/mergerequests"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/projects"
@@ -31,6 +32,17 @@ import (
 type ProjectFixture struct {
 	ID   int64
 	Path string
+}
+
+// GroupFixture holds identifiers for a test group created by a fixture builder.
+type GroupFixture struct {
+	ID   int64
+	Path string
+}
+
+// gidStr returns the group ID as a plain string for use in meta-tool params.
+func (f GroupFixture) gidStr() string {
+	return strconv.FormatInt(f.ID, 10)
 }
 
 // pidOf returns the project ID as a StringOrInt for use in individual tool inputs.
@@ -269,6 +281,44 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 func createProjectMeta(ctx context.Context, t *testing.T, session *mcp.ClientSession) ProjectFixture {
 	t.Helper()
 	return CreateProjectMeta(ctx, NewE2EContext(t), session)
+}
+
+// CreateGroupMeta creates a group via the gitlab_group meta-tool and registers
+// deletion in the per-test resource ledger.
+func CreateGroupMeta(ctx context.Context, e2e *E2EContext, session *mcp.ClientSession, namePrefix string) GroupFixture {
+	e2e.T.Helper()
+	if session == nil {
+		e2e.T.Skip("group fixture MCP session not configured")
+	}
+	t := e2e.T
+	name := uniqueName(namePrefix)
+	out, err := callToolOn[groups.Output](ctx, session, "gitlab_group", map[string]any{
+		"action": "create",
+		"params": map[string]any{
+			"name": name,
+			"path": name,
+		},
+	})
+	requireNoError(t, err, "create group fixture (meta)")
+
+	id := strconv.FormatInt(out.ID, 10)
+	e2e.Ledger.Register(ResourceRecord{
+		Kind:      ResourceKindGroup,
+		ID:        id,
+		Path:      out.FullPath,
+		Name:      out.Name,
+		OwnerTest: e2e.Name,
+		RunID:     e2e.RunID,
+		CreatedAt: time.Now(),
+		Cleanup: func(cleanupCtx context.Context) error {
+			return callToolVoidOn(cleanupCtx, session, "gitlab_group", map[string]any{
+				"action": "delete",
+				"params": map[string]any{"group_id": id},
+			})
+		},
+	})
+
+	return GroupFixture{ID: out.ID, Path: out.FullPath}
 }
 
 // unprotectMain removes protection from the main branch so commits can

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -541,7 +541,7 @@ func waitForMRReadyState(ctx context.Context, client *gitlabclient.Client, proje
 			}
 		}
 		if pollCtx.Err() != nil {
-			return false, "", nil
+			return false, "", pollCtx.Err()
 		}
 		return false, fmt.Sprintf("error polling MR !%d in project %d: %v", mrIID, projectID, err), nil
 	})

--- a/test/e2e/suite/fixture_test.go
+++ b/test/e2e/suite/fixture_test.go
@@ -128,24 +128,13 @@ func isRetryableError(err error) bool {
 // the last error after all attempts are exhausted.
 func retryOnTransient[O any](ctx context.Context, t *testing.T, label string, maxRetries int, fn func() (O, error)) (O, error) {
 	t.Helper()
-	var out O
-	var err error
-	for attempt := range maxRetries {
-		out, err = fn()
+	return retryWithBackoff(ctx, t, label, maxRetries, func(int) (O, bool, string, error) {
+		out, err := fn()
 		if err == nil {
-			return out, nil
+			return out, false, "", nil
 		}
-		if attempt >= maxRetries-1 || !isRetryableError(err) {
-			break
-		}
-		t.Logf("%s: attempt %d/%d failed (retrying): %v", label, attempt+1, maxRetries, err)
-		select {
-		case <-ctx.Done():
-			return out, err
-		case <-time.After(time.Duration(attempt+1) * time.Second):
-		}
-	}
-	return out, err
+		return out, isRetryableError(err), "retryable error", err
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -165,11 +154,9 @@ func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSess
 		e2e.T.Skip("project fixture MCP session not configured")
 	}
 	t := e2e.T
-	var out projects.Output
-	var err error
-	for attempt := range projectCreateRetries {
+	out, err := retryWithBackoff(ctx, t, "create project fixture", projectCreateRetries, func(int) (projects.Output, bool, string, error) {
 		name := uniqueName(e2eProjectPrefix + sanitizeTestName(t.Name()))
-		out, err = callToolOn[projects.Output](ctx, session, "gitlab_project_create", projects.CreateInput{
+		out, err := callToolOn[projects.Output](ctx, session, "gitlab_project_create", projects.CreateInput{
 			Name:                 name,
 			Description:          "E2E: " + t.Name(),
 			Visibility:           "private",
@@ -177,15 +164,11 @@ func CreateProject(ctx context.Context, e2e *E2EContext, session *mcp.ClientSess
 			DefaultBranch:        defaultBranch,
 		})
 		if err == nil {
-			break
+			return out, false, "", nil
 		}
 		retryable := strings.Contains(err.Error(), "already been taken") || isTransientNetworkError(err)
-		if retryable && attempt < projectCreateRetries-1 {
-			t.Logf("project create attempt %d failed, retrying: %v", attempt+1, err)
-			time.Sleep(time.Duration(attempt+1) * time.Second)
-			continue
-		}
-	}
+		return out, retryable, "name collision or transient network error", err
+	})
 	requireNoError(t, err, "create project fixture")
 
 	e2e.Ledger.Register(ResourceRecord{
@@ -225,11 +208,9 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 		e2e.T.Skip("project fixture MCP session not configured")
 	}
 	t := e2e.T
-	var out projects.Output
-	var err error
-	for attempt := range projectCreateRetries {
+	out, err := retryWithBackoff(ctx, t, "create project fixture (meta)", projectCreateRetries, func(int) (projects.Output, bool, string, error) {
 		name := uniqueName(e2eProjectPrefix + "meta-" + sanitizeTestName(t.Name()))
-		out, err = callToolOn[projects.Output](ctx, session, "gitlab_project", map[string]any{
+		out, err := callToolOn[projects.Output](ctx, session, "gitlab_project", map[string]any{
 			"action": "create",
 			"params": map[string]any{
 				"name":                   name,
@@ -240,15 +221,11 @@ func CreateProjectMeta(ctx context.Context, e2e *E2EContext, session *mcp.Client
 			},
 		})
 		if err == nil {
-			break
+			return out, false, "", nil
 		}
 		retryable := strings.Contains(err.Error(), "already been taken") || isTransientNetworkError(err)
-		if retryable && attempt < projectCreateRetries-1 {
-			t.Logf("project create attempt %d failed, retrying: %v", attempt+1, err)
-			time.Sleep(time.Duration(attempt+1) * time.Second)
-			continue
-		}
-	}
+		return out, retryable, "name collision or transient network error", err
+	})
 	requireNoError(t, err, "create project fixture (meta)")
 
 	e2e.Ledger.Register(ResourceRecord{
@@ -336,7 +313,7 @@ func unprotectMain(ctx context.Context, t *testing.T, proj ProjectFixture) {
 func commitFile(ctx context.Context, t *testing.T, session *mcp.ClientSession, proj ProjectFixture, branch, path, content, message string) CommitFixture {
 	t.Helper()
 	const maxRetries = 5
-	for attempt := range maxRetries {
+	fixture, err := retryWithBackoff(ctx, t, "commit file "+path, maxRetries, func(int) (CommitFixture, bool, string, error) {
 		out, err := callToolOn[commits.Output](ctx, session, "gitlab_commit_create", commits.CreateInput{
 			ProjectID:     proj.pidOf(),
 			Branch:        branch,
@@ -346,17 +323,13 @@ func commitFile(ctx context.Context, t *testing.T, session *mcp.ClientSession, p
 			},
 		})
 		if err == nil {
-			return CommitFixture{SHA: out.ID, ShortID: out.ShortID}
+			return CommitFixture{SHA: out.ID, ShortID: out.ShortID}, false, "", nil
 		}
-		if attempt < maxRetries-1 && strings.Contains(err.Error(), "only create or edit files when you are on a branch") {
-			t.Logf("commitFile %s: retry %d/%d (branch not ready)", path, attempt+1, maxRetries)
-			time.Sleep(time.Duration(attempt+1) * time.Second)
-			continue
-		}
-		requireNoError(t, err, "commit file "+path)
-	}
-	t.Fatalf("commitFile %s: exhausted %d retries", path, maxRetries)
-	return CommitFixture{}
+		retryable := strings.Contains(err.Error(), "only create or edit files when you are on a branch")
+		return CommitFixture{}, retryable, "branch not ready", err
+	})
+	requireNoError(t, err, "commit file "+path)
+	return fixture
 }
 
 // commitFileMeta creates a file via the gitlab_repository meta-tool.
@@ -365,7 +338,7 @@ func commitFileMeta(ctx context.Context, t *testing.T, session *mcp.ClientSessio
 	t.Helper()
 	const maxRetries = 8
 	needStartBranch := false
-	for attempt := range maxRetries {
+	fixture, err := retryWithBackoff(ctx, t, "commit file meta "+path, maxRetries, func(int) (CommitFixture, bool, string, error) {
 		params := map[string]any{
 			"project_id":     proj.pidStr(),
 			"branch":         branch,
@@ -382,27 +355,21 @@ func commitFileMeta(ctx context.Context, t *testing.T, session *mcp.ClientSessio
 			"params": params,
 		})
 		if err == nil {
-			return CommitFixture{SHA: out.ID, ShortID: out.ShortID}
+			return CommitFixture{SHA: out.ID, ShortID: out.ShortID}, false, "", nil
 		}
-		if attempt < maxRetries-1 {
-			errMsg := err.Error()
-			if strings.Contains(errMsg, "only create or edit files when you are on a branch") {
-				needStartBranch = true
-				t.Logf("commitFileMeta %s: retry %d/%d (branch not ready, adding start_branch)", path, attempt+1, maxRetries)
-				time.Sleep(time.Duration(attempt+1) * time.Second)
-				continue
-			}
-			if strings.Contains(errMsg, "already exists") {
-				needStartBranch = false
-				t.Logf("commitFileMeta %s: retry %d/%d (branch already exists, removing start_branch)", path, attempt+1, maxRetries)
-				time.Sleep(time.Second)
-				continue
-			}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "only create or edit files when you are on a branch") {
+			needStartBranch = true
+			return CommitFixture{}, true, "branch not ready, adding start_branch", err
 		}
-		requireNoError(t, err, "commit file meta "+path)
-	}
-	t.Fatalf("commitFileMeta %s: exhausted %d retries", path, maxRetries)
-	return CommitFixture{}
+		if strings.Contains(errMsg, "already exists") {
+			needStartBranch = false
+			return CommitFixture{}, true, "branch already exists, removing start_branch", err
+		}
+		return CommitFixture{}, false, "", err
+	})
+	requireNoError(t, err, "commit file meta "+path)
+	return fixture
 }
 
 // createBranch creates a branch from the default branch via individual tools.

--- a/test/e2e/suite/groupreleases_test.go
+++ b/test/e2e/suite/groupreleases_test.go
@@ -79,7 +79,7 @@ func TestMeta_GroupReleases(t *testing.T) {
 	t.Logf("Created project %d in group %d", projOut.ID, groupID)
 
 	// Wait for default branch to be available.
-	waitForBranchOn(ctx, t, sess.meta, projOut.ID, "main")
+	waitForBranchOn(ctx, t, sess.glClient, projOut.ID, "main")
 
 	// Commit a file so there's content for the tag.
 	commitFileMeta(ctx, t, sess.meta, ProjectFixture{ID: projOut.ID, Path: projOut.PathWithNamespace},

--- a/test/e2e/suite/groupreleases_test.go
+++ b/test/e2e/suite/groupreleases_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// groupreleases_test.go exercises group-level release aggregation through the
+// gitlab_group meta-tool against a live GitLab instance.
 package suite
 
 import (

--- a/test/e2e/suite/groupserviceaccounts_test.go
+++ b/test/e2e/suite/groupserviceaccounts_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// groupserviceaccounts_test.go exercises EE-only group service account actions
+// through the gitlab_group meta-tool when the target GitLab instance supports them.
 package suite
 
 import (

--- a/test/e2e/suite/mergerequests_test.go
+++ b/test/e2e/suite/mergerequests_test.go
@@ -99,7 +99,7 @@ func TestIndividual_MergeRequests(t *testing.T) {
 	})
 
 	t.Run("Commits", func(t *testing.T) {
-		waitForMRReady(ctx, t, proj.ID, mrIID)
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mrIID)
 		var out mergerequests.CommitsOutput
 		var err error
 		deadline := time.Now().Add(120 * time.Second)
@@ -213,7 +213,7 @@ func TestMeta_MergeRequests(t *testing.T) {
 	})
 
 	t.Run("Commits", func(t *testing.T) {
-		waitForMRReady(ctx, t, proj.ID, mrIID)
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mrIID)
 		var out mergerequests.CommitsOutput
 		var err error
 		deadline := time.Now().Add(120 * time.Second)

--- a/test/e2e/suite/meta_schema_resource_test.go
+++ b/test/e2e/suite/meta_schema_resource_test.go
@@ -3,7 +3,6 @@
 // meta_schema_resource_test.go validates that, after the full meta-tool
 // registry is wired into a server, the gitlab://schema/meta/* resources
 // expose the captured per-action InputSchemas for real meta-tools.
-
 package suite
 
 import (

--- a/test/e2e/suite/meta_schema_resource_test.go
+++ b/test/e2e/suite/meta_schema_resource_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/internal/resources"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/internal/toolutil"
@@ -23,14 +24,14 @@ import (
 // toolutil.MetaRoutes) plus the meta-schema resources in a single MCP
 // server, then returns an in-memory client session. It pins mode=full so
 // per-action InputSchemas are captured with their real structured shape.
-func metaSchemaResourceSession(t *testing.T) *mcp.ClientSession {
+func metaSchemaResourceSession(t *testing.T, client *gitlabclient.Client, enterprise bool) *mcp.ClientSession {
 	t.Helper()
 	tools.SetMetaParamSchema("full")
 	t.Cleanup(func() { tools.SetMetaParamSchema("opaque") })
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
 	metaRoutes := toolutil.CaptureMetaRoutes(func() {
-		tools.RegisterAllMeta(server, sess.glClient, sess.enterprise)
+		tools.RegisterAllMeta(server, client, enterprise)
 	})
 	resources.RegisterMetaSchemaResources(server, metaRoutes)
 
@@ -51,7 +52,7 @@ func metaSchemaResourceSession(t *testing.T) *mcp.ClientSession {
 // TestMetaSchemaResource_ListsTemplate verifies the per-action template URI
 // is advertised via ListResourceTemplates.
 func TestMetaSchemaResource_ListsTemplate(t *testing.T) {
-	session := metaSchemaResourceSession(t)
+	session := metaSchemaResourceSession(t, sess.glClient, sess.enterprise)
 
 	result, err := session.ListResourceTemplates(context.Background(), nil)
 	if err != nil {
@@ -73,7 +74,7 @@ func TestMetaSchemaResource_ListsTemplate(t *testing.T) {
 // schema for gitlab_merge_request/create exposes the expected structural
 // fields callers actually need to construct an MR.
 func TestMetaSchemaResource_ReadMergeRequestCreate(t *testing.T) {
-	session := metaSchemaResourceSession(t)
+	session := metaSchemaResourceSession(t, sess.glClient, sess.enterprise)
 
 	result, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{
 		URI: "gitlab://schema/meta/gitlab_merge_request/create",
@@ -103,7 +104,7 @@ func TestMetaSchemaResource_ReadMergeRequestCreate(t *testing.T) {
 // TestMetaSchemaResource_NotFound verifies unknown tool/action pairs return
 // ResourceNotFoundError when looked up via the live registry.
 func TestMetaSchemaResource_NotFound(t *testing.T) {
-	session := metaSchemaResourceSession(t)
+	session := metaSchemaResourceSession(t, sess.glClient, sess.enterprise)
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{
 		URI: "gitlab://schema/meta/gitlab_merge_request/nonexistent_action",
@@ -116,7 +117,7 @@ func TestMetaSchemaResource_NotFound(t *testing.T) {
 // TestMetaSchemaResource_IndexEnumeratesMetaTools verifies the index lists
 // at least the canonical meta-tools wired in RegisterAllMeta.
 func TestMetaSchemaResource_IndexEnumeratesMetaTools(t *testing.T) {
-	session := metaSchemaResourceSession(t)
+	session := metaSchemaResourceSession(t, sess.glClient, sess.enterprise)
 
 	result, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{
 		URI: "gitlab://schema/meta/",

--- a/test/e2e/suite/mrapproval_test.go
+++ b/test/e2e/suite/mrapproval_test.go
@@ -61,8 +61,8 @@ func TestIndividual_MRApproval(t *testing.T) {
 	})
 
 	t.Run("Individual/MR/Merge", func(t *testing.T) {
-		drainSidekiq(ctx, t)
-		waitForMRReady(ctx, t, proj.ID, mr.IID)
+		drainSidekiq(ctx, t, sess.glClient)
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mr.IID)
 		var out mergerequests.Output
 		var err error
 		for i := range 5 {
@@ -75,7 +75,7 @@ func TestIndividual_MRApproval(t *testing.T) {
 				break
 			}
 			t.Logf("merge attempt %d: %v", i+1, err)
-			waitForMRReady(ctx, t, proj.ID, mr.IID)
+			waitForMRReady(ctx, t, sess.glClient, proj.ID, mr.IID)
 		}
 		requireNoError(t, err, "merge MR")
 		requireTruef(t, out.State == "merged", "expected state 'merged', got %q", out.State)
@@ -144,8 +144,8 @@ func TestMeta_MRApproval(t *testing.T) {
 	})
 
 	t.Run("Meta/MR/Merge", func(t *testing.T) {
-		drainSidekiq(ctx, t)
-		waitForMRReady(ctx, t, proj.ID, mr.IID)
+		drainSidekiq(ctx, t, sess.glClient)
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mr.IID)
 		var out mergerequests.Output
 		var err error
 		for i := range 5 {
@@ -161,7 +161,7 @@ func TestMeta_MRApproval(t *testing.T) {
 				break
 			}
 			t.Logf("meta merge attempt %d: %v", i+1, err)
-			waitForMRReady(ctx, t, proj.ID, mr.IID)
+			waitForMRReady(ctx, t, sess.glClient, proj.ID, mr.IID)
 		}
 		requireNoError(t, err, "meta merge MR")
 		requireTruef(t, out.State == "merged", "expected state merged, got %q", out.State)

--- a/test/e2e/suite/mrreview_meta_test.go
+++ b/test/e2e/suite/mrreview_meta_test.go
@@ -63,7 +63,7 @@ func TestMeta_MRReviewChanges(t *testing.T) {
 	})
 
 	t.Run("DiffVersionsList", func(t *testing.T) {
-		waitForMRReady(ctx, t, proj.ID, mrOut.IID)
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mrOut.IID)
 		var out mrchanges.DiffVersionsListOutput
 		var listErr error
 		deadline := time.Now().Add(120 * time.Second)

--- a/test/e2e/suite/name_helpers.go
+++ b/test/e2e/suite/name_helpers.go
@@ -31,7 +31,7 @@ func configuredE2ERunID(now time.Time) string {
 
 func newE2ERunID(now time.Time) string {
 	source := fmt.Sprintf("%d-%d-%d", now.UnixNano(), os.Getpid(), runIDCounter.Add(1))
-	return fmt.Sprintf("%s-%s", now.UTC().Format("20060102T150405Z"), shortStableHash(source))
+	return fmt.Sprintf("%s-%s", now.UTC().Format("20060102t150405z"), shortStableHash(source))
 }
 
 func shortStableHash(value string) string {

--- a/test/e2e/suite/name_helpers.go
+++ b/test/e2e/suite/name_helpers.go
@@ -1,3 +1,5 @@
+// name_helpers.go builds deterministic, GitLab-safe identifiers for E2E
+// resources so parallel runs can isolate their projects, groups, and branches.
 package suite
 
 import (
@@ -11,8 +13,11 @@ import (
 	"time"
 )
 
+// stableHashLength is the number of hexadecimal characters kept from SHA-256
+// hashes used in generated E2E names.
 const stableHashLength = 10
 
+// E2E name generation state shared by all tests in the process.
 var (
 	e2eRunID      = newE2ERunID(time.Now())
 	uniqueCounter atomic.Int64
@@ -20,6 +25,8 @@ var (
 	runIDCounter  atomic.Int64
 )
 
+// configuredE2ERunID returns the sanitized E2E_RUN_ID override or creates a
+// fresh timestamped run identifier when no valid override is configured.
 func configuredE2ERunID(now time.Time) string {
 	if value := os.Getenv("E2E_RUN_ID"); value != "" {
 		if runID := sanitizeNamePart(value, 48); runID != "" {
@@ -29,20 +36,28 @@ func configuredE2ERunID(now time.Time) string {
 	return newE2ERunID(now)
 }
 
+// newE2ERunID builds a lowercase, GitLab-safe run identifier from the UTC time,
+// process ID, and an atomic counter to avoid collisions in rapid startups.
 func newE2ERunID(now time.Time) string {
 	source := fmt.Sprintf("%d-%d-%d", now.UnixNano(), os.Getpid(), runIDCounter.Add(1))
 	return fmt.Sprintf("%s-%s", now.UTC().Format("20060102t150405z"), shortStableHash(source))
 }
 
+// shortStableHash returns a deterministic short hexadecimal SHA-256 prefix for
+// value, suitable for compact E2E resource names.
 func shortStableHash(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])[:stableHashLength]
 }
 
+// sanitizeTestName converts a Go test name into the shorter slug segment used
+// in GitLab resource names.
 func sanitizeTestName(name string) string {
 	return sanitizeNamePart(name, 40)
 }
 
+// sanitizeNamePrefix normalizes a caller-provided prefix and falls back to
+// "e2e" when the sanitized value is empty.
 func sanitizeNamePrefix(prefix string) string {
 	name := sanitizeNamePart(prefix, 80)
 	if name == "" {
@@ -51,6 +66,8 @@ func sanitizeNamePrefix(prefix string) string {
 	return name
 }
 
+// sanitizeNamePart lowercases name, removes unsupported characters, trims dash
+// boundaries, and optionally truncates the result to maxLength characters.
 func sanitizeNamePart(name string, maxLength int) string {
 	sanitized := strings.ToLower(name)
 	sanitized = strings.ReplaceAll(sanitized, "/", "-")
@@ -63,6 +80,8 @@ func sanitizeNamePart(name string, maxLength int) string {
 	return sanitized
 }
 
+// uniqueName returns a process-unique, run-scoped GitLab-safe resource name for
+// the supplied prefix.
 func uniqueName(prefix string) string {
 	sanitizedPrefix := sanitizeNamePrefix(prefix)
 	return fmt.Sprintf("%s-%s-%s-%d", sanitizedPrefix, e2eRunID, shortStableHash(sanitizedPrefix), uniqueCounter.Add(1))

--- a/test/e2e/suite/name_helpers.go
+++ b/test/e2e/suite/name_helpers.go
@@ -19,7 +19,7 @@ const stableHashLength = 10
 
 // E2E name generation state shared by all tests in the process.
 var (
-	e2eRunID      = newE2ERunID(time.Now())
+	e2eRunID      = configuredE2ERunID(time.Now())
 	uniqueCounter atomic.Int64
 	unsafeChars   = regexp.MustCompile(`[^a-z0-9-]`)
 	runIDCounter  atomic.Int64

--- a/test/e2e/suite/name_helpers.go
+++ b/test/e2e/suite/name_helpers.go
@@ -1,0 +1,69 @@
+package suite
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const stableHashLength = 10
+
+var (
+	e2eRunID      = newE2ERunID(time.Now())
+	uniqueCounter atomic.Int64
+	unsafeChars   = regexp.MustCompile(`[^a-z0-9-]`)
+	runIDCounter  atomic.Int64
+)
+
+func configuredE2ERunID(now time.Time) string {
+	if value := os.Getenv("E2E_RUN_ID"); value != "" {
+		if runID := sanitizeNamePart(value, 48); runID != "" {
+			return runID
+		}
+	}
+	return newE2ERunID(now)
+}
+
+func newE2ERunID(now time.Time) string {
+	source := fmt.Sprintf("%d-%d-%d", now.UnixNano(), os.Getpid(), runIDCounter.Add(1))
+	return fmt.Sprintf("%s-%s", now.UTC().Format("20060102T150405Z"), shortStableHash(source))
+}
+
+func shortStableHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:stableHashLength]
+}
+
+func sanitizeTestName(name string) string {
+	return sanitizeNamePart(name, 40)
+}
+
+func sanitizeNamePrefix(prefix string) string {
+	name := sanitizeNamePart(prefix, 80)
+	if name == "" {
+		return "e2e"
+	}
+	return name
+}
+
+func sanitizeNamePart(name string, maxLength int) string {
+	sanitized := strings.ToLower(name)
+	sanitized = strings.ReplaceAll(sanitized, "/", "-")
+	sanitized = strings.ReplaceAll(sanitized, "_", "-")
+	sanitized = unsafeChars.ReplaceAllString(sanitized, "")
+	sanitized = strings.Trim(sanitized, "-")
+	if maxLength > 0 && len(sanitized) > maxLength {
+		sanitized = strings.Trim(sanitized[:maxLength], "-")
+	}
+	return sanitized
+}
+
+func uniqueName(prefix string) string {
+	sanitizedPrefix := sanitizeNamePrefix(prefix)
+	return fmt.Sprintf("%s-%s-%s-%d", sanitizedPrefix, e2eRunID, shortStableHash(sanitizedPrefix), uniqueCounter.Add(1))
+}

--- a/test/e2e/suite/network_endpoints_test.go
+++ b/test/e2e/suite/network_endpoints_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// network_endpoints_test.go centralizes deterministic URLs used by Docker E2E
+// tests for webhook, custom emoji, and remote mirror operations.
 package suite
 
 import (
@@ -9,11 +11,15 @@ import (
 	"testing"
 )
 
+// Default Docker network endpoints used when setup-gitlab.sh has not written
+// explicit E2E fixture settings into the environment.
 const (
 	defaultE2EFixtureURL        = "http://e2e-fixture:8080"
 	defaultE2EGitLabInternalURL = "http://gitlab-e2e"
 )
 
+// e2eFixtureServiceURL returns a URL on the Docker-local fixture service for
+// resourcePath, falling back to the default service name when unset.
 func e2eFixtureServiceURL(resourcePath string) string {
 	baseURL := os.Getenv("E2E_FIXTURE_URL")
 	if baseURL == "" {
@@ -22,6 +28,8 @@ func e2eFixtureServiceURL(resourcePath string) string {
 	return joinE2EURL(baseURL, resourcePath)
 }
 
+// remoteMirrorTargetURL returns an authenticated Git URL for target that GitLab
+// can reach from inside the Docker network when configuring push mirrors.
 func remoteMirrorTargetURL(t *testing.T, target ProjectFixture) string {
 	t.Helper()
 
@@ -46,6 +54,8 @@ func remoteMirrorTargetURL(t *testing.T, target ProjectFixture) string {
 	return parsedURL.String()
 }
 
+// joinE2EURL joins baseURL and resourcePath without preserving duplicate slash
+// boundaries from either side.
 func joinE2EURL(baseURL, resourcePath string) string {
 	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(resourcePath, "/")
 }

--- a/test/e2e/suite/network_endpoints_test.go
+++ b/test/e2e/suite/network_endpoints_test.go
@@ -18,6 +18,15 @@ const (
 	defaultE2EGitLabInternalURL = "http://gitlab-e2e"
 )
 
+// hasE2EFixtureService reports whether the Docker-local fixture service should
+// be reachable from GitLab during this E2E run.
+func hasE2EFixtureService() bool {
+	if os.Getenv("E2E_FIXTURE_URL") != "" {
+		return true
+	}
+	return strings.EqualFold(os.Getenv("E2E_MODE"), "docker")
+}
+
 // e2eFixtureServiceURL returns a URL on the Docker-local fixture service for
 // resourcePath, falling back to the default service name when unset.
 func e2eFixtureServiceURL(resourcePath string) string {

--- a/test/e2e/suite/network_endpoints_test.go
+++ b/test/e2e/suite/network_endpoints_test.go
@@ -47,9 +47,6 @@ func remoteMirrorTargetURL(t *testing.T, target ProjectFixture) string {
 
 	baseURL := os.Getenv("E2E_GITLAB_INTERNAL_URL")
 	if baseURL == "" {
-		baseURL = os.Getenv("GITLAB_URL")
-	}
-	if baseURL == "" {
 		baseURL = defaultE2EGitLabInternalURL
 	}
 

--- a/test/e2e/suite/network_endpoints_test.go
+++ b/test/e2e/suite/network_endpoints_test.go
@@ -1,0 +1,51 @@
+//go:build e2e
+
+package suite
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	defaultE2EFixtureURL        = "http://e2e-fixture:8080"
+	defaultE2EGitLabInternalURL = "http://gitlab-e2e"
+)
+
+func e2eFixtureServiceURL(resourcePath string) string {
+	baseURL := os.Getenv("E2E_FIXTURE_URL")
+	if baseURL == "" {
+		baseURL = defaultE2EFixtureURL
+	}
+	return joinE2EURL(baseURL, resourcePath)
+}
+
+func remoteMirrorTargetURL(t *testing.T, target ProjectFixture) string {
+	t.Helper()
+
+	token := os.Getenv("GITLAB_TOKEN")
+	requireTruef(t, token != "", "GITLAB_TOKEN is required to configure a remote mirror target")
+
+	baseURL := os.Getenv("E2E_GITLAB_INTERNAL_URL")
+	if baseURL == "" {
+		baseURL = os.Getenv("GITLAB_URL")
+	}
+	if baseURL == "" {
+		baseURL = defaultE2EGitLabInternalURL
+	}
+
+	parsedURL, err := url.Parse(baseURL)
+	requireNoError(t, err, "parse internal GitLab URL")
+	parsedURL.User = url.UserPassword("oauth2", token)
+	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/") + "/" + strings.TrimLeft(target.Path, "/") + ".git"
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+
+	return parsedURL.String()
+}
+
+func joinE2EURL(baseURL, resourcePath string) string {
+	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(resourcePath, "/")
+}

--- a/test/e2e/suite/oauth_helpers_test.go
+++ b/test/e2e/suite/oauth_helpers_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// oauth_helpers_test.go provides raw HTTP helpers for OAuth E2E tests that need
+// to exercise MCP streamable HTTP authentication outside the in-memory transport.
 package suite
 
 import (

--- a/test/e2e/suite/pipelines_meta_test.go
+++ b/test/e2e/suite/pipelines_meta_test.go
@@ -25,7 +25,6 @@ func TestMeta_PipelinesExtended(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
 		defer cancel()
 

--- a/test/e2e/suite/pipelines_meta_test.go
+++ b/test/e2e/suite/pipelines_meta_test.go
@@ -38,7 +38,7 @@ func TestMeta_PipelinesExtended(t *testing.T) {
 	// Wait for pipeline creation with polling. Sidekiq + runner registration in
 	// ephemeral Docker GitLab CE can be slow on cold starts.
 	t.Run("Latest", func(t *testing.T) {
-		drainSidekiq(ctx, t)
+		drainSidekiq(ctx, t, sess.glClient)
 		var out pipelines.DetailOutput
 		var err error
 		deadline := time.Now().Add(600 * time.Second)

--- a/test/e2e/suite/pipelines_meta_test.go
+++ b/test/e2e/suite/pipelines_meta_test.go
@@ -24,131 +24,133 @@ func TestMeta_PipelinesExtended(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
+		defer cancel()
 
-	proj := createProjectMeta(ctx, t, sess.meta)
+		proj := createProjectMeta(ctx, t, sess.meta)
 
-	// Commit a .gitlab-ci.yml to trigger a pipeline
-	commitFileMeta(ctx, t, sess.meta, proj, "main", ".gitlab-ci.yml",
-		"stages:\n  - test\ntest_job:\n  stage: test\n  script:\n    - echo hello\n",
-		"add CI config")
+		// Commit a .gitlab-ci.yml to trigger a pipeline
+		commitFileMeta(ctx, t, sess.meta, proj, "main", ".gitlab-ci.yml",
+			"stages:\n  - test\ntest_job:\n  stage: test\n  script:\n    - echo hello\n",
+			"add CI config")
 
-	// Wait for pipeline creation with polling. Sidekiq + runner registration in
-	// ephemeral Docker GitLab CE can be slow on cold starts.
-	t.Run("Latest", func(t *testing.T) {
-		drainSidekiq(ctx, t, sess.glClient)
-		var out pipelines.DetailOutput
-		var err error
-		deadline := time.Now().Add(600 * time.Second)
-		delay := 2 * time.Second
-		for time.Now().Before(deadline) {
-			out, err = callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+		// Wait for pipeline creation with polling. Sidekiq + runner registration in
+		// ephemeral Docker GitLab CE can be slow on cold starts.
+		t.Run("Latest", func(t *testing.T) {
+			drainSidekiq(ctx, t, sess.glClient)
+			var out pipelines.DetailOutput
+			var err error
+			deadline := time.Now().Add(600 * time.Second)
+			delay := 2 * time.Second
+			for time.Now().Before(deadline) {
+				out, err = callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+					"action": "latest",
+					"params": map[string]any{"project_id": proj.pidStr()},
+				})
+				if err == nil {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					t.Fatalf("context canceled waiting for pipeline: %v", ctx.Err())
+				case <-time.After(delay):
+				}
+			}
+			requireNoError(t, err, "latest pipeline")
+			requireTruef(t, out.ID > 0, "latest: expected ID > 0")
+			t.Logf("Latest pipeline: %d (status: %s)", out.ID, out.Status)
+		})
+
+		t.Run("Variables", func(t *testing.T) {
+			// Create a pipeline with variables
+			createOut, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "create",
+				"params": map[string]any{
+					"project_id": proj.pidStr(),
+					"ref":        "main",
+				},
+			})
+			requireNoError(t, err, "create pipeline for variables")
+			out, err := callToolOn[pipelines.VariablesOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "variables",
+				"params": map[string]any{
+					"project_id":  proj.pidStr(),
+					"pipeline_id": createOut.ID,
+				},
+			})
+			requireNoError(t, err, "variables")
+			t.Logf("Pipeline %d variables: %d", createOut.ID, len(out.Variables))
+		})
+
+		t.Run("TestReport", func(t *testing.T) {
+			latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
 				"action": "latest",
 				"params": map[string]any{"project_id": proj.pidStr()},
 			})
-			if err == nil {
-				break
-			}
-			select {
-			case <-ctx.Done():
-				t.Fatalf("context canceled waiting for pipeline: %v", ctx.Err())
-			case <-time.After(delay):
-			}
-		}
-		requireNoError(t, err, "latest pipeline")
-		requireTruef(t, out.ID > 0, "latest: expected ID > 0")
-		t.Logf("Latest pipeline: %d (status: %s)", out.ID, out.Status)
-	})
+			requireNoError(t, err, "get latest for test_report")
+			// test_report may return error if pipeline hasn't finished, but we test the action works
+			_, _ = callToolOn[pipelines.TestReportOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "test_report",
+				"params": map[string]any{
+					"project_id":  proj.pidStr(),
+					"pipeline_id": latest.ID,
+				},
+			})
+			t.Logf("TestReport called for pipeline %d", latest.ID)
+		})
 
-	t.Run("Variables", func(t *testing.T) {
-		// Create a pipeline with variables
-		createOut, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "create",
-			"params": map[string]any{
-				"project_id": proj.pidStr(),
-				"ref":        "main",
-			},
+		t.Run("TestReportSummary", func(t *testing.T) {
+			latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "latest",
+				"params": map[string]any{"project_id": proj.pidStr()},
+			})
+			requireNoError(t, err, "get latest for test_report_summary")
+			_, _ = callToolOn[pipelines.TestReportSummaryOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "test_report_summary",
+				"params": map[string]any{
+					"project_id":  proj.pidStr(),
+					"pipeline_id": latest.ID,
+				},
+			})
+			t.Logf("TestReportSummary called for pipeline %d", latest.ID)
 		})
-		requireNoError(t, err, "create pipeline for variables")
-		out, err := callToolOn[pipelines.VariablesOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "variables",
-			"params": map[string]any{
-				"project_id":  proj.pidStr(),
-				"pipeline_id": createOut.ID,
-			},
-		})
-		requireNoError(t, err, "variables")
-		t.Logf("Pipeline %d variables: %d", createOut.ID, len(out.Variables))
-	})
 
-	t.Run("TestReport", func(t *testing.T) {
-		latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "latest",
-			"params": map[string]any{"project_id": proj.pidStr()},
+		t.Run("UpdateMetadata", func(t *testing.T) {
+			latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "latest",
+				"params": map[string]any{"project_id": proj.pidStr()},
+			})
+			requireNoError(t, err, "get latest for update_metadata")
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "update_metadata",
+				"params": map[string]any{
+					"project_id":  proj.pidStr(),
+					"pipeline_id": latest.ID,
+					"name":        "e2e-renamed",
+				},
+			})
+			requireNoError(t, err, "update_metadata")
+			requireTruef(t, out.ID == latest.ID, "update_metadata: ID mismatch")
 		})
-		requireNoError(t, err, "get latest for test_report")
-		// test_report may return error if pipeline hasn't finished, but we test the action works
-		_, _ = callToolOn[pipelines.TestReportOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "test_report",
-			"params": map[string]any{
-				"project_id":  proj.pidStr(),
-				"pipeline_id": latest.ID,
-			},
-		})
-		t.Logf("TestReport called for pipeline %d", latest.ID)
-	})
 
-	t.Run("TestReportSummary", func(t *testing.T) {
-		latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "latest",
-			"params": map[string]any{"project_id": proj.pidStr()},
+		t.Run("Cancel", func(t *testing.T) {
+			latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "latest",
+				"params": map[string]any{"project_id": proj.pidStr()},
+			})
+			requireNoError(t, err, "get latest for cancel")
+			// Cancel may fail if already finished, that's acceptable
+			_, _ = callToolOn[pipelines.StatusOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "cancel",
+				"params": map[string]any{
+					"project_id":  proj.pidStr(),
+					"pipeline_id": latest.ID,
+				},
+			})
+			t.Logf("Cancel attempted for pipeline %d", latest.ID)
 		})
-		requireNoError(t, err, "get latest for test_report_summary")
-		_, _ = callToolOn[pipelines.TestReportSummaryOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "test_report_summary",
-			"params": map[string]any{
-				"project_id":  proj.pidStr(),
-				"pipeline_id": latest.ID,
-			},
-		})
-		t.Logf("TestReportSummary called for pipeline %d", latest.ID)
-	})
-
-	t.Run("UpdateMetadata", func(t *testing.T) {
-		latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "latest",
-			"params": map[string]any{"project_id": proj.pidStr()},
-		})
-		requireNoError(t, err, "get latest for update_metadata")
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "update_metadata",
-			"params": map[string]any{
-				"project_id":  proj.pidStr(),
-				"pipeline_id": latest.ID,
-				"name":        "e2e-renamed",
-			},
-		})
-		requireNoError(t, err, "update_metadata")
-		requireTruef(t, out.ID == latest.ID, "update_metadata: ID mismatch")
-	})
-
-	t.Run("Cancel", func(t *testing.T) {
-		latest, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "latest",
-			"params": map[string]any{"project_id": proj.pidStr()},
-		})
-		requireNoError(t, err, "get latest for cancel")
-		// Cancel may fail if already finished, that's acceptable
-		_, _ = callToolOn[pipelines.StatusOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "cancel",
-			"params": map[string]any{
-				"project_id":  proj.pidStr(),
-				"pipeline_id": latest.ID,
-			},
-		})
-		t.Logf("Cancel attempted for pipeline %d", latest.ID)
 	})
 }
 

--- a/test/e2e/suite/pipelines_test.go
+++ b/test/e2e/suite/pipelines_test.go
@@ -103,7 +103,7 @@ func TestPipelines(t *testing.T) {
 	})
 
 	t.Run("Individual/WaitAndJobList", func(t *testing.T) {
-		status := waitForPipeline(t, proj.ID, pipelineID, 900*time.Second)
+		status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
 		t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
 
 		out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
@@ -156,7 +156,7 @@ func TestPipelines(t *testing.T) {
 			t.Fatalf("pipeline retry: %v", err)
 		}
 		t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
-		waitForPipeline(t, proj.ID, pipelineID, 900*time.Second)
+		waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
 	})
 
 	t.Run("Individual/Delete", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestPipelines(t *testing.T) {
 	})
 
 	t.Run("Meta/WaitAndJobList", func(t *testing.T) {
-		status := waitForPipeline(t, projM.ID, mPipelineID, 900*time.Second)
+		status := waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
 		t.Logf("Meta pipeline %d finished: %s", mPipelineID, status)
 
 		out, err := callToolOn[jobs.ListOutput](ctx, sess.meta, "gitlab_job", map[string]any{
@@ -303,7 +303,7 @@ func TestPipelines(t *testing.T) {
 		if err != nil {
 			t.Fatalf("meta pipeline retry: %v", err)
 		}
-		waitForPipeline(t, projM.ID, mPipelineID, 900*time.Second)
+		waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
 	})
 
 	t.Run("Meta/Delete", func(t *testing.T) {

--- a/test/e2e/suite/pipelines_test.go
+++ b/test/e2e/suite/pipelines_test.go
@@ -35,7 +35,12 @@ fast-pass:
 // timeouts on slower hosts.
 func TestPipelines(t *testing.T) {
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
+		if deadline, ok := t.Deadline(); ok {
+			cancel()
+			ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		}
+		defer cancel()
 
 		// --- Individual tool session ---
 		proj := createProject(ctx, t, sess.individual)

--- a/test/e2e/suite/pipelines_test.go
+++ b/test/e2e/suite/pipelines_test.go
@@ -28,294 +28,293 @@ fast-pass:
 `
 
 // TestPipelines exercises the pipeline lifecycle: create, get, list, wait for jobs,
-// job get, job trace, retry, and delete. Requires Docker mode with a CI runner.
+// job get, job trace, retry, and delete. Requires a CI runner.
 //
 // NOT parallelized: pipeline-heavy tests share a single CI runner in Docker mode.
 // Running them concurrently causes pipelines to queue, leading to spurious
 // timeouts on slower hosts.
 func TestPipelines(t *testing.T) {
-	if !isDockerMode() {
-		t.Skip("pipeline tests require Docker mode with CI runner")
-	}
+	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
 
-	ctx := context.Background()
+		ctx := context.Background()
 
-	// --- Individual tool session ---
-	proj := createProject(ctx, t, sess.individual)
-	commitFile(ctx, t, sess.individual, proj, "main", "init.txt", "bootstrap", "init commit")
+		// --- Individual tool session ---
+		proj := createProject(ctx, t, sess.individual)
+		commitFile(ctx, t, sess.individual, proj, "main", "init.txt", "bootstrap", "init commit")
 
-	// Commit a .gitlab-ci.yml to enable pipelines.
-	_, ciErr := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
-		ProjectID:     proj.pidOf(),
-		Branch:        "main",
-		CommitMessage: "ci: add .gitlab-ci.yml for pipeline tests",
-		Actions: []commits.Action{{
-			Action:   "create",
-			FilePath: ".gitlab-ci.yml",
-			Content:  pipelineCIYAML,
-		}},
-	})
-	if ciErr != nil {
-		t.Fatalf("commit CI config: %v", ciErr)
-	}
-
-	var pipelineID int64
-	var jobID int64
-
-	t.Run("Individual/Create", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
-			ProjectID: proj.pidOf(),
-			Ref:       "main",
-		})
-		if err != nil {
-			t.Fatalf("pipeline create: %v", err)
-		}
-		if out.ID <= 0 {
-			t.Fatal("expected positive pipeline ID")
-		}
-		pipelineID = out.ID
-		t.Logf("Created pipeline ID=%d status=%s", pipelineID, out.Status)
-	})
-
-	t.Run("Individual/Get", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_get", pipelines.GetInput{
-			ProjectID:  proj.pidOf(),
-			PipelineID: pipelineID,
-		})
-		if err != nil {
-			t.Fatalf("pipeline get: %v", err)
-		}
-		if out.ID != pipelineID {
-			t.Fatalf("expected pipeline ID %d, got %d", pipelineID, out.ID)
-		}
-	})
-
-	t.Run("Individual/List", func(t *testing.T) {
-		out, err := callToolOn[pipelines.ListOutput](ctx, sess.individual, "gitlab_pipeline_list", pipelines.ListInput{
-			ProjectID: proj.pidOf(),
-		})
-		if err != nil {
-			t.Fatalf("pipeline list: %v", err)
-		}
-		if len(out.Pipelines) == 0 {
-			t.Fatal("expected at least one pipeline")
-		}
-	})
-
-	t.Run("Individual/WaitAndJobList", func(t *testing.T) {
-		status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
-		t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
-
-		out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
-			ProjectID:  proj.pidOf(),
-			PipelineID: pipelineID,
-		})
-		if err != nil {
-			t.Fatalf("job list: %v", err)
-		}
-		if len(out.Jobs) == 0 {
-			t.Fatal("expected at least 1 job")
-		}
-		jobID = out.Jobs[0].ID
-		t.Logf("Listed %d jobs; first: ID=%d name=%s status=%s", len(out.Jobs), jobID, out.Jobs[0].Name, out.Jobs[0].Status)
-	})
-
-	t.Run("Individual/JobGet", func(t *testing.T) {
-		out, err := callToolOn[jobs.Output](ctx, sess.individual, "gitlab_job_get", jobs.GetInput{
-			ProjectID: proj.pidOf(),
-			JobID:     jobID,
-		})
-		if err != nil {
-			t.Fatalf("job get: %v", err)
-		}
-		if out.ID != jobID {
-			t.Fatalf("expected job ID %d, got %d", jobID, out.ID)
-		}
-	})
-
-	t.Run("Individual/JobTrace", func(t *testing.T) {
-		out, err := callToolOn[jobs.TraceOutput](ctx, sess.individual, "gitlab_job_trace", jobs.TraceInput{
-			ProjectID: proj.pidOf(),
-			JobID:     jobID,
-		})
-		if err != nil {
-			t.Fatalf("job trace: %v", err)
-		}
-		if len(out.Trace) == 0 {
-			t.Fatal("expected non-empty job trace")
-		}
-		t.Logf("Job trace: %d chars, truncated=%v", len(out.Trace), out.Truncated)
-	})
-
-	t.Run("Individual/Retry", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_retry", pipelines.ActionInput{
-			ProjectID:  proj.pidOf(),
-			PipelineID: pipelineID,
-		})
-		if err != nil {
-			t.Fatalf("pipeline retry: %v", err)
-		}
-		t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
-		waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
-	})
-
-	t.Run("Individual/Delete", func(t *testing.T) {
-		err := callToolVoidOn(ctx, sess.individual, "gitlab_pipeline_delete", pipelines.DeleteInput{
-			ProjectID:  proj.pidOf(),
-			PipelineID: pipelineID,
-		})
-		if err != nil {
-			t.Fatalf("pipeline delete: %v", err)
-		}
-	})
-
-	// --- Meta-tool session ---
-	projM := createProjectMeta(ctx, t, sess.meta)
-	commitFileMeta(ctx, t, sess.meta, projM, "main", "init.txt", "bootstrap", "init commit")
-
-	// Commit CI config via meta.
-	_, ciErr = callToolOn[commits.Output](ctx, sess.meta, "gitlab_repository", map[string]any{
-		"action": "commit_create",
-		"params": map[string]any{
-			"project_id":     projM.pidStr(),
-			"branch":         "main",
-			"commit_message": "ci: add .gitlab-ci.yml",
-			"actions": []map[string]any{{
-				"action":    "create",
-				"file_path": ".gitlab-ci.yml",
-				"content":   pipelineCIYAML,
+		// Commit a .gitlab-ci.yml to enable pipelines.
+		_, ciErr := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
+			ProjectID:     proj.pidOf(),
+			Branch:        "main",
+			CommitMessage: "ci: add .gitlab-ci.yml for pipeline tests",
+			Actions: []commits.Action{{
+				Action:   "create",
+				FilePath: ".gitlab-ci.yml",
+				Content:  pipelineCIYAML,
 			}},
-		},
-	})
-	if ciErr != nil {
-		t.Fatalf("meta commit CI config: %v", ciErr)
-	}
+		})
+		if ciErr != nil {
+			t.Fatalf("commit CI config: %v", ciErr)
+		}
 
-	var mPipelineID int64
-	var mJobID int64
+		var pipelineID int64
+		var jobID int64
 
-	t.Run("Meta/Create", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "create",
+		t.Run("Individual/Create", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
+				ProjectID: proj.pidOf(),
+				Ref:       "main",
+			})
+			if err != nil {
+				t.Fatalf("pipeline create: %v", err)
+			}
+			if out.ID <= 0 {
+				t.Fatal("expected positive pipeline ID")
+			}
+			pipelineID = out.ID
+			t.Logf("Created pipeline ID=%d status=%s", pipelineID, out.Status)
+		})
+
+		t.Run("Individual/Get", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_get", pipelines.GetInput{
+				ProjectID:  proj.pidOf(),
+				PipelineID: pipelineID,
+			})
+			if err != nil {
+				t.Fatalf("pipeline get: %v", err)
+			}
+			if out.ID != pipelineID {
+				t.Fatalf("expected pipeline ID %d, got %d", pipelineID, out.ID)
+			}
+		})
+
+		t.Run("Individual/List", func(t *testing.T) {
+			out, err := callToolOn[pipelines.ListOutput](ctx, sess.individual, "gitlab_pipeline_list", pipelines.ListInput{
+				ProjectID: proj.pidOf(),
+			})
+			if err != nil {
+				t.Fatalf("pipeline list: %v", err)
+			}
+			if len(out.Pipelines) == 0 {
+				t.Fatal("expected at least one pipeline")
+			}
+		})
+
+		t.Run("Individual/WaitAndJobList", func(t *testing.T) {
+			status := waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
+			t.Logf("Pipeline %d finished with status: %s", pipelineID, status)
+
+			out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
+				ProjectID:  proj.pidOf(),
+				PipelineID: pipelineID,
+			})
+			if err != nil {
+				t.Fatalf("job list: %v", err)
+			}
+			if len(out.Jobs) == 0 {
+				t.Fatal("expected at least 1 job")
+			}
+			jobID = out.Jobs[0].ID
+			t.Logf("Listed %d jobs; first: ID=%d name=%s status=%s", len(out.Jobs), jobID, out.Jobs[0].Name, out.Jobs[0].Status)
+		})
+
+		t.Run("Individual/JobGet", func(t *testing.T) {
+			out, err := callToolOn[jobs.Output](ctx, sess.individual, "gitlab_job_get", jobs.GetInput{
+				ProjectID: proj.pidOf(),
+				JobID:     jobID,
+			})
+			if err != nil {
+				t.Fatalf("job get: %v", err)
+			}
+			if out.ID != jobID {
+				t.Fatalf("expected job ID %d, got %d", jobID, out.ID)
+			}
+		})
+
+		t.Run("Individual/JobTrace", func(t *testing.T) {
+			out, err := callToolOn[jobs.TraceOutput](ctx, sess.individual, "gitlab_job_trace", jobs.TraceInput{
+				ProjectID: proj.pidOf(),
+				JobID:     jobID,
+			})
+			if err != nil {
+				t.Fatalf("job trace: %v", err)
+			}
+			if len(out.Trace) == 0 {
+				t.Fatal("expected non-empty job trace")
+			}
+			t.Logf("Job trace: %d chars, truncated=%v", len(out.Trace), out.Truncated)
+		})
+
+		t.Run("Individual/Retry", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_retry", pipelines.ActionInput{
+				ProjectID:  proj.pidOf(),
+				PipelineID: pipelineID,
+			})
+			if err != nil {
+				t.Fatalf("pipeline retry: %v", err)
+			}
+			t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
+			waitForPipeline(t, sess.glClient, proj.ID, pipelineID, 900*time.Second)
+		})
+
+		t.Run("Individual/Delete", func(t *testing.T) {
+			err := callToolVoidOn(ctx, sess.individual, "gitlab_pipeline_delete", pipelines.DeleteInput{
+				ProjectID:  proj.pidOf(),
+				PipelineID: pipelineID,
+			})
+			if err != nil {
+				t.Fatalf("pipeline delete: %v", err)
+			}
+		})
+
+		// --- Meta-tool session ---
+		projM := createProjectMeta(ctx, t, sess.meta)
+		commitFileMeta(ctx, t, sess.meta, projM, "main", "init.txt", "bootstrap", "init commit")
+
+		// Commit CI config via meta.
+		_, ciErr = callToolOn[commits.Output](ctx, sess.meta, "gitlab_repository", map[string]any{
+			"action": "commit_create",
 			"params": map[string]any{
-				"project_id": projM.pidStr(),
-				"ref":        "main",
+				"project_id":     projM.pidStr(),
+				"branch":         "main",
+				"commit_message": "ci: add .gitlab-ci.yml",
+				"actions": []map[string]any{{
+					"action":    "create",
+					"file_path": ".gitlab-ci.yml",
+					"content":   pipelineCIYAML,
+				}},
 			},
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline create: %v", err)
+		if ciErr != nil {
+			t.Fatalf("meta commit CI config: %v", ciErr)
 		}
-		mPipelineID = out.ID
-		t.Logf("Meta created pipeline ID=%d", mPipelineID)
-	})
 
-	t.Run("Meta/Get", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "get",
-			"params": map[string]any{
-				"project_id":  projM.pidStr(),
-				"pipeline_id": mPipelineID,
-			},
+		var mPipelineID int64
+		var mJobID int64
+
+		t.Run("Meta/Create", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "create",
+				"params": map[string]any{
+					"project_id": projM.pidStr(),
+					"ref":        "main",
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline create: %v", err)
+			}
+			mPipelineID = out.ID
+			t.Logf("Meta created pipeline ID=%d", mPipelineID)
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline get: %v", err)
-		}
-		if out.ID != mPipelineID {
-			t.Fatalf("expected pipeline ID %d, got %d", mPipelineID, out.ID)
-		}
-	})
 
-	t.Run("Meta/List", func(t *testing.T) {
-		out, err := callToolOn[pipelines.ListOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "list",
-			"params": map[string]any{
-				"project_id": projM.pidStr(),
-			},
+		t.Run("Meta/Get", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "get",
+				"params": map[string]any{
+					"project_id":  projM.pidStr(),
+					"pipeline_id": mPipelineID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline get: %v", err)
+			}
+			if out.ID != mPipelineID {
+				t.Fatalf("expected pipeline ID %d, got %d", mPipelineID, out.ID)
+			}
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline list: %v", err)
-		}
-		if len(out.Pipelines) == 0 {
-			t.Fatal("expected at least one pipeline (meta)")
-		}
-	})
 
-	t.Run("Meta/WaitAndJobList", func(t *testing.T) {
-		status := waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
-		t.Logf("Meta pipeline %d finished: %s", mPipelineID, status)
-
-		out, err := callToolOn[jobs.ListOutput](ctx, sess.meta, "gitlab_job", map[string]any{
-			"action": "list",
-			"params": map[string]any{
-				"project_id":  projM.pidStr(),
-				"pipeline_id": mPipelineID,
-			},
+		t.Run("Meta/List", func(t *testing.T) {
+			out, err := callToolOn[pipelines.ListOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "list",
+				"params": map[string]any{
+					"project_id": projM.pidStr(),
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline list: %v", err)
+			}
+			if len(out.Pipelines) == 0 {
+				t.Fatal("expected at least one pipeline (meta)")
+			}
 		})
-		if err != nil {
-			t.Fatalf("meta job list: %v", err)
-		}
-		if len(out.Jobs) == 0 {
-			t.Fatal("expected at least 1 job (meta)")
-		}
-		mJobID = out.Jobs[0].ID
-	})
 
-	t.Run("Meta/JobGet", func(t *testing.T) {
-		out, err := callToolOn[jobs.Output](ctx, sess.meta, "gitlab_job", map[string]any{
-			"action": "get",
-			"params": map[string]any{
-				"project_id": projM.pidStr(),
-				"job_id":     mJobID,
-			},
-		})
-		if err != nil {
-			t.Fatalf("meta job get: %v", err)
-		}
-		if out.ID != mJobID {
-			t.Fatalf("expected job ID %d, got %d", mJobID, out.ID)
-		}
-	})
+		t.Run("Meta/WaitAndJobList", func(t *testing.T) {
+			status := waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
+			t.Logf("Meta pipeline %d finished: %s", mPipelineID, status)
 
-	t.Run("Meta/JobTrace", func(t *testing.T) {
-		out, err := callToolOn[jobs.TraceOutput](ctx, sess.meta, "gitlab_job", map[string]any{
-			"action": "trace",
-			"params": map[string]any{
-				"project_id": projM.pidStr(),
-				"job_id":     mJobID,
-			},
+			out, err := callToolOn[jobs.ListOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+				"action": "list",
+				"params": map[string]any{
+					"project_id":  projM.pidStr(),
+					"pipeline_id": mPipelineID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta job list: %v", err)
+			}
+			if len(out.Jobs) == 0 {
+				t.Fatal("expected at least 1 job (meta)")
+			}
+			mJobID = out.Jobs[0].ID
 		})
-		if err != nil {
-			t.Fatalf("meta job trace: %v", err)
-		}
-		if len(out.Trace) == 0 {
-			t.Fatal("expected non-empty job trace (meta)")
-		}
-	})
 
-	t.Run("Meta/Retry", func(t *testing.T) {
-		_, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "retry",
-			"params": map[string]any{
-				"project_id":  projM.pidStr(),
-				"pipeline_id": mPipelineID,
-			},
+		t.Run("Meta/JobGet", func(t *testing.T) {
+			out, err := callToolOn[jobs.Output](ctx, sess.meta, "gitlab_job", map[string]any{
+				"action": "get",
+				"params": map[string]any{
+					"project_id": projM.pidStr(),
+					"job_id":     mJobID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta job get: %v", err)
+			}
+			if out.ID != mJobID {
+				t.Fatalf("expected job ID %d, got %d", mJobID, out.ID)
+			}
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline retry: %v", err)
-		}
-		waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
-	})
 
-	t.Run("Meta/Delete", func(t *testing.T) {
-		err := callToolVoidOn(ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "delete",
-			"params": map[string]any{
-				"project_id":  projM.pidStr(),
-				"pipeline_id": mPipelineID,
-			},
+		t.Run("Meta/JobTrace", func(t *testing.T) {
+			out, err := callToolOn[jobs.TraceOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+				"action": "trace",
+				"params": map[string]any{
+					"project_id": projM.pidStr(),
+					"job_id":     mJobID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta job trace: %v", err)
+			}
+			if len(out.Trace) == 0 {
+				t.Fatal("expected non-empty job trace (meta)")
+			}
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline delete: %v", err)
-		}
+
+		t.Run("Meta/Retry", func(t *testing.T) {
+			_, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "retry",
+				"params": map[string]any{
+					"project_id":  projM.pidStr(),
+					"pipeline_id": mPipelineID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline retry: %v", err)
+			}
+			waitForPipeline(t, sess.glClient, projM.ID, mPipelineID, 900*time.Second)
+		})
+
+		t.Run("Meta/Delete", func(t *testing.T) {
+			err := callToolVoidOn(ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "delete",
+				"params": map[string]any{
+					"project_id":  projM.pidStr(),
+					"pipeline_id": mPipelineID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline delete: %v", err)
+			}
+		})
 	})
 }

--- a/test/e2e/suite/pipelines_test.go
+++ b/test/e2e/suite/pipelines_test.go
@@ -35,7 +35,6 @@ fast-pass:
 // timeouts on slower hosts.
 func TestPipelines(t *testing.T) {
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
-
 		ctx := context.Background()
 
 		// --- Individual tool session ---

--- a/test/e2e/suite/projectmirrors_test.go
+++ b/test/e2e/suite/projectmirrors_test.go
@@ -16,7 +16,6 @@ import (
 // Remote mirrors are a Free-tier feature (push mirrors).
 func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 	t.Parallel()
-	RequireCapabilities(t, CapabilityExternalNetwork)
 
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
@@ -26,6 +25,8 @@ func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 	defer cancel()
 
 	proj := createProjectMeta(ctx, t, sess.meta)
+	target := createProjectMeta(ctx, t, sess.meta)
+	mirrorURL := remoteMirrorTargetURL(t, target)
 
 	// List — should be empty on a fresh project.
 	t.Run("MirrorList_Empty", func(t *testing.T) {
@@ -45,9 +46,9 @@ func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 			"action": "mirror_add",
 			"params": map[string]any{
 				"project_id":              proj.pidStr(),
-				"url":                     "ssh://git@example.com/mirror-target.git",
+				"url":                     mirrorURL,
 				"enabled":                 true,
-				"auth_method":             "ssh_public_key",
+				"auth_method":             "password",
 				"only_protected_branches": true,
 			},
 		})
@@ -72,19 +73,18 @@ func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 		t.Logf("Got mirror %d, enabled=%v", out.ID, out.Enabled)
 	})
 
-	// Get SSH public key for the mirror (requires auth_method=ssh_public_key).
-	t.Run("MirrorGetPublicKey", func(t *testing.T) {
+	// Password-authenticated mirrors do not expose SSH public keys.
+	t.Run("MirrorGetPublicKey_PasswordMirror", func(t *testing.T) {
 		requireTruef(t, mirrorID > 0, "mirrorID not set")
-		out, err := callToolOn[projectmirrors.PublicKeyOutput](ctx, sess.meta, "gitlab_project", map[string]any{
+		_, err := callToolOn[projectmirrors.PublicKeyOutput](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "mirror_get_public_key",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
 				"mirror_id":  mirrorID,
 			},
 		})
-		requireNoError(t, err, "mirror_get_public_key")
-		requireTruef(t, out.PublicKey != "", "mirror_get_public_key: expected non-empty public key")
-		t.Logf("Public key length: %d chars", len(out.PublicKey))
+		requireTruef(t, err != nil, "expected mirror_get_public_key to fail for password-authenticated mirror")
+		t.Logf("Expected public key error for password-authenticated mirror: %v", err)
 	})
 
 	// Edit mirror.

--- a/test/e2e/suite/projectmirrors_test.go
+++ b/test/e2e/suite/projectmirrors_test.go
@@ -16,6 +16,8 @@ import (
 // Remote mirrors are a Free-tier feature (push mirrors).
 func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 	t.Parallel()
+	RequireCapabilities(t, CapabilityExternalNetwork)
+
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}

--- a/test/e2e/suite/projectmirrors_test.go
+++ b/test/e2e/suite/projectmirrors_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// projectmirrors_test.go exercises project remote mirror actions through the
+// gitlab_project meta-tool using Docker-local GitLab mirror targets.
 package suite
 
 import (

--- a/test/e2e/suite/projects_meta_test.go
+++ b/test/e2e/suite/projects_meta_test.go
@@ -223,6 +223,9 @@ func TestMeta_ProjectHooks(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	if !hasE2EFixtureService() {
+		t.Skip("E2E fixture service unavailable; set E2E_FIXTURE_URL or run with E2E_MODE=docker")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()

--- a/test/e2e/suite/projects_meta_test.go
+++ b/test/e2e/suite/projects_meta_test.go
@@ -219,6 +219,8 @@ func TestMeta_ProjectCore(t *testing.T) {
 // gitlab_project meta-tool (hook_*).
 func TestMeta_ProjectHooks(t *testing.T) {
 	t.Parallel()
+	RequireCapabilities(t, CapabilityExternalNetwork)
+
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}

--- a/test/e2e/suite/projects_meta_test.go
+++ b/test/e2e/suite/projects_meta_test.go
@@ -219,7 +219,6 @@ func TestMeta_ProjectCore(t *testing.T) {
 // gitlab_project meta-tool (hook_*).
 func TestMeta_ProjectHooks(t *testing.T) {
 	t.Parallel()
-	RequireCapabilities(t, CapabilityExternalNetwork)
 
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
@@ -229,6 +228,8 @@ func TestMeta_ProjectHooks(t *testing.T) {
 	defer cancel()
 
 	proj := createProjectMeta(ctx, t, sess.meta)
+	hookURL := e2eFixtureServiceURL("/hook")
+	hookUpdatedURL := e2eFixtureServiceURL("/hook-updated")
 
 	var hookID int64
 
@@ -237,7 +238,7 @@ func TestMeta_ProjectHooks(t *testing.T) {
 			"action": "hook_add",
 			"params": map[string]any{
 				"project_id":  proj.pidStr(),
-				"url":         "https://example.com/hook",
+				"url":         hookURL,
 				"push_events": true,
 				"token":       "test-secret-token",
 				"name":        "E2E Test Hook",
@@ -281,7 +282,7 @@ func TestMeta_ProjectHooks(t *testing.T) {
 			"params": map[string]any{
 				"project_id":    proj.pidStr(),
 				"hook_id":       hookID,
-				"url":           "https://example.com/hook-updated",
+				"url":           hookUpdatedURL,
 				"issues_events": true,
 			},
 		})
@@ -352,17 +353,16 @@ func TestMeta_ProjectHooks(t *testing.T) {
 
 	t.Run("HookTest", func(t *testing.T) {
 		requireTruef(t, hookID > 0, "hookID not set")
-		// Webhook URL points to unreachable endpoint — expected to fail
-		_, err := callToolOn[projects.TriggerTestHookOutput](ctx, sess.meta, "gitlab_project", map[string]any{
+		out, err := callToolOn[projects.TriggerTestHookOutput](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "hook_test",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
 				"hook_id":    hookID,
-				"trigger":    "push_events",
+				"event":      "push_events",
 			},
 		})
-		requireTruef(t, err != nil, "expected error: webhook endpoint unreachable")
-		t.Logf("Expected error for unreachable hook test: %v", err)
+		requireNoError(t, err, "meta project hook_test")
+		t.Logf("Tested hook %d: %s", hookID, out.Message)
 	})
 
 	t.Run("HookDelete", func(t *testing.T) {

--- a/test/e2e/suite/resource_ledger_test.go
+++ b/test/e2e/suite/resource_ledger_test.go
@@ -4,6 +4,7 @@ package suite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"testing"
 	"time"
 )
+
+var errResourceLedgerClosed = errors.New("resource ledger closed")
 
 // ResourceKind identifies a GitLab or MCP resource owned by an E2E test.
 type ResourceKind string
@@ -56,11 +59,16 @@ type ResourceLedger struct {
 }
 
 // Register adds a resource cleanup record to the ledger.
-func (ledger *ResourceLedger) Register(record ResourceRecord) {
+func (ledger *ResourceLedger) Register(record ResourceRecord) error {
 	ledger.mu.Lock()
 	defer ledger.mu.Unlock()
 
+	if ledger.cleaned {
+		return fmt.Errorf("register %s: %w", record.redactedLabel(), errResourceLedgerClosed)
+	}
+
 	ledger.records = append(ledger.records, record)
+	return nil
 }
 
 // Records returns a snapshot copy of registered resources.
@@ -120,14 +128,18 @@ func TestResourceLedger_CleansInReverseRegistrationOrder(t *testing.T) {
 	var ledger ResourceLedger
 	var cleaned []string
 
-	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+	if err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
 		cleaned = append(cleaned, "project")
 		return nil
-	}})
-	ledger.Register(ResourceRecord{Kind: ResourceKindGroup, ID: "2", Cleanup: func(context.Context) error {
+	}}); err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
+	if err := ledger.Register(ResourceRecord{Kind: ResourceKindGroup, ID: "2", Cleanup: func(context.Context) error {
 		cleaned = append(cleaned, "group")
 		return nil
-	}})
+	}}); err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
 
 	failures := ledger.CleanupAll(context.Background(), t)
 	if len(failures) != 0 {
@@ -146,7 +158,9 @@ func TestResourceLedger_CleansInReverseRegistrationOrder(t *testing.T) {
 // expecting the original ID to remain unchanged.
 func TestResourceLedger_RecordsReturnsCopy(t *testing.T) {
 	var ledger ResourceLedger
-	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1"})
+	if err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1"}); err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
 
 	records := ledger.Records()
 	records[0].ID = "changed"
@@ -169,7 +183,9 @@ func TestResourceLedger_RegisterIsConcurrentSafe(t *testing.T) {
 	for i := range 50 {
 		id := fmt.Sprintf("%d", i)
 		wg.Go(func() {
-			ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: id})
+			if err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: id}); err != nil {
+				t.Errorf("Register() error = %v, want nil", err)
+			}
 		})
 	}
 	wg.Wait()
@@ -186,9 +202,11 @@ func TestResourceLedger_RegisterIsConcurrentSafe(t *testing.T) {
 // error includes kind, ID, and failure text for actionable diagnostics.
 func TestResourceLedger_CleanupAllReportsFailures(t *testing.T) {
 	var ledger ResourceLedger
-	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+	if err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
 		return fmt.Errorf("delete failed")
-	}})
+	}}); err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
 
 	failures := ledger.CleanupAll(context.Background(), t)
 	if len(failures) != 1 {
@@ -207,16 +225,34 @@ func TestResourceLedger_CleanupAllReportsFailures(t *testing.T) {
 func TestResourceLedger_CleanupAllIsIdempotent(t *testing.T) {
 	var ledger ResourceLedger
 	var calls int
-	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+	if err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
 		calls++
 		return nil
-	}})
+	}}); err != nil {
+		t.Fatalf("Register() error = %v, want nil", err)
+	}
 
 	ledger.CleanupAll(context.Background(), t)
 	ledger.CleanupAll(context.Background(), t)
 
 	if calls != 1 {
 		t.Fatalf("cleanup calls = %d, want 1", calls)
+	}
+}
+
+// TestResourceLedger_RegisterAfterCleanupReturnsError verifies that the ledger
+// rejects records registered after cleanup has started.
+//
+// The test runs CleanupAll first, then attempts to add another record and
+// expects a closed-ledger error. This prevents late fixture registrations from
+// being silently skipped by idempotent cleanup.
+func TestResourceLedger_RegisterAfterCleanupReturnsError(t *testing.T) {
+	var ledger ResourceLedger
+
+	ledger.CleanupAll(context.Background(), t)
+	err := ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "late"})
+	if !errors.Is(err, errResourceLedgerClosed) {
+		t.Fatalf("Register() error = %v, want %v", err, errResourceLedgerClosed)
 	}
 }
 

--- a/test/e2e/suite/resource_ledger_test.go
+++ b/test/e2e/suite/resource_ledger_test.go
@@ -30,6 +30,7 @@ const (
 	ResourceKindCustomAttribute     ResourceKind = "custom_attribute"
 	ResourceKindPipeline            ResourceKind = "pipeline"
 	ResourceKindJob                 ResourceKind = "job"
+	ResourceKindCurrentUserState    ResourceKind = "current_user_state"
 )
 
 // ResourceRecord describes one resource and its best-effort cleanup action.

--- a/test/e2e/suite/resource_ledger_test.go
+++ b/test/e2e/suite/resource_ledger_test.go
@@ -1,0 +1,198 @@
+package suite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ResourceKind identifies a GitLab or MCP resource owned by an E2E test.
+type ResourceKind string
+
+// ResourceKind values cover the resource families currently created by E2E tests.
+const (
+	ResourceKindProject             ResourceKind = "project"
+	ResourceKindGroup               ResourceKind = "group"
+	ResourceKindUser                ResourceKind = "user"
+	ResourceKindSSHKey              ResourceKind = "ssh_key"
+	ResourceKindDeployKey           ResourceKind = "deploy_key"
+	ResourceKindDeployToken         ResourceKind = "deploy_token"
+	ResourceKindPersonalAccessToken ResourceKind = "personal_access_token"
+	ResourceKindImpersonationToken  ResourceKind = "impersonation_token"
+	ResourceKindTopic               ResourceKind = "topic"
+	ResourceKindBroadcastMessage    ResourceKind = "broadcast_message"
+	ResourceKindSystemHook          ResourceKind = "system_hook"
+	ResourceKindApplication         ResourceKind = "application"
+	ResourceKindFeatureFlag         ResourceKind = "feature_flag"
+	ResourceKindCustomAttribute     ResourceKind = "custom_attribute"
+	ResourceKindPipeline            ResourceKind = "pipeline"
+	ResourceKindJob                 ResourceKind = "job"
+)
+
+// ResourceRecord describes one resource and its best-effort cleanup action.
+type ResourceRecord struct {
+	Kind      ResourceKind
+	ID        string
+	Path      string
+	Name      string
+	OwnerTest string
+	RunID     string
+	CreatedAt time.Time
+	Cleanup   func(context.Context) error
+}
+
+// ResourceLedger records resources owned by one test and cleans them up once.
+type ResourceLedger struct {
+	mu      sync.Mutex
+	records []ResourceRecord
+	cleaned bool
+}
+
+// Register adds a resource cleanup record to the ledger.
+func (ledger *ResourceLedger) Register(record ResourceRecord) {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+
+	ledger.records = append(ledger.records, record)
+}
+
+// Records returns a snapshot copy of registered resources.
+func (ledger *ResourceLedger) Records() []ResourceRecord {
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+
+	return append([]ResourceRecord(nil), ledger.records...)
+}
+
+// CleanupAll runs registered cleanup actions in reverse registration order.
+func (ledger *ResourceLedger) CleanupAll(ctx context.Context, t testing.TB) []error {
+	t.Helper()
+
+	ledger.mu.Lock()
+	if ledger.cleaned {
+		ledger.mu.Unlock()
+		return nil
+	}
+	ledger.cleaned = true
+	records := append([]ResourceRecord(nil), ledger.records...)
+	ledger.mu.Unlock()
+
+	failures := make([]error, 0)
+	for i := len(records) - 1; i >= 0; i-- {
+		record := records[i]
+		if record.Cleanup == nil {
+			continue
+		}
+		if err := record.Cleanup(ctx); err != nil {
+			failure := fmt.Errorf("cleanup %s: %w", record.redactedLabel(), err)
+			failures = append(failures, failure)
+			t.Logf("e2e cleanup failed: %v", failure)
+		}
+		if ctx.Err() != nil {
+			failures = append(failures, ctx.Err())
+			t.Logf("e2e cleanup stopped: %v", ctx.Err())
+			break
+		}
+	}
+	return failures
+}
+
+func (record ResourceRecord) redactedLabel() string {
+	return fmt.Sprintf("kind=%s id=%q path=%q name=%q owner=%q run_id=%q", record.Kind, record.ID, record.Path, record.Name, record.OwnerTest, record.RunID)
+}
+
+func TestResourceLedger_CleansInReverseRegistrationOrder(t *testing.T) {
+	var ledger ResourceLedger
+	var cleaned []string
+
+	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+		cleaned = append(cleaned, "project")
+		return nil
+	}})
+	ledger.Register(ResourceRecord{Kind: ResourceKindGroup, ID: "2", Cleanup: func(context.Context) error {
+		cleaned = append(cleaned, "group")
+		return nil
+	}})
+
+	failures := ledger.CleanupAll(context.Background(), t)
+	if len(failures) != 0 {
+		t.Fatalf("CleanupAll failures = %v, want none", failures)
+	}
+	want := []string{"group", "project"}
+	if fmt.Sprint(cleaned) != fmt.Sprint(want) {
+		t.Fatalf("cleanup order = %v, want %v", cleaned, want)
+	}
+}
+
+func TestResourceLedger_RecordsReturnsCopy(t *testing.T) {
+	var ledger ResourceLedger
+	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1"})
+
+	records := ledger.Records()
+	records[0].ID = "changed"
+
+	got := ledger.Records()[0].ID
+	if got != "1" {
+		t.Fatalf("ledger record ID = %q, want original value", got)
+	}
+}
+
+func TestResourceLedger_RegisterIsConcurrentSafe(t *testing.T) {
+	var ledger ResourceLedger
+	var wg sync.WaitGroup
+
+	for i := range 50 {
+		id := fmt.Sprintf("%d", i)
+		wg.Go(func() {
+			ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: id})
+		})
+	}
+	wg.Wait()
+
+	if got := len(ledger.Records()); got != 50 {
+		t.Fatalf("registered records = %d, want 50", got)
+	}
+}
+
+func TestResourceLedger_CleanupAllReportsFailures(t *testing.T) {
+	var ledger ResourceLedger
+	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+		return fmt.Errorf("delete failed")
+	}})
+
+	failures := ledger.CleanupAll(context.Background(), t)
+	if len(failures) != 1 {
+		t.Fatalf("failures = %d, want 1", len(failures))
+	}
+	if got := failures[0].Error(); got == "" || !containsAll(got, "kind=project", "id=\"1\"", "delete failed") {
+		t.Fatalf("failure message = %q, want redacted resource label and cause", got)
+	}
+}
+
+func TestResourceLedger_CleanupAllIsIdempotent(t *testing.T) {
+	var ledger ResourceLedger
+	var calls int
+	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
+		calls++
+		return nil
+	}})
+
+	ledger.CleanupAll(context.Background(), t)
+	ledger.CleanupAll(context.Background(), t)
+
+	if calls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", calls)
+	}
+}
+
+func containsAll(value string, fragments ...string) bool {
+	for _, fragment := range fragments {
+		if !strings.Contains(value, fragment) {
+			return false
+		}
+	}
+	return true
+}

--- a/test/e2e/suite/resource_ledger_test.go
+++ b/test/e2e/suite/resource_ledger_test.go
@@ -1,3 +1,5 @@
+// resource_ledger_test.go defines the per-test resource cleanup ledger and
+// verifies that cleanup is ordered, idempotent, and safe under concurrent use.
 package suite
 
 import (
@@ -101,10 +103,19 @@ func (ledger *ResourceLedger) CleanupAll(ctx context.Context, t testing.TB) []er
 	return failures
 }
 
+// redactedLabel returns a diagnostic label for cleanup failures without
+// including secrets or credential-bearing URLs.
 func (record ResourceRecord) redactedLabel() string {
 	return fmt.Sprintf("kind=%s id=%q path=%q name=%q owner=%q run_id=%q", record.Kind, record.ID, record.Path, record.Name, record.OwnerTest, record.RunID)
 }
 
+// TestResourceLedger_CleansInReverseRegistrationOrder verifies that CleanupAll
+// runs cleanup callbacks in last-in-first-out order.
+//
+// The test registers project and group cleanup callbacks, invokes CleanupAll,
+// and asserts that the group cleanup runs before the project cleanup. This
+// protects nested fixtures where dependent resources should be removed before
+// their parents.
 func TestResourceLedger_CleansInReverseRegistrationOrder(t *testing.T) {
 	var ledger ResourceLedger
 	var cleaned []string
@@ -128,6 +139,11 @@ func TestResourceLedger_CleansInReverseRegistrationOrder(t *testing.T) {
 	}
 }
 
+// TestResourceLedger_RecordsReturnsCopy verifies that Records returns a copy of
+// the internal slice rather than exposing mutable ledger state.
+//
+// The test mutates the returned record and then reads the ledger again,
+// expecting the original ID to remain unchanged.
 func TestResourceLedger_RecordsReturnsCopy(t *testing.T) {
 	var ledger ResourceLedger
 	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1"})
@@ -141,6 +157,11 @@ func TestResourceLedger_RecordsReturnsCopy(t *testing.T) {
 	}
 }
 
+// TestResourceLedger_RegisterIsConcurrentSafe verifies that concurrent Register
+// calls preserve every cleanup record.
+//
+// The test launches 50 goroutines that register project records and asserts
+// that the final snapshot contains all 50 entries.
 func TestResourceLedger_RegisterIsConcurrentSafe(t *testing.T) {
 	var ledger ResourceLedger
 	var wg sync.WaitGroup
@@ -158,6 +179,11 @@ func TestResourceLedger_RegisterIsConcurrentSafe(t *testing.T) {
 	}
 }
 
+// TestResourceLedger_CleanupAllReportsFailures verifies that CleanupAll returns
+// cleanup errors with the redacted resource label and original cause.
+//
+// The test registers a failing cleanup callback and asserts that the returned
+// error includes kind, ID, and failure text for actionable diagnostics.
 func TestResourceLedger_CleanupAllReportsFailures(t *testing.T) {
 	var ledger ResourceLedger
 	ledger.Register(ResourceRecord{Kind: ResourceKindProject, ID: "1", Cleanup: func(context.Context) error {
@@ -173,6 +199,11 @@ func TestResourceLedger_CleanupAllReportsFailures(t *testing.T) {
 	}
 }
 
+// TestResourceLedger_CleanupAllIsIdempotent verifies that calling CleanupAll
+// more than once does not repeat cleanup callbacks.
+//
+// The test registers one cleanup callback, calls CleanupAll twice, and expects
+// the callback counter to increment only once.
 func TestResourceLedger_CleanupAllIsIdempotent(t *testing.T) {
 	var ledger ResourceLedger
 	var calls int
@@ -189,6 +220,8 @@ func TestResourceLedger_CleanupAllIsIdempotent(t *testing.T) {
 	}
 }
 
+// containsAll reports whether value contains every fragment in order-insensitive
+// fashion for compact failure-message assertions.
 func containsAll(value string, fragments ...string) bool {
 	for _, fragment := range fragments {
 		if !strings.Contains(value, fragment) {

--- a/test/e2e/suite/resource_ledger_test.go
+++ b/test/e2e/suite/resource_ledger_test.go
@@ -5,6 +5,7 @@ package suite
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -84,8 +85,7 @@ func (ledger *ResourceLedger) CleanupAll(ctx context.Context, t testing.TB) []er
 	ledger.mu.Unlock()
 
 	failures := make([]error, 0)
-	for i := len(records) - 1; i >= 0; i-- {
-		record := records[i]
+	for _, record := range slices.Backward(records) {
 		if record.Cleanup == nil {
 			continue
 		}

--- a/test/e2e/suite/scope_filter_test.go
+++ b/test/e2e/suite/scope_filter_test.go
@@ -4,7 +4,6 @@
 // end-to-end scenario. It creates a non-admin user with a limited-scope
 // token and asserts that admin-only meta-tools are removed while regular
 // meta-tools remain accessible.
-
 package suite
 
 import (

--- a/test/e2e/suite/search_meta_test.go
+++ b/test/e2e/suite/search_meta_test.go
@@ -26,7 +26,7 @@ func TestMeta_SearchExtended(t *testing.T) {
 	proj := createProjectMeta(ctx, t, sess.meta)
 	commitFileMeta(ctx, t, sess.meta, proj, "main", "search_target.txt", "searchable content for e2e", "add searchable file")
 
-	drainSidekiq(ctx, t)
+	drainSidekiq(ctx, t, sess.glClient)
 
 	t.Run("SearchMergeRequests", func(t *testing.T) {
 		out, err := callToolOn[search.MergeRequestsOutput](ctx, sess.meta, "gitlab_search", map[string]any{

--- a/test/e2e/suite/search_test.go
+++ b/test/e2e/suite/search_test.go
@@ -28,7 +28,7 @@ func TestIndividual_Search(t *testing.T) {
 	unprotectMain(ctx, t, proj)
 	commitFile(ctx, t, sess.individual, proj, defaultBranch, "searchable.txt", "unique-e2e-search-token-12345", "add searchable content")
 
-	drainSidekiq(ctx, t)
+	drainSidekiq(ctx, t, sess.glClient)
 
 	t.Run("Code", func(t *testing.T) {
 		out, err := callToolOn[search.CodeOutput](ctx, sess.individual, "gitlab_search_code", search.CodeInput{
@@ -64,7 +64,7 @@ func TestMeta_Search(t *testing.T) {
 	unprotectMain(ctx, t, proj)
 	commitFileMeta(ctx, t, sess.meta, proj, defaultBranch, "searchable-meta.txt", "unique-e2e-meta-search-67890", "add searchable meta content")
 
-	drainSidekiq(ctx, t)
+	drainSidekiq(ctx, t, sess.glClient)
 
 	t.Run("Code", func(t *testing.T) {
 		out, err := callToolOn[search.CodeOutput](ctx, sess.meta, "gitlab_search", map[string]any{

--- a/test/e2e/suite/setup_helpers_test.go
+++ b/test/e2e/suite/setup_helpers_test.go
@@ -1,0 +1,90 @@
+package suite
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestShortStableHash_ReturnsStableLowercaseHex(t *testing.T) {
+	first := shortStableHash("TestIndividual_Branches/Create")
+	second := shortStableHash("TestIndividual_Branches/Create")
+
+	if first != second {
+		t.Fatalf("hash is not stable: first=%q second=%q", first, second)
+	}
+	if len(first) != stableHashLength {
+		t.Fatalf("hash length = %d, want %d", len(first), stableHashLength)
+	}
+	if !regexp.MustCompile(`^[a-f0-9]+$`).MatchString(first) {
+		t.Fatalf("hash %q is not lowercase hex", first)
+	}
+}
+
+func TestSanitizeTestName_ConvertsGoTestNameToSlug(t *testing.T) {
+	got := sanitizeTestName("TestIndividual_Branches/Create With Spaces!")
+	want := "testindividual-branches-createwithspaces"
+	if got != want {
+		t.Fatalf("sanitizeTestName() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeTestName_TruncatesToFortyCharacters(t *testing.T) {
+	got := sanitizeTestName(strings.Repeat("a", 80))
+	if len(got) != 40 {
+		t.Fatalf("sanitized name length = %d, want 40", len(got))
+	}
+}
+
+func TestNewE2ERunID_UsesUTCStampAndHashSuffix(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 34, 56, 789, time.FixedZone("UTC+2", 2*60*60))
+	got := newE2ERunID(now)
+
+	if !regexp.MustCompile(`^20260430T103456Z-[a-f0-9]{10}$`).MatchString(got) {
+		t.Fatalf("newE2ERunID() = %q, want UTC timestamp plus 10-char hex suffix", got)
+	}
+}
+
+func TestConfiguredE2ERunID_UsesEnvironmentOverride(t *testing.T) {
+	t.Setenv("E2E_RUN_ID", "Custom_Run/ID!")
+	got := configuredE2ERunID(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC))
+	want := "custom-run-id"
+	if got != want {
+		t.Fatalf("configuredE2ERunID() = %q, want %q", got, want)
+	}
+}
+
+func TestUniqueName_IncludesRunIDHashAndCounter(t *testing.T) {
+	originalRunID := e2eRunID
+	originalCounter := uniqueCounter.Load()
+	e2eRunID = "run-abc123"
+	uniqueCounter.Store(0)
+	t.Cleanup(func() {
+		e2eRunID = originalRunID
+		uniqueCounter.Store(originalCounter)
+	})
+
+	got := uniqueName("E2E_Project/Test")
+	want := "e2e-project-test-run-abc123-" + shortStableHash("e2e-project-test") + "-1"
+	if got != want {
+		t.Fatalf("uniqueName() = %q, want %q", got, want)
+	}
+}
+
+func TestUniqueName_UsesDefaultPrefixForEmptyInput(t *testing.T) {
+	originalRunID := e2eRunID
+	originalCounter := uniqueCounter.Load()
+	e2eRunID = "run-xyz789"
+	uniqueCounter.Store(0)
+	t.Cleanup(func() {
+		e2eRunID = originalRunID
+		uniqueCounter.Store(originalCounter)
+	})
+
+	got := uniqueName("")
+	wantPrefix := "e2e-run-xyz789-" + shortStableHash("e2e") + "-1"
+	if got != wantPrefix {
+		t.Fatalf("uniqueName() = %q, want %q", got, wantPrefix)
+	}
+}

--- a/test/e2e/suite/setup_helpers_test.go
+++ b/test/e2e/suite/setup_helpers_test.go
@@ -1,3 +1,5 @@
+// setup_helpers_test.go verifies E2E name generation helpers without requiring
+// a live GitLab instance.
 package suite
 
 import (
@@ -7,6 +9,8 @@ import (
 	"time"
 )
 
+// TestShortStableHash_ReturnsStableLowercaseHex verifies that shortStableHash
+// is deterministic, uses the configured hash length, and emits lowercase hex.
 func TestShortStableHash_ReturnsStableLowercaseHex(t *testing.T) {
 	first := shortStableHash("TestIndividual_Branches/Create")
 	second := shortStableHash("TestIndividual_Branches/Create")
@@ -22,6 +26,8 @@ func TestShortStableHash_ReturnsStableLowercaseHex(t *testing.T) {
 	}
 }
 
+// TestSanitizeTestName_ConvertsGoTestNameToSlug verifies that Go test names are
+// converted into GitLab-safe slug segments.
 func TestSanitizeTestName_ConvertsGoTestNameToSlug(t *testing.T) {
 	got := sanitizeTestName("TestIndividual_Branches/Create With Spaces!")
 	want := "testindividual-branches-createwithspaces"
@@ -30,6 +36,8 @@ func TestSanitizeTestName_ConvertsGoTestNameToSlug(t *testing.T) {
 	}
 }
 
+// TestSanitizeTestName_TruncatesToFortyCharacters verifies that sanitized test
+// name segments are capped at 40 characters for compact resource names.
 func TestSanitizeTestName_TruncatesToFortyCharacters(t *testing.T) {
 	got := sanitizeTestName(strings.Repeat("a", 80))
 	if len(got) != 40 {
@@ -37,6 +45,8 @@ func TestSanitizeTestName_TruncatesToFortyCharacters(t *testing.T) {
 	}
 }
 
+// TestNewE2ERunID_UsesUTCStampAndHashSuffix verifies that newE2ERunID encodes
+// the UTC timestamp and a stable lowercase hash suffix.
 func TestNewE2ERunID_UsesUTCStampAndHashSuffix(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 34, 56, 789, time.FixedZone("UTC+2", 2*60*60))
 	got := newE2ERunID(now)
@@ -46,6 +56,8 @@ func TestNewE2ERunID_UsesUTCStampAndHashSuffix(t *testing.T) {
 	}
 }
 
+// TestConfiguredE2ERunID_UsesEnvironmentOverride verifies that E2E_RUN_ID is
+// sanitized and used instead of generating a timestamped run ID.
 func TestConfiguredE2ERunID_UsesEnvironmentOverride(t *testing.T) {
 	t.Setenv("E2E_RUN_ID", "Custom_Run/ID!")
 	got := configuredE2ERunID(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC))
@@ -55,6 +67,8 @@ func TestConfiguredE2ERunID_UsesEnvironmentOverride(t *testing.T) {
 	}
 }
 
+// TestUniqueName_IncludesRunIDHashAndCounter verifies that uniqueName combines
+// the sanitized prefix, run ID, prefix hash, and monotonically increasing count.
 func TestUniqueName_IncludesRunIDHashAndCounter(t *testing.T) {
 	originalRunID := e2eRunID
 	originalCounter := uniqueCounter.Load()
@@ -72,6 +86,8 @@ func TestUniqueName_IncludesRunIDHashAndCounter(t *testing.T) {
 	}
 }
 
+// TestUniqueName_UsesDefaultPrefixForEmptyInput verifies that uniqueName falls
+// back to the e2e prefix when the supplied prefix sanitizes to an empty string.
 func TestUniqueName_UsesDefaultPrefixForEmptyInput(t *testing.T) {
 	originalRunID := e2eRunID
 	originalCounter := uniqueCounter.Load()

--- a/test/e2e/suite/setup_helpers_test.go
+++ b/test/e2e/suite/setup_helpers_test.go
@@ -41,8 +41,8 @@ func TestNewE2ERunID_UsesUTCStampAndHashSuffix(t *testing.T) {
 	now := time.Date(2026, 4, 30, 12, 34, 56, 789, time.FixedZone("UTC+2", 2*60*60))
 	got := newE2ERunID(now)
 
-	if !regexp.MustCompile(`^20260430T103456Z-[a-f0-9]{10}$`).MatchString(got) {
-		t.Fatalf("newE2ERunID() = %q, want UTC timestamp plus 10-char hex suffix", got)
+	if !regexp.MustCompile(`^20260430t103456z-[a-f0-9]{10}$`).MatchString(got) {
+		t.Fatalf("newE2ERunID() = %q, want lowercase UTC timestamp plus 10-char hex suffix", got)
 	}
 }
 

--- a/test/e2e/suite/setup_test.go
+++ b/test/e2e/suite/setup_test.go
@@ -319,9 +319,6 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
-	// Cleanup: delete any orphaned test projects (prefix-based).
-	cleanupOrphanedProjects(glClient)
-
 	// Verify snapshot integrity in self-hosted mode.
 	if !isDockerMode() && sess.snapshot != nil {
 		if intErr := verifySnapshotIntegrity(glClient, sess.snapshot); intErr != nil {
@@ -333,6 +330,9 @@ func TestMain(m *testing.M) {
 			log.Println("e2e: snapshot integrity verified — all pre-existing resources unchanged")
 		}
 	}
+
+	// Cleanup: delete any orphaned test projects (prefix-based).
+	cleanupOrphanedProjects(glClient)
 
 	_ = session.Close()
 	serverCancel()
@@ -682,36 +682,16 @@ func snapshotState(client *gitlabclient.Client) (*resourceSnapshot, error) {
 	return snap, nil
 }
 
-// verifySnapshotIntegrity re-fetches all groups and projects and compares
-// them against the initial snapshot. Returns an error if any pre-existing
-// resource was deleted or renamed.
+// verifySnapshotIntegrity re-snapshots groups and projects and compares them
+// against the initial snapshot. Returns an error if any pre-existing resource
+// was deleted or renamed.
 func verifySnapshotIntegrity(client *gitlabclient.Client, snap *resourceSnapshot) error {
-	var missing []string
-
-	// Check groups still exist with same path.
-	for id, origPath := range snap.groups {
-		g, _, err := client.GL().Groups.GetGroup(int(id), &gl.GetGroupOptions{})
-		if err != nil {
-			missing = append(missing, fmt.Sprintf("group %q (ID=%d): %v", origPath, id, err))
-			continue
-		}
-		if g.FullPath != origPath {
-			missing = append(missing, fmt.Sprintf("group ID=%d renamed: %q → %q", id, origPath, g.FullPath))
-		}
+	current, err := snapshotState(client)
+	if err != nil {
+		return fmt.Errorf("snapshot current state: %w", err)
 	}
 
-	// Check projects still exist with same path.
-	for id, origPath := range snap.projects {
-		p, _, err := client.GL().Projects.GetProject(int(id), &gl.GetProjectOptions{})
-		if err != nil {
-			missing = append(missing, fmt.Sprintf("project %q (ID=%d): %v", origPath, id, err))
-			continue
-		}
-		if p.PathWithNamespace != origPath {
-			missing = append(missing, fmt.Sprintf("project ID=%d renamed: %q → %q", id, origPath, p.PathWithNamespace))
-		}
-	}
-
+	missing := snapshotIntegrityDifferences(snap, current)
 	if len(missing) > 0 {
 		return fmt.Errorf("%d pre-existing resources were modified or deleted:\n  %s",
 			len(missing), strings.Join(missing, "\n  "))
@@ -719,21 +699,62 @@ func verifySnapshotIntegrity(client *gitlabclient.Client, snap *resourceSnapshot
 	return nil
 }
 
+func snapshotIntegrityDifferences(original, current *resourceSnapshot) []string {
+	var missing []string
+
+	// Check groups still exist with same path.
+	for id, origPath := range original.groups {
+		currentPath, ok := current.groups[id]
+		if !ok {
+			missing = append(missing, fmt.Sprintf("group %q (ID=%d): missing", origPath, id))
+			continue
+		}
+		if currentPath != origPath {
+			missing = append(missing, fmt.Sprintf("group ID=%d renamed: %q → %q", id, origPath, currentPath))
+		}
+	}
+
+	// Check projects still exist with same path.
+	for id, origPath := range original.projects {
+		currentPath, ok := current.projects[id]
+		if !ok {
+			missing = append(missing, fmt.Sprintf("project %q (ID=%d): missing", origPath, id))
+			continue
+		}
+		if currentPath != origPath {
+			missing = append(missing, fmt.Sprintf("project ID=%d renamed: %q → %q", id, origPath, currentPath))
+		}
+	}
+	return missing
+}
+
 // cleanupOrphanedProjects permanently deletes any projects whose name starts
 // with the E2E prefix. This catches orphans from previous failed runs,
 // including projects already marked for delayed deletion.
 func cleanupOrphanedProjects(client *gitlabclient.Client) {
 	log.Printf("e2e: cleanup: scanning orphaned projects with prefix %q for run ID %q", e2eProjectPrefix, e2eRunID)
-	opts := &gl.ListProjectsOptions{
-		Owned:                new(true),
-		IncludePendingDelete: new(true),
+	var projects []*gl.Project
+	var page int64 = 1
+	for {
+		opts := &gl.ListProjectsOptions{
+			Owned:                new(true),
+			IncludePendingDelete: new(true),
+		}
+		opts.Page = page
+		opts.PerPage = 100
+
+		pageProjects, resp, err := client.GL().Projects.ListProjects(opts)
+		if err != nil {
+			log.Printf("e2e: cleanup: failed to list projects page %d: %v", page, err)
+			return
+		}
+		projects = append(projects, pageProjects...)
+		if resp.NextPage == 0 {
+			break
+		}
+		page = resp.NextPage
 	}
-	opts.PerPage = 100
-	projects, _, err := client.GL().Projects.ListProjects(opts)
-	if err != nil {
-		log.Printf("e2e: cleanup: failed to list projects: %v", err)
-		return
-	}
+
 	for _, p := range projects {
 		if strings.HasPrefix(p.Name, e2eProjectPrefix) {
 			permanentlyDeleteProject(client, p)

--- a/test/e2e/suite/setup_test.go
+++ b/test/e2e/suite/setup_test.go
@@ -699,6 +699,8 @@ func verifySnapshotIntegrity(client *gitlabclient.Client, snap *resourceSnapshot
 	return nil
 }
 
+// snapshotIntegrityDifferences returns descriptions of pre-existing groups or
+// projects that disappeared or changed path during the E2E run.
 func snapshotIntegrityDifferences(original, current *resourceSnapshot) []string {
 	var missing []string
 
@@ -875,6 +877,8 @@ func waitForPipeline(t *testing.T, client *gitlabclient.Client, projectID int64,
 	return lastStatus
 }
 
+// isTerminalPipelineStatus reports whether status is a GitLab pipeline state
+// that will not transition further.
 func isTerminalPipelineStatus(status string) bool {
 	switch status {
 	case "success", "failed", "canceled", "skipped":

--- a/test/e2e/suite/setup_test.go
+++ b/test/e2e/suite/setup_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -100,6 +99,8 @@ func TestMain(m *testing.M) {
 	if p := os.Getenv("E2E_PROJECT_PREFIX"); p != "" {
 		e2eProjectPrefix = p
 	}
+	e2eRunID = configuredE2ERunID(time.Now())
+	log.Printf("e2e: run ID %s", e2eRunID)
 
 	// Load .env — Docker mode uses a different file.
 	if isDockerMode() {
@@ -344,14 +345,6 @@ func TestMain(m *testing.M) {
 	_ = safeModeSession.Close()
 	safeModeServerCancel()
 	os.Exit(code)
-}
-
-// uniqueCounter provides a monotonic counter for guaranteed unique project names.
-var uniqueCounter atomic.Int64
-
-// uniqueName generates a timestamped name with an atomic counter to avoid collisions.
-func uniqueName(prefix string) string {
-	return fmt.Sprintf("%s-%d-%d", prefix, time.Now().UnixMilli(), uniqueCounter.Add(1))
 }
 
 // mockCreateMessageHandler returns a deterministic mock LLM response for
@@ -730,6 +723,7 @@ func verifySnapshotIntegrity(client *gitlabclient.Client, snap *resourceSnapshot
 // with the E2E prefix. This catches orphans from previous failed runs,
 // including projects already marked for delayed deletion.
 func cleanupOrphanedProjects(client *gitlabclient.Client) {
+	log.Printf("e2e: cleanup: scanning orphaned projects with prefix %q for run ID %q", e2eProjectPrefix, e2eRunID)
 	opts := &gl.ListProjectsOptions{
 		Owned:                new(true),
 		IncludePendingDelete: new(true),

--- a/test/e2e/suite/setup_test.go
+++ b/test/e2e/suite/setup_test.go
@@ -832,42 +832,56 @@ func drainSidekiq(ctx context.Context, t *testing.T, client *gitlabclient.Client
 //   - Polls every 5 s.
 //   - Tolerates transient API errors (logs and retries up to 10 consecutive
 //     errors before giving up).
-//   - Logs the final status before failing so test output makes the runner
-//     state easy to diagnose.
+//   - Reports the final observed status in timeout errors so runner state is
+//     easy to diagnose.
 func waitForPipeline(t *testing.T, client *gitlabclient.Client, projectID int64, pipelineID int64, timeout time.Duration) string {
 	t.Helper()
+	if client == nil {
+		t.Fatal("waitForPipeline: GitLab client not configured")
+	}
 	drainSidekiq(context.Background(), t, client)
 	if timeout == 0 {
 		timeout = 900 * time.Second
 	}
 	const pollInterval = 5 * time.Second
 	const maxConsecutiveErrors = 10
-	deadline := time.Now().Add(timeout)
+	pollCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	lastStatus := "unknown"
 	consecutiveErrors := 0
-	for time.Now().Before(deadline) {
-		p, _, err := client.GL().Pipelines.GetPipeline(projectID, pipelineID)
+	err := Poll(pollCtx, pollInterval, timeout, func() (bool, string, error) {
+		p, _, err := client.GL().Pipelines.GetPipeline(projectID, pipelineID, gl.WithContext(pollCtx))
 		if err != nil {
 			consecutiveErrors++
-			t.Logf("waitForPipeline: error polling pipeline %d (%d/%d): %v", pipelineID, consecutiveErrors, maxConsecutiveErrors, err)
+			state := fmt.Sprintf("pipeline %d in project %d: last_status=%s consecutive_errors=%d/%d error=%v", pipelineID, projectID, lastStatus, consecutiveErrors, maxConsecutiveErrors, err)
 			if consecutiveErrors >= maxConsecutiveErrors {
-				t.Fatalf("waitForPipeline: pipeline %d aborted after %d consecutive API errors: %v", pipelineID, consecutiveErrors, err)
+				return false, state, fmt.Errorf("poll pipeline %d in project %d after %d consecutive API errors: %w", pipelineID, projectID, consecutiveErrors, err)
 			}
-			time.Sleep(pollInterval)
-			continue
+			return false, state, nil
 		}
 		consecutiveErrors = 0
 		lastStatus = p.Status
-		switch p.Status {
-		case "success", "failed", "canceled", "skipped":
-			t.Logf("waitForPipeline: pipeline %d reached terminal status: %s", pipelineID, p.Status)
-			return p.Status
+		state := fmt.Sprintf("pipeline %d in project %d: status=%s", pipelineID, projectID, p.Status)
+		if isTerminalPipelineStatus(p.Status) {
+			return true, state, nil
 		}
-		t.Logf("waitForPipeline: pipeline %d status=%s, waiting...", pipelineID, p.Status)
-		time.Sleep(pollInterval)
+		return false, state, nil
+	})
+	if err != nil {
+		t.Fatalf("waitForPipeline: pipeline %d in project %d did not reach terminal status within %s (last status: %s): %v", pipelineID, projectID, timeout, lastStatus, err)
 	}
-	t.Fatalf("waitForPipeline: pipeline %d did not reach terminal status within %s (last status: %s)", pipelineID, timeout, lastStatus)
-	return ""
+	t.Logf("waitForPipeline: pipeline %d reached terminal status: %s", pipelineID, lastStatus)
+	return lastStatus
+}
+
+func isTerminalPipelineStatus(status string) bool {
+	switch status {
+	case "success", "failed", "canceled", "skipped":
+		return true
+	default:
+		return false
+	}
 }
 
 // hasRunner returns true if a CI runner is available for pipeline tests.

--- a/test/e2e/suite/setup_test.go
+++ b/test/e2e/suite/setup_test.go
@@ -778,9 +778,9 @@ func permanentlyDeleteProject(client *gitlabclient.Client, p *gl.Project) {
 // queues are idle (enqueued == 0). Accelerates E2E tests by allowing async
 // operations (MR merge checks, pipeline creation, commit indexing) to complete
 // before assertions. No-op if the API is unavailable or context is done.
-func drainSidekiq(ctx context.Context, t *testing.T) {
+func drainSidekiq(ctx context.Context, t *testing.T, client *gitlabclient.Client) {
 	t.Helper()
-	if sess.glClient == nil {
+	if client == nil {
 		return
 	}
 	const maxWait = 15 * time.Second
@@ -788,7 +788,7 @@ func drainSidekiq(ctx context.Context, t *testing.T) {
 
 	deadline := time.Now().Add(maxWait)
 	for time.Now().Before(deadline) {
-		stats, _, err := sess.glClient.GL().Sidekiq.GetJobStats()
+		stats, _, err := client.GL().Sidekiq.GetJobStats()
 		if err != nil {
 			return
 		}
@@ -813,9 +813,9 @@ func drainSidekiq(ctx context.Context, t *testing.T) {
 //     errors before giving up).
 //   - Logs the final status before failing so test output makes the runner
 //     state easy to diagnose.
-func waitForPipeline(t *testing.T, projectID int64, pipelineID int64, timeout time.Duration) string {
+func waitForPipeline(t *testing.T, client *gitlabclient.Client, projectID int64, pipelineID int64, timeout time.Duration) string {
 	t.Helper()
-	drainSidekiq(context.Background(), t)
+	drainSidekiq(context.Background(), t, client)
 	if timeout == 0 {
 		timeout = 900 * time.Second
 	}
@@ -825,7 +825,7 @@ func waitForPipeline(t *testing.T, projectID int64, pipelineID int64, timeout ti
 	lastStatus := "unknown"
 	consecutiveErrors := 0
 	for time.Now().Before(deadline) {
-		p, _, err := sess.glClient.GL().Pipelines.GetPipeline(projectID, pipelineID)
+		p, _, err := client.GL().Pipelines.GetPipeline(projectID, pipelineID)
 		if err != nil {
 			consecutiveErrors++
 			t.Logf("waitForPipeline: error polling pipeline %d (%d/%d): %v", pipelineID, consecutiveErrors, maxConsecutiveErrors, err)
@@ -852,12 +852,15 @@ func waitForPipeline(t *testing.T, projectID int64, pipelineID int64, timeout ti
 // hasRunner returns true if a CI runner is available for pipeline tests.
 // In Docker mode it always returns true; in self-hosted mode it checks the
 // Runners API for registered instance runners.
-func hasRunner() bool {
+func hasRunner(client *gitlabclient.Client) bool {
 	if isDockerMode() {
 		return true
 	}
+	if client == nil {
+		return false
+	}
 	runnerType := "instance_type"
-	runners, _, err := sess.glClient.GL().Runners.ListRunners(&gl.ListRunnersOptions{
+	runners, _, err := client.GL().Runners.ListRunners(&gl.ListRunnersOptions{
 		Type: &runnerType,
 	})
 	return err == nil && len(runners) > 0

--- a/test/e2e/suite/todos_test.go
+++ b/test/e2e/suite/todos_test.go
@@ -21,7 +21,6 @@ func TestIndividual_Todos(t *testing.T) {
 		t.Skip("individual session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -47,7 +46,6 @@ func TestMeta_Todos(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 

--- a/test/e2e/suite/todos_test.go
+++ b/test/e2e/suite/todos_test.go
@@ -20,20 +20,22 @@ func TestIndividual_Todos(t *testing.T) {
 	if sess.individual == nil {
 		t.Skip("individual session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("List", func(t *testing.T) {
-		out, err := callToolOn[todos.ListOutput](ctx, sess.individual, "gitlab_todo_list", todos.ListInput{})
-		requireNoError(t, err, "list todos")
-		t.Logf("Listed %d todos", len(out.Todos))
-	})
+		t.Run("List", func(t *testing.T) {
+			out, err := callToolOn[todos.ListOutput](ctx, sess.individual, "gitlab_todo_list", todos.ListInput{})
+			requireNoError(t, err, "list todos")
+			t.Logf("Listed %d todos", len(out.Todos))
+		})
 
-	t.Run("MarkAllDone", func(t *testing.T) {
-		out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.individual, "gitlab_todo_mark_all_done", todos.MarkAllDoneInput{})
-		requireNoError(t, err, "mark all todos done")
-		t.Logf("Marked all done: %s", out.Message)
+		t.Run("MarkAllDone", func(t *testing.T) {
+			out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.individual, "gitlab_todo_mark_all_done", todos.MarkAllDoneInput{})
+			requireNoError(t, err, "mark all todos done")
+			t.Logf("Marked all done: %s", out.Message)
+		})
 	})
 }
 
@@ -44,25 +46,27 @@ func TestMeta_Todos(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("List", func(t *testing.T) {
-		out, err := callToolOn[todos.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "todo_list",
-			"params": map[string]any{},
+		t.Run("List", func(t *testing.T) {
+			out, err := callToolOn[todos.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "todo_list",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "meta list todos")
+			t.Logf("Listed %d todos via meta-tool", len(out.Todos))
 		})
-		requireNoError(t, err, "meta list todos")
-		t.Logf("Listed %d todos via meta-tool", len(out.Todos))
-	})
 
-	t.Run("MarkAllDone", func(t *testing.T) {
-		out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "todo_mark_all_done",
-			"params": map[string]any{},
+		t.Run("MarkAllDone", func(t *testing.T) {
+			out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "todo_mark_all_done",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "meta mark all done")
+			t.Logf("Marked all done via meta-tool: %s", out.Message)
 		})
-		requireNoError(t, err, "meta mark all done")
-		t.Logf("Marked all done via meta-tool: %s", out.Message)
 	})
 }

--- a/test/e2e/suite/user_state_test.go
+++ b/test/e2e/suite/user_state_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// user_state_test.go snapshots and restores current-user state mutated by E2E
+// tests so notification and status changes do not leak across test cases.
 package suite
 
 import (
@@ -74,6 +76,8 @@ func RestoreCurrentUserState(ctx context.Context, e2e *E2EContext, snapshot Curr
 	return errors.Join(failures...)
 }
 
+// restoreCurrentUserStatus restores the GitLab current-user status using the
+// raw GitLab client because the status update operation is user-scoped state.
 func restoreCurrentUserStatus(ctx context.Context, e2e *E2EContext, status users.StatusOutput) error {
 	if e2e.GitLab == nil {
 		return nil
@@ -93,6 +97,8 @@ func restoreCurrentUserStatus(ctx context.Context, e2e *E2EContext, status users
 	return nil
 }
 
+// restoreGlobalNotification restores the user's global notification level when
+// the snapshot contained one.
 func restoreGlobalNotification(ctx context.Context, e2e *E2EContext, notification notifications.Output) error {
 	if notification.Level == "" {
 		return nil

--- a/test/e2e/suite/user_state_test.go
+++ b/test/e2e/suite/user_state_test.go
@@ -49,7 +49,7 @@ func RegisterCurrentUserStateRestore(ctx context.Context, e2e *E2EContext) Curre
 	snapshot, err := SnapshotCurrentUserState(ctx, e2e)
 	requireNoError(e2e.T, err, "snapshot current-user state")
 
-	e2e.Ledger.Register(ResourceRecord{
+	requireNoError(e2e.T, e2e.Ledger.Register(ResourceRecord{
 		Kind:      ResourceKindCurrentUserState,
 		ID:        "current-user",
 		Name:      "current-user-state",
@@ -59,7 +59,7 @@ func RegisterCurrentUserStateRestore(ctx context.Context, e2e *E2EContext) Curre
 		Cleanup: func(cleanupCtx context.Context) error {
 			return RestoreCurrentUserState(cleanupCtx, e2e, snapshot)
 		},
-	})
+	}), "register current-user state restore")
 
 	return snapshot
 }

--- a/test/e2e/suite/user_state_test.go
+++ b/test/e2e/suite/user_state_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+package suite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/tools/notifications"
+	"github.com/jmrplens/gitlab-mcp-server/internal/tools/users"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// CurrentUserStateSnapshot captures mutable current-user settings touched by E2E tests.
+type CurrentUserStateSnapshot struct {
+	Status             users.StatusOutput
+	GlobalNotification notifications.Output
+}
+
+// SnapshotCurrentUserState captures current-user state that selected E2E tests mutate.
+func SnapshotCurrentUserState(ctx context.Context, e2e *E2EContext) (CurrentUserStateSnapshot, error) {
+	status, err := callToolOn[users.StatusOutput](ctx, e2e.Meta(), "gitlab_user", map[string]any{
+		"action": "current_user_status",
+		"params": map[string]any{},
+	})
+	if err != nil {
+		return CurrentUserStateSnapshot{}, fmt.Errorf("snapshot current-user status: %w", err)
+	}
+
+	globalNotification, err := callToolOn[notifications.Output](ctx, e2e.Meta(), "gitlab_user", map[string]any{
+		"action": "notification_global_get",
+		"params": map[string]any{},
+	})
+	if err != nil {
+		return CurrentUserStateSnapshot{}, fmt.Errorf("snapshot global notification: %w", err)
+	}
+
+	return CurrentUserStateSnapshot{Status: status, GlobalNotification: globalNotification}, nil
+}
+
+// RegisterCurrentUserStateRestore snapshots current-user state and restores it during cleanup.
+func RegisterCurrentUserStateRestore(ctx context.Context, e2e *E2EContext) CurrentUserStateSnapshot {
+	e2e.T.Helper()
+	snapshot, err := SnapshotCurrentUserState(ctx, e2e)
+	requireNoError(e2e.T, err, "snapshot current-user state")
+
+	e2e.Ledger.Register(ResourceRecord{
+		Kind:      ResourceKindCurrentUserState,
+		ID:        "current-user",
+		Name:      "current-user-state",
+		OwnerTest: e2e.Name,
+		RunID:     e2e.RunID,
+		CreatedAt: time.Now(),
+		Cleanup: func(cleanupCtx context.Context) error {
+			return RestoreCurrentUserState(cleanupCtx, e2e, snapshot)
+		},
+	})
+
+	return snapshot
+}
+
+// RestoreCurrentUserState best-effort restores mutable current-user settings.
+func RestoreCurrentUserState(ctx context.Context, e2e *E2EContext, snapshot CurrentUserStateSnapshot) error {
+	var failures []error
+	if err := restoreCurrentUserStatus(ctx, e2e, snapshot.Status); err != nil {
+		failures = append(failures, err)
+	}
+	if err := restoreGlobalNotification(ctx, e2e, snapshot.GlobalNotification); err != nil {
+		failures = append(failures, err)
+	}
+	return errors.Join(failures...)
+}
+
+func restoreCurrentUserStatus(ctx context.Context, e2e *E2EContext, status users.StatusOutput) error {
+	if e2e.GitLab == nil {
+		return nil
+	}
+	opts := &gl.UserStatusOptions{
+		Emoji:   &status.Emoji,
+		Message: &status.Message,
+	}
+	if status.Availability != "" {
+		availability := gl.AvailabilityValue(status.Availability)
+		opts.Availability = &availability
+	}
+	_, _, err := e2e.GitLab.GL().Users.SetUserStatus(opts, gl.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("restore current-user status: %w", err)
+	}
+	return nil
+}
+
+func restoreGlobalNotification(ctx context.Context, e2e *E2EContext, notification notifications.Output) error {
+	if notification.Level == "" {
+		return nil
+	}
+	_, err := callToolOn[notifications.Output](ctx, e2e.Meta(), "gitlab_user", map[string]any{
+		"action": "notification_global_update",
+		"params": map[string]any{"level": notification.Level},
+	})
+	if err != nil {
+		return fmt.Errorf("restore global notification: %w", err)
+	}
+	return nil
+}

--- a/test/e2e/suite/user_state_test.go
+++ b/test/e2e/suite/user_state_test.go
@@ -80,7 +80,7 @@ func RestoreCurrentUserState(ctx context.Context, e2e *E2EContext, snapshot Curr
 // raw GitLab client because the status update operation is user-scoped state.
 func restoreCurrentUserStatus(ctx context.Context, e2e *E2EContext, status users.StatusOutput) error {
 	if e2e.GitLab == nil {
-		return nil
+		return fmt.Errorf("restore current-user status: gitlab client not configured; set GITLAB_URL and GITLAB_TOKEN for E2E setup")
 	}
 	opts := &gl.UserStatusOptions{
 		Emoji:   &status.Emoji,

--- a/test/e2e/suite/users_meta_test.go
+++ b/test/e2e/suite/users_meta_test.go
@@ -32,113 +32,115 @@ func TestMeta_UserSelf(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	var currentUserID int64
+		var currentUserID int64
 
-	t.Run("Me", func(t *testing.T) {
-		out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "me",
-			"params": map[string]any{},
+		t.Run("Me", func(t *testing.T) {
+			out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "me",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "user me")
+			requireTruef(t, out.ID > 0, "user me: expected user ID > 0")
+			currentUserID = out.ID
+			t.Logf("Me → user %d (%s)", out.ID, out.Username)
 		})
-		requireNoError(t, err, "user me")
-		requireTruef(t, out.ID > 0, "user me: expected user ID > 0")
-		currentUserID = out.ID
-		t.Logf("Me → user %d (%s)", out.ID, out.Username)
-	})
 
-	t.Run("CurrentUserStatus", func(t *testing.T) {
-		out, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "current_user_status",
-			"params": map[string]any{},
+		t.Run("CurrentUserStatus", func(t *testing.T) {
+			out, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "current_user_status",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "current_user_status")
+			t.Logf("Current status: emoji=%s message=%s", out.Emoji, out.Message)
 		})
-		requireNoError(t, err, "current_user_status")
-		t.Logf("Current status: emoji=%s message=%s", out.Emoji, out.Message)
-	})
 
-	t.Run("SetAndGetStatus", func(t *testing.T) {
-		out, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "set_status",
-			"params": map[string]any{
-				"emoji":   "coffee",
-				"message": "e2e-testing",
-			},
-		})
-		requireNoError(t, err, "set_status")
-		t.Logf("Set status: emoji=%s message=%s", out.Emoji, out.Message)
+		t.Run("SetAndGetStatus", func(t *testing.T) {
+			out, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "set_status",
+				"params": map[string]any{
+					"emoji":   "coffee",
+					"message": "e2e-testing",
+				},
+			})
+			requireNoError(t, err, "set_status")
+			t.Logf("Set status: emoji=%s message=%s", out.Emoji, out.Message)
 
-		// Get status back
-		requireTruef(t, currentUserID > 0, "need currentUserID")
-		got, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "get_status",
-			"params": map[string]any{"user_id": currentUserID},
-		})
-		requireNoError(t, err, "get_status")
-		t.Logf("Got status: emoji=%s message=%s", got.Emoji, got.Message)
+			// Get status back
+			requireTruef(t, currentUserID > 0, "need currentUserID")
+			got, err := callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "get_status",
+				"params": map[string]any{"user_id": currentUserID},
+			})
+			requireNoError(t, err, "get_status")
+			t.Logf("Got status: emoji=%s message=%s", got.Emoji, got.Message)
 
-		// Clear status
-		_, _ = callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "set_status",
-			"params": map[string]any{"emoji": "", "message": ""},
+			// Clear status
+			_, _ = callToolOn[users.StatusOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "set_status",
+				"params": map[string]any{"emoji": "", "message": ""},
+			})
 		})
-	})
 
-	t.Run("Emails", func(t *testing.T) {
-		out, err := callToolOn[users.EmailListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "emails",
-			"params": map[string]any{},
+		t.Run("Emails", func(t *testing.T) {
+			out, err := callToolOn[users.EmailListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "emails",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "emails")
+			t.Logf("Emails: %d found", len(out.Emails))
 		})
-		requireNoError(t, err, "emails")
-		t.Logf("Emails: %d found", len(out.Emails))
-	})
 
-	t.Run("ContributionEvents", func(t *testing.T) {
-		requireTruef(t, currentUserID > 0, "need currentUserID")
-		out, err := callToolOn[users.ContributionEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "contribution_events",
-			"params": map[string]any{"user_id": currentUserID},
+		t.Run("ContributionEvents", func(t *testing.T) {
+			requireTruef(t, currentUserID > 0, "need currentUserID")
+			out, err := callToolOn[users.ContributionEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "contribution_events",
+				"params": map[string]any{"user_id": currentUserID},
+			})
+			requireNoError(t, err, "contribution_events")
+			t.Logf("Contribution events: %d", len(out.Events))
 		})
-		requireNoError(t, err, "contribution_events")
-		t.Logf("Contribution events: %d", len(out.Events))
-	})
 
-	t.Run("AssociationsCount", func(t *testing.T) {
-		requireTruef(t, currentUserID > 0, "need currentUserID")
-		_, err := callToolOn[users.AssociationsCountOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "associations_count",
-			"params": map[string]any{"user_id": currentUserID},
+		t.Run("AssociationsCount", func(t *testing.T) {
+			requireTruef(t, currentUserID > 0, "need currentUserID")
+			_, err := callToolOn[users.AssociationsCountOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "associations_count",
+				"params": map[string]any{"user_id": currentUserID},
+			})
+			requireNoError(t, err, "associations_count")
 		})
-		requireNoError(t, err, "associations_count")
-	})
 
-	t.Run("Memberships", func(t *testing.T) {
-		requireTruef(t, currentUserID > 0, "need currentUserID")
-		out, err := callToolOn[users.UserMembershipsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "memberships",
-			"params": map[string]any{"user_id": currentUserID},
+		t.Run("Memberships", func(t *testing.T) {
+			requireTruef(t, currentUserID > 0, "need currentUserID")
+			out, err := callToolOn[users.UserMembershipsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "memberships",
+				"params": map[string]any{"user_id": currentUserID},
+			})
+			requireNoError(t, err, "memberships")
+			t.Logf("Memberships: %d", len(out.Memberships))
 		})
-		requireNoError(t, err, "memberships")
-		t.Logf("Memberships: %d", len(out.Memberships))
-	})
 
-	t.Run("Activities", func(t *testing.T) {
-		out, err := callToolOn[users.UserActivitiesOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "activities",
-			"params": map[string]any{},
+		t.Run("Activities", func(t *testing.T) {
+			out, err := callToolOn[users.UserActivitiesOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "activities",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "activities")
+			t.Logf("Activities: %d", len(out.Activities))
 		})
-		requireNoError(t, err, "activities")
-		t.Logf("Activities: %d", len(out.Activities))
-	})
 
-	t.Run("AvatarGet", func(t *testing.T) {
-		out, err := callToolOn[avatar.GetOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "avatar_get",
-			"params": map[string]any{"email": "test@example.com"},
+		t.Run("AvatarGet", func(t *testing.T) {
+			out, err := callToolOn[avatar.GetOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "avatar_get",
+				"params": map[string]any{"email": "test@example.com"},
+			})
+			requireNoError(t, err, "avatar_get")
+			t.Logf("Avatar URL: %s", out.AvatarURL)
 		})
-		requireNoError(t, err, "avatar_get")
-		t.Logf("Avatar URL: %s", out.AvatarURL)
 	})
 }
 
@@ -149,45 +151,47 @@ func TestMeta_UserTodosEvents(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("TodoList", func(t *testing.T) {
-		out, err := callToolOn[todos.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "todo_list",
-			"params": map[string]any{},
+		t.Run("TodoList", func(t *testing.T) {
+			out, err := callToolOn[todos.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "todo_list",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "todo_list")
+			t.Logf("Todos: %d", len(out.Todos))
 		})
-		requireNoError(t, err, "todo_list")
-		t.Logf("Todos: %d", len(out.Todos))
-	})
 
-	t.Run("TodoMarkAllDone", func(t *testing.T) {
-		out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "todo_mark_all_done",
-			"params": map[string]any{},
+		t.Run("TodoMarkAllDone", func(t *testing.T) {
+			out, err := callToolOn[todos.MarkAllDoneOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "todo_mark_all_done",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "todo_mark_all_done")
+			t.Logf("Mark all done: %s", out.Message)
 		})
-		requireNoError(t, err, "todo_mark_all_done")
-		t.Logf("Mark all done: %s", out.Message)
-	})
 
-	t.Run("EventListContributions", func(t *testing.T) {
-		out, err := callToolOn[events.ListContributionEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "event_list_contributions",
-			"params": map[string]any{},
+		t.Run("EventListContributions", func(t *testing.T) {
+			out, err := callToolOn[events.ListContributionEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "event_list_contributions",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "event_list_contributions")
+			t.Logf("Contribution events: %d", len(out.Events))
 		})
-		requireNoError(t, err, "event_list_contributions")
-		t.Logf("Contribution events: %d", len(out.Events))
-	})
 
-	t.Run("EventListProject", func(t *testing.T) {
-		proj := createProjectMeta(ctx, t, sess.meta)
-		out, err := callToolOn[events.ListProjectEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "event_list_project",
-			"params": map[string]any{"project_id": proj.pidStr()},
+		t.Run("EventListProject", func(t *testing.T) {
+			proj := createProjectMeta(ctx, t, sess.meta)
+			out, err := callToolOn[events.ListProjectEventsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "event_list_project",
+				"params": map[string]any{"project_id": proj.pidStr()},
+			})
+			requireNoError(t, err, "event_list_project")
+			t.Logf("Project events: %d", len(out.Events))
 		})
-		requireNoError(t, err, "event_list_project")
-		t.Logf("Project events: %d", len(out.Events))
 	})
 }
 
@@ -197,151 +201,153 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	t.Run("NamespaceList", func(t *testing.T) {
-		out, err := callToolOn[namespaces.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "namespace_list",
-			"params": map[string]any{},
-		})
-		requireNoError(t, err, "namespace_list")
-		requireTruef(t, len(out.Namespaces) > 0, "expected at least 1 namespace")
-		t.Logf("Namespaces: %d", len(out.Namespaces))
-	})
-
-	t.Run("NamespaceSearch", func(t *testing.T) {
-		username := sess.username
-		out, err := callToolOn[namespaces.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "namespace_search",
-			"params": map[string]any{"query": username},
-		})
-		requireNoError(t, err, "namespace_search")
-		t.Logf("Namespace search '%s': %d results", username, len(out.Namespaces))
-	})
-
-	t.Run("NamespaceExists", func(t *testing.T) {
-		username := sess.username
-		out, err := callToolOn[namespaces.ExistsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "namespace_exists",
-			"params": map[string]any{"id": username},
-		})
-		requireNoError(t, err, "namespace_exists")
-		t.Logf("Namespace exists: %v", out.Exists)
-	})
-
-	t.Run("NamespaceGet", func(t *testing.T) {
-		// First get current user to find their namespace
-		usr, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "current",
-			"params": map[string]any{},
-		})
-		requireNoError(t, err, "get current user")
-		out, err := callToolOn[namespaces.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "namespace_get",
-			"params": map[string]any{"id": strconv.FormatInt(usr.ID, 10)},
-		})
-		requireNoError(t, err, "namespace_get")
-		requireTruef(t, out.ID > 0, "namespace_get: expected ID > 0")
-		t.Logf("Namespace %d: %s", out.ID, out.Name)
-	})
-
-	t.Run("NotificationGlobalGet", func(t *testing.T) {
-		out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "notification_global_get",
-			"params": map[string]any{},
-		})
-		requireNoError(t, err, "notification_global_get")
-		t.Logf("Global notification level: %s", out.Level)
-	})
-
-	t.Run("NotificationGlobalUpdate", func(t *testing.T) {
-		out, err := retryOnTransient(ctx, t, "notification_global_update", 3, func() (notifications.Output, error) {
-			return callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "notification_global_update",
-				"params": map[string]any{"level": "participating"},
+		t.Run("NamespaceList", func(t *testing.T) {
+			out, err := callToolOn[namespaces.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "namespace_list",
+				"params": map[string]any{},
 			})
+			requireNoError(t, err, "namespace_list")
+			requireTruef(t, len(out.Namespaces) > 0, "expected at least 1 namespace")
+			t.Logf("Namespaces: %d", len(out.Namespaces))
 		})
-		requireNoError(t, err, "notification_global_update")
-		t.Logf("Updated global notification level: %s", out.Level)
-	})
 
-	t.Run("NotificationProjectGetUpdate", func(t *testing.T) {
-		proj := createProjectMeta(ctx, t, sess.meta)
-		out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "notification_project_get",
-			"params": map[string]any{"project_id": proj.pidStr()},
+		t.Run("NamespaceSearch", func(t *testing.T) {
+			username := sess.username
+			out, err := callToolOn[namespaces.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "namespace_search",
+				"params": map[string]any{"query": username},
+			})
+			requireNoError(t, err, "namespace_search")
+			t.Logf("Namespace search '%s': %d results", username, len(out.Namespaces))
 		})
-		requireNoError(t, err, "notification_project_get")
-		t.Logf("Project notification level: %s", out.Level)
 
-		upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "notification_project_update",
-			"params": map[string]any{"project_id": proj.pidStr(), "level": "watch"},
+		t.Run("NamespaceExists", func(t *testing.T) {
+			username := sess.username
+			out, err := callToolOn[namespaces.ExistsOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "namespace_exists",
+				"params": map[string]any{"id": username},
+			})
+			requireNoError(t, err, "namespace_exists")
+			t.Logf("Namespace exists: %v", out.Exists)
 		})
-		requireNoError(t, err, "notification_project_update")
-		t.Logf("Updated project notification level: %s", upd.Level)
-	})
 
-	t.Run("NotificationGroupGetUpdate", func(t *testing.T) {
-		// Need a group — create one for the test
-		grp, err := callToolOn[struct{ ID int64 }](ctx, sess.meta, "gitlab_group", map[string]any{
-			"action": "create",
-			"params": map[string]any{
-				"name": uniqueName("notif-grp"),
-				"path": uniqueName("notif-grp"),
-			},
+		t.Run("NamespaceGet", func(t *testing.T) {
+			// First get current user to find their namespace
+			usr, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "current",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "get current user")
+			out, err := callToolOn[namespaces.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "namespace_get",
+				"params": map[string]any{"id": strconv.FormatInt(usr.ID, 10)},
+			})
+			requireNoError(t, err, "namespace_get")
+			requireTruef(t, out.ID > 0, "namespace_get: expected ID > 0")
+			t.Logf("Namespace %d: %s", out.ID, out.Name)
 		})
-		requireNoError(t, err, "create group for notification test")
-		grpIDStr := strconv.FormatInt(grp.ID, 10)
-		defer func() {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_group", map[string]any{
-				"action": "delete",
+
+		t.Run("NotificationGlobalGet", func(t *testing.T) {
+			out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "notification_global_get",
+				"params": map[string]any{},
+			})
+			requireNoError(t, err, "notification_global_get")
+			t.Logf("Global notification level: %s", out.Level)
+		})
+
+		t.Run("NotificationGlobalUpdate", func(t *testing.T) {
+			out, err := retryOnTransient(ctx, t, "notification_global_update", 3, func() (notifications.Output, error) {
+				return callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "notification_global_update",
+					"params": map[string]any{"level": "participating"},
+				})
+			})
+			requireNoError(t, err, "notification_global_update")
+			t.Logf("Updated global notification level: %s", out.Level)
+		})
+
+		t.Run("NotificationProjectGetUpdate", func(t *testing.T) {
+			proj := createProjectMeta(ctx, t, sess.meta)
+			out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "notification_project_get",
+				"params": map[string]any{"project_id": proj.pidStr()},
+			})
+			requireNoError(t, err, "notification_project_get")
+			t.Logf("Project notification level: %s", out.Level)
+
+			upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "notification_project_update",
+				"params": map[string]any{"project_id": proj.pidStr(), "level": "watch"},
+			})
+			requireNoError(t, err, "notification_project_update")
+			t.Logf("Updated project notification level: %s", upd.Level)
+		})
+
+		t.Run("NotificationGroupGetUpdate", func(t *testing.T) {
+			// Need a group — create one for the test
+			grp, err := callToolOn[struct{ ID int64 }](ctx, sess.meta, "gitlab_group", map[string]any{
+				"action": "create",
+				"params": map[string]any{
+					"name": uniqueName("notif-grp"),
+					"path": uniqueName("notif-grp"),
+				},
+			})
+			requireNoError(t, err, "create group for notification test")
+			grpIDStr := strconv.FormatInt(grp.ID, 10)
+			defer func() {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_group", map[string]any{
+					"action": "delete",
+					"params": map[string]any{"group_id": grpIDStr},
+				})
+			}()
+
+			out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "notification_group_get",
 				"params": map[string]any{"group_id": grpIDStr},
 			})
-		}()
+			requireNoError(t, err, "notification_group_get")
+			t.Logf("Group notification level: %s", out.Level)
 
-		out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "notification_group_get",
-			"params": map[string]any{"group_id": grpIDStr},
+			upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "notification_group_update",
+				"params": map[string]any{"group_id": grpIDStr, "level": "watch"},
+			})
+			requireNoError(t, err, "notification_group_update")
+			t.Logf("Updated group notification level: %s", upd.Level)
 		})
-		requireNoError(t, err, "notification_group_get")
-		t.Logf("Group notification level: %s", out.Level)
 
-		upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "notification_group_update",
-			"params": map[string]any{"group_id": grpIDStr, "level": "watch"},
-		})
-		requireNoError(t, err, "notification_group_update")
-		t.Logf("Updated group notification level: %s", upd.Level)
-	})
+		t.Run("KeyGetByFingerprint", func(t *testing.T) {
+			// Create an SSH key so we always have one
+			sshKey := generateTestSSHKey(t)
+			addOut, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "add_ssh_key",
+				"params": map[string]any{
+					"title": "e2e-fingerprint-test",
+					"key":   sshKey,
+				},
+			})
+			requireNoError(t, err, "add_ssh_key for fingerprint test")
+			defer func() {
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "delete_ssh_key",
+					"params": map[string]any{"key_id": addOut.ID},
+				})
+			}()
 
-	t.Run("KeyGetByFingerprint", func(t *testing.T) {
-		// Create an SSH key so we always have one
-		sshKey := generateTestSSHKey(t)
-		addOut, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "add_ssh_key",
-			"params": map[string]any{
-				"title": "e2e-fingerprint-test",
-				"key":   sshKey,
-			},
-		})
-		requireNoError(t, err, "add_ssh_key for fingerprint test")
-		defer func() {
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "delete_ssh_key",
+			out, err := callToolOn[keys.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "key_get_with_user",
 				"params": map[string]any{"key_id": addOut.ID},
 			})
-		}()
-
-		out, err := callToolOn[keys.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "key_get_with_user",
-			"params": map[string]any{"key_id": addOut.ID},
+			requireNoError(t, err, "key_get_with_user")
+			requireTruef(t, out.ID > 0, "key_get_with_user: expected ID > 0")
+			t.Logf("Key %d with user", out.ID)
 		})
-		requireNoError(t, err, "key_get_with_user")
-		requireTruef(t, out.ID > 0, "key_get_with_user: expected ID > 0")
-		t.Logf("Key %d with user", out.ID)
 	})
 }
 
@@ -351,46 +357,48 @@ func TestMeta_UserSSHKeyLifecycle(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	sshKey := generateTestSSHKey(t)
-	var keyID int64
+		sshKey := generateTestSSHKey(t)
+		var keyID int64
 
-	t.Run("AddSSHKey", func(t *testing.T) {
-		out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "add_ssh_key",
-			"params": map[string]any{
-				"title": "e2e-test-key-" + uniqueName(""),
-				"key":   sshKey,
-			},
+		t.Run("AddSSHKey", func(t *testing.T) {
+			out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "add_ssh_key",
+				"params": map[string]any{
+					"title": "e2e-test-key-" + uniqueName(""),
+					"key":   sshKey,
+				},
+			})
+			requireNoError(t, err, "add_ssh_key")
+			requireTruef(t, out.ID > 0, "add_ssh_key: expected ID > 0")
+			keyID = out.ID
+			t.Logf("Added SSH key %d", keyID)
 		})
-		requireNoError(t, err, "add_ssh_key")
-		requireTruef(t, out.ID > 0, "add_ssh_key: expected ID > 0")
-		keyID = out.ID
-		t.Logf("Added SSH key %d", keyID)
-	})
 
-	t.Run("GetSSHKey", func(t *testing.T) {
-		requireTruef(t, keyID > 0, "keyID not set")
-		out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "get_ssh_key",
-			"params": map[string]any{"key_id": keyID},
+		t.Run("GetSSHKey", func(t *testing.T) {
+			requireTruef(t, keyID > 0, "keyID not set")
+			out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "get_ssh_key",
+				"params": map[string]any{"key_id": keyID},
+			})
+			requireNoError(t, err, "get_ssh_key")
+			requireTruef(t, out.ID == keyID, "get_ssh_key: ID mismatch")
+			t.Logf("Got SSH key %d: %s", out.ID, out.Title)
 		})
-		requireNoError(t, err, "get_ssh_key")
-		requireTruef(t, out.ID == keyID, "get_ssh_key: ID mismatch")
-		t.Logf("Got SSH key %d: %s", out.ID, out.Title)
-	})
 
-	t.Run("DeleteSSHKey", func(t *testing.T) {
-		requireTruef(t, keyID > 0, "keyID not set")
-		err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "delete_ssh_key",
-			"params": map[string]any{"key_id": keyID},
+		t.Run("DeleteSSHKey", func(t *testing.T) {
+			requireTruef(t, keyID > 0, "keyID not set")
+			err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "delete_ssh_key",
+				"params": map[string]any{"key_id": keyID},
+			})
+			requireNoError(t, err, "delete_ssh_key")
+			t.Logf("Deleted SSH key %d", keyID)
 		})
-		requireNoError(t, err, "delete_ssh_key")
-		t.Logf("Deleted SSH key %d", keyID)
 	})
 }
 
@@ -702,50 +710,52 @@ func TestMeta_UserServiceAccounts(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
 
-	if sess.enterprise {
-		t.Run("ListServiceAccounts", func(t *testing.T) {
-			out, err := callToolOn[users.ServiceAccountListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "list_service_accounts",
-				"params": map[string]any{},
+		if sess.enterprise {
+			t.Run("ListServiceAccounts", func(t *testing.T) {
+				out, err := callToolOn[users.ServiceAccountListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "list_service_accounts",
+					"params": map[string]any{},
+				})
+				requireNoError(t, err, "list_service_accounts")
+				t.Logf("Service accounts: %d", len(out.Accounts))
 			})
-			requireNoError(t, err, "list_service_accounts")
-			t.Logf("Service accounts: %d", len(out.Accounts))
-		})
 
-		t.Run("CreateServiceAccount", func(t *testing.T) {
-			saName := uniqueName("sa-e2e")
-			out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "create_service_account",
+			t.Run("CreateServiceAccount", func(t *testing.T) {
+				saName := uniqueName("sa-e2e")
+				out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "create_service_account",
+					"params": map[string]any{
+						"name":     saName,
+						"username": saName,
+					},
+				})
+				requireNoError(t, err, "create_service_account")
+				requireTruef(t, out.ID > 0, "create_service_account: expected ID > 0")
+				t.Logf("Created service account %d: %s", out.ID, saName)
+				// Clean up
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "delete",
+					"params": map[string]any{"user_id": out.ID},
+				})
+			})
+		}
+
+		t.Run("CreateCurrentUserPAT", func(t *testing.T) {
+			out, err := callToolOn[users.CurrentUserPATOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "create_current_user_pat",
 				"params": map[string]any{
-					"name":     saName,
-					"username": saName,
+					"name":   "e2e-current-pat",
+					"scopes": []string{"k8s_proxy"},
 				},
 			})
-			requireNoError(t, err, "create_service_account")
-			requireTruef(t, out.ID > 0, "create_service_account: expected ID > 0")
-			t.Logf("Created service account %d: %s", out.ID, saName)
-			// Clean up
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "delete",
-				"params": map[string]any{"user_id": out.ID},
-			})
+			requireNoError(t, err, "create_current_user_pat")
+			requireTruef(t, out.ID > 0, "create_current_user_pat: expected ID > 0")
+			t.Logf("Created current user PAT %d", out.ID)
 		})
-	}
-
-	t.Run("CreateCurrentUserPAT", func(t *testing.T) {
-		out, err := callToolOn[users.CurrentUserPATOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "create_current_user_pat",
-			"params": map[string]any{
-				"name":   "e2e-current-pat",
-				"scopes": []string{"k8s_proxy"},
-			},
-		})
-		requireNoError(t, err, "create_current_user_pat")
-		requireTruef(t, out.ID > 0, "create_current_user_pat: expected ID > 0")
-		t.Logf("Created current user PAT %d", out.ID)
 	})
 }

--- a/test/e2e/suite/users_meta_test.go
+++ b/test/e2e/suite/users_meta_test.go
@@ -32,10 +32,11 @@ func TestMeta_UserSelf(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
-	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, e2e *E2EContext) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
+		RegisterCurrentUserStateRestore(ctx, e2e)
 
 		var currentUserID int64
 
@@ -205,6 +206,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
+		RegisterCurrentUserStateRestore(ctx, e2e)
 
 		t.Run("NamespaceList", func(t *testing.T) {
 			out, err := callToolOn[namespaces.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{

--- a/test/e2e/suite/users_meta_test.go
+++ b/test/e2e/suite/users_meta_test.go
@@ -33,7 +33,6 @@ func TestMeta_UserSelf(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, e2e *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 		RegisterCurrentUserStateRestore(ctx, e2e)
@@ -153,7 +152,6 @@ func TestMeta_UserTodosEvents(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -203,7 +201,6 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, e2e *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 		RegisterCurrentUserStateRestore(ctx, e2e)
@@ -345,7 +342,6 @@ func TestMeta_UserSSHKeyLifecycle(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
@@ -399,7 +395,6 @@ func TestMeta_UserAdmin(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 		defer cancel()
 
@@ -700,7 +695,6 @@ func TestMeta_UserServiceAccounts(t *testing.T) {
 		t.Skip("meta session not configured")
 	}
 	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
-
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 

--- a/test/e2e/suite/users_meta_test.go
+++ b/test/e2e/suite/users_meta_test.go
@@ -396,295 +396,297 @@ func TestMeta_UserAdmin(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
+	RunWithCapabilities(t, []Capability{CapabilityAdmin, CapabilityInstanceGlobal}, func(t *testing.T, _ *E2EContext) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+		defer cancel()
 
-	uname := uniqueName("usr-adm")
-	var testUserID int64
+		uname := uniqueName("usr-adm")
+		var testUserID int64
 
-	t.Run("CreateUser", func(t *testing.T) {
-		out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "create",
-			"params": map[string]any{
-				"email":                 uname + "@e2e-test.local",
-				"name":                  "E2E Test " + uname,
-				"username":              uname,
-				"password":              "E2eT!Gx9K#p2mNq$8BcZ",
-				"skip_confirmation":     true,
-				"force_random_password": false,
-			},
+		t.Run("CreateUser", func(t *testing.T) {
+			out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "create",
+				"params": map[string]any{
+					"email":                 uname + "@e2e-test.local",
+					"name":                  "E2E Test " + uname,
+					"username":              uname,
+					"password":              "E2eT!Gx9K#p2mNq$8BcZ",
+					"skip_confirmation":     true,
+					"force_random_password": false,
+				},
+			})
+			requireNoError(t, err, "create user")
+			requireTruef(t, out.ID > 0, "created user ID > 0")
+			testUserID = out.ID
+			t.Logf("Created user %d: %s", testUserID, uname)
 		})
-		requireNoError(t, err, "create user")
-		requireTruef(t, out.ID > 0, "created user ID > 0")
-		testUserID = out.ID
-		t.Logf("Created user %d: %s", testUserID, uname)
-	})
-	defer func() {
-		if testUserID > 0 {
-			// Unblock first in case blocked
-			_, _ = callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+		defer func() {
+			if testUserID > 0 {
+				// Unblock first in case blocked
+				_, _ = callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "unblock",
+					"params": map[string]any{"user_id": testUserID},
+				})
+				_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+					"action": "delete",
+					"params": map[string]any{"user_id": testUserID},
+				})
+			}
+		}()
+
+		t.Run("ModifyUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "modify",
+				"params": map[string]any{
+					"user_id": testUserID,
+					"bio":     "E2E test user - modified",
+				},
+			})
+			requireNoError(t, err, "modify user")
+			requireTruef(t, out.ID == testUserID, "modify: ID mismatch")
+			t.Logf("Modified user %d", testUserID)
+		})
+
+		t.Run("BlockUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "block",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "block user")
+			requireTruef(t, out.Success, "block should succeed")
+			t.Logf("Blocked user %d", testUserID)
+		})
+
+		t.Run("UnblockUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
 				"action": "unblock",
 				"params": map[string]any{"user_id": testUserID},
 			})
-			_ = callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-				"action": "delete",
+			requireNoError(t, err, "unblock user")
+			requireTruef(t, out.Success, "unblock should succeed")
+			t.Logf("Unblocked user %d", testUserID)
+		})
+
+		t.Run("DeactivateUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "deactivate",
 				"params": map[string]any{"user_id": testUserID},
 			})
-		}
-	}()
-
-	t.Run("ModifyUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "modify",
-			"params": map[string]any{
-				"user_id": testUserID,
-				"bio":     "E2E test user - modified",
-			},
+			requireNoError(t, err, "deactivate user")
+			requireTruef(t, out.Success, "deactivate should succeed")
 		})
-		requireNoError(t, err, "modify user")
-		requireTruef(t, out.ID == testUserID, "modify: ID mismatch")
-		t.Logf("Modified user %d", testUserID)
-	})
 
-	t.Run("BlockUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "block",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("ActivateUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "activate",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "activate user")
+			requireTruef(t, out.Success, "activate should succeed")
 		})
-		requireNoError(t, err, "block user")
-		requireTruef(t, out.Success, "block should succeed")
-		t.Logf("Blocked user %d", testUserID)
-	})
 
-	t.Run("UnblockUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "unblock",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("BanUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "ban",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "ban user")
+			requireTruef(t, out.Success, "ban should succeed")
 		})
-		requireNoError(t, err, "unblock user")
-		requireTruef(t, out.Success, "unblock should succeed")
-		t.Logf("Unblocked user %d", testUserID)
-	})
 
-	t.Run("DeactivateUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "deactivate",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("UnbanUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "unban",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "unban user")
+			requireTruef(t, out.Success, "unban should succeed")
 		})
-		requireNoError(t, err, "deactivate user")
-		requireTruef(t, out.Success, "deactivate should succeed")
-	})
 
-	t.Run("ActivateUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "activate",
-			"params": map[string]any{"user_id": testUserID},
+		// ── SSH keys for user ────────────────────────────────────────────────
+		var userKeyID int64
+		t.Run("SSHKeysForUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[users.SSHKeyListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "ssh_keys_for_user",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "ssh_keys_for_user")
+			t.Logf("SSH keys for user %d: %d", testUserID, len(out.Keys))
 		})
-		requireNoError(t, err, "activate user")
-		requireTruef(t, out.Success, "activate should succeed")
-	})
 
-	t.Run("BanUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "ban",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("AddSSHKeyForUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			sshKey := generateTestSSHKey(t)
+			out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "add_ssh_key_for_user",
+				"params": map[string]any{
+					"user_id": testUserID,
+					"title":   "e2e-user-key",
+					"key":     sshKey,
+				},
+			})
+			requireNoError(t, err, "add_ssh_key_for_user")
+			requireTruef(t, out.ID > 0, "add_ssh_key_for_user: expected key ID > 0")
+			userKeyID = out.ID
+			t.Logf("Added SSH key %d for user %d", userKeyID, testUserID)
 		})
-		requireNoError(t, err, "ban user")
-		requireTruef(t, out.Success, "ban should succeed")
-	})
 
-	t.Run("UnbanUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.AdminActionOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "unban",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("GetSSHKeyForUser", func(t *testing.T) {
+			requireTruef(t, userKeyID > 0, "userKeyID not set")
+			out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "get_ssh_key_for_user",
+				"params": map[string]any{"user_id": testUserID, "key_id": userKeyID},
+			})
+			requireNoError(t, err, "get_ssh_key_for_user")
+			requireTruef(t, out.ID == userKeyID, "get_ssh_key_for_user: ID mismatch")
 		})
-		requireNoError(t, err, "unban user")
-		requireTruef(t, out.Success, "unban should succeed")
-	})
 
-	// ── SSH keys for user ────────────────────────────────────────────────
-	var userKeyID int64
-	t.Run("SSHKeysForUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[users.SSHKeyListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "ssh_keys_for_user",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("DeleteSSHKeyForUser", func(t *testing.T) {
+			requireTruef(t, userKeyID > 0, "userKeyID not set")
+			err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "delete_ssh_key_for_user",
+				"params": map[string]any{"user_id": testUserID, "key_id": userKeyID},
+			})
+			requireNoError(t, err, "delete_ssh_key_for_user")
+			t.Logf("Deleted SSH key %d for user %d", userKeyID, testUserID)
 		})
-		requireNoError(t, err, "ssh_keys_for_user")
-		t.Logf("SSH keys for user %d: %d", testUserID, len(out.Keys))
-	})
 
-	t.Run("AddSSHKeyForUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		sshKey := generateTestSSHKey(t)
-		out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "add_ssh_key_for_user",
-			"params": map[string]any{
-				"user_id": testUserID,
-				"title":   "e2e-user-key",
-				"key":     sshKey,
-			},
+		// ── Emails for user ──────────────────────────────────────────────────
+		var emailID int64
+		t.Run("EmailsForUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[useremails.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "emails_for_user",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "emails_for_user")
+			t.Logf("Emails for user %d: %d", testUserID, len(out.Emails))
 		})
-		requireNoError(t, err, "add_ssh_key_for_user")
-		requireTruef(t, out.ID > 0, "add_ssh_key_for_user: expected key ID > 0")
-		userKeyID = out.ID
-		t.Logf("Added SSH key %d for user %d", userKeyID, testUserID)
-	})
 
-	t.Run("GetSSHKeyForUser", func(t *testing.T) {
-		requireTruef(t, userKeyID > 0, "userKeyID not set")
-		out, err := callToolOn[users.SSHKeyOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "get_ssh_key_for_user",
-			"params": map[string]any{"user_id": testUserID, "key_id": userKeyID},
+		t.Run("AddEmailForUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[useremails.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "add_email_for_user",
+				"params": map[string]any{
+					"user_id":           testUserID,
+					"email":             uname + "-extra@e2e-test.local",
+					"skip_confirmation": true,
+				},
+			})
+			requireNoError(t, err, "add_email_for_user")
+			requireTruef(t, out.ID > 0, "add_email_for_user: expected email ID > 0")
+			emailID = out.ID
+			t.Logf("Added email %d for user %d", emailID, testUserID)
 		})
-		requireNoError(t, err, "get_ssh_key_for_user")
-		requireTruef(t, out.ID == userKeyID, "get_ssh_key_for_user: ID mismatch")
-	})
 
-	t.Run("DeleteSSHKeyForUser", func(t *testing.T) {
-		requireTruef(t, userKeyID > 0, "userKeyID not set")
-		err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "delete_ssh_key_for_user",
-			"params": map[string]any{"user_id": testUserID, "key_id": userKeyID},
+		t.Run("GetEmail", func(t *testing.T) {
+			requireTruef(t, emailID > 0, "emailID not set")
+			// get_email fetches emails for the currently authenticated user, not testUserID— error expected
+			_, err := callToolOn[useremails.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "get_email",
+				"params": map[string]any{"email_id": emailID},
+			})
+			requireTruef(t, err != nil, "expected error: email belongs to different user")
+			t.Logf("Expected error for cross-user email access: %v", err)
 		})
-		requireNoError(t, err, "delete_ssh_key_for_user")
-		t.Logf("Deleted SSH key %d for user %d", userKeyID, testUserID)
-	})
 
-	// ── Emails for user ──────────────────────────────────────────────────
-	var emailID int64
-	t.Run("EmailsForUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[useremails.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "emails_for_user",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("DeleteEmailForUser", func(t *testing.T) {
+			requireTruef(t, emailID > 0, "emailID not set")
+			err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "delete_email_for_user",
+				"params": map[string]any{"user_id": testUserID, "email_id": emailID},
+			})
+			requireNoError(t, err, "delete_email_for_user")
+			t.Logf("Deleted email %d for user %d", emailID, testUserID)
 		})
-		requireNoError(t, err, "emails_for_user")
-		t.Logf("Emails for user %d: %d", testUserID, len(out.Emails))
-	})
 
-	t.Run("AddEmailForUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[useremails.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "add_email_for_user",
-			"params": map[string]any{
-				"user_id":           testUserID,
-				"email":             uname + "-extra@e2e-test.local",
-				"skip_confirmation": true,
-			},
+		// ── GPG keys for user ────────────────────────────────────────────────
+		t.Run("GPGKeysForUser", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[usergpgkeys.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "gpg_keys_for_user",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "gpg_keys_for_user")
+			t.Logf("GPG keys for user %d: %d", testUserID, len(out.Keys))
 		})
-		requireNoError(t, err, "add_email_for_user")
-		requireTruef(t, out.ID > 0, "add_email_for_user: expected email ID > 0")
-		emailID = out.ID
-		t.Logf("Added email %d for user %d", emailID, testUserID)
-	})
 
-	t.Run("GetEmail", func(t *testing.T) {
-		requireTruef(t, emailID > 0, "emailID not set")
-		// get_email fetches emails for the currently authenticated user, not testUserID— error expected
-		_, err := callToolOn[useremails.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "get_email",
-			"params": map[string]any{"email_id": emailID},
+		// ── Impersonation tokens ─────────────────────────────────────────────
+		var impTokenID int64
+		t.Run("ListImpersonationTokens", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[impersonationtokens.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "list_impersonation_tokens",
+				"params": map[string]any{"user_id": testUserID},
+			})
+			requireNoError(t, err, "list_impersonation_tokens")
+			t.Logf("Impersonation tokens for user %d: %d", testUserID, len(out.Tokens))
 		})
-		requireTruef(t, err != nil, "expected error: email belongs to different user")
-		t.Logf("Expected error for cross-user email access: %v", err)
-	})
 
-	t.Run("DeleteEmailForUser", func(t *testing.T) {
-		requireTruef(t, emailID > 0, "emailID not set")
-		err := callToolVoidOn(ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "delete_email_for_user",
-			"params": map[string]any{"user_id": testUserID, "email_id": emailID},
+		t.Run("CreateImpersonationToken", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[impersonationtokens.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "create_impersonation_token",
+				"params": map[string]any{
+					"user_id":    testUserID,
+					"name":       "e2e-imp-token",
+					"scopes":     []string{"api"},
+					"expires_at": time.Now().AddDate(0, 0, 364).Format("2006-01-02"),
+				},
+			})
+			requireNoError(t, err, "create_impersonation_token")
+			requireTruef(t, out.ID > 0, "create_impersonation_token: expected token ID > 0")
+			impTokenID = out.ID
+			t.Logf("Created impersonation token %d", impTokenID)
 		})
-		requireNoError(t, err, "delete_email_for_user")
-		t.Logf("Deleted email %d for user %d", emailID, testUserID)
-	})
 
-	// ── GPG keys for user ────────────────────────────────────────────────
-	t.Run("GPGKeysForUser", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[usergpgkeys.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "gpg_keys_for_user",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("GetImpersonationToken", func(t *testing.T) {
+			requireTruef(t, impTokenID > 0, "impTokenID not set")
+			out, err := callToolOn[impersonationtokens.Output](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "get_impersonation_token",
+				"params": map[string]any{"user_id": testUserID, "token_id": impTokenID},
+			})
+			requireNoError(t, err, "get_impersonation_token")
+			requireTruef(t, out.ID == impTokenID, "get_impersonation_token: ID mismatch")
 		})
-		requireNoError(t, err, "gpg_keys_for_user")
-		t.Logf("GPG keys for user %d: %d", testUserID, len(out.Keys))
-	})
 
-	// ── Impersonation tokens ─────────────────────────────────────────────
-	var impTokenID int64
-	t.Run("ListImpersonationTokens", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[impersonationtokens.ListOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "list_impersonation_tokens",
-			"params": map[string]any{"user_id": testUserID},
+		t.Run("RevokeImpersonationToken", func(t *testing.T) {
+			requireTruef(t, impTokenID > 0, "impTokenID not set")
+			_, err := callToolOn[impersonationtokens.RevokeOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "revoke_impersonation_token",
+				"params": map[string]any{"user_id": testUserID, "token_id": impTokenID},
+			})
+			requireNoError(t, err, "revoke_impersonation_token")
+			t.Logf("Revoked impersonation token %d", impTokenID)
 		})
-		requireNoError(t, err, "list_impersonation_tokens")
-		t.Logf("Impersonation tokens for user %d: %d", testUserID, len(out.Tokens))
-	})
 
-	t.Run("CreateImpersonationToken", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[impersonationtokens.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "create_impersonation_token",
-			"params": map[string]any{
-				"user_id":    testUserID,
-				"name":       "e2e-imp-token",
-				"scopes":     []string{"api"},
-				"expires_at": time.Now().AddDate(0, 0, 364).Format("2006-01-02"),
-			},
+		// ── Personal Access Tokens (admin) ───────────────────────────────────
+		t.Run("CreatePersonalAccessToken", func(t *testing.T) {
+			requireTruef(t, testUserID > 0, "testUserID not set")
+			out, err := callToolOn[impersonationtokens.PATOutput](ctx, sess.meta, "gitlab_user", map[string]any{
+				"action": "create_personal_access_token",
+				"params": map[string]any{
+					"user_id": testUserID,
+					"name":    "e2e-pat",
+					"scopes":  []string{"read_api"},
+				},
+			})
+			requireNoError(t, err, "create_personal_access_token")
+			requireTruef(t, out.ID > 0, "create_personal_access_token: expected ID > 0")
+			t.Logf("Created PAT %d for user %d", out.ID, testUserID)
 		})
-		requireNoError(t, err, "create_impersonation_token")
-		requireTruef(t, out.ID > 0, "create_impersonation_token: expected token ID > 0")
-		impTokenID = out.ID
-		t.Logf("Created impersonation token %d", impTokenID)
-	})
 
-	t.Run("GetImpersonationToken", func(t *testing.T) {
-		requireTruef(t, impTokenID > 0, "impTokenID not set")
-		out, err := callToolOn[impersonationtokens.Output](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "get_impersonation_token",
-			"params": map[string]any{"user_id": testUserID, "token_id": impTokenID},
-		})
-		requireNoError(t, err, "get_impersonation_token")
-		requireTruef(t, out.ID == impTokenID, "get_impersonation_token: ID mismatch")
+		// Delete user is handled by defer above
 	})
-
-	t.Run("RevokeImpersonationToken", func(t *testing.T) {
-		requireTruef(t, impTokenID > 0, "impTokenID not set")
-		_, err := callToolOn[impersonationtokens.RevokeOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "revoke_impersonation_token",
-			"params": map[string]any{"user_id": testUserID, "token_id": impTokenID},
-		})
-		requireNoError(t, err, "revoke_impersonation_token")
-		t.Logf("Revoked impersonation token %d", impTokenID)
-	})
-
-	// ── Personal Access Tokens (admin) ───────────────────────────────────
-	t.Run("CreatePersonalAccessToken", func(t *testing.T) {
-		requireTruef(t, testUserID > 0, "testUserID not set")
-		out, err := callToolOn[impersonationtokens.PATOutput](ctx, sess.meta, "gitlab_user", map[string]any{
-			"action": "create_personal_access_token",
-			"params": map[string]any{
-				"user_id": testUserID,
-				"name":    "e2e-pat",
-				"scopes":  []string{"read_api"},
-			},
-		})
-		requireNoError(t, err, "create_personal_access_token")
-		requireTruef(t, out.ID > 0, "create_personal_access_token: expected ID > 0")
-		t.Logf("Created PAT %d for user %d", out.ID, testUserID)
-	})
-
-	// Delete user is handled by defer above
 }
 
 // TestMeta_UserServiceAccounts exercises service account and current-user PAT

--- a/test/e2e/suite/users_meta_test.go
+++ b/test/e2e/suite/users_meta_test.go
@@ -201,7 +201,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 	if sess.meta == nil {
 		t.Skip("meta session not configured")
 	}
-	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, _ *E2EContext) {
+	RunWithCapabilities(t, []Capability{CapabilityCurrentUserState}, func(t *testing.T, e2e *E2EContext) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
@@ -290,33 +290,18 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 		})
 
 		t.Run("NotificationGroupGetUpdate", func(t *testing.T) {
-			// Need a group — create one for the test
-			grp, err := callToolOn[struct{ ID int64 }](ctx, sess.meta, "gitlab_group", map[string]any{
-				"action": "create",
-				"params": map[string]any{
-					"name": uniqueName("notif-grp"),
-					"path": uniqueName("notif-grp"),
-				},
-			})
-			requireNoError(t, err, "create group for notification test")
-			grpIDStr := strconv.FormatInt(grp.ID, 10)
-			defer func() {
-				_ = callToolVoidOn(ctx, sess.meta, "gitlab_group", map[string]any{
-					"action": "delete",
-					"params": map[string]any{"group_id": grpIDStr},
-				})
-			}()
+			grp := CreateGroupMeta(ctx, e2e, sess.meta, "notif-grp")
 
 			out, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
 				"action": "notification_group_get",
-				"params": map[string]any{"group_id": grpIDStr},
+				"params": map[string]any{"group_id": grp.gidStr()},
 			})
 			requireNoError(t, err, "notification_group_get")
 			t.Logf("Group notification level: %s", out.Level)
 
 			upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
 				"action": "notification_group_update",
-				"params": map[string]any{"group_id": grpIDStr, "level": "watch"},
+				"params": map[string]any{"group_id": grp.gidStr(), "level": "watch"},
 			})
 			requireNoError(t, err, "notification_group_update")
 			t.Logf("Updated group notification level: %s", upd.Level)

--- a/test/e2e/suite/wait_helpers_test.go
+++ b/test/e2e/suite/wait_helpers_test.go
@@ -1,0 +1,158 @@
+package suite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ErrPollTimeout identifies polling operations that exhausted their wait budget.
+var ErrPollTimeout = errors.New("poll timeout")
+
+// Poll repeatedly evaluates condition until it succeeds, fails, times out, or
+// the context is canceled. The condition should return an error only for
+// non-retryable failures; retryable observations should be reported as state.
+func Poll(ctx context.Context, interval time.Duration, max time.Duration, condition func() (bool, string, error)) error {
+	if condition == nil {
+		return errors.New("poll condition is nil")
+	}
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+	if max <= 0 {
+		max = interval
+	}
+
+	deadline := time.NewTimer(max)
+	defer deadline.Stop()
+
+	lastState := "no state observed"
+	for {
+		select {
+		case <-ctx.Done():
+			return pollContextError(ctx.Err(), max, lastState)
+		default:
+		}
+
+		done, state, err := condition()
+		if state != "" {
+			lastState = state
+		}
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		wait := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			stopTimer(wait)
+			return pollContextError(ctx.Err(), max, lastState)
+		case <-deadline.C:
+			stopTimer(wait)
+			return pollTimeoutError(max, lastState)
+		case <-wait.C:
+		}
+	}
+}
+
+func pollContextError(err error, max time.Duration, lastState string) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return pollTimeoutError(max, lastState)
+	}
+	return fmt.Errorf("poll canceled: %w", err)
+}
+
+func pollTimeoutError(max time.Duration, lastState string) error {
+	return fmt.Errorf("%w after %s (last state: %s)", ErrPollTimeout, max, lastState)
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+func TestPoll_ImmediateSuccess(t *testing.T) {
+	calls := 0
+	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
+		calls++
+		return true, "ready", nil
+	})
+
+	if err != nil {
+		t.Fatalf("Poll() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("condition calls = %d, want 1", calls)
+	}
+}
+
+func TestPoll_RetrySuccess(t *testing.T) {
+	calls := 0
+	err := Poll(context.Background(), time.Millisecond, 100*time.Millisecond, func() (bool, string, error) {
+		calls++
+		if calls < 3 {
+			return false, fmt.Sprintf("attempt %d", calls), nil
+		}
+		return true, "ready", nil
+	})
+
+	if err != nil {
+		t.Fatalf("Poll() error = %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Fatalf("condition calls = %d, want 3", calls)
+	}
+}
+
+func TestPoll_ReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := Poll(ctx, time.Millisecond, time.Second, func() (bool, string, error) {
+		calls++
+		return false, "waiting", nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Poll() error = %v, want context.Canceled", err)
+	}
+	if calls != 0 {
+		t.Fatalf("condition calls = %d, want 0", calls)
+	}
+}
+
+func TestPoll_ReturnsTimeoutWithLastState(t *testing.T) {
+	err := Poll(context.Background(), time.Millisecond, 3*time.Millisecond, func() (bool, string, error) {
+		return false, "still waiting", nil
+	})
+
+	if !errors.Is(err, ErrPollTimeout) {
+		t.Fatalf("Poll() error = %v, want ErrPollTimeout", err)
+	}
+	if !strings.Contains(err.Error(), "still waiting") {
+		t.Fatalf("Poll() error = %q, want last state", err.Error())
+	}
+}
+
+func TestPoll_ReturnsConditionError(t *testing.T) {
+	conditionErr := errors.New("condition failed")
+	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
+		return false, "failed", conditionErr
+	})
+
+	if !errors.Is(err, conditionErr) {
+		t.Fatalf("Poll() error = %v, want condition error", err)
+	}
+}

--- a/test/e2e/suite/wait_helpers_test.go
+++ b/test/e2e/suite/wait_helpers_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package suite
 
 import (
@@ -15,25 +17,25 @@ var ErrPollTimeout = errors.New("poll timeout")
 // Poll repeatedly evaluates condition until it succeeds, fails, times out, or
 // the context is canceled. The condition should return an error only for
 // non-retryable failures; retryable observations should be reported as state.
-func Poll(ctx context.Context, interval time.Duration, max time.Duration, condition func() (bool, string, error)) error {
+func Poll(ctx context.Context, interval time.Duration, timeout time.Duration, condition func() (bool, string, error)) error {
 	if condition == nil {
 		return errors.New("poll condition is nil")
 	}
 	if interval <= 0 {
 		interval = 100 * time.Millisecond
 	}
-	if max <= 0 {
-		max = interval
+	if timeout <= 0 {
+		timeout = interval
 	}
 
-	deadline := time.NewTimer(max)
+	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 
 	lastState := "no state observed"
 	for {
 		select {
 		case <-ctx.Done():
-			return pollContextError(ctx.Err(), max, lastState)
+			return pollContextError(ctx.Err(), timeout, lastState)
 		default:
 		}
 
@@ -52,24 +54,24 @@ func Poll(ctx context.Context, interval time.Duration, max time.Duration, condit
 		select {
 		case <-ctx.Done():
 			stopTimer(wait)
-			return pollContextError(ctx.Err(), max, lastState)
+			return pollContextError(ctx.Err(), timeout, lastState)
 		case <-deadline.C:
 			stopTimer(wait)
-			return pollTimeoutError(max, lastState)
+			return pollTimeoutError(timeout, lastState)
 		case <-wait.C:
 		}
 	}
 }
 
-func pollContextError(err error, max time.Duration, lastState string) error {
+func pollContextError(err error, timeout time.Duration, lastState string) error {
 	if errors.Is(err, context.DeadlineExceeded) {
-		return pollTimeoutError(max, lastState)
+		return pollTimeoutError(timeout, lastState)
 	}
 	return fmt.Errorf("poll canceled: %w", err)
 }
 
-func pollTimeoutError(max time.Duration, lastState string) error {
-	return fmt.Errorf("%w after %s (last state: %s)", ErrPollTimeout, max, lastState)
+func pollTimeoutError(timeout time.Duration, lastState string) error {
+	return fmt.Errorf("%w after %s (last state: %s)", ErrPollTimeout, timeout, lastState)
 }
 
 func stopTimer(timer *time.Timer) {
@@ -116,7 +118,7 @@ func retryWithBackoffInterval[O any](ctx context.Context, t *testing.T, label st
 		delay := time.Duration(attempt+1) * baseDelay
 		select {
 		case <-ctx.Done():
-			return output, fmt.Errorf("%s canceled before retry after attempt %d/%d: %w (last error: %v)", label, attempt+1, maxRetries, ctx.Err(), err)
+			return output, fmt.Errorf("%s canceled before retry after attempt %d/%d: %w (last error: %s)", label, attempt+1, maxRetries, ctx.Err(), err.Error())
 		case <-time.After(delay):
 		}
 	}

--- a/test/e2e/suite/wait_helpers_test.go
+++ b/test/e2e/suite/wait_helpers_test.go
@@ -1,5 +1,7 @@
 //go:build e2e
 
+// wait_helpers_test.go contains polling and retry helpers used by E2E tests to
+// absorb GitLab Docker startup lag and eventual-consistency delays.
 package suite
 
 import (
@@ -63,6 +65,8 @@ func Poll(ctx context.Context, interval time.Duration, timeout time.Duration, co
 	}
 }
 
+// pollContextError maps context cancellation into the timeout sentinel when the
+// context ended because the polling wait budget expired.
 func pollContextError(err error, timeout time.Duration, lastState string) error {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return pollTimeoutError(timeout, lastState)
@@ -70,10 +74,14 @@ func pollContextError(err error, timeout time.Duration, lastState string) error 
 	return fmt.Errorf("poll canceled: %w", err)
 }
 
+// pollTimeoutError wraps [ErrPollTimeout] with the configured wait budget and
+// last observed state for actionable failure messages.
 func pollTimeoutError(timeout time.Duration, lastState string) error {
 	return fmt.Errorf("%w after %s (last state: %s)", ErrPollTimeout, timeout, lastState)
 }
 
+// stopTimer stops timer and drains its channel when needed so callers can leave
+// select blocks without leaking timer state.
 func stopTimer(timer *time.Timer) {
 	if timer.Stop() {
 		return
@@ -84,10 +92,14 @@ func stopTimer(timer *time.Timer) {
 	}
 }
 
+// retryWithBackoff runs operation with a one-second base delay between
+// retryable failures.
 func retryWithBackoff[O any](ctx context.Context, t *testing.T, label string, maxRetries int, operation func(attempt int) (O, bool, string, error)) (O, error) {
 	return retryWithBackoffInterval(ctx, t, label, maxRetries, time.Second, operation)
 }
 
+// retryWithBackoffInterval runs operation until it succeeds, returns a
+// non-retryable error, exhausts maxRetries, or ctx is canceled.
 func retryWithBackoffInterval[O any](ctx context.Context, t *testing.T, label string, maxRetries int, baseDelay time.Duration, operation func(attempt int) (O, bool, string, error)) (O, error) {
 	t.Helper()
 	var output O
@@ -126,6 +138,8 @@ func retryWithBackoffInterval[O any](ctx context.Context, t *testing.T, label st
 	return output, fmt.Errorf("%s failed without executing retry operation", label)
 }
 
+// TestPoll_ImmediateSuccess verifies that Poll returns immediately when the
+// condition reports success on the first call.
 func TestPoll_ImmediateSuccess(t *testing.T) {
 	calls := 0
 	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
@@ -141,6 +155,8 @@ func TestPoll_ImmediateSuccess(t *testing.T) {
 	}
 }
 
+// TestPoll_RetrySuccess verifies that Poll keeps evaluating retryable state
+// observations until a later condition call reports success.
 func TestPoll_RetrySuccess(t *testing.T) {
 	calls := 0
 	err := Poll(context.Background(), time.Millisecond, 100*time.Millisecond, func() (bool, string, error) {
@@ -159,6 +175,9 @@ func TestPoll_RetrySuccess(t *testing.T) {
 	}
 }
 
+// TestPoll_ReturnsContextCancellation verifies that Poll returns
+// [context.Canceled] without calling the condition when the context is already
+// canceled.
 func TestPoll_ReturnsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -177,6 +196,9 @@ func TestPoll_ReturnsContextCancellation(t *testing.T) {
 	}
 }
 
+// TestPoll_ReturnsTimeoutWithLastState verifies that Poll wraps
+// [ErrPollTimeout] and includes the last observed state when the wait budget is
+// exhausted.
 func TestPoll_ReturnsTimeoutWithLastState(t *testing.T) {
 	err := Poll(context.Background(), time.Millisecond, 3*time.Millisecond, func() (bool, string, error) {
 		return false, "still waiting", nil
@@ -190,6 +212,8 @@ func TestPoll_ReturnsTimeoutWithLastState(t *testing.T) {
 	}
 }
 
+// TestPoll_ReturnsConditionError verifies that Poll stops and returns a
+// non-retryable condition error unchanged for [errors.Is] checks.
 func TestPoll_ReturnsConditionError(t *testing.T) {
 	conditionErr := errors.New("condition failed")
 	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
@@ -201,6 +225,8 @@ func TestPoll_ReturnsConditionError(t *testing.T) {
 	}
 }
 
+// TestRetryWithBackoffInterval_RetrySuccess verifies that retryWithBackoffInterval
+// retries a retryable failure and returns the later successful result.
 func TestRetryWithBackoffInterval_RetrySuccess(t *testing.T) {
 	attempts := 0
 	result, err := retryWithBackoffInterval(context.Background(), t, "retry test", 3, time.Millisecond, func(int) (int, bool, string, error) {
@@ -222,6 +248,9 @@ func TestRetryWithBackoffInterval_RetrySuccess(t *testing.T) {
 	}
 }
 
+// TestRetryWithBackoffInterval_ReturnsNonRetryableError verifies that
+// retryWithBackoffInterval stops immediately when operation marks an error as
+// non-retryable.
 func TestRetryWithBackoffInterval_ReturnsNonRetryableError(t *testing.T) {
 	failure := errors.New("permanent failure")
 	_, err := retryWithBackoffInterval(context.Background(), t, "retry test", 3, time.Millisecond, func(int) (int, bool, string, error) {
@@ -233,6 +262,9 @@ func TestRetryWithBackoffInterval_ReturnsNonRetryableError(t *testing.T) {
 	}
 }
 
+// TestRetryWithBackoffInterval_RespectsContextCancellation verifies that
+// retryWithBackoffInterval returns [context.Canceled] while waiting between
+// retryable attempts.
 func TestRetryWithBackoffInterval_RespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	attempts := 0

--- a/test/e2e/suite/wait_helpers_test.go
+++ b/test/e2e/suite/wait_helpers_test.go
@@ -82,6 +82,48 @@ func stopTimer(timer *time.Timer) {
 	}
 }
 
+func retryWithBackoff[O any](ctx context.Context, t *testing.T, label string, maxRetries int, operation func(attempt int) (O, bool, string, error)) (O, error) {
+	return retryWithBackoffInterval(ctx, t, label, maxRetries, time.Second, operation)
+}
+
+func retryWithBackoffInterval[O any](ctx context.Context, t *testing.T, label string, maxRetries int, baseDelay time.Duration, operation func(attempt int) (O, bool, string, error)) (O, error) {
+	t.Helper()
+	var output O
+	if operation == nil {
+		return output, errors.New("retry operation is nil")
+	}
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	if baseDelay <= 0 {
+		baseDelay = time.Millisecond
+	}
+
+	for attempt := range maxRetries {
+		result, retryable, reason, err := operation(attempt)
+		output = result
+		if err == nil {
+			return output, nil
+		}
+		if attempt >= maxRetries-1 || !retryable {
+			return output, fmt.Errorf("%s failed after %d attempt(s): %w", label, attempt+1, err)
+		}
+		if reason == "" {
+			reason = "retryable error"
+		}
+
+		t.Logf("%s: attempt %d/%d failed (%s), retrying: %v", label, attempt+1, maxRetries, reason, err)
+		delay := time.Duration(attempt+1) * baseDelay
+		select {
+		case <-ctx.Done():
+			return output, fmt.Errorf("%s canceled before retry after attempt %d/%d: %w (last error: %v)", label, attempt+1, maxRetries, ctx.Err(), err)
+		case <-time.After(delay):
+		}
+	}
+
+	return output, fmt.Errorf("%s failed without executing retry operation", label)
+}
+
 func TestPoll_ImmediateSuccess(t *testing.T) {
 	calls := 0
 	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
@@ -154,5 +196,54 @@ func TestPoll_ReturnsConditionError(t *testing.T) {
 
 	if !errors.Is(err, conditionErr) {
 		t.Fatalf("Poll() error = %v, want condition error", err)
+	}
+}
+
+func TestRetryWithBackoffInterval_RetrySuccess(t *testing.T) {
+	attempts := 0
+	result, err := retryWithBackoffInterval(context.Background(), t, "retry test", 3, time.Millisecond, func(int) (int, bool, string, error) {
+		attempts++
+		if attempts < 2 {
+			return 0, true, "transient", errors.New("try again")
+		}
+		return 42, false, "", nil
+	})
+
+	if err != nil {
+		t.Fatalf("retryWithBackoffInterval() error = %v, want nil", err)
+	}
+	if result != 42 {
+		t.Fatalf("result = %d, want 42", result)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestRetryWithBackoffInterval_ReturnsNonRetryableError(t *testing.T) {
+	failure := errors.New("permanent failure")
+	_, err := retryWithBackoffInterval(context.Background(), t, "retry test", 3, time.Millisecond, func(int) (int, bool, string, error) {
+		return 0, false, "", failure
+	})
+
+	if !errors.Is(err, failure) {
+		t.Fatalf("retryWithBackoffInterval() error = %v, want permanent failure", err)
+	}
+}
+
+func TestRetryWithBackoffInterval_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	_, err := retryWithBackoffInterval(ctx, t, "retry test", 3, 10*time.Millisecond, func(int) (int, bool, string, error) {
+		attempts++
+		cancel()
+		return 0, true, "transient", errors.New("try again")
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("retryWithBackoffInterval() error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
 	}
 }

--- a/test/e2e/suite/wait_test.go
+++ b/test/e2e/suite/wait_test.go
@@ -31,7 +31,6 @@ wait-job:
 func TestWaitTools(t *testing.T) {
 	t.Parallel()
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
-
 		ctx := context.Background()
 
 		// --- Individual tool session ---

--- a/test/e2e/suite/wait_test.go
+++ b/test/e2e/suite/wait_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 
 // wait_test.go tests the gitlab_pipeline_wait and gitlab_job_wait MCP tools
-// against a live GitLab instance. Requires Docker mode with a CI runner.
+// against a live GitLab instance. Requires a CI runner.
 // Covers both individual tools and the gitlab_pipeline/gitlab_job meta-tools.
 package suite
 
@@ -30,220 +30,219 @@ wait-job:
 // MCP wait tool (not the direct API helper), then waits for each job.
 func TestWaitTools(t *testing.T) {
 	t.Parallel()
-	if !isDockerMode() {
-		t.Skip("wait tool tests require Docker mode with CI runner")
-	}
+	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
 
-	ctx := context.Background()
+		ctx := context.Background()
 
-	// --- Individual tool session ---
-	proj := createProject(ctx, t, sess.individual)
-	commitFile(ctx, t, sess.individual, proj, "main", "init.txt", "bootstrap", "init commit")
+		// --- Individual tool session ---
+		proj := createProject(ctx, t, sess.individual)
+		commitFile(ctx, t, sess.individual, proj, "main", "init.txt", "bootstrap", "init commit")
 
-	_, ciErr := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
-		ProjectID:     proj.pidOf(),
-		Branch:        "main",
-		CommitMessage: "ci: add .gitlab-ci.yml for wait tool tests",
-		Actions: []commits.Action{{
-			Action:   "create",
-			FilePath: ".gitlab-ci.yml",
-			Content:  waitCIYAML,
-		}},
-	})
-	if ciErr != nil {
-		t.Fatalf("commit CI config: %v", ciErr)
-	}
-
-	var pipelineID int64
-
-	t.Run("Individual/PipelineCreate", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
-			ProjectID: proj.pidOf(),
-			Ref:       "main",
-		})
-		if err != nil {
-			t.Fatalf("pipeline create: %v", err)
-		}
-		if out.ID <= 0 {
-			t.Fatal("expected positive pipeline ID")
-		}
-		pipelineID = out.ID
-		t.Logf("Created pipeline ID=%d status=%s", pipelineID, out.Status)
-	})
-
-	t.Run("Individual/PipelineWait", func(t *testing.T) {
-		drainSidekiq(ctx, t, sess.glClient)
-		failOnErr := false
-		out, err := callToolOn[pipelines.WaitOutput](ctx, sess.individual, "gitlab_pipeline_wait", pipelines.WaitInput{
-			ProjectID:       proj.pidOf(),
-			PipelineID:      pipelineID,
-			IntervalSeconds: 5,
-			TimeoutSeconds:  600,
-			FailOnError:     &failOnErr,
-		})
-		if err != nil {
-			t.Fatalf("pipeline wait: %v", err)
-		}
-		if out.FinalStatus == "" {
-			t.Fatal("expected non-empty FinalStatus")
-		}
-		if out.TimedOut {
-			t.Fatalf("pipeline wait timed out, last status: %s", out.FinalStatus)
-		}
-		if out.PollCount <= 0 {
-			t.Error("expected PollCount > 0")
-		}
-		if out.WaitedFor == "" {
-			t.Error("expected non-empty WaitedFor")
-		}
-		t.Logf("Pipeline wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
-	})
-
-	var jobID int64
-
-	t.Run("Individual/JobList", func(t *testing.T) {
-		out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
-			ProjectID:  proj.pidOf(),
-			PipelineID: pipelineID,
-		})
-		if err != nil {
-			t.Fatalf("job list: %v", err)
-		}
-		if len(out.Jobs) == 0 {
-			t.Fatal("expected at least 1 job")
-		}
-		jobID = out.Jobs[0].ID
-		t.Logf("Found %d jobs; first: ID=%d name=%s status=%s", len(out.Jobs), jobID, out.Jobs[0].Name, out.Jobs[0].Status)
-	})
-
-	t.Run("Individual/JobWait", func(t *testing.T) {
-		failOnErr := false
-		out, err := callToolOn[jobs.WaitOutput](ctx, sess.individual, "gitlab_job_wait", jobs.WaitInput{
-			ProjectID:       proj.pidOf(),
-			JobID:           jobID,
-			IntervalSeconds: 5,
-			TimeoutSeconds:  600,
-			FailOnError:     &failOnErr,
-		})
-		if err != nil {
-			t.Fatalf("job wait: %v", err)
-		}
-		if out.FinalStatus == "" {
-			t.Fatal("expected non-empty FinalStatus")
-		}
-		if out.TimedOut {
-			t.Fatalf("job wait timed out, last status: %s", out.FinalStatus)
-		}
-		if out.PollCount <= 0 {
-			t.Error("expected PollCount > 0")
-		}
-		if out.WaitedFor == "" {
-			t.Error("expected non-empty WaitedFor")
-		}
-		t.Logf("Job wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
-	})
-
-	// --- Meta-tool session ---
-	projM := createProjectMeta(ctx, t, sess.meta)
-	commitFileMeta(ctx, t, sess.meta, projM, "main", "init.txt", "bootstrap", "init commit")
-
-	_, ciErr = callToolOn[commits.Output](ctx, sess.meta, "gitlab_repository", map[string]any{
-		"action": "commit_create",
-		"params": map[string]any{
-			"project_id":     projM.pidStr(),
-			"branch":         "main",
-			"commit_message": "ci: add .gitlab-ci.yml for wait tool tests",
-			"actions": []map[string]any{{
-				"action":    "create",
-				"file_path": ".gitlab-ci.yml",
-				"content":   waitCIYAML,
+		_, ciErr := callToolOn[commits.Output](ctx, sess.individual, "gitlab_commit_create", commits.CreateInput{
+			ProjectID:     proj.pidOf(),
+			Branch:        "main",
+			CommitMessage: "ci: add .gitlab-ci.yml for wait tool tests",
+			Actions: []commits.Action{{
+				Action:   "create",
+				FilePath: ".gitlab-ci.yml",
+				Content:  waitCIYAML,
 			}},
-		},
-	})
-	if ciErr != nil {
-		t.Fatalf("meta commit CI config: %v", ciErr)
-	}
+		})
+		if ciErr != nil {
+			t.Fatalf("commit CI config: %v", ciErr)
+		}
 
-	var mPipelineID int64
+		var pipelineID int64
 
-	t.Run("Meta/PipelineCreate", func(t *testing.T) {
-		out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "create",
+		t.Run("Individual/PipelineCreate", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.individual, "gitlab_pipeline_create", pipelines.CreateInput{
+				ProjectID: proj.pidOf(),
+				Ref:       "main",
+			})
+			if err != nil {
+				t.Fatalf("pipeline create: %v", err)
+			}
+			if out.ID <= 0 {
+				t.Fatal("expected positive pipeline ID")
+			}
+			pipelineID = out.ID
+			t.Logf("Created pipeline ID=%d status=%s", pipelineID, out.Status)
+		})
+
+		t.Run("Individual/PipelineWait", func(t *testing.T) {
+			drainSidekiq(ctx, t, sess.glClient)
+			failOnErr := false
+			out, err := callToolOn[pipelines.WaitOutput](ctx, sess.individual, "gitlab_pipeline_wait", pipelines.WaitInput{
+				ProjectID:       proj.pidOf(),
+				PipelineID:      pipelineID,
+				IntervalSeconds: 5,
+				TimeoutSeconds:  600,
+				FailOnError:     &failOnErr,
+			})
+			if err != nil {
+				t.Fatalf("pipeline wait: %v", err)
+			}
+			if out.FinalStatus == "" {
+				t.Fatal("expected non-empty FinalStatus")
+			}
+			if out.TimedOut {
+				t.Fatalf("pipeline wait timed out, last status: %s", out.FinalStatus)
+			}
+			if out.PollCount <= 0 {
+				t.Error("expected PollCount > 0")
+			}
+			if out.WaitedFor == "" {
+				t.Error("expected non-empty WaitedFor")
+			}
+			t.Logf("Pipeline wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
+		})
+
+		var jobID int64
+
+		t.Run("Individual/JobList", func(t *testing.T) {
+			out, err := callToolOn[jobs.ListOutput](ctx, sess.individual, "gitlab_job_list", jobs.ListInput{
+				ProjectID:  proj.pidOf(),
+				PipelineID: pipelineID,
+			})
+			if err != nil {
+				t.Fatalf("job list: %v", err)
+			}
+			if len(out.Jobs) == 0 {
+				t.Fatal("expected at least 1 job")
+			}
+			jobID = out.Jobs[0].ID
+			t.Logf("Found %d jobs; first: ID=%d name=%s status=%s", len(out.Jobs), jobID, out.Jobs[0].Name, out.Jobs[0].Status)
+		})
+
+		t.Run("Individual/JobWait", func(t *testing.T) {
+			failOnErr := false
+			out, err := callToolOn[jobs.WaitOutput](ctx, sess.individual, "gitlab_job_wait", jobs.WaitInput{
+				ProjectID:       proj.pidOf(),
+				JobID:           jobID,
+				IntervalSeconds: 5,
+				TimeoutSeconds:  600,
+				FailOnError:     &failOnErr,
+			})
+			if err != nil {
+				t.Fatalf("job wait: %v", err)
+			}
+			if out.FinalStatus == "" {
+				t.Fatal("expected non-empty FinalStatus")
+			}
+			if out.TimedOut {
+				t.Fatalf("job wait timed out, last status: %s", out.FinalStatus)
+			}
+			if out.PollCount <= 0 {
+				t.Error("expected PollCount > 0")
+			}
+			if out.WaitedFor == "" {
+				t.Error("expected non-empty WaitedFor")
+			}
+			t.Logf("Job wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
+		})
+
+		// --- Meta-tool session ---
+		projM := createProjectMeta(ctx, t, sess.meta)
+		commitFileMeta(ctx, t, sess.meta, projM, "main", "init.txt", "bootstrap", "init commit")
+
+		_, ciErr = callToolOn[commits.Output](ctx, sess.meta, "gitlab_repository", map[string]any{
+			"action": "commit_create",
 			"params": map[string]any{
-				"project_id": projM.pidStr(),
-				"ref":        "main",
+				"project_id":     projM.pidStr(),
+				"branch":         "main",
+				"commit_message": "ci: add .gitlab-ci.yml for wait tool tests",
+				"actions": []map[string]any{{
+					"action":    "create",
+					"file_path": ".gitlab-ci.yml",
+					"content":   waitCIYAML,
+				}},
 			},
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline create: %v", err)
+		if ciErr != nil {
+			t.Fatalf("meta commit CI config: %v", ciErr)
 		}
-		mPipelineID = out.ID
-		t.Logf("Meta created pipeline ID=%d", mPipelineID)
-	})
 
-	t.Run("Meta/PipelineWait", func(t *testing.T) {
-		drainSidekiq(ctx, t, sess.glClient)
-		out, err := callToolOn[pipelines.WaitOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-			"action": "wait",
-			"params": map[string]any{
-				"project_id":       projM.pidStr(),
-				"pipeline_id":      mPipelineID,
-				"interval_seconds": 5,
-				"timeout_seconds":  600,
-				"fail_on_error":    false,
-			},
+		var mPipelineID int64
+
+		t.Run("Meta/PipelineCreate", func(t *testing.T) {
+			out, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "create",
+				"params": map[string]any{
+					"project_id": projM.pidStr(),
+					"ref":        "main",
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline create: %v", err)
+			}
+			mPipelineID = out.ID
+			t.Logf("Meta created pipeline ID=%d", mPipelineID)
 		})
-		if err != nil {
-			t.Fatalf("meta pipeline wait: %v", err)
-		}
-		if out.FinalStatus == "" {
-			t.Fatal("expected non-empty FinalStatus (meta)")
-		}
-		if out.TimedOut {
-			t.Fatalf("meta pipeline wait timed out, last status: %s", out.FinalStatus)
-		}
-		t.Logf("Meta pipeline wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
-	})
 
-	var mJobID int64
-
-	t.Run("Meta/JobList", func(t *testing.T) {
-		out, err := callToolOn[jobs.ListOutput](ctx, sess.meta, "gitlab_job", map[string]any{
-			"action": "list",
-			"params": map[string]any{
-				"project_id":  projM.pidStr(),
-				"pipeline_id": mPipelineID,
-			},
+		t.Run("Meta/PipelineWait", func(t *testing.T) {
+			drainSidekiq(ctx, t, sess.glClient)
+			out, err := callToolOn[pipelines.WaitOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+				"action": "wait",
+				"params": map[string]any{
+					"project_id":       projM.pidStr(),
+					"pipeline_id":      mPipelineID,
+					"interval_seconds": 5,
+					"timeout_seconds":  600,
+					"fail_on_error":    false,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta pipeline wait: %v", err)
+			}
+			if out.FinalStatus == "" {
+				t.Fatal("expected non-empty FinalStatus (meta)")
+			}
+			if out.TimedOut {
+				t.Fatalf("meta pipeline wait timed out, last status: %s", out.FinalStatus)
+			}
+			t.Logf("Meta pipeline wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
 		})
-		if err != nil {
-			t.Fatalf("meta job list: %v", err)
-		}
-		if len(out.Jobs) == 0 {
-			t.Fatal("expected at least 1 job (meta)")
-		}
-		mJobID = out.Jobs[0].ID
-	})
 
-	t.Run("Meta/JobWait", func(t *testing.T) {
-		out, err := callToolOn[jobs.WaitOutput](ctx, sess.meta, "gitlab_job", map[string]any{
-			"action": "wait",
-			"params": map[string]any{
-				"project_id":       projM.pidStr(),
-				"job_id":           mJobID,
-				"interval_seconds": 5,
-				"timeout_seconds":  180,
-				"fail_on_error":    false,
-			},
+		var mJobID int64
+
+		t.Run("Meta/JobList", func(t *testing.T) {
+			out, err := callToolOn[jobs.ListOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+				"action": "list",
+				"params": map[string]any{
+					"project_id":  projM.pidStr(),
+					"pipeline_id": mPipelineID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta job list: %v", err)
+			}
+			if len(out.Jobs) == 0 {
+				t.Fatal("expected at least 1 job (meta)")
+			}
+			mJobID = out.Jobs[0].ID
 		})
-		if err != nil {
-			t.Fatalf("meta job wait: %v", err)
-		}
-		if out.FinalStatus == "" {
-			t.Fatal("expected non-empty FinalStatus (meta)")
-		}
-		if out.TimedOut {
-			t.Fatalf("meta job wait timed out, last status: %s", out.FinalStatus)
-		}
-		t.Logf("Meta job wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
+
+		t.Run("Meta/JobWait", func(t *testing.T) {
+			out, err := callToolOn[jobs.WaitOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+				"action": "wait",
+				"params": map[string]any{
+					"project_id":       projM.pidStr(),
+					"job_id":           mJobID,
+					"interval_seconds": 5,
+					"timeout_seconds":  180,
+					"fail_on_error":    false,
+				},
+			})
+			if err != nil {
+				t.Fatalf("meta job wait: %v", err)
+			}
+			if out.FinalStatus == "" {
+				t.Fatal("expected non-empty FinalStatus (meta)")
+			}
+			if out.TimedOut {
+				t.Fatalf("meta job wait timed out, last status: %s", out.FinalStatus)
+			}
+			t.Logf("Meta job wait done: status=%s waited=%s polls=%d", out.FinalStatus, out.WaitedFor, out.PollCount)
+		})
 	})
 }

--- a/test/e2e/suite/wait_test.go
+++ b/test/e2e/suite/wait_test.go
@@ -8,6 +8,7 @@ package suite
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/commits"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/jobs"
@@ -31,7 +32,12 @@ wait-job:
 func TestWaitTools(t *testing.T) {
 	t.Parallel()
 	RunWithCapabilities(t, []Capability{CapabilityRunner}, func(t *testing.T, _ *E2EContext) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
+		if deadline, ok := t.Deadline(); ok {
+			cancel()
+			ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		}
+		defer cancel()
 
 		// --- Individual tool session ---
 		proj := createProject(ctx, t, sess.individual)

--- a/test/e2e/suite/wait_test.go
+++ b/test/e2e/suite/wait_test.go
@@ -72,7 +72,7 @@ func TestWaitTools(t *testing.T) {
 	})
 
 	t.Run("Individual/PipelineWait", func(t *testing.T) {
-		drainSidekiq(ctx, t)
+		drainSidekiq(ctx, t, sess.glClient)
 		failOnErr := false
 		out, err := callToolOn[pipelines.WaitOutput](ctx, sess.individual, "gitlab_pipeline_wait", pipelines.WaitInput{
 			ProjectID:       proj.pidOf(),
@@ -182,7 +182,7 @@ func TestWaitTools(t *testing.T) {
 	})
 
 	t.Run("Meta/PipelineWait", func(t *testing.T) {
-		drainSidekiq(ctx, t)
+		drainSidekiq(ctx, t, sess.glClient)
 		out, err := callToolOn[pipelines.WaitOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
 			"action": "wait",
 			"params": map[string]any{


### PR DESCRIPTION
## Summary

- Add E2E foundations for per-test context, resource cleanup, capability gates, and polling/retry helpers.
- Make Docker E2E network-dependent non-EE coverage deterministic with in-network fixture endpoints and test-owned GitLab mirror targets.
- Update E2E documentation, AI guidance, and Go source comments for the test helpers.
- Clean E2E helper lint/static-analysis findings while keeping behavior focused on the suite refactor.

## Validation

- `make test-e2e-docker` completed successfully with 1,166 tests, 0 skips, 0 failures, and 0 errors.
- `make analyze` passed all 9 static-analysis tools.
- `go vet -tags e2e ./test/e2e/suite/`
- `go test -tags e2e -c -o /dev/null ./test/e2e/suite/`
- `golangci-lint run ./test/e2e/suite/...`
- `go doc -all ./test/e2e/suite`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2E Docker mode now includes a local fixture service for deterministic webhooks, custom emoji, and mirror testing without external Internet.

* **Improvements**
  * Capability-based gating for E2E tests to safely control access and enable scoped parallelism.
  * Improved test resource lifecycle and cleanup via a ledger and more robust polling/retry helpers.
  * Makefile test pipeline now propagates failures reliably.

* **Documentation**
  * Updated E2E docs and run instructions to reflect fixture service, capabilities, and improved test flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->