### PR TITLE
Default stdio GitLab URL to GitLab.com

### DIFF
--- a/.github/skills/update-starlight-docs/SKILL.md
+++ b/.github/skills/update-starlight-docs/SKILL.md
@@ -93,7 +93,7 @@ import { Aside, Tabs, TabItem, Card, CardGrid, Steps, FileTree, LinkCard } from 
 ### 6. Build verification
 
 ```bash
-cd site && npx astro build
+cd site && pnpm run build
 ```
 
 Must produce zero errors. Check `site/dist/` for output.
@@ -114,6 +114,6 @@ Must produce zero errors. Check `site/dist/` for output.
 - [ ] All affected ES pages updated with translated content
 - [ ] Frontmatter (title, description, sidebar order) is correct
 - [ ] Starlight components used correctly (imports present)
-- [ ] `cd site && npx astro build` succeeds with zero errors
+- [ ] `cd site && pnpm run build` succeeds with zero errors
 - [ ] No broken internal links between pages
 - [ ] Developer docs (`docs/`) also updated if applicable

--- a/Makefile
+++ b/Makefile
@@ -431,12 +431,11 @@ endif
 	docker push $(DOCKER_REGISTRY):$(VERSION)
 	docker push $(DOCKER_REGISTRY):latest
 
+GITLAB_URL ?= https://gitlab.com
+
 ## docker-run: run the Docker image locally in HTTP mode (port 8080)
-## Usage: make docker-run GITLAB_URL=https://gitlab.example.com
+## Usage: make docker-run [GITLAB_URL=https://gitlab.example.com]
 docker-run:
-ifndef GITLAB_URL
-	$(error GITLAB_URL is required. Usage: make docker-run GITLAB_URL=https://gitlab.example.com)
-endif
 	docker run --rm -p 8080:8080 \
 		$(BINARY_NAME):latest \
 		--http \
@@ -570,7 +569,7 @@ checksum:
 	@cat dist/checksums.txt
 
 # ─── MCP Inspector ───────────────────────────────────────────────────────────
-# Requires: Node.js >= 22, npx, .env with GITLAB_URL and GITLAB_TOKEN.
+# Requires: Node.js >= 22, npx, .env with GITLAB_TOKEN. Add GITLAB_URL for self-managed instances.
 # Compiles a fresh binary to /tmp, launches the Inspector, and cleans up on exit.
 
 INSPECTOR_BIN := /tmp/$(BINARY_NAME)-inspector$(BINARY_EXT)
@@ -578,7 +577,7 @@ INSPECTOR_BIN := /tmp/$(BINARY_NAME)-inspector$(BINARY_EXT)
 ## inspector: compile the server and launch MCP Inspector UI via stdio.
 ## Reads credentials from .env. The temporary binary is removed on exit.
 inspector:
-	@if [ ! -f .env ]; then echo "ERROR: .env file not found. Create it with GITLAB_URL and GITLAB_TOKEN."; exit 1; fi
+	@if [ ! -f .env ]; then echo "ERROR: .env file not found. Create it with GITLAB_TOKEN; add GITLAB_URL for self-managed instances."; exit 1; fi
 	@echo "Compiling $(BINARY_NAME) to $(INSPECTOR_BIN)..."
 	@go build -ldflags="$(LDFLAGS)" -o $(INSPECTOR_BIN) $(CMD_PATH)
 	@echo "Starting MCP Inspector (stdio) — press Ctrl+C to stop..."
@@ -587,7 +586,7 @@ inspector:
 		ALLOWED_ORIGINS="http://localhost:6274,http://127.0.0.1:6274,http://0.0.0.0:6274" \
 		HOST=0.0.0.0 \
 		npx -y @modelcontextprotocol/inspector \
-			-e GITLAB_URL="$$GITLAB_URL" \
+			-e GITLAB_URL="$${GITLAB_URL:-https://gitlab.com}" \
 			-e GITLAB_TOKEN="$$GITLAB_TOKEN" \
 			-e GITLAB_SKIP_TLS_VERIFY="$${GITLAB_SKIP_TLS_VERIFY:-false}" \
 			-e AUTO_UPDATE=false \

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ chmod +x gitlab-mcp-server-*  # Linux/macOS only
 
 **Or configure manually** — expand your client below:
 
+`GITLAB_URL` defaults to `https://gitlab.com`; add it only when you connect to a self-managed GitLab instance.
+
 <details>
 <summary><strong>VS Code (GitHub Copilot)</strong></summary>
 
@@ -90,7 +92,6 @@ Add to `.vscode/mcp.json` in your workspace:
       "type": "stdio",
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -111,7 +112,6 @@ Add to `claude_desktop_config.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -132,7 +132,6 @@ Add to `.cursor/mcp.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -147,7 +146,6 @@ Add to `.cursor/mcp.json`:
 
 ```bash
 claude mcp add gitlab /path/to/gitlab-mcp-server \
-  -e GITLAB_URL=https://gitlab.example.com \
   -e GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
@@ -164,7 +162,6 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -186,7 +183,6 @@ Add to the MCP configuration in **Settings → Tools → AI Assistant → MCP Se
       "type": "stdio",
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -208,7 +204,6 @@ Add to Zed settings (`settings.json`):
       "command": "/path/to/gitlab-mcp-server",
       "args": [],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -230,7 +225,6 @@ Add to `.kiro/settings/mcp.json`:
       "command": "/path/to/gitlab-mcp-server",
       "args": [],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -255,7 +249,6 @@ Open the Cline sidebar in VS Code → click the MCP servers icon → **Edit Glob
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -276,7 +269,6 @@ Open the Roo Code sidebar in VS Code → MCP servers icon → **Edit Global MCP*
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -425,12 +417,12 @@ following patterns depending on how your MCP client connects.
 ```bash
 docker pull ghcr.io/jmrplens/gitlab-mcp-server:latest
 
-# Single-instance mode (fixed GitLab URL for all clients)
+# Single-instance mode (fixed GitLab.com URL for all clients; replace for self-managed GitLab)
 docker run -d --name gitlab-mcp-server -p 8080:8080 \
   ghcr.io/jmrplens/gitlab-mcp-server:latest \
   --http \
   --http-addr=0.0.0.0:8080 \
-  --gitlab-url=https://gitlab.example.com
+  --gitlab-url=https://gitlab.com
 
 # Multi-instance mode (clients send GITLAB-URL header per request)
 docker run -d --name gitlab-mcp-server -p 8080:8080 \
@@ -460,8 +452,6 @@ for this mode.
         "-i",
         "--rm",
         "-e",
-        "GITLAB_URL",
-        "-e",
         "GITLAB_TOKEN",
         "-e",
         "GITLAB_SKIP_TLS_VERIFY",
@@ -469,7 +459,6 @@ for this mode.
         "--http=false"
       ],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "${input:gitlab-token}",
         "GITLAB_SKIP_TLS_VERIFY": "false"
       }
@@ -480,10 +469,12 @@ for this mode.
 
 ## FAQ
 
+For self-managed GitLab in Docker stdio mode, add `GITLAB_URL` to `env` and pass `-e GITLAB_URL` in `args`.
+
 <details>
 <summary><strong>Does it work with self-hosted GitLab?</strong></summary>
 
