### PR TITLE
Expand dynamic toolset documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Three registration modes, controlled by `META_TOOLS` or `TOOL_SURFACE`:
 
 For dynamic experiments where resources and prompts dominate initial context, set `CAPABILITY_SURFACE=minimal` (stdio) or `--capability-surface=minimal` (HTTP) to keep only `gitlab://workspace/roots` and omit optional MCP resources and prompts. The default remains `full`.
 
-Meta-tools remain the default today. Dynamic mode is the current low-token candidate for a future default; see [Dynamic Toolset](docs/dynamic-tools.md) for the search/describe/execute workflow, diagrams, and migration guidance.
+Meta-tools remain the default today. Dynamic mode is the current low-token candidate for a future default; see [Dynamic Toolset](docs/dynamic-tools.md) for the fuzzy search ranking model, MCP response shapes, search/describe/execute workflow, diagrams, and migration guidance.
 
 Meta-tool summary:
 

--- a/docs/dynamic-tools.md
+++ b/docs/dynamic-tools.md
@@ -97,6 +97,93 @@ sequenceDiagram
     LLM-->>User: Human-readable result
 ```
 
+The three dynamic tools return normal MCP tool results. Each response includes Markdown text for human-readable clients and structured content for models that inspect JSON payloads directly. The dynamic layer does not invent a second execution path: `gitlab_execute_tool` dispatches to the same handler, markdown formatter, schema validation, policy checks, and GitLab client used by the corresponding meta-tool action.
+
+## MCP Response Shapes
+
+### `gitlab_search_tools`
+
+Search returns a ranked shortlist of catalog actions. The Markdown response is a compact table with action IDs, destructive flags, and required params. The structured response uses this shape:
+
+```json
+{
+  "query": "merge request list open authored by me project",
+  "count": 1,
+  "results": [
+    {
+      "id": "merge_request.list",
+      "tool": "gitlab_merge_request",
+      "domain": "merge_request",
+      "action": "list",
+      "schema_uri": "gitlab://schema/meta/gitlab_merge_request/list",
+      "destructive": false,
+      "required_params": ["project_id"],
+      "usage": "",
+      "score": 275
+    }
+  ]
+}
+```
+
+An empty query returns `isError: true` with example search terms. A query with no matches returns a non-error result with a no-match message and `count: 0`, so the model can broaden the query and try again.
+
+### `gitlab_describe_tools`
+
+Describe hydrates one or more canonical action IDs. It accepts either `action` or `actions`, trims duplicates, resolves unambiguous aliases, and rejects unknown or ambiguous IDs with repair guidance. The response includes the exact action-specific input schema and an executable example:
+
+```json
+{
+  "count": 1,
+  "actions": [
+    {
+      "id": "merge_request.list",
+      "tool": "gitlab_merge_request",
+      "domain": "merge_request",
+      "action": "list",
+      "schema_uri": "gitlab://schema/meta/gitlab_merge_request/list",
+      "destructive": false,
+      "required_params": ["project_id"],
+      "input_schema": {
+        "type": "object",
+        "required": ["project_id"],
+        "properties": {
+          "project_id": { "type": "string" },
+          "state": { "type": "string" },
+          "scope": { "type": "string" }
+        }
+      },
+      "example": {
+        "tool": "gitlab_execute_tool",
+        "arguments": {
+          "action": "merge_request.list",
+          "params": { "project_id": "group/project" }
+        }
+      }
+    }
+  ]
+}
+```
+
+`output_schema` is included when the underlying action route provides one. The Markdown response mirrors the same details and embeds the compact JSON input schema for clients that display only text content.
+
+### `gitlab_execute_tool`
+
+Execute accepts a canonical `domain.action` ID and a required `params` object. Use `params: {}` for actions with no parameters. Before dispatching, it resolves unambiguous aliases, normalizes known parameter aliases against the selected schema, applies a small set of action-scoped compatibility conversions, and moves top-level `confirm: true` into action params for destructive calls.
+
+```json
+{
+  "action": "merge_request.list",
+  "params": {
+    "project_id": "my-group/my-project",
+    "state": "opened",
+    "scope": "created_by_me",
+    "per_page": 20
+  }
+}
+```
+
+The response is the existing action response: the same Markdown and structured result returned by the backing meta-tool handler. If the action ID is unknown, execute returns `isError: true` and may suggest nearby canonical IDs. If params fail validation, the backing handler returns the same repairable validation error it would return in meta-tool mode.
+
 ## Example Calls
 
 ### Search
@@ -111,7 +198,7 @@ sequenceDiagram
 }
 ```
 
