### PR TITLE
Document canonical action core tool surfaces

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ gitlab-mcp-server/
 │   ├── testutil/           # Shared test helpers (NewTestClient, RespondJSON)
 │   ├── tools/              # Tool orchestration layer + 163 domain sub-packages
 │   │   ├── register.go     # RegisterAll() — delegates to sub-package RegisterTools()
-│   │   ├── register_meta.go # RegisterAllMeta() — delegates to sub-package RegisterMeta()
+│   │   ├── register_meta.go # RegisterAllMeta() — builds meta route groups for the canonical action catalog
 │   │   ├── dynamic/        # Low-token dynamic search/describe/execute tool surface
 │   │   ├── branches/       # Branch & protected branch tools
 │   │   ├── commits/        # Commit tools
@@ -86,7 +86,8 @@ gitlab-mcp-server/
 - Resources for read-only data (project info, user info, etc.)
 - Graceful shutdown via signal handling
 - Dynamic mode (`TOOL_SURFACE=dynamic`/`dynamic-3`) exposes `gitlab_search_tools`, `gitlab_describe_tools`, and `gitlab_execute_tool` over the canonical action catalog shared with meta-tools. Meta-tools remain the default today; dynamic is the current low-token candidate for a future default. Keep dynamic-2 parked unless explicitly requested.
-- When adding GitLab actions, register route metadata once through `internal/tools/register_meta.go` or delegated domain `RegisterMeta` route maps using typed `ActionRoute` constructors. Meta-tools, dynamic search/describe/execute, schema resources, LLM files, and audits all consume the canonical action catalog built from those definitions.
+- When adding GitLab actions, register route metadata once through the canonical action catalog route definitions in `internal/tools/register_meta.go` or an approved delegated meta group using typed `ActionRoute` constructors. Meta-tools, dynamic search/describe/execute, schema resources, LLM files, and audits consume that catalog. Individual `RegisterTools` remains a separate compatibility surface.
+- For the detailed developer architecture of individual tools, meta-tools, dynamic mode, and the canonical action core, see `docs/development/tool-surfaces-and-action-core.md`.
 
 ### GitLab Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ gitlab-mcp-server/
 │   ├── testutil/                # Shared test helpers (NewTestClient, RespondJSON)
 │   ├── tools/                   # Tool orchestration layer + 163 domain sub-packages
 │   │   ├── register.go          # RegisterAll() — delegates to sub-package RegisterTools()
-│   │   ├── register_meta.go     # RegisterAllMeta() — delegates to sub-package RegisterMeta()
+│   │   ├── register_meta.go     # RegisterAllMeta() — builds meta route groups for the canonical action catalog
 │   │   ├── dynamic/             # Low-token dynamic search/describe/execute surface over catalog routes
 │   │   ├── markdown.go          # Thin delegator to type-based markdown registry (toolutil.MarkdownForResult)
 │   │   ├── metatool.go          # Meta-tool registration: addMetaTool (DeriveAnnotations), addReadOnlyMetaTool, route wrappers
