### PR TITLE
docs(tools): define action builder ownership

### DIFF
--- a/docs/development/tool-surfaces-and-action-core.md
+++ b/docs/development/tool-surfaces-and-action-core.md
@@ -108,20 +108,20 @@ and Enterprise/Premium route injection for one visible catalog group.
 Target builder rules:
 
 - A builder must return catalog metadata or captureable meta-tool metadata; it
-        must not require a live MCP server to produce routes.
+  must not require a live MCP server to produce routes.
 - Building the catalog must not register MCP tools as a side effect. Visible
-        tool registration belongs to `RegisterMetaCatalog` for meta mode and
-        `dynamic.RegisterCatalogTools` / `dynamic.RegisterCatalogFindExecuteTools` for
-        dynamic modes.
+  tool registration belongs to `RegisterMetaCatalog` for meta mode and
+  `dynamic.RegisterCatalogTools` / `dynamic.RegisterCatalogFindExecuteTools` for
+  dynamic modes.
 - Builders may stay in `internal/tools` while they depend on many domain
-        packages. Prefer splitting central files by domain area before moving builders
-        into domain sub-packages.
+  packages. Prefer splitting central files by domain area before moving builders
+  into domain sub-packages.
 - Domain packages should expose typed handlers and individual `RegisterTools`
-        functions. They should not import the catalog package unless a later ADR moves
-        group ownership into those packages.
+  functions. They should not import `internal/tools/actioncatalog` unless a
+  later ADR moves group ownership into those packages.
 - Delegated meta groups are allowed only for packages explicitly called from
-        `registerAllMetaGroups`; otherwise ordinary GitLab API operations should flow
-        through the central catalog builders.
+  `registerAllMetaGroups`; otherwise ordinary GitLab API operations should flow
+  through the central catalog builders.
 
 Current direction: keep builders in `internal/tools`, split them into focused
 `register_meta_*.go` files by domain area, and keep `register_meta.go` as the