-Yes. Set `GITLAB_URL` to your instance URL. Self-signed TLS certificates are supported via `GITLAB_SKIP_TLS_VERIFY=true`.
+Yes. Set `GITLAB_URL` to your instance URL. When `GITLAB_URL` is omitted, stdio mode uses `https://gitlab.com`. Self-signed TLS certificates are supported via `GITLAB_SKIP_TLS_VERIFY=true`.
 </details>
 
 <details>

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -206,7 +206,7 @@ func writeLLMSTxt(version string, individual, metaBase, metaEnterprise []*mcp.To
 	b.WriteString("3. The wizard configures your AI client (VS Code, Cursor, Claude Desktop, etc.)\n\n")
 
 	b.WriteString("## Configuration (environment variables — stdio mode)\n\n")
-	b.WriteString("- GITLAB_URL: GitLab instance URL (required)\n")
+	b.WriteString("- GITLAB_URL: GitLab instance URL (default: https://gitlab.com; set for self-managed instances)\n")
 	b.WriteString("- GITLAB_TOKEN: Personal Access Token (required)\n")
 	b.WriteString("- GITLAB_SKIP_TLS_VERIFY: Skip TLS verification for self-signed certs (default: false)\n")
 	b.WriteString("- META_TOOLS: Enable meta-tools for reduced tool count (default: true)\n")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -235,7 +235,7 @@ FLAGS
   -trusted-proxy-header str HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
 
 ENVIRONMENT VARIABLES (stdio mode)
-  GITLAB_URL                GitLab instance URL (e.g. https://gitlab.example.com)
+  GITLAB_URL                GitLab instance URL (default: https://gitlab.com; set for self-managed instances)
   GITLAB_TOKEN              Personal Access Token (glpat-...)
   GITLAB_SKIP_TLS_VERIFY    Skip TLS verification: true/false (default false)
   META_TOOLS                Enable meta-tools: true/false (default true)
@@ -974,7 +974,7 @@ func buildServerCard(cfg *config.Config) ([]byte, error) {
 	// parseable URL to register tools; it never makes real API calls.
 	gitlabURL := cfg.GitLabURL
 	if gitlabURL == "" {
-		gitlabURL = "https://gitlab.com"
+		gitlabURL = config.DefaultGitLabURL
 	}
 
 	dummyClient, err := gitlabclient.NewClientWithToken(gitlabURL, "dummy-token-for-tool-discovery", cfg.SkipTLSVerify)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -160,7 +160,7 @@ func parseJSONRPCResponse(t *testing.T, resp *http.Response) map[string]any {
 }
 
 // TestRun_InvalidConfig_ReturnsError verifies that [run] returns an error when
-// required environment variables (GITLAB_URL, GITLAB_TOKEN) are missing.
+// required environment variables are missing.
 func TestRun_InvalidConfig_ReturnsError(t *testing.T) {
 	t.Setenv("GITLAB_URL", "")
 	t.Setenv("GITLAB_TOKEN", "")
@@ -171,8 +171,8 @@ func TestRun_InvalidConfig_ReturnsError(t *testing.T) {
 	}
 
 	msg := err.Error()
-	if !strings.Contains(msg, "GITLAB_URL") && !strings.Contains(msg, "GITLAB_TOKEN") {
-		t.Errorf("error should mention GITLAB_URL or GITLAB_TOKEN, got: %s", msg)
+	if !strings.Contains(msg, "GITLAB_TOKEN") {
+		t.Errorf("error should mention GITLAB_TOKEN, got: %s", msg)
 	}
 }
 
@@ -546,7 +546,7 @@ func TestRunWithContext_SuccessStdio(t *testing.T) {
 }
 
 // TestRunWithContext_InvalidConfig verifies that [runWithContext] returns an
-// error when configuration is invalid (missing required fields).
+// error when configuration is invalid.
 func TestRunWithContext_InvalidConfig(t *testing.T) {
 	t.Setenv("GITLAB_URL", "")
 	t.Setenv("GITLAB_TOKEN", "")
@@ -554,6 +554,9 @@ func TestRunWithContext_InvalidConfig(t *testing.T) {
 	err := runWithContext(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected error when config is invalid")
+	}
+	if !strings.Contains(err.Error(), "GITLAB_TOKEN") {
+		t.Fatalf("error = %q, want GITLAB_TOKEN", err.Error())
 	}
 }
 
@@ -2182,6 +2185,25 @@ func TestRunHTTP_InvalidAuthMode(t *testing.T) {
 	}
 }
 
+// TestRunHTTP_OAuthRequiresGitLabURL verifies that OAuth mode requires a
+// fixed GitLab URL and cannot silently fall back to HTTP multi-instance mode.
+func TestRunHTTP_OAuthRequiresGitLabURL(t *testing.T) {
+	err := runHTTP(context.Background(), &httpConfig{
+		gitlabURL:         "",
+		maxHTTPClients:    config.DefaultMaxHTTPClients,
+		sessionTimeout:    config.DefaultSessionTimeout,
+		autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
+		authMode:          "oauth",
+		oauthCacheTTL:     config.DefaultOAuthCacheTTL,
+	})
+	if err == nil {
+		t.Fatal("expected error when OAuth mode has no fixed GitLab URL")
+	}
+	if !strings.Contains(err.Error(), "--auth-mode=oauth requires --gitlab-url") {
+		t.Errorf("error = %q, want OAuth GitLab URL requirement", err.Error())
+	}
+}
+
 // TestRunHTTP_OAuthCacheTTL_BelowMin verifies that runHTTP rejects an
 // oauth-cache-ttl below the minimum allowed value.
 func TestRunHTTP_OAuthCacheTTL_BelowMin(t *testing.T) {
@@ -2623,7 +2645,7 @@ func TestBuildServerCard_ReturnsValidJSON(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		GitLabURL:     "", // empty — buildServerCard falls back to https://gitlab.com
+		GitLabURL:     "", // empty uses config.DefaultGitLabURL for dummy client registration
 		SkipTLSVerify: true,
 		MetaTools:     true,
 		Enterprise:    false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,11 +141,11 @@ The `main()` function supports two runtime modes:
 
 ### Configuration (`internal/config`)
 
-Loads settings from environment variables with optional `.env` file support (via `godotenv`). Used by **stdio mode** to validate that required variables (`GITLAB_URL`, `GITLAB_TOKEN`) are present. HTTP mode uses CLI flags instead (see Transport Selection).
+Loads settings from environment variables with optional `.env` file support (via `godotenv`). Used by **stdio mode** to validate that `GITLAB_TOKEN` is present and to default `GITLAB_URL` to `https://gitlab.com` when omitted. HTTP mode uses CLI flags instead (see Transport Selection).
 
 | Variable                 | Required | Default | Description                                          |
 | ------------------------ | -------- | ------- | ---------------------------------------------------- |
-| `GITLAB_URL`             | Stdio    | —       | GitLab instance base URL                             |
+| `GITLAB_URL`             | Stdio    | `https://gitlab.com` | GitLab instance base URL                             |
 | `GITLAB_TOKEN`           | Stdio    | —       | Personal Access Token with `api` scope               |
 | `GITLAB_SKIP_TLS_VERIFY` | No       | `false` | Skip TLS certificate verification                    |
 | `META_TOOLS`             | No       | `true`  | Use meta-tools instead of individual tools            |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ Loads settings from environment variables with optional `.env` file support (via
 
 | Variable                 | Required | Default | Description                                          |
 | ------------------------ | -------- | ------- | ---------------------------------------------------- |
-| `GITLAB_URL`             | Stdio    | `https://gitlab.com` | GitLab instance base URL                             |
+| `GITLAB_URL`             | No       | `https://gitlab.com` | GitLab instance base URL                             |
 | `GITLAB_TOKEN`           | Stdio    | —       | Personal Access Token with `api` scope               |
 | `GITLAB_SKIP_TLS_VERIFY` | No       | `false` | Skip TLS certificate verification                    |
 | `META_TOOLS`             | No       | `true`  | Use meta-tools instead of individual tools            |

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -411,7 +411,6 @@ jobs:
   list-issues:
     runs-on: ubuntu-latest
     env:
-      GITLAB_URL: https://gitlab.example.com
       GITLAB_TOKEN: ${{ secrets.MCP_PAT }}
     steps:
       - name: Download gitlab-mcp-server
@@ -443,7 +442,6 @@ jobs:
   review:
     runs-on: ubuntu-latest
     env:
-      GITLAB_URL: https://gitlab.example.com
       GITLAB_TOKEN: ${{ secrets.MCP_PAT }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_KEY }}
     steps:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,10 +72,11 @@ The server reads configuration from environment variables and communicates via s
 
 ```bash
 # Configuration via environment variables
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 gitlab-mcp-server
 ```
+
+Set `GITLAB_URL` only for self-managed instances; stdio mode defaults to `https://gitlab.com`.
 
 ```bash
 # Configuration via .env file in current directory
@@ -87,11 +88,11 @@ gitlab-mcp-server
 The server listens on an HTTP endpoint. Each client provides its own GitLab token per-request via `PRIVATE-TOKEN` header or `Authorization: Bearer`. When the server starts without `--gitlab-url`, clients also specify a `GITLAB-URL` header to target a specific GitLab instance per request. No `GITLAB_TOKEN` is needed at startup.
 
 ```bash
-# Single GitLab instance (all clients use the fixed URL)
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --http-addr=localhost:9090
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --max-http-clients=50 --session-timeout=1h
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --auth-mode=oauth --oauth-cache-ttl=15m
+# Single GitLab.com instance (all clients use the fixed URL; replace for self-managed GitLab)
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --http-addr=localhost:9090
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --max-http-clients=50 --session-timeout=1h
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth --oauth-cache-ttl=15m
 
 # Multi-instance (each client specifies their GitLab URL via GITLAB-URL header)
 gitlab-mcp-server --http --http-addr=:8080
@@ -148,19 +149,19 @@ gitlab-mcp-server -h
 gitlab-mcp-server
 
 # Start HTTP server with custom address
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --http-addr=:9090
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --http-addr=:9090
 
 # Start HTTP server without fixed URL (clients must send GITLAB-URL header)
 gitlab-mcp-server --http --http-addr=:8080
 
-# Start HTTP server with TLS skip and custom session timeout
+# Start HTTP server for self-managed GitLab with TLS skip and custom session timeout
 gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --skip-tls-verify --session-timeout=2h
 
 # Start HTTP server with individual tools (no meta-tools)
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --meta-tools=false
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --meta-tools=false
 
 # Start with auto-update in check-only mode
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --auto-update=check
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auto-update=check
 
 # Terminate all running instances (used by external updaters)
 gitlab-mcp-server --shutdown

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,13 +19,13 @@ These are the settings every user needs to get started.
 
 | Variable | Description | Example |
 | --- | --- | --- |
-| `GITLAB_URL` | GitLab instance base URL | `https://gitlab.example.com` |
 | `GITLAB_TOKEN` | Personal Access Token with `api` scope | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ### Common Options
 
 | Variable | Default | Description |
 | --- | --- | --- |
+| `GITLAB_URL` | `https://gitlab.com` | GitLab instance base URL. Set this for self-managed instances |
 | `GITLAB_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed certs |
 | `META_TOOLS` | `true` | Enable domain-level meta-tools (32 base / 47 enterprise instead of 1006) |
 | `GITLAB_ENTERPRISE` | `false` | Enable Enterprise/Premium tools in stdio mode. In HTTP mode, `--enterprise` explicitly forces the Enterprise/Premium catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
@@ -38,14 +38,15 @@ These are the settings every user needs to get started.
 ### .env File Example
 
 ```env
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
-GITLAB_SKIP_TLS_VERIFY=true
+GITLAB_SKIP_TLS_VERIFY=false
 META_TOOLS=true
 GITLAB_READ_ONLY=false
 GITLAB_SAFE_MODE=false
 LOG_LEVEL=info
 ```
+
+For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
 
 > **Security**: The `.env` file is gitignored. Never commit tokens or credentials.
 
@@ -104,7 +105,6 @@ VS Code [input variables](https://code.visualstudio.com/docs/copilot/reference/m
       "type": "stdio",
       "command": "/usr/local/bin/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "${input:gitlab-token}",
         "META_TOOLS": "true"
       }
@@ -132,11 +132,12 @@ VS Code supports loading all environment variables from a file on disk via the `
 Where `~/.gitlab-mcp-server.env` (or any path you choose) contains:
 
 ```env
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 GITLAB_SKIP_TLS_VERIFY=true
 META_TOOLS=true
 ```
+
+Add `GITLAB_URL=https://gitlab.example.com` for self-managed GitLab.
 
 > **Tip**: You can combine `envFile` with `env` — values in `env` override those from `envFile`.
 
@@ -236,10 +237,12 @@ To enable server-side token verification, set `--auth-mode=oauth`:
 
 ```bash
 gitlab-mcp-server --http \
-  --gitlab-url=https://gitlab.example.com \
+  --gitlab-url=https://gitlab.com \
   --auth-mode=oauth \
   --oauth-cache-ttl=15m
 ```
+
+Replace `https://gitlab.com` with your self-managed GitLab URL when needed.
 
 With OAuth mode:
 
@@ -276,4 +279,4 @@ Configuration is loaded by `internal/config/` in this order:
 
 > **Note**: `godotenv` does not overwrite existing variables, so values from step 1 take precedence over step 2, and explicit environment variables (step 3) override both.
 
-The `config.Load()` function validates that `GITLAB_URL` and `GITLAB_TOKEN` are set (used by stdio mode only). In HTTP mode, configuration comes from CLI flags and no token is required at startup — each client provides its own token per-request via `PRIVATE-TOKEN` or `Authorization: Bearer` headers. Clients can provide `GITLAB-URL` only in multi-instance mode, when the server starts without `--gitlab-url`; all other MCP server settings are process policy and cannot be overridden per request. When `--auth-mode=oauth`, the server validates tokens against the GitLab `/api/v4/user` endpoint and caches verified identities with a configurable TTL (see [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode)).
+The `config.Load()` function validates that `GITLAB_TOKEN` is set and defaults `GITLAB_URL` to `https://gitlab.com` when it is omitted (stdio mode only). In HTTP mode, configuration comes from CLI flags and no token is required at startup — each client provides its own token per-request via `PRIVATE-TOKEN` or `Authorization: Bearer` headers. Clients can provide `GITLAB-URL` only in multi-instance mode, when the server starts without `--gitlab-url`; all other MCP server settings are process policy and cannot be overridden per request. When `--auth-mode=oauth`, the server validates tokens against the GitLab `/api/v4/user` endpoint and caches verified identities with a configurable TTL (see [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode)).

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -147,6 +147,8 @@ docker build \
 #### Run locally
 
 ```bash
+make docker-run
+# or, for self-managed GitLab:
 make docker-run GITLAB_URL=https://gitlab.example.com
 ```
 
@@ -273,7 +275,7 @@ make inspector-stop  # Stop Inspector processes and clean up temp binary
 
 This compiles the server to a temporary binary (`/tmp/gitlab-mcp-server-inspector`), reads credentials from `.env`, and launches the Inspector at `http://127.0.0.1:6274/`. The temporary binary is automatically cleaned up on exit.
 
-**Prerequisites**: Node.js >= 22, `.env` file with `GITLAB_URL` and `GITLAB_TOKEN`.
+**Prerequisites**: Node.js >= 22, `.env` file with `GITLAB_TOKEN`. Add `GITLAB_URL` for self-managed instances.
 
 ## Linting & Formatting
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -12,7 +12,6 @@
 
 | Variable | Description | Example |
 | --- | --- | --- |
-| `GITLAB_URL` | GitLab instance base URL (must use `http://` or `https://` scheme) | `https://gitlab.example.com` |
 | `GITLAB_TOKEN` | Personal Access Token with `api` scope | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ---
@@ -21,6 +20,7 @@
 
 | Variable | Default | Description |
 | --- | --- | --- |
+| `GITLAB_URL` | `https://gitlab.com` | GitLab instance base URL (must use `http://` or `https://` scheme). Set this for self-managed instances |
 | `GITLAB_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification (`true`/`false`). Use for self-signed certs |
 
 ---
@@ -105,16 +105,17 @@ Configuration is loaded by `internal/config/` in this precedence order (higher w
 
 ```env
 # Required
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 
 # Optional
-GITLAB_SKIP_TLS_VERIFY=true
+GITLAB_SKIP_TLS_VERIFY=false
 META_TOOLS=true
 LOG_LEVEL=info
 UPLOAD_MAX_FILE_SIZE=500MB
 AUTO_UPDATE=true
 ```
+
+For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
 
 > **Security**: The `.env` file is gitignored. Never commit tokens or credentials. The Setup Wizard writes secrets to `~/.gitlab-mcp-server.env` with `0600` permissions on Unix.
 
@@ -126,7 +127,7 @@ In HTTP mode, configuration comes from CLI flags instead of environment variable
 
 | Environment Variable | CLI Flag | Notes |
 | --- | --- | --- |
-| `GITLAB_URL` | `--gitlab-url` | Required in stdio mode. Optional in HTTP mode. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
+| `GITLAB_URL` | `--gitlab-url` | Optional in stdio mode; defaults to `https://gitlab.com`. Optional in HTTP mode. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
 | `GITLAB_TOKEN` | *(none)* | Not needed in HTTP mode — clients provide tokens per-request |
 | `GITLAB_SKIP_TLS_VERIFY` | `--skip-tls-verify` | |
 | `META_TOOLS` | `--meta-tools` | |

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -127,7 +127,7 @@ In HTTP mode, configuration comes from CLI flags instead of environment variable
 
 | Environment Variable | CLI Flag | Notes |
 | --- | --- | --- |
-| `GITLAB_URL` | `--gitlab-url` | Optional in stdio mode; defaults to `https://gitlab.com`. Optional in HTTP mode. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
+| `GITLAB_URL` | `--gitlab-url` | Optional in stdio mode; defaults to `https://gitlab.com`. Optional in HTTP mode unless `--auth-mode=oauth` is used, which requires a fixed `--gitlab-url`. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
 | `GITLAB_TOKEN` | *(none)* | Not needed in HTTP mode — clients provide tokens per-request |
 | `GITLAB_SKIP_TLS_VERIFY` | `--skip-tls-verify` | |
 | `META_TOOLS` | `--meta-tools` | |

--- a/docs/examples/usage-examples.md
+++ b/docs/examples/usage-examples.md
@@ -20,7 +20,6 @@ Configure your MCP client (VS Code, Cursor, Copilot CLI, OpenCode) with:
     "gitlab-mcp-server": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxx"
       }
     }
@@ -28,16 +27,20 @@ Configure your MCP client (VS Code, Cursor, Copilot CLI, OpenCode) with:
 }
 ```
 
+For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
+
 ### HTTP Mode
 
 Start the server with HTTP transport for multi-client scenarios:
 
 ```bash
 ./gitlab-mcp-server --http \
-  --gitlab-url=https://gitlab.example.com \
+  --gitlab-url=https://gitlab.com \
   --http-addr=:8080 \
   --max-http-clients=100
 ```
+
+Replace `https://gitlab.com` with your self-managed GitLab URL when needed.
 
 Clients connect to `http://localhost:8080/mcp` with their GitLab token in the `Authorization` header.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,7 +170,7 @@ The host passes these environment variables through to the container:
 
 | Variable                 | Required | Description                                              |
 | ------------------------ | -------- | -------------------------------------------------------- |
-| `GITLAB_URL`             | Yes      | GitLab instance URL                                      |
+| `GITLAB_URL`             | No       | GitLab instance URL. Defaults to `https://gitlab.com`; set for self-managed instances |
 | `GITLAB_TOKEN`           | Yes      | Personal Access Token                                    |
 | `GITLAB_SKIP_TLS_VERIFY` | No       | `true` for self-signed certs (default `false`)           |
 | `META_TOOLS`             | No       | Group tools per domain (default `true`)                  |
@@ -190,9 +190,10 @@ For detached HTTP deployments, do not use a stdio client entry. Run the Docker i
 If you prefer not to use the wizard, create a `.env` file next to the binary:
 
 ```env
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
+
+For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
 
 Then add the server to your MCP client config manually.
 
@@ -207,7 +208,6 @@ Add to `.vscode/mcp.json` in your project:
       "type": "stdio",
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -225,7 +225,6 @@ Add to `claude_desktop_config.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -243,7 +242,6 @@ Add to `.cursor/mcp.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -260,7 +258,8 @@ Add to `.cursor/mcp.json`:
 For shared server deployments, run in HTTP mode:
 
 ```bash
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --http-addr=:8080
+# Use https://gitlab.com for GitLab.com, or replace it with your self-managed URL.
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --http-addr=:8080
 ```
 
 Each client provides its own token via HTTP header:
@@ -285,7 +284,7 @@ For production deployments, enable server-side token verification with OAuth mod
 
 ```bash
 gitlab-mcp-server --http \
-  --gitlab-url=https://gitlab.example.com \
+  --gitlab-url=https://gitlab.com \
   --auth-mode=oauth \
   --oauth-cache-ttl=15m
 ```

--- a/docs/http-server-mode.md
+++ b/docs/http-server-mode.md
@@ -30,9 +30,9 @@ By default, gitlab-mcp-server runs in **stdio mode** — each AI client (VS Code
 HTTP mode is configured entirely via CLI flags — no environment variables are needed:
 
 ```bash
-# Single GitLab instance (all clients use the same instance)
+# Single GitLab.com instance (all clients use the same instance; replace for self-managed GitLab)
 gitlab-mcp-server --http \
-  --gitlab-url=https://gitlab.example.com \
+  --gitlab-url=https://gitlab.com \
   --http-addr=:8080
 
 # Multi-instance (each client specifies their GitLab URL via GITLAB-URL header)
@@ -195,7 +195,7 @@ The default `--auth-mode=legacy` accepts tokens via `PRIVATE-TOKEN` or `Authoriz
 
 ```bash
 gitlab-mcp-server --http \
-  --gitlab-url=https://gitlab.example.com \
+  --gitlab-url=https://gitlab.com \
   --auth-mode=oauth \
   --oauth-cache-ttl=15m
 ```

--- a/docs/ide-configuration.md
+++ b/docs/ide-configuration.md
@@ -45,6 +45,8 @@ Per-IDE MCP client configuration examples for gitlab-mcp-server, covering both s
 
 ### Stdio Mode
 
+`GITLAB_URL` defaults to `https://gitlab.com`; add it to `env` only for self-managed GitLab instances.
+
 Add to `.vscode/mcp.json`:
 
 ```json
@@ -54,7 +56,6 @@ Add to `.vscode/mcp.json`:
       "type": "stdio",
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "${input:gitlab-token}"
       }
     }
@@ -83,8 +84,6 @@ Docker stdio variant:
         "-i",
         "--rm",
         "-e",
-        "GITLAB_URL",
-        "-e",
         "GITLAB_TOKEN",
         "-e",
         "GITLAB_SKIP_TLS_VERIFY",
@@ -92,7 +91,6 @@ Docker stdio variant:
         "--http=false"
       ],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "${input:gitlab-token}",
         "GITLAB_SKIP_TLS_VERIFY": "false"
       }
@@ -166,7 +164,6 @@ Edit `claude_desktop_config.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -214,9 +211,10 @@ claude mcp add gitlab \
 Set environment variables before launching:
 
 ```bash
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 ```
+
+Set `GITLAB_URL` here only for self-managed instances.
 
 ### HTTP OAuth Mode
 
@@ -270,7 +268,6 @@ Create or edit `.cursor/mcp.json` in your project root:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -328,7 +325,6 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -362,10 +358,9 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 1. Open **Settings → Tools → AI Assistant → MCP Servers**
 2. Click **+ Add** and select **stdio**
 3. Set the command to `/path/to/gitlab-mcp-server`
-4. Add environment variables:
-   - `GITLAB_URL` = `https://gitlab.example.com`
-   - `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
-5. Click **OK** and restart the IDE
+4. Add `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
+5. Add `GITLAB_URL` only for self-managed instances
+6. Click **OK** and restart the IDE
 
 ### HTTP Legacy Mode
 
@@ -403,7 +398,6 @@ Edit your Zed `settings.json`:
       "command": "/path/to/gitlab-mcp-server",
       "args": [],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -441,7 +435,6 @@ Create or edit `.kiro/settings/mcp.json` in your project root (or `~/.kiro/setti
       "command": "/path/to/gitlab-mcp-server",
       "args": [],
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -476,7 +469,6 @@ Create or edit `.kiro/settings/mcp.json` in your project root (or `~/.kiro/setti
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -517,7 +509,6 @@ Open the Cline sidebar in VS Code → click the MCP servers icon → **Edit Glob
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }
@@ -554,7 +545,6 @@ Open the Roo Code sidebar in VS Code → click the MCP servers icon → **Edit G
     "gitlab": {
       "command": "/path/to/gitlab-mcp-server",
       "env": {
-        "GITLAB_URL": "https://gitlab.example.com",
         "GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
       }
     }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,6 @@ Common issues and solutions for gitlab-mcp-server.
 | Symptom | Cause | Solution |
 | --- | --- | --- |
 | `GITLAB_TOKEN is required` at startup | Token not set | Set `GITLAB_TOKEN` in `.env` or environment |
-| `GITLAB_URL is required` at startup | URL not set | Set `GITLAB_URL` in `.env` or use `--gitlab-url` flag. In HTTP mode, `--gitlab-url` is optional if clients send the `GITLAB-URL` header |
 | `401 Unauthorized` from GitLab API | Invalid or expired PAT | Generate a new token with `api` scope in GitLab → User Settings → Access Tokens |
 | `403 Forbidden` on specific operations | Token lacks required scope | Ensure the token has `api` scope (not just `read_api`) |
 | Connection refused or timeout | GitLab instance unreachable | Verify `GITLAB_URL` is reachable: `curl -s $GITLAB_URL/api/v4/version` |
@@ -100,7 +99,7 @@ See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode) for the fu
 | Server does not appear in MCP status | Configuration not loaded | Run `Ctrl+Shift+P` → **MCP: List Servers** to verify. Check that the binary path is absolute and the file exists |
 | "Permission denied" on startup (Linux/macOS) | Binary not executable | Run `chmod +x /path/to/gitlab-mcp-server` |
 | Token prompt does not appear | `${input:...}` misconfigured | Ensure the `inputs` array is at the top level of `mcp.json`, not inside `servers` |
-| Server restarts repeatedly | Crash loop due to missing env vars | Check Output panel → **MCP Logs** for `GITLAB_URL is required` or `GITLAB_TOKEN is required` |
+| Server restarts repeatedly | Crash loop due to missing env vars | Check Output panel → **MCP Logs** for `GITLAB_TOKEN is required` or other startup errors |
 
 ### Cursor
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,9 @@ func (c *Config) ServerConfig() *ServerConfig {
 // EnvFileName is the name of the env file where the setup wizard stores secrets.
 const EnvFileName = ".gitlab-mcp-server.env"
 
+// DefaultGitLabURL is the GitLab instance used when GITLAB_URL is unset.
+const DefaultGitLabURL = "https://gitlab.com"
+
 // Load reads configuration from environment variables.
 // It attempts to load a .env file from the current directory first, then
 // falls back to ~/.gitlab-mcp-server.env (written by the setup wizard) for
@@ -269,7 +272,7 @@ func Load() (*Config, error) {
 	}
 
 	cfg := &Config{
-		GitLabURL:          os.Getenv("GITLAB_URL"),
+		GitLabURL:          gitLabURLFromEnv(),
 		GitLabToken:        os.Getenv("GITLAB_TOKEN"),
 		SkipTLSVerify:      skipTLS,
 		MetaTools:          metaTools,
@@ -301,10 +304,18 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
+func gitLabURLFromEnv() string {
+	gitLabURL := strings.TrimSpace(os.Getenv("GITLAB_URL"))
+	if gitLabURL == "" {
+		return DefaultGitLabURL
+	}
+	return gitLabURL
+}
+
 // validate checks that all required configuration fields are present and valid.
 func (c *Config) validate() error {
 	if c.GitLabURL == "" {
-		return errors.New("GITLAB_URL is required")
+		return errors.New("GITLAB_URL cannot be empty")
 	}
 	u, err := url.Parse(c.GitLabURL)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -46,22 +47,67 @@ func TestLoad_ValidConfig(t *testing.T) {
 	}
 }
 
-// TestLoad_MissingURL verifies that [Load] returns an error when GITLAB_URL
-// is empty, since it is a required configuration field.
-func TestLoad_MissingURL(t *testing.T) {
-	t.Setenv("GITLAB_URL", "")
-	t.Setenv("GITLAB_TOKEN", testGitLabToken)
+// TestLoad_DefaultGitLabURLWhenUnset verifies that [Load] uses GitLab.com when
+// GITLAB_URL is not configured.
+func TestLoad_DefaultGitLabURLWhenUnset(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "whitespace", value: "   "},
+	}
 
-	_, err := Load()
-	if err == nil {
-		t.Fatal("Load() expected error when GITLAB_URL is empty, got nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITLAB_URL", tt.value)
+			t.Setenv("GITLAB_TOKEN", testGitLabToken)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf(fmtLoadUnexpected, err)
+			}
+			if cfg.GitLabURL != DefaultGitLabURL {
+				t.Errorf("GitLabURL = %q, want %q", cfg.GitLabURL, DefaultGitLabURL)
+			}
+		})
+	}
+}
+
+// TestLoad_InvalidExplicitGitLabURL verifies that malformed explicit
+// GITLAB_URL values are rejected instead of being replaced by the default.
+func TestLoad_InvalidExplicitGitLabURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "missing scheme", value: "gitlab.example.com", wantErr: "must use http:// or https://"},
+		{name: "unsupported scheme", value: "ftp://gitlab.example.com", wantErr: "must use http:// or https://"},
+		{name: "missing host", value: "https://", wantErr: "must include a host"},
+		{name: "malformed URL", value: "http://[::1", wantErr: "is not a valid URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITLAB_URL", tt.value)
+			t.Setenv("GITLAB_TOKEN", testGitLabToken)
+
+			_, err := Load()
+			if err == nil {
+				t.Fatal("Load() expected error for invalid GITLAB_URL, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Load() error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 
 // TestLoad_MissingToken verifies that [Load] returns an error when GITLAB_TOKEN
 // is empty, since it is a required configuration field.
 func TestLoad_MissingToken(t *testing.T) {
-	t.Setenv("GITLAB_URL", testGitLabURL)
+	t.Setenv("GITLAB_URL", "")
 	t.Setenv("GITLAB_TOKEN", "")
 
 	_, err := Load()

--- a/internal/wizard/cli.go
+++ b/internal/wizard/cli.go
@@ -125,6 +125,7 @@ func stepGitLabConfig(p *Prompter, w io.Writer, existing ServerConfig, hasExisti
 	if err != nil {
 		return nil, err
 	}
+	gitlabURL = effectiveGitLabURL(gitlabURL)
 
 	if _, parseErr := url.ParseRequestURI(gitlabURL); parseErr != nil {
 		return nil, fmt.Errorf("invalid URL %q: %w", gitlabURL, parseErr)

--- a/internal/wizard/cli_test.go
+++ b/internal/wizard/cli_test.go
@@ -123,6 +123,34 @@ func TestStepGitLabConfig_ValidInput(t *testing.T) {
 	}
 }
 
+// TestStepGitLabConfig_DefaultURL verifies that pressing Enter at the GitLab
+// URL prompt, or entering whitespace, uses the GitLab.com default.
+func TestStepGitLabConfig_DefaultURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "enter", input: "\nglpat-xxxxxxxxxxxxxxxxxxxx\n"},
+		{name: "whitespace", input: "   \nglpat-xxxxxxxxxxxxxxxxxxxx\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.input)
+			var w bytes.Buffer
+			p := NewPrompter(r, &w)
+
+			cfg, err := stepGitLabConfig(p, &w, ServerConfig{}, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.GitLabURL != DefaultGitLabURL {
+				t.Errorf("GitLabURL = %q, want %q", cfg.GitLabURL, DefaultGitLabURL)
+			}
+		})
+	}
+}
+
 // TestStepGitLabConfig_URLError verifies stepGitLabConfig returns an error
 // when the user enters a URL without a scheme.
 func TestStepGitLabConfig_WithExistingConfig(t *testing.T) {

--- a/internal/wizard/clients.go
+++ b/internal/wizard/clients.go
@@ -5,6 +5,8 @@ package wizard
 import (
 	"fmt"
 	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/internal/config"
 )
 
 // ClientID identifies a supported MCP client.
@@ -34,12 +36,20 @@ const (
 )
 
 // DefaultGitLabURL is pre-filled in UI modes as a convenience default.
-const DefaultGitLabURL = ""
+const DefaultGitLabURL = config.DefaultGitLabURL
+
+func effectiveGitLabURL(gitLabURL string) string {
+	gitLabURL = strings.TrimSpace(gitLabURL)
+	if gitLabURL == "" {
+		return DefaultGitLabURL
+	}
+	return gitLabURL
+}
 
 // TokenCreationURL returns the GitLab URL for creating a personal access token
 // with the "api" scope pre-selected, which is required for full MCP functionality.
 func TokenCreationURL(gitlabURL string) string {
-	return strings.TrimRight(gitlabURL, "/") + "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"
+	return strings.TrimRight(effectiveGitLabURL(gitlabURL), "/") + "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"
 }
 
 // ServerConfig holds the user's configuration values for the MCP server.

--- a/internal/wizard/clients_test.go
+++ b/internal/wizard/clients_test.go
@@ -438,33 +438,27 @@ func TestEnvMap_AllFlagsEnabled(t *testing.T) {
 }
 
 // TestTokenCreationURL verifies the token creation URL is constructed
-// correctly, including trimming trailing slashes.
+// correctly for defaults, custom instances, and trailing slashes.
 func TestTokenCreationURL(t *testing.T) {
+	const tokenPath = "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"
+
 	tests := []struct {
-		name     string
-		input    string
-		wantSufx string
+		name  string
+		input string
+		want  string
 	}{
-		{"no trailing slash", "https://gitlab.com", "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"},
-		{"trailing slash", "https://gitlab.com/", "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"},
-		{"custom url", "https://custom.dev", "/-/user_settings/personal_access_tokens?name=gitlab-mcp-server&scopes=api"},
+		{name: "empty URL uses default", input: "", want: DefaultGitLabURL + tokenPath},
+		{name: "whitespace URL uses default", input: "   ", want: DefaultGitLabURL + tokenPath},
+		{name: "no trailing slash", input: "https://gitlab.com", want: "https://gitlab.com" + tokenPath},
+		{name: "trailing slash", input: "https://gitlab.com/", want: "https://gitlab.com" + tokenPath},
+		{name: "custom HTTPS URL", input: "https://custom.dev", want: "https://custom.dev" + tokenPath},
+		{name: "custom HTTP URL", input: "http://gitlab.local:8080/", want: "http://gitlab.local:8080" + tokenPath},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := TokenCreationURL(tt.input)
-			if got == "" {
-				t.Fatal("returned empty URL")
-			}
-			wantPrefix := "https://"
-			if got[:8] != wantPrefix {
-				t.Errorf("URL should start with https://, got %q", got)
-			}
-			if len(got) < len(tt.wantSufx) {
-				t.Fatalf("URL too short: %q", got)
-			}
-			suffix := got[len(got)-len(tt.wantSufx):]
-			if suffix != tt.wantSufx {
-				t.Errorf("URL suffix = %q, want %q", suffix, tt.wantSufx)
+			if got != tt.want {
+				t.Errorf("TokenCreationURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/wizard/tui.go
+++ b/internal/wizard/tui.go
@@ -231,16 +231,13 @@ func (m tuiModel) updateGitLab(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch keyMsg.String() {
 		case "enter":
 			if m.gitlabFocus == 0 {
+				m.urlInput.SetValue(effectiveGitLabURL(m.urlInput.Value()))
 				m.gitlabFocus = 1
 				m.urlInput.Blur()
 				m.tokenInput.Focus()
 				return m, textinput.Blink
 			}
-			// Validate
-			if m.urlInput.Value() == "" {
-				m.err = "GitLab URL is required"
-				return m, nil
-			}
+			m.urlInput.SetValue(effectiveGitLabURL(m.urlInput.Value()))
 			if _, parseErr := url.ParseRequestURI(m.urlInput.Value()); parseErr != nil {
 				m.err = fmt.Sprintf("Invalid URL: %v", parseErr)
 				return m, nil
@@ -260,10 +257,7 @@ func (m tuiModel) updateGitLab(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+o":
 			// Only from token field: open advanced options
 			if m.gitlabFocus == 1 {
-				if m.urlInput.Value() == "" {
-					m.err = "GitLab URL is required"
-					return m, nil
-				}
+				m.urlInput.SetValue(effectiveGitLabURL(m.urlInput.Value()))
 				if m.tokenInput.Value() == "" {
 					m.err = "Token is required"
 					return m, nil

--- a/internal/wizard/tui_test.go
+++ b/internal/wizard/tui_test.go
@@ -43,6 +43,15 @@ func newTestModel(t *testing.T) tuiModel {
 	return newTUIModel("1.0.0", io.Discard)
 }
 
+// TestNewTUIModel_DefaultGitLabURL verifies that new setups prefill the
+// GitLab.com default.
+func TestNewTUIModel_DefaultGitLabURL(t *testing.T) {
+	m := newTestModel(t)
+	if m.urlInput.Value() != DefaultGitLabURL {
+		t.Fatalf("urlInput value = %q, want %q", m.urlInput.Value(), DefaultGitLabURL)
+	}
+}
+
 // advanceToGitLab moves the model from tuiStepInstall to tuiStepGitLab.
 func advanceToGitLab(m tuiModel) tuiModel {
 	result, _ := m.Update(keyMsg(tea.KeyEnter))
@@ -195,6 +204,7 @@ func TestUpdateGitLab_TabSwitchesFields(t *testing.T) {
 func TestUpdateGitLab_EnterOnURL_MovesToToken(t *testing.T) {
 	m := newTestModel(t)
 	m = advanceToGitLab(m)
+	m.urlInput.SetValue("")
 	result, _ := m.Update(keyMsg(tea.KeyEnter))
 	final := result.(tuiModel)
 	if final.gitlabFocus != 1 {
@@ -203,12 +213,15 @@ func TestUpdateGitLab_EnterOnURL_MovesToToken(t *testing.T) {
 	if final.step != tuiStepGitLab {
 		t.Error("step should remain tuiStepGitLab")
 	}
+	if final.urlInput.Value() != DefaultGitLabURL {
+		t.Errorf("urlInput value = %q, want %q", final.urlInput.Value(), DefaultGitLabURL)
+	}
 }
 
 // TestUpdateGitLab_EnterOnToken_ValidatesAndAdvances uses table-driven
 // subtests to verify Enter on the token field validates URL and token and
 // advances to tuiStepClients only for valid input, setting error messages
-// for empty URL, invalid URL format, or empty token.
+// for invalid URL format or empty token.
 func TestUpdateGitLab_EnterOnToken_ValidatesAndAdvances(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -218,11 +231,10 @@ func TestUpdateGitLab_EnterOnToken_ValidatesAndAdvances(t *testing.T) {
 		wantError string
 	}{
 		{
-			name:      "empty URL",
-			url:       "",
-			token:     "glpat-test",
-			wantStep:  tuiStepGitLab,
-			wantError: "GitLab URL is required",
+			name:     "empty URL uses default",
+			url:      "",
+			token:    "glpat-test",
+			wantStep: tuiStepClients,
 		},
 		{
 			name:      "invalid URL format",
@@ -263,6 +275,9 @@ func TestUpdateGitLab_EnterOnToken_ValidatesAndAdvances(t *testing.T) {
 			if tc.wantError == "" && final.err != "" {
 				t.Errorf("unexpected error: %q", final.err)
 			}
+			if tc.url == "" && tc.wantError == "" && final.urlInput.Value() != DefaultGitLabURL {
+				t.Errorf("urlInput value = %q, want %q", final.urlInput.Value(), DefaultGitLabURL)
+			}
 		})
 	}
 }
@@ -288,12 +303,11 @@ func TestUpdateGitLab_CtrlO_OpensAdvancedOptions(t *testing.T) {
 			wantStep: tuiStepOptions,
 		},
 		{
-			name:      "empty URL from token field",
-			url:       "",
-			token:     "glpat-abc123",
-			focus:     1,
-			wantStep:  tuiStepGitLab,
-			wantError: "GitLab URL is required",
+			name:     "empty URL from token field uses default",
+			url:      "",
+			token:    "glpat-abc123",
+			focus:    1,
+			wantStep: tuiStepOptions,
 		},
 		{
 			name:      "empty token from token field",

--- a/internal/wizard/webui.go
+++ b/internal/wizard/webui.go
@@ -185,10 +185,7 @@ func handleConfigure(w io.Writer, onDone func(error)) http.HandlerFunc {
 			return
 		}
 
-		if req.GitLabURL == "" {
-			http.Error(rw, "GitLab URL is required", http.StatusBadRequest)
-			return
-		}
+		req.GitLabURL = effectiveGitLabURL(req.GitLabURL)
 
 		// Allow empty token when an existing config has one
 		if req.GitLabToken == "" {

--- a/internal/wizard/webui_test.go
+++ b/internal/wizard/webui_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -106,25 +107,58 @@ func TestHandleConfigure_InvalidURL(t *testing.T) {
 	}
 }
 
-// TestHandleConfigure_MissingURL verifies that the configure endpoint
-// returns 400 when GitLab URL is missing.
-func TestHandleConfigure_MissingURL(t *testing.T) {
-	var output bytes.Buffer
-	doneCh := make(chan error, 1)
-	handler := handleConfigure(&output, func(err error) { doneCh <- err })
-
-	body := `{"gitlab_url":"","gitlab_token":"glpat-xxx","selected_clients":[]}`
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/configure", strings.NewReader(body))
-	if err != nil {
-		t.Fatal(err)
+// TestHandleConfigure_DefaultsEmptyURL verifies that an empty GitLab URL uses
+// the GitLab.com default.
+func TestHandleConfigure_DefaultsEmptyURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		gitLabURL string
+	}{
+		{name: "empty", gitLabURL: ""},
+		{name: "whitespace", gitLabURL: "   "},
 	}
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
 
-	handler.ServeHTTP(rec, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubLoadExistingConfig(t)
+			stubInstallBinary(t)
+			envPath := stubWriteEnvFile(t)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			var output bytes.Buffer
+			doneCh := make(chan error, 1)
+			handler := handleConfigure(&output, func(err error) { doneCh <- err })
+
+			reqBody := configureRequest{
+				InstallPath:     t.TempDir(),
+				GitLabURL:       tt.gitLabURL,
+				GitLabToken:     "glpat-xxx",
+				LogLevel:        "info",
+				SelectedClients: []int{},
+			}
+			body, mErr := json.Marshal(reqBody)
+			if mErr != nil {
+				t.Fatalf("marshal request: %v", mErr)
+			}
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/configure", bytes.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			data, readErr := os.ReadFile(envPath)
+			if readErr != nil {
+				t.Fatalf("read env file: %v", readErr)
+			}
+			if !strings.Contains(string(data), "GITLAB_URL="+DefaultGitLabURL) {
+				t.Fatalf("env file = %q, want default GitLab URL", string(data))
+			}
+		})
 	}
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ It provides 1006 individual MCP tools across 96 GitLab API domains, 32 meta-tool
 
 ## Configuration (environment variables — stdio mode)
 
-- GITLAB_URL: GitLab instance URL (required)
+- GITLAB_URL: GitLab instance URL (default: https://gitlab.com; set for self-managed instances)
 - GITLAB_TOKEN: Personal Access Token (required)
 - GITLAB_SKIP_TLS_VERIFY: Skip TLS verification for self-signed certs (default: false)
 - META_TOOLS: Enable meta-tools for reduced tool count (default: true)

--- a/mcp.json
+++ b/mcp.json
@@ -28,7 +28,6 @@
                 "--http=false"
             ],
             "env": {
-                "GITLAB_URL": "${GITLAB_URL}",
                 "GITLAB_TOKEN": "${GITLAB_TOKEN}",
                 "GITLAB_SKIP_TLS_VERIFY": "${GITLAB_SKIP_TLS_VERIFY:-false}",
                 "META_TOOLS": "${META_TOOLS:-true}",

--- a/server.json
+++ b/server.json
@@ -40,9 +40,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",
@@ -160,9 +161,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",
@@ -280,9 +282,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",
@@ -400,9 +403,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",
@@ -520,9 +524,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",
@@ -640,9 +645,10 @@
       "environmentVariables": [
         {
           "name": "GITLAB_URL",
-          "description": "GitLab instance URL (e.g. https://gitlab.example.com)",
-          "isRequired": true,
-          "placeholder": "https://gitlab.example.com"
+          "description": "GitLab instance URL (default: https://gitlab.com; set for self-managed instances)",
+          "isRequired": false,
+          "placeholder": "https://gitlab.com",
+          "default": "https://gitlab.com"
         },
         {
           "name": "GITLAB_TOKEN",

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -95,7 +95,7 @@ sequenceDiagram
 Start HTTP mode with:
 
 ```bash
-./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
+./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.com
 # Or without --gitlab-url (clients send GITLAB-URL header per-request)
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080
 ```

--- a/site/src/content/docs/capabilities/logging.mdx
+++ b/site/src/content/docs/capabilities/logging.mdx
@@ -65,7 +65,7 @@ Set the log level via environment variable:
 LOG_LEVEL=debug ./gitlab-mcp-server
 
 # HTTP mode
-LOG_LEVEL=info ./gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com
+LOG_LEVEL=info ./gitlab-mcp-server --http --gitlab-url=https://gitlab.com
 ```
 
 The default level is `info`.

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -19,26 +19,26 @@ GitLab MCP Server is configured through environment variables for stdio mode and
 
 ## Required variables
 
-These must be set for the server to start in stdio mode:
+This must be set for the server to start in stdio mode:
 
 | Variable       | Description                            | Example                      |
 | -------------- | -------------------------------------- | ---------------------------- |
-| `GITLAB_URL`   | GitLab instance base URL               | `https://gitlab.example.com` |
 | `GITLAB_TOKEN` | Personal Access Token with `api` scope | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ## Core options
 
-| Variable                 | Default  | Description                                                                                                                                                                       |
-| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITLAB_SKIP_TLS_VERIFY` | `false`  | Skip TLS certificate verification for self-signed certs                                                                                                                           |
-| `META_TOOLS`             | `true`   | Enable meta-tool mode (32 domain tools instead of 1006+ individual tools)                                                                                                         |
-| `META_PARAM_SCHEMA`      | `opaque` | Meta-tool input-schema strategy: `opaque` (default), `compact` (~5x), or `full` (~10x). Per-action schema always discoverable via `gitlab://schema/meta/{tool}/{action}` resource |
-| `GITLAB_ENTERPRISE`      | `false`  | Enable Enterprise/Premium tools in stdio mode. In HTTP mode, `--enterprise` can force the catalog; otherwise edition is auto-detected per token+URL entry                         |
-| `GITLAB_READ_ONLY`       | `false`  | Disable all mutating tools (create, update, delete)                                                                                                                               |
-| `GITLAB_SAFE_MODE`       | `false`  | Return structured JSON preview instead of executing mutating tools (dry-run mode)                                                                                                 |
-| `EXCLUDE_TOOLS`          | —        | Comma-separated list of tool names to exclude (e.g., `gitlab_delete_project,gitlab_admin`)                                                                                        |
-| `GITLAB_IGNORE_SCOPES`   | `false`  | Skip automatic PAT scope detection — register all tools regardless of token scopes                                                                                                |
-| `LOG_LEVEL`              | `info`   | Log verbosity: `debug`, `info`, `warn`, `error`                                                                                                                                   |
+| Variable                 | Default              | Description                                                                                                                                                                       |
+| ------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | `https://gitlab.com` | GitLab instance base URL. Set this for self-managed instances                                                                                                                     |
+| `GITLAB_SKIP_TLS_VERIFY` | `false`              | Skip TLS certificate verification for self-signed certs                                                                                                                           |
+| `META_TOOLS`             | `true`               | Enable meta-tool mode (32 domain tools instead of 1006+ individual tools)                                                                                                         |
+| `META_PARAM_SCHEMA`      | `opaque`             | Meta-tool input-schema strategy: `opaque` (default), `compact` (~5x), or `full` (~10x). Per-action schema always discoverable via `gitlab://schema/meta/{tool}/{action}` resource |
+| `GITLAB_ENTERPRISE`      | `false`              | Enable Enterprise/Premium tools in stdio mode. In HTTP mode, `--enterprise` can force the catalog; otherwise edition is auto-detected per token+URL entry                         |
+| `GITLAB_READ_ONLY`       | `false`              | Disable all mutating tools (create, update, delete)                                                                                                                               |
+| `GITLAB_SAFE_MODE`       | `false`              | Return structured JSON preview instead of executing mutating tools (dry-run mode)                                                                                                 |
+| `EXCLUDE_TOOLS`          | —                    | Comma-separated list of tool names to exclude (e.g., `gitlab_delete_project,gitlab_admin`)                                                                                        |
+| `GITLAB_IGNORE_SCOPES`   | `false`              | Skip automatic PAT scope detection — register all tools regardless of token scopes                                                                                                |
+| `LOG_LEVEL`              | `info`               | Log verbosity: `debug`, `info`, `warn`, `error`                                                                                                                                   |
 
 :::tip
 **Meta-tools mode** (`META_TOOLS=true`) is strongly recommended. It groups tools by domain (e.g., `gitlab_issue` handles list, get, create, update, delete) which reduces token usage and improves AI tool selection accuracy.
@@ -65,7 +65,6 @@ These must be set for the server to start in stdio mode:
 
 ```bash title=".env"
 # Required
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 
 # Optional
@@ -82,6 +81,8 @@ LOG_LEVEL=info
 AUTO_UPDATE=true
 ```
 
+For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
+
 ## Client configuration
 
 <Tabs>
@@ -96,7 +97,6 @@ Create `.vscode/mcp.json` in your workspace:
 			"type": "stdio",
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -121,7 +121,6 @@ Create `.vscode/mcp.json` in your workspace:
 			"type": "stdio",
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlab-token}"
 			}
 		}
@@ -147,7 +146,6 @@ Edit `claude_desktop_config.json`:
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -166,7 +164,6 @@ Create `.cursor/mcp.json` in your project:
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -186,9 +183,10 @@ claude mcp add gitlab \
 Set environment variables before launching:
 
 ```bash
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 ```
+
+Set `GITLAB_URL` here only for self-managed instances.
 
 Or use a `.env` file in the working directory.
 
@@ -202,7 +200,6 @@ mcpServers:
   - name: gitlab
     command: /path/to/gitlab-mcp-server
     env:
-      GITLAB_URL: https://gitlab.example.com
       GITLAB_TOKEN: glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
@@ -219,7 +216,6 @@ Edit `~/.codeium/windsurf/mcp_config.json` (Cascade → Plugins → Configure):
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -238,7 +234,9 @@ Add a stdio entry pointing at the binary:
 
 - **Name**: `gitlab`
 - **Command**: `/path/to/gitlab-mcp-server`
-- **Environment variables**: `GITLAB_URL=https://gitlab.example.com`, `GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx`
+- **Environment variables**: `GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx`
+
+Add `GITLAB_URL=https://gitlab.example.com` for self-managed GitLab.
 
 Alternatively, create `.idea/mcp.json` in the project root with the same JSON shape used by VS Code / Cursor. Restart the IDE after editing.
 
@@ -283,11 +281,11 @@ When running in HTTP mode (`--http`), configuration uses CLI flags instead of en
 Example:
 
 ```bash
-# Single GitLab instance (default URL for all clients)
+# Single GitLab.com instance (fixed URL for all clients; replace for self-managed GitLab)
 ./gitlab-mcp-server \
   --http \
   --http-addr=0.0.0.0:8080 \
-  --gitlab-url=https://gitlab.example.com \
+	--gitlab-url=https://gitlab.com \
   --max-http-clients=200 \
   --session-timeout=1h
 

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -284,7 +284,7 @@ Example:
 # Single GitLab.com instance (fixed URL for all clients; replace for self-managed GitLab)
 ./gitlab-mcp-server \
   --http \
-  --http-addr=0.0.0.0:8080 \
+	--http-addr=0.0.0.0:8080 \
 	--gitlab-url=https://gitlab.com \
   --max-http-clients=200 \
   --session-timeout=1h

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -95,7 +95,7 @@ sequenceDiagram
 Inicia el modo HTTP con:
 
 ```bash
-./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
+./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.com
 # O sin --gitlab-url (los clientes envían la cabecera GITLAB-URL por solicitud)
 ./gitlab-mcp-server --http --http-addr=0.0.0.0:8080
 ```

--- a/site/src/content/docs/es/capabilities/logging.mdx
+++ b/site/src/content/docs/es/capabilities/logging.mdx
@@ -65,7 +65,7 @@ Establece el nivel de log mediante variable de entorno:
 LOG_LEVEL=debug ./gitlab-mcp-server
 
 # Modo HTTP
-LOG_LEVEL=info ./gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com
+LOG_LEVEL=info ./gitlab-mcp-server --http --gitlab-url=https://gitlab.com
 ```
 
 El nivel predeterminado es `info`.

--- a/site/src/content/docs/es/configuration.mdx
+++ b/site/src/content/docs/es/configuration.mdx
@@ -284,7 +284,7 @@ Ejemplo:
 # Instancia única de GitLab.com (URL fija para todos los clientes; reemplázala para GitLab autogestionado)
 ./gitlab-mcp-server \
   --http \
-  --http-addr=0.0.0.0:8080 \
+	--http-addr=0.0.0.0:8080 \
 	--gitlab-url=https://gitlab.com \
   --max-http-clients=200 \
   --session-timeout=1h

--- a/site/src/content/docs/es/configuration.mdx
+++ b/site/src/content/docs/es/configuration.mdx
@@ -19,26 +19,26 @@ GitLab MCP Server se configura mediante variables de entorno en modo stdio y fla
 
 ## Variables requeridas
 
-Estas deben establecerse para que el servidor arranque en modo stdio:
+Esta debe establecerse para que el servidor arranque en modo stdio:
 
 | Variable       | Descripción                           | Ejemplo                      |
 | -------------- | ------------------------------------- | ---------------------------- |
-| `GITLAB_URL`   | URL base de la instancia de GitLab    | `https://gitlab.example.com` |
 | `GITLAB_TOKEN` | Personal Access Token con scope `api` | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ## Opciones principales
 
-| Variable                 | Predeterminado | Descripción                                                                                                                                                                                                        |
-| ------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `GITLAB_SKIP_TLS_VERIFY` | `false`        | Omitir verificación de certificados TLS para certificados autofirmados                                                                                                                                             |
-| `META_TOOLS`             | `true`         | Habilitar modo meta-herramientas (32 herramientas de dominio en lugar de 1006+ herramientas individuales)                                                                                                          |
-| `META_PARAM_SCHEMA`      | `opaque`       | Estrategia de esquema de entrada para meta-herramientas: `opaque` (por defecto), `compact` (~5x) o `full` (~10x). El esquema por acción siempre es accesible vía el recurso `gitlab://schema/meta/{tool}/{action}` |
-| `GITLAB_ENTERPRISE`      | `false`        | Habilitar herramientas Enterprise/Premium en modo stdio. En modo HTTP, `--enterprise` puede forzar el catálogo; si se omite, la edición se autodetecta por entrada token+URL                                       |
-| `GITLAB_READ_ONLY`       | `false`        | Desactivar todas las herramientas de escritura (crear, actualizar, eliminar)                                                                                                                                       |
-| `GITLAB_SAFE_MODE`       | `false`        | Devolver vista previa JSON estructurada en lugar de ejecutar herramientas de escritura (modo dry-run)                                                                                                              |
-| `EXCLUDE_TOOLS`          | —              | Lista de herramientas a excluir separadas por comas (ej., `gitlab_delete_project,gitlab_admin`)                                                                                                                    |
-| `GITLAB_IGNORE_SCOPES`   | `false`        | Omitir detección automática de scopes del PAT — registrar todas las herramientas sin importar los scopes                                                                                                           |
-| `LOG_LEVEL`              | `info`         | Nivel de verbosidad del log: `debug`, `info`, `warn`, `error`                                                                                                                                                      |
+| Variable                 | Predeterminado       | Descripción                                                                                                                                                                                                        |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GITLAB_URL`             | `https://gitlab.com` | URL base de la instancia GitLab. Establécela para instancias autogestionadas                                                                                                                                       |
+| `GITLAB_SKIP_TLS_VERIFY` | `false`              | Omitir verificación de certificados TLS para certificados autofirmados                                                                                                                                             |
+| `META_TOOLS`             | `true`               | Habilitar modo meta-herramientas (32 herramientas de dominio en lugar de 1006+ herramientas individuales)                                                                                                          |
+| `META_PARAM_SCHEMA`      | `opaque`             | Estrategia de esquema de entrada para meta-herramientas: `opaque` (por defecto), `compact` (~5x) o `full` (~10x). El esquema por acción siempre es accesible vía el recurso `gitlab://schema/meta/{tool}/{action}` |
+| `GITLAB_ENTERPRISE`      | `false`              | Habilitar herramientas Enterprise/Premium en modo stdio. En modo HTTP, `--enterprise` puede forzar el catálogo; si se omite, la edición se autodetecta por entrada token+URL                                       |
+| `GITLAB_READ_ONLY`       | `false`              | Desactivar todas las herramientas de escritura (crear, actualizar, eliminar)                                                                                                                                       |
+| `GITLAB_SAFE_MODE`       | `false`              | Devolver vista previa JSON estructurada en lugar de ejecutar herramientas de escritura (modo dry-run)                                                                                                              |
+| `EXCLUDE_TOOLS`          | —                    | Lista de herramientas a excluir separadas por comas (ej., `gitlab_delete_project,gitlab_admin`)                                                                                                                    |
+| `GITLAB_IGNORE_SCOPES`   | `false`              | Omitir detección automática de scopes del PAT — registrar todas las herramientas sin importar los scopes                                                                                                           |
+| `LOG_LEVEL`              | `info`               | Nivel de verbosidad del log: `debug`, `info`, `warn`, `error`                                                                                                                                                      |
 
 :::tip
 **El modo meta-herramientas** (`META_TOOLS=true`) es altamente recomendado. Agrupa las herramientas por dominio (p. ej., `gitlab_issue` gestiona list, get, create, update, delete) lo que reduce el uso de tokens y mejora la precisión de selección de herramientas por la IA.
@@ -65,7 +65,6 @@ Estas deben establecerse para que el servidor arranque en modo stdio:
 
 ```bash title=".env"
 # Requeridas
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 
 # Opcionales
@@ -82,6 +81,8 @@ LOG_LEVEL=info
 AUTO_UPDATE=true
 ```
 
+Para GitLab autogestionado, añade `GITLAB_URL=https://gitlab.example.com`.
+
 ## Configuración de clientes
 
 <Tabs>
@@ -96,7 +97,6 @@ Crea `.vscode/mcp.json` en tu workspace:
 			"type": "stdio",
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -121,7 +121,6 @@ Crea `.vscode/mcp.json` en tu workspace:
 			"type": "stdio",
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlab-token}"
 			}
 		}
@@ -147,7 +146,6 @@ Edita `claude_desktop_config.json`:
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -166,7 +164,6 @@ Crea `.cursor/mcp.json` en tu proyecto:
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -186,9 +183,10 @@ claude mcp add gitlab \
 Establece las variables de entorno antes de iniciar:
 
 ```bash
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 ```
+
+Establece `GITLAB_URL` aquí solo para instancias autogestionadas.
 
 O usa un archivo `.env` en el directorio de trabajo.
 
@@ -202,7 +200,6 @@ mcpServers:
   - name: gitlab
     command: /ruta/a/gitlab-mcp-server
     env:
-      GITLAB_URL: https://gitlab.example.com
       GITLAB_TOKEN: glpat-xxxxxxxxxxxxxxxxxxxx
 ```
 
@@ -219,7 +216,6 @@ Edita `~/.codeium/windsurf/mcp_config.json` (Cascade → Plugins → Configure):
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -238,7 +234,9 @@ Añade una entrada stdio apuntando al binario:
 
 - **Nombre**: `gitlab`
 - **Comando**: `/ruta/a/gitlab-mcp-server`
-- **Variables de entorno**: `GITLAB_URL=https://gitlab.example.com`, `GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx`
+- **Variables de entorno**: `GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx`
+
+Añade `GITLAB_URL=https://gitlab.example.com` para GitLab autogestionado.
 
 Alternativamente, crea `.idea/mcp.json` en la raíz del proyecto con la misma estructura JSON usada por VS Code / Cursor. Reinicia el IDE tras editar.
 
@@ -283,11 +281,11 @@ Al ejecutar en modo HTTP (`--http`), la configuración usa flags de CLI en lugar
 Ejemplo:
 
 ```bash
-# Instancia única de GitLab (URL por defecto para todos los clientes)
+# Instancia única de GitLab.com (URL fija para todos los clientes; reemplázala para GitLab autogestionado)
 ./gitlab-mcp-server \
   --http \
   --http-addr=0.0.0.0:8080 \
-  --gitlab-url=https://gitlab.example.com \
+	--gitlab-url=https://gitlab.com \
   --max-http-clients=200 \
   --session-timeout=1h
 

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -88,16 +88,16 @@ El plugin usa la imagen Docker publicada `ghcr.io/jmrplens/gitlab-mcp-server:lat
 
 El host debe proporcionar estas variables antes de habilitar el plugin:
 
-| Variable                 | Obligatoria | Descripción                                                                       |
-| ------------------------ | ----------- | --------------------------------------------------------------------------------- |
-| `GITLAB_URL`             | Sí          | URL de la instancia GitLab (p. ej. `https://gitlab.example.com`)                  |
-| `GITLAB_TOKEN`           | Sí          | Personal Access Token (`glpat-...`)                                               |
-| `GITLAB_SKIP_TLS_VERIFY` | No          | `true` para certificados autofirmados (por defecto `false`)                       |
-| `META_TOOLS`             | No          | `true` para herramientas agrupadas, `false` individuales (por defecto `true`)     |
-| `GITLAB_ENTERPRISE`      | No          | `true` para habilitar herramientas Premium/Ultimate (por defecto `false`)         |
-| `GITLAB_READ_ONLY`       | No          | `true` para deshabilitar herramientas de escritura (por defecto `false`)          |
-| `GITLAB_SAFE_MODE`       | No          | `true` para previsualizar entradas de herramientas mutantes (por defecto `false`) |
-| `LOG_LEVEL`              | No          | `debug`, `info`, `warn`, `error` (por defecto `info`)                             |
+| Variable                 | Obligatoria | Descripción                                                                                                   |
+| ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | No          | URL de la instancia GitLab. Por defecto usa `https://gitlab.com`; establécela para instancias autogestionadas |
+| `GITLAB_TOKEN`           | Sí          | Personal Access Token (`glpat-...`)                                                                           |
+| `GITLAB_SKIP_TLS_VERIFY` | No          | `true` para certificados autofirmados (por defecto `false`)                                                   |
+| `META_TOOLS`             | No          | `true` para herramientas agrupadas, `false` individuales (por defecto `true`)                                 |
+| `GITLAB_ENTERPRISE`      | No          | `true` para habilitar herramientas Premium/Ultimate (por defecto `false`)                                     |
+| `GITLAB_READ_ONLY`       | No          | `true` para deshabilitar herramientas de escritura (por defecto `false`)                                      |
+| `GITLAB_SAFE_MODE`       | No          | `true` para previsualizar entradas de herramientas mutantes (por defecto `false`)                             |
+| `LOG_LEVEL`              | No          | `debug`, `info`, `warn`, `error` (por defecto `info`)                                                         |
 
 ### ¿Prefieres binario nativo en lugar de Docker?
 
@@ -111,7 +111,6 @@ Si prefieres el binario nativo, instala el plugin, localiza el directorio del pl
 		"gitlab": {
 			"command": "/usr/local/bin/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "${GITLAB_URL}",
 				"GITLAB_TOKEN": "${GITLAB_TOKEN}"
 			}
 		}
@@ -120,6 +119,8 @@ Si prefieres el binario nativo, instala el plugin, localiza el directorio del pl
 ```
 
 ## Configuración manual
+
+`GITLAB_URL` usa `https://gitlab.com` por defecto; añádela solo para instancias GitLab autogestionadas.
 
 Si prefieres configurar manualmente, elige tu cliente de IA:
 
@@ -135,7 +136,6 @@ Crea o edita `.vscode/mcp.json` en la raíz de tu workspace:
 			"type": "stdio",
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -161,7 +161,6 @@ Usa variables de entrada de VS Code para evitar almacenar el token en texto plan
 			"type": "stdio",
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlab-token}"
 			}
 		}
@@ -182,7 +181,6 @@ Edita `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) 
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -201,7 +199,6 @@ Crea o edita `.cursor/mcp.json` en la raíz de tu proyecto:
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -220,14 +217,13 @@ claude mcp add gitlab \
   -- /ruta/a/gitlab-mcp-server
 ```
 
-Luego establece las variables de entorno requeridas:
+Luego establece el token requerido:
 
 ```bash
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 ```
 
-O crea un archivo `.env` en tu directorio de trabajo con las variables anteriores.
+Establece `GITLAB_URL` aquí solo para instancias autogestionadas, o crea un archivo `.env` en tu directorio de trabajo con las variables anteriores.
 
 </TabItem>
 <TabItem label="Windsurf">
@@ -240,7 +236,6 @@ Edita `~/.codeium/windsurf/mcp_config.json`:
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -254,10 +249,9 @@ Edita `~/.codeium/windsurf/mcp_config.json`:
 1. Abre **Settings → Tools → AI Assistant → MCP Servers**
 2. Haz clic en **+ Add** y selecciona **stdio**
 3. Establece el comando a `/ruta/a/gitlab-mcp-server`
-4. Añade las variables de entorno:
-   - `GITLAB_URL` = `https://gitlab.example.com`
-   - `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
-5. Haz clic en **OK** y reinicia el IDE
+4. Añade `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
+5. Añade `GITLAB_URL` solo para instancias autogestionadas
+6. Haz clic en **OK** y reinicia el IDE
 
 </TabItem>
 <TabItem label="Zed">
@@ -271,7 +265,6 @@ Edita tu `settings.json` de Zed y añade:
 			"command": "/ruta/a/gitlab-mcp-server",
 			"args": [],
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -291,7 +284,6 @@ Crea o edita `.kiro/mcp.json` en la raíz de tu proyecto:
 			"command": "/ruta/a/gitlab-mcp-server",
 			"args": [],
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -314,7 +306,6 @@ Abre la barra lateral de Cline → haz clic en el icono de servidores MCP → **
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -333,7 +324,6 @@ Abre la barra lateral de Roo Code → haz clic en el icono de servidores MCP →
 		"gitlab": {
 			"command": "/ruta/a/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -349,9 +339,10 @@ Abre la barra lateral de Roo Code → haz clic en el icono de servidores MCP →
 En lugar de colocar secretos en archivos de configuración del cliente, puedes usar un archivo `.env`:
 
 ```bash title=".env"
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
+
+Añade `GITLAB_URL=https://gitlab.example.com` para GitLab autogestionado.
 
 El servidor carga `.env` desde el directorio de trabajo actual automáticamente. Consulta [Configuración](/gitlab-mcp-server/configuration/) para el orden de carga completo.
 
@@ -360,7 +351,7 @@ El servidor carga `.env` desde el directorio de trabajo actual automáticamente.
 Para despliegues en equipo, puedes ejecutar el servidor en modo HTTP donde cada usuario se autentica con su propio token:
 
 ```bash
-./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
+./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.com
 ```
 
 Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consulta [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para más detalles.
@@ -370,7 +361,7 @@ Cada cliente se conecta vía HTTP y proporciona su propio token de GitLab. Consu
 Para gestión de tokens sin configuración manual, usa el modo OAuth. Los usuarios autorizan a través del navegador — no se requiere copiar ni distribuir tokens:
 
 ```bash
-./gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --auth-mode=oauth
+./gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth
 ```
 
 Los clientes MCP que soportan OAuth 2.1 (VS Code, Claude Code) descubren el servidor de autorización automáticamente vía `/.well-known/oauth-protected-resource`. Consulta [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) para crear la Aplicación OAuth de GitLab requerida.

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -24,8 +24,8 @@ Por defecto, GitLab MCP Server se ejecuta en **modo stdio** — cada cliente de 
 ## Iniciar el servidor
 
 ```bash
-# Instancia única de GitLab (URL por defecto para todos los clientes)
-gitlab-mcp-server --http --gitlab-url=https://tu-gitlab.ejemplo.com
+# Instancia única de GitLab.com (URL fija para todos los clientes; reemplázala para GitLab autogestionado)
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com
 
 # Multi-instancia (cada cliente especifica su URL de GitLab mediante la cabecera GITLAB-URL)
 gitlab-mcp-server --http --http-addr=:8080
@@ -100,7 +100,7 @@ Si ambas cabeceras están presentes, `PRIVATE-TOKEN` tiene precedencia. Las soli
 El modo OAuth (`--auth-mode=oauth`) habilita autenticación OAuth 2.1 compatible con RFC 9728. En lugar de gestionar tokens manualmente, los clientes MCP descubren el servidor de autorización automáticamente y manejan el flujo OAuth:
 
 ```bash
-gitlab-mcp-server --http --gitlab-url=https://tu-gitlab.ejemplo.com --auth-mode=oauth
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth
 ```
 
 **Cómo funciona:**
@@ -303,7 +303,7 @@ docker run -d \
   ghcr.io/jmrplens/gitlab-mcp-server:latest \
   --http \
   --http-addr=0.0.0.0:8080 \
-  --gitlab-url=https://gitlab.ejemplo.com
+  --gitlab-url=https://gitlab.com
 ```
 
 </TabItem>
@@ -339,9 +339,9 @@ services:
     ports:
       - "8080:8080"
     command:
-      # Modo instancia única (URL por defecto para todos los clientes):
+      # Modo instancia única (URL fija de GitLab.com para todos los clientes; reemplázala para GitLab autogestionado):
       - "--http"
-      - "--gitlab-url=https://gitlab.ejemplo.com"
+      - "--gitlab-url=https://gitlab.com"
       - "--http-addr=:8080"
       - "--max-http-clients=200"
       - "--session-timeout=1h"

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -42,8 +42,8 @@ Almacena tu token en un archivo `.env` con permisos restringidos:
 
 ```bash
 # Crear archivo .env
-echo 'GITLAB_URL=https://gitlab.example.com' > .env
-echo 'GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx' >> .env
+echo 'GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx' > .env
+# Añade GITLAB_URL aquí solo para instancias autogestionadas.
 
 # Restringir permisos (solo lectura/escritura del propietario)
 chmod 600 .env
@@ -64,7 +64,6 @@ Para usuarios de VS Code, puedes usar variables de entrada para evitar almacenar
 			"type": "stdio",
 			"command": "gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlabToken}"
 			}
 		}

--- a/site/src/content/docs/es/operations/troubleshooting.mdx
+++ b/site/src/content/docs/es/operations/troubleshooting.mdx
@@ -15,7 +15,7 @@ Para la referencia técnica completa, consulta [`docs/troubleshooting.md`](https
 flowchart TD
     A[El servidor no arranca] --> B{Mensaje de error?}
     B -->|GITLAB_TOKEN required| C[Establece GITLAB_TOKEN<br/>en .env o entorno]
-    B -->|GITLAB_URL required| D[Establece GITLAB_URL<br/>en .env o flag]
+    B -->|Invalid GITLAB_URL| D[Corrige GITLAB_URL<br/>autogestionado]
     B -->|401 Unauthorized| E[Regenera token<br/>con scope api]
     B -->|403 Forbidden| F[Verifica scope api<br/>del token]
     B -->|Conexión rechazada| G{GitLab accesible?}
@@ -36,13 +36,13 @@ flowchart TD
     style K fill:#3b82f6,color:#fff
 ```
 
-| Síntoma                                    | Causa                               | Solución                                                                                                                                                |
-| ------------------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITLAB_TOKEN is required` al inicio       | Token no establecido                | Establece `GITLAB_TOKEN` en `.env` o en el entorno                                                                                                      |
-| `GITLAB_URL is required` al inicio         | URL no establecida                  | Establece `GITLAB_URL` en `.env` o usa el flag `--gitlab-url`. En modo HTTP, `--gitlab-url` es opcional si los clientes envían la cabecera `GITLAB-URL` |
-| `401 Unauthorized` de la API de GitLab     | PAT inválido o expirado             | Genera un nuevo token con scope `api` en GitLab → Preferences → Access Tokens                                                                           |
-| `403 Forbidden` en operaciones específicas | El token carece del scope requerido | Asegúrate de que el token tiene scope `api` (no solo `read_api`)                                                                                        |
-| Conexión rechazada o timeout               | Instancia de GitLab inaccesible     | Verifica que `GITLAB_URL` es accesible: `curl -s $GITLAB_URL/api/v4/version`                                                                            |
+| Síntoma                                    | Causa                               | Solución                                                                      |
+| ------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------------- |
+| `GITLAB_TOKEN is required` al inicio       | Token no establecido                | Establece `GITLAB_TOKEN` en `.env` o en el entorno                            |
+| `GITLAB_URL is not a valid URL` al inicio  | La URL tiene sintaxis inválida      | Corrige `GITLAB_URL` u omítela para usar `https://gitlab.com` en modo stdio   |
+| `401 Unauthorized` de la API de GitLab     | PAT inválido o expirado             | Genera un nuevo token con scope `api` en GitLab → Preferences → Access Tokens |
+| `403 Forbidden` en operaciones específicas | El token carece del scope requerido | Asegúrate de que el token tiene scope `api` (no solo `read_api`)              |
+| Conexión rechazada o timeout               | Instancia de GitLab inaccesible     | Verifica que `GITLAB_URL` es accesible: `curl -s $GITLAB_URL/api/v4/version`  |
 
 ## TLS y certificados
 
@@ -175,7 +175,7 @@ Habilita el registro detallado para diagnosticar problemas:
    LOG_LEVEL=debug ./gitlab-mcp-server 2>debug.log
 
    # Modo HTTP (logs mezclados con la salida del servidor)
-   LOG_LEVEL=debug ./gitlab-mcp-server --http --gitlab-url=https://gitlab.ejemplo.com 2>debug.log
+   LOG_LEVEL=debug ./gitlab-mcp-server --http --gitlab-url=https://gitlab.com 2>debug.log
    ```
 
 2. **Reproduce el problema** ejecutando la misma operación que falló.

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -88,16 +88,16 @@ The plugin uses the published Docker image `ghcr.io/jmrplens/gitlab-mcp-server:l
 
 The host must provide these variables before enabling the plugin:
 
-| Variable                 | Required | Description                                                       |
-| ------------------------ | -------- | ----------------------------------------------------------------- |
-| `GITLAB_URL`             | Yes      | GitLab instance URL (e.g. `https://gitlab.example.com`)           |
-| `GITLAB_TOKEN`           | Yes      | Personal Access Token (`glpat-...`)                               |
-| `GITLAB_SKIP_TLS_VERIFY` | No       | `true` for self-signed certs (default `false`)                    |
-| `META_TOOLS`             | No       | `true` for grouped tools, `false` for individual (default `true`) |
-| `GITLAB_ENTERPRISE`      | No       | `true` to enable Premium/Ultimate tools (default `false`)         |
-| `GITLAB_READ_ONLY`       | No       | `true` to disable mutating tools (default `false`)                |
-| `GITLAB_SAFE_MODE`       | No       | `true` to preview mutating tool inputs (default `false`)          |
-| `LOG_LEVEL`              | No       | `debug`, `info`, `warn`, `error` (default `info`)                 |
+| Variable                 | Required | Description                                                                           |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | No       | GitLab instance URL. Defaults to `https://gitlab.com`; set for self-managed instances |
+| `GITLAB_TOKEN`           | Yes      | Personal Access Token (`glpat-...`)                                                   |
+| `GITLAB_SKIP_TLS_VERIFY` | No       | `true` for self-signed certs (default `false`)                                        |
+| `META_TOOLS`             | No       | `true` for grouped tools, `false` for individual (default `true`)                     |
+| `GITLAB_ENTERPRISE`      | No       | `true` to enable Premium/Ultimate tools (default `false`)                             |
+| `GITLAB_READ_ONLY`       | No       | `true` to disable mutating tools (default `false`)                                    |
+| `GITLAB_SAFE_MODE`       | No       | `true` to preview mutating tool inputs (default `false`)                              |
+| `LOG_LEVEL`              | No       | `debug`, `info`, `warn`, `error` (default `info`)                                     |
 
 ### Prefer a native binary instead of Docker?
 
@@ -111,7 +111,6 @@ If you prefer the native binary, install the plugin, locate the installed `gitla
 		"gitlab": {
 			"command": "/usr/local/bin/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "${GITLAB_URL}",
 				"GITLAB_TOKEN": "${GITLAB_TOKEN}"
 			}
 		}
@@ -120,6 +119,8 @@ If you prefer the native binary, install the plugin, locate the installed `gitla
 ```
 
 ## Manual configuration
+
+`GITLAB_URL` defaults to `https://gitlab.com`; add it only for self-managed GitLab instances.
 
 If you prefer to configure manually, choose your AI client:
 
@@ -135,7 +136,6 @@ Create or edit `.vscode/mcp.json` in your workspace root:
 			"type": "stdio",
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -161,7 +161,6 @@ Use VS Code input variables to avoid storing the token in plain text:
 			"type": "stdio",
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlab-token}"
 			}
 		}
@@ -182,7 +181,6 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -201,7 +199,6 @@ Create or edit `.cursor/mcp.json` in your project root:
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -220,14 +217,13 @@ claude mcp add gitlab \
   -- /path/to/gitlab-mcp-server
 ```
 
-Then set the required environment variables:
+Then set the required token:
 
 ```bash
-export GITLAB_URL="https://gitlab.example.com"
 export GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
 ```
 
-Or create a `.env` file in your working directory with the variables above.
+Set `GITLAB_URL` here only for self-managed instances, or create a `.env` file in your working directory with the variables above.
 
 </TabItem>
 <TabItem label="Windsurf">
@@ -240,7 +236,6 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -254,10 +249,9 @@ Edit `~/.codeium/windsurf/mcp_config.json`:
 1. Open **Settings → Tools → AI Assistant → MCP Servers**
 2. Click **+ Add** and select **stdio**
 3. Set the command to `/path/to/gitlab-mcp-server`
-4. Add environment variables:
-   - `GITLAB_URL` = `https://gitlab.example.com`
-   - `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
-5. Click **OK** and restart the IDE
+4. Add `GITLAB_TOKEN` = `glpat-xxxxxxxxxxxxxxxxxxxx`
+5. Add `GITLAB_URL` only for self-managed instances
+6. Click **OK** and restart the IDE
 
 </TabItem>
 <TabItem label="Zed">
@@ -271,7 +265,6 @@ Edit your Zed `settings.json` and add:
 			"command": "/path/to/gitlab-mcp-server",
 			"args": [],
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -291,7 +284,6 @@ Create or edit `.kiro/mcp.json` in your project root:
 			"command": "/path/to/gitlab-mcp-server",
 			"args": [],
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -314,7 +306,6 @@ Open the Cline sidebar → click the MCP servers icon → **Edit Global MCP**, o
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -333,7 +324,6 @@ Open the Roo Code sidebar → click the MCP servers icon → **Edit Global MCP**
 		"gitlab": {
 			"command": "/path/to/gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "glpat-xxxxxxxxxxxxxxxxxxxx"
 			}
 		}
@@ -349,9 +339,10 @@ Open the Roo Code sidebar → click the MCP servers icon → **Edit Global MCP**
 Instead of placing secrets in client config files, you can use a `.env` file:
 
 ```bash title=".env"
-GITLAB_URL=https://gitlab.example.com
 GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
 ```
+
+Add `GITLAB_URL=https://gitlab.example.com` for self-managed GitLab.
 
 The server loads `.env` from the current working directory automatically. See [Configuration](/gitlab-mcp-server/configuration/) for the full load order.
 
@@ -360,7 +351,7 @@ The server loads `.env` from the current working directory automatically. See [C
 For team deployments, you can run the server in HTTP mode where each user authenticates with their own token:
 
 ```bash
-./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.example.com
+./gitlab-mcp-server --http --http-addr=0.0.0.0:8080 --gitlab-url=https://gitlab.com
 ```
 
 Each client connects via HTTP and provides their own GitLab token. See [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for details.
@@ -370,7 +361,7 @@ Each client connects via HTTP and provides their own GitLab token. See [HTTP Ser
 For zero-config token management, use OAuth mode. Users authorize through the browser — no token copying or distribution required:
 
 ```bash
-./gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --auth-mode=oauth
+./gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth
 ```
 
 MCP clients that support OAuth 2.1 (VS Code, Claude Code) discover the authorization server automatically via `/.well-known/oauth-protected-resource`. See [`docs/oauth-app-setup.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/oauth-app-setup.md) for creating the required GitLab OAuth Application.

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -24,8 +24,8 @@ By default, GitLab MCP Server runs in **stdio mode** — each AI client spawns i
 ## Starting the server
 
 ```bash
-# Single GitLab instance (default URL for all clients)
-gitlab-mcp-server --http --gitlab-url=https://your-gitlab.example.com
+# Single GitLab.com instance (fixed URL for all clients; replace for self-managed GitLab)
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com
 
 # Multi-instance (each client specifies their GitLab URL via GITLAB-URL header)
 gitlab-mcp-server --http --http-addr=:8080
@@ -100,7 +100,7 @@ If both headers are present, `PRIVATE-TOKEN` takes precedence. Requests without 
 OAuth mode (`--auth-mode=oauth`) enables RFC 9728–compliant OAuth 2.1 authentication. Instead of managing tokens manually, MCP clients discover the authorization server automatically and handle the OAuth flow:
 
 ```bash
-gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com --auth-mode=oauth
+gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth
 ```
 
 **How it works:**
@@ -303,7 +303,7 @@ docker run -d \
   ghcr.io/jmrplens/gitlab-mcp-server:latest \
   --http \
   --http-addr=0.0.0.0:8080 \
-  --gitlab-url=https://gitlab.example.com
+  --gitlab-url=https://gitlab.com
 ```
 
 </TabItem>
@@ -339,9 +339,9 @@ services:
     ports:
       - "8080:8080"
     command:
-      # Single instance mode (default URL for all clients):
+      # Single instance mode (fixed GitLab.com URL for all clients; replace for self-managed GitLab):
       - "--http"
-      - "--gitlab-url=https://gitlab.example.com"
+      - "--gitlab-url=https://gitlab.com"
       - "--http-addr=:8080"
       - "--max-http-clients=200"
       - "--session-timeout=1h"

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -42,8 +42,8 @@ Store your token in a `.env` file with restricted permissions:
 
 ```bash
 # Create .env file
-echo 'GITLAB_URL=https://gitlab.example.com' > .env
-echo 'GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx' >> .env
+echo 'GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx' > .env
+# Add GITLAB_URL here only for self-managed instances.
 
 # Restrict permissions (owner read/write only)
 chmod 600 .env
@@ -64,7 +64,6 @@ For VS Code users, you can use input variables to avoid storing tokens in plain 
 			"type": "stdio",
 			"command": "gitlab-mcp-server",
 			"env": {
-				"GITLAB_URL": "https://gitlab.example.com",
 				"GITLAB_TOKEN": "${input:gitlabToken}"
 			}
 		}

--- a/site/src/content/docs/operations/troubleshooting.mdx
+++ b/site/src/content/docs/operations/troubleshooting.mdx
@@ -15,7 +15,7 @@ For the complete technical reference, see [`docs/troubleshooting.md`](https://gi
 flowchart TD
     A[Server won't start] --> B{Error message?}
     B -->|GITLAB_TOKEN required| C[Set GITLAB_TOKEN<br/>in .env or env]
-    B -->|GITLAB_URL required| D[Set GITLAB_URL<br/>in .env or flag]
+    B -->|Invalid GITLAB_URL| D[Fix self-managed<br/>GITLAB_URL]
     B -->|401 Unauthorized| E[Regenerate token<br/>with api scope]
     B -->|403 Forbidden| F[Check token has<br/>api scope]
     B -->|Connection refused| G{Is GitLab reachable?}
@@ -36,13 +36,13 @@ flowchart TD
     style K fill:#3b82f6,color:#fff
 ```
 
-| Symptom                                | Cause                       | Solution                                                                                                                                |
-| -------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITLAB_TOKEN is required` at startup  | Token not set               | Set `GITLAB_TOKEN` in `.env` or environment                                                                                             |
-| `GITLAB_URL is required` at startup    | URL not set                 | Set `GITLAB_URL` in `.env` or use `--gitlab-url` flag. In HTTP mode, `--gitlab-url` is optional if clients send the `GITLAB-URL` header |
-| `401 Unauthorized` from GitLab API     | Invalid or expired PAT      | Generate a new token with `api` scope at GitLab → Preferences → Access Tokens                                                           |
-| `403 Forbidden` on specific operations | Token lacks required scope  | Ensure the token has `api` scope (not just `read_api`)                                                                                  |
-| Connection refused or timeout          | GitLab instance unreachable | Verify `GITLAB_URL` is reachable: `curl -s $GITLAB_URL/api/v4/version`                                                                  |
+| Symptom                                    | Cause                       | Solution                                                                      |
+| ------------------------------------------ | --------------------------- | ----------------------------------------------------------------------------- |
+| `GITLAB_TOKEN is required` at startup      | Token not set               | Set `GITLAB_TOKEN` in `.env` or environment                                   |
+| `GITLAB_URL is not a valid URL` at startup | URL has invalid syntax      | Fix `GITLAB_URL` or omit it to use `https://gitlab.com` in stdio mode         |
+| `401 Unauthorized` from GitLab API         | Invalid or expired PAT      | Generate a new token with `api` scope at GitLab → Preferences → Access Tokens |
+| `403 Forbidden` on specific operations     | Token lacks required scope  | Ensure the token has `api` scope (not just `read_api`)                        |
+| Connection refused or timeout              | GitLab instance unreachable | Verify `GITLAB_URL` is reachable: `curl -s $GITLAB_URL/api/v4/version`        |
 
 ## TLS and certificates
 
@@ -175,7 +175,7 @@ Enable verbose logging to diagnose issues:
    LOG_LEVEL=debug ./gitlab-mcp-server 2>debug.log
 
    # HTTP mode (logs interleaved with server output)
-   LOG_LEVEL=debug ./gitlab-mcp-server --http --gitlab-url=https://gitlab.example.com 2>debug.log
+   LOG_LEVEL=debug ./gitlab-mcp-server --http --gitlab-url=https://gitlab.com 2>debug.log
    ```
 
 2. **Reproduce the issue** by running the same operation that failed.


### PR DESCRIPTION
## Summary

Default stdio-mode configuration to `https://gitlab.com` when `GITLAB_URL` is omitted, while preserving HTTP multi-instance behavior where clients provide `GITLAB-URL` per request.

## Changes

- Add `config.DefaultGitLabURL` and use it in stdio config loading, server card generation, and wizard flows.
- Keep HTTP mode without a default fixed URL, including an explicit OAuth guard requiring `--gitlab-url`.
- Update README, docs, Starlight documentation, manifests, and generated LLM metadata to describe the new default.
- Expand unit coverage for empty/whitespace URLs, malformed explicit URLs, wizard defaults, token creation URLs, and OAuth fixed-URL requirements.

## Validation

- `make test`
- `make test-e2e-docker`
- `go test ./cmd/... ./internal/...`
- `go test ./internal/config ./internal/wizard ./internal/serverpool ./cmd/server -count=1`
- `go vet ./internal/config ./internal/wizard ./cmd/server`
- `golangci-lint run ./internal/config ./internal/wizard ./cmd/server`
- `git diff --check`
- `npx markdownlint-cli2 README.md docs/architecture.md docs/ci-cd.md docs/cli-reference.md docs/configuration.md docs/development/development.md docs/env-reference.md docs/examples/usage-examples.md docs/getting-started.md docs/http-server-mode.md docs/ide-configuration.md docs/troubleshooting.md .github/skills/update-starlight-docs/SKILL.md`
- `cd site && pnpm run lint`
- `cd site && pnpm run build`
- `go test -tags e2e -c -o /dev/null ./test/e2e/suite/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * `GITLAB_URL` is now optional and defaults to `https://gitlab.com`, simplifying configuration for GitLab.com users.
  * Only `GITLAB_TOKEN` is required for stdio mode setup; `GITLAB_URL` only needs to be set for self-managed GitLab instances.

* **Documentation**
  * Updated all configuration guides, examples, and IDE setup instructions to reflect optional `GITLAB_URL` with default behavior.
  * Clarified troubleshooting and FAQ guidance for self-managed GitLab deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->