### PR TITLE
Document meta-tool schema resources

### DIFF
--- a/docs/meta-tools.md
+++ b/docs/meta-tools.md
@@ -255,6 +255,45 @@ Meta-tools advertise a deliberately compact input schema by default (`META_PARAM
 
    For example, `gitlab://schema/meta/gitlab_merge_request/create` returns the JSON Schema for the `create` action's `params`. The `gitlab://schema/meta/` index resource enumerates every registered meta-tool and its actions.
 
+   The index resource returns a JSON object with the URI template and the action catalog visible for the current server configuration:
+
+   ```json
+   {
+     "uri_template": "gitlab://schema/meta/{tool}/{action}",
+     "tools": [
+       {
+         "tool": "gitlab_merge_request",
+         "actions": ["create", "get", "list", "merge"]
+       }
+     ]
+   }
+   ```
+
+   After choosing a tool/action pair, read the concrete resource for that action. For example:
+
+   ```json
+   {
+     "method": "resources/read",
+     "params": {
+       "uri": "gitlab://schema/meta/gitlab_merge_request/create"
+     }
+   }
+   ```
+
+   The response content is the JSON Schema for the `params` object only. The final tool call still uses the common meta-tool envelope:
+
+   ```json
+   {
+     "action": "create",
+     "params": {
+       "project_id": "42",
+       "source_branch": "feature/docs",
+       "target_branch": "main",
+       "title": "Update documentation"
+     }
+   }
+   ```
+
 2. **Embed schemas in the tool description** — set `META_PARAM_SCHEMA=full` (or the lighter `compact` mode) at startup. The meta-tool's `inputSchema` then exposes a `oneOf` discriminating on `action`, with the per-action params shape inlined. See [env-reference.md](env-reference.md) for size/cost trade-offs.
 
 The dispatch behaviour is identical across modes — only the schema sent to the LLM changes.

--- a/docs/resources-reference.md
+++ b/docs/resources-reference.md
@@ -92,6 +92,14 @@ Resource templates use URI variables (e.g., `{project_id}`) that the client fill
 |---|------|--------------|-------------|
 | 41 | `meta_action_schema` | `gitlab://schema/meta/{tool}/{action}` | JSON Schema for the `params` property of a specific meta-tool action. Replace `{tool}` with a meta-tool name (e.g. `gitlab_merge_request`) and `{action}` with one of its actions (e.g. `create`). Use the `gitlab://schema/meta/` index resource to enumerate valid combinations. Always available regardless of `META_PARAM_SCHEMA` mode. |
 
+The schema resources are designed for meta-tool clients that keep the default compact schema mode (`META_PARAM_SCHEMA=opaque`). The normal discovery flow is:
+
+1. Read `gitlab://schema/meta/` to list every registered meta-tool and action available in the current server configuration. The response is a JSON object with `uri_template` and a sorted `tools` array, where each entry contains `tool` and `actions`.
+2. Read `gitlab://schema/meta/{tool}/{action}` for the action you want to call. The response is the JSON Schema for that action's `params` object, not the full `{action, params}` envelope.
+3. Call the meta-tool with the shared envelope: `{"action":"create","params":{...}}`.
+
+For example, `gitlab://schema/meta/gitlab_merge_request/create` returns the parameter schema for the `create` action of `gitlab_merge_request`. If a route has no captured schema, the template resource returns a permissive object schema with `additionalProperties: true` and a description explaining that `{}` is acceptable or that the meta-tool description should be consulted.
+
 ## Workflow Guide Resources (5)
 
 Static best-practice guides that provide AI assistants with GitLab workflow knowledge without requiring API calls.

--- a/site/src/content/docs/es/tools/meta-tools.mdx
+++ b/site/src/content/docs/es/tools/meta-tools.mdx
@@ -42,22 +42,66 @@ flowchart LR
 
 El parámetro action siempre es requerido y debe ser uno de los valores enumerados. Los parámetros adicionales dependen de la acción elegida.
 
+## Descubrir parámetros por acción
+
+Las meta-herramientas usan un sobre común:
+
+```json
+{
+  "action": "create",
+  "params": {
+    "project_id": "42"
+  }
+}
+```
+
+Por defecto, `META_PARAM_SCHEMA=opaque` mantiene pequeño el schema de la herramienta: los clientes ven el enum válido de `action`, mientras `params` queda como un objeto específico de la acción. Para descubrir la forma exacta de una acción concreta, lee los recursos de schema:
+
+| Recurso                                | Uso                                                                                                              |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `gitlab://schema/meta/`                | Lista todas las meta-herramientas registradas y las acciones disponibles en la configuración actual del servidor |
+| `gitlab://schema/meta/{tool}/{action}` | Devuelve el JSON Schema del objeto `params` de una acción concreta                                               |
+
+Ejemplos de lectura de recursos:
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/"
+  }
+}
+```
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
+  }
+}
+```
+
+La respuesta del schema por acción describe solo `params`. La llamada final a la herramienta sigue usando el sobre de meta-herramienta con `action` y `params`. Estos recursos están siempre disponibles, incluso si configuras `META_PARAM_SCHEMA=compact` o `META_PARAM_SCHEMA=full` para incluir más detalle de schema en `tools/list`.
+
 ## Ejemplos de uso
 
 ### Crear un issue
 
 ```json
 {
-	"tool": "gitlab_issue",
-	"arguments": {
-		"action": "create",
-		"project": "my-group/my-project",
-		"title": "Update API documentation",
-		"description": "The REST API docs are missing the new v2 endpoints",
-		"labels": "documentation,api",
-		"assignee_ids": "42",
-		"milestone_id": 7
-	}
+  "tool": "gitlab_issue",
+  "arguments": {
+    "action": "create",
+    "params": {
+      "project_id": "my-group/my-project",
+      "title": "Update API documentation",
+      "description": "The REST API docs are missing the new v2 endpoints",
+      "labels": "documentation,api",
+      "assignee_ids": "42",
+      "milestone_id": 7
+    }
+  }
 }
 ```
 
