### PR TITLE
test(tools): add meta builder catalog guardrails

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,566 |
-| Unit test functions | 9,319 |
+| Total test functions | 9,568 |
+| Unit test functions | 9,321 |
 | E2E test functions | 247 |
 | cmd test functions | 409 |
 | Test files (internal/) | 407 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,573 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,575 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 288 | 3.0% |
 
@@ -46,11 +46,11 @@
 | Layer | Test Functions | Test Files | Description |
 | --- | ---: | ---: | --- |
 | Core packages | 1,592 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
-| Tools orchestration | 234 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
+| Tools orchestration | 236 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,084 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
 | cmd packages | 409 | 14 | server entry point and developer command utilities |
-| **Total** | **9,566** | **530** |  |
+| **Total** | **9,568** | **530** |  |
 
 ### Core Packages
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/internal/tools/actioncatalog"
 	"github.com/jmrplens/gitlab-mcp-server/internal/toolutil"
 )
@@ -99,6 +101,98 @@ func TestBuildActionCatalog_DoesNotLeakCaptureState(t *testing.T) {
 	}
 }
 
+// TestBuildActionCatalog_KeyBuilderRoutes verifies that representative split
+// meta builders preserve catalog metadata. It builds the enterprise catalog and
+// checks expected tool names, derived action IDs and domains, destructive flags,
+// schema URIs, and input schemas so future builder moves cannot silently weaken
+// the canonical action catalog.
+func TestBuildActionCatalog_KeyBuilderRoutes(t *testing.T) {
+	catalog := mustBuildActionCatalog(t, nil, ActionCatalogOptions{Enterprise: true})
+
+	testCases := []struct {
+		name        string
+		toolName    string
+		actionName  string
+		destructive bool
+	}{
+		{name: "source project list", toolName: "gitlab_project", actionName: "list"},
+		{name: "source repository file delete", toolName: "gitlab_repository", actionName: "file_delete", destructive: true},
+		{name: "collaboration merge request merge", toolName: "gitlab_merge_request", actionName: "merge", destructive: true},
+		{name: "delivery package download", toolName: "gitlab_package", actionName: "download"},
+		{name: "admin access token revoke", toolName: "gitlab_access", actionName: "token_project_revoke", destructive: true},
+		{name: "admin group list", toolName: "gitlab_group", actionName: "list"},
+		{name: "enterprise vulnerability list", toolName: "gitlab_vulnerability", actionName: "list"},
+		{name: "enterprise geo delete", toolName: "gitlab_geo", actionName: "delete", destructive: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			group, ok := catalog.Group(tc.toolName)
+			if !ok {
+				t.Fatalf("catalog missing group %s", tc.toolName)
+			}
+			if group.ToolName != tc.toolName {
+				t.Fatalf("group.ToolName = %q, want %q", group.ToolName, tc.toolName)
+			}
+
+			action, ok := group.Actions[tc.actionName]
+			if !ok {
+				t.Fatalf("%s missing action %s", tc.toolName, tc.actionName)
+			}
+			wantDomain := actioncatalog.DomainFromToolName(tc.toolName)
+			wantID := actioncatalog.ActionID(wantDomain + "." + tc.actionName)
+			if action.ID != wantID {
+				t.Fatalf("action.ID = %q, want %q", action.ID, wantID)
+			}
+			if action.Domain != wantDomain {
+				t.Fatalf("action.Domain = %q, want %q", action.Domain, wantDomain)
+			}
+			if action.Route.Destructive != tc.destructive {
+				t.Fatalf("action.Route.Destructive = %v, want %v", action.Route.Destructive, tc.destructive)
+			}
+			wantSchemaURI := toolutil.MetaSchemaURI(tc.toolName, tc.actionName)
+			if action.SchemaURI != wantSchemaURI {
+				t.Fatalf("action.SchemaURI = %q, want %q", action.SchemaURI, wantSchemaURI)
+			}
+			if action.Route.InputSchema == nil {
+				t.Fatal("action.Route.InputSchema is nil")
+			}
+		})
+	}
+}
+
+// TestBuildActionCatalog_EnterpriseAndGitLabDotComGates verifies catalog gating
+// for base, enterprise, and GitLab.com enterprise surfaces. It compares action
+// presence across those catalogs so enterprise-only routes and GitLab.com-only
+// Orbit routes remain registered only for the intended surfaces.
+func TestBuildActionCatalog_EnterpriseAndGitLabDotComGates(t *testing.T) {
+	base := mustBuildActionCatalog(t, nil, ActionCatalogOptions{})
+	enterprise := mustBuildActionCatalog(t, nil, ActionCatalogOptions{Enterprise: true})
+	gitLabDotComEnterprise := mustBuildActionCatalog(t, newGitLabDotComClient(t), ActionCatalogOptions{Enterprise: true})
+
+	for _, actionID := range []actioncatalog.ActionID{
+		"merge_train.list_project",
+		"audit_event.list_instance",
+		"dora_metrics.project",
+		"dependency.list",
+		"vulnerability.list",
+		"security_finding.list",
+		"project.push_rule_get",
+		"group.epic_list",
+		"issue.iteration_list_project",
+	} {
+		t.Run(string(actionID), func(t *testing.T) {
+			assertCatalogMissingAction(t, base, actionID)
+			assertCatalogHasAction(t, enterprise, actionID)
+			assertCatalogHasAction(t, gitLabDotComEnterprise, actionID)
+		})
+	}
+
+	assertCatalogMissingAction(t, base, "orbit.status")
+	assertCatalogMissingAction(t, enterprise, "orbit.status")
+	assertCatalogHasAction(t, gitLabDotComEnterprise, "orbit.status")
+}
+
 func TestBuildMCPActionGroup_NilUpdaterOmitsUpdateActions(t *testing.T) {
 	group := BuildMCPActionGroup(nil, nil)
 	if _, ok := group.Actions["status"]; !ok {
@@ -109,5 +203,40 @@ func TestBuildMCPActionGroup_NilUpdaterOmitsUpdateActions(t *testing.T) {
 	}
 	if group.ToolName != "gitlab_server" || group.Description == "" || len(group.Icons) == 0 {
 		t.Fatalf("BuildMCPActionGroup metadata = %+v, want tool name, description, and icons", group)
+	}
+}
+
+func mustBuildActionCatalog(t *testing.T, client *gitlabclient.Client, opts ActionCatalogOptions) *actioncatalog.Catalog {
+	t.Helper()
+	catalog, err := BuildActionCatalog(client, opts)
+	if err != nil {
+		t.Fatalf("BuildActionCatalog(%+v) error = %v", opts, err)
+	}
+	return catalog
+}
+
+func newGitLabDotComClient(t *testing.T) *gitlabclient.Client {
+	t.Helper()
+	client, err := gitlabclient.NewClient(&config.Config{
+		GitLabURL:   "https://gitlab.com",
+		GitLabToken: "test-token",
+	})
+	if err != nil {
+		t.Fatalf("NewClient(gitlab.com) error = %v", err)
+	}
+	return client
+}
+
+func assertCatalogHasAction(t *testing.T, catalog *actioncatalog.Catalog, actionID actioncatalog.ActionID) {
+	t.Helper()
+	if _, ok := catalog.Action(actionID); !ok {
+		t.Fatalf("catalog missing action %s", actionID)
+	}
+}
+
+func assertCatalogMissingAction(t *testing.T, catalog *actioncatalog.Catalog, actionID actioncatalog.ActionID) {
+	t.Helper()
+	if _, ok := catalog.Action(actionID); ok {
+		t.Fatalf("catalog contains action %s", actionID)
 	}
 }


### PR DESCRIPTION
## Summary
- Add catalog-level guardrails for representative split meta builders across source, collaboration, delivery, admin, and enterprise domains.
- Verify base, enterprise, and GitLab.com Enterprise catalog gating for enterprise-only and Orbit actions.
- Refresh generated testing documentation after adding the two test functions.

## Verification
- `go test ./internal/tools -run 'TestBuildActionCatalog_(KeyBuilderRoutes|EnterpriseAndGitLabDotComGates)' -count=1`
- `go test ./internal/tools ./internal/tools/dynamic -count=1`
- `go run ./cmd/gen_testing_docs/`
- `go run ./cmd/gen_testing_docs/ --check`
- `go vet ./internal/tools`
- `golangci-lint run ./internal/tools`
- `npx markdownlint-cli2 docs/testing/testing.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Updated testing reference: total test functions +2, unit tests +2; naming-convention counts adjusted; Tools orchestration +2 (E2E integration and cmd packages unchanged).

* **Tests**
  - Added tests expanding action-catalog coverage, validating catalog metadata and enterprise vs. cloud-scoped gating behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/97)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->