### PR TITLE
Fix evaluator report startup output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,8 +185,9 @@ linters:
       strconcat: false
 
   exclusions:
-    # Log a warning if an exclusion rule is unused.
-    warn-unused: true
+    # Keep focused package runs warning-free when exclusions for unrelated
+    # packages are not exercised by the selected target.
+    warn-unused: false
     # Default exclusion presets
     presets:
       - comments

--- a/cmd/eval_meta_tools/README.md
+++ b/cmd/eval_meta_tools/README.md
@@ -193,6 +193,8 @@ E2E_MODE=docker timeout 900s go run ./cmd/eval_meta_tools \
 
 The Docker presets apply safe defaults for `--backend=gitlab`, `--gitlab-env-file test/e2e/.env.docker`, `--execute-tools`, `--use-fixtures`, `--skip-unavailable`, and the matching partition. Override any of those flags explicitly when debugging a narrower case.
 
+Long model-backed runs create the selected `--out` Markdown file at startup with a `Status: running` placeholder. The placeholder is replaced by the final metrics report when the run completes, or by a failure report if the evaluator stops before final metrics are available. For long local runs, always set an explicit `--out` path and redirect stdout/stderr to a sibling `.log` file so the terminal does not become the report artifact.
+
 Use `scripts/eval-compare-version.sh` to orchestrate the standard snapshot, token audit, schema dry-run, optional model-backed run, and optional comparison report for one target label.
 
 ## Safety

--- a/cmd/eval_meta_tools/main.go
+++ b/cmd/eval_meta_tools/main.go
@@ -458,7 +458,7 @@ func main() {
 }
 
 // run is an internal helper for the main package.