@@ -65,14 +109,16 @@ El parámetro action siempre es requerido y debe ser uno de los valores enumerad
 
 ```json
 {
-	"tool": "gitlab_merge_request",
-	"arguments": {
-		"action": "list",
-		"project": "my-group/my-project",
-		"state": "opened",
-		"order_by": "updated_at",
-		"per_page": 20
-	}
+  "tool": "gitlab_merge_request",
+  "arguments": {
+    "action": "list",
+    "params": {
+      "project_id": "my-group/my-project",
+      "state": "opened",
+      "order_by": "updated_at",
+      "per_page": 20
+    }
+  }
 }
 ```
 
@@ -80,12 +126,14 @@ El parámetro action siempre es requerido y debe ser uno de los valores enumerad
 
 ```json
 {
-	"tool": "gitlab_search",
-	"arguments": {
-		"action": "code",
-		"search": "func handleWebhook",
-		"project": "my-group/my-project"
-	}
+  "tool": "gitlab_search",
+  "arguments": {
+    "action": "code",
+    "params": {
+      "search": "func handleWebhook",
+      "project_id": "my-group/my-project"
+    }
+  }
 }
 ```
 
@@ -210,8 +258,9 @@ Puedes comprobar qué herramientas tiene registradas tu servidor mirando la sali
 
 ## Configuración
 
