### PR TITLE
fix(orbit): accept schema response_format alias

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,559 |
-| Unit test functions | 9,312 |
+| Total test functions | 9,560 |
+| Unit test functions | 9,313 |
 | E2E test functions | 247 |
 | cmd test functions | 398 |
 | Test files (internal/) | 404 |
@@ -37,7 +37,7 @@
 | --- | ---: | ---: |
 | `TestFunc_Scenario` (2-part) | 8,573 | 89.7% |
 | `TestFunc` (no underscore) | 698 | 7.3% |
-| `TestFunc_Scenario_Expected` (3+ part) | 288 | 3.0% |
+| `TestFunc_Scenario_Expected` (3+ part) | 289 | 3.0% |
 
 ## Test Distribution
 
@@ -47,10 +47,10 @@
 | --- | ---: | ---: | --- |
 | Core packages | 1,587 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration | 233 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
-| Tool sub-packages (165) | 7,094 | 313 | domain-specific GitLab tool handlers |
+| Tool sub-packages (165) | 7,095 | 313 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
 | cmd packages | 398 | 13 | server entry point and developer command utilities |
-| **Total** | **9,559** | **526** |  |
+| **Total** | **9,560** | **526** |  |
 
 ### Core Packages
 
@@ -223,7 +223,7 @@
 | mrnotes | 36 | 2 | 99.3% | 5 |
 | namespaces | 36 | 1 | 98.3% | 5 |
 | notifications | 30 | 1 | 100.0% | 7 |
-| orbit | 23 | 1 | 99.7% | 5 |
+| orbit | 24 | 1 | 99.7% | 5 |
 | packages | 108 | 4 | 95.6% | 9 |
 | pages | 55 | 2 | 99.1% | 10 |
 | pipelines | 99 | 2 | 97.4% | 12 |
@@ -276,7 +276,7 @@
 | vulnerabilities | 52 | 3 | 98.5% | 8 |
 | wikis | 58 | 2 | 98.9% | 6 |
 | workitems | 66 | 2 | 100.0% | 5 |
-| **Total** | **7,094** | **313** |  | **1,061** |
+| **Total** | **7,095** | **313** |  | **1,061** |
 
 </details>
 

--- a/docs/tools/orbit.md
+++ b/docs/tools/orbit.md
@@ -14,6 +14,8 @@
 
 The Orbit domain exposes GitLab's experimental Knowledge Graph API for GitLab.com. It is registered only when the MCP server is connected to `https://gitlab.com` and the Enterprise/Premium catalog is enabled; self-managed GitLab instances and non-enterprise catalogs do not advertise these tools. GitLab may still return `404 Not Found` when the `knowledge_graph` feature flag is disabled, `403 Forbidden` when the token cannot access a Knowledge Graph-enabled namespace or project, or `503 Service Unavailable` when the Orbit backend is unavailable.
 
+The upstream Orbit API is moving quickly. This MCP surface follows the latest GitLab client and CLI coverage, including `graph_status`; GitLab's public API reference may lag behind that endpoint. For schema formatting, the live API currently uses the `format` query parameter, while this server also accepts `response_format` as an input alias for compatibility with public documentation wording.
+
 When `META_TOOLS=true` (the default), all five individual tools below are consolidated into the `gitlab_orbit` meta-tool with an `action` parameter.
 
 | Meta-tool Action | Individual Tool | Purpose |
@@ -55,7 +57,7 @@ Get Orbit cluster health and component status. Optional `response_format` accept
 
 ### `gitlab_orbit_schema`
 
-Get the Orbit graph ontology, including schema version, domains, node summaries, and edges. Optional `expand` requests expanded node definitions for named node types, and optional `format` accepts `raw` or `llm`.
+Get the Orbit graph ontology, including schema version, domains, node summaries, and edges. Optional `expand` requests expanded node definitions for named node types, and optional `format` accepts `raw` or `llm`. The input also accepts `response_format` as an alias; if both are set, they must match.
 
 | Annotation | **Read** |
 | ---------- | -------- |