--- a/docs/development/tool-surfaces-and-action-core.md
+++ b/docs/development/tool-surfaces-and-action-core.md
@@ -98,6 +98,35 @@ cmd/server.buildDynamicActionCatalog
 dynamic.RegisterCatalogFindExecuteTools
 ```
 
+## Action Group Builder Ownership
+
+Action group builders are the boundary between domain handler packages and the
+canonical action catalog. A builder owns route maps, descriptions, icons,
+read-only status, destructive route classification, custom markdown formatters,
+and Enterprise/Premium route injection for one visible catalog group.
+
+Target builder rules:
+
+- A builder must return catalog metadata or captureable meta-tool metadata; it
+        must not require a live MCP server to produce routes.
+- Building the catalog must not register MCP tools as a side effect. Visible
+        tool registration belongs to `RegisterMetaCatalog` for meta mode and
+        `dynamic.RegisterCatalogTools` / `dynamic.RegisterCatalogFindExecuteTools` for
+        dynamic modes.
+- Builders may stay in `internal/tools` while they depend on many domain
+        packages. Prefer splitting central files by domain area before moving builders
+        into domain sub-packages.
+- Domain packages should expose typed handlers and individual `RegisterTools`
+        functions. They should not import the catalog package unless a later ADR moves
+        group ownership into those packages.
+- Delegated meta groups are allowed only for packages explicitly called from
+        `registerAllMetaGroups`; otherwise ordinary GitLab API operations should flow
+        through the central catalog builders.
+
+Current direction: keep builders in `internal/tools`, split them into focused
+`register_meta_*.go` files by domain area, and keep `register_meta.go` as the
+composition entry point for visible meta registration and catalog capture.
+
 ## Standalone Dynamic Actions
 
 Most dynamic actions come from the canonical catalog built from meta route
@@ -151,9 +180,9 @@ Current baseline for cleanup planning:
 
 | Metric | Count |
 | --- | ---: |
-| Package-level `RegisterMeta` definitions under `internal/tools/*` | 54 |
+| Package-level `RegisterMeta` definitions under `internal/tools/*` | 4 |
 | Delegated `RegisterMeta` calls referenced from `internal/tools/register_meta.go` | 4 |
-| Apparent legacy `RegisterMeta` definitions requiring verification | Approximately 50 |
+| Apparent legacy `RegisterMeta` definitions requiring verification | 0 |
 
 Known stale examples:
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,565 |
-| Unit test functions | 9,318 |
+| Total test functions | 9,566 |
+| Unit test functions | 9,319 |
 | E2E test functions | 247 |
 | cmd test functions | 409 |
 | Test files (internal/) | 407 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,572 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,573 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 288 | 3.0% |
 
@@ -46,11 +46,11 @@
 | Layer | Test Functions | Test Files | Description |
 | --- | ---: | ---: | --- |
 | Core packages | 1,592 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
-| Tools orchestration | 233 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
+| Tools orchestration | 234 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,084 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
 | cmd packages | 409 | 14 | server entry point and developer command utilities |
-| **Total** | **9,565** | **530** |  |
+| **Total** | **9,566** | **530** |  |
 
 ### Core Packages
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/actioncatalog"
 )
 
@@ -71,6 +73,22 @@ func TestBuildActionCatalog_CapturesInlineAndDelegatedGroups(t *testing.T) {
 	}
 	if group.FormatResult == nil {
 		t.Fatal("gitlab_analyze group should preserve its custom formatter")
+	}
+}
+
+func TestBuildActionCatalog_DoesNotRegisterMCPTools(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+
+	catalog, err := BuildActionCatalog(nil, ActionCatalogOptions{Enterprise: true})
+	if err != nil {
+		t.Fatalf("BuildActionCatalog() error = %v", err)
+	}
+	if catalog.CountGroups() == 0 || catalog.CountActions() == 0 {
+		t.Fatalf("catalog counts = groups %d actions %d, want non-zero", catalog.CountGroups(), catalog.CountActions())
+	}
+
+	if names := toolNamesFromServer(t, server); len(names) != 0 {
+		t.Fatalf("BuildActionCatalog() registered MCP tools as a side effect: %v", names)
 	}
 }
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -1,11 +1,13 @@
 package tools
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/actioncatalog"
+	"github.com/jmrplens/gitlab-mcp-server/internal/toolutil"
 )
 
 func TestBuildActionCatalog_IncludesBaseEnterpriseAndMCPActions(t *testing.T) {
@@ -76,9 +78,7 @@ func TestBuildActionCatalog_CapturesInlineAndDelegatedGroups(t *testing.T) {
 	}
 }
 
-func TestBuildActionCatalog_DoesNotRegisterMCPTools(t *testing.T) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
-
+func TestBuildActionCatalog_DoesNotLeakCaptureState(t *testing.T) {
 	catalog, err := BuildActionCatalog(nil, ActionCatalogOptions{Enterprise: true})
 	if err != nil {
 		t.Fatalf("BuildActionCatalog() error = %v", err)
@@ -87,8 +87,15 @@ func TestBuildActionCatalog_DoesNotRegisterMCPTools(t *testing.T) {
 		t.Fatalf("catalog counts = groups %d actions %d, want non-zero", catalog.CountGroups(), catalog.CountActions())
 	}
 
-	if names := toolNamesFromServer(t, server); len(names) != 0 {
-		t.Fatalf("BuildActionCatalog() registered MCP tools as a side effect: %v", names)
+	if leaked := toolutil.CaptureMetaToolDefinitions(func() {}); len(leaked) != 0 {
+		t.Fatalf("BuildActionCatalog() leaked captured meta-tool definitions: %v", leaked)
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	registerProjectMeta(server, nil, false)
+	names := toolNamesFromServer(t, server)
+	if !slices.Contains(names, "gitlab_project") {
+		t.Fatalf("registerProjectMeta() after BuildActionCatalog() registered tools %v, want gitlab_project", names)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Document the target ownership rules for action group builders in the canonical action core guide.
- Update the post-Chapter-3 RegisterMeta cleanup baseline in the same guide.
- Add a guardrail test proving `BuildActionCatalog` builds a non-empty catalog without registering tools on an MCP server.
- Regenerate `docs/testing/testing.md` after adding the test.

## Validation

- `go test ./internal/tools -run 'TestBuildActionCatalog|TestBuildMCPActionGroup' -count=1`
- `go test ./internal/tools -count=1`
- `go run ./cmd/gen_testing_docs/ --check`
- `go vet ./internal/tools`
- `golangci-lint run ./internal/tools`
- `npx markdownlint-cli2 docs/development/tool-surfaces-and-action-core.md docs/testing/testing.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance defining builder ownership and boundaries for action group metadata
  * Updated historical duplication baseline and testing statistics for cleanup planning

* **Tests**
  * Added a test to validate action-catalog build does not leak capture state and verifies expected tool registration during catalog build

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/92)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->