-| Variable            | Predeterminado | Descripción                                                                                               |
-| ------------------- | -------------- | --------------------------------------------------------------------------------------------------------- |
-| `META_TOOLS`        | `true`         | Habilitar modo meta-herramientas. Establecer a `false` para herramientas individuales.                    |
-| `GITLAB_ENTERPRISE` | `false`        | Habilitar meta-herramientas solo enterprise en modo stdio (requiere Premium/Ultimate).                    |
-| `--enterprise`      | `false`        | En modo HTTP, forzar meta-herramientas enterprise; omítelo para autodetectar CE/EE por entrada token+URL. |
+| Variable            | Predeterminado | Descripción                                                                                                                                                           |
+| ------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `META_TOOLS`        | `true`         | Habilitar modo meta-herramientas. Establecer a `false` para herramientas individuales.                                                                                |
+| `META_PARAM_SCHEMA` | `opaque`       | Controla cuánto schema de `params` por acción se incluye en `tools/list`: `opaque`, `compact` o `full`. Los recursos de schema siguen disponibles en todos los modos. |
+| `GITLAB_ENTERPRISE` | `false`        | Habilitar meta-herramientas solo enterprise en modo stdio (requiere Premium/Ultimate).                                                                                |
+| `--enterprise`      | `false`        | En modo HTTP, forzar meta-herramientas enterprise; omítelo para autodetectar CE/EE por entrada token+URL.                                                             |

--- a/site/src/content/docs/es/tools/meta-tools.mdx
+++ b/site/src/content/docs/es/tools/meta-tools.mdx
@@ -48,10 +48,10 @@ Las meta-herramientas usan un sobre común:
 
 ```json
 {
-  "action": "create",
-  "params": {
-    "project_id": "42"
-  }
+	"action": "create",
+	"params": {
+		"project_id": "42"
+	}
 }
 ```
 
@@ -66,19 +66,19 @@ Ejemplos de lectura de recursos:
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/"
+	}
 }
 ```
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/gitlab_merge_request/create"
+	}
 }
 ```
 
@@ -90,18 +90,18 @@ La respuesta del schema por acción describe solo `params`. La llamada final a l
 
 ```json
 {
-  "tool": "gitlab_issue",
-  "arguments": {
-    "action": "create",
-    "params": {
-      "project_id": "my-group/my-project",
-      "title": "Update API documentation",
-      "description": "The REST API docs are missing the new v2 endpoints",
-      "labels": "documentation,api",
-      "assignee_ids": "42",
-      "milestone_id": 7
-    }
-  }
+	"tool": "gitlab_issue",
+	"arguments": {
+		"action": "create",
+		"params": {
+			"project_id": "my-group/my-project",
+			"title": "Update API documentation",
+			"description": "The REST API docs are missing the new v2 endpoints",
+			"labels": "documentation,api",
+			"assignee_ids": "42",
+			"milestone_id": 7
+		}
+	}
 }
 ```
 
@@ -109,16 +109,16 @@ La respuesta del schema por acción describe solo `params`. La llamada final a l
 
 ```json
 {
-  "tool": "gitlab_merge_request",
-  "arguments": {
-    "action": "list",
-    "params": {
-      "project_id": "my-group/my-project",
-      "state": "opened",
-      "order_by": "updated_at",
-      "per_page": 20
-    }
-  }
+	"tool": "gitlab_merge_request",
+	"arguments": {
+		"action": "list",
+		"params": {
+			"project_id": "my-group/my-project",
+			"state": "opened",
+			"order_by": "updated_at",
+			"per_page": 20
+		}
+	}
 }
 ```
 
@@ -126,14 +126,14 @@ La respuesta del schema por acción describe solo `params`. La llamada final a l
 
 ```json
 {
-  "tool": "gitlab_search",
-  "arguments": {
-    "action": "code",
-    "params": {
-      "search": "func handleWebhook",
-      "project_id": "my-group/my-project"
-    }
-  }
+	"tool": "gitlab_search",
+	"arguments": {
+		"action": "code",
+		"params": {
+			"search": "func handleWebhook",
+			"project_id": "my-group/my-project"
+		}
+	}
 }
 ```
 

