### PR TITLE
docs(tools): align meta-tool taxonomy

### DIFF
--- a/docs/tools/access.md
+++ b/docs/tools/access.md
@@ -3,7 +3,7 @@
 > **Diátaxis type**: Reference
 > **Domain**: Access & Authentication
 > **Individual tools**: 62
-> **Meta-tools**: `gitlab_access_token`, `gitlab_deploy_token`, `gitlab_deploy_key`, `gitlab_access_request`, `gitlab_invite`, `gitlab_job_token_scope` (when `META_TOOLS=true`, default)
+> **Meta-tool**: `gitlab_access` (when `META_TOOLS=true`, default)
 > **GitLab API**: [Access Tokens API](https://docs.gitlab.com/ee/api/project_access_tokens.html), [Deploy Tokens API](https://docs.gitlab.com/ee/api/deploy_tokens.html), [Deploy Keys API](https://docs.gitlab.com/ee/api/deploy_keys.html), [Members API](https://docs.gitlab.com/ee/api/members.html)
 > **Audience**: 👤 End users, AI assistant users
 
@@ -13,7 +13,7 @@
 
 The access & authentication domain covers project/group/personal access tokens, deploy tokens, deploy keys, access requests, invitations, CI/CD job token scope management, and project member management.
 
-When `META_TOOLS=true` (the default), the 62 individual tools below are consolidated into domain-specific meta-tools that dispatch by `action` parameter.
+When `META_TOOLS=true` (the default), the 62 individual tools below are consolidated into the `gitlab_access` meta-tool. It dispatches access token, deploy token, deploy key, access request, and invitation workflows through action prefixes such as `token_*`, `deploy_token_*`, `deploy_key_*`, `request_*`, `approve_*`, `deny_*`, and `invite_*`.
 
 ### Common Questions
 

--- a/docs/tools/packages.md
+++ b/docs/tools/packages.md
@@ -3,7 +3,7 @@
 > **Diátaxis type**: Reference
 > **Domain**: Packages, Container Registry & Package Protection Rules
 > **Individual tools**: 28
-> **Meta-tools**: `gitlab_package`, `gitlab_registry`, `gitlab_registry_protection` (when `META_TOOLS=true`, default)
+> **Meta-tool**: `gitlab_package` (when `META_TOOLS=true`, default)
 > **GitLab API**: [Packages API](https://docs.gitlab.com/ee/api/packages.html), [Container Registry API](https://docs.gitlab.com/ee/api/container_registry.html), [Package Protection Rules API](https://docs.gitlab.com/ee/api/project_packages_protection_rules.html)
 > **Audience**: 👤 End users, AI assistant users
 
@@ -13,7 +13,7 @@
 
 The packages domain covers the GitLab Generic Package Registry (publish, download, list, delete packages and files) and the Container Registry (repositories, tags, protection rules). It also includes composite operations like publish-and-link (publish a file and create a release asset link in one step) and publish-directory (batch-publish files from a local directory).
 
-When `META_TOOLS=true` (the default), 24 of the 28 package-domain tools below are consolidated into three meta-tools: `gitlab_package` (12 actions including 4 protection rules), `gitlab_registry` (8 actions), and `gitlab_registry_protection` (4 actions). The 4 dependency tools remain exposed individually because they are Enterprise/Premium-only tools gated by `GITLAB_ENTERPRISE=true`.
+When `META_TOOLS=true` (the default), the package-domain tools below are consolidated into the `gitlab_package` meta-tool. It includes generic package actions (`publish`, `download`, `list`, `file_list`, delete actions), container registry actions with `registry_*` prefixes, container registry protection actions with `registry_rule_*` prefixes, and package protection actions with `protection_rule_*` prefixes. Enterprise/Premium dependency tools remain gated by `GITLAB_ENTERPRISE=true`.
 
 ### Common Questions
 

--- a/docs/tools/security.md
+++ b/docs/tools/security.md
@@ -3,7 +3,7 @@
 > **Diátaxis type**: Reference
 > **Domain**: Security & Monitoring
 > **Individual tools**: 28
-> **Meta-tools**: `gitlab_feature_flag`, `gitlab_ff_user_list`, `gitlab_secure_file`, `gitlab_error_tracking`, `gitlab_alert_management` (when `META_TOOLS=true`, default)
+> **Meta-tools**: `gitlab_feature_flags`, `gitlab_admin`, `gitlab_user` (when `META_TOOLS=true`, default)
 > **GitLab API**: [Feature Flags](https://docs.gitlab.com/ee/api/feature_flags.html) · [Feature Flag User Lists](https://docs.gitlab.com/ee/api/feature_flag_user_lists.html) · [Secure Files](https://docs.gitlab.com/ee/api/secure_files.html) · [Error Tracking](https://docs.gitlab.com/ee/api/error_tracking.html) · [Alert Management](https://docs.gitlab.com/ee/api/alert_management_alerts.html) · [Impersonation Tokens](https://docs.gitlab.com/ee/api/users.html#get-all-impersonation-tokens-of-a-user)
 > **Audience**: 👤 End users, AI assistant users
 
@@ -13,7 +13,7 @@
 
 The security & monitoring domain covers project feature flags, feature flag user lists, CI/CD secure files, error tracking settings and client keys, alert management metric images, and user impersonation/personal access token management (admin only).
 
-When `META_TOOLS=true` (the default), the individual tools below are consolidated into five meta-tools that dispatch by `action` parameter.
+When `META_TOOLS=true` (the default), feature flag and feature-flag user-list actions are consolidated into `gitlab_feature_flags` with `feature_flag_*` and `ff_user_list_*` action prefixes. Secure file, error tracking, and alert metric image actions are exposed through `gitlab_admin` action prefixes, while user impersonation and personal access token actions are exposed through `gitlab_user` or `gitlab_access` depending on scope.
 
 ### Common Questions
 

--- a/docs/tools/snippets.md
+++ b/docs/tools/snippets.md
@@ -3,7 +3,7 @@
 > **Diátaxis type**: Reference
 > **Domain**: Snippets
 > **Individual tools**: 26
-> **Meta-tools**: `gitlab_snippet`, `gitlab_project_snippet`, `gitlab_snippet_discussion` (when `META_TOOLS=true`, default)
+> **Meta-tool**: `gitlab_snippet` (when `META_TOOLS=true`, default)
 > **GitLab API**: [Snippets API](https://docs.gitlab.com/ee/api/snippets.html), [Project Snippets API](https://docs.gitlab.com/ee/api/project_snippets.html), [Snippet Discussions API](https://docs.gitlab.com/ee/api/discussions.html#snippets), [Notes API — Snippets](https://docs.gitlab.com/ee/api/notes.html#snippets)
 > **Audience**: 👤 End users, AI assistant users
 
@@ -13,7 +13,7 @@
 
 The snippets domain covers personal snippets, project snippets, snippet discussion threads, and snippet notes. Personal snippets belong to the authenticated user, while project snippets are scoped to a specific project. Discussion threads enable threaded conversations on project snippets. Snippet notes are individual comments (non-threaded) on project snippets.
 
-When `META_TOOLS=true` (the default), the 26 individual tools below are consolidated into three meta-tools: `gitlab_snippet` (9 actions), `gitlab_project_snippet` (11 actions including notes), and `gitlab_snippet_discussion` (6 actions).
+When `META_TOOLS=true` (the default), the 26 individual tools below are consolidated into the `gitlab_snippet` meta-tool. Personal snippet actions use direct names such as `list`, `get`, `create`, and `delete`; project-scoped snippets use `project_*`; threaded discussions use `discussion_*`; project snippet notes use `note_*`; award emoji actions use `emoji_snippet_*` and `emoji_snippet_note_*`.
 
 ### Common Questions
 


### PR DESCRIPTION
## Summary

- Update per-domain tool docs to reflect the current consolidated meta-tool taxonomy.
- Replace stale visible meta-tool names with `gitlab_access`, `gitlab_package`, `gitlab_feature_flags`, and `gitlab_snippet`.
- Keep the individual tool listings unchanged; this is documentation-only and does not change runtime behavior.

## Before / After

- `gitlab_package`: before docs described `gitlab_registry` and `gitlab_registry_protection` as visible meta-tools; after, registry and protection flows are documented as action prefixes on `gitlab_package`.
- `gitlab_access`: before docs listed separate access/deploy/invite meta-tools; after, token, deploy token, deploy key, access request, and invite flows are documented as action prefixes on `gitlab_access`.
- `gitlab_feature_flags`: before docs listed `gitlab_feature_flag` and `gitlab_ff_user_list`; after, feature flags and user lists are documented as `feature_flag_*` and `ff_user_list_*` actions on `gitlab_feature_flags`.
- `gitlab_snippet`: before docs listed separate project snippet and snippet discussion meta-tools; after, project, discussion, note, and emoji flows are documented as action prefixes on `gitlab_snippet`.

## Validation

- `rg -n "gitlab_feature_flag\\b|gitlab_ff_user_list\\b|gitlab_registry\\b|gitlab_registry_protection\\b|gitlab_access_request\\b|gitlab_project_snippet\\b|gitlab_secure_file\\b|gitlab_error_tracking\\b|gitlab_alert_management\\b|gitlab_snippet_discussion\\b" README.md docs site llms.txt llms-full.txt --glob '!site/node_modules/**' --glob '!site/dist/**'`
- `npx markdownlint-cli2 docs/tools/access.md docs/tools/packages.md docs/tools/security.md docs/tools/snippets.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tool reference guides to clarify how meta-tools consolidate access management, package operations, security features, and snippet functionality.
  * Documented action routing via prefix-based naming conventions, enabling streamlined access to multiple underlying tools through unified interfaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->