-A result contains canonical action IDs such as `merge_request.list`, domains, summaries, aliases, read-only/destructive metadata, and short reasoning hints.
+A result contains canonical action IDs such as `merge_request.list`, backing meta-tool names, domains, action names, schema URIs, destructive metadata, required params, usage hints, and scores.
 
 ### Describe
 
@@ -124,7 +211,7 @@ A result contains canonical action IDs such as `merge_request.list`, domains, su
 }
 ```
 
-Descriptions include input schemas and examples. Output schemas are intentionally omitted from the dynamic description payload to keep discovery small; output behavior remains documented in action summaries and normal tool responses.
+Descriptions include input schemas and examples. Output schemas are included when the underlying action route provides one; otherwise the normal action response remains the authoritative result contract.
 
 ### Execute
 
@@ -144,6 +231,18 @@ Descriptions include input schemas and examples. Output schemas are intentionall
 ```
 
 The action ID is canonical. Aliases can help search, but execution should use the action ID returned by search or describe.
+
+## Repair Loop
+
+Dynamic mode is designed for repairable failures. Models should treat `isError: true` as feedback, not as a dead end:
+
+| Failure | Server response | Model recovery |
+| --- | --- | --- |
+| Missing search query | Error result with example query terms | Retry `gitlab_search_tools` with domain, resource, verb, and filters |
+| Unknown action ID | Error result, often with `Did you mean ...?` canonical IDs | Search or describe the suggested canonical action ID |
+| Ambiguous alias | Error result listing the valid canonical targets | Pick one listed `domain.action` ID and describe it |
+| Invalid params | Backing handler validation error | Call `gitlab_describe_tools` and rebuild `params` from `input_schema` |
+| Destructive action without confirmation | Error result explaining that `confirm=true` is required | Ask the user for explicit approval, then retry with confirmation only if approved |
 
 ## Destructive Actions
 
@@ -221,15 +320,16 @@ The canonical action catalog is filtered after policy decisions such as enterpri
 
 `gitlab_search_tools` combines several signals:
 
-- Canonical IDs such as `merge_request.list`.
-- Domain and action names.
-- Human descriptions and aliases.
-- Verb synonyms such as show/list/get and remove/delete.
-- Stopword filtering for natural language queries.
-- Fuzzy matching for typo recovery.
-- Segmented matching for multi-intent prompts, such as `discover project from remote url merge request list current user open authored`.
+- **Normalization**: query text is lower-cased and split on spaces, dots, underscores, and hyphens. Frequent words such as `the`, `to`, `with`, and `please` are dropped.
+- **Search corpus**: each action is indexed by canonical ID, split ID words, backing meta-tool name, domain, action name, aliases, tags, required params, and schema property names.
+- **Synonyms**: common task words expand to domain-specific alternatives. For example, `mr` expands toward merge-request terms, `secret` toward CI variables and tokens, `show` toward `get`, and `remove` toward `delete`.
+- **Exact ranking**: exact canonical IDs score highest, followed by aliases, tags, domain/action names, partial ID matches, and broader search-text matches.
+- **Fuzzy fallback**: typo-tolerant matching runs only when exact lexical search returns no matches. It uses bounded Levenshtein distance up to two edits, ignores query tokens shorter than three characters, and requires all terms for one- or two-term queries or all but one term for longer queries.
+- **Segmented matching**: long multi-intent prompts are also searched in overlapping three- to six-term windows. This helps prompts such as `discover project from remote url merge request list current user open authored` surface both project discovery and merge-request listing candidates.
 
 The goal is not to make the model guess blindly. The model should use search to shortlist actions, describe to fetch exact schemas, then execute.