-func run() error {
+func run() (runErr error) {
 	opts := parseFlags()
 	var presetErr error
 	opts, presetErr = applyPresetDefaults(opts)
@@ -503,6 +503,20 @@ func run() error {
 	}
 	if opts.TraceDir == "" && !opts.DryRun {
 		opts.TraceDir = defaultTraceDir(opts.Output)
+	}
+	finalReportWritten := false
+	if shouldWriteStartupReport(opts) {
+		if writeErr := writeStartupReport(opts.Output, opts); writeErr != nil {
+			return writeErr
+		}
+		defer func() {
+			if runErr == nil || finalReportWritten {
+				return
+			}
+			if writeErr := writeErrorReport(opts.Output, opts, runErr); writeErr != nil {
+				runErr = errors.Join(runErr, writeErr)
+			}
+		}()
 	}
 	var fixtures *liveFixtureState
 	if opts.PrepareFixtures {
@@ -614,6 +628,7 @@ func run() error {
 		if err := writeReport(opts.Output, opts, results, catalog, routes, true); err != nil {
 			return err
 		}
+		finalReportWritten = true
 		return writeCoverageReportIfRequested(opts, results, routes)
 	}
 
@@ -684,6 +699,7 @@ func run() error {
 	if writeErr := writeReport(opts.Output, opts, results, catalog, routes, false); writeErr != nil {
 		return writeErr
 	}
+	finalReportWritten = true
 	if err := writeCoverageReportIfRequested(opts, results, routes); err != nil {
 		return err
 	}
@@ -6333,6 +6349,59 @@ func valueOrZero(value string) string {
 	return escapeTable(value)
 }
 
+// shouldWriteStartupReport is an internal helper for the main package.
+func shouldWriteStartupReport(opts options) bool {
+	return opts.Output != "" && !opts.FixturesOnly
+}
+
+// writeStartupReport is an internal helper for the main package.
+func writeStartupReport(path string, opts options) error {
+	return writeStatusReport(path, opts, "running", "The evaluator created this placeholder at startup. It will be replaced by the final metrics report when the run completes.", nil)
+}
+
+// writeErrorReport is an internal helper for the main package.
+func writeErrorReport(path string, opts options, runErr error) error {
+	return writeStatusReport(path, opts, "failed", "The evaluator stopped before it could write the final metrics report.", runErr)
+}
+
+// writeStatusReport is an internal helper for the main package.
+func writeStatusReport(path string, opts options, status, message string, runErr error) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create report directory: %w", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Meta-Tool Model Evaluation\n\n")
+	fmt.Fprintf(&b, "Date: %s\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "Status: `%s`\n", status)
+	fmt.Fprintf(&b, "Mode: %s\n", reportMode(opts.DryRun))
+	fmt.Fprintf(&b, "Model: `%s`\n", opts.Model)
+	fmt.Fprintf(&b, "Tool surface: `%s`\n", opts.ToolSurface)
+	fmt.Fprintf(&b, "Backend: `%s`\n", normalizedBackend(opts.Backend))
+	fmt.Fprintf(&b, "Tool execution: `%s`\n", toolExecutionMode(opts))
+	if opts.TraceDir != "" && !opts.DryRun {
+		fmt.Fprintf(&b, "Trace artifacts: `%s`\n", opts.TraceDir)
+	}
+	fmt.Fprintf(&b, "\n## Status\n\n%s\n", message)
+	if runErr != nil {
+		fmt.Fprintf(&b, "\n## Error\n\n")
+		for line := range strings.SplitSeq(runErr.Error(), "\n") {
+			fmt.Fprintf(&b, "    %s\n", line)
+		}
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return fmt.Errorf("write status report: %w", err)
+	}
+	return nil
+}
+
+// reportMode is an internal helper for the main package.
+func reportMode(dryRun bool) string {
+	if dryRun {
+		return "static route/schema validation"
+	}
+	return "model tool-calling"
+}
+
 // writeReport is an internal helper for the main package.
 func writeReport(path string, opts options, results []taskResult, catalog []modelTool, routes map[string]toolutil.ActionMap, dryRun bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
@@ -6340,10 +6409,6 @@ func writeReport(path string, opts options, results []taskResult, catalog []mode
 	}
 	var b strings.Builder
 	metrics := calculateMetrics(results)
-	mode := "model tool-calling"
-	if dryRun {
-		mode = "static route/schema validation"
-	}
 	fmt.Fprintf(&b, "# Meta-Tool Model Evaluation\n\n")
 	fmt.Fprintf(&b, "Date: %s\n", time.Now().UTC().Format(time.RFC3339))
 	if branch, commit := currentGitReportMetadata(); branch != "" || commit != "" {
@@ -6354,7 +6419,7 @@ func writeReport(path string, opts options, results []taskResult, catalog []mode
 			fmt.Fprintf(&b, "Git commit: `%s`\n", commit)
 		}
 	}
-	fmt.Fprintf(&b, "Mode: %s\n", mode)
+	fmt.Fprintf(&b, "Mode: %s\n", reportMode(dryRun))
 	fmt.Fprintf(&b, "Model: `%s`\n", opts.Model)
 	fmt.Fprintf(&b, "Tool surface: `%s`\n", opts.ToolSurface)
 	fmt.Fprintf(&b, "Backend: `%s`\n", normalizedBackend(opts.Backend))

--- a/cmd/eval_meta_tools/main.go
+++ b/cmd/eval_meta_tools/main.go
@@ -6370,14 +6370,8 @@ func writeStatusReport(path string, opts options, status, message string, runErr
 		return fmt.Errorf("create report directory: %w", err)
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "# Meta-Tool Model Evaluation\n\n")
-	fmt.Fprintf(&b, "Date: %s\n", time.Now().UTC().Format(time.RFC3339))
+	writeReportHeader(&b, opts, opts.DryRun)
 	fmt.Fprintf(&b, "Status: `%s`\n", status)
-	fmt.Fprintf(&b, "Mode: %s\n", reportMode(opts.DryRun))
-	fmt.Fprintf(&b, "Model: `%s`\n", opts.Model)
-	fmt.Fprintf(&b, "Tool surface: `%s`\n", opts.ToolSurface)
-	fmt.Fprintf(&b, "Backend: `%s`\n", normalizedBackend(opts.Backend))
-	fmt.Fprintf(&b, "Tool execution: `%s`\n", toolExecutionMode(opts))
 	if opts.TraceDir != "" && !opts.DryRun {
 		fmt.Fprintf(&b, "Trace artifacts: `%s`\n", opts.TraceDir)
 	}
@@ -6392,6 +6386,34 @@ func writeStatusReport(path string, opts options, status, message string, runErr
 		return fmt.Errorf("write status report: %w", err)
 	}
 	return nil
+}
+
+// writeReportHeader is an internal helper for the main package.
+func writeReportHeader(b *strings.Builder, opts options, dryRun bool) {
+	fmt.Fprintf(b, "# Meta-Tool Model Evaluation\n\n")
+	fmt.Fprintf(b, "Date: %s\n", time.Now().UTC().Format(time.RFC3339))
+	if branch, commit := currentGitReportMetadata(); branch != "" || commit != "" {
+		if branch != "" {
+			fmt.Fprintf(b, "Git branch: `%s`\n", branch)
+		}
+		if commit != "" {
+			fmt.Fprintf(b, "Git commit: `%s`\n", commit)
+		}
+	}
+	fmt.Fprintf(b, "Mode: %s\n", reportMode(dryRun))
+	fmt.Fprintf(b, "Model: `%s`\n", opts.Model)
+	fmt.Fprintf(b, "Tool surface: `%s`\n", opts.ToolSurface)
+	fmt.Fprintf(b, "Backend: `%s`\n", normalizedBackend(opts.Backend))
+	if opts.Preset != "" {
+		fmt.Fprintf(b, "Preset: `%s`\n", opts.Preset)
+	}
+	fmt.Fprintf(b, "Tool execution: `%s`\n", toolExecutionMode(opts))
+	if opts.ToolsFile != "" {
+		fmt.Fprintf(b, "Tools file: `%s`\n", opts.ToolsFile)
+	}
+	if opts.Partition != "" {
+		fmt.Fprintf(b, "Partition: `%s`\n", opts.Partition)
+	}
 }
 
 // reportMode is an internal helper for the main package.
@@ -6409,30 +6431,7 @@ func writeReport(path string, opts options, results []taskResult, catalog []mode
 	}
 	var b strings.Builder
 	metrics := calculateMetrics(results)
-	fmt.Fprintf(&b, "# Meta-Tool Model Evaluation\n\n")
-	fmt.Fprintf(&b, "Date: %s\n", time.Now().UTC().Format(time.RFC3339))
-	if branch, commit := currentGitReportMetadata(); branch != "" || commit != "" {
-		if branch != "" {
-			fmt.Fprintf(&b, "Git branch: `%s`\n", branch)
-		}
-		if commit != "" {
-			fmt.Fprintf(&b, "Git commit: `%s`\n", commit)
-		}
-	}
-	fmt.Fprintf(&b, "Mode: %s\n", reportMode(dryRun))
-	fmt.Fprintf(&b, "Model: `%s`\n", opts.Model)
-	fmt.Fprintf(&b, "Tool surface: `%s`\n", opts.ToolSurface)
-	fmt.Fprintf(&b, "Backend: `%s`\n", normalizedBackend(opts.Backend))
-	if opts.Preset != "" {
-		fmt.Fprintf(&b, "Preset: `%s`\n", opts.Preset)
-	}
-	fmt.Fprintf(&b, "Tool execution: `%s`\n", toolExecutionMode(opts))
-	if opts.ToolsFile != "" {
-		fmt.Fprintf(&b, "Tools file: `%s`\n", opts.ToolsFile)
-	}
-	if opts.Partition != "" {
-		fmt.Fprintf(&b, "Partition: `%s`\n", opts.Partition)
-	}
+	writeReportHeader(&b, opts, dryRun)
 	fmt.Fprintf(&b, "Catalog tools: %d\n", len(catalog))
 	fmt.Fprintf(&b, "Runs: %d\n", opts.Repeat)
 	fmt.Fprintf(&b, "Task attempts: %d\n\n", len(results))

--- a/cmd/eval_meta_tools/main_test.go
+++ b/cmd/eval_meta_tools/main_test.go
@@ -4567,6 +4567,56 @@ func TestDefaultOutputPath_UsesShortNameForMultiModel(t *testing.T) {
 	}
 }
 
+// TestWriteStartupReport_CreatesPlaceholder verifies that startup reports are written before model evaluation finishes.
+func TestWriteStartupReport_CreatesPlaceholder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "report.md")
+	opts := options{
+		Model:       "test:model",
+		ToolSurface: config.ToolSurfaceDynamic,
+		Backend:     backendGitLab,
+		Output:      path,
+		TraceDir:    defaultTraceDir(path),
+	}
+
+	if err := writeStartupReport(path, opts); err != nil {
+		t.Fatalf("writeStartupReport() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read startup report: %v", err)
+	}
+	requireContainsAll(t, "startup report", string(data), []string{
+		"# Meta-Tool Model Evaluation",
+		"Status: `running`",
+		"Tool surface: `dynamic`",
+		"Backend: `gitlab`",
+		"It will be replaced by the final metrics report",
+	})
+}
+
+// TestWriteErrorReport_RecordsFailure verifies that early failures replace the startup placeholder with an error report.
+func TestWriteErrorReport_RecordsFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.md")
+	opts := options{Model: "test:model", ToolSurface: config.ToolSurfaceMeta, Backend: backendMock, Output: path}
+	runErr := errors.New("fixture validation failed\nmissing project fixture")
+
+	if err := writeErrorReport(path, opts, runErr); err != nil {
+		t.Fatalf("writeErrorReport() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read error report: %v", err)
+	}
+	requireContainsAll(t, "error report", string(data), []string{
+		"Status: `failed`",
+		"The evaluator stopped before it could write the final metrics report.",
+		"fixture validation failed",
+		"missing project fixture",
+	})
+}
+
 // TestResolveModelSpecs_UsesEvalModels verifies that ResolveModelSpecs handles the uses eval models scenario correctly.
 func TestResolveModelSpecs_UsesEvalModels(t *testing.T) {
 	t.Setenv("EVAL_MODELS", "anthropic:claude-sonnet-4-6, google:gemini-3.0-flash, openai:gpt-5.4-mini, qwen:qwen3.6-flash")

--- a/cmd/eval_meta_tools/main_test.go
+++ b/cmd/eval_meta_tools/main_test.go
@@ -4601,6 +4601,10 @@ func TestWriteErrorReport_RecordsFailure(t *testing.T) {
 	opts := options{Model: "test:model", ToolSurface: config.ToolSurfaceMeta, Backend: backendMock, Output: path}
 	runErr := errors.New("fixture validation failed\nmissing project fixture")
 
+	if err := writeStartupReport(path, opts); err != nil {
+		t.Fatalf("writeStartupReport() error = %v", err)
+	}
+
 	if err := writeErrorReport(path, opts, runErr); err != nil {
 		t.Fatalf("writeErrorReport() error = %v", err)
 	}
@@ -4615,6 +4619,9 @@ func TestWriteErrorReport_RecordsFailure(t *testing.T) {
 		"fixture validation failed",
 		"missing project fixture",
 	})
+	if strings.Contains(string(data), "Status: `running`") {
+		t.Fatalf("error report still contains startup placeholder content: %s", data)
+	}
 }
 
 // TestResolveModelSpecs_UsesEvalModels verifies that ResolveModelSpecs handles the uses eval models scenario correctly.

