### PR TITLE
fix: improve dynamic action metadata guidance

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,573 |
-| Unit test functions | 9,326 |
+| Total test functions | 9,574 |
+| Unit test functions | 9,327 |
 | E2E test functions | 247 |
 | cmd test functions | 413 |
 | Test files (internal/) | 407 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,579 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,580 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 289 | 3.0% |
 
@@ -47,10 +47,10 @@
 | --- | ---: | ---: | --- |
 | Core packages | 1,593 | 83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration | 236 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
-| Tool sub-packages (165) | 7,084 | 316 | domain-specific GitLab tool handlers |
+| Tool sub-packages (165) | 7,085 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
 | cmd packages | 413 | 14 | server entry point and developer command utilities |
-| **Total** | **9,573** | **530** |  |
+| **Total** | **9,574** | **530** |  |
 
 ### Core Packages
 
@@ -85,8 +85,8 @@
 | samplingtools | 165 | 100.0% | 11 |
 | groups | 123 | 98.9% | 18 |
 | jobs | 118 | 96.1% | 17 |
+| dynamic | 114 | 99.5% | 4 |
 | search | 114 | 100.0% | 10 |
-| dynamic | 113 | 99.8% | 4 |
 | awardemoji | 105 | 65.0% | 24 |
 | pipelines | 99 | 97.4% | 12 |
 | packages | 98 | 96.6% | 8 |
@@ -148,7 +148,7 @@
 | deploytokens | 64 | 2 | 100.0% | 9 |
 | dockerfiletemplates | 14 | 1 | 100.0% | 2 |
 | dorametrics | 9 | 2 | 100.0% | 2 |
-| dynamic | 113 | 7 | 99.8% | 4 |
+| dynamic | 114 | 7 | 99.5% | 4 |
 | elicitationtools | 57 | 2 | 98.2% | 4 |
 | enterpriseusers | 33 | 3 | 100.0% | 4 |
 | environments | 47 | 2 | 100.0% | 6 |
@@ -276,7 +276,7 @@
 | vulnerabilities | 52 | 3 | 98.5% | 8 |
 | wikis | 58 | 2 | 98.9% | 6 |
 | workitems | 66 | 2 | 100.0% | 5 |
-| **Total** | **7,084** | **316** |  | **1,009** |
+| **Total** | **7,085** | **316** |  | **1,009** |
 
 </details>
 
@@ -361,7 +361,7 @@
 | deploytokens | 100.0% |
 | dockerfiletemplates | 100.0% |
 | dorametrics | 100.0% |
-| dynamic | 99.8% |
+| dynamic | 99.5% |
 | elicitationtools | 98.2% |
 | enterpriseusers | 100.0% |
 | environments | 100.0% |

--- a/internal/tools/dynamic/alias_audit.go
+++ b/internal/tools/dynamic/alias_audit.go
@@ -19,6 +19,17 @@ type AliasAuditFinding struct {
 	Message   string
 }
 
+// CatalogDiscoveryFinding describes one catalog action whose dynamic search
+// metadata is weak enough to deserve review.
+type CatalogDiscoveryFinding struct {
+	Severity string
+	Problem  string
+	Tool     string
+	Action   string
+	ID       string
+	Message  string
+}
+
 // AuditDefaultActionAliases returns governance findings for built-in dynamic
 // compatibility aliases. It reports duplicate alias/canonical pairs, aliases
 // that map to missing canonical actions when a catalog is provided, and