--- a/internal/tools/orbit/orbit.go
+++ b/internal/tools/orbit/orbit.go
@@ -29,8 +29,9 @@ type StatusInput struct {
 
 // SchemaInput holds parameters for retrieving the Orbit graph schema.
 type SchemaInput struct {
-	Expand []string `json:"expand,omitempty" jsonschema:"Node names to expand with full properties and relationships."`
-	Format string   `json:"format,omitempty" jsonschema:"Schema response format to request: raw or llm. Defaults to raw."`
+	Expand         []string `json:"expand,omitempty" jsonschema:"Node names to expand with full properties and relationships."`
+	Format         string   `json:"format,omitempty" jsonschema:"Schema response format to request: raw or llm. Defaults to raw."`
+	ResponseFormat string   `json:"response_format,omitempty" jsonschema:"Alias for format, accepted for compatibility with GitLab's public Orbit API documentation."`
 }
 
 // ToolsInput is the input for listing Orbit MCP tool manifests.
@@ -183,7 +184,7 @@ func Schema(ctx context.Context, client *gitlabclient.Client, input SchemaInput)
 	if err := ctx.Err(); err != nil {
 		return SchemaOutput{}, err
 	}
-	format, err := responseFormat(input.Format, "format")
+	format, err := schemaResponseFormat(input)
 	if err != nil {
 		return SchemaOutput{}, err
 	}
@@ -252,6 +253,18 @@ func GraphStatus(ctx context.Context, client *gitlabclient.Client, input GraphSt
 		return GraphStatusOutput{}, wrapOrbitErr("orbit_graph_status", err)
 	}
 	return convertGraphStatus(status), nil
+}
+
+func schemaResponseFormat(input SchemaInput) (*gl.OrbitResponseFormatValue, error) {
+	format := strings.TrimSpace(input.Format)
+	responseFormatAlias := strings.TrimSpace(input.ResponseFormat)
+	if format != "" && responseFormatAlias != "" && !strings.EqualFold(format, responseFormatAlias) {
+		return nil, errors.New("format and response_format must match when both are set")
+	}
+	if format != "" {
+		return responseFormat(format, "format")
+	}
+	return responseFormat(responseFormatAlias, "response_format")
 }
 
 func responseFormat(format, field string) (*gl.OrbitResponseFormatValue, error) {
@@ -331,6 +344,10 @@ func wrapOrbitErr(op string, err error) error {
 	if toolutil.IsHTTPStatus(err, http.StatusBadRequest) {
 		return toolutil.WrapErrWithHint(op, err,
 			"check the Orbit query, response_format, and graph_status scope parameters")
+	}
+	if toolutil.IsHTTPStatus(err, http.StatusTooManyRequests) {
+		return toolutil.WrapErrWithHint(op, err,
+			"Orbit request was rate-limited; retry later with a smaller query or lower request volume")
 	}
 	if toolutil.IsHTTPStatus(err, http.StatusServiceUnavailable) {
 		return toolutil.WrapErrWithHint(op, err,

--- a/internal/tools/orbit/orbit_test.go
+++ b/internal/tools/orbit/orbit_test.go
@@ -70,6 +70,28 @@ func TestSchema_WithExpandAndFormat_ForwardsQuery(t *testing.T) {
 	}
 }
 
+// TestSchema_ResponseFormatAlias_ForwardsFormat verifies that Schema accepts
+// response_format as a compatibility alias while forwarding GitLab's format query parameter.
+func TestSchema_ResponseFormatAlias_ForwardsFormat(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.AssertRequestMethod(t, r, http.MethodGet)
+		testutil.AssertRequestPath(t, r, "/api/v4/orbit/schema")
+		testutil.AssertQueryParam(t, r, "format", "llm")
+		if got := r.URL.Query().Get("response_format"); got != "" {
+			t.Fatalf("response_format query parameter = %q, want empty", got)
+		}
+		testutil.RespondJSON(w, http.StatusOK, `{"schema_version":"1.0"}`)
+	}))
+
+	out, err := Schema(context.Background(), client, SchemaInput{ResponseFormat: "llm"})
+	if err != nil {
+		t.Fatalf("Schema() error: %v", err)
+	}
+	if out.SchemaVersion != "1.0" {
+		t.Fatalf("Schema() = %+v, want schema version 1.0", out)
+	}
+}
+
 // TestTools_Success_ExpectedOutput verifies that Tools decodes the Orbit tools
 // catalog returned by the GitLab API.
 func TestTools_Success_ExpectedOutput(t *testing.T) {
@@ -226,6 +248,14 @@ func TestOrbit_ValidationErrors_ReturnActionableErrors(t *testing.T) {
 			want: "use raw or llm",
 		},
 		{
+			name: "conflicting schema formats",
+			call: func() error {
+				_, err := Schema(context.Background(), client, SchemaInput{Format: "raw", ResponseFormat: "llm"})
+				return err
+			},
+			want: "must match",
+		},
+		{
 			name: "invalid query response format",
 			call: func() error {
 				_, err := Query(context.Background(), client, QueryInput{
@@ -307,6 +337,16 @@ func TestOrbit_HTTPErrorHints_ReturnExpectedGuidance(t *testing.T) {
 				return err
 			},
 			want: "check the Orbit query",
+		},
+		{
+			name:   "rate limited",
+			path:   "/api/v4/orbit/query",
+			status: http.StatusTooManyRequests,
+			call: func(ctx context.Context, client *gitlabclient.Client) error {
+				_, err := Query(ctx, client, QueryInput{Query: map[string]any{"query_type": "traversal"}})
+				return err
+			},
+			want: "rate-limited",
 		},
 		{
 			name:   "service unavailable",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18877,6 +18877,7 @@ Get the experimental GitLab Orbit Knowledge Graph ontology. This tool is registe
 
 - `expand` (): Node names to expand with full properties and relationships.
 - `format` (string): Schema response format to request: raw or llm. Defaults to raw.
+- `response_format` (string): Alias for format, accepted for compatibility with GitLab's public Orbit API documentation.
 
 Annotations: readOnly=true, destructive=false, idempotent=true, openWorld=true
 


### PR DESCRIPTION
## Summary

- Accept `response_format` as a compatibility alias for Orbit schema requests while still forwarding GitLab's live `format` query parameter.
- Add explicit Orbit `429 Too Many Requests` guidance.
- Document the Orbit API drift around `graph_status` and schema formatting, and refresh generated testing/LLM artifacts.

## Verification

- `go test ./internal/tools/orbit/ -count=1`
- `go vet ./internal/tools/orbit/`
- `golangci-lint run ./internal/tools/orbit/`
- `npx markdownlint-cli2 docs/tools/orbit.md docs/testing/testing.md`
- `go run ./cmd/gen_testing_docs/ && go run ./cmd/gen_testing_docs/ --check`
- `go run ./cmd/gen_llms/`

## Summary by Sourcery

Support Orbit schema requests using a backward-compatible response_format alias while improving error guidance and documentation for the Orbit tools.

New Features:
- Allow Orbit schema requests to accept response_format as an alias for the format parameter while still using GitLab's format query parameter.

Enhancements:
- Validate and reconcile Orbit schema format and response_format inputs to prevent conflicting configurations.
- Add explicit handling and user-facing hints for Orbit 429 Too Many Requests errors.

Documentation:
- Clarify Orbit API behavior, including graph_status coverage and schema formatting aliases, and regenerate related testing and LLM documentation artifacts.

Tests:
- Extend Orbit tests to cover response_format alias behavior, conflicting format validation, and 429 rate limiting error hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orbit tool now accepts `response_format` as an alias for the `format` parameter for improved API compatibility.

* **Improvements**
  * Enhanced error messaging for rate-limited API requests with actionable retry guidance.

* **Documentation**
  * Updated Orbit tool reference with API compatibility details and schema formatting specifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->