@@ -471,7 +471,7 @@ Markdown formatters use a type-based registry in `internal/toolutil/mdregistry.g
 
 `TOOL_SURFACE=dynamic` and `TOOL_SURFACE=dynamic-3` register only `gitlab_search_tools`, `gitlab_describe_tools`, and `gitlab_execute_tool`. The dynamic registry is built from the canonical action catalog shared with meta-tools and augmented with standalone routes such as project discovery, so execution reuses existing handlers, typed schemas, destructive-action classification, read-only filtering, safe-mode previews, markdown formatters, and scope filtering. Meta-tools remain the default today; dynamic is the current low-token candidate (minimizes LLM context-window usage) for a future default. `dynamic-2` is a parked comparison surface (`gitlab_find_action` + `gitlab_execute_tool`) and should not be promoted unless explicitly requested.
 
-Developers add normal GitLab actions through the route definitions that feed `internal/tools/register_meta.go` or delegated domain `RegisterMeta` functions. `internal/tools/action_catalog.go` builds the canonical catalog from those definitions; meta-tools register visible domain dispatchers from it, and dynamic mode builds search/describe/execute over it. Do not add duplicate dynamic-only action definitions for ordinary GitLab API operations.
+Developers add normal GitLab actions through the route definitions that feed `internal/tools/register_meta.go` or approved delegated meta groups. `internal/tools/action_catalog.go` builds the canonical catalog from those definitions; meta-tools register visible domain dispatchers from it, and dynamic mode builds search/describe/execute over it. Individual `RegisterTools` remains a separate compatibility surface. Do not add duplicate dynamic-only action definitions for ordinary GitLab API operations. See `docs/development/tool-surfaces-and-action-core.md` for the detailed developer architecture.
 
 Search combines canonical `domain.action` IDs, domain/action names, aliases, natural-language stopword filtering (removing frequent non-informative words), synonyms, fuzzy matching, and segmented matching for multi-intent prompts. Models should search, describe exact schemas, then execute the canonical action ID returned by search or describe. See `docs/dynamic-tools.md` and ADR-0011.
 
@@ -513,7 +513,7 @@ curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" -d '{
 ### Common issues
 
 - **TLS errors**: Set `GITLAB_SKIP_TLS_VERIFY=true` for self-signed certs
-- **Tool not found**: Check `register.go` and `register_meta.go` for registration
+- **Tool not found**: Check `register.go` for individual tools, `register_meta.go` / `action_catalog.go` for catalog-backed meta and dynamic actions, and `docs/development/tool-surfaces-and-action-core.md` for surface ownership rules
 - **Meta-tools disabled**: `META_TOOLS=false` disables discovery tools — set to `true` (default)
 - **Dynamic mode shows only three tools**: this is expected when `TOOL_SURFACE=dynamic` or `dynamic-3` is set. Use `gitlab_search_tools`, `gitlab_describe_tools`, and `gitlab_execute_tool`; unset `TOOL_SURFACE` or set `TOOL_SURFACE=meta` to return to default meta-tools.
 - **Pagination missing**: Ensure tool uses `buildPaginationResponse()` helper for list operations

--- a/cmd/audit_tools/main.go
+++ b/cmd/audit_tools/main.go
@@ -89,7 +89,19 @@ func main() {
 	violations = append(violations, auditDuplicates(individualTools, "individual")...)
 	violations = append(violations, auditDuplicates(metaTools, "meta")...)
 
-	printReport(individualTools, metaTools, violations)
+	root, err := repositoryRoot(".")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "register meta audit skipped: %v\n", err)
+	}
+	var registerMetaDefinitions []registerMetaDefinition
+	if root != "" {
+		registerMetaDefinitions, err = auditRegisterMetaDefinitions(root)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "register meta audit skipped: %v\n", err)
+		}
+	}
+
+	printReport(individualTools, metaTools, violations, registerMetaDefinitions)
 }
 
 // listTools registers all MCP tools on an in-memory server and returns
@@ -288,7 +300,7 @@ func isDeleteToolName(name string) bool {
 // printReport writes the full markdown audit report to stdout,
 // including summary counts, violations grouped by category, and a
 // complete listing of all individual and meta-tools with their annotations.
-func printReport(individual, meta []*mcp.Tool, vs []violation) {
+func printReport(individual, meta []*mcp.Tool, vs []violation, registerMetaDefinitions []registerMetaDefinition) {
 	now := time.Now().Format("2006-01-02 15:04:05")
 	fmt.Printf("# MCP Tool Metadata Audit Report\n\n")
 	fmt.Printf("Generated: %s\n\n", now)
@@ -298,6 +310,7 @@ func printReport(individual, meta []*mcp.Tool, vs []violation) {
 	fmt.Printf("| Individual tools | %d |\n", len(individual))
 	fmt.Printf("| Meta-tools | %d |\n", len(meta))
 	fmt.Printf("| Total violations | %d |\n\n", len(vs))
+	printRegisterMetaDefinitions(registerMetaDefinitions)
 
 	if len(vs) == 0 {
 		fmt.Println("**No violations found.**")
@@ -359,6 +372,39 @@ func printReport(individual, meta []*mcp.Tool, vs []violation) {
 		}
 		fmt.Printf("| %d | `%s` | %s | %s |\n", i+1, t.Name, desc, ann)
 	}
+}
+
+func printRegisterMetaDefinitions(definitions []registerMetaDefinition) {
+	if len(definitions) == 0 {
+		return
+	}
+	referenced := 0
+	for _, definition := range definitions {
+		if definition.Referenced {
+			referenced++
+		}
+	}
+	fmt.Printf("## RegisterMeta Definition Inventory\n\n")
+	fmt.Printf("This section is informational. Unreferenced package-level `RegisterMeta` definitions are historical cleanup candidates, not metadata violations yet.\n\n")
+	fmt.Printf("| Metric | Count |\n")
+	fmt.Printf("| --- | ---: |\n")
+	fmt.Printf("| Package-level RegisterMeta definitions | %d |\n", len(definitions))
+	fmt.Printf("| Referenced from central meta hub | %d |\n", referenced)
+	fmt.Printf("| Unreferenced cleanup candidates | %d |\n\n", len(definitions)-referenced)
+	fmt.Printf("| Status | Package | File | Meta tool names |\n")
+	fmt.Printf("| --- | --- | --- | --- |\n")
+	for _, definition := range definitions {
+		status := "unreferenced"
+		if definition.Referenced {
+			status = "referenced"
+		}
+		toolNames := strings.Join(definition.ToolNames, ", ")
+		if toolNames == "" {
+			toolNames = "-"
+		}
+		fmt.Printf("| %s | `%s` | `%s` | `%s` |\n", status, definition.Package, definition.File, toolNames)
+	}
+	fmt.Println()
 }
 
 // ptrBool formats a *bool as "true", "false", or "nil".

--- a/cmd/audit_tools/register_meta_audit.go
+++ b/cmd/audit_tools/register_meta_audit.go
@@ -38,6 +38,7 @@ func auditRegisterMetaDefinitions(root string) ([]registerMetaDefinition, error)
 
 func findRegisterMetaDefinitions(root, toolsDir string) ([]registerMetaDefinition, error) {
 	var definitions []registerMetaDefinition
+	fileSet := token.NewFileSet()
 	err := filepath.WalkDir(toolsDir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -52,7 +53,6 @@ func findRegisterMetaDefinitions(root, toolsDir string) ([]registerMetaDefinitio
 			return nil
 		}
 
-		fileSet := token.NewFileSet()
 		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
 		if parseErr != nil {
 			return fmt.Errorf("parse %s: %w", path, parseErr)

--- a/cmd/audit_tools/register_meta_audit.go
+++ b/cmd/audit_tools/register_meta_audit.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type registerMetaDefinition struct {
+	Package    string
+	File       string
+	ToolNames  []string
+	Referenced bool
+}
+
+func auditRegisterMetaDefinitions(root string) ([]registerMetaDefinition, error) {
+	toolsDir := filepath.Join(root, "internal", "tools")
+	definitions, err := findRegisterMetaDefinitions(root, toolsDir)
+	if err != nil {
+		return nil, err
+	}
+	references, err := referencedRegisterMetaPackages(filepath.Join(toolsDir, "register_meta.go"))
+	if err != nil {
+		return nil, err
+	}
+	for index := range definitions {
+		_, definitions[index].Referenced = references[definitions[index].Package]
+	}
+	return definitions, nil
+}
+
+func findRegisterMetaDefinitions(root, toolsDir string) ([]registerMetaDefinition, error) {
+	var definitions []registerMetaDefinition
+	err := filepath.WalkDir(toolsDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fileSet := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Name.Name != "RegisterMeta" || function.Recv != nil {
+				continue
+			}
+			relative, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
+			definitions = append(definitions, registerMetaDefinition{
+				Package:   file.Name.Name,
+				File:      filepath.ToSlash(relative),
+				ToolNames: registerMetaToolNames(function),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(definitions, func(i, j int) bool {
+		if definitions[i].Package == definitions[j].Package {
+			return definitions[i].File < definitions[j].File
+		}
+		return definitions[i].Package < definitions[j].Package
+	})
+	return definitions, nil
+}
+
+func registerMetaToolNames(function *ast.FuncDecl) []string {
+	seen := make(map[string]struct{})
+	var names []string
+	ast.Inspect(function.Body, func(node ast.Node) bool {
+		keyValue, ok := node.(*ast.KeyValueExpr)
+		if !ok {
+			return true
+		}
+		key, ok := keyValue.Key.(*ast.Ident)
+		if !ok || key.Name != "Name" {
+			return true
+		}
+		literal, ok := keyValue.Value.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err != nil || !strings.HasPrefix(value, "gitlab_") {
+			return true
+		}
+		if _, found := seen[value]; found {
+			return true
+		}
+		seen[value] = struct{}{}
+		names = append(names, value)
+		return true
+	})
+	sort.Strings(names)
+	return names
+}
+
+func referencedRegisterMetaPackages(registerMetaPath string) (map[string]struct{}, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, registerMetaPath, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", registerMetaPath, err)
+	}
+	references := make(map[string]struct{})
+	ast.Inspect(file, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "RegisterMeta" {
+			return true
+		}
+		identifier, ok := selector.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		references[identifier.Name] = struct{}{}
+		return true
+	})
+	return references, nil
+}
+
+func repositoryRoot(start string) (string, error) {
+	current, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(current, "go.mod")); statErr == nil {
+			return current, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("go.mod not found from %s", start)
+		}
+		current = parent
+	}
+}

--- a/cmd/audit_tools/register_meta_audit_test.go
+++ b/cmd/audit_tools/register_meta_audit_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuditRegisterMetaDefinitions_ClassifiesCentralReferences(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "internal/tools/register_meta.go", `package tools
+
+func registerAllMetaGroups() {
+	search.RegisterMeta(nil, nil)
+	orbit.RegisterMeta(nil, nil)
+}
+`)
+	writeTestFile(t, root, "internal/tools/search/register.go", `package search
+
+func RegisterMeta() {
+	_ = struct{Name string}{Name: "gitlab_search"}
+}
+`)
+	writeTestFile(t, root, "internal/tools/legacy/register.go", `package legacy
+
+func RegisterMeta() {
+	_ = struct{Name string}{Name: "gitlab_legacy"}
+	_ = struct{Name string}{Name: "gitlab_legacy_extra"}
+}
+`)
+
+	definitions, err := auditRegisterMetaDefinitions(root)
+	if err != nil {
+		t.Fatalf("auditRegisterMetaDefinitions() error = %v", err)
+	}
+	if len(definitions) != 2 {
+		t.Fatalf("len(definitions) = %d, want 2", len(definitions))
+	}
+
+	byPackage := make(map[string]registerMetaDefinition, len(definitions))
+	for _, definition := range definitions {
+		byPackage[definition.Package] = definition
+	}
+
+	if !byPackage["search"].Referenced {
+		t.Fatal("search RegisterMeta was not marked referenced")
+	}
+	if byPackage["legacy"].Referenced {
+		t.Fatal("legacy RegisterMeta was marked referenced")
+	}
+	if got := byPackage["legacy"].ToolNames; len(got) != 2 || got[0] != "gitlab_legacy" || got[1] != "gitlab_legacy_extra" {
+		t.Fatalf("legacy tool names = %#v, want gitlab_legacy and gitlab_legacy_extra", got)
+	}
+}
+
+func writeTestFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}

--- a/cmd/audit_tools/register_meta_audit_test.go
+++ b/cmd/audit_tools/register_meta_audit_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +55,75 @@ func RegisterMeta() {
 	}
 }
 
+func TestPrintRegisterMetaDefinitions_WritesInventorySummary(t *testing.T) {
+	output := captureStdout(t, func() {
+		printRegisterMetaDefinitions([]registerMetaDefinition{
+			{
+				Package:    "search",
+				File:       "internal/tools/search/register.go",
+				ToolNames:  nil,
+				Referenced: true,
+			},
+			{
+				Package:    "legacy",
+				File:       "internal/tools/legacy/register.go",
+				ToolNames:  []string{"gitlab_legacy"},
+				Referenced: false,
+			},
+		})
+	})
+
+	expectedFragments := []string{
+		"## RegisterMeta Definition Inventory",
+		"| Package-level RegisterMeta definitions | 2 |",
+		"| Referenced from central meta hub | 1 |",
+		"| Unreferenced cleanup candidates | 1 |",
+		"| referenced | `search` | `internal/tools/search/register.go` | `-` |",
+		"| unreferenced | `legacy` | `internal/tools/legacy/register.go` | `gitlab_legacy` |",
+	}
+	for _, expected := range expectedFragments {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("output missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestPrintRegisterMetaDefinitions_EmptyDefinitionsWritesNothing(t *testing.T) {
+	output := captureStdout(t, func() {
+		printRegisterMetaDefinitions(nil)
+	})
+	if output != "" {
+		t.Fatalf("output = %q, want empty string", output)
+	}
+}
+
+func TestRepositoryRoot_FindsNearestGoMod(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.com/test\n")
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", nested, err)
+	}
+
+	foundRoot, err := repositoryRoot(nested)
+	if err != nil {
+		t.Fatalf("repositoryRoot() error = %v", err)
+	}
+	if foundRoot != root {
+		t.Fatalf("repositoryRoot() = %q, want %q", foundRoot, root)
+	}
+}
+
+func TestRepositoryRoot_MissingGoModReturnsError(t *testing.T) {
+	_, err := repositoryRoot(t.TempDir())
+	if err == nil {
+		t.Fatal("repositoryRoot() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "go.mod not found") {
+		t.Fatalf("repositoryRoot() error = %q, want go.mod not found", err)
+	}
+}
+
 func writeTestFile(t *testing.T, root string, name string, content string) {
 	t.Helper()
 	path := filepath.Join(root, name)
@@ -62,4 +133,29 @@ func writeTestFile(t *testing.T, root string, name string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q) error = %v", path, err)
 	}
+}
+
+func captureStdout(t *testing.T, action func()) string {
+	t.Helper()
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe() error = %v", err)
+	}
+	os.Stdout = writer
+
+	action()
+
+	os.Stdout = originalStdout
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatalf("Close() writer error = %v", closeErr)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if closeErr := reader.Close(); closeErr != nil {
+		t.Fatalf("Close() reader error = %v", closeErr)
+	}
+	return string(output)
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Project documentation for gitlab-mcp-server — a Model Context Protocol server 
 | Document | Description |
 | --- | --- |
 | [Development Guide](development/development.md) | Developer guide: setup, building, testing, adding new tools |
+| [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md) | Developer architecture for individual tools, meta-tools, dynamic mode, and shared action catalog |
 | [Testing](testing/testing.md) | Test suite overview, coverage breakdown, and per-package statistics |
 | [AI Model Evaluation](testing/model-evaluation.md) | How model evaluations validate MCP tool use against schema and Docker GitLab |
 | [AI Model Evaluation Developer Guide](testing/model-evaluation-developer.md) | Commands, fixtures, traces, and maintenance workflow for model evaluation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,8 @@ Thin wrapper around the official `gitlab.com/gitlab-org/api/client-go/v2` librar
 
 The largest package — contains 1006 self-managed Enterprise/Premium MCP tool implementations, plus 5 GitLab.com-only Orbit handlers for 1011 total in that catalog, organized across 163 domain sub-packages under `internal/tools/`. Each sub-package owns its types, handlers, Markdown formatters, and registration functions.
 
+For the detailed relationship between individual tools, meta-tools, dynamic mode, and the canonical action catalog, see [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md).
+
 **Orchestration files** in `internal/tools/`:
 
 | File               | Purpose                                                       |
@@ -285,6 +287,8 @@ sequenceDiagram
 The dynamic toolset is a progressive-disclosure layer over the canonical action catalog. Instead of exposing all domain
 meta-tools in `tools/list`, it exposes only `gitlab_search_tools`, `gitlab_describe_tools`, and `gitlab_execute_tool`.
 The current default remains meta-tools, but dynamic mode is the low-token candidate for a future default.
+
+For developer guidance on shared catalog ownership, standalone dynamic actions, and registration rules, see [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md).
 
 Startup builds the canonical action catalog from the same route definitions used by meta-tools, then adds standalone
 actions such as project discovery for dynamic mode. This preserves existing typed schemas, route classification, markdown formatters,

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -344,16 +344,17 @@ With the modular sub-package architecture (ADR-0004):
 1. **Create sub-package**: `internal/tools/{domain}/`
 2. **Create handler file**: `{domain}.go` with typed input/output structs (no domain prefix — package provides namespace)
 3. **Create test file**: `{domain}_test.go` with table-driven tests using `testutil.NewTestClient`
-4. **Create register file**: `register.go` with `RegisterTools(server, client)` and optionally `RegisterMeta(server, client)`
-5. **Create markdown formatters**: `Format*Markdown()` functions in the sub-package
+4. **Create register file**: `register.go` with `RegisterTools(server, client)` for the individual tool surface
+5. **Create markdown formatters**: register output formatters from the sub-package with `toolutil.RegisterMarkdown` or `toolutil.RegisterMarkdownResult`
 6. **Wire in orchestration**:
-   - Add to `internal/tools/register.go` (call `{domain}.RegisterTools()`)
-   - Add to `internal/tools/register_meta.go` (call `{domain}.RegisterMeta()` or add the action to the relevant domain route map)
-   - Add markdown dispatch in `internal/tools/markdown.go`
+    - Add to `internal/tools/register.go` (call `{domain}.RegisterTools()`)
+    - Add catalog-backed action routes to `internal/tools/register_meta.go` or an approved delegated meta group
 7. **Update documentation**: `docs/tools/{domain}.md` and `docs/tools/README.md`
 
 Meta-tools and the dynamic toolset share the canonical action catalog built by `internal/tools/action_catalog.go`.
 When adding a normal GitLab operation, define the route once with typed `ActionRoute` constructors (`RouteAction`, `DestructiveAction`, `RouteActionWithRequest`, and void variants). The same catalog entry then powers the visible meta-tool action, `gitlab_search_tools`, `gitlab_describe_tools`, `gitlab_execute_tool`, schema resources, generated LLM files, and audit commands. Avoid adding dynamic-only copies of ordinary GitLab actions.
+
+See [Tool Surfaces And Canonical Action Core](tool-surfaces-and-action-core.md) for the ownership rules across individual tools, meta-tools, dynamic mode, and the canonical action catalog.
 
 ### Example: Adding a tools sub-package
 

--- a/docs/development/tool-surfaces-and-action-core.md
+++ b/docs/development/tool-surfaces-and-action-core.md
@@ -1,0 +1,201 @@
+# Tool Surfaces And Canonical Action Core
+
+> **Diátaxis type**: Explanation
+> **Audience**: Developers and AI agents changing GitLab tool registration
+> **Prerequisites**: Familiarity with MCP tools, Go packages, and the project architecture
+
+gitlab-mcp-server exposes the GitLab API through multiple MCP tool surfaces. The
+surfaces differ in packaging and discovery behavior, not in the underlying
+GitLab business logic.
+
+## Tool Surfaces
+
+| Surface | Selector | Visible MCP tools | Source of action metadata |
+| --- | --- | ---: | --- |
+| Individual tools | `TOOL_SURFACE=individual` or `META_TOOLS=false` | One tool per GitLab operation | Direct `RegisterTools` calls in domain packages |
+| Meta-tools | default, `TOOL_SURFACE=meta` | Domain dispatchers with `action` and `params` | Canonical action catalog |
+| Dynamic / dynamic-3 | `TOOL_SURFACE=dynamic` or `TOOL_SURFACE=dynamic-3` | `gitlab_search_tools`, `gitlab_describe_tools`, `gitlab_execute_tool` | Canonical action catalog |
+| Dynamic-2 | `TOOL_SURFACE=dynamic-2` | `gitlab_find_action`, `gitlab_execute_tool` | Canonical action catalog |
+
+Individual tools are a direct compatibility surface. Meta-tools and dynamic
+tools are catalog-backed surfaces over the same action core.
+
+## Canonical Action Core
+
+The canonical action core is the intermediate layer between typed GitLab domain
+handlers and catalog-backed MCP surfaces.
+
+```text
+Typed domain handlers and route constructors
+                 |
+                 v
+Canonical action catalog
+       |                         |
+       v                         v
+Visible meta-tools        Dynamic search/describe/execute
+```
+
+The core pieces are:
+
+| File | Responsibility |
+| --- | --- |
+| `internal/toolutil/metatool.go` | Route primitives such as `ActionRoute`, `ActionMap`, schema helpers, destructive confirmation dispatch, and `MakeMetaHandler` |
+| `internal/tools/actionregistry/registry.go` | Canonical action catalog data model, deterministic ordering, filters, and `domain.action` IDs |
+| `internal/tools/action_catalog.go` | Builds the catalog from current meta route definitions without constructing an MCP server |
+| `internal/tools/meta_catalog.go` | Registers visible meta-tools from catalog groups |
+| `internal/tools/dynamic/register.go` | Builds the dynamic registry, search index, describe output, and execute dispatch from the catalog |
+| `internal/tools/dynamic/standalone.go` | Adds dynamic-only catalog actions that do not fit the normal meta route model |
+
+The catalog stores executable routes with input schemas, output schemas,
+destructive flags, read-only status, icons, descriptions, aliases, tags, and
+formatters. Dynamic action IDs use stable `domain.action` names such as
+`project.create`, `merge_request.list`, and `repository.file_get`.
+
+## Registration Flow
+
+`cmd/server/main.go` selects one tool surface when the server is created.
+
+```text
+TOOL_SURFACE=individual
+        |
+        v
+internal/tools.RegisterAll
+        |
+        v
+domain RegisterTools functions
+```
+
+```text
+TOOL_SURFACE=meta
+        |
+        v
+internal/tools.BuildActionCatalog
+        |
+        v
+internal/tools.RegisterMetaCatalog
+```
+
+```text
+TOOL_SURFACE=dynamic or dynamic-3
+        |
+        v
+cmd/server.buildDynamicActionCatalog
+        |
+        v
+dynamic.AddStandaloneCatalog
+        |
+        v
+dynamic.RegisterCatalogTools
+```
+
+```text
+TOOL_SURFACE=dynamic-2
+        |
+        v
+cmd/server.buildDynamicActionCatalog
+        |
+        v
+dynamic.RegisterCatalogFindExecuteTools
+```
+
+## Standalone Dynamic Actions
+
+Most dynamic actions come from the canonical catalog built from meta route
+definitions. A small set of actions are added only for dynamic mode because they
+are standalone tools or interactive flows rather than normal meta-tool actions.
+
+Current standalone dynamic additions live in `internal/tools/dynamic/standalone.go`:
+
+- `discover_project.resolve` from `gitlab_discover_project`.
+- `interactive.issue_create`, `interactive.mr_create`, `interactive.project_create`, and `interactive.release_create` when read-only mode and exclusions allow them.
+
+Do not add dynamic-only copies of ordinary GitLab API operations. Add ordinary
+operations through the normal route definitions that feed the canonical catalog.
+
+## Filtering And Policy Order
+
+Filtering must happen before a catalog-backed surface exposes actions to a
+client. The relevant policies are:
+
+- Enterprise/Premium and GitLab.com-only catalog selection.
+- `ExcludeTools` configuration.
+- Token-scope filtering.
+- `GITLAB_READ_ONLY` / `--read-only` filtering.
+- `GITLAB_SAFE_MODE` / `--safe-mode` previews.
+- Capability surface selection for resources and prompts.
+
+Dynamic mode builds a filtered catalog before constructing the dynamic registry,
+so search and execute cannot see hidden actions. Meta mode registers visible
+meta-tools from the filtered catalog and then exposes schema resources for the
+visible route set.
+
+## Schema Resources
+
+Meta and dynamic modes can register meta-schema resources when the capability
+surface is full. The URI format remains:
+
+```text
+gitlab://schema/meta/{tool}/{action}
+```
+
+Individual mode does not need these resources for action-specific schemas
+because every individual tool already advertises its own tool input schema.
+
+## Historical Duplication
+
+ADR-0005 consolidated many standalone meta-tools into broader domain meta-tools.
+The visible taxonomy changed, but many package-level `RegisterMeta` functions
+were intentionally left in place during the migration.
+
+Current baseline for cleanup planning:
+
+| Metric | Count |
+| --- | ---: |
+| Package-level `RegisterMeta` definitions under `internal/tools/*` | 54 |
+| Delegated `RegisterMeta` calls referenced from `internal/tools/register_meta.go` | 4 |
+| Apparent legacy `RegisterMeta` definitions requiring verification | Approximately 50 |
+
+Known stale examples:
+
+| Historical name | Current visible surface |
+| --- | --- |
+| `gitlab_feature_flag` | `gitlab_feature_flags` |
+| `gitlab_ff_user_list` | `gitlab_feature_flags` |
+| `gitlab_registry` | `gitlab_package` |
+| `gitlab_registry_protection` | `gitlab_package` |
+| `gitlab_access_request` | `gitlab_access` |
+| `gitlab_project_snippet` | `gitlab_snippet` |
+
+Before deleting any legacy `RegisterMeta` function, prove that its actions are
+covered by `BuildActionCatalog(...).ActionMaps()` through the current visible
+meta-tool group and that no tests or generated docs depend on the historical
+tool name.
+
+## Import Layering Rules
+
+- Domain packages under `internal/tools/{domain}` may import `internal/toolutil`.
+- `internal/toolutil` must not import domain packages.
+- `internal/tools` may import domain packages to wire registration.
+- `internal/tools/actionregistry` may import `internal/toolutil` for route metadata.
+- `internal/tools/dynamic` may import `internal/tools/actionregistry` and `internal/toolutil`, but must not depend on visible individual MCP tools.
+- `cmd/server` is the composition root for selecting and filtering the active surface.
+
+## When Adding A GitLab Action
+
+1. Add or update the typed handler in the appropriate domain package.
+2. Register the individual tool through that package's `RegisterTools` when the individual surface should expose it.
+3. Add the catalog-backed route to the central route definitions or an approved delegated meta group using typed `ActionRoute` constructors.
+4. Keep destructive classification on the route metadata, not in dynamic-only code.
+5. Add dynamic search tags or aliases only when natural language discovery is weak.
+6. Update tests, generated docs, and schema resources as required.
+
+## Useful Checks
+
+```bash
+rg -n "func RegisterMeta\(" internal/tools --glob '*.go'
+rg -n "RegisterMeta\(server, client\)|RegisterMeta\(server, .*client" internal/tools/register_meta.go
+rg -n "BuildActionCatalog\(|RegisterMetaCatalog\(|actionregistry\.|internal/tools/actionregistry|internal/tools/dynamic" --glob '*.go' cmd internal
+```
+
+Use these checks before removing legacy registration functions or moving the
+catalog package.

--- a/docs/dynamic-tools.md
+++ b/docs/dynamic-tools.md
@@ -360,6 +360,8 @@ For most users today, meta-tools remain the conservative default. Dynamic mode i
 
 Implementation entry points:
 
+For the broader developer architecture of individual tools, meta-tools, dynamic surfaces, and the canonical action core, see [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md).
+
 | File | Responsibility |
 | --- | --- |
 | `internal/tools/actionregistry/registry.go` | Canonical action catalog data model, deterministic action ordering, lookup, and filters |

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,24 +18,24 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,624 |
-| Unit test functions | 9,377 |
+| Total test functions | 9,625 |
+| Unit test functions | 9,378 |
 | E2E test functions | 247 |
-| cmd test functions | 401 |
+| cmd test functions | 402 |
 | Test files (internal/) | 407 |
-| Test files (cmd/) | 13 |
+| Test files (cmd/) | 14 |
 | Test files (test/e2e/suite/) | 109 |
 | Tool sub-packages tested | 165 |
 | Core packages tested | 16 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) | 87.7% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) | 87.6% |
 | Overall coverage (`go test ./internal/...`) | 97.0% |
-| Average package coverage | 94.9% |
+| Average package coverage | 94.5% |
 
 ### Naming Convention Stats
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,629 | 89.7% |
+| `TestFunc_Scenario` (2-part) | 8,630 | 89.7% |
 | `TestFunc` (no underscore) | 705 | 7.3% |
 | `TestFunc_Scenario_Expected` (3+ part) | 290 | 3.0% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration | 233 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,151 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
-| cmd packages | 401 | 13 | server entry point and developer command utilities |
-| **Total** | **9,624** | **529** |  |
+| cmd packages | 402 | 14 | server entry point and developer command utilities |
+| **Total** | **9,625** | **530** |  |
 
 ### Core Packages
 
@@ -291,6 +291,7 @@
 | cmd/audit_metrics | 19.7% |
 | cmd/audit_output | 23.0% |
 | cmd/audit_tokens | 19.0% |
+| cmd/audit_tools | 21.2% |
 | cmd/eval_meta_tools | 57.3% |
 | cmd/gen_llms | 7.2% |
 | cmd/gen_readme | 14.6% |
@@ -496,6 +497,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_tokens** (19.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (19.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (20.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tools** (21.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_meta_tools** (57.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,24 +18,24 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,625 |
-| Unit test functions | 9,378 |
+| Total test functions | 9,629 |
+| Unit test functions | 9,382 |
 | E2E test functions | 247 |
-| cmd test functions | 402 |
+| cmd test functions | 406 |
 | Test files (internal/) | 407 |
 | Test files (cmd/) | 14 |
 | Test files (test/e2e/suite/) | 109 |
 | Tool sub-packages tested | 165 |
 | Core packages tested | 16 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) | 87.6% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) | 87.7% |
 | Overall coverage (`go test ./internal/...`) | 97.0% |
-| Average package coverage | 94.5% |
+| Average package coverage | 94.6% |
 
 ### Naming Convention Stats
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,630 | 89.7% |
+| `TestFunc_Scenario` (2-part) | 8,634 | 89.7% |
 | `TestFunc` (no underscore) | 705 | 7.3% |
 | `TestFunc_Scenario_Expected` (3+ part) | 290 | 3.0% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration | 233 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,151 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
-| cmd packages | 402 | 14 | server entry point and developer command utilities |
-| **Total** | **9,625** | **530** |  |
+| cmd packages | 406 | 14 | server entry point and developer command utilities |
+| **Total** | **9,629** | **530** |  |
 
 ### Core Packages
 
@@ -291,7 +291,7 @@
 | cmd/audit_metrics | 19.7% |
 | cmd/audit_output | 23.0% |
 | cmd/audit_tokens | 19.0% |
-| cmd/audit_tools | 21.2% |
+| cmd/audit_tools | 32.5% |
 | cmd/eval_meta_tools | 57.3% |
 | cmd/gen_llms | 7.2% |
 | cmd/gen_readme | 14.6% |
@@ -497,8 +497,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_tokens** (19.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (19.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (20.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_tools** (21.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tools** (32.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_meta_tools** (57.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **testutil** (60.9%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.

--- a/internal/tools/action_catalog.go
+++ b/internal/tools/action_catalog.go
@@ -10,15 +10,16 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/internal/toolutil"
 )
 
-// ActionCatalogOptions controls which action groups are included in a catalog.
+// ActionCatalogOptions controls which action groups are included in the
+// canonical catalog.
 type ActionCatalogOptions struct {
 	Enterprise bool
 	IncludeMCP bool
 	Updater    *autoupdate.Updater
 }
 
-// BuildActionCatalog builds the canonical action catalog for meta-style GitLab
-// actions without constructing an MCP server.
+// BuildActionCatalog builds the canonical action catalog for catalog-backed
+// GitLab action surfaces without constructing an MCP server.
 func BuildActionCatalog(client *gitlabclient.Client, opts ActionCatalogOptions) (*actionregistry.Catalog, error) {
 	definitions := toolutil.CaptureMetaToolDefinitions(func() {
 		registerAllMetaGroups(nil, client, opts.Enterprise)

--- a/internal/tools/actionregistry/doc.go
+++ b/internal/tools/actionregistry/doc.go
@@ -1,0 +1,20 @@
+// Package actionregistry provides the canonical GitLab action catalog shared by
+// catalog-backed MCP tool surfaces.
+//
+// The catalog is the intermediate action core between typed GitLab handlers and
+// the public meta and dynamic tool surfaces. It stores executable actions as
+// deterministic groups, preserving route metadata such as input schemas, output
+// schemas, destructive flags, action aliases, tags, icons, descriptions, and
+// formatter hooks.
+//
+// Action IDs use the stable domain.action form derived from the backing
+// meta-tool name and action name. For example, gitlab_project/create becomes
+// project.create, and gitlab_merge_request/list becomes merge_request.list.
+// Dynamic mode uses these IDs directly, while meta-tools expose the same routes
+// through action dispatch inside domain tools.
+//
+// This package is not the registry for individual MCP tools. Individual tools
+// are still registered directly by internal/tools.RegisterAll for compatibility.
+// Meta-tools and dynamic tools consume this catalog through adapters such as
+// internal/tools.RegisterMetaCatalog and internal/tools/dynamic.NewRegistryFromCatalog.
+package actionregistry

--- a/internal/tools/actionregistry/registry.go
+++ b/internal/tools/actionregistry/registry.go
@@ -1,5 +1,3 @@
-// Package actionregistry provides the canonical GitLab action catalog used by
-// higher-level MCP tool surfaces.
 package actionregistry
 
 import (

--- a/internal/tools/doc.go
+++ b/internal/tools/doc.go
@@ -1,10 +1,11 @@
 // Package tools provides the MCP tool orchestration layer for the GitLab MCP
 // server.
 //
-// The package wires individual GitLab MCP tools and domain-scoped meta-tools to
-// the server, delegates domain implementations to internal/tools/{domain}
-// sub-packages, exposes the gitlab_server meta-tool, applies read-only and safe
-// mode behavior, filters tools by personal access token scopes, and delegates
+// The package wires the individual, meta, and dynamic GitLab MCP tool surfaces
+// to the server. It delegates domain implementations to internal/tools/{domain}
+// sub-packages, builds the canonical action catalog for catalog-backed
+// surfaces, exposes the gitlab_server meta-tool, applies read-only and safe mode
+// behavior, filters tools by personal access token scopes, and delegates
 // meta-tool Markdown rendering to the type-based registry in internal/toolutil.
 //
 // # Architecture
@@ -13,17 +14,15 @@
 //
 //	cmd/server
 //	    |
-//	    v
-//	RegisterAll and RegisterAllMeta
+//	    +--> RegisterAll --> internal/tools/{domain}.RegisterTools
 //	    |
-//	    v
-//	internal/tools/{domain}
+//	    +--> BuildActionCatalog --> RegisterMetaCatalog
 //	    |
-//	    v
-//	GitLab REST and GraphQL APIs
+//	    +--> BuildActionCatalog --> dynamic.RegisterCatalogTools
 //
-// [RegisterAll] registers the individual tools. [RegisterAllMeta] registers the
-// domain-scoped meta-tools that dispatch to action maps. [SafeModePreview]
-// describes the preview payload returned when safe mode intercepts mutating
-// calls.
+// [RegisterAll] registers the individual tools directly. [BuildActionCatalog]
+// builds the canonical action catalog used by [RegisterMetaCatalog] and dynamic
+// mode. [RegisterAllMeta] preserves the legacy meta registration entry point by
+// building and registering that catalog. [SafeModePreview] describes the preview
+// payload returned when safe mode intercepts mutating calls.
 package tools

--- a/internal/tools/dynamic/doc.go
+++ b/internal/tools/dynamic/doc.go
@@ -1,0 +1,14 @@
+// Package dynamic implements low-token GitLab MCP tool surfaces over the
+// canonical action catalog.
+//
+// Dynamic mode exposes a small discovery and execution interface instead of
+// advertising every GitLab operation as an MCP tool. The stable dynamic and
+// dynamic-3 surfaces register gitlab_search_tools, gitlab_describe_tools, and
+// gitlab_execute_tool. The parked dynamic-2 comparison surface registers
+// gitlab_find_action and gitlab_execute_tool.
+//
+// The package builds a deterministic search index from actionregistry.Catalog,
+// resolves canonical domain.action IDs and aliases, returns exact schemas on
+// demand, and dispatches execution through the same ActionRoute metadata used
+// by meta-tools. It does not wrap or call the visible individual MCP tools.
+package dynamic

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -1,4 +1,3 @@
-// Package dynamic registers the low-token dynamic toolset for GitLab actions.
 package dynamic
 
 import (

--- a/internal/tools/meta_catalog.go
+++ b/internal/tools/meta_catalog.go
@@ -7,7 +7,8 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/internal/toolutil"
 )
 
-// RegisterMetaCatalog registers visible meta-tools from a canonical action catalog.
+// RegisterMetaCatalog registers visible meta-tools from the canonical action
+// catalog.
 func RegisterMetaCatalog(server *mcp.Server, catalog *actionregistry.Catalog) {
 	if server == nil || catalog == nil {
 		return


### PR DESCRIPTION
## Summary

- Document how individual tools, meta-tools, dynamic mode, and dynamic-2 relate to the canonical action catalog.
- Add package-level documentation for the action registry and dynamic tool surfaces.
- Add an informational `RegisterMeta` inventory to `cmd/audit_tools` so legacy cleanup candidates are visible without failing CI.
- Refresh generated testing documentation after adding focused audit coverage.

## Validation

- `go test ./cmd/audit_tools ./internal/tools/actionregistry ./internal/tools/dynamic ./internal/tools -count=1`
- `go vet ./cmd/audit_tools ./internal/tools/actionregistry ./internal/tools/dynamic ./internal/tools`
- `golangci-lint run ./cmd/audit_tools ./internal/tools/actionregistry ./internal/tools/dynamic ./internal/tools`
- `go run ./cmd/gen_testing_docs/ --check`
- `npx markdownlint-cli2 docs/development/tool-surfaces-and-action-core.md docs/architecture.md docs/dynamic-tools.md docs/development/development.md docs/README.md docs/testing/testing.md .github/copilot-instructions.md CLAUDE.md`
- `git diff --check`

## Summary by Sourcery

Document the relationship between individual tools, meta-tools, dynamic tool surfaces, and the canonical action catalog, and add a non-failing audit of legacy RegisterMeta definitions.

Enhancements:
- Extend cmd/audit_tools to scan RegisterMeta definitions under internal/tools, classify which are referenced by the central meta registry, and include an informational inventory section in the markdown report without affecting CI results.
- Clarify comments and documentation around the canonical action catalog, meta catalog registration, and dynamic registry to emphasize their shared role as the action core for catalog-backed surfaces.

Documentation:
- Add a dedicated developer architecture guide for tool surfaces and the canonical action core, and link it from existing development, architecture, dynamic tools, and docs index pages.
- Clarify package-level documentation for internal/tools, the action registry, dynamic tool surfaces, and contributor guides (CLAUDE and Copilot instructions) around catalog-backed actions and ownership rules.
- Refresh testing documentation metrics to account for new audit coverage and cmd/audit_tools tests.

Tests:
- Add unit tests for the new RegisterMeta audit in cmd/audit_tools to ensure referenced and legacy definitions are correctly detected and reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository audit tooling to discover and report registration metadata and central references.
* **Documentation**
  * Clarified tool registration patterns, canonical action catalog ownership, and developer workflows; added a comprehensive guide for tool surfaces and action catalog usage.
* **Tests**
  * Added unit tests and coverage for the registration audit and repository-root discovery.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/88)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->