@@ -30,6 +41,87 @@ type AliasAuditFinding struct {
 // informational states such as intentionally unsearchable aliases.
 func AuditDefaultActionAliases(catalog *actioncatalog.Catalog) []AliasAuditFinding {
 	return auditActionAliases(catalog, actionAliases())
+}
+
+// AuditCatalogDiscoveryTerms reports actions in dense catalog groups that have
+// no discovery signal beyond their canonical ID/domain/action words. It is a
+// deterministic audit helper for targeted metadata work, not a hard production
+// validation gate.
+func AuditCatalogDiscoveryTerms(catalog *actioncatalog.Catalog) []CatalogDiscoveryFinding {
+	if catalog == nil {
+		return nil
+	}
+	return AuditRegistryDiscoveryTerms(NewRegistryFromCatalog(catalog))
+}
+
+// AuditRegistryDiscoveryTerms reports actions in dense dynamic registry groups
+// that have no discovery signal beyond their canonical ID/domain/action words.
+// Use this variant when a caller already has a dynamic registry available.
+func AuditRegistryDiscoveryTerms(registry *Registry) []CatalogDiscoveryFinding {
+	if registry == nil {
+		return nil
+	}
+	denseGroups := denseRegistryGroups(registry)
+	if len(denseGroups) == 0 {
+		return nil
+	}
+
+	findings := make([]CatalogDiscoveryFinding, 0)
+	for _, entry := range registry.entries {
+		if !denseGroups[entry.Tool] || hasActionDiscoverySignal(entry) {
+			continue
+		}
+		findings = append(findings, CatalogDiscoveryFinding{
+			Severity: "warning",
+			Problem:  "weak_discovery_terms",
+			Tool:     entry.Tool,
+			Action:   entry.Action,
+			ID:       entry.ID,
+			Message:  "dense catalog action has no aliases, tags, usage guidance, related actions, parameter names, schema descriptions, or enum values beyond its canonical ID",
+		})
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Severity != findings[j].Severity {
+			return findings[i].Severity < findings[j].Severity
+		}
+		if findings[i].Tool != findings[j].Tool {
+			return findings[i].Tool < findings[j].Tool
+		}
+		return findings[i].ID < findings[j].ID
+	})
+	return findings
+}
+
+// denseRegistryGroups returns tool groups large enough that weak per-action
+// discovery metadata can make adjacent actions hard to distinguish.
+func denseRegistryGroups(registry *Registry) map[string]bool {
+	const minDenseGroupActions = 8
+	groupCounts := make(map[string]int)
+	for _, entry := range registry.entries {
+		groupCounts[entry.Tool]++
+	}
+
+	dense := make(map[string]bool)
+	for toolName, count := range groupCounts {
+		if count >= minDenseGroupActions {
+			dense[toolName] = true
+		}
+	}
+	return dense
+}
+
+// hasActionDiscoverySignal reports whether an action has any searchable signal
+// beyond its derived canonical ID, domain, and action words.
+func hasActionDiscoverySignal(entry actionEntry) bool {
+	if len(entry.Aliases) > 0 || len(entry.Tags) > 0 || usageHintForEntry(entry) != "" || len(relatedActionsForEntry(entry)) > 0 {
+		return true
+	}
+	document := entry.Document
+	return len(entry.RequiredParams) > 0 ||
+		len(document.OptionalParams) > 0 ||
+		len(document.SchemaProperties) > 0 ||
+		len(document.SchemaEnums) > 0 ||
+		len(document.SchemaDescTerms) > 0
 }
 
 func auditActionAliases(catalog *actioncatalog.Catalog, aliases []actionAlias) []AliasAuditFinding {

--- a/internal/tools/dynamic/alias_audit_test.go
+++ b/internal/tools/dynamic/alias_audit_test.go
@@ -76,3 +76,45 @@ func TestAuditDefaultActionAliases_ReturnsOnlyExpectedDefaultFindings(t *testing
 		}
 	}
 }