--- a/docs/development/tool-surfaces-and-action-core.md
+++ b/docs/development/tool-surfaces-and-action-core.md
@@ -214,13 +214,21 @@ tool name.
 - `internal/tools/dynamic` may import `internal/tools/actioncatalog` and `internal/toolutil`, but must not depend on visible individual MCP tools.
 - `cmd/server` is the composition root for selecting and filtering the active surface.
 
+## Catalog Metadata Guidance
+
+The canonical catalog should stay compact and executable first. Route definitions must carry the stable action ID, typed input/output schemas, read-only and destructive flags, schema resource links, icons, and markdown formatter metadata. Dynamic search derives most discovery signals from that source: canonical ID words, domain and action names, required params, schema properties, enum values, aliases, tags, usage hints, and related actions.
+
+Add hand-authored dynamic aliases, tags, usage hints, or related actions only when there is evidence of model confusion. Evidence can come from the deterministic dynamic search corpus, provider traces, targeted model-backed evaluations, or a real user prompt that mapped to the wrong action. Keep additions narrow to the confused family and prefer terms that disambiguate competing routes instead of generic keywords that would match many actions.
+
+Use the alias and discovery audits in `internal/tools/dynamic` after metadata changes. If a registry is already built, call `AuditRegistryDiscoveryTerms`; use `AuditCatalogDiscoveryTerms` when only a catalog is available. A dense action family should either be discoverable from schemas and route names or have compact targeted guidance.
+
 ## When Adding A GitLab Action
 
 1. Add or update the typed handler in the appropriate domain package.
 2. Register the individual tool through that package's `RegisterTools` when the individual surface should expose it.
 3. Add the catalog-backed route to the central route definitions or an approved delegated meta group using typed `ActionRoute` constructors.
 4. Keep destructive classification on the route metadata, not in dynamic-only code.