+
+Search returns only actions visible to the current server instance. Enterprise gating, GitLab.com-only routing, `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, excluded tools, and token-scope filtering are applied before the dynamic registry is exposed.
 
 ## Dynamic vs Meta-Tools
 

--- a/docs/dynamic-tools.md
+++ b/docs/dynamic-tools.md
@@ -97,13 +97,13 @@ sequenceDiagram
     LLM-->>User: Human-readable result
 ```
 
-The three dynamic tools return normal MCP tool results. Each response includes Markdown text for human-readable clients and structured content for models that inspect JSON payloads directly. The dynamic layer does not invent a second execution path: `gitlab_execute_tool` dispatches to the same handler, markdown formatter, schema validation, policy checks, and GitLab client used by the corresponding meta-tool action.
+The three dynamic tools return normal MCP tool results. The examples below show the `structuredContent` payloads, not the full MCP envelope. In the full result, human-readable Markdown appears in `content`, JSON data appears in `structuredContent`, and `isError` is set on the MCP result envelope when the server returns repair guidance instead of a successful action payload. The dynamic layer does not invent a second execution path: `gitlab_execute_tool` dispatches to the same handler, markdown formatter, schema validation, policy checks, and GitLab client used by the corresponding meta-tool action.
 
 ## MCP Response Shapes
 
 ### `gitlab_search_tools`
 
-Search returns a ranked shortlist of catalog actions. The Markdown response is a compact table with action IDs, destructive flags, and required params. The structured response uses this shape:
+Search returns a ranked shortlist of catalog actions. The Markdown response is a compact table with action IDs, destructive flags, and required params. The `structuredContent` payload uses this shape:
 
 ```json
 {
@@ -129,7 +129,7 @@ An empty query returns `isError: true` with example search terms. A query with n
 
 ### `gitlab_describe_tools`
 
-Describe hydrates one or more canonical action IDs. It accepts either `action` or `actions`, trims duplicates, resolves unambiguous aliases, and rejects unknown or ambiguous IDs with repair guidance. The response includes the exact action-specific input schema and an executable example:
+Describe hydrates one or more canonical action IDs. It accepts either `action` or `actions`, trims duplicates, resolves unambiguous aliases, and rejects unknown or ambiguous IDs with repair guidance. The `structuredContent` payload includes the exact action-specific input schema and an executable example:
 
 ```json
 {
@@ -164,7 +164,7 @@ Describe hydrates one or more canonical action IDs. It accepts either `action` o
 }
 ```
 
-`output_schema` is included when the underlying action route provides one. The Markdown response mirrors the same details and embeds the compact JSON input schema for clients that display only text content.
+`output_schema` is included when the underlying action route provides one. The Markdown response includes the core metadata and embeds the compact JSON input schema for clients that display only text content.
 
 ### `gitlab_execute_tool`
 

--- a/site/src/content/docs/es/tools/dynamic-tools.mdx
+++ b/site/src/content/docs/es/tools/dynamic-tools.mdx
@@ -104,6 +104,37 @@ sequenceDiagram
     AI-->>User: Respuesta formateada
 ```
 