+
+// TestAuditCatalogDiscoveryTerms_FlagsDenseActionsWithoutSignals verifies the
+// metadata audit catches actions in crowded groups when their only searchable
+// text is the canonical identifier, while ignoring actions with targeted tags
+// or schema-derived parameter signals.
+func TestAuditCatalogDiscoveryTerms_FlagsDenseActionsWithoutSignals(t *testing.T) {
+	catalog := actioncatalog.NewCatalog()
+	group := actioncatalog.NewGroup(actioncatalog.GroupOptions{ToolName: "gitlab_project"})
+	weakRoute := toolutil.Route(func(_ context.Context, _ map[string]any) (any, error) { return nil, nil })
+	for index := range 8 {
+		action := actioncatalog.Action{Name: "weak_action_" + string(rune('a'+index)), Route: weakRoute}
+		if index == 0 {
+			action.Tags = []string{"project cleanup"}
+		}
+		if index == 1 {
+			action.Route.InputSchema = map[string]any{"properties": map[string]any{"project_id": map[string]any{}}}
+		}
+		group.SetAction(action)
+	}
+	if err := catalog.AddGroup(group); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
+	}
+
+	findings := AuditCatalogDiscoveryTerms(catalog)
+	registryFindings := AuditRegistryDiscoveryTerms(NewRegistryFromCatalog(catalog))
+	if len(registryFindings) != len(findings) {
+		t.Fatalf("AuditRegistryDiscoveryTerms() returned %d findings, want %d", len(registryFindings), len(findings))
+	}
+	if len(findings) != 6 {
+		t.Fatalf("AuditCatalogDiscoveryTerms() returned %d findings, want 6: %+v", len(findings), findings)
+	}
+	for _, ignored := range []string{"project.weak_action_a", "project.weak_action_b"} {
+		if slices.ContainsFunc(findings, func(finding CatalogDiscoveryFinding) bool { return finding.ID == ignored }) {
+			t.Fatalf("findings = %+v, want %s ignored because it has discovery signals", findings, ignored)
+		}
+	}
+	for _, finding := range findings {
+		if finding.Severity != "warning" || finding.Problem != "weak_discovery_terms" || finding.Tool != "gitlab_project" || finding.Message == "" {
+			t.Fatalf("finding = %+v, want populated weak discovery warning", finding)
+		}
+	}
+}

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -1324,6 +1324,7 @@ var searchSynonymsMap = map[string][]string{
 	"current":       {"current_user", "self", "me", "author", "author_username", "assignee", "assignee_username", "settings"},
 	"deploy":        {"deployment", "environment", "key"},
 	"deployment":    {"deploy", "environment"},
+	"deployments":   {"deployment", "deploy", "environment"},
 	"details":       {"get"},
 	"discussion":    {"comment", "thread", "note"},
 	"draft":         {"wip", "work_in_progress", "proposal"},
@@ -1361,12 +1362,15 @@ var searchSynonymsMap = map[string][]string{
 	"repo":          {"repository", "file", "tree", "branch", "tag"},
 	"runner":        {"job", "ci", "pipeline"},
 	"secret":        {"variable", "ci_variable", "token", "password"},
+	"credential":    {"credentials", "token"},
+	"credentials":   {"credential", "token"},
 	"show":          {"get"},
 	"state":         {"status", "condition", "filter", "list"},
 	"ticket":        {"issue", "work_item"},
 	"unresolved":    {"open", "active", "list"},
 	"user":          {"username", "user_id", "author_username", "assignee_username", "current_user", "member"},
 	"users":         {"username", "user_id", "author_username", "assignee_username", "current_user", "member"},
+	"tokens":        {"token"},
 	"verify":        {"get", "exists"},
 	"webhook":       {"hook"},
 	"webhooks":      {"hook"},
@@ -1432,6 +1436,8 @@ func actionTags(id, domain, action string, schema map[string]any) []string {
 		add("webhook", "web hook", "project webhook", "webhook create", "webhook add", "project hook add", "hook add")
 	case strings.Contains(id, "deploy_key"):
 		add("deploy key", "ssh key", "access key")
+	case strings.Contains(id, "deploy_token"):
+		add("deploy token", "deploy tokens", "project deploy token", "project deploy tokens", "deployment token", "credential", "credentials", "token list", "deploy token list")
 	case strings.Contains(id, "member_") && domain == "project":
 		add("project member", "project membership")
 	case strings.Contains(id, "member_") && domain == "group":
@@ -1460,6 +1466,14 @@ func actionTags(id, domain, action string, schema map[string]any) []string {
 		add("ci variable", "ci secret", "secret", "environment variable")
 	case domain == "environment":
 		add("env", "deployment")
+		switch {
+		case strings.HasPrefix(action, "protected_"):
+			add("protected environment", "environment protection", "protected environment get", "protected environment list")
+		case strings.HasPrefix(action, "deployment_"):
+			add("environment deployment", "deployment list", "deployment approval", "deployment approve", "deployment reject")
+		}
+	case domain == "feature_flags" && strings.HasPrefix(action, "ff_user_list_"):
+		add("feature flag user list", "user list", "user_list_iid", "feature flag users")
 	case domain == "job":
 		add("ci job", "pipeline job")
 		switch action {
@@ -1533,6 +1547,16 @@ func actionTags(id, domain, action string, schema map[string]any) []string {
 		}
 	case domain == "issue":
 		switch action {
+		case "note_create":
+			add("issue note", "issue comment", "create note", "create comment")
+		case "note_get":
+			add("issue note", "issue comment", "get note", "note_id", "read one note")
+		case "note_list":
+			add("issue notes", "issue comments", "list notes", "list comments")
+		case "note_update":
+			add("issue note", "issue comment", "update note", "edit comment", "note_id")
+		case "note_delete":
+			add("issue note", "issue comment", "delete note", "remove comment", "note_id")
 		case "time_estimate_set":
 			add("issue time tracking", "set estimate", "time estimate", "estimate", "2h")
 		case "spent_time_add":
@@ -1865,6 +1889,66 @@ var actionUXMetadataByID = map[string]actionUXMetadata{
 		Usage:          "Creates a broadcast message after any requested settings read; message text goes in params.message.",
 		RelatedActions: []string{"admin.settings_get", "admin.broadcast_message_list"},
 	},
+	"access.deploy_key_list_project": {
+		Usage:          "Lists deploy keys, not deploy tokens; use access.deploy_token_list_project when credentials/tokens are requested.",
+		RelatedActions: []string{"access.deploy_token_list_project"},
+	},
+	"access.deploy_token_list_project": {
+		Usage:          "Lists deploy tokens/credentials for a project; use access.deploy_key_list_project for SSH deploy keys.",
+		RelatedActions: []string{"access.deploy_key_list_project"},
+	},
+	"environment.protected_get": {
+		Usage:          "Gets one protected environment by params.name; environment.get reads a normal environment by environment_id.",
+		RelatedActions: []string{"environment.protected_list", "environment.deployment_list"},
+	},
+	"environment.deployment_list": {
+		Usage:          "Lists deployments for an environment/project; use after environment.list or protected environment lookup when deployment approval context is needed.",
+		RelatedActions: []string{"environment.list", "environment.deployment_approve_or_reject"},
+	},
+	"environment.deployment_approve_or_reject": {
+		Usage:          "Approves or rejects a deployment and requires params.deployment_id plus params.status.",
+		RelatedActions: []string{"environment.deployment_list"},
+	},
+	"feature_flags.ff_user_list_get": {
+		Usage:          "Gets one feature flag user list by params.user_list_iid; ff_user_list_list lists all user lists and does not accept user_list_iid.",
+		RelatedActions: []string{"feature_flags.ff_user_list_list", "feature_flags.ff_user_list_update"},
+	},
+	"feature_flags.ff_user_list_list": {
+		Usage:          "Lists feature flag user lists for a project; use ff_user_list_get when a specific user_list_iid is known.",
+		RelatedActions: []string{"feature_flags.ff_user_list_get"},
+	},
+	"feature_flags.ff_user_list_update": {
+		Usage:          "Updates one feature flag user list and requires params.user_list_iid.",
+		RelatedActions: []string{"feature_flags.ff_user_list_get", "feature_flags.ff_user_list_list"},
+	},
+	"feature_flags.ff_user_list_delete": {
+		Usage:          "Deletes one feature flag user list and requires params.user_list_iid.",
+		RelatedActions: []string{"feature_flags.ff_user_list_get", "feature_flags.ff_user_list_list"},
+	},
+	"issue.note_create": {
+		Usage:          "Creates a note/comment on an issue; subsequent get/update/delete steps need the returned note_id.",
+		RelatedActions: []string{"issue.note_get", "issue.note_update", "issue.note_delete"},
+	},
+	"issue.note_get": {
+		Usage:          "Gets one issue note by params.note_id; issue.note_list lists notes and does not fetch a specific note.",
+		RelatedActions: []string{"issue.note_list", "issue.note_update", "issue.note_delete"},
+	},
+	"issue.note_list": {
+		Usage:          "Lists issue notes/comments; use issue.note_get when a specific note_id is known.",
+		RelatedActions: []string{"issue.note_get"},
+	},
+	"issue.note_update": {
+		Usage:          "Updates one issue note/comment and requires params.note_id.",
+		RelatedActions: []string{"issue.note_get", "issue.note_delete"},
+	},
+	"issue.note_delete": {
+		Usage:          "Deletes one issue note/comment and requires params.note_id.",
+		RelatedActions: []string{"issue.note_get", "issue.note_update"},
+	},
+	"mr_review.draft_note_publish_all": {
+		Usage:          "Publishes all pending draft MR review notes; use draft_note_create first when adding draft comments.",
+		RelatedActions: []string{"mr_review.draft_note_create", "mr_review.draft_note_list"},
+	},
 	"project.get": {
 		RelatedActions: []string{"project.archive", "project.delete", "project.update"},
 	},
@@ -1879,6 +1963,18 @@ var actionUXMetadataByID = map[string]actionUXMetadata{
 	"release.link_list": {
 		Usage:          "Lists asset links for an existing release tag; it is not a release existence check.",
 		RelatedActions: []string{"release.get", "release.link_create", "release.link_delete"},
+	},
+	"release.link_get": {
+		Usage:          "Gets one release asset link by link_id; use release.link_list to discover link IDs for a tag.",
+		RelatedActions: []string{"release.link_list", "release.link_update", "release.link_delete"},
+	},
+	"release.link_update": {
+		Usage:          "Updates one release asset link by link_id; use release.link_list or release.link_get before editing when the ID is unknown.",
+		RelatedActions: []string{"release.link_get", "release.link_list", "release.link_delete"},
+	},
+	"release.link_delete": {
+		Usage:          "Deletes one release asset link by link_id; use release.link_list before deletion when the ID is unknown.",
+		RelatedActions: []string{"release.link_get", "release.link_list"},
 	},
 	"repository.compare": {
 		Usage:          "Compares two refs using params.from and params.to; use before analyze.release_notes when the task asks to inspect the diff.",
@@ -2178,9 +2274,14 @@ func actionAliases() []actionAlias {
 		{Alias: "issue_note.create", Canonical: "issue.note_create"},
 		{Alias: "release.create_link", Canonical: "release.link_create"},
 		{Alias: "release.asset_link.create", Canonical: "release.link_create"},
+		{Alias: "release.asset_link.delete", Canonical: "release.link_delete"},
+		{Alias: "release.asset_link.get", Canonical: "release.link_get"},
+		{Alias: "release.asset_link.list", Canonical: "release.link_list"},
+		{Alias: "release.asset_link.update", Canonical: "release.link_update"},
 		{Alias: "release_link.link_list", Canonical: "release.link_list"},
 		{Alias: "release.generate_notes", Canonical: "analyze.release_notes"},
 		{Alias: "package.list_project", Canonical: "package.list"},
+		{Alias: "package.list_project_packages", Canonical: "package.list"},
 		{Alias: "variable.create", Canonical: "ci_variable.create"},
 		{Alias: "group.variable.create", Canonical: "ci_variable.group_create"},
 		{Alias: "group.audit_events", Canonical: "audit_event.list_group"},
@@ -2192,6 +2293,9 @@ func actionAliases() []actionAlias {
 		{Alias: "gitlab_interactive_mr_create", Canonical: "interactive.mr_create"},
 		{Alias: "gitlab_interactive_project_create", Canonical: "interactive.project_create"},
 		{Alias: "gitlab_interactive_release_create", Canonical: "interactive.release_create"},
+		{Alias: "job.token_scope_remove_inbound", Canonical: "job.token_scope_remove_project"},
+		{Alias: "mr_review.draft_notes_publish_all", Canonical: "mr_review.draft_note_publish_all"},
+		{Alias: "repository.tag.delete", Canonical: "tag.delete"},
 		{Alias: "runner.delete", Canonical: "runner.remove"},
 		{Alias: "wiki.show", Canonical: "wiki.get"},
 		{Alias: "webhook.add", Canonical: "project.hook_add"},

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -1093,10 +1093,18 @@ func TestDescribe_CanonicalizesProviderSpecificAliases(t *testing.T) {
 		"merge_request.emoji_mr_award_create":        "merge_request.emoji_mr_create",
 		"merge_request.emoji_mr_award_delete":        "merge_request.emoji_mr_delete",
 		"generic_package.list":                       "package.list",
+		"job.token_scope_remove_inbound":             "job.token_scope_remove_project",
 		"issue_note.create":                          "issue.note_create",
 		"issue_note.delete":                          "issue.note_delete",
 		"issue_note.update":                          "issue.note_update",
+		"mr_review.draft_notes_publish_all":          "mr_review.draft_note_publish_all",
+		"package.list_project_packages":              "package.list",
+		"release.asset_link.delete":                  "release.link_delete",
+		"release.asset_link.get":                     "release.link_get",
+		"release.asset_link.list":                    "release.link_list",
+		"release.asset_link.update":                  "release.link_update",
 		"release_link.link_list":                     "release.link_list",
+		"repository.tag.delete":                      "tag.delete",
 		"wiki.show":                                  "wiki.get",
 		"gitlab_interactive_issue.create":            "interactive.issue_create",
 	}
@@ -1123,13 +1131,21 @@ func TestDescribe_IncludesDisambiguationUsage(t *testing.T) {
 	registry := realCatalogRegistry(t)
 
 	tests := map[string]string{
-		"admin.settings_get":            "current instance/application settings",
-		"job.download_single_artifact":  "one artifact file path",
-		"package.list":                  "package registry packages",
-		"runner.remove":                 "numeric runner_id",
-		"repository.compare":            "params.from and params.to",
-		"analyze.release_notes":         "after requested release/compare",
-		"package.registry_list_project": "container registry image repositories",
+		"admin.settings_get":               "current instance/application settings",
+		"access.deploy_key_list_project":   "deploy keys, not deploy tokens",
+		"access.deploy_token_list_project": "deploy tokens/credentials",
+		"environment.protected_get":        "protected environment",
+		"environment.deployment_list":      "Lists deployments",
+		"feature_flags.ff_user_list_get":   "params.user_list_iid",
+		"issue.note_get":                   "params.note_id",
+		"job.download_single_artifact":     "one artifact file path",
+		"mr_review.draft_note_publish_all": "Publishes all pending draft MR review notes",
+		"package.list":                     "package registry packages",
+		"runner.remove":                    "numeric runner_id",
+		"release.link_get":                 "release asset link by link_id",
+		"repository.compare":               "params.from and params.to",
+		"analyze.release_notes":            "after requested release/compare",
+		"package.registry_list_project":    "container registry image repositories",
 	}
 
 	for actionID, wantSubstring := range tests {
@@ -2256,6 +2272,10 @@ func TestSearch_ProviderConfusionQueries_ReturnExpectedActions(t *testing.T) {
 		{name: "generic package list", query: "list package registry packages", want: []string{"package.list"}},
 		{name: "runner removal by id", query: "remove runner by numeric runner_id", want: []string{"runner.remove"}},
 		{name: "issue time tracking sequence", query: "issue time tracking set estimate add spent time reset spent time reset estimate", limit: 8, want: []string{"issue.time_estimate_set", "issue.spent_time_add", "issue.spent_time_reset", "issue.time_estimate_reset"}},
+		{name: "deploy token inventory", query: "list project deploy tokens credentials not deploy keys", limit: 8, want: []string{"access.deploy_token_list_project"}},
+		{name: "protected environment deployment approval", query: "protected environment deployment_list deployment approve_or_reject", limit: 12, want: []string{"environment.protected_get", "environment.deployment_list", "environment.deployment_approve_or_reject"}},
+		{name: "feature flag user list lifecycle", query: "feature flag user list get user_list_iid update delete", limit: 8, want: []string{"feature_flags.ff_user_list_get", "feature_flags.ff_user_list_update", "feature_flags.ff_user_list_delete"}},
+		{name: "issue note lifecycle", query: "issue note get by note_id update delete comment", limit: 8, want: []string{"issue.note_get", "issue.note_update", "issue.note_delete"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Type of Change
- Bug fix / reliability improvement

## Changes Made
- Added a deterministic dynamic catalog discovery audit for dense groups with weak action metadata.
- Added targeted dynamic aliases, tags, usage hints, and related-action guidance for evaluator-observed confusion cases.
- Covered the new metadata with dynamic search/describe tests.
- Refreshed generated testing documentation.

## How to Test
- go test ./internal/tools/dynamic/ -count=1
- go vet ./internal/tools/dynamic/
- golangci-lint run ./internal/tools/dynamic/
- go run ./cmd/audit_dynamic_aliases/
- go run ./cmd/gen_testing_docs/ --check
- npx markdownlint-cli2 docs/testing/testing.md
- git diff --check

## Breaking Changes
- None.

## Checklist
- [x] Tests updated or added
- [x] Generated testing docs refreshed
- [x] Targeted static analysis passed
- [x] No default tool-surface behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added catalog discovery audit to highlight actions with weak discovery signals.
  * Expanded action search vocabulary with new synonyms and aliases.
  * Enhanced action metadata with additional usage guidance and related-action hints.

* **Tests**
  * Added unit tests for the new audit behavior.
  * Updated existing tests to cover expanded alias/search and metadata changes.

* **Documentation**
  * Regenerated testing statistics and coverage metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/102)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->