-5. Add dynamic search tags or aliases only when natural language discovery is weak.
+5. Add dynamic search tags or aliases only when natural language discovery is weak and there is evidence from tests, traces, evaluations, or user prompts.
 6. Update tests, generated docs, and schema resources as required.
 
 ## Useful Checks

--- a/docs/dynamic-tools.md
+++ b/docs/dynamic-tools.md
@@ -343,6 +343,12 @@ The goal is not to make the model guess blindly. The model should use search to 
 
 Search returns only actions visible to the current server instance. Enterprise gating, GitLab.com-only routing, `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, excluded tools, and token-scope filtering are applied before the dynamic registry is exposed.
 
+### Metadata Guidance
+
+Dynamic search intentionally keeps most action metadata derived from canonical IDs, route schemas, required params, enum values, and route safety flags. Add hand-authored aliases, tags, usage hints, or related-action guidance only when deterministic corpus tests or model-backed Docker evaluations show that models confuse a specific family of actions.
+
+Prefer compact metadata that teaches the distinction rather than broad synonyms on every action. Good candidates are dense domains where similar verbs compete, such as deploy keys versus deploy tokens, protected environments versus deployment approvals, release assets versus release links, issue notes versus issue discussions, and feature-flag user lists versus feature flags. After adding metadata, run the dynamic search corpus and a targeted Docker-backed model evaluation for the affected tasks.
+
 ## Dynamic vs Meta-Tools
 
 | Concern | Meta-tools | Dynamic toolset |

--- a/docs/testing/model-evaluation-developer.md
+++ b/docs/testing/model-evaluation-developer.md
@@ -191,11 +191,15 @@ Each model-backed run writes:
 
 | Output | Purpose |
 | --- | --- |
-| `*.md` report | Summary metrics, task results, API usage, failure triage. |
+| `*.md` report | Startup placeholder, then final summary metrics, task results, API usage, and failure triage. If the run stops before final metrics, the file is replaced with a failure report. |
 | `*.traces/index.md` | Trace index. |
 | `*.traces/*.json` | Per-task trace with prompts, tool calls, validation, MCP results, and repairs. |
 | `*.traces/traces.jsonl` | JSONL stream for programmatic analysis. |
 | `e2e-fixtures.json` | Docker model-evaluation fixture IDs; generated and ignored. |
+
+For long runs, always pass an explicit `--out` path and redirect stdout/stderr
+to a sibling `.log` file. The Markdown report is the review artifact; terminal
+output is only progress logging.
 
 ## Triage Workflow
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -292,7 +292,7 @@
 | cmd/audit_output | 23.0% |
 | cmd/audit_tokens | 19.0% |
 | cmd/audit_tools | 37.7% |
-| cmd/eval_meta_tools | 57.6% |
+| cmd/eval_meta_tools | 57.8% |
 | cmd/gen_llms | 7.2% |
 | cmd/gen_readme | 14.6% |
 | cmd/gen_testing_docs | 20.7% |
@@ -500,7 +500,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tools** (37.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/eval_meta_tools** (57.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/eval_meta_tools** (57.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **testutil** (60.9%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **awardemoji** (65.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/server** (77.7%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric | Value |
 | --- | ---: |
-| Total test functions | 9,574 |
-| Unit test functions | 9,327 |
+| Total test functions | 9,576 |
+| Unit test functions | 9,329 |
 | E2E test functions | 247 |
-| cmd test functions | 413 |
+| cmd test functions | 415 |
 | Test files (internal/) | 407 |
 | Test files (cmd/) | 14 |
 | Test files (test/e2e/suite/) | 109 |
@@ -35,7 +35,7 @@
 
 | Pattern | Count | % |
 | --- | ---: | ---: |
-| `TestFunc_Scenario` (2-part) | 8,580 | 89.6% |
+| `TestFunc_Scenario` (2-part) | 8,582 | 89.6% |
 | `TestFunc` (no underscore) | 705 | 7.4% |
 | `TestFunc_Scenario_Expected` (3+ part) | 289 | 3.0% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration | 236 | 8 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests |
 | Tool sub-packages (165) | 7,085 | 316 | domain-specific GitLab tool handlers |
 | E2E integration | 247 | 109 | build-tagged real GitLab integration suite |
-| cmd packages | 413 | 14 | server entry point and developer command utilities |
-| **Total** | **9,574** | **530** |  |
+| cmd packages | 415 | 14 | server entry point and developer command utilities |
+| **Total** | **9,576** | **530** |  |
 
 ### Core Packages
 
@@ -292,7 +292,7 @@
 | cmd/audit_output | 23.0% |
 | cmd/audit_tokens | 19.0% |
 | cmd/audit_tools | 37.7% |
-| cmd/eval_meta_tools | 57.5% |
+| cmd/eval_meta_tools | 57.6% |
 | cmd/gen_llms | 7.2% |
 | cmd/gen_readme | 14.6% |
 | cmd/gen_testing_docs | 20.7% |
@@ -500,7 +500,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tools** (37.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/eval_meta_tools** (57.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/eval_meta_tools** (57.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **testutil** (60.9%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **awardemoji** (65.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/server** (77.7%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.


### PR DESCRIPTION
## Summary

- create an evaluation Markdown placeholder at startup and replace it with either final metrics or an error report
- extract common evaluator report header rendering so status and final reports stay consistent
- document the report/log workflow for long model-backed evaluations
- add evidence-based dynamic catalog metadata guidance to developer docs
- disable unused-exclusion warnings in focused `golangci-lint` package runs

## Review fixes

- hardened the error-report test to prove the startup placeholder is replaced, not appended
- resolved the shared report-header duplication noted by review

## Validation

- `go test ./cmd/eval_meta_tools -count=1`
- `go vet ./cmd/eval_meta_tools`
- `golangci-lint run ./cmd/eval_meta_tools`
- `go run ./cmd/gen_testing_docs/ --check`
- `npx markdownlint-cli2 cmd/eval_meta_tools/README.md docs/dynamic-tools.md docs/development/tool-surfaces-and-action-core.md docs/testing/model-evaluation-developer.md docs/testing/testing.md`
- `git diff --check`
- `make analyze`
- `go test ./... -count=1`

## Notes

- Docker-backed targeted validation for Chapter 8 completed locally before this PR: dynamic and meta both reached 100% tool/action/first-pass/final success on the live-executable metadata tasks, while the two GitLab CE-unavailable workflows were covered by dynamic simulated-selection.