+Cada herramienta dinámica devuelve un resultado MCP normal: Markdown para clientes que muestran texto y contenido estructurado para modelos que inspeccionan JSON. `gitlab_execute_tool` no usa un camino especial hacia GitLab. Despacha al mismo handler de acción que usan las meta-herramientas, así que los schemas, las comprobaciones de política, las previsualizaciones de safe mode, las confirmaciones destructivas y el formato de resultados siguen siendo coherentes.
+
+## Qué devuelve cada llamada
+
+| Llamada                 | Qué recibe el asistente                                                                                                                                                           | Cómo debe usarlo el asistente                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `gitlab_search_tools`   | Una lista ordenada de IDs de acción canónicos con meta-herramienta base, dominio, acción, URI de schema, indicador destructivo, parámetros requeridos, pistas de uso y puntuación | Elegir el mejor candidato `domain.action` y describirlo antes de ejecutar                         |
+| `gitlab_describe_tools` | `input_schema` exacto, parámetros requeridos, metadatos de seguridad, `output_schema` opcional, URI de schema y ejemplo ejecutable con `gitlab_execute_tool`                      | Construir `params` desde el schema y evitar nombres de campos inventados                          |
+| `gitlab_execute_tool`   | La respuesta existente de la acción desde el handler base, normalmente Markdown y JSON estructurado                                                                               | Usar los datos devueltos para responder al usuario, o reparar a partir de errores `isError: true` |
+
+Buscar y describir son llamadas deliberadamente pequeñas comparadas con anunciar todas las operaciones de GitLab en `tools/list`. El modelo solo paga por schemas detallados cuando necesita una acción concreta.
+
+## Cómo encuentra acciones la búsqueda
+
+`gitlab_search_tools` es más que una búsqueda de subcadenas. Indexa IDs canónicos, palabras del ID separadas, nombres de meta-herramientas base, dominios, nombres de acción, alias, etiquetas, parámetros requeridos y nombres de propiedades del schema.
+
+El pipeline de ranking:
+
+1. Normaliza la consulta en minúsculas y separa espacios, puntos, guiones bajos y guiones.
+2. Elimina palabras frecuentes como `the`, `to`, `with` y `please`.
+3. Expande sinónimos como `mr` → merge request, `secret` → variable/token de CI, `show` → get y `remove` → delete.
+4. Puntúa primero IDs canónicos exactos, después alias, etiquetas, nombres de dominio/acción, coincidencias parciales de ID y metadatos más amplios.
+5. Ejecuta recuperación fuzzy de errores tipográficos solo cuando la búsqueda léxica no devuelve resultados.
+6. Busca prompts largos en ventanas de tres a seis términos para que prompts de varios pasos puedan sacar varias acciones relevantes.
+
+La recuperación fuzzy está limitada a propósito: permite hasta dos errores de edición en tokens de al menos tres caracteres. Eso ayuda con prompts como `merje requesy list`, mientras que términos cortos como `mr` siguen apoyándose en alias y sinónimos en lugar de coincidencias tipográficas demasiado permisivas.
+
+:::tip[Usa IDs canónicos]
+Los alias ayudan en la búsqueda y pueden resolverse si no son ambiguos, pero los IDs canónicos `domain.action` son el contrato estable de ejecución. Ante la duda, describe el ID de acción devuelto por la búsqueda y ejecuta exactamente ese ID.
+:::
+
 ## Ejemplo
 
 Primero, busca la acción:
