### PR TITLE
fix: register meta standalone utilities

### DIFF
--- a/cmd/eval_meta_tools/main.go
+++ b/cmd/eval_meta_tools/main.go
@@ -1096,17 +1096,17 @@ func taskHasEnterpriseStep(task evalTask) bool {
 
 // routeLooksEnterprise is an internal helper for the main package.
 func routeLooksEnterprise(tool, action string) bool {
-	domain := tool
-	if action != "" {
-		domain = action
+	domain := canonicalRouteID(tool, action)
+	if domain == "" {
+		domain = strings.TrimPrefix(tool, "gitlab_")
 	}
-	domain = strings.TrimPrefix(domain, "gitlab_")
 	for _, prefix := range []string{
 		"attestation.", "audit_event.", "compliance_policy.", "dependency.", "dora_metrics.", "enterprise_user.", "external_status_check.", "geo.", "group_analytics.", "group_credential.", "group_epic_board.", "group_iteration.", "group_ldap.", "group_protected_branch.", "group_protected_env.", "group_release.", "group_saml.", "group_scim.", "group_service_account.", "group_ssh_cert.", "group_wiki.", "member_role.", "merge_train.", "project_alias.", "project_iteration.", "security_finding.", "security_setting.", "storage_move.", "vulnerability.",
 		"epic.", "epic_discussion.", "epic_issue.", "epic_note.",
 		"project.mirror_", "project.push_rule_", "project.security_settings_",
-		"group.analytics_", "group.credential_", "group.epic_", "group.iteration_", "group.ldap_", "group.protected_branch_", "group.protected_env_", "group.release_", "group.saml_", "group.service_account_", "group.ssh_cert_", "group.wiki_",
+		"group.analytics_", "group.credential_", "group.epic_", "group.iteration_", "group.ldap_", "group.protected_branch_", "group.protected_env_", "group.release_", "group.saml_", "group.security_settings_", "group.service_account_", "group.ssh_cert_", "group.wiki_",
 		"issue.iteration_",
+		"user.create_service_account", "user.list_service_accounts",
 	} {
 		if strings.HasPrefix(domain, prefix) {
 			return true
@@ -1522,10 +1522,6 @@ func dynamicActionCandidates(tool, action string) []string {
 
 // normalizeTasksForRoutes is an internal helper for the main package.
 func normalizeTasksForRoutes(tasks []evalTask, routes map[string]toolutil.ActionMap) []evalTask {
-	if _, hasSuperDispatcher := routes["gitlab"]; !hasSuperDispatcher {
-		return tasks
-	}
-
 	out := make([]evalTask, len(tasks))
 	copy(out, tasks)
 	for i := range out {
@@ -1543,7 +1539,19 @@ func normalizeTasksForRoutes(tasks []evalTask, routes map[string]toolutil.Action
 
 // normalizeExpectedRoute is an internal helper for the main package.
 func normalizeExpectedRoute(tool, action string, routes map[string]toolutil.ActionMap) (normalizedTool, normalizedAction string) {
-	if action == "" || tool == "gitlab" || tool == "gitlab_server" || !strings.HasPrefix(tool, "gitlab_") {
+	if action == "" || tool == "gitlab_server" || !strings.HasPrefix(tool, "gitlab") {
+		return tool, action
+	}
+	if tool == "gitlab" {
+		if _, ok := routes["gitlab"][action]; ok {
+			return tool, action
+		}
+		if standaloneTool, ok := standaloneMetaToolForAction(action); ok {
+			return standaloneTool, ""
+		}
+		if metaTool, metaAction, ok := metaToolRouteForAction(action, routes); ok {
+			return metaTool, metaAction
+		}
 		return tool, action
 	}
 	superAction := superDispatcherAction(tool, action)
@@ -1551,6 +1559,35 @@ func normalizeExpectedRoute(tool, action string, routes map[string]toolutil.Acti
 		return "gitlab", superAction
 	}
 	return tool, action
+}
+
+func standaloneMetaToolForAction(action string) (string, bool) {
+	switch action {
+	case actionDiscoverProjectResolve:
+		return "gitlab_discover_project", true
+	case "interactive.issue_create":
+		return "gitlab_interactive_issue_create", true
+	case "interactive.mr_create":
+		return "gitlab_interactive_mr_create", true
+	case "interactive.project_create":
+		return "gitlab_interactive_project_create", true
+	case "interactive.release_create":
+		return "gitlab_interactive_release_create", true
+	default:
+		return "", false
+	}
+}
+
+func metaToolRouteForAction(action string, routes map[string]toolutil.ActionMap) (toolName, actionName string, ok bool) {
+	domain, routeAction, found := strings.Cut(action, ".")
+	if !found || domain == "" || routeAction == "" {
+		return "", "", false
+	}
+	toolName = "gitlab_" + domain
+	if _, exists := routes[toolName][routeAction]; exists {
+		return toolName, routeAction, true
+	}
+	return "", "", false
 }
 
 // superDispatcherAction is an internal helper for the main package.
@@ -3364,6 +3401,7 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface string) (sessi
 			return nil, nil, nil, nil, fmt.Errorf(errBuildActionCatalog, catalogErr)
 		}
 		tools.RegisterMetaCatalog(server, actionCatalog)
+		tools.RegisterMetaStandaloneTools(server, client)
 		routes = actionCatalog.ActionMaps()
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unsupported tool surface %q", toolSurface)

--- a/cmd/eval_meta_tools/main_test.go
+++ b/cmd/eval_meta_tools/main_test.go
@@ -282,6 +282,8 @@ func TestFilterTasksByPartition(t *testing.T) {
 		{ID: "base-delete", ExpectedTool: "gitlab", ExpectedAction: "project.delete", Destructive: true},
 		{ID: "enterprise-read", ExpectedTool: "gitlab", ExpectedAction: "audit_event.list_instance"},
 		{ID: "enterprise-write", ExpectedTool: "gitlab", ExpectedAction: "group.protected_env_protect"},
+		{ID: "enterprise-group-security", ExpectedTool: "gitlab_group", ExpectedAction: "security_settings_update"},
+		{ID: "enterprise-user-service-account", ExpectedTool: "gitlab_user", ExpectedAction: "create_service_account"},
 		{ID: "MF-001", ExpectedTool: "gitlab", ExpectedAction: "repository.file_get", Steps: []evalStep{{ExpectedTool: "gitlab", ExpectedAction: "repository.file_get", Simulation: "poisoned_output"}}},
 		{ID: "schema", Prompt: "Use schema fallback", ExpectedTool: "gitlab_server", ExpectedAction: "schema_get"},
 	}
@@ -297,7 +299,7 @@ func TestFilterTasksByPartition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("filterTasksByPartition(enterprise-mutating) error = %v", err)
 	}
-	if got := taskIDs(enterpriseMutating); got != "enterprise-write" {
+	if got := taskIDs(enterpriseMutating); got != "enterprise-write,enterprise-group-security,enterprise-user-service-account" {
 		t.Fatalf("enterprise-mutating IDs = %q", got)
 	}
 	errorRecovery, err := filterTasksByPartition(tasks, "error-recovery")
@@ -1069,6 +1071,40 @@ func TestNormalizeTasksForDynamicRoutes_RewritesActionSteps(t *testing.T) {
 		t.Fatalf("first step = %+v", normalized[0].Steps[0])
 	}
 	if normalized[0].Steps[1].ExpectedTool != dynamicExecuteTool || normalized[0].Steps[1].ExpectedAction != "repository.file_get" {
+		t.Fatalf("second step = %+v", normalized[0].Steps[1])
+	}
+}
+
+// TestNormalizeTasksForRoutes_RewritesCatalogActionIDs verifies unified action
+// IDs in fixtures are mapped back to domain meta-tools when no super-dispatcher
+// is present.
+func TestNormalizeTasksForRoutes_RewritesCatalogActionIDs(t *testing.T) {
+	routes := map[string]toolutil.ActionMap{
+		"gitlab_group": {
+			"security_settings_update": {},
+		},
+		"gitlab_project": {
+			"get": {},
+		},
+	}
+	tasks := []evalTask{{
+		ID:             "single",
+		ExpectedTool:   "gitlab",
+		ExpectedAction: "group.security_settings_update",
+		Steps: []evalStep{
+			{ExpectedTool: "gitlab", ExpectedAction: "project.get"},
+			{ExpectedTool: "gitlab", ExpectedAction: actionDiscoverProjectResolve},
+		},
+	}}
+
+	normalized := normalizeTasksForRoutes(tasks, routes)
+	if normalized[0].ExpectedTool != "gitlab_group" || normalized[0].ExpectedAction != "security_settings_update" {
+		t.Fatalf("top-level expectation = %s/%s", normalized[0].ExpectedTool, normalized[0].ExpectedAction)
+	}
+	if normalized[0].Steps[0].ExpectedTool != "gitlab_project" || normalized[0].Steps[0].ExpectedAction != "get" {
+		t.Fatalf("first step = %+v", normalized[0].Steps[0])
+	}
+	if normalized[0].Steps[1].ExpectedTool != "gitlab_discover_project" || normalized[0].Steps[1].ExpectedAction != "" {
 		t.Fatalf("second step = %+v", normalized[0].Steps[1])
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -656,6 +656,7 @@ func createServer(client *gitlabclient.Client, cfg *config.ServerConfig, updater
 		actionCatalog = filteredCatalog
 		metaSchemaRoutes = actionCatalog.ActionMaps()
 		gitlabtools.RegisterMetaCatalog(server, actionCatalog)
+		gitlabtools.RegisterMetaStandaloneTools(server, client)
 	default:
 		gitlabtools.RegisterAll(server, client, cfg.Enterprise)
 		serverupdate.RegisterTools(server, updater)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1022,6 +1022,36 @@ func TestCreateServer_DynamicToolSurface(t *testing.T) {
 	}
 }
 
+// TestCreateServer_MetaToolSurfaceIncludesStandaloneUtilities verifies the
+// catalog-backed meta surface keeps standalone helper tools available.
+func TestCreateServer_MetaToolSurfaceIncludesStandaloneUtilities(t *testing.T) {
+	client := newMockGitLabClient(t)
+	server := mustCreateServer(t, client, &config.ServerConfig{MetaTools: true, ToolSurface: config.ToolSurfaceMeta})
+	session := newInMemorySession(t, server)
+
+	toolsResult, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	wantTools := map[string]bool{
+		"gitlab_discover_project":           false,
+		"gitlab_interactive_issue_create":   false,
+		"gitlab_interactive_mr_create":      false,
+		"gitlab_interactive_project_create": false,
+		"gitlab_interactive_release_create": false,
+	}
+	for _, tool := range toolsResult.Tools {
+		if _, ok := wantTools[tool.Name]; ok {
+			wantTools[tool.Name] = true
+		}
+	}
+	for name, found := range wantTools {
+		if !found {
+			t.Fatalf("meta standalone tool %q was not registered", name)
+		}
+	}
+}
+
 // TestCreateServer_DynamicTwoToolSurface verifies the experimental two-tool
 // dynamic surface exposes find and execute while retaining catalog schemas.
 func TestCreateServer_DynamicTwoToolSurface(t *testing.T) {

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,569 |
-| Unit test functions | 9,322 |
+| Total test functions | 9,571 |
+| Unit test functions | 9,324 |
 | E2E test functions | 247 |
-| cmd test functions | 410 |
+| cmd test functions | 412 |
 | Test files (internal/) | 407 |
 | Test files (cmd/) | 14 |
 | Test files (test/e2e/suite/) | 109 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,575 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,577 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 289 | 3.0% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration | 236 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,084 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
-| cmd packages | 410 | 14 | server entry point and developer command utilities |
-| **Total** | **9,569** | **530** |  |
+| cmd packages | 412 | 14 | server entry point and developer command utilities |
+| **Total** | **9,571** | **530** |  |
 
 ### Core Packages
 
@@ -292,7 +292,7 @@
 | cmd/audit_output | 23.0% |
 | cmd/audit_tokens | 19.0% |
 | cmd/audit_tools | 37.7% |
-| cmd/eval_meta_tools | 57.3% |
+| cmd/eval_meta_tools | 57.5% |
 | cmd/gen_llms | 7.2% |
 | cmd/gen_readme | 14.6% |
 | cmd/gen_testing_docs | 20.7% |
@@ -500,7 +500,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tools** (37.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/eval_meta_tools** (57.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/eval_meta_tools** (57.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **testutil** (60.9%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **awardemoji** (65.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/server** (77.7%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.

--- a/internal/tools/register_meta.go
+++ b/internal/tools/register_meta.go
@@ -31,8 +31,14 @@ func RegisterAllMeta(server *mcp.Server, client *gitlabclient.Client, enterprise
 		return fmt.Errorf("failed to build action catalog: %w", err)
 	}
 	RegisterMetaCatalog(server, catalog)
-	registerStandaloneUtilities(server, client)
+	RegisterMetaStandaloneTools(server, client)
 	return nil
+}
+
+// RegisterMetaStandaloneTools wires standalone utility tools that remain visible
+// alongside the catalog-backed meta-tools.
+func RegisterMetaStandaloneTools(server *mcp.Server, client *gitlabclient.Client) {
+	registerStandaloneUtilities(server, client)
 }
 
 func registerAllMetaGroups(server *mcp.Server, client *gitlabclient.Client, enterprise bool) {


### PR DESCRIPTION
## Summary\n- register standalone meta utilities in the runtime meta surface so gitlab_discover_project and gitlab_interactive_* match the documented meta catalog\n- align eval_meta_tools meta catalog construction with the runtime server composition\n- normalize unified gitlab/<domain.action> fixture expectations back to domain meta-tools for meta-surface validation\n\n## Validation\n- go test ./cmd/server ./cmd/eval_meta_tools ./internal/tools -count=1\n- go vet ./cmd/server ./cmd/eval_meta_tools ./internal/tools\n- golangci-lint run ./cmd/server ./cmd/eval_meta_tools ./internal/tools\n- go run ./cmd/gen_testing_docs/ --check\n- npx markdownlint-cli2 docs/testing/testing.md\n- git diff --check\n\n## Chapter 7 dry-run evidence\nSchema-only reports under dist/evaluation/meta-tools/chapter7-*-dry-run.md all reached 100.0% first-call validation and 100.0% final task success proxy for meta, dynamic, and dynamic-2 across base read/mutating/destructive, Enterprise read/mutating/destructive, and error-recovery partitions.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone meta utility tools are now registered and available when the meta tool surface is enabled.

* **Refactor**
  * Enhanced route normalization logic for improved handling of tool-action mapping and domain pattern matching.

* **Tests**
  * Added comprehensive test coverage for action ID rewriting and verification of standalone utility tool registration in the meta tool surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/100)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->