### PR TITLE
fix: publish properties for empty tool schemas

### DIFF
--- a/cmd/eval_meta_tools/main.go
+++ b/cmd/eval_meta_tools/main.go
@@ -3406,6 +3406,7 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface string) (sessi
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unsupported tool surface %q", toolSurface)
 	}
+	toolutil.LockdownInputSchemas(server)
 
 	st, ct := mcp.NewInMemoryTransports()
 	ctx := context.Background()

--- a/cmd/eval_meta_tools/main_test.go
+++ b/cmd/eval_meta_tools/main_test.go
@@ -698,6 +698,43 @@ func TestBuildCatalogSession_UsesClientEnterpriseMode(t *testing.T) {
 	}
 }
 
+// TestBuildCatalogSession_MetaSurfaceAppliesSchemaLockdown verifies the
+// evaluator sees the same no-input object schema shape as runtime tools/list.
+func TestBuildCatalogSession_MetaSurfaceAppliesSchemaLockdown(t *testing.T) {
+	client := newEvalTestClient(t, false)
+	_, closeSession, toolList, _, err := buildCatalogSession(client, config.ToolSurfaceMeta)
+	if err != nil {
+		t.Fatalf("buildCatalogSession(meta) error = %v", err)
+	}
+	defer closeSession()
+
+	var schema map[string]any
+	for _, tool := range toolList {
+		if tool.Name != "gitlab_interactive_project_create" {
+			continue
+		}
+		var ok bool
+		schema, ok = tool.InputSchema.(map[string]any)
+		if !ok {
+			t.Fatalf("input schema = %T, want map[string]any", tool.InputSchema)
+		}
+		break
+	}
+	if schema == nil {
+		t.Fatal("gitlab_interactive_project_create was not registered")
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok || properties == nil {
+		t.Fatalf("properties = %T, want map[string]any in %#v", schema["properties"], schema)
+	}
+	if len(properties) != 0 {
+		t.Fatalf("properties = %#v, want empty map", properties)
+	}
+	if v, boolOK := schema["additionalProperties"].(bool); !boolOK || v {
+		t.Fatalf("additionalProperties = %v, want false", schema["additionalProperties"])
+	}
+}
+
 // TestBuildCatalogSession_DynamicSurfaceExposesExecuteRoutes verifies dynamic
 // mode advertises only the low-token public tools while retaining catalog routes
 // for validation and execution.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1044,6 +1044,22 @@ func TestCreateServer_MetaToolSurfaceIncludesStandaloneUtilities(t *testing.T) {
 		if _, ok := wantTools[tool.Name]; ok {
 			wantTools[tool.Name] = true
 		}
+		if tool.Name == "gitlab_interactive_project_create" {
+			schema, ok := tool.InputSchema.(map[string]any)
+			if !ok {
+				t.Fatalf("gitlab_interactive_project_create input schema = %T, want map[string]any", tool.InputSchema)
+			}
+			properties, ok := schema["properties"].(map[string]any)
+			if !ok || properties == nil {
+				t.Fatalf("gitlab_interactive_project_create properties = %T, want map[string]any in %#v", schema["properties"], schema)
+			}
+			if len(properties) != 0 {
+				t.Fatalf("gitlab_interactive_project_create properties = %#v, want empty map", properties)
+			}
+			if v, boolOK := schema["additionalProperties"].(bool); !boolOK || v {
+				t.Fatalf("gitlab_interactive_project_create additionalProperties = %v, want false", schema["additionalProperties"])
+			}
+		}
 	}
 	for name, found := range wantTools {
 		if !found {

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,571 |
-| Unit test functions | 9,324 |
+| Total test functions | 9,573 |
+| Unit test functions | 9,326 |
 | E2E test functions | 247 |
-| cmd test functions | 412 |
+| cmd test functions | 413 |
 | Test files (internal/) | 407 |
 | Test files (cmd/) | 14 |
 | Test files (test/e2e/suite/) | 109 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,577 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,579 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 289 | 3.0% |
 
@@ -45,12 +45,12 @@
 
 | Layer | Test Functions | Test Files | Description |
 | --- | ---: | ---: | --- |
-| Core packages | 1,592 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages | 1,593 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration | 236 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,084 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
-| cmd packages | 412 | 14 | server entry point and developer command utilities |
-| **Total** | **9,571** | **530** |  |
+| cmd packages | 413 | 14 | server entry point and developer command utilities |
+| **Total** | **9,573** | **530** |  |
 
 ### Core Packages
 
@@ -70,9 +70,9 @@
 | sampling | 83 | 99.5% | Package sampling provides a client for requesting LLM analysis through MCP sampling and for executing allow-listed tool calls during iterative analysis. |
 | serverpool | 47 | 99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL. |
 | testutil | 21 | 60.9% | Package testutil provides shared test utilities for MCP tool tests. |
-| toolutil | 374 | 93.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages. |
+| toolutil | 375 | 93.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages. |
 | wizard | 241 | 87.4% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,592** |  |  |
+| **Subtotal** | **1,593** |  |  |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/internal/tools/testdata/tools_individual.json
+++ b/internal/tools/testdata/tools_individual.json
@@ -10856,6 +10856,7 @@
     "description": "Retrieve the status of the currently authenticated GitLab user. Returns emoji, message, availability, and clear-at time.\n\nSee also: gitlab_set_user_status, gitlab_user_current\n\nReturns: JSON with current user status.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -14589,6 +14590,7 @@
     "description": "List all instance-level deploy tokens. Requires admin access.\n\nSee also: gitlab_deploy_token_list_project, gitlab_deploy_token_list_group\n\nReturns: JSON array of deploy tokens with pagination.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -21288,6 +21290,7 @@
     "description": "Get current application appearance settings. Requires admin access.\n\nReturns: JSON with appearance settings details.\n\nSee also: gitlab_update_appearance, gitlab_list_broadcast_messages",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -21381,6 +21384,7 @@
     "description": "Get application statistics (admin). Returns counts for users, projects, groups, issues, MRs, etc.\n\nReturns: JSON with application statistics.\n\nSee also: gitlab_server_status.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -22311,6 +22315,7 @@
     "description": "Get the admin-level compliance policy settings for the GitLab instance.\n\nReturns: JSON with compliance policy settings.\n\nSee also: gitlab_update_compliance_policy_settings",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -24520,6 +24525,7 @@
     "description": "Get current GitLab license information (admin). Returns plan, expiry, user counts and licensee.\n\nReturns: JSON with license details.\n\nSee also: gitlab_add_license.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -24873,6 +24879,7 @@
     "description": "Get GitLab instance metadata (version, revision, KAS info, enterprise flag).\n\nReturns: JSON with GitLab instance metadata.\n\nSee also: gitlab_server_status",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -24941,6 +24948,7 @@
     "description": "Get metric definitions as YAML (admin). Returns all metric definitions used in service ping.\n\nReturns: YAML with all metric definitions.\n\nSee also: gitlab_get_service_ping, gitlab_get_usage_queries",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -24976,6 +24984,7 @@
     "description": "Get non-SQL service ping metrics (admin). Returns instance info, license details, and settings.\n\nReturns: JSON with non-SQL metrics including instance and license details.\n\nSee also: gitlab_get_service_ping, gitlab_get_usage_queries",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -26679,6 +26688,7 @@
     "description": "Get service ping data (admin). Returns recorded_at, license info, and usage counts.\n\nReturns: JSON with service ping data including usage counts and license info.\n\nSee also: gitlab_get_non_sql_metrics, gitlab_get_metric_definitions",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -26728,6 +26738,7 @@
     "description": "Get current application settings. Requires admin access. Returns all instance-level settings as key-value pairs.\n\nReturns: JSON with all application settings.\n\nSee also: gitlab_update_settings.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -26764,6 +26775,7 @@
     "description": "Get all Sidekiq metrics in a single compound response (admin). Returns queue metrics, process metrics, and job statistics combined.\n\nReturns: JSON with combined queue, process, and job metrics.\n\nSee also: gitlab_get_sidekiq_queue_metrics.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -26902,6 +26914,7 @@
     "description": "Get Sidekiq job statistics (admin). Returns processed, failed, and enqueued counts.\n\nReturns: JSON with job statistics.\n\nSee also: gitlab_get_sidekiq_compound_metrics.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -26954,6 +26967,7 @@
     "description": "Get Sidekiq process metrics (admin). Returns information about running Sidekiq processes.\n\nReturns: JSON with process metrics.\n\nSee also: gitlab_get_sidekiq_compound_metrics.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -27044,6 +27058,7 @@
     "description": "Get Sidekiq queue metrics (admin). Returns backlog and latency for all queues.\n\nReturns: JSON with queue metrics.\n\nSee also: gitlab_get_sidekiq_compound_metrics.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -27795,6 +27810,7 @@
     "description": "Get service ping SQL queries (admin). Returns the raw SQL queries used for service ping collection.\n\nReturns: JSON with raw SQL queries used for service ping.\n\nSee also: gitlab_get_service_ping, gitlab_get_non_sql_metrics",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -40990,6 +41006,7 @@
     "description": "Create a GitLab project through step-by-step prompts, with explicit confirmation before calling the GitLab API. Cancellation at any prompt aborts without creating the project except initialize_with_readme, where decline/cancel continues with false.\n\nInput: no fields; every project detail is elicited. Requires permission to create projects for the authenticated user.\n\nAfter invocation, the tool elicits in order:\n- name (string, required) — project display name and (when path is omitted) URL slug.\n- description (string, optional) — leave empty to skip.\n- visibility (enum, required) — one of private, internal, public.\n- initialize_with_readme (boolean, optional) — yes/no confirmation; explicit no, decline, or cancel continues with false.\n- default_branch (string, optional) — leave empty to use the GitLab default ('main').\n- confirm (boolean, required) — final yes/no review of the assembled summary.\n\nWhen to use: human-in-the-loop project creation. NOT for: scripted/programmatic creation — use gitlab_project (action='create') with all fields pre-supplied.\n\nBehavior: each successful invocation creates ONE new project after explicit user confirmation. NON-idempotent — re-running with the same project path/name can fail with 400/409. Cancellation/decline at any prompt aborts with no GitLab API call and no side effects, except initialize_with_readme where no/decline/cancel is accepted as initialize_with_readme=false. Side effects on success: GitLab may initialize a repository and notify project members.\n\nRequires the MCP client to support the elicitation capability. If unsupported, returns a structured error naming gitlab_project (action='create') as the alternative.\n\nReturns: JSON with the created project (id, path_with_namespace, web_url, visibility, default_branch).\n\nSee also: gitlab_project, gitlab_group.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -52338,6 +52355,7 @@
     "description": "List email addresses for the currently authenticated GitLab user. Returns email ID, address, and confirmation status.\n\nSee also: gitlab_user_current, gitlab_list_users\n\nReturns: JSON array of user email addresses.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -52960,6 +52978,7 @@
     "description": "List all feature definitions (admin). Returns name, type, group, milestone and default_enabled for each definition.\n\nReturns: JSON array of feature definitions.\n\nSee also: gitlab_list_features.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -53033,6 +53052,7 @@
     "description": "List all feature flags (admin). Returns name, state and gates for each flag.\n\nReturns: JSON array of feature flags.\n\nSee also: gitlab_set_feature_flag.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -53554,6 +53574,7 @@
     "description": "List GPG keys for the currently authenticated GitLab user.\n\nSee also: gitlab_add_gpg_key, gitlab_get_gpg_key\n\nReturns: JSON array of GPG keys.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -55316,6 +55337,7 @@
     "description": "List all custom member roles at the GitLab instance level. Requires admin access.\n\nReturns: JSON with roles array. See also: gitlab_create_instance_member_role.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -56566,6 +56588,7 @@
     "description": "List all project aliases (admin-only). Project aliases allow accessing projects via alternative names.\n\nReturns: JSON with aliases array.\n\nSee also: gitlab_get_project_alias, gitlab_create_project_alias",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -59469,6 +59492,7 @@
     "description": "List all system hooks (admin). Returns ID, URL and event subscriptions.\n\nReturns: JSON with array of system hooks and pagination info.\n\nSee also: gitlab_add_system_hook, gitlab_list_integrations",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -72701,6 +72725,7 @@
     "description": "Get global notification settings for the authenticated user.\n\nReturns: JSON with global notification settings.\n\nSee also: gitlab_notification_global_update, gitlab_notification_project_get",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -75303,6 +75328,7 @@
     "description": "List all Pages domains across all projects accessible to the authenticated user.\n\nReturns: JSON array of Pages domains.\n\nSee also: gitlab_pages_domain_list",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -76110,6 +76136,7 @@
     "description": "Revoke the personal access token used for the current request. This action cannot be undone.\n\nSee also: gitlab_personal_access_token_revoke, gitlab_personal_access_token_list\n\nReturns: confirmation message.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -101376,6 +101403,7 @@
     "description": "Reset the instance-level runner registration token. Deprecated: scheduled for removal in GitLab 20.0.\n\nSee also: gitlab_runner_reset_group_reg_token, gitlab_runner_reset_project_reg_token\n\nReturns: JSON with the new registration token.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -104329,6 +104357,7 @@
     "description": "Check MCP server health and GitLab connectivity. Returns server version, author, department, repository, GitLab version, authentication status, current user, and response time. Use this to diagnose connection issues.\n\nReturns: JSON with server health and connectivity information.\n\nSee also: gitlab_server_check_update, gitlab_get_metadata",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -108959,6 +108988,7 @@
     "description": "Mark ALL pending to-do items as done for the authenticated user. This affects all pending to-dos, not just those on a specific project.\n\nReturns: JSON with count of marked to-do items.\n\nSee also: gitlab_todo_list",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -110988,6 +111018,7 @@
         "settings": {
           "additionalProperties": true,
           "description": "Map of setting_name to new value. Use snake_case keys matching GitLab API fields (e.g. signup_enabled, default_project_visibility, max_artifacts_size).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -111683,6 +111714,7 @@
     "description": "Retrieve information about the currently authenticated GitLab user. Returns user ID, username, name, email, state, avatar URL, web URL, and admin status. Useful for confirming identity and permissions.\n\nSee also: gitlab_get_user, gitlab_list_users\n\nReturns: JSON with current user profile details.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {

--- a/internal/tools/testdata/tools_meta.json
+++ b/internal/tools/testdata/tools_meta.json
@@ -62,6 +62,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -228,6 +229,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -317,6 +319,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -399,6 +402,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -485,6 +489,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -576,6 +581,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -656,6 +662,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -751,6 +758,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -831,6 +839,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -912,6 +921,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -994,6 +1004,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1156,6 +1167,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1240,6 +1252,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1341,6 +1354,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1427,6 +1441,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1515,6 +1530,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1601,6 +1617,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1809,6 +1826,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -1891,6 +1909,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -2401,6 +2420,7 @@
     "description": "Create a GitLab project through step-by-step prompts, with explicit confirmation before calling the GitLab API. Cancellation at any prompt aborts without creating the project except initialize_with_readme, where decline/cancel continues with false.\n\nInput: no fields; every project detail is elicited. Requires permission to create projects for the authenticated user.\n\nAfter invocation, the tool elicits in order:\n- name (string, required) — project display name and (when path is omitted) URL slug.\n- description (string, optional) — leave empty to skip.\n- visibility (enum, required) — one of private, internal, public.\n- initialize_with_readme (boolean, optional) — yes/no confirmation; explicit no, decline, or cancel continues with false.\n- default_branch (string, optional) — leave empty to use the GitLab default ('main').\n- confirm (boolean, required) — final yes/no review of the assembled summary.\n\nWhen to use: human-in-the-loop project creation. NOT for: scripted/programmatic creation — use gitlab_project (action='create') with all fields pre-supplied.\n\nBehavior: each successful invocation creates ONE new project after explicit user confirmation. NON-idempotent — re-running with the same project path/name can fail with 400/409. Cancellation/decline at any prompt aborts with no GitLab API call and no side effects, except initialize_with_readme where no/decline/cancel is accepted as initialize_with_readme=false. Side effects on success: GitLab may initialize a repository and notify project members.\n\nRequires the MCP client to support the elicitation capability. If unsupported, returns a structured error naming gitlab_project (action='create') as the alternative.\n\nReturns: JSON with the created project (id, path_with_namespace, web_url, visibility, default_branch).\n\nSee also: gitlab_project, gitlab_group.",
     "inputSchema": {
       "additionalProperties": false,
+      "properties": {},
       "type": "object"
     },
     "outputSchema": {
@@ -2898,6 +2918,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3001,6 +3022,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3085,6 +3107,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3221,6 +3244,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3303,6 +3327,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3382,6 +3407,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3485,6 +3511,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3587,6 +3614,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3698,6 +3726,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3898,6 +3927,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -3980,6 +4010,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4070,6 +4101,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4189,6 +4221,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4301,6 +4334,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4389,6 +4423,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4470,6 +4505,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4584,6 +4620,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4680,6 +4717,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4767,6 +4805,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -4857,6 +4896,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -5011,6 +5051,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -5097,6 +5138,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },
@@ -5181,6 +5223,7 @@
         "params": {
           "additionalProperties": true,
           "description": "Action-specific parameters as a JSON object. Required and optional fields differ per action. This envelope schema stays broad; runtime validation applies the chosen action's schema after reserved meta keys like `confirm` are stripped. For the JSON Schema of a specific action's `params`, read the MCP resource `gitlab://schema/meta/{tool}/{action}` (replace placeholders with the tool name and the chosen action).",
+          "properties": {},
           "type": "object"
         }
       },

--- a/internal/toolutil/schema_lockdown.go
+++ b/internal/toolutil/schema_lockdown.go
@@ -90,10 +90,13 @@ func schemaMap(schema any) map[string]any {
 	return decoded
 }
 
-// lockdownSchemaNode forces additionalProperties=false on any object schema
-// node that does not already declare it, recursing through nested schemas.
+// lockdownSchemaNode forces additionalProperties=false and ensures a properties
+// object exists on any object schema node, recursing through nested schemas.
 func lockdownSchemaNode(node map[string]any) {
 	if isObjectType(node) {
+		if _, present := node["properties"]; !present {
+			node["properties"] = map[string]any{}
+		}
 		if _, present := node["additionalProperties"]; !present {
 			node["additionalProperties"] = false
 		}

--- a/internal/toolutil/schema_lockdown_test.go
+++ b/internal/toolutil/schema_lockdown_test.go
@@ -82,6 +82,28 @@ func TestLockdownInputSchemas_PreservesExisting(t *testing.T) {
 	}
 }
 
+// TestLockdownSchemaNode_AddsEmptyPropertiesForObject verifies object schemas
+// without fields still publish an explicit empty properties object for model
+// providers that require it.
+func TestLockdownSchemaNode_AddsEmptyPropertiesForObject(t *testing.T) {
+	t.Parallel()
+
+	node := map[string]any{"type": "object"}
+
+	lockdownSchemaNode(node)
+
+	properties, ok := node["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties = %T, want map[string]any", node["properties"])
+	}
+	if len(properties) != 0 {
+		t.Fatalf("properties = %#v, want empty map", properties)
+	}
+	if v, boolOK := node["additionalProperties"].(bool); !boolOK || v {
+		t.Fatalf("additionalProperties = %v, want false", node["additionalProperties"])
+	}
+}
+
 // TestLockdownSchemaNode_NestedObjects verifies recursion into nested object
 // schemas referenced via properties, items, and anyOf.
 func TestLockdownSchemaNode_NestedObjects(t *testing.T) {


### PR DESCRIPTION
## Summary
- publish explicit empty `properties` objects for object schemas with no fields during tools/list lockdown
- apply the same schema lockdown in the meta-tools evaluator catalog session as runtime
- update schema snapshots and testing docs

## Validation
- `go test ./internal/toolutil ./internal/tools ./cmd/eval_meta_tools ./cmd/server -count=1`
- `go run ./cmd/gen_testing_docs/ --check`
- `go vet ./internal/toolutil ./internal/tools ./cmd/eval_meta_tools ./cmd/server`
- `golangci-lint run ./internal/toolutil ./internal/tools ./cmd/eval_meta_tools ./cmd/server`
- `npx markdownlint-cli2 docs/testing/testing.md`
- `git diff --check`
- `GITLAB_ENTERPRISE=true go run ./cmd/eval_meta_tools --tool-surface=meta --model openai:gpt-5.4-nano --task MT-001,MS-001,MS-002,MF-001,MT-152,MT-175 --repeat=1 --pause=250ms --retries=4 --retry-wait=65s --out dist/evaluation/meta-tools/chapter7-meta-openai-schema-fix-smoke.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying meta and standalone tool input schemas are locked down: object properties are empty and additional properties are disallowed.

* **Refactor**
  * Enforced schema lockdown when registering meta tools so input schemas explicitly include empty properties and forbid extra properties.
  * Standardized tool schema representations across test data.

* **Documentation**
  * Updated testing docs to reflect refreshed test counts and coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/101)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->