--- a/site/src/content/docs/es/tools/resources-prompts.mdx
+++ b/site/src/content/docs/es/tools/resources-prompts.mdx
@@ -117,10 +117,10 @@ Los clientes MCP pueden solicitar recursos en cualquier momento usando el métod
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://user/current"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://user/current"
+	}
 }
 ```
 
@@ -130,19 +130,19 @@ Para inspeccionar parámetros de meta-herramientas, lee primero el índice de sc
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/"
+	}
 }
 ```
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/gitlab_merge_request/create"
+	}
 }
 ```
 
@@ -245,14 +245,14 @@ Los prompts se solicitan mediante el método MCP `prompts/get`:
 
 ```json
 {
-  "method": "prompts/get",
-  "params": {
-    "name": "review_mr",
-    "arguments": {
-      "project_id": "my-group/my-project",
-      "merge_request_iid": "42"
-    }
-  }
+	"method": "prompts/get",
+	"params": {
+		"name": "review_mr",
+		"arguments": {
+			"project_id": "my-group/my-project",
+			"merge_request_iid": "42"
+		}
+	}
 }
 ```
 

--- a/site/src/content/docs/es/tools/resources-prompts.mdx
+++ b/site/src/content/docs/es/tools/resources-prompts.mdx
@@ -26,6 +26,14 @@ El servidor expone **46 recursos** en varias categorías:
 | -------------------------------------- | ----------------------------------------------------------------- |
 | `gitlab://schema/meta/{tool}/{action}` | JSON Schema para los `params` de una acción concreta de meta-tool |
 
+Usa los recursos de meta-esquema cuando un cliente necesite la forma exacta de los parámetros de una acción de meta-herramienta sin expandir todos los schemas en `tools/list`.
+
+1. Lee `gitlab://schema/meta/` para obtener un catálogo JSON con `uri_template` y una lista ordenada de meta-herramientas y acciones registradas.
+2. Sustituye `{tool}` y `{action}` en `gitlab://schema/meta/{tool}/{action}` para leer el JSON Schema del objeto `params` de esa acción.
+3. Llama a la meta-herramienta con el sobre normal `{ "action": "...", "params": { ... } }`.
+
+Por ejemplo, `gitlab://schema/meta/gitlab_merge_request/create` devuelve el schema de parámetros para la acción `create` de `gitlab_merge_request`. Estos recursos de schema están disponibles sin importar el modo de `META_PARAM_SCHEMA`.
+
 ### Plantillas de recursos de proyecto (23)
 
 | Recurso                                                      | Descripción                                                                                 |
@@ -109,14 +117,34 @@ Los clientes MCP pueden solicitar recursos en cualquier momento usando el métod
 
 ```json
 {
-	"method": "resources/read",
-	"params": {
-		"uri": "gitlab://user/current"
-	}
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://user/current"
+  }
 }
 ```
 
 El servidor devuelve el contenido del recurso como datos JSON estructurados.
+
+Para inspeccionar parámetros de meta-herramientas, lee primero el índice de schemas y después el schema de la acción:
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/"
+  }
+}
+```
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
+  }
+}
+```
 
 ## Prompts
 
@@ -217,14 +245,14 @@ Los prompts se solicitan mediante el método MCP `prompts/get`:
 
 ```json
 {
-	"method": "prompts/get",
-	"params": {
-		"name": "review_mr",
-		"arguments": {
-			"project_id": "my-group/my-project",
-			"merge_request_iid": "42"
-		}
-	}
+  "method": "prompts/get",
+  "params": {
+    "name": "review_mr",
+    "arguments": {
+      "project_id": "my-group/my-project",
+      "merge_request_iid": "42"
+    }
+  }
 }
 ```
 

--- a/site/src/content/docs/tools/meta-tools.mdx
+++ b/site/src/content/docs/tools/meta-tools.mdx
@@ -48,10 +48,10 @@ Meta-tools use a common envelope:
 
 ```json
 {
-  "action": "create",
-  "params": {
-    "project_id": "42"
-  }
+	"action": "create",
+	"params": {
+		"project_id": "42"
+	}
 }
 ```
 
@@ -66,19 +66,19 @@ Example resource reads:
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/"
+	}
 }
 ```
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/gitlab_merge_request/create"
+	}
 }
 ```
 