@@ -147,6 +178,18 @@ Por último, ejecútala:
 ```
 
 El asistente debe ejecutar el ID de acción canónico devuelto por búsqueda o descripción. Los alias ayudan al descubrimiento, pero los IDs canónicos son el contrato estable de ejecución.
+
+## Comportamiento de reparación
+
+El modo dinámico está diseñado para poder repararse. Si una llamada devuelve `isError: true`, el asistente debe usar el mensaje como feedback y repetir el paso correcto.
+
+| Fallo                                  | Recuperación                                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| La consulta de búsqueda está vacía     | Reintentar la búsqueda con dominio, recurso, verbo y filtros útiles                               |
+| La búsqueda es demasiado amplia        | Añadir términos como `project`, `merge request`, `issue`, `pipeline`, `authored by me` u `opened` |
+| El ID de acción es desconocido         | Buscar de nuevo o usar los IDs canónicos sugeridos por el mensaje de error                        |
+| Los parámetros son rechazados          | Describir la acción y reconstruir `params` desde `input_schema`                                   |
+| Una acción destructiva queda bloqueada | Pedir aprobación explícita al usuario antes de reintentar con `confirm: true`                     |
 
 ## Las acciones destructivas siguen protegidas
 

--- a/site/src/content/docs/es/tools/dynamic-tools.mdx
+++ b/site/src/content/docs/es/tools/dynamic-tools.mdx
@@ -4,7 +4,7 @@ description: Modo de búsqueda, descripción y ejecución con bajo consumo de to
 ---
 
 :::note[Documentación para desarrolladores]
-Para la referencia técnica completa, consulta [`docs/dynamic-tools.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/dynamic-tools.md) en el repositorio.
+Esta página es la guía de usuario. Para el contrato autoritativo a nivel de campos y las notas de implementación, consulta [`docs/dynamic-tools.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/dynamic-tools.md) en el repositorio.
 :::
 
 El conjunto de herramientas dinámico es el modo de bajo consumo de tokens de GitLab MCP Server. Mantiene disponible todo el catálogo de acciones de GitLab, pero muestra a tu cliente de IA solo tres herramientas públicas:
@@ -104,7 +104,7 @@ sequenceDiagram
     AI-->>User: Respuesta formateada
 ```
 
-Cada herramienta dinámica devuelve un resultado MCP normal: Markdown para clientes que muestran texto y contenido estructurado para modelos que inspeccionan JSON. `gitlab_execute_tool` no usa un camino especial hacia GitLab. Despacha al mismo handler de acción que usan las meta-herramientas, así que los schemas, las comprobaciones de política, las previsualizaciones de safe mode, las confirmaciones destructivas y el formato de resultados siguen siendo coherentes.
+Cada herramienta dinámica devuelve un resultado MCP normal: Markdown en `content`, datos JSON en `structuredContent` e `isError` en el envoltorio del resultado cuando el servidor devuelve una guía de reparación. `gitlab_execute_tool` no usa un camino especial hacia GitLab. Despacha al mismo handler de acción que usan las meta-herramientas, así que los schemas, las comprobaciones de política, las previsualizaciones de safe mode, las confirmaciones destructivas y el formato de resultados siguen siendo coherentes.
 
 ## Qué devuelve cada llamada
 
@@ -183,13 +183,13 @@ El asistente debe ejecutar el ID de acción canónico devuelto por búsqueda o d
 
 El modo dinámico está diseñado para poder repararse. Si una llamada devuelve `isError: true`, el asistente debe usar el mensaje como feedback y repetir el paso correcto.
 
-| Fallo                                  | Recuperación                                                                                      |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| La consulta de búsqueda está vacía     | Reintentar la búsqueda con dominio, recurso, verbo y filtros útiles                               |
-| La búsqueda es demasiado amplia        | Añadir términos como `project`, `merge request`, `issue`, `pipeline`, `authored by me` u `opened` |
-| El ID de acción es desconocido         | Buscar de nuevo o usar los IDs canónicos sugeridos por el mensaje de error                        |
-| Los parámetros son rechazados          | Describir la acción y reconstruir `params` desde `input_schema`                                   |
-| Una acción destructiva queda bloqueada | Pedir aprobación explícita al usuario antes de reintentar con `confirm: true`                     |
+| Fallo                                  | Recuperación                                                                  |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| La consulta de búsqueda está vacía     | Reintentar la búsqueda con dominio, recurso, verbo y filtros útiles           |
+| El ID de acción es desconocido         | Buscar de nuevo o usar los IDs canónicos sugeridos por el mensaje de error    |
+| Alias ambiguo                          | Elegir uno de los IDs `domain.action` listados y describirlo                  |
+| Los parámetros son rechazados          | Describir la acción y reconstruir `params` desde `input_schema`               |
+| Una acción destructiva queda bloqueada | Pedir aprobación explícita al usuario antes de reintentar con `confirm: true` |
 
 ## Las acciones destructivas siguen protegidas
 

--- a/site/src/content/docs/tools/dynamic-tools.mdx
+++ b/site/src/content/docs/tools/dynamic-tools.mdx
@@ -104,6 +104,37 @@ sequenceDiagram
     AI-->>User: Formatted answer
 ```
 
+Each dynamic tool returns a normal MCP tool result: Markdown for clients that render text and structured content for models that inspect JSON. `gitlab_execute_tool` does not use a special GitLab path. It dispatches to the same underlying action handler used by meta-tools, so schemas, policy checks, safe-mode previews, destructive confirmations, and result formatting stay consistent.
+
+## What each call returns
+
+| Call                    | What the assistant receives                                                                                                                             | How the assistant should use it                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `gitlab_search_tools`   | A ranked list of canonical action IDs with the backing meta-tool, domain, action, schema URI, destructive flag, required params, usage hints, and score | Pick the best `domain.action` candidate and describe it before execution          |
+| `gitlab_describe_tools` | Exact `input_schema`, required params, safety metadata, optional `output_schema`, schema URI, and an executable `gitlab_execute_tool` example           | Build `params` from the schema and avoid guessed field names                      |
+| `gitlab_execute_tool`   | The existing action response from the backing handler, usually Markdown plus structured JSON                                                            | Use the returned data to answer the user, or repair from `isError: true` feedback |
+
+Search and describe are deliberately cheap compared with advertising every GitLab operation in `tools/list`. The model pays for detailed schemas only when it needs a specific action.
+
+## How search finds actions
+
+`gitlab_search_tools` is more than a substring search. It indexes canonical IDs, split ID words, backing meta-tool names, domains, action names, aliases, tags, required params, and schema property names.
+
+The ranking pipeline:
+
+1. Normalizes the query by lower-casing it and splitting spaces, dots, underscores, and hyphens.
+2. Removes common stopwords such as `the`, `to`, `with`, and `please`.
+3. Expands synonyms such as `mr` → merge request, `secret` → CI variable/token, `show` → get, and `remove` → delete.
+4. Scores exact canonical IDs first, then aliases, tags, domain/action names, partial ID matches, and broader metadata matches.
+5. Runs fuzzy typo recovery only when lexical search returns no matches.
+6. Searches long prompts in three- to six-term windows so multi-step prompts can surface multiple relevant actions.
+
+Fuzzy recovery is bounded on purpose: it allows up to two edit mistakes for tokens of at least three characters. That helps with prompts like `merje requesy list`, while short terms such as `mr` still rely on aliases and synonyms instead of loose typo matching.
+
+:::tip[Use canonical IDs]
+Aliases help search and may resolve when unambiguous, but canonical `domain.action` IDs are the stable execution contract. When in doubt, describe the action ID returned by search and execute exactly that ID.
+:::
+
 ## Example
 
 First, search for the action:
@@ -147,6 +178,18 @@ Finally, execute it:
 ```
 
 The assistant should execute the canonical action ID returned by search or describe. Aliases are useful for discovery, but canonical IDs are the stable execution contract.
+
+## Repair behavior
+
+Dynamic mode is built to be repairable. If a call returns `isError: true`, the assistant should use the message as feedback and retry the right step.
+
+| Failure                       | Recovery                                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| Search query is empty         | Retry search with a domain, resource, verb, and useful filters                                |
+| Search is too broad           | Add terms like `project`, `merge request`, `issue`, `pipeline`, `authored by me`, or `opened` |
+| Action ID is unknown          | Search again or use the suggested canonical IDs from the error message                        |
+| Params are rejected           | Describe the action and rebuild `params` from `input_schema`                                  |
+| Destructive action is blocked | Ask the user for explicit approval before retrying with `confirm: true`                       |
 
 ## Destructive actions stay protected
 

--- a/site/src/content/docs/tools/dynamic-tools.mdx
+++ b/site/src/content/docs/tools/dynamic-tools.mdx
@@ -4,7 +4,7 @@ description: Low-token search, describe, and execute mode for large GitLab MCP c
 ---
 
 :::note[Developer Documentation]
-For the complete technical reference, see [`docs/dynamic-tools.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/dynamic-tools.md) in the repository.
+This page is the user-facing overview. For the authoritative field-level contract and implementation notes, see [`docs/dynamic-tools.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/dynamic-tools.md) in the repository.
 :::
 
 The dynamic toolset is the low-token mode for GitLab MCP Server. It keeps the complete GitLab action catalog available, but shows your AI client only three public tools:
@@ -104,7 +104,7 @@ sequenceDiagram
     AI-->>User: Formatted answer
 ```
 
-Each dynamic tool returns a normal MCP tool result: Markdown for clients that render text and structured content for models that inspect JSON. `gitlab_execute_tool` does not use a special GitLab path. It dispatches to the same underlying action handler used by meta-tools, so schemas, policy checks, safe-mode previews, destructive confirmations, and result formatting stay consistent.
+Each dynamic tool returns a normal MCP tool result: Markdown in `content`, JSON data in `structuredContent`, and `isError` on the result envelope when the server returns repair guidance. `gitlab_execute_tool` does not use a special GitLab path. It dispatches to the same underlying action handler used by meta-tools, so schemas, policy checks, safe-mode previews, destructive confirmations, and result formatting stay consistent.
 
 ## What each call returns
 
@@ -183,13 +183,13 @@ The assistant should execute the canonical action ID returned by search or descr
 
 Dynamic mode is built to be repairable. If a call returns `isError: true`, the assistant should use the message as feedback and retry the right step.
 
-| Failure                       | Recovery                                                                                      |
-| ----------------------------- | --------------------------------------------------------------------------------------------- |
-| Search query is empty         | Retry search with a domain, resource, verb, and useful filters                                |
-| Search is too broad           | Add terms like `project`, `merge request`, `issue`, `pipeline`, `authored by me`, or `opened` |
-| Action ID is unknown          | Search again or use the suggested canonical IDs from the error message                        |
-| Params are rejected           | Describe the action and rebuild `params` from `input_schema`                                  |
-| Destructive action is blocked | Ask the user for explicit approval before retrying with `confirm: true`                       |
+| Failure                       | Recovery                                                                |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Search query is empty         | Retry search with a domain, resource, verb, and useful filters          |
+| Action ID is unknown          | Search again or use the suggested canonical IDs from the error message  |
+| Ambiguous alias               | Pick one listed `domain.action` ID and describe it                      |
+| Params are rejected           | Describe the action and rebuild `params` from `input_schema`            |
+| Destructive action is blocked | Ask the user for explicit approval before retrying with `confirm: true` |
 
 ## Destructive actions stay protected
 


### PR DESCRIPTION
## Summary

- Document how the three dynamic tools respond to MCP calls, including search, describe, and execute response shapes.
- Explain the dynamic search ranking pipeline, including normalization, stopwords, synonyms, fuzzy typo recovery, and segmented matching.
- Add repair guidance for `isError: true` responses and mirror the user-facing content in Astro EN/ES docs.
- Update the README Dynamic Toolset link description to point readers at the richer technical reference.

## Validation

- `npx markdownlint-cli2 README.md docs/dynamic-tools.md site/src/content/docs/tools/dynamic-tools.mdx site/src/content/docs/es/tools/dynamic-tools.mdx`
- `pnpm --dir site format:check`
- `pnpm --dir site build`

## Summary by Sourcery

Expand and clarify documentation for the GitLab dynamic toolset’s behavior, including MCP response shapes, search ranking, and repair workflows.

Documentation:
- Document MCP response shapes and behaviors for `gitlab_search_tools`, `gitlab_describe_tools`, and `gitlab_execute_tool`, including example payloads and error handling guidance in the dynamic tools reference.
- Explain the dynamic search ranking pipeline (normalization, stopwords, synonyms, fuzzy typo recovery, segmented matching) and how it impacts tool discovery in the English and Spanish dynamic tools docs.
- Clarify how dynamic tools reuse existing meta-tool handlers and schemas, and document recommended usage patterns for canonical IDs vs aliases and repair loops for `isError: true` responses.
- Update the README Dynamic Toolset reference to highlight the richer technical details on fuzzy search ranking and MCP response shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Dynamic toolset documentation with MCP response contracts, error-recovery behavior, and search ranking mechanics.
  * Added repair behavior guidance for common failures including recovery steps and expected outcomes.
  * Enhanced search ranking documentation with normalization, synonym expansion, fuzzy matching, and policy filtering details.
  * Added Spanish language documentation for dynamic tools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->