### PR TITLE
Docs: add dynamic toolset to sidebar

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -330,6 +330,11 @@ export default defineConfig({
 							translations: { es: "Meta-herramientas" },
 						},
 						{
+							slug: "tools/dynamic-tools",
+							label: "Dynamic Toolset",
+							translations: { es: "Conjunto dinámico" },
+						},
+						{
 							slug: "tools/orbit",
 							label: "Orbit",
 							translations: { es: "Orbit" },

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -332,7 +332,7 @@ export default defineConfig({
 						{
 							slug: "tools/dynamic-tools",
 							label: "Dynamic Toolset",
-							translations: { es: "Conjunto dinámico" },
+							translations: { es: "Herramientas dinámicas" },
 						},
 						{
 							slug: "tools/orbit",


### PR DESCRIPTION
## Summary

- Add the Dynamic Toolset page to the Starlight Tools sidebar.
- Makes the already-generated English and Spanish dynamic-tools pages discoverable from docs navigation.

## Validation

- `pnpm --dir site build`
- `pnpm --dir site format:check`
- `git diff --check`

## Summary by Sourcery

Documentation:
- Expose the Dynamic Toolset docs page (English and Spanish) in the tools sidebar navigation.