@@ -90,18 +90,18 @@ The per-action schema response describes only `params`. The final tool call stil
 
 ```json
 {
-  "tool": "gitlab_issue",
-  "arguments": {
-    "action": "create",
-    "params": {
-      "project_id": "my-group/my-project",
-      "title": "Update API documentation",
-      "description": "The REST API docs are missing the new v2 endpoints",
-      "labels": "documentation,api",
-      "assignee_ids": "42",
-      "milestone_id": 7
-    }
-  }
+	"tool": "gitlab_issue",
+	"arguments": {
+		"action": "create",
+		"params": {
+			"project_id": "my-group/my-project",
+			"title": "Update API documentation",
+			"description": "The REST API docs are missing the new v2 endpoints",
+			"labels": "documentation,api",
+			"assignee_ids": "42",
+			"milestone_id": 7
+		}
+	}
 }
 ```
 
@@ -109,16 +109,16 @@ The per-action schema response describes only `params`. The final tool call stil
 
 ```json
 {
-  "tool": "gitlab_merge_request",
-  "arguments": {
-    "action": "list",
-    "params": {
-      "project_id": "my-group/my-project",
-      "state": "opened",
-      "order_by": "updated_at",
-      "per_page": 20
-    }
-  }
+	"tool": "gitlab_merge_request",
+	"arguments": {
+		"action": "list",
+		"params": {
+			"project_id": "my-group/my-project",
+			"state": "opened",
+			"order_by": "updated_at",
+			"per_page": 20
+		}
+	}
 }
 ```
 
@@ -126,14 +126,14 @@ The per-action schema response describes only `params`. The final tool call stil
 
 ```json
 {
-  "tool": "gitlab_search",
-  "arguments": {
-    "action": "code",
-    "params": {
-      "search": "func handleWebhook",
-      "project_id": "my-group/my-project"
-    }
-  }
+	"tool": "gitlab_search",
+	"arguments": {
+		"action": "code",
+		"params": {
+			"search": "func handleWebhook",
+			"project_id": "my-group/my-project"
+		}
+	}
 }
 ```
 

--- a/site/src/content/docs/tools/meta-tools.mdx
+++ b/site/src/content/docs/tools/meta-tools.mdx
@@ -42,22 +42,66 @@ flowchart LR
 
 The action parameter is always required and must be one of the enumerated values. Additional parameters depend on the chosen action.
 
+## Discovering action parameters
+
+Meta-tools use a common envelope:
+
+```json
+{
+  "action": "create",
+  "params": {
+    "project_id": "42"
+  }
+}
+```
+
+By default, `META_PARAM_SCHEMA=opaque` keeps the tool schema small: clients see the valid `action` enum, while `params` remains an action-specific object. To discover the exact shape for a specific action, read the schema resources:
+
+| Resource                               | Use                                                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `gitlab://schema/meta/`                | Lists every registered meta-tool and the actions available in the current server configuration |
+| `gitlab://schema/meta/{tool}/{action}` | Returns the JSON Schema for the `params` object of one concrete action                         |
+
+Example resource reads:
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/"
+  }
+}
+```
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
+  }
+}
+```
+
+The per-action schema response describes only `params`. The final tool call still uses the meta-tool envelope with both `action` and `params`. These resources are always available, even if you set `META_PARAM_SCHEMA=compact` or `META_PARAM_SCHEMA=full` to inline more schema detail in `tools/list`.
+
 ## Example usage
 
 ### Creating an issue
 
 ```json
 {
-	"tool": "gitlab_issue",
-	"arguments": {
-		"action": "create",
-		"project": "my-group/my-project",
-		"title": "Update API documentation",
-		"description": "The REST API docs are missing the new v2 endpoints",
-		"labels": "documentation,api",
-		"assignee_ids": "42",
-		"milestone_id": 7
-	}
+  "tool": "gitlab_issue",
+  "arguments": {
+    "action": "create",
+    "params": {
+      "project_id": "my-group/my-project",
+      "title": "Update API documentation",
+      "description": "The REST API docs are missing the new v2 endpoints",
+      "labels": "documentation,api",
+      "assignee_ids": "42",
+      "milestone_id": 7
+    }
+  }
 }
 ```
 
@@ -65,14 +109,16 @@ The action parameter is always required and must be one of the enumerated values
 
 ```json
 {
-	"tool": "gitlab_merge_request",
-	"arguments": {
-		"action": "list",
-		"project": "my-group/my-project",
-		"state": "opened",
-		"order_by": "updated_at",
-		"per_page": 20
-	}
+  "tool": "gitlab_merge_request",
+  "arguments": {
+    "action": "list",
+    "params": {
+      "project_id": "my-group/my-project",
+      "state": "opened",
+      "order_by": "updated_at",
+      "per_page": 20
+    }
+  }
 }
 ```
 
@@ -80,12 +126,14 @@ The action parameter is always required and must be one of the enumerated values
 
 ```json
 {
-	"tool": "gitlab_search",
-	"arguments": {
-		"action": "code",
-		"search": "func handleWebhook",
-		"project": "my-group/my-project"
-	}
+  "tool": "gitlab_search",
+  "arguments": {
+    "action": "code",
+    "params": {
+      "search": "func handleWebhook",
+      "project_id": "my-group/my-project"
+    }
+  }
 }
 ```
 
@@ -210,8 +258,9 @@ You can check which tools your server has registered by looking at the startup l
 
 ## Configuration
 
-| Variable            | Default | Description                                                                                    |
-| ------------------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `META_TOOLS`        | `true`  | Enable meta-tool mode. Set to `false` for individual tools.                                    |
-| `GITLAB_ENTERPRISE` | `false` | Enable enterprise-only meta-tools in stdio mode (requires Premium/Ultimate).                   |
-| `--enterprise`      | `false` | In HTTP mode, force enterprise-only meta-tools; omit to auto-detect CE/EE per token+URL entry. |
+| Variable            | Default  | Description                                                                                                                                               |
+| ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `META_TOOLS`        | `true`   | Enable meta-tool mode. Set to `false` for individual tools.                                                                                               |
+| `META_PARAM_SCHEMA` | `opaque` | Controls how much per-action `params` schema is inlined in `tools/list`: `opaque`, `compact`, or `full`. Schema resources remain available in every mode. |
+| `GITLAB_ENTERPRISE` | `false`  | Enable enterprise-only meta-tools in stdio mode (requires Premium/Ultimate).                                                                              |
+| `--enterprise`      | `false`  | In HTTP mode, force enterprise-only meta-tools; omit to auto-detect CE/EE per token+URL entry.                                                            |

--- a/site/src/content/docs/tools/resources-prompts.mdx
+++ b/site/src/content/docs/tools/resources-prompts.mdx
@@ -26,6 +26,14 @@ The server exposes **46 resources** across several categories:
 | -------------------------------------- | ----------------------------------------------------------- |
 | `gitlab://schema/meta/{tool}/{action}` | JSON Schema for the `params` of a specific meta-tool action |
 
+Use the meta-schema resources when a client needs the exact parameter shape for a meta-tool action without expanding every schema in `tools/list`.
+
+1. Read `gitlab://schema/meta/` to get a JSON catalog with `uri_template` and a sorted list of registered meta-tools and actions.
+2. Replace `{tool}` and `{action}` in `gitlab://schema/meta/{tool}/{action}` to read the JSON Schema for that action's `params` object.
+3. Call the meta-tool with the normal `{ "action": "...", "params": { ... } }` envelope.
+
+For example, `gitlab://schema/meta/gitlab_merge_request/create` returns the parameter schema for the `create` action of `gitlab_merge_request`. These schema resources are available regardless of `META_PARAM_SCHEMA` mode.
+
 ### Project resource templates (23)
 
 | Resource                                                     | Description                                                                        |
@@ -109,14 +117,34 @@ MCP clients can request resources at any time using the `resources/read` method:
 
 ```json
 {
-	"method": "resources/read",
-	"params": {
-		"uri": "gitlab://user/current"
-	}
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://user/current"
+  }
 }
 ```
 
 The server returns the resource content as structured JSON data.
+
+To inspect meta-tool parameters, read the schema index first and then the action schema:
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/"
+  }
+}
+```
+
+```json
+{
+  "method": "resources/read",
+  "params": {
+    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
+  }
+}
+```
 
 ## Prompts
 
@@ -217,14 +245,14 @@ Prompts are requested via the `prompts/get` MCP method:
 
 ```json
 {
-	"method": "prompts/get",
-	"params": {
-		"name": "review_mr",
-		"arguments": {
-			"project_id": "my-group/my-project",
-			"merge_request_iid": "42"
-		}
-	}
+  "method": "prompts/get",
+  "params": {
+    "name": "review_mr",
+    "arguments": {
+      "project_id": "my-group/my-project",
+      "merge_request_iid": "42"
+    }
+  }
 }
 ```
 

--- a/site/src/content/docs/tools/resources-prompts.mdx
+++ b/site/src/content/docs/tools/resources-prompts.mdx
@@ -117,10 +117,10 @@ MCP clients can request resources at any time using the `resources/read` method:
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://user/current"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://user/current"
+	}
 }
 ```
 
@@ -130,19 +130,19 @@ To inspect meta-tool parameters, read the schema index first and then the action
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/"
+	}
 }
 ```
 
 ```json
 {
-  "method": "resources/read",
-  "params": {
-    "uri": "gitlab://schema/meta/gitlab_merge_request/create"
-  }
+	"method": "resources/read",
+	"params": {
+		"uri": "gitlab://schema/meta/gitlab_merge_request/create"
+	}
 }
 ```
 
@@ -245,14 +245,14 @@ Prompts are requested via the `prompts/get` MCP method:
 
 ```json
 {
-  "method": "prompts/get",
-  "params": {
-    "name": "review_mr",
-    "arguments": {
-      "project_id": "my-group/my-project",
-      "merge_request_iid": "42"
-    }
-  }
+	"method": "prompts/get",
+	"params": {
+		"name": "review_mr",
+		"arguments": {
+			"project_id": "my-group/my-project",
+			"merge_request_iid": "42"
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
## Summary
- Document the `gitlab://schema/meta/` index resource and `gitlab://schema/meta/{tool}/{action}` action parameter schema resource in Markdown docs.
- Update English and Spanish Astro docs with the meta-tool schema discovery workflow.
- Correct meta-tool examples to use the shared `{ action, params }` envelope and document `META_PARAM_SCHEMA`.

## Version and generated files
- Verified project version references are already aligned to `1.4.1`.
- Ran `make gen-llms`; `llms.txt` and `llms-full.txt` were already up to date and produced no diff.

## Validation
- `npx markdownlint-cli2 docs/meta-tools.md docs/resources-reference.md site/src/content/docs/tools/meta-tools.mdx site/src/content/docs/es/tools/meta-tools.mdx site/src/content/docs/tools/resources-prompts.mdx site/src/content/docs/es/tools/resources-prompts.mdx`
- `cd site && npx astro build`

## Summary by Sourcery

Document meta-tool parameter schema discovery resources and clarify the shared action/params envelope across meta-tool usage.

Enhancements:
- Align meta-tool and resource examples to consistently wrap arguments in the shared `params` object and update JSON snippets and formatting accordingly in English and Spanish docs.

Documentation:
- Explain how to use the `gitlab://schema/meta/` index and per-action schema resources to discover meta-tool parameter shapes in both English and Spanish docs.
- Clarify that meta-tools use a common `{ action, params }` envelope and that schema resources describe only `params`, including an example of the schema index response.
- Document the `META_PARAM_SCHEMA` environment variable and how schema resources behave across its modes in configuration and resources reference docs.