### PR TITLE
Add Markdown table formatter and update site dependencies

### DIFF
--- a/.github/agents/documentation-writer.agent.md
+++ b/.github/agents/documentation-writer.agent.md
@@ -31,6 +31,7 @@ You are a Documentation Writer specializing in technical documentation for Go-ba
 - Diátaxis documentation framework (Tutorials, How-to, Reference, Explanation)
 - C4 Model documentation levels (Context, Containers, Components, Code)
 - Up-to-date external reference research via Context7 and web fetching
+- Project Markdown table formatting with `go run ./cmd/format_md_tables/`
 - Markdown linting and validation with markdownlint-cli2
 
 ## Mandatory Research Workflow
@@ -143,19 +144,28 @@ Label each document with its quadrant in a comment or front matter to maintain c
 
 ### Phase 5: Validate
 
+1. **Normalize README.md/docs tables** when generated or modified documentation contains Markdown pipe tables:
+
+  ```bash
+  go run ./cmd/format_md_tables/
+  go run ./cmd/format_md_tables/ --check
+  ```
+
+  The formatter scans `README.md` and `docs/`, skips fenced code blocks, preserves left/right/center alignment markers, and pads table columns for readable source Markdown.
+
 1. **Run markdownlint-cli2** on every generated or modified `.md` file:
 
    ```bash
    npx markdownlint-cli2 path/to/document.md
    ```
 
-2. Fix any reported violations before considering the document complete
-3. The project uses `.markdownlint-cli2.jsonc` with these disabled rules: MD013 (line length), MD024 (duplicate headings), MD025 (single H1), MD033 (inline HTML for Mermaid), MD041 (first line heading), MD060 (native syntax)
-4. Verify all Mermaid diagrams render correctly
-5. Verify parity: every public API, type, and configuration option is documented
-6. Validate all file references, cross-links, and external URLs
-7. Check for missing sections in the coverage matrix
-8. Ensure no TBD/TODO placeholders remain in final output
+1. Fix any reported violations before considering the document complete
+1. The project uses `.markdownlint-cli2.jsonc` with these disabled rules: MD013 (line length), MD024 (duplicate headings), MD025 (single H1), MD033 (inline HTML for Mermaid), MD041 (first line heading), MD060 (native syntax)
+1. Verify all Mermaid diagrams render correctly
+1. Verify parity: every public API, type, and configuration option is documented
+1. Validate all file references, cross-links, and external URLs
+1. Check for missing sections in the coverage matrix
+1. Ensure no TBD/TODO placeholders remain in final output
 
 ### Phase 6: Reflect (for complex documents only)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,8 @@ gitlab-mcp-server/
 │   │   └── main.go         # Audits MCP tool metrics (tool count, resource count, etc.)
 │   ├── audit_test_names/
 │   │   └── main.go         # Audits test function naming convention compliance
+│   ├── format_md_tables/
+│   │   └── main.go         # Formats Markdown pipe tables in README.md and docs/
 │   ├── gen_llms/
 │   │   └── main.go         # Generates llms.txt and llms-full.txt for LLM discovery
 │   └── find_dupes/
@@ -117,10 +119,15 @@ golangci-lint run ./internal/tools/{domain}/
 
 # Markdown files — run on specific changed .md files
 npx markdownlint-cli2 path/to/changed.md
+
+# README.md/docs tables — normalize pipe tables, or verify with --check
+go run ./cmd/format_md_tables/
+go run ./cmd/format_md_tables/ --check
 ```
 
 - 9 analysis tools available: `goimports`, `gofmt`, `go vet`, `modernize`, `golangci-lint` (v2), `gosec`, `staticcheck`, `govulncheck`, `markdownlint-cli2`
 - Configuration: `.golangci.yml` (Go linters), `.markdownlint-cli2.jsonc` (Markdown rules)
+- Markdown table formatting: when creating or editing pipe tables in `README.md` or `docs/`, use `go run ./cmd/format_md_tables/` to normalize column padding and alignment markers, then verify with `go run ./cmd/format_md_tables/ --check`
 - Formatting: always run `make analyze-fix` before committing to apply `goimports` + `gofmt` standard formatting
 - Full project: `make analyze` (all tools), `make analyze-fix` (auto-fix), `make analyze-report` (LLM report)
 - See `docs/development/static-analysis.md` for full documentation

--- a/.github/skills/generate-project-documentation/SKILL.md
+++ b/.github/skills/generate-project-documentation/SKILL.md
@@ -266,6 +266,7 @@ MCP Client → MCP Server → Tool Handler → GitLab Client → GitLab API → 
 6. **No placeholders**: Final output must have no TBD, TODO, or placeholder text
 7. **Consistent terminology**: Use the same names as the source code
 8. **Pagination**: Document pagination patterns once and reference from each list tool
+9. **Markdown tables**: When generated content creates or edits pipe tables in `README.md` or `docs/`, run `go run ./cmd/format_md_tables/` and verify with `go run ./cmd/format_md_tables/ --check` before markdownlint
 
 ## Quality Checklist
 
@@ -277,6 +278,6 @@ Before considering documentation complete, verify:
 - [ ] All cross-reference links are valid
 - [ ] No TBD/TODO placeholders remain
 - [ ] Code examples are syntactically valid
-- [ ] Tables are properly formatted
+- [ ] Tables in `README.md` and `docs/` are normalized with `go run ./cmd/format_md_tables/ --check`
 - [ ] English language used throughout
 - [ ] Progressive disclosure: overview → details → advanced topics

--- a/.github/skills/update-project-documentation/SKILL.md
+++ b/.github/skills/update-project-documentation/SKILL.md
@@ -60,6 +60,7 @@ For each affected document:
 - **UPD-006**: Add deprecation notices for removed APIs rather than deleting immediately
 - **UPD-007**: Never introduce TBD/TODO placeholders in updates
 - **UPD-008**: Maintain consistent terminology with the rest of the documentation
+- **UPD-009**: When creating or editing Markdown pipe tables in `README.md` or `docs/`, run `go run ./cmd/format_md_tables/` and verify with `go run ./cmd/format_md_tables/ --check` so source tables keep consistent padding and alignment markers
 
 ### For New APIs
 
@@ -114,6 +115,7 @@ After all updates are applied, perform a parity check:
 - [ ] No TBD/TODO placeholders in updated sections
 - [ ] Consistent terminology and style with surrounding content
 - [ ] Deprecation notices added for removed APIs
+- [ ] Markdown pipe tables in `README.md` and `docs/` were normalized with `go run ./cmd/format_md_tables/ --check`
 
 ## Output Format
 

--- a/.github/skills/update-project-documentation/SKILL.md
+++ b/.github/skills/update-project-documentation/SKILL.md
@@ -115,7 +115,7 @@ After all updates are applied, perform a parity check:
 - [ ] No TBD/TODO placeholders in updated sections
 - [ ] Consistent terminology and style with surrounding content
 - [ ] Deprecation notices added for removed APIs
-- [ ] Markdown pipe tables in `README.md` and `docs/` were normalized with `go run ./cmd/format_md_tables/ --check`
+- [ ] Markdown pipe tables in `README.md` and `docs/` were verified with `go run ./cmd/format_md_tables/ --check`
 
 ## Output Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ gitlab-mcp-server/
 │   ├── audit_metrics/main.go   # Audits MCP tool metrics (tool count, resource count, etc.)
 │   ├── audit_tools/main.go     # Audits MCP tool metadata violations (naming, annotations)
 │   ├── audit_test_names/main.go # Audits test function naming convention compliance
+│   ├── format_md_tables/main.go # Formats Markdown pipe tables in README.md and docs/
 │   ├── gen_llms/main.go        # Generates llms.txt and llms-full.txt for LLM discovery
 │   └── find_dupes/main.go      # Finds duplicated string literals missing constants
 ├── internal/
@@ -218,6 +219,10 @@ golangci-lint run ./internal/tools/branches/   # lint on changed package
 npx markdownlint-cli2 docs/auto-update.md README.md  # lint specific .md files
 npx markdownlint-cli2 --fix docs/auto-update.md      # auto-fix specific .md files
 
+# README.md/docs tables — normalize pipe tables, or verify with --check
+go run ./cmd/format_md_tables/
+go run ./cmd/format_md_tables/ --check
+
 # MCP Inspector (interactive tool testing UI at http://127.0.0.1:6274)
 make inspector                             # compile + launch Inspector via stdio
 make inspector-stop                        # stop Inspector and clean up
@@ -229,6 +234,8 @@ make analyze-report                        # generate LLM-consumable report
 ```
 
 **Static analysis tools** (9 total): `goimports`, `gofmt`, `go vet`, `modernize`, `golangci-lint` (v2, 25+ linters), `gosec`, `staticcheck`, `govulncheck`, `markdownlint-cli2`. Configuration: `.golangci.yml`, `.markdownlint-cli2.jsonc`. Full docs: `docs/development/static-analysis.md`.
+
+**Markdown table formatter**: When creating or editing pipe tables in `README.md` or `docs/`, run `go run ./cmd/format_md_tables/` to normalize source-readable padding and left/right/center alignment markers, then verify with `go run ./cmd/format_md_tables/ --check` before markdownlint.
 
 **Formatting tools**: Before committing, always run `make analyze-fix` to apply `goimports` (import grouping) and `gofmt` (standard formatting). These are the Go equivalents of `clang-format` — all Go code must pass both.
 

--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ See the [Getting Started guide](https://jmrplens.github.io/gitlab-mcp-server/get
 
 Three registration modes, controlled by `TOOL_SURFACE`:
 
-| Mode | Tools | Description |
-|------|-------|-------------|
-| **Dynamic Toolset** (default) | 2 visible tools | Low-token find/execute surface over the canonical action catalog. |
-| **Meta-Tools** | 33 base domain meta-tools plus the `gitlab_server` helper | Domain-grouped dispatchers with `action` parameter. Enable with `TOOL_SURFACE=meta`; see the full 33/49/50 catalog in [Meta-Tools Reference](docs/meta-tools.md). |
-| **Individual** | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Every GitLab operation as a separate MCP tool. |
+| Mode                          | Tools                                                              | Description                                                                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dynamic Toolset** (default) | 2 visible tools                                                    | Low-token find/execute surface over the canonical action catalog.                                                                                                 |
+| **Meta-Tools**                | 33 base domain meta-tools plus the `gitlab_server` helper          | Domain-grouped dispatchers with `action` parameter. Enable with `TOOL_SURFACE=meta`; see the full 33/49/50 catalog in [Meta-Tools Reference](docs/meta-tools.md). |
+| **Individual**                | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Every GitLab operation as a separate MCP tool.                                                                                                                    |
 
 For dynamic experiments where resources and prompts dominate initial context, set `CAPABILITY_SURFACE=minimal` (stdio) or `--capability-surface=minimal` (HTTP). Dynamic minimal keeps only `gitlab://workspace/roots`; meta minimal keeps workspace roots plus meta-schema resources so opaque meta-tools can still read exact action schemas. The default remains `full`.
 
@@ -258,17 +258,17 @@ The detailed meta-tool catalog now lives in [Meta-Tools Reference](docs/meta-too
 
 ## Compatibility
 
-| MCP Capability | Support |
-|----------------|---------|
-| **Tools** | Up to 1022 individual / 33–50 meta |
-| **Resources** | 46 (static + templates) |
-| **Prompts** | 37 templates |
-| **Completions** | Project, user, group, branch, tag |
-| **Logging** | Structured (text/JSON) + MCP notifications |
-| **Progress** | Tool execution progress reporting |
-| **Sampling** | 11 LLM-powered analysis actions via `gitlab_analyze` |
-| **Elicitation** | 4 interactive creation wizards |
-| **Roots** | Workspace root tracking |
+| MCP Capability  | Support                                              |
+| --------------- | ---------------------------------------------------- |
+| **Tools**       | Up to 1022 individual / 33–50 meta                   |
+| **Resources**   | 46 (static + templates)                              |
+| **Prompts**     | 37 templates                                         |
+| **Completions** | Project, user, group, branch, tag                    |
+| **Logging**     | Structured (text/JSON) + MCP notifications           |
+| **Progress**    | Tool execution progress reporting                    |
+| **Sampling**    | 11 LLM-powered analysis actions via `gitlab_analyze` |
+| **Elicitation** | 4 interactive creation wizards                       |
+| **Roots**       | Workspace root tracking                              |
 
 Tested with: VS Code + GitHub Copilot, Claude Desktop, Claude Code, Cursor, Windsurf, JetBrains IDEs, Zed, Kiro, Cline, Roo Code.
 
@@ -313,31 +313,31 @@ The published model-evaluation set covers 536 task attempts and 1024 expected MC
 
 Full documentation is available at **[jmrplens.github.io/gitlab-mcp-server](https://jmrplens.github.io/gitlab-mcp-server/)**.
 
-| Document | Description |
-|----------|-------------|
-| [Getting Started](docs/getting-started.md) | Download, setup wizard, per-client configuration |
-| [IDE Configuration](docs/ide-configuration.md) | Per-client stdio, HTTP legacy, and HTTP OAuth examples |
-| [Configuration](docs/configuration.md) | Environment variables, transport modes, TLS |
-| [HTTP Server Mode](docs/http-server-mode.md) | Shared HTTP deployments, authentication, server pool isolation |
-| [Tools Reference](docs/tools/README.md) | All individual tools with input/output schemas, including GitLab.com-only Orbit |
-| [Meta-Tools](docs/meta-tools.md) | 33/49/50 domain meta-tools with action dispatching |
-| [Dynamic Toolset](docs/dynamic-tools.md) | 2-tool low-token mode with canonical action catalog, safety model, and examples |
-| [Resources](docs/resources-reference.md) | All 46 resources with URI templates |
-| [Prompts](docs/prompts-reference.md) | All 37 prompts with arguments and output format |
-| [Auto-Update](docs/auto-update.md) | Self-update mechanism, modes, and release format |
-| [Testing](docs/testing/README.md) | Unit, E2E, schema model evaluation, Docker model evaluation, and curated model results |
-| [Security](docs/security.md) | Security model, token scopes, input validation |
-| [Architecture](docs/architecture.md) | System architecture, component design, data flow |
-| [Development Guide](docs/development/development.md) | Building, testing, CI/CD, contributing |
+| Document                                             | Description                                                                            |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [Getting Started](docs/getting-started.md)           | Download, setup wizard, per-client configuration                                       |
+| [IDE Configuration](docs/ide-configuration.md)       | Per-client stdio, HTTP legacy, and HTTP OAuth examples                                 |
+| [Configuration](docs/configuration.md)               | Environment variables, transport modes, TLS                                            |
+| [HTTP Server Mode](docs/http-server-mode.md)         | Shared HTTP deployments, authentication, server pool isolation                         |
+| [Tools Reference](docs/tools/README.md)              | All individual tools with input/output schemas, including GitLab.com-only Orbit        |
+| [Meta-Tools](docs/meta-tools.md)                     | 33/49/50 domain meta-tools with action dispatching                                     |
+| [Dynamic Toolset](docs/dynamic-tools.md)             | 2-tool low-token mode with canonical action catalog, safety model, and examples        |
+| [Resources](docs/resources-reference.md)             | All 46 resources with URI templates                                                    |
+| [Prompts](docs/prompts-reference.md)                 | All 37 prompts with arguments and output format                                        |
+| [Auto-Update](docs/auto-update.md)                   | Self-update mechanism, modes, and release format                                       |
+| [Testing](docs/testing/README.md)                    | Unit, E2E, schema model evaluation, Docker model evaluation, and curated model results |
+| [Security](docs/security.md)                         | Security model, token scopes, input validation                                         |
+| [Architecture](docs/architecture.md)                 | System architecture, component design, data flow                                       |
+| [Development Guide](docs/development/development.md) | Building, testing, CI/CD, contributing                                                 |
 
 ## Tech Stack
 
-| Component | Technology |
-|-----------|------------|
-| Language | Go 1.26+ |
-| MCP SDK | `github.com/modelcontextprotocol/go-sdk` v1.6.0 |
+| Component     | Technology                                       |
+| ------------- | ------------------------------------------------ |
+| Language      | Go 1.26+                                         |
+| MCP SDK       | `github.com/modelcontextprotocol/go-sdk` v1.6.0  |
 | GitLab Client | `gitlab.com/gitlab-org/api/client-go/v2` v2.27.0 |
-| Transport | stdio (default), HTTP (Streamable HTTP) |
+| Transport     | stdio (default), HTTP (Streamable HTTP)          |
 
 ## Building from Source
 

--- a/cmd/format_md_tables/main.go
+++ b/cmd/format_md_tables/main.go
@@ -1,0 +1,177 @@
+// Command format_md_tables normalizes Markdown pipe tables in README.md and docs/.
+//
+// Usage:
+//
+//	go run ./cmd/format_md_tables/
+//	go run ./cmd/format_md_tables/ --check
+//	go run ./cmd/format_md_tables/ README.md docs
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/docgen"
+)
+
+const defaultRoot = "."
+
+type options struct {
+	root  string
+	check bool
+	paths []string
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	opts, err := parseOptions(args)
+	if err != nil {
+		return err
+	}
+	root, err := filepath.Abs(opts.root)
+	if err != nil {
+		return fmt.Errorf("resolve root %s: %w", opts.root, err)
+	}
+	opts.root = root
+
+	files, err := discoverMarkdownFiles(opts.root, opts.paths)
+	if err != nil {
+		return err
+	}
+
+	changed := make([]string, 0)
+	for _, file := range files {
+		var fileChanged bool
+		fileChanged, err = formatMarkdownTableFile(file, opts.check)
+		if err != nil {
+			return err
+		}
+		if fileChanged {
+			changed = append(changed, displayPath(opts.root, file))
+		}
+	}
+
+	if opts.check {
+		if len(changed) > 0 {
+			return fmt.Errorf("markdown tables are out of date in %d file(s): %s", len(changed), strings.Join(changed, ", "))
+		}
+		_, _ = fmt.Fprintln(stdout, "Markdown tables are up to date")
+		return nil
+	}
+
+	if len(changed) == 0 {
+		_, _ = fmt.Fprintln(stdout, "Markdown tables already formatted")
+		return nil
+	}
+	_, _ = fmt.Fprintf(stdout, "Formatted Markdown tables in %d file(s):\n", len(changed))
+	for _, file := range changed {
+		_, _ = fmt.Fprintf(stdout, "- %s\n", file)
+	}
+	return nil
+}
+
+func parseOptions(args []string) (options, error) {
+	flags := flag.NewFlagSet("format_md_tables", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	opts := options{}
+	flags.StringVar(&opts.root, "root", defaultRoot, "repository root containing README.md and docs/")
+	flags.BoolVar(&opts.check, "check", false, "fail if any Markdown table needs formatting")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	opts.paths = flags.Args()
+	if len(opts.paths) == 0 {
+		opts.paths = []string{"README.md", "docs"}
+	}
+	return opts, nil
+}
+
+func discoverMarkdownFiles(root string, paths []string) ([]string, error) {
+	files := make([]string, 0)
+	for _, item := range paths {
+		path, err := resolveInputPath(root, item)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, err)
+		}
+		if info.IsDir() {
+			walkErr := filepath.WalkDir(path, func(path string, entry iofs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if entry.IsDir() {
+					return nil
+				}
+				if strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+					files = append(files, path)
+				}
+				return nil
+			})
+			if walkErr != nil {
+				return nil, fmt.Errorf("walk %s: %w", path, walkErr)
+			}
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(info.Name()), ".md") {
+			files = append(files, path)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func resolveInputPath(root, item string) (string, error) {
+	path := filepath.Clean(filepath.Join(root, item))
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", item, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %s escapes root %s", item, root)
+	}
+	return path, nil
+}
+
+func formatMarkdownTableFile(path string, check bool) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	formatted, changed := docgen.FormatMarkdownTables(string(content))
+	if !changed || check {
+		return changed, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	// #nosec G703 -- paths are resolved under --root before formatting repository files.
+	writeErr := os.WriteFile(path, []byte(formatted), info.Mode().Perm())
+	if writeErr != nil {
+		return false, fmt.Errorf("write %s: %w", path, writeErr)
+	}
+	return true, nil
+}
+
+func displayPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/cmd/format_md_tables/main.go
+++ b/cmd/format_md_tables/main.go
@@ -46,7 +46,13 @@ func run(args []string, stdout io.Writer) error {
 	}
 	opts.root = root
 
-	files, err := discoverMarkdownFiles(opts.root, opts.paths)
+	rootFS, err := os.OpenRoot(opts.root)
+	if err != nil {
+		return fmt.Errorf("open root %s: %w", opts.root, err)
+	}
+	defer rootFS.Close()
+
+	files, err := discoverMarkdownFiles(rootFS, opts.root, opts.paths)
 	if err != nil {
 		return err
 	}
@@ -54,12 +60,12 @@ func run(args []string, stdout io.Writer) error {
 	changed := make([]string, 0)
 	for _, file := range files {
 		var fileChanged bool
-		fileChanged, err = formatMarkdownTableFile(file, opts.check)
+		fileChanged, err = formatMarkdownTableFile(rootFS, file, opts.check)
 		if err != nil {
 			return err
 		}
 		if fileChanged {
-			changed = append(changed, displayPath(opts.root, file))
+			changed = append(changed, displayPath(file))
 		}
 	}
 
@@ -67,17 +73,26 @@ func run(args []string, stdout io.Writer) error {
 		if len(changed) > 0 {
 			return fmt.Errorf("markdown tables are out of date in %d file(s): %s", len(changed), strings.Join(changed, ", "))
 		}
-		_, _ = fmt.Fprintln(stdout, "Markdown tables are up to date")
-		return nil
+		return writeStdout(stdout, "Markdown tables are up to date")
 	}
 
 	if len(changed) == 0 {
-		_, _ = fmt.Fprintln(stdout, "Markdown tables already formatted")
-		return nil
+		return writeStdout(stdout, "Markdown tables already formatted")
 	}
-	_, _ = fmt.Fprintf(stdout, "Formatted Markdown tables in %d file(s):\n", len(changed))
+	if _, writeErr := fmt.Fprintf(stdout, "Formatted Markdown tables in %d file(s):\n", len(changed)); writeErr != nil {
+		return fmt.Errorf("write stdout: %w", writeErr)
+	}
 	for _, file := range changed {
-		_, _ = fmt.Fprintf(stdout, "- %s\n", file)
+		if _, writeErr := fmt.Fprintf(stdout, "- %s\n", file); writeErr != nil {
+			return fmt.Errorf("write stdout: %w", writeErr)
+		}
+	}
+	return nil
+}
+
+func writeStdout(stdout io.Writer, message string) error {
+	if _, err := fmt.Fprintln(stdout, message); err != nil {
+		return fmt.Errorf("write stdout: %w", err)
 	}
 	return nil
 }
@@ -98,19 +113,19 @@ func parseOptions(args []string) (options, error) {
 	return opts, nil
 }
 
-func discoverMarkdownFiles(root string, paths []string) ([]string, error) {
+func discoverMarkdownFiles(rootFS *os.Root, root string, paths []string) ([]string, error) {
 	files := make([]string, 0)
 	for _, item := range paths {
-		path, err := resolveInputPath(root, item)
+		rel, err := resolveInputPath(root, item)
 		if err != nil {
 			return nil, err
 		}
-		info, err := os.Stat(path)
+		info, err := rootFS.Stat(rel)
 		if err != nil {
-			return nil, fmt.Errorf("stat %s: %w", path, err)
+			return nil, fmt.Errorf("stat %s: %w", item, err)
 		}
 		if info.IsDir() {
-			walkErr := filepath.WalkDir(path, func(path string, entry iofs.DirEntry, err error) error {
+			walkErr := iofs.WalkDir(rootFS.FS(), filepath.ToSlash(rel), func(path string, entry iofs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -118,25 +133,38 @@ func discoverMarkdownFiles(root string, paths []string) ([]string, error) {
 					return nil
 				}
 				if strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
-					files = append(files, path)
+					relPath := filepath.FromSlash(path)
+					fileInfo, statErr := rootFS.Stat(relPath)
+					if statErr != nil {
+						return fmt.Errorf("stat %s: %w", relPath, statErr)
+					}
+					if !fileInfo.IsDir() {
+						files = append(files, relPath)
+					}
 				}
 				return nil
 			})
 			if walkErr != nil {
-				return nil, fmt.Errorf("walk %s: %w", path, walkErr)
+				return nil, fmt.Errorf("walk %s: %w", item, walkErr)
 			}
 			continue
 		}
-		if strings.EqualFold(filepath.Ext(info.Name()), ".md") {
-			files = append(files, path)
+		if strings.EqualFold(filepath.Ext(rel), ".md") {
+			files = append(files, rel)
 		}
 	}
-	sort.Strings(files)
+	sort.Slice(files, func(i, j int) bool {
+		return filepath.ToSlash(files[i]) < filepath.ToSlash(files[j])
+	})
 	return files, nil
 }
 
 func resolveInputPath(root, item string) (string, error) {
-	path := filepath.Clean(filepath.Join(root, item))
+	path := item
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(root, item)
+	}
+	path = filepath.Clean(path)
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
 		return "", fmt.Errorf("resolve %s: %w", item, err)
@@ -144,11 +172,11 @@ func resolveInputPath(root, item string) (string, error) {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %s escapes root %s", item, root)
 	}
-	return path, nil
+	return rel, nil
 }
 
-func formatMarkdownTableFile(path string, check bool) (bool, error) {
-	content, err := os.ReadFile(path)
+func formatMarkdownTableFile(rootFS *os.Root, path string, check bool) (bool, error) {
+	content, err := rootFS.ReadFile(path)
 	if err != nil {
 		return false, fmt.Errorf("read %s: %w", path, err)
 	}
@@ -156,22 +184,17 @@ func formatMarkdownTableFile(path string, check bool) (bool, error) {
 	if !changed || check {
 		return changed, nil
 	}
-	info, err := os.Stat(path)
+	info, err := rootFS.Stat(path)
 	if err != nil {
 		return false, fmt.Errorf("stat %s: %w", path, err)
 	}
-	// #nosec G703 -- paths are resolved under --root before formatting repository files.
-	writeErr := os.WriteFile(path, []byte(formatted), info.Mode().Perm())
+	writeErr := rootFS.WriteFile(path, []byte(formatted), info.Mode().Perm())
 	if writeErr != nil {
 		return false, fmt.Errorf("write %s: %w", path, writeErr)
 	}
 	return true, nil
 }
 
-func displayPath(root, path string) string {
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
-		return filepath.ToSlash(path)
-	}
-	return filepath.ToSlash(rel)
+func displayPath(path string) string {
+	return filepath.ToSlash(path)
 }

--- a/cmd/format_md_tables/main.go
+++ b/cmd/format_md_tables/main.go
@@ -20,7 +20,11 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/docgen"
 )
 
-const defaultRoot = "."
+const (
+	defaultRoot          = "."
+	statPathErrorFormat  = "stat %s: %w"
+	writeStdoutErrorText = "write stdout: %w"
+)
 
 type options struct {
 	root  string
@@ -80,11 +84,11 @@ func run(args []string, stdout io.Writer) error {
 		return writeStdout(stdout, "Markdown tables already formatted")
 	}
 	if _, writeErr := fmt.Fprintf(stdout, "Formatted Markdown tables in %d file(s):\n", len(changed)); writeErr != nil {
-		return fmt.Errorf("write stdout: %w", writeErr)
+		return fmt.Errorf(writeStdoutErrorText, writeErr)
 	}
 	for _, file := range changed {
 		if _, writeErr := fmt.Fprintf(stdout, "- %s\n", file); writeErr != nil {
-			return fmt.Errorf("write stdout: %w", writeErr)
+			return fmt.Errorf(writeStdoutErrorText, writeErr)
 		}
 	}
 	return nil
@@ -92,7 +96,7 @@ func run(args []string, stdout io.Writer) error {
 
 func writeStdout(stdout io.Writer, message string) error {
 	if _, err := fmt.Fprintln(stdout, message); err != nil {
-		return fmt.Errorf("write stdout: %w", err)
+		return fmt.Errorf(writeStdoutErrorText, err)
 	}
 	return nil
 }
@@ -122,7 +126,7 @@ func discoverMarkdownFiles(rootFS *os.Root, root string, paths []string) ([]stri
 		}
 		info, err := rootFS.Stat(rel)
 		if err != nil {
-			return nil, fmt.Errorf("stat %s: %w", item, err)
+			return nil, fmt.Errorf(statPathErrorFormat, item, err)
 		}
 		if info.IsDir() {
 			walkErr := iofs.WalkDir(rootFS.FS(), filepath.ToSlash(rel), func(path string, entry iofs.DirEntry, err error) error {
@@ -136,7 +140,7 @@ func discoverMarkdownFiles(rootFS *os.Root, root string, paths []string) ([]stri
 					relPath := filepath.FromSlash(path)
 					fileInfo, statErr := rootFS.Stat(relPath)
 					if statErr != nil {
-						return fmt.Errorf("stat %s: %w", relPath, statErr)
+						return fmt.Errorf(statPathErrorFormat, relPath, statErr)
 					}
 					if !fileInfo.IsDir() {
 						files = append(files, relPath)
@@ -186,7 +190,7 @@ func formatMarkdownTableFile(rootFS *os.Root, path string, check bool) (bool, er
 	}
 	info, err := rootFS.Stat(path)
 	if err != nil {
-		return false, fmt.Errorf("stat %s: %w", path, err)
+		return false, fmt.Errorf(statPathErrorFormat, path, err)
 	}
 	writeErr := rootFS.WriteFile(path, []byte(formatted), info.Mode().Perm())
 	if writeErr != nil {

--- a/cmd/format_md_tables/main_test.go
+++ b/cmd/format_md_tables/main_test.go
@@ -2,113 +2,124 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestRun_FormatsDefaultMarkdownFiles(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "README.md"), "| A | B |\n| --- | ---: |\n| one | 2 |\n")
-	writeTestFile(t, filepath.Join(root, "docs", "guide.md"), "| Name | Value |\n| --- | --- |\n| longer | x |\n")
-	writeTestFile(t, filepath.Join(root, "docs", "ignored.txt"), "| A | B |\n| --- | --- |\n")
-
-	var stdout bytes.Buffer
-	if err := run([]string{"--root", root}, &stdout); err != nil {
-		t.Fatalf("run() error: %v", err)
+func TestRun_TableDriven(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		files        map[string]string
+		dirs         []string
+		wantErr      string
+		wantStdout   []string
+		wantContains map[string]string
+		wantExact    map[string]string
+	}{
+		{
+			name: "formats default markdown files",
+			files: map[string]string{
+				"README.md":        "| A | B |\n| --- | ---: |\n| one | 2 |\n",
+				"docs/guide.md":    "| Name | Value |\n| --- | --- |\n| longer | x |\n",
+				"docs/ignored.txt": "| A | B |\n| --- | --- |\n",
+			},
+			wantStdout: []string{"README.md", "docs/guide.md"},
+			wantContains: map[string]string{
+				"README.md":     "| one |    2 |",
+				"docs/guide.md": "| longer | x     |",
+			},
+		},
+		{
+			name:    "check fails without writing",
+			args:    []string{"--check"},
+			files:   map[string]string{"README.md": "| A | B |\n| --- | --- |\n| longer | x |\n"},
+			dirs:    []string{"docs"},
+			wantErr: "README.md",
+			wantExact: map[string]string{
+				"README.md": "| A | B |\n| --- | --- |\n| longer | x |\n",
+			},
+		},
+		{
+			name: "formats explicit path",
+			args: []string{"custom.md"},
+			files: map[string]string{
+				"custom.md": "| A | B |\n| --- | --- |\n| one | two |\n",
+			},
+			wantContains: map[string]string{"custom.md": "| one | two |"},
+		},
+		{
+			name:       "check succeeds when formatted",
+			args:       []string{"--check"},
+			files:      map[string]string{"README.md": "# Title\n"},
+			dirs:       []string{"docs"},
+			wantStdout: []string{"up to date"},
+		},
+		{
+			name:       "reports already formatted",
+			files:      map[string]string{"README.md": "# Title\n"},
+			dirs:       []string{"docs"},
+			wantStdout: []string{"already formatted"},
+		},
+		{
+			name:    "rejects path outside root",
+			args:    []string{"../outside.md"},
+			wantErr: "escapes root",
+		},
+		{
+			name:    "rejects invalid flag",
+			args:    []string{"--missing"},
+			wantErr: "flag provided but not defined",
+		},
 	}
 
-	readme := readTestFile(t, filepath.Join(root, "README.md"))
-	if !strings.Contains(readme, "| one |    2 |") {
-		t.Fatalf("README.md was not formatted:\n%s", readme)
-	}
-	guide := readTestFile(t, filepath.Join(root, "docs", "guide.md"))
-	if !strings.Contains(guide, "| longer | x     |") {
-		t.Fatalf("guide.md was not formatted:\n%s", guide)
-	}
-	if !strings.Contains(stdout.String(), "README.md") || !strings.Contains(stdout.String(), "docs/guide.md") {
-		t.Fatalf("stdout = %q, want changed files", stdout.String())
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for path, content := range tt.files {
+				writeTestFile(t, filepath.Join(root, filepath.FromSlash(path)), content)
+			}
+			for _, dir := range tt.dirs {
+				if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(dir)), 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", dir, err)
+				}
+			}
 
-func TestRun_CheckFailsWithoutWriting(t *testing.T) {
-	root := t.TempDir()
-	path := filepath.Join(root, "README.md")
-	original := "| A | B |\n| --- | --- |\n| longer | x |\n"
-	writeTestFile(t, path, original)
-	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
-		t.Fatalf("mkdir docs: %v", err)
-	}
+			var stdout bytes.Buffer
+			args := append([]string{"--root", root}, tt.args...)
+			err := run(args, &stdout)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("run() error = nil, want error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("run() error = %v, want %q", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("run() error: %v", err)
+			}
 
-	var stdout bytes.Buffer
-	err := run([]string{"--root", root, "--check"}, &stdout)
-	if err == nil {
-		t.Fatal("run() error = nil, want check failure")
-	}
-	if !strings.Contains(err.Error(), "README.md") {
-		t.Fatalf("run() error = %v, want README.md", err)
-	}
-	if got := readTestFile(t, path); got != original {
-		t.Fatalf("check mode wrote file:\n%s", got)
-	}
-}
-
-func TestRun_ExplicitPath(t *testing.T) {
-	root := t.TempDir()
-	path := filepath.Join(root, "custom.md")
-	writeTestFile(t, path, "| A | B |\n| --- | --- |\n| one | two |\n")
-
-	var stdout bytes.Buffer
-	if err := run([]string{"--root", root, "custom.md"}, &stdout); err != nil {
-		t.Fatalf("run() error: %v", err)
-	}
-	if got := readTestFile(t, path); !strings.Contains(got, "| one | two |") {
-		t.Fatalf("custom.md was not processed:\n%s", got)
-	}
-}
-
-func TestRun_CheckSucceedsWhenFormatted(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
-	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
-		t.Fatalf("mkdir docs: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	if err := run([]string{"--root", root, "--check"}, &stdout); err != nil {
-		t.Fatalf("run() error: %v", err)
-	}
-	if !strings.Contains(stdout.String(), "up to date") {
-		t.Fatalf("stdout = %q, want up to date", stdout.String())
-	}
-}
-
-func TestRun_ReportsAlreadyFormatted(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
-	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
-		t.Fatalf("mkdir docs: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	if err := run([]string{"--root", root}, &stdout); err != nil {
-		t.Fatalf("run() error: %v", err)
-	}
-	if !strings.Contains(stdout.String(), "already formatted") {
-		t.Fatalf("stdout = %q, want already formatted", stdout.String())
-	}
-}
-
-func TestRun_RejectsPathOutsideRoot(t *testing.T) {
-	root := t.TempDir()
-	var stdout bytes.Buffer
-	err := run([]string{"--root", root, "../outside.md"}, &stdout)
-	if err == nil {
-		t.Fatal("run() error = nil, want root escape failure")
-	}
-	if !strings.Contains(err.Error(), "escapes root") {
-		t.Fatalf("run() error = %v, want escapes root", err)
+			for _, want := range tt.wantStdout {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+				}
+			}
+			for path, want := range tt.wantContains {
+				got := readTestFile(t, filepath.Join(root, filepath.FromSlash(path)))
+				if !strings.Contains(got, want) {
+					t.Fatalf("%s =\n%s\nwant substring %q", path, got, want)
+				}
+			}
+			for path, want := range tt.wantExact {
+				got := readTestFile(t, filepath.Join(root, filepath.FromSlash(path)))
+				if got != want {
+					t.Fatalf("%s =\n%s\nwant\n%s", path, got, want)
+				}
+			}
+		})
 	}
 }
 
@@ -117,18 +128,67 @@ func TestDiscoverMarkdownFiles_SortsMarkdownFiles(t *testing.T) {
 	writeTestFile(t, filepath.Join(root, "docs", "b.md"), "# B\n")
 	writeTestFile(t, filepath.Join(root, "docs", "a.md"), "# A\n")
 	writeTestFile(t, filepath.Join(root, "docs", "ignored.txt"), "# Ignored\n")
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer rootFS.Close()
 
-	files, err := discoverMarkdownFiles(root, []string{"docs"})
+	files, err := discoverMarkdownFiles(rootFS, root, []string{"docs"})
 	if err != nil {
 		t.Fatalf("discoverMarkdownFiles() error: %v", err)
 	}
 	want := []string{
-		filepath.Join(root, "docs", "a.md"),
-		filepath.Join(root, "docs", "b.md"),
+		filepath.Join("docs", "a.md"),
+		filepath.Join("docs", "b.md"),
 	}
 	if strings.Join(files, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("discoverMarkdownFiles() = %#v, want %#v", files, want)
 	}
+}
+
+func TestRun_RejectsSymlinkEscapingRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
+	writeTestFile(t, filepath.Join(outside, "target.md"), "| A | B |\n| --- | --- |\n")
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "target.md"), filepath.Join(root, "docs", "link.md")); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{"--root", root}, &stdout)
+	if err == nil {
+		t.Fatal("run() error = nil, want symlink escape failure")
+	}
+	if !strings.Contains(err.Error(), "link.md") {
+		t.Fatalf("run() error = %v, want link.md", err)
+	}
+}
+
+func TestRun_ReturnsStdoutWriteErrors(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
+	if err := os.MkdirAll(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+
+	err := run([]string{"--root", root}, errWriter{})
+	if err == nil {
+		t.Fatal("run() error = nil, want stdout write failure")
+	}
+	if !strings.Contains(err.Error(), "write stdout") {
+		t.Fatalf("run() error = %v, want write stdout", err)
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
 }
 
 func writeTestFile(t *testing.T, path, content string) {

--- a/cmd/format_md_tables/main_test.go
+++ b/cmd/format_md_tables/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRun_FormatsDefaultMarkdownFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "README.md"), "| A | B |\n| --- | ---: |\n| one | 2 |\n")
+	writeTestFile(t, filepath.Join(root, "docs", "guide.md"), "| Name | Value |\n| --- | --- |\n| longer | x |\n")
+	writeTestFile(t, filepath.Join(root, "docs", "ignored.txt"), "| A | B |\n| --- | --- |\n")
+
+	var stdout bytes.Buffer
+	if err := run([]string{"--root", root}, &stdout); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+
+	readme := readTestFile(t, filepath.Join(root, "README.md"))
+	if !strings.Contains(readme, "| one |    2 |") {
+		t.Fatalf("README.md was not formatted:\n%s", readme)
+	}
+	guide := readTestFile(t, filepath.Join(root, "docs", "guide.md"))
+	if !strings.Contains(guide, "| longer | x     |") {
+		t.Fatalf("guide.md was not formatted:\n%s", guide)
+	}
+	if !strings.Contains(stdout.String(), "README.md") || !strings.Contains(stdout.String(), "docs/guide.md") {
+		t.Fatalf("stdout = %q, want changed files", stdout.String())
+	}
+}
+
+func TestRun_CheckFailsWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "README.md")
+	original := "| A | B |\n| --- | --- |\n| longer | x |\n"
+	writeTestFile(t, path, original)
+	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{"--root", root, "--check"}, &stdout)
+	if err == nil {
+		t.Fatal("run() error = nil, want check failure")
+	}
+	if !strings.Contains(err.Error(), "README.md") {
+		t.Fatalf("run() error = %v, want README.md", err)
+	}
+	if got := readTestFile(t, path); got != original {
+		t.Fatalf("check mode wrote file:\n%s", got)
+	}
+}
+
+func TestRun_ExplicitPath(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "custom.md")
+	writeTestFile(t, path, "| A | B |\n| --- | --- |\n| one | two |\n")
+
+	var stdout bytes.Buffer
+	if err := run([]string{"--root", root, "custom.md"}, &stdout); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+	if got := readTestFile(t, path); !strings.Contains(got, "| one | two |") {
+		t.Fatalf("custom.md was not processed:\n%s", got)
+	}
+}
+
+func TestRun_CheckSucceedsWhenFormatted(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
+	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"--root", root, "--check"}, &stdout); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "up to date") {
+		t.Fatalf("stdout = %q, want up to date", stdout.String())
+	}
+}
+
+func TestRun_ReportsAlreadyFormatted(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")
+	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"--root", root}, &stdout); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "already formatted") {
+		t.Fatalf("stdout = %q, want already formatted", stdout.String())
+	}
+}
+
+func TestRun_RejectsPathOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	var stdout bytes.Buffer
+	err := run([]string{"--root", root, "../outside.md"}, &stdout)
+	if err == nil {
+		t.Fatal("run() error = nil, want root escape failure")
+	}
+	if !strings.Contains(err.Error(), "escapes root") {
+		t.Fatalf("run() error = %v, want escapes root", err)
+	}
+}
+
+func TestDiscoverMarkdownFiles_SortsMarkdownFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "docs", "b.md"), "# B\n")
+	writeTestFile(t, filepath.Join(root, "docs", "a.md"), "# A\n")
+	writeTestFile(t, filepath.Join(root, "docs", "ignored.txt"), "# Ignored\n")
+
+	files, err := discoverMarkdownFiles(root, []string{"docs"})
+	if err != nil {
+		t.Fatalf("discoverMarkdownFiles() error: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "docs", "a.md"),
+		filepath.Join(root, "docs", "b.md"),
+	}
+	if strings.Join(files, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("discoverMarkdownFiles() = %#v, want %#v", files, want)
+	}
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}

--- a/cmd/format_md_tables/main_test.go
+++ b/cmd/format_md_tables/main_test.go
@@ -47,9 +47,9 @@ func TestRun_TableDriven(t *testing.T) {
 			name: "formats explicit path",
 			args: []string{"custom.md"},
 			files: map[string]string{
-				"custom.md": "| A | B |\n| --- | --- |\n| one | two |\n",
+				"custom.md": "| A | B |\n| --- | ---: |\n| one | 2 |\n",
 			},
-			wantContains: map[string]string{"custom.md": "| one | two |"},
+			wantContains: map[string]string{"custom.md": "| one |    2 |"},
 		},
 		{
 			name:       "check succeeds when formatted",

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,58 +4,58 @@ Project documentation for gitlab-mcp-server — a Model Context Protocol server 
 
 ## Guides
 
-| Document | Description |
-| --- | --- |
-| [Getting Started](getting-started.md) | Step-by-step tutorial: download, configure, first query (~5 min) |
-| [Architecture](architecture.md) | System architecture with C4 diagrams, component details, and data flow |
-| [Development](development/development.md) | Developer guide: setup, building, testing, adding new tools |
-| [Configuration](configuration.md) | Environment variables, transport modes, and `.env` setup |
-| [Error Handling](error-handling.md) | Error types, classification, Markdown formatting, and issue reporting |
-| [Security](security.md) | Authentication, TLS, input validation, and transport security |
-| [HTTP Server Mode](http-server-mode.md) | Multi-user HTTP transport with per-token+URL server pool |
-| [OAuth App Setup](oauth-app-setup.md) | Creating GitLab OAuth applications for MCP clients |
-| [IDE Configuration](ide-configuration.md) | Per-IDE MCP JSON configuration (stdio, HTTP legacy, HTTP OAuth) |
-| [CI/CD Usage](ci-cd.md) | Using gitlab-mcp-server in CI/CD pipelines (with or without LLM) |
-| [Auto-Update](auto-update.md) | Self-update mechanism, modes, MCP tools, and release requirements |
-| [Resource Consumption](resource-consumption.md) | Memory footprint, scaling limits, and optimization strategies |
-| [Meta-Tools](meta-tools.md) | Domain-level meta-tool reference with action mappings |
-| [Dynamic Toolset](dynamic-tools.md) | Low-token find/execute mode with canonical action catalog and migration guidance |
-| [Output Format](output-format.md) | How tool responses are structured: Markdown + JSON, annotations, clickable links, next-step hints |
-| [Testing](testing/) | Unit, E2E, and AI model evaluation documentation |
-| [GraphQL Integration](graphql.md) | When and how the server uses GitLab's GraphQL API |
-| [Troubleshooting](troubleshooting.md) | Common issues and solutions for connection, TLS, tools, and transport |
+| Document                                        | Description                                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Getting Started](getting-started.md)           | Step-by-step tutorial: download, configure, first query (~5 min)                                  |
+| [Architecture](architecture.md)                 | System architecture with C4 diagrams, component details, and data flow                            |
+| [Development](development/development.md)       | Developer guide: setup, building, testing, adding new tools                                       |
+| [Configuration](configuration.md)               | Environment variables, transport modes, and `.env` setup                                          |
+| [Error Handling](error-handling.md)             | Error types, classification, Markdown formatting, and issue reporting                             |
+| [Security](security.md)                         | Authentication, TLS, input validation, and transport security                                     |
+| [HTTP Server Mode](http-server-mode.md)         | Multi-user HTTP transport with per-token+URL server pool                                          |
+| [OAuth App Setup](oauth-app-setup.md)           | Creating GitLab OAuth applications for MCP clients                                                |
+| [IDE Configuration](ide-configuration.md)       | Per-IDE MCP JSON configuration (stdio, HTTP legacy, HTTP OAuth)                                   |
+| [CI/CD Usage](ci-cd.md)                         | Using gitlab-mcp-server in CI/CD pipelines (with or without LLM)                                  |
+| [Auto-Update](auto-update.md)                   | Self-update mechanism, modes, MCP tools, and release requirements                                 |
+| [Resource Consumption](resource-consumption.md) | Memory footprint, scaling limits, and optimization strategies                                     |
+| [Meta-Tools](meta-tools.md)                     | Domain-level meta-tool reference with action mappings                                             |
+| [Dynamic Toolset](dynamic-tools.md)             | Low-token find/execute mode with canonical action catalog and migration guidance                  |
+| [Output Format](output-format.md)               | How tool responses are structured: Markdown + JSON, annotations, clickable links, next-step hints |
+| [Testing](testing/)                             | Unit, E2E, and AI model evaluation documentation                                                  |
+| [GraphQL Integration](graphql.md)               | When and how the server uses GitLab's GraphQL API                                                 |
+| [Troubleshooting](troubleshooting.md)           | Common issues and solutions for connection, TLS, tools, and transport                             |
 
 ## Development
 
-| Document | Description |
-| --- | --- |
-| [Development Guide](development/development.md) | Developer guide: setup, building, testing, adding new tools |
-| [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md) | Developer architecture for individual tools, meta-tools, dynamic mode, and shared action catalog |
-| [Catalog-First Individual Tools Evaluation](development/catalog-first-individual-tools.md) | Evaluation of whether individual tools should be generated from the canonical action catalog |
-| [Testing](testing/testing.md) | Test suite overview, coverage breakdown, and per-package statistics |
-| [AI Model Evaluation](testing/model-evaluation.md) | How model evaluations validate MCP tool use against schema and Docker GitLab |
-| [AI Model Evaluation Developer Guide](testing/model-evaluation-developer.md) | Commands, fixtures, traces, and maintenance workflow for model evaluation |
-| [AI Model Evaluation Results](testing/model-results.md) | Curated model compatibility and benchmark snapshots |
-| [Static Analysis](development/static-analysis.md) | Static analysis tools: vet, modernize, golangci-lint, gosec, staticcheck, govulncheck |
-| [Godoc Compliance](development/godoc.md) | Godoc audit workflow for packages, exported symbols, and test functions |
+| Document                                                                                   | Description                                                                                      |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| [Development Guide](development/development.md)                                            | Developer guide: setup, building, testing, adding new tools                                      |
+| [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md)    | Developer architecture for individual tools, meta-tools, dynamic mode, and shared action catalog |
+| [Catalog-First Individual Tools Evaluation](development/catalog-first-individual-tools.md) | Evaluation of whether individual tools should be generated from the canonical action catalog     |
+| [Testing](testing/testing.md)                                                              | Test suite overview, coverage breakdown, and per-package statistics                              |
+| [AI Model Evaluation](testing/model-evaluation.md)                                         | How model evaluations validate MCP tool use against schema and Docker GitLab                     |
+| [AI Model Evaluation Developer Guide](testing/model-evaluation-developer.md)               | Commands, fixtures, traces, and maintenance workflow for model evaluation                        |
+| [AI Model Evaluation Results](testing/model-results.md)                                    | Curated model compatibility and benchmark snapshots                                              |
+| [Static Analysis](development/static-analysis.md)                                          | Static analysis tools: vet, modernize, golangci-lint, gosec, staticcheck, govulncheck            |
+| [Godoc Compliance](development/godoc.md)                                                   | Godoc audit workflow for packages, exported symbols, and test functions                          |
 
 ## Reference
 
-| Document | Description |
-| --- | --- |
-| [CLI Reference](cli-reference.md) | Complete command-line flags and usage examples |
-| [Environment Variables](env-reference.md) | All environment variables with defaults and descriptions |
-| [tools/](tools/) | Per-domain tool documentation (25 domain docs) |
-| [Resources Reference](resources-reference.md) | All 46 MCP resources with URI templates |
-| [Prompts Reference](prompts-reference.md) | All 37 prompts with arguments and output format |
-| [Capabilities](capabilities/) | 6 MCP capabilities: logging, completions, roots, progress, sampling, elicitation |
-| [Usage Examples](examples/usage-examples.md) | Real-world MCP usage scenarios |
-| [adr/](adr/) | Architectural Decision Records |
+| Document                                      | Description                                                                      |
+| --------------------------------------------- | -------------------------------------------------------------------------------- |
+| [CLI Reference](cli-reference.md)             | Complete command-line flags and usage examples                                   |
+| [Environment Variables](env-reference.md)     | All environment variables with defaults and descriptions                         |
+| [tools/](tools/)                              | Per-domain tool documentation (25 domain docs)                                   |
+| [Resources Reference](resources-reference.md) | All 46 MCP resources with URI templates                                          |
+| [Prompts Reference](prompts-reference.md)     | All 37 prompts with arguments and output format                                  |
+| [Capabilities](capabilities/)                 | 6 MCP capabilities: logging, completions, roots, progress, sampling, elicitation |
+| [Usage Examples](examples/usage-examples.md)  | Real-world MCP usage scenarios                                                   |
+| [adr/](adr/)                                  | Architectural Decision Records                                                   |
 
 ## Learning
 
-| Document | Description |
-| --- | --- |
+| Document                                                            | Description                                                     |
+| ------------------------------------------------------------------- | --------------------------------------------------------------- |
 | [MCP Specification](https://modelcontextprotocol.io/specification/) | Official Model Context Protocol specification and documentation |
 
 ## Quick Links

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,22 +10,22 @@ This directory contains Architectural Decision Records (ADRs) for gitlab-mcp-ser
 
 ## ADR Index
 
-| ADR | Title | Status | Classification | Date |
-| --- | --- | --- | --- | --- |
-| ADR-0001 | Go as implementation language | Implicit founding decision (not formally recorded) | Current | — |
-| ADR-0002 | stdio as primary MCP transport | Implicit founding decision (not formally recorded) | Current | — |
-| ADR-0003 | GitLab REST API v4 via official client | Implicit founding decision (not formally recorded) | Current | — |
-| [ADR-0004](adr-0004-modular-tools-subpackages.md) | Modular sub-packages under `internal/tools/{domain}/` | Accepted; runtime registration superseded by ADR-0014 | Historical but useful | 2026-02-15 |
-| [ADR-0005](adr-0005-meta-tool-consolidation.md) | Meta-tool consolidation from 68 to a compact domain catalog | Accepted; registration mechanics superseded by ADR-0014 | Historical but useful | 2026-03-06 |
-| [ADR-0006](adr-0006-raw-graphql-for-uncovered-domains.md) | Raw GraphQL.Do() for domains without client-go service wrappers | Accepted | Current | 2026-03-23 |
-| [ADR-0007](adr-0007-rich-error-semantics.md) | Rich error semantics for LLM-actionable diagnostics | Accepted | Current | 2026-04-06 |
-| [ADR-0008](adr-0008-universal-identity.md) | Universal identity system | Accepted | Current | 2026-04-13 |
-| [ADR-0009](adr-0009-progressive-graphql-migration.md) | Progressive GraphQL migration strategy | Accepted | Current | 2026-04-20 |
-| [ADR-0010](adr-0010-no-resource-subscribe.md) | No resource subscribe capability | Accepted | Current | 2026-04-26 |
-| [ADR-0011](adr-0011-low-token-dynamic-toolset.md) | Low-token dynamic toolset mode | Accepted; catalog source refined by ADR-0014 | Current, with catalog-first terminology updates | 2026-05-07 |
-| [ADR-0012](adr-0012-action-catalog-package-name.md) | Action catalog package name | Accepted | Current | 2026-05-12 |
-| [ADR-0013](adr-0013-documentation-artifact-boundaries.md) | Documentation artifact boundaries | Accepted | Current | 2026-05-13 |
-| [ADR-0014](adr-0014-catalog-first-runtime-architecture.md) | Catalog-first runtime architecture | Accepted | Current | 2026-05-15 |
+| ADR                                                        | Title                                                           | Status                                                  | Classification                                  | Date       |
+| ---------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------- | ---------- |
+| ADR-0001                                                   | Go as implementation language                                   | Implicit founding decision (not formally recorded)      | Current                                         | —          |
+| ADR-0002                                                   | stdio as primary MCP transport                                  | Implicit founding decision (not formally recorded)      | Current                                         | —          |
+| ADR-0003                                                   | GitLab REST API v4 via official client                          | Implicit founding decision (not formally recorded)      | Current                                         | —          |
+| [ADR-0004](adr-0004-modular-tools-subpackages.md)          | Modular sub-packages under `internal/tools/{domain}/`           | Accepted; runtime registration superseded by ADR-0014   | Historical but useful                           | 2026-02-15 |
+| [ADR-0005](adr-0005-meta-tool-consolidation.md)            | Meta-tool consolidation from 68 to a compact domain catalog     | Accepted; registration mechanics superseded by ADR-0014 | Historical but useful                           | 2026-03-06 |
+| [ADR-0006](adr-0006-raw-graphql-for-uncovered-domains.md)  | Raw GraphQL.Do() for domains without client-go service wrappers | Accepted                                                | Current                                         | 2026-03-23 |
+| [ADR-0007](adr-0007-rich-error-semantics.md)               | Rich error semantics for LLM-actionable diagnostics             | Accepted                                                | Current                                         | 2026-04-06 |
+| [ADR-0008](adr-0008-universal-identity.md)                 | Universal identity system                                       | Accepted                                                | Current                                         | 2026-04-13 |
+| [ADR-0009](adr-0009-progressive-graphql-migration.md)      | Progressive GraphQL migration strategy                          | Accepted                                                | Current                                         | 2026-04-20 |
+| [ADR-0010](adr-0010-no-resource-subscribe.md)              | No resource subscribe capability                                | Accepted                                                | Current                                         | 2026-04-26 |
+| [ADR-0011](adr-0011-low-token-dynamic-toolset.md)          | Low-token dynamic toolset mode                                  | Accepted; catalog source refined by ADR-0014            | Current, with catalog-first terminology updates | 2026-05-07 |
+| [ADR-0012](adr-0012-action-catalog-package-name.md)        | Action catalog package name                                     | Accepted                                                | Current                                         | 2026-05-12 |
+| [ADR-0013](adr-0013-documentation-artifact-boundaries.md)  | Documentation artifact boundaries                               | Accepted                                                | Current                                         | 2026-05-13 |
+| [ADR-0014](adr-0014-catalog-first-runtime-architecture.md) | Catalog-first runtime architecture                              | Accepted                                                | Current                                         | 2026-05-15 |
 
 ## About Missing ADRs
 

--- a/docs/adr/adr-0005-meta-tool-consolidation.md
+++ b/docs/adr/adr-0005-meta-tool-consolidation.md
@@ -25,11 +25,11 @@ superseded_by: "ADR-0014 for meta registration mechanics"
 
 ADR-0004 established modular domain sub-packages and each package could originally expose its own `RegisterMeta()` function. Over time the meta-tool count grew organically:
 
-| Metric                          | Count |
-| ------------------------------- | ----- |
-| Inline meta-tools (register_meta.go) | 19    |
-| Standalone RegisterMeta calls   | 49    |
-| **Total meta-tools exposed**    | **68** |
+| Metric                               | Count  |
+| ------------------------------------ | ------ |
+| Inline meta-tools (register_meta.go) | 19     |
+| Standalone RegisterMeta calls        | 49     |
+| **Total meta-tools exposed**         | **68** |
 
 ### Problems with 68 meta-tools
 
@@ -116,57 +116,57 @@ Enterprise/Premium deployments add 16 gated meta-tools. GitLab.com Enterprise/Pr
 
 ### Consolidation mapping (49 standalone → absorbed)
 
-| Standalone package        | Target meta-tool      | Action prefix |
-| ------------------------- | --------------------- | ------------- |
-| accessrequests            | gitlab_access         | access_request_* |
-| accesstokens              | gitlab_access         | token_* |
-| alertmanagement           | gitlab_admin → gitlab_security | alert_* |
-| avatar                    | gitlab_admin          | avatar_* |
-| awardemoji                | gitlab_notification   | emoji_* |
-| boards                    | gitlab_board          | board_* |
-| clusteragents             | gitlab_admin          | cluster_agent_* |
-| commitdiscussions         | gitlab_repository     | commit_discussion_* |
-| containerregistry         | gitlab_package        | registry_* |
-| dependencyproxy           | gitlab_admin          | dependency_proxy_* |
-| deploykeys                | gitlab_access         | deploy_key_* |
-| deploytokens              | gitlab_access         | deploy_token_* |
-| epicdiscussions           | gitlab_snippet        | epic_discussion_* |
-| errortracking             | gitlab_security       | error_tracking_* |
-| events                    | gitlab_notification   | event_* |
-| featureflags              | gitlab_security       | feature_flag_* |
-| ffuserlists               | gitlab_security       | user_list_* |
-| freezeperiods             | gitlab_environment    | freeze_period_* |
-| groupboards               | gitlab_board          | group_board_* |
-| groupimportexport         | gitlab_group          | import_*, export_* |
-| grouplabels               | gitlab_group          | label_* |
-| groupmarkdownuploads      | gitlab_group          | upload_* |
-| groupmembers              | gitlab_group          | member_* |
-| groupmilestones           | gitlab_group          | milestone_* |
-| grouprelationsexport      | gitlab_group          | relations_export_* |
-| groupvariables            | gitlab_ci             | group_variable_* |
-| importservice             | gitlab_admin          | import_* |
-| instancevariables         | gitlab_ci             | instance_variable_* |
-| invites                   | gitlab_access         | invite_* |
-| issuediscussions          | gitlab_issue          | discussion_* |
-| issuestatistics           | gitlab_issue          | statistics_* |
-| jobtokenscope             | gitlab_job            | token_scope_* |
-| keys                      | gitlab_user           | key_* |
-| namespaces                | gitlab_user           | namespace_* |
-| notifications             | gitlab_notification   | notification_* |
-| packages                  | gitlab_package        | package_* |
-| pages                     | gitlab_admin          | pages_* |
-| pipelinetriggers          | gitlab_pipeline       | trigger_* |
-| projectimportexport       | gitlab_project        | import_*, export_* |
-| projectstatistics         | gitlab_project        | statistics_* |
-| protectedenvs             | gitlab_environment    | protected_env_* |
-| resourceevents            | gitlab_notification   | resource_event_* |
-| resourcegroups            | gitlab_job            | resource_group_* |
-| runners                   | gitlab_runner         | runner_* |
-| search                    | gitlab_search         | (already standalone) |
-| securefiles               | gitlab_security       | secure_file_* |
-| snippetdiscussions        | gitlab_snippet        | snippet_discussion_* |
-| snippets                  | gitlab_snippet        | snippet_* |
-| terraformstates           | gitlab_admin          | terraform_* |
+| Standalone package   | Target meta-tool               | Action prefix        |
+| -------------------- | ------------------------------ | -------------------- |
+| accessrequests       | gitlab_access                  | access_request_*     |
+| accesstokens         | gitlab_access                  | token_*              |
+| alertmanagement      | gitlab_admin → gitlab_security | alert_*              |
+| avatar               | gitlab_admin                   | avatar_*             |
+| awardemoji           | gitlab_notification            | emoji_*              |
+| boards               | gitlab_board                   | board_*              |
+| clusteragents        | gitlab_admin                   | cluster_agent_*      |
+| commitdiscussions    | gitlab_repository              | commit_discussion_*  |
+| containerregistry    | gitlab_package                 | registry_*           |
+| dependencyproxy      | gitlab_admin                   | dependency_proxy_*   |
+| deploykeys           | gitlab_access                  | deploy_key_*         |
+| deploytokens         | gitlab_access                  | deploy_token_*       |
+| epicdiscussions      | gitlab_snippet                 | epic_discussion_*    |
+| errortracking        | gitlab_security                | error_tracking_*     |
+| events               | gitlab_notification            | event_*              |
+| featureflags         | gitlab_security                | feature_flag_*       |
+| ffuserlists          | gitlab_security                | user_list_*          |
+| freezeperiods        | gitlab_environment             | freeze_period_*      |
+| groupboards          | gitlab_board                   | group_board_*        |
+| groupimportexport    | gitlab_group                   | import_*, export_*   |
+| grouplabels          | gitlab_group                   | label_*              |
+| groupmarkdownuploads | gitlab_group                   | upload_*             |
+| groupmembers         | gitlab_group                   | member_*             |
+| groupmilestones      | gitlab_group                   | milestone_*          |
+| grouprelationsexport | gitlab_group                   | relations_export_*   |
+| groupvariables       | gitlab_ci                      | group_variable_*     |
+| importservice        | gitlab_admin                   | import_*             |
+| instancevariables    | gitlab_ci                      | instance_variable_*  |
+| invites              | gitlab_access                  | invite_*             |
+| issuediscussions     | gitlab_issue                   | discussion_*         |
+| issuestatistics      | gitlab_issue                   | statistics_*         |
+| jobtokenscope        | gitlab_job                     | token_scope_*        |
+| keys                 | gitlab_user                    | key_*                |
+| namespaces           | gitlab_user                    | namespace_*          |
+| notifications        | gitlab_notification            | notification_*       |
+| packages             | gitlab_package                 | package_*            |
+| pages                | gitlab_admin                   | pages_*              |
+| pipelinetriggers     | gitlab_pipeline                | trigger_*            |
+| projectimportexport  | gitlab_project                 | import_*, export_*   |
+| projectstatistics    | gitlab_project                 | statistics_*         |
+| protectedenvs        | gitlab_environment             | protected_env_*      |
+| resourceevents       | gitlab_notification            | resource_event_*     |
+| resourcegroups       | gitlab_job                     | resource_group_*     |
+| runners              | gitlab_runner                  | runner_*             |
+| search               | gitlab_search                  | (already standalone) |
+| securefiles          | gitlab_security                | secure_file_*        |
+| snippetdiscussions   | gitlab_snippet                 | snippet_discussion_* |
+| snippets             | gitlab_snippet                 | snippet_*            |
+| terraformstates      | gitlab_admin                   | terraform_*          |
 
 ### Implementation approach
 

--- a/docs/adr/adr-0006-raw-graphql-for-uncovered-domains.md
+++ b/docs/adr/adr-0006-raw-graphql-for-uncovered-domains.md
@@ -19,13 +19,13 @@ The project uses the official GitLab Go client (`gitlab.com/gitlab-org/api/clien
 
 However, several GitLab API domains are **only available via GraphQL** and have no corresponding service wrapper in `client-go`:
 
-| Domain             | GitLab API Coverage                          | client-go Status     |
-| ------------------ | -------------------------------------------- | -------------------- |
-| Vulnerabilities    | REST (partial) + GraphQL (full: mutations, severity counts, pipeline summary) | REST only, no mutations |
-| Security Findings  | GraphQL only (pipeline security tab)         | Not covered          |
-| CI/CD Catalog      | GraphQL only (catalog resources, components) | Not covered          |
-| Branch Rules       | GraphQL only (consolidated branch protections) | Not covered          |
-| Custom Emoji       | GraphQL only (group-level custom emoji CRUD) | Not covered          |
+| Domain            | GitLab API Coverage                                                           | client-go Status        |
+| ----------------- | ----------------------------------------------------------------------------- | ----------------------- |
+| Vulnerabilities   | REST (partial) + GraphQL (full: mutations, severity counts, pipeline summary) | REST only, no mutations |
+| Security Findings | GraphQL only (pipeline security tab)                                          | Not covered             |
+| CI/CD Catalog     | GraphQL only (catalog resources, components)                                  | Not covered             |
+| Branch Rules      | GraphQL only (consolidated branch protections)                                | Not covered             |
+| Custom Emoji      | GraphQL only (group-level custom emoji CRUD)                                  | Not covered             |
 
 ### Options considered
 
@@ -88,18 +88,18 @@ Used by `samplingtools` to fetch rich context (vulnerability summaries, pipeline
 
 Shared GraphQL utilities live in `internal/toolutil/graphql.go`:
 
-| Utility                     | Purpose                                                  |
-| --------------------------- | -------------------------------------------------------- |
-| `GraphQLPaginationInput`    | Cursor-based pagination input (first/after/last/before)  |
-| `GraphQLPaginationOutput`   | Pagination metadata for tool responses                   |
-| `GraphQLRawPageInfo`        | Raw camelCase PageInfo from GitLab API                   |
-| `PageInfoToOutput()`        | Converts camelCase PageInfo to snake_case output          |
-| `FormatGraphQLPagination()` | Formats pagination metadata as Markdown summary          |
-| `FormatGID()`               | Builds GitLab Global ID (`gid://gitlab/Type/123`)        |
-| `ParseGID()`                | Extracts type and numeric ID from a GitLab Global ID     |
-| `MergeVariables()`          | Merges multiple variable maps for complex queries        |
-| `GraphQLDefaultFirst`       | Default page size (20)                                   |
-| `GraphQLMaxFirst`           | Maximum page size (100)                                  |
+| Utility                     | Purpose                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| `GraphQLPaginationInput`    | Cursor-based pagination input (first/after/last/before) |
+| `GraphQLPaginationOutput`   | Pagination metadata for tool responses                  |
+| `GraphQLRawPageInfo`        | Raw camelCase PageInfo from GitLab API                  |
+| `PageInfoToOutput()`        | Converts camelCase PageInfo to snake_case output        |
+| `FormatGraphQLPagination()` | Formats pagination metadata as Markdown summary         |
+| `FormatGID()`               | Builds GitLab Global ID (`gid://gitlab/Type/123`)       |
+| `ParseGID()`                | Extracts type and numeric ID from a GitLab Global ID    |
+| `MergeVariables()`          | Merges multiple variable maps for complex queries       |
+| `GraphQLDefaultFirst`       | Default page size (20)                                  |
+| `GraphQLMaxFirst`           | Maximum page size (100)                                 |
 
 ### Testing approach
 

--- a/docs/adr/adr-0007-rich-error-semantics.md
+++ b/docs/adr/adr-0007-rich-error-semantics.md
@@ -51,11 +51,11 @@ LLMs using MCP tools need actionable error messages to self-correct without huma
 
 Introduce three new functions in `internal/toolutil/errors.go` that layer on top of the existing `WrapErr`:
 
-| Function | Purpose | When to use |
-| --- | --- | --- |
-| `ExtractGitLabMessage(err)` | Extracts specific detail from `gl.ErrorResponse.Message` | Building block for other functions |
-| `WrapErrWithMessage(op, err)` | Like `WrapErr` but includes the GitLab error message | Mutating operations (default) |
-| `WrapErrWithHint(op, err, hint)` | Like `WrapErrWithMessage` plus an actionable suggestion | When a specific corrective action is known |
+| Function                         | Purpose                                                  | When to use                                |
+| -------------------------------- | -------------------------------------------------------- | ------------------------------------------ |
+| `ExtractGitLabMessage(err)`      | Extracts specific detail from `gl.ErrorResponse.Message` | Building block for other functions         |
+| `WrapErrWithMessage(op, err)`    | Like `WrapErr` but includes the GitLab error message     | Mutating operations (default)              |
+| `WrapErrWithHint(op, err, hint)` | Like `WrapErrWithMessage` plus an actionable suggestion  | When a specific corrective action is known |
 
 ### Error format progression
 

--- a/docs/adr/adr-0009-progressive-graphql-migration.md
+++ b/docs/adr/adr-0009-progressive-graphql-migration.md
@@ -79,13 +79,13 @@ When migrating:
 
 Current priority queue based on known deprecation timelines:
 
-| Priority | Domain | Trigger | Timeline |
-| -------- | ------ | ------- | -------- |
-| ✅ | Epics (6 tools) | REST deprecated 17.0, removal 19.0 | Migrated to Work Items API via client-go `WorkItems` service |
-| ✅ | Epic Issues (4 tools) | REST deprecated 17.0, removal 19.0 | Migrated to Work Items children/parent widgets |
-| ✅ | Epic Notes (5 tools) | REST deprecated 17.0, removal 19.0 | Migrated to Work Items notes widgets |
-| ✅ | Epic Discussions (7 tools) | REST deprecated 17.0, removal 19.0 | Migrated to Work Items discussions widgets |
-| P3 | Iterations | Feature gap | Migrate when client-go adds GraphQL wrapper |
+| Priority | Domain                     | Trigger                            | Timeline                                                     |
+| -------- | -------------------------- | ---------------------------------- | ------------------------------------------------------------ |
+| ✅        | Epics (6 tools)            | REST deprecated 17.0, removal 19.0 | Migrated to Work Items API via client-go `WorkItems` service |
+| ✅        | Epic Issues (4 tools)      | REST deprecated 17.0, removal 19.0 | Migrated to Work Items children/parent widgets               |
+| ✅        | Epic Notes (5 tools)       | REST deprecated 17.0, removal 19.0 | Migrated to Work Items notes widgets                         |
+| ✅        | Epic Discussions (7 tools) | REST deprecated 17.0, removal 19.0 | Migrated to Work Items discussions widgets                   |
+| P3       | Iterations                 | Feature gap                        | Migrate when client-go adds GraphQL wrapper                  |
 
 ## References
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,16 +156,16 @@ The `main()` function supports two runtime modes:
 
 Loads settings from environment variables with optional `.env` file support (via `godotenv`). Used by **stdio mode** to validate that `GITLAB_TOKEN` is present and to default `GITLAB_URL` to `https://gitlab.com` when omitted. HTTP mode uses CLI flags instead (see Transport Selection).
 
-| Variable                 | Required | Default | Description                                          |
-| ------------------------ | -------- | ------- | ---------------------------------------------------- |
-| `GITLAB_URL`             | No       | `https://gitlab.com` | GitLab instance base URL                             |
-| `GITLAB_TOKEN`           | Stdio    | —       | Personal Access Token with `api` scope               |
-| `GITLAB_SKIP_TLS_VERIFY` | No       | `false` | Skip TLS certificate verification                    |
-| `TOOL_SURFACE`           | No       | `dynamic` | Canonical tool catalog selector (`dynamic`, `meta`, `individual`) |
-| `META_TOOLS`             | No       | —       | Deprecated compatibility selector mapped to `TOOL_SURFACE` when `TOOL_SURFACE` is absent |
-| `ISSUE_REPORTS`          | No       | `false` | Auto-generate GitLab issues on tool errors            |
-| `YOLO_MODE`              | No       | `false` | Skip destructive action confirmations                |
-| `UPLOAD_MAX_FILE_SIZE`   | No       | `2GB`   | Maximum allowed upload file size                     |
+| Variable                 | Required | Default              | Description                                                                              |
+| ------------------------ | -------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | No       | `https://gitlab.com` | GitLab instance base URL                                                                 |
+| `GITLAB_TOKEN`           | Stdio    | —                    | Personal Access Token with `api` scope                                                   |
+| `GITLAB_SKIP_TLS_VERIFY` | No       | `false`              | Skip TLS certificate verification                                                        |
+| `TOOL_SURFACE`           | No       | `dynamic`            | Canonical tool catalog selector (`dynamic`, `meta`, `individual`)                        |
+| `META_TOOLS`             | No       | —                    | Deprecated compatibility selector mapped to `TOOL_SURFACE` when `TOOL_SURFACE` is absent |
+| `ISSUE_REPORTS`          | No       | `false`              | Auto-generate GitLab issues on tool errors                                               |
+| `YOLO_MODE`              | No       | `false`              | Skip destructive action confirmations                                                    |
+| `UPLOAD_MAX_FILE_SIZE`   | No       | `2GB`                | Maximum allowed upload file size                                                         |
 
 ### GitLab Client (`internal/gitlab`)
 
@@ -184,69 +184,69 @@ For the detailed relationship between individual tools, meta-tools, dynamic mode
 
 **Orchestration files** in `internal/tools/`:
 
-| File               | Purpose                                                       |
-| ------------------ | ------------------------------------------------------------- |
-| `register.go`      | `RegisterAll()` — builds the canonical catalog and registers the individual tool projection |
-| `register_meta.go` | `RegisterAllMeta()` — builds the canonical catalog and registers visible meta-tool groups plus approved standalone surfaces |
+| File                | Purpose                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `register.go`       | `RegisterAll()` — builds the canonical catalog and registers the individual tool projection                                                |
+| `register_meta.go`  | `RegisterAllMeta()` — builds the canonical catalog and registers visible meta-tool groups plus approved standalone surfaces                |
 | `action_catalog.go` | `BuildActionCatalog()` — builds the canonical action catalog shared by meta-tools, dynamic tools, schema resources, audits, and generators |
-| `meta_catalog.go`  | `RegisterMetaCatalog()` — registers visible meta-tools from the canonical action catalog |
-| `actioncatalog/`  | Canonical catalog data model, deterministic ordering, action lookup, adapters, and filters |
-| `metatool.go`      | Re-exports from `toolutil`: `makeMetaHandler`, `addMetaTool`, `addReadOnlyMetaTool`   |
-| `markdown.go`      | Thin `markdownForResult` delegator to the type-based Markdown registry |
-| `pagination.go`    | Shared pagination type aliases                                |
-| `errors.go`        | Error helpers (`wrapErr`, `handleGitLabError`)                |
-| `logging.go`       | `logToolCall` helper                                          |
+| `meta_catalog.go`   | `RegisterMetaCatalog()` — registers visible meta-tools from the canonical action catalog                                                   |
+| `actioncatalog/`    | Canonical catalog data model, deterministic ordering, action lookup, adapters, and filters                                                 |
+| `metatool.go`       | Re-exports from `toolutil`: `makeMetaHandler`, `addMetaTool`, `addReadOnlyMetaTool`                                                        |
+| `markdown.go`       | Thin `markdownForResult` delegator to the type-based Markdown registry                                                                     |
+| `pagination.go`     | Shared pagination type aliases                                                                                                             |
+| `errors.go`         | Error helpers (`wrapErr`, `handleGitLabError`)                                                                                             |
+| `logging.go`        | `logToolCall` helper                                                                                                                       |
 
 **Domain sub-packages** (163 total, grouped by category):
 
-| Category          | Sub-packages                                                                                    |
-| ----------------- | ----------------------------------------------------------------------------------------------- |
-| Project lifecycle | `projects`, `members`, `uploads`, `labels`, `milestones`                                        |
-| Source control    | `branches`, `tags`, `commits`, `files`, `repository`                                            |
-| Merge requests    | `mergerequests`, `mrnotes`, `mrdiscussions`, `mrchanges`, `mrapprovals`, `mrdraftnotes`         |
-| Issues            | `issues`, `issuenotes`, `issuelinks`                                                            |
-| CI/CD             | `pipelines`, `pipelineschedules`, `jobs`, `cilint`, `civariables`, `runners`                    |
-| Releases          | `releases`, `releaselinks`                                                                      |
-| Groups            | `groups`                                                                                        |
-| Search & users    | `search`, `users`, `todos`                                                                      |
-| Infrastructure    | `environments`, `deployments`, `packages`, `wikis`, `health`                                    |
-| LLM capabilities  | `samplingtools`, `elicitationtools`                                                             |
-| Extended domains  | `snippets`, `snippetdiscussions`, `securefiles`, `terraformstates`, `resourcegroups`, etc.      |
+| Category          | Sub-packages                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------ |
+| Project lifecycle | `projects`, `members`, `uploads`, `labels`, `milestones`                                   |
+| Source control    | `branches`, `tags`, `commits`, `files`, `repository`                                       |
+| Merge requests    | `mergerequests`, `mrnotes`, `mrdiscussions`, `mrchanges`, `mrapprovals`, `mrdraftnotes`    |
+| Issues            | `issues`, `issuenotes`, `issuelinks`                                                       |
+| CI/CD             | `pipelines`, `pipelineschedules`, `jobs`, `cilint`, `civariables`, `runners`               |
+| Releases          | `releases`, `releaselinks`                                                                 |
+| Groups            | `groups`                                                                                   |
+| Search & users    | `search`, `users`, `todos`                                                                 |
+| Infrastructure    | `environments`, `deployments`, `packages`, `wikis`, `health`                               |
+| LLM capabilities  | `samplingtools`, `elicitationtools`                                                        |
+| Extended domains  | `snippets`, `snippetdiscussions`, `securefiles`, `terraformstates`, `resourcegroups`, etc. |
 
 ### Shared Tool Utilities (`internal/toolutil`)
 
 Infrastructure shared by all tool sub-packages:
 
-| File               | Purpose                                                        |
-| ------------------ | -------------------------------------------------------------- |
-| `action_spec.go`   | `ActionSpec`, compatibility policy, individual projection metadata, and schema/result policy fields |
-| `metatool.go`      | `MetaToolInput`, `ActionRoute`, `MakeMetaHandler`, `DeriveAnnotations`, `Route`, `DestructiveRoute` |
+| File               | Purpose                                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `action_spec.go`   | `ActionSpec`, compatibility policy, individual projection metadata, and schema/result policy fields                                 |
+| `metatool.go`      | `MetaToolInput`, `ActionRoute`, `MakeMetaHandler`, `DeriveAnnotations`, `Route`, `DestructiveRoute`                                 |
 | `annotations.go`   | Tool annotations (`ReadAnnotations`, `DeleteAnnotations`) and content annotations (`ContentList`, `ContentDetail`, `ContentMutate`) |
-| `hints.go`         | Next-step hints: `WriteHints`, `ExtractHints`, `HintPreserveLinks` |
-| `addtool.go`       | `AddTool` wrapper — suppresses structuredContent for individual tools |
-| `markdown.go`      | `ToolResultWithMarkdown`, `FormatPagination`, emoji helpers    |
-| `errors.go`        | `ToolError`, `DetailedError`, `ErrorResultMarkdown`            |
-| `confirm.go`       | `ConfirmDestructiveAction`, `IsYOLOMode`                       |
-| `output.go`        | `SuccessResult`, `ErrorResult` — standard output helpers       |
-| `text.go`          | `NormalizeText`, `EscapeMdTableCell`, `WrapGFMBody`            |
-| `pagination.go`    | `PaginationInput`, `PaginationOutput` shared types             |
-| `logging.go`       | `LogToolCallAll` structured logging helper                     |
-| `diff.go`          | Diff formatting utilities                                      |
-| `doc.go`           | Package documentation                                          |
-| `fileutils.go`     | File operation helpers (upload size validation, SHA-256)       |
-| `issue_report.go`  | Auto-generate GitLab issue reports on tool errors              |
-| `string_or_int.go` | Flexible JSON unmarshalling for string-or-int fields           |
-| `time_helpers.go`  | Time formatting and parsing utilities                          |
+| `hints.go`         | Next-step hints: `WriteHints`, `ExtractHints`, `HintPreserveLinks`                                                                  |
+| `addtool.go`       | `AddTool` wrapper — suppresses structuredContent for individual tools                                                               |
+| `markdown.go`      | `ToolResultWithMarkdown`, `FormatPagination`, emoji helpers                                                                         |
+| `errors.go`        | `ToolError`, `DetailedError`, `ErrorResultMarkdown`                                                                                 |
+| `confirm.go`       | `ConfirmDestructiveAction`, `IsYOLOMode`                                                                                            |
+| `output.go`        | `SuccessResult`, `ErrorResult` — standard output helpers                                                                            |
+| `text.go`          | `NormalizeText`, `EscapeMdTableCell`, `WrapGFMBody`                                                                                 |
+| `pagination.go`    | `PaginationInput`, `PaginationOutput` shared types                                                                                  |
+| `logging.go`       | `LogToolCallAll` structured logging helper                                                                                          |
+| `diff.go`          | Diff formatting utilities                                                                                                           |
+| `doc.go`           | Package documentation                                                                                                               |
+| `fileutils.go`     | File operation helpers (upload size validation, SHA-256)                                                                            |
+| `issue_report.go`  | Auto-generate GitLab issue reports on tool errors                                                                                   |
+| `string_or_int.go` | Flexible JSON unmarshalling for string-or-int fields                                                                                |
+| `time_helpers.go`  | Time formatting and parsing utilities                                                                                               |
 
 ### Server Pool (`internal/serverpool`)
 
 Manages a bounded pool of per-token+URL MCP server instances in HTTP mode. Each unique combination of GitLab Personal Access Token and GitLab instance URL gets its own isolated MCP server, GitLab client, and server configuration snapshot. The snapshot combines global process policy with detected token scopes and CE/EE edition for that specific entry.
 
-| File         | Purpose                                                          |
-| ------------ | ---------------------------------------------------------------- |
-| `pool.go`    | `ServerPool` with LRU eviction, `GetOrCreate()`, `Close()`      |
-| `token.go`   | `ExtractToken()` — reads token from `PRIVATE-TOKEN` or `Authorization: Bearer` headers. `ResolveRequestOptions()` — accepts `GITLAB-URL` only in multi-instance mode and records ignored config-like request headers |
-| `doc.go`     | Package documentation                                            |
+| File       | Purpose                                                                                                                                                                                                              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pool.go`  | `ServerPool` with LRU eviction, `GetOrCreate()`, `Close()`                                                                                                                                                           |
+| `token.go` | `ExtractToken()` — reads token from `PRIVATE-TOKEN` or `Authorization: Bearer` headers. `ResolveRequestOptions()` — accepts `GITLAB-URL` only in multi-instance mode and records ignored config-like request headers |
+| `doc.go`   | Package documentation                                                                                                                                                                                                |
 
 Key characteristics:
 
@@ -348,54 +348,54 @@ See [Dynamic Toolset](dynamic-tools.md) for configuration, examples, safety beha
 
 46 read-only MCP resources accessed by URI templates. Resources provide contextual data without modifying state:
 
-| Resource        | URI                                         | Description                        |
-| --------------- | ------------------------------------------- | ---------------------------------- |
-| Current User    | `gitlab://user/current`                     | Authenticated user profile         |
-| Groups          | `gitlab://groups`                           | Accessible groups list             |
-| Workspace Roots | `gitlab://workspace/roots`                  | Client workspace root directories  |
-| Meta Schema     | `gitlab://schema/meta/`                     | Registered meta-tool action index  |
-| Meta Action     | `gitlab://schema/meta/{tool}/{action}`      | JSON Schema for action params      |
-| Group           | `gitlab://group/{id}`                       | Group details by ID                |
-| Group Members   | `gitlab://group/{id}/members`               | Group members with access levels   |
-| Group Projects  | `gitlab://group/{id}/projects`              | Projects within a group            |
-| Project         | `gitlab://project/{id}`                     | Project metadata                   |
-| Members         | `gitlab://project/{id}/members`             | Project members with access levels |
-| Issues          | `gitlab://project/{id}/issues`              | Open issues for a project          |
-| Issue           | `gitlab://project/{id}/issue/{iid}`         | Specific issue details             |
-| Latest Pipeline | `gitlab://project/{id}/pipelines/latest`    | Most recent pipeline               |
-| Pipeline        | `gitlab://project/{id}/pipeline/{pid}`      | Specific pipeline details          |
-| Pipeline Jobs   | `gitlab://project/{id}/pipeline/{pid}/jobs` | Jobs for a pipeline                |
-| Labels          | `gitlab://project/{id}/labels`              | Project labels                     |
-| Milestones      | `gitlab://project/{id}/milestones`          | Project milestones                 |
-| Merge Request   | `gitlab://project/{id}/mr/{iid}`            | MR details by IID                  |
-| Branches        | `gitlab://project/{id}/branches`            | All branches                       |
-| Branch          | `gitlab://project/{id}/branch/{name}`       | Single branch by name              |
-| Releases        | `gitlab://project/{id}/releases`            | Project releases                   |
-| Release         | `gitlab://project/{id}/release/{tag}`       | Single release by tag              |
-| Tags            | `gitlab://project/{id}/tags`                | Repository tags                    |
-| Tag             | `gitlab://project/{id}/tag/{name}`          | Single repository tag              |
-| Commit          | `gitlab://project/{id}/commit/{sha}`        | Single commit by SHA               |
-| File Blob       | `gitlab://project/{id}/file/{ref}/{+path}`  | File contents at ref               |
-| Wiki Page       | `gitlab://project/{id}/wiki/{slug}`         | Wiki page by slug                  |
-| Label           | `gitlab://project/{id}/label/{label_id}`    | Single project label               |
-| Milestone       | `gitlab://project/{id}/milestone/{iid}`     | Single project milestone           |
-| Board           | `gitlab://project/{id}/board/{board_id}`    | Single issue board                 |
-| Deployment      | `gitlab://project/{id}/deployment/{did}`    | Single deployment                  |
-| Environment     | `gitlab://project/{id}/environment/{eid}`   | Single environment                 |
-| Job             | `gitlab://project/{id}/job/{job_id}`        | Single CI/CD job                   |
-| Feature Flag    | `gitlab://project/{id}/feature_flag/{name}` | Single feature flag                |
-| Deploy Key      | `gitlab://project/{id}/deploy_key/{kid}`    | Single deploy key                  |
-| Project Snippet | `gitlab://project/{id}/snippet/{sid}`       | Single project snippet             |
-| MR Notes        | `gitlab://project/{id}/mr/{iid}/notes`      | Notes on a merge request           |
-| MR Discussions  | `gitlab://project/{id}/mr/{iid}/discussions`| Discussion threads on a MR         |
-| Group Label     | `gitlab://group/{id}/label/{label_id}`      | Single group label                 |
-| Group Milestone | `gitlab://group/{id}/milestone/{iid}`       | Single group milestone             |
-| Snippet         | `gitlab://snippet/{snippet_id}`             | Personal snippet                   |
-| Git Workflow Guide | `gitlab://guides/git-workflow`           | Branching and commit best practices |
-| MR Hygiene Guide | `gitlab://guides/merge-request-hygiene`    | MR sizing and review workflow      |
-| Conventional Commits Guide | `gitlab://guides/conventional-commits` | Commit message conventions     |
-| Code Review Guide | `gitlab://guides/code-review`             | Code review checklist              |
-| Pipeline Troubleshooting Guide | `gitlab://guides/pipeline-troubleshooting` | CI/CD debugging guide     |
+| Resource                       | URI                                          | Description                         |
+| ------------------------------ | -------------------------------------------- | ----------------------------------- |
+| Current User                   | `gitlab://user/current`                      | Authenticated user profile          |
+| Groups                         | `gitlab://groups`                            | Accessible groups list              |
+| Workspace Roots                | `gitlab://workspace/roots`                   | Client workspace root directories   |
+| Meta Schema                    | `gitlab://schema/meta/`                      | Registered meta-tool action index   |
+| Meta Action                    | `gitlab://schema/meta/{tool}/{action}`       | JSON Schema for action params       |
+| Group                          | `gitlab://group/{id}`                        | Group details by ID                 |
+| Group Members                  | `gitlab://group/{id}/members`                | Group members with access levels    |
+| Group Projects                 | `gitlab://group/{id}/projects`               | Projects within a group             |
+| Project                        | `gitlab://project/{id}`                      | Project metadata                    |
+| Members                        | `gitlab://project/{id}/members`              | Project members with access levels  |
+| Issues                         | `gitlab://project/{id}/issues`               | Open issues for a project           |
+| Issue                          | `gitlab://project/{id}/issue/{iid}`          | Specific issue details              |
+| Latest Pipeline                | `gitlab://project/{id}/pipelines/latest`     | Most recent pipeline                |
+| Pipeline                       | `gitlab://project/{id}/pipeline/{pid}`       | Specific pipeline details           |
+| Pipeline Jobs                  | `gitlab://project/{id}/pipeline/{pid}/jobs`  | Jobs for a pipeline                 |
+| Labels                         | `gitlab://project/{id}/labels`               | Project labels                      |
+| Milestones                     | `gitlab://project/{id}/milestones`           | Project milestones                  |
+| Merge Request                  | `gitlab://project/{id}/mr/{iid}`             | MR details by IID                   |
+| Branches                       | `gitlab://project/{id}/branches`             | All branches                        |
+| Branch                         | `gitlab://project/{id}/branch/{name}`        | Single branch by name               |
+| Releases                       | `gitlab://project/{id}/releases`             | Project releases                    |
+| Release                        | `gitlab://project/{id}/release/{tag}`        | Single release by tag               |
+| Tags                           | `gitlab://project/{id}/tags`                 | Repository tags                     |
+| Tag                            | `gitlab://project/{id}/tag/{name}`           | Single repository tag               |
+| Commit                         | `gitlab://project/{id}/commit/{sha}`         | Single commit by SHA                |
+| File Blob                      | `gitlab://project/{id}/file/{ref}/{+path}`   | File contents at ref                |
+| Wiki Page                      | `gitlab://project/{id}/wiki/{slug}`          | Wiki page by slug                   |
+| Label                          | `gitlab://project/{id}/label/{label_id}`     | Single project label                |
+| Milestone                      | `gitlab://project/{id}/milestone/{iid}`      | Single project milestone            |
+| Board                          | `gitlab://project/{id}/board/{board_id}`     | Single issue board                  |
+| Deployment                     | `gitlab://project/{id}/deployment/{did}`     | Single deployment                   |
+| Environment                    | `gitlab://project/{id}/environment/{eid}`    | Single environment                  |
+| Job                            | `gitlab://project/{id}/job/{job_id}`         | Single CI/CD job                    |
+| Feature Flag                   | `gitlab://project/{id}/feature_flag/{name}`  | Single feature flag                 |
+| Deploy Key                     | `gitlab://project/{id}/deploy_key/{kid}`     | Single deploy key                   |
+| Project Snippet                | `gitlab://project/{id}/snippet/{sid}`        | Single project snippet              |
+| MR Notes                       | `gitlab://project/{id}/mr/{iid}/notes`       | Notes on a merge request            |
+| MR Discussions                 | `gitlab://project/{id}/mr/{iid}/discussions` | Discussion threads on a MR          |
+| Group Label                    | `gitlab://group/{id}/label/{label_id}`       | Single group label                  |
+| Group Milestone                | `gitlab://group/{id}/milestone/{iid}`        | Single group milestone              |
+| Snippet                        | `gitlab://snippet/{snippet_id}`              | Personal snippet                    |
+| Git Workflow Guide             | `gitlab://guides/git-workflow`               | Branching and commit best practices |
+| MR Hygiene Guide               | `gitlab://guides/merge-request-hygiene`      | MR sizing and review workflow       |
+| Conventional Commits Guide     | `gitlab://guides/conventional-commits`       | Commit message conventions          |
+| Code Review Guide              | `gitlab://guides/code-review`                | Code review checklist               |
+| Pipeline Troubleshooting Guide | `gitlab://guides/pipeline-troubleshooting`   | CI/CD debugging guide               |
 
 ### Prompts (`internal/prompts`)
 
@@ -420,14 +420,14 @@ See [Dynamic Toolset](dynamic-tools.md) for configuration, examples, safety beha
 
 6 MCP capabilities extend the server beyond basic tool/resource/prompt handling:
 
-| Capability    | Package                | MCP Spec                | Description                                           |
-| ------------- | ---------------------- | ----------------------- | ----------------------------------------------------- |
-| Logging       | `internal/logging`     | Server → Client utility | Structured session logging (debug/info/warning/error) |
-| Completions   | `internal/completions` | Server → Client utility | Autocomplete for 17 argument types plus resource URIs |
-| Roots         | `internal/roots`       | Client → Server         | Workspace root tracking with git heuristics           |
-| Progress      | `internal/progress`    | Bidirectional utility   | Progress notifications for multi-step operations      |
-| Sampling      | `internal/sampling`    | Client → Server (LLM)  | LLM-assisted analysis with credential sanitization    |
-| Elicitation   | `internal/elicitation` | Client → Server (User)  | Interactive user prompts and confirmation dialogs     |
+| Capability  | Package                | MCP Spec                | Description                                           |
+| ----------- | ---------------------- | ----------------------- | ----------------------------------------------------- |
+| Logging     | `internal/logging`     | Server → Client utility | Structured session logging (debug/info/warning/error) |
+| Completions | `internal/completions` | Server → Client utility | Autocomplete for 17 argument types plus resource URIs |
+| Roots       | `internal/roots`       | Client → Server         | Workspace root tracking with git heuristics           |
+| Progress    | `internal/progress`    | Bidirectional utility   | Progress notifications for multi-step operations      |
+| Sampling    | `internal/sampling`    | Client → Server (LLM)   | LLM-assisted analysis with credential sanitization    |
+| Elicitation | `internal/elicitation` | Client → Server (User)  | Interactive user prompts and confirmation dialogs     |
 
 See [Capabilities Overview](capabilities/README.md) for detailed documentation.
 
@@ -579,18 +579,18 @@ sequenceDiagram
 
 ## Key Design Decisions
 
-| Decision                       | Rationale                                             | ADR                                                    |
-| ------------------------------ | ----------------------------------------------------- | ------------------------------------------------------ |
-| Go with official MCP SDK       | Type safety, single binary, cross-compilation         | —                                                      |
-| Official GitLab client library | Maintained by GitLab, complete API coverage           | —                                                      |
-| Modular tools sub-packages     | Domain isolation, independent testing, clean imports  | [ADR-0004](adr/adr-0004-modular-tools-subpackages.md)  |
-| Meta-tool consolidation (33/49/50) | Reduce tool count for LLM token efficiency; enterprise tier adds 16 self-managed tools plus GitLab.com-only Orbit | [ADR-0005](adr/adr-0005-meta-tool-consolidation.md)    |
-| Struct-based I/O               | Type safety + automatic JSON Schema generation        | Go SDK convention                                      |
-| Dual response format           | JSON for LLM tool-chaining + Markdown for display     | See [Output Format](output-format.md)               |
-| Content annotations            | Audience targeting + priority for display optimization | See [Output Format](output-format.md)               |
-| `next_steps` JSON enrichment   | Hints in structuredContent for JSON-only clients       | See [Output Format](output-format.md)               |
-| Tool annotations               | readOnlyHint, destructiveHint for client safety hints | MCP spec compliance                                    |
-| YOLO_MODE for automation       | Skip confirmations in CI/scripted environments        | —                                                      |
+| Decision                           | Rationale                                                                                                         | ADR                                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Go with official MCP SDK           | Type safety, single binary, cross-compilation                                                                     | —                                                     |
+| Official GitLab client library     | Maintained by GitLab, complete API coverage                                                                       | —                                                     |
+| Modular tools sub-packages         | Domain isolation, independent testing, clean imports                                                              | [ADR-0004](adr/adr-0004-modular-tools-subpackages.md) |
+| Meta-tool consolidation (33/49/50) | Reduce tool count for LLM token efficiency; enterprise tier adds 16 self-managed tools plus GitLab.com-only Orbit | [ADR-0005](adr/adr-0005-meta-tool-consolidation.md)   |
+| Struct-based I/O                   | Type safety + automatic JSON Schema generation                                                                    | Go SDK convention                                     |
+| Dual response format               | JSON for LLM tool-chaining + Markdown for display                                                                 | See [Output Format](output-format.md)                 |
+| Content annotations                | Audience targeting + priority for display optimization                                                            | See [Output Format](output-format.md)                 |
+| `next_steps` JSON enrichment       | Hints in structuredContent for JSON-only clients                                                                  | See [Output Format](output-format.md)                 |
+| Tool annotations                   | readOnlyHint, destructiveHint for client safety hints                                                             | MCP spec compliance                                   |
+| YOLO_MODE for automation           | Skip confirmations in CI/scripted environments                                                                    | —                                                     |
 
 ## Cross-Cutting Concerns
 
@@ -639,15 +639,15 @@ All list endpoints support pagination via `PaginationInput` (page, per_page) and
 
 ### Key files to understand the architecture
 
-| File                                   | What it teaches you                    |
-| -------------------------------------- | -------------------------------------- |
-| `cmd/server/main.go`                   | How all components wire together       |
-| `internal/toolutil/metatool.go`        | The meta-tool dispatcher pattern       |
-| `internal/tools/register_meta.go`      | How tools become meta-tools            |
-| `internal/tools/branches/branches.go`  | A complete tool handler example        |
-| `internal/toolutil/errors.go`          | Error handling patterns                |
-| `internal/tools/markdown.go`           | Response formatting conventions        |
-| `internal/completions/completions.go`  | Capability implementation pattern      |
+| File                                  | What it teaches you               |
+| ------------------------------------- | --------------------------------- |
+| `cmd/server/main.go`                  | How all components wire together  |
+| `internal/toolutil/metatool.go`       | The meta-tool dispatcher pattern  |
+| `internal/tools/register_meta.go`     | How tools become meta-tools       |
+| `internal/tools/branches/branches.go` | A complete tool handler example   |
+| `internal/toolutil/errors.go`         | Error handling patterns           |
+| `internal/tools/markdown.go`          | Response formatting conventions   |
+| `internal/completions/completions.go` | Capability implementation pattern |
 
 ---
 

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -55,11 +55,11 @@ The update mechanism uses [creativeprojects/go-selfupdate](https://github.com/cr
 
 The `AUTO_UPDATE` variable controls behaviour:
 
-| Value | Mode | Behaviour |
-| --- | --- | --- |
-| `true` (default) | Auto | Detect and apply updates automatically |
-| `check` | Check-only | Detect updates and log availability, but do not apply |
-| `false` | Disabled | Skip all update checks entirely |
+| Value            | Mode       | Behaviour                                             |
+| ---------------- | ---------- | ----------------------------------------------------- |
+| `true` (default) | Auto       | Detect and apply updates automatically                |
+| `check`          | Check-only | Detect updates and log availability, but do not apply |
+| `false`          | Disabled   | Skip all update checks entirely                       |
 
 Accepted aliases: `1`/`yes` for true, `0`/`no` for false. The value is case-insensitive.
 
@@ -124,23 +124,23 @@ When running as an HTTP server (`--http`), auto-update runs as a **background pe
 
 ### Environment Variables (Stdio Mode)
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `AUTO_UPDATE` | `true` | Update mode: `true`, `check`, or `false` |
-| `AUTO_UPDATE_REPO` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
-| `AUTO_UPDATE_INTERVAL` | `1h` | Check interval (used by HTTP mode periodic checks) |
-| `AUTO_UPDATE_TIMEOUT` | `60s` | Timeout for pre-start update download (range: 5s–10m) |
+| Variable               | Default                      | Description                                            |
+| ---------------------- | ---------------------------- | ------------------------------------------------------ |
+| `AUTO_UPDATE`          | `true`                       | Update mode: `true`, `check`, or `false`               |
+| `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
+| `AUTO_UPDATE_INTERVAL` | `1h`                         | Check interval (used by HTTP mode periodic checks)     |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Timeout for pre-start update download (range: 5s–10m)  |
 
 Auto-update uses the GitHub Releases API via `AUTO_UPDATE_REPO`. It does **not** use the user's `GITLAB_URL`, `GITLAB_TOKEN`, or `GITLAB_SKIP_TLS_VERIFY`.
 
 ### CLI Flags (HTTP Mode)
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--auto-update` | `true` | Update mode: `true`, `check`, or `false` |
-| `--auto-update-repo` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
-| `--auto-update-interval` | `1h` | Interval between periodic update checks |
-| `--auto-update-timeout` | `60s` | Timeout for pre-start update download (range: 5s–10m) |
+| Flag                     | Default                      | Description                                            |
+| ------------------------ | ---------------------------- | ------------------------------------------------------ |
+| `--auto-update`          | `true`                       | Update mode: `true`, `check`, or `false`               |
+| `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
+| `--auto-update-interval` | `1h`                         | Interval between periodic update checks                |
+| `--auto-update-timeout`  | `60s`                        | Timeout for pre-start update download (range: 5s–10m)  |
 
 Auto-update uses the GitHub Releases API, so `--gitlab-url` and `--skip-tls-verify` do **not** affect auto-update behaviour.
 
@@ -193,14 +193,14 @@ Check if a newer version of the MCP server is available.
 
 **Output**:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `update_available` | boolean | Whether a newer version exists |
-| `current_version` | string | Currently running version |
-| `latest_version` | string | Latest release version (if available) |
-| `release_url` | string | URL to the release page |
-| `release_notes` | string | Release notes content |
-| `mode` | string | Current auto-update mode |
+| Field              | Type    | Description                           |
+| ------------------ | ------- | ------------------------------------- |
+| `update_available` | boolean | Whether a newer version exists        |
+| `current_version`  | string  | Currently running version             |
+| `latest_version`   | string  | Latest release version (if available) |
+| `release_url`      | string  | URL to the release page               |
+| `release_notes`    | string  | Release notes content                 |
+| `mode`             | string  | Current auto-update mode              |
 
 **Annotations**: Read-only (`readOnlyHint: true`, `idempotentHint: true`).
 
@@ -227,12 +227,12 @@ Download and apply the latest MCP server update. The binary is replaced using th
 
 **Output**:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `applied` | boolean | Whether the update was applied (binary replaced on disk) |
-| `previous_version` | string | Version before the update |
-| `new_version` | string | Version after applying the update |
-| `message` | string | Human-readable status message |
+| Field              | Type    | Description                                              |
+| ------------------ | ------- | -------------------------------------------------------- |
+| `applied`          | boolean | Whether the update was applied (binary replaced on disk) |
+| `previous_version` | string  | Version before the update                                |
+| `new_version`      | string  | Version after applying the update                        |
+| `message`          | string  | Human-readable status message                            |
 
 **Annotations**: Destructive (`destructiveHint: true`) — replaces the server binary.
 
@@ -292,14 +292,14 @@ graph TD
 
 ### Package Responsibilities
 
-| Package | Role |
-| --- | --- |
-| `internal/autoupdate` | Core update logic: detect releases, download, rename trick replacement, re-exec (Unix), old binary cleanup. Transport-agnostic. |
-| `internal/autoupdate/exec_unix.go` | `ExecSelf()` — `syscall.Exec` to re-exec the process (same PID, same FDs). Build tag: `!windows`. |
-| `internal/autoupdate/exec_windows.go` | `ExecSelf()` — stub returning an error (exec not supported). Build tag: `windows`. |
-| `internal/autoupdate/prestart.go` | `PreStartUpdate()` — pre-start flow: check → download → rename → exec/log. |
-| `internal/tools/serverupdate` | MCP tool wrappers exposing `Check` and `Apply` as MCP tools with Markdown formatting. |
-| `cmd/server/main.go` | Wiring: calls `CleanupOldBinary()` and `preStartAutoUpdate` (stdio), `startAutoUpdate` (HTTP), `newUpdaterForTools` (MCP tools). |
+| Package                               | Role                                                                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/autoupdate`                 | Core update logic: detect releases, download, rename trick replacement, re-exec (Unix), old binary cleanup. Transport-agnostic.  |
+| `internal/autoupdate/exec_unix.go`    | `ExecSelf()` — `syscall.Exec` to re-exec the process (same PID, same FDs). Build tag: `!windows`.                                |
+| `internal/autoupdate/exec_windows.go` | `ExecSelf()` — stub returning an error (exec not supported). Build tag: `windows`.                                               |
+| `internal/autoupdate/prestart.go`     | `PreStartUpdate()` — pre-start flow: check → download → rename → exec/log.                                                       |
+| `internal/tools/serverupdate`         | MCP tool wrappers exposing `Check` and `Apply` as MCP tools with Markdown formatting.                                            |
+| `cmd/server/main.go`                  | Wiring: calls `CleanupOldBinary()` and `preStartAutoUpdate` (stdio), `startAutoUpdate` (HTTP), `newUpdaterForTools` (MCP tools). |
 
 ## Release Requirements
 
@@ -335,21 +335,21 @@ The Makefile `release` target generates all of these automatically.
 
 ## Troubleshooting
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `autoupdate: current version is required (binary built without -ldflags?)` | Binary built without version injection | Build with `make build` or add `-ldflags "-X main.version=1.2.0"` |
-| `autoupdate: repository is required` | `AUTO_UPDATE_REPO` is empty | Set `AUTO_UPDATE_REPO` or use the default |
-| `autoupdate: creating GitHub source` | Network error reaching GitHub API | Verify network connectivity to `github.com` |
-| `autoupdate: detecting latest release` | No releases in repository, or token lacks permissions | Create a release or check token permissions |
-| `autoupdate: startup check failed` | Network timeout (`AUTO_UPDATE_TIMEOUT`, default 60s) | Check network connectivity or increase `AUTO_UPDATE_TIMEOUT`; the server starts anyway |
-| `autoupdate: could not initialize periodic updater` | Missing required config in HTTP mode | Verify `--auto-update-repo` flag and network connectivity |
-| Update detected but not applied | Mode is `check` | Set `AUTO_UPDATE=true` to enable automatic application |
-| Server still runs old version after update (Windows) | Binary replaced but process not restarted | Restart the server process (Windows only — Unix re-execs automatically) |
-| `autoupdate: exec-self failed` | `syscall.Exec` failed on Unix | Server continues with old code; restart manually |
-| `autoupdate: skipping update check (just re-executed after update)` | Normal: re-exec guard preventing loop | No action needed — this is expected after a successful update |
-| `autoupdate: invalid GPG public key, falling back to checksum-only validation` | Malformed or corrupted PGP key file | Verify the key file is a valid armored PGP public key (`gpg --show-keys key.pub`) |
-| `autoupdate: GPG key path is not a regular file` | Path points to directory, symlink, or device | Ensure `AUTO_UPDATE_GPG_KEY` points to a regular file |
-| GPG verification configured but updates still work without `.asc` file | `checksums.txt.asc` missing in release → falls back to checksum-only | Upload signed checksums to the release (`GPG_SIGN=1 make release`) |
+| Symptom                                                                        | Cause                                                                | Solution                                                                               |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `autoupdate: current version is required (binary built without -ldflags?)`     | Binary built without version injection                               | Build with `make build` or add `-ldflags "-X main.version=1.2.0"`                      |
+| `autoupdate: repository is required`                                           | `AUTO_UPDATE_REPO` is empty                                          | Set `AUTO_UPDATE_REPO` or use the default                                              |
+| `autoupdate: creating GitHub source`                                           | Network error reaching GitHub API                                    | Verify network connectivity to `github.com`                                            |
+| `autoupdate: detecting latest release`                                         | No releases in repository, or token lacks permissions                | Create a release or check token permissions                                            |
+| `autoupdate: startup check failed`                                             | Network timeout (`AUTO_UPDATE_TIMEOUT`, default 60s)                 | Check network connectivity or increase `AUTO_UPDATE_TIMEOUT`; the server starts anyway |
+| `autoupdate: could not initialize periodic updater`                            | Missing required config in HTTP mode                                 | Verify `--auto-update-repo` flag and network connectivity                              |
+| Update detected but not applied                                                | Mode is `check`                                                      | Set `AUTO_UPDATE=true` to enable automatic application                                 |
+| Server still runs old version after update (Windows)                           | Binary replaced but process not restarted                            | Restart the server process (Windows only — Unix re-execs automatically)                |
+| `autoupdate: exec-self failed`                                                 | `syscall.Exec` failed on Unix                                        | Server continues with old code; restart manually                                       |
+| `autoupdate: skipping update check (just re-executed after update)`            | Normal: re-exec guard preventing loop                                | No action needed — this is expected after a successful update                          |
+| `autoupdate: invalid GPG public key, falling back to checksum-only validation` | Malformed or corrupted PGP key file                                  | Verify the key file is a valid armored PGP public key (`gpg --show-keys key.pub`)      |
+| `autoupdate: GPG key path is not a regular file`                               | Path points to directory, symlink, or device                         | Ensure `AUTO_UPDATE_GPG_KEY` points to a regular file                                  |
+| GPG verification configured but updates still work without `.asc` file         | `checksums.txt.asc` missing in release → falls back to checksum-only | Upload signed checksums to the release (`GPG_SIGN=1 make release`)                     |
 
 ## Disabling Auto-Update
 

--- a/docs/capabilities/completions.md
+++ b/docs/capabilities/completions.md
@@ -93,40 +93,40 @@ The server supports **17 argument types** across prompts and resources.
 
 These completers search across the entire GitLab instance. They do not require a project context.
 
-| Argument | Query Method | Example Input → Suggestions |
-| -------- | ------------ | --------------------------- |
+| Argument     | Query Method                    | Example Input → Suggestions                                   |
+| ------------ | ------------------------------- | ------------------------------------------------------------- |
 | `project_id` | Search projects by path or name | `mcp` → `group/gitlab-mcp-server`, `group/redmine-mcp-server` |
-| `group_id` | Search groups by name | `eng` → `engineering` |
-| `username` | Search GitLab users | `jreq` → `jmrplens` |
+| `group_id`   | Search groups by name           | `eng` → `engineering`                                         |
+| `username`   | Search GitLab users             | `jreq` → `jmrplens`                                           |
 
 ### Per-Project Completers
 
 These completers require a `project_id` context, which is extracted from previously resolved arguments in the same request.
 
-| Argument | Query Method | Example Input → Suggestions |
-| -------- | ------------ | --------------------------- |
-| `branch`, `source_branch`, `target_branch` | List branches matching prefix | `feat` → `feature/login`, `feature/signup` |
-| `from`, `to`, `ref` | Branches + tags matching prefix | `v1` → `v1.0.0`, `v1.1.7`, `v1-branch` |
-| `tag` | List tags matching prefix | `v1.1` → `v1.1.5`, `v1.1.6`, `v1.1.7` |
-| `merge_request_iid` | List open MRs, filter by IID prefix | `1` → `15`, `14` (titles fetched separately by client) |
-| `issue_iid` | List open issues, filter by IID | `3` → `33`, `34` |
-| `pipeline_id` | Recent pipelines, filter by ID prefix | `415` → `41557`, `41556` |
-| `sha` | Recent commits, filter by SHA prefix | `ddc` → `ddcc2f13` |
-| `label` | Project labels matching prefix | `type` → `type::bug`, `type::enhancement` |
-| `milestone_id` | Milestones matching title | `v1` → `1`, `2` (IDs; titles fetched separately) |
-| `job_id` | Jobs in a pipeline, filter by ID | `10` → `100`, `101` |
+| Argument                                   | Query Method                          | Example Input → Suggestions                            |
+| ------------------------------------------ | ------------------------------------- | ------------------------------------------------------ |
+| `branch`, `source_branch`, `target_branch` | List branches matching prefix         | `feat` → `feature/login`, `feature/signup`             |
+| `from`, `to`, `ref`                        | Branches + tags matching prefix       | `v1` → `v1.0.0`, `v1.1.7`, `v1-branch`                 |
+| `tag`                                      | List tags matching prefix             | `v1.1` → `v1.1.5`, `v1.1.6`, `v1.1.7`                  |
+| `merge_request_iid`                        | List open MRs, filter by IID prefix   | `1` → `15`, `14` (titles fetched separately by client) |
+| `issue_iid`                                | List open issues, filter by IID       | `3` → `33`, `34`                                       |
+| `pipeline_id`                              | Recent pipelines, filter by ID prefix | `415` → `41557`, `41556`                               |
+| `sha`                                      | Recent commits, filter by SHA prefix  | `ddc` → `ddcc2f13`                                     |
+| `label`                                    | Project labels matching prefix        | `type` → `type::bug`, `type::enhancement`              |
+| `milestone_id`                             | Milestones matching title             | `v1` → `1`, `2` (IDs; titles fetched separately)       |
+| `job_id`                                   | Jobs in a pipeline, filter by ID      | `10` → `100`, `101`                                    |
 
 The `job_id` completer is special — it requires both `project_id` and `pipeline_id` to be resolved first.
 
 ## Configuration
 
-| Setting | Value | Notes |
-| ------- | ----- | ----- |
-| Max results | 10 per request | `maxCompletionResults` constant; aligned with MCP spec recommendation |
-| Error handling | Graceful | Returns empty results on API errors |
-| Caching | None | Queries GitLab API in real-time for freshness |
-| `total` field | Populated from GitLab `X-Total` header | When the underlying GitLab call returns `X-Total`, the value is forwarded to `CompletionResultDetails.Total` so clients can display “N of M matches” |
-| `hasMore` field | Computed from total vs. returned | Set to `true` when more results exist beyond the returned slice |
+| Setting         | Value                                  | Notes                                                                                                                                                |
+| --------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Max results     | 10 per request                         | `maxCompletionResults` constant; aligned with MCP spec recommendation                                                                                |
+| Error handling  | Graceful                               | Returns empty results on API errors                                                                                                                  |
+| Caching         | None                                   | Queries GitLab API in real-time for freshness                                                                                                        |
+| `total` field   | Populated from GitLab `X-Total` header | When the underlying GitLab call returns `X-Total`, the value is forwarded to `CompletionResultDetails.Total` so clients can display “N of M matches” |
+| `hasMore` field | Computed from total vs. returned       | Set to `true` when more results exist beyond the returned slice                                                                                      |
 
 ### Spec compliance
 
@@ -208,11 +208,11 @@ Values are the bare IIDs; the client fetches MR titles via `gitlab_mr_get` (or a
 
 Completions are not just a user-facing convenience — they also help the **AI itself** select correct parameters. When the AI is composing a tool call and needs to fill in a `branch` argument, completions provide the actual branch names from GitLab rather than forcing the AI to guess or hallucinate.
 
-| Without Completions | With Completions |
-| ------------------- | ---------------- |
+| Without Completions               | With Completions                              |
+| --------------------------------- | --------------------------------------------- |
 | AI guesses `main` (may not exist) | AI receives `develop` (actual default branch) |
-| AI uses wrong MR IID from memory | AI gets list of actual open MRs |
-| AI invents a tag name | AI selects from real tags |
+| AI uses wrong MR IID from memory  | AI gets list of actual open MRs               |
+| AI invents a tag name             | AI selects from real tags                     |
 
 This is especially valuable for **per-project context** — branch names, labels, and milestones vary across projects and cannot be guessed reliably.
 

--- a/docs/capabilities/elicitation.md
+++ b/docs/capabilities/elicitation.md
@@ -107,19 +107,19 @@ if !elicitClient.IsSupported() {
 
 ### Methods
 
-| Method | Signature | Purpose |
-| ------ | --------- | ------- |
-| `FromRequest(req)` | `(*mcp.CallToolRequest) Client` | Create client from tool request |
-| `IsSupported()` | `() bool` | Check if client has elicitation capability |
-| `IsURLSupported()` | `() bool` | Check if client supports URL mode elicitation |
-| `Confirm(ctx, message)` | `(...) (bool, error)` | Ask a yes/no question |
-| `PromptText(ctx, message, field)` | `(...) (string, error)` | Request free-form text input |
-| `PromptNumber(ctx, message, field, min, max)` | `(...) (float64, error)` | Request numeric input with bounds |
-| `SelectOne(ctx, message, options)` | `(...) (string, error)` | Single-choice selection from a list |
-| `SelectOneInt(ctx, message, options)` | `(...) (int, error)` | Single-choice selection from an integer list |
-| `SelectMulti(ctx, message, options, min, max)` | `(...) ([]string, error)` | Multi-choice selection with cardinality bounds |
-| `GatherData(ctx, message, schema)` | `(...) (map[string]any, error)` | Request structured data via JSON Schema |
-| `ElicitURL(ctx, gitlabBaseURL, targetURL, msg)` | `(...) error` | Open a GitLab URL in the client (URL mode) |
+| Method                                          | Signature                       | Purpose                                        |
+| ----------------------------------------------- | ------------------------------- | ---------------------------------------------- |
+| `FromRequest(req)`                              | `(*mcp.CallToolRequest) Client` | Create client from tool request                |
+| `IsSupported()`                                 | `() bool`                       | Check if client has elicitation capability     |
+| `IsURLSupported()`                              | `() bool`                       | Check if client supports URL mode elicitation  |
+| `Confirm(ctx, message)`                         | `(...) (bool, error)`           | Ask a yes/no question                          |
+| `PromptText(ctx, message, field)`               | `(...) (string, error)`         | Request free-form text input                   |
+| `PromptNumber(ctx, message, field, min, max)`   | `(...) (float64, error)`        | Request numeric input with bounds              |
+| `SelectOne(ctx, message, options)`              | `(...) (string, error)`         | Single-choice selection from a list            |
+| `SelectOneInt(ctx, message, options)`           | `(...) (int, error)`            | Single-choice selection from an integer list   |
+| `SelectMulti(ctx, message, options, min, max)`  | `(...) ([]string, error)`       | Multi-choice selection with cardinality bounds |
+| `GatherData(ctx, message, schema)`              | `(...) (map[string]any, error)` | Request structured data via JSON Schema        |
+| `ElicitURL(ctx, gitlabBaseURL, targetURL, msg)` | `(...) error`                   | Open a GitLab URL in the client (URL mode)     |
 
 **Method selection guide:**
 
@@ -134,12 +134,12 @@ if !elicitClient.IsSupported() {
 
 ### Error Types
 
-| Error | Meaning | Tool Handler Action |
-| ----- | ------- | ------------------- |
-| `ErrElicitationNotSupported` | Client does not support elicitation | Return informational message explaining the requirement |
-| `ErrURLElicitationNotSupported` | Client does not support URL mode elicitation | Fall back to text-based workflow |
-| `ErrDeclined` | User declined the elicitation request | Return cancellation message via `CancelledResult` |
-| `ErrCancelled` | User cancelled the elicitation flow | Return cancellation message via `CancelledResult` |
+| Error                           | Meaning                                      | Tool Handler Action                                     |
+| ------------------------------- | -------------------------------------------- | ------------------------------------------------------- |
+| `ErrElicitationNotSupported`    | Client does not support elicitation          | Return informational message explaining the requirement |
+| `ErrURLElicitationNotSupported` | Client does not support URL mode elicitation | Fall back to text-based workflow                        |
+| `ErrDeclined`                   | User declined the elicitation request        | Return cancellation message via `CancelledResult`       |
+| `ErrCancelled`                  | User cancelled the elicitation flow          | Return cancellation message via `CancelledResult`       |
 
 ### Cancellation Helper
 
@@ -177,46 +177,46 @@ Every elicitation tool includes a final `Confirm` step before executing any writ
 
 ### `gitlab_interactive_issue_create`
 
-| Step | Method | Field | Required |
-| ---: | ------ | ----- | :------: |
-| 1 | `PromptText` | Title | Yes |
-| 2 | `PromptText` | Description | No |
-| 3 | `PromptText` | Labels (comma-separated) | No |
-| 4 | `Confirm` | Confidential? | — |
-| 5 | `Confirm` | Create issue? | — |
+| Step | Method       | Field                    | Required |
+| ---: | ------------ | ------------------------ | :------: |
+|    1 | `PromptText` | Title                    |   Yes    |
+|    2 | `PromptText` | Description              |    No    |
+|    3 | `PromptText` | Labels (comma-separated) |    No    |
+|    4 | `Confirm`    | Confidential?            |    —     |
+|    5 | `Confirm`    | Create issue?            |    —     |
 
 ### `gitlab_interactive_mr_create`
 
-| Step | Method | Field | Required |
-| ---: | ------ | ----- | :------: |
-| 1 | `PromptText` | Source branch | Yes |
-| 2 | `PromptText` | Target branch | Yes |
-| 3 | `PromptText` | Title | Yes |
-| 4 | `PromptText` | Description | No |
-| 5 | `PromptText` | Labels (comma-separated) | No |
-| 6 | `Confirm` | Squash commits? | — |
-| 7 | `Confirm` | Remove source branch? | — |
-| 8 | `Confirm` | Create MR? | — |
+| Step | Method       | Field                    | Required |
+| ---: | ------------ | ------------------------ | :------: |
+|    1 | `PromptText` | Source branch            |   Yes    |
+|    2 | `PromptText` | Target branch            |   Yes    |
+|    3 | `PromptText` | Title                    |   Yes    |
+|    4 | `PromptText` | Description              |    No    |
+|    5 | `PromptText` | Labels (comma-separated) |    No    |
+|    6 | `Confirm`    | Squash commits?          |    —     |
+|    7 | `Confirm`    | Remove source branch?    |    —     |
+|    8 | `Confirm`    | Create MR?               |    —     |
 
 ### `gitlab_interactive_release_create`
 
-| Step | Method | Field | Required |
-| ---: | ------ | ----- | :------: |
-| 1 | `PromptText` | Tag name | Yes |
-| 2 | `PromptText` | Release name | Yes |
-| 3 | `PromptText` | Description | No |
-| 4 | `Confirm` | Create release? | — |
+| Step | Method       | Field           | Required |
+| ---: | ------------ | --------------- | :------: |
+|    1 | `PromptText` | Tag name        |   Yes    |
+|    2 | `PromptText` | Release name    |   Yes    |
+|    3 | `PromptText` | Description     |    No    |
+|    4 | `Confirm`    | Create release? |    —     |
 
 ### `gitlab_interactive_project_create`
 
-| Step | Method | Field | Required |
-| ---: | ------ | ----- | :------: |
-| 1 | `PromptText` | Project name | Yes |
-| 2 | `PromptText` | Description | No |
-| 3 | `SelectOne` | Visibility (public/private/internal) | Yes |
-| 4 | `Confirm` | Initialize with README? | — |
-| 5 | `PromptText` | Default branch name | No |
-| 6 | `Confirm` | Create project? | — |
+| Step | Method       | Field                                | Required |
+| ---: | ------------ | ------------------------------------ | :------: |
+|    1 | `PromptText` | Project name                         |   Yes    |
+|    2 | `PromptText` | Description                          |    No    |
+|    3 | `SelectOne`  | Visibility (public/private/internal) |   Yes    |
+|    4 | `Confirm`    | Initialize with README?              |    —     |
+|    5 | `PromptText` | Default branch name                  |    No    |
+|    6 | `Confirm`    | Create project?                      |    —     |
 
 ## Real-World Scenarios
 
@@ -246,14 +246,14 @@ The entire flow happens in structured form fields rather than back-and-forth cha
 
 ## Elicitation vs Parameterized Tools
 
-| Aspect | Parameterized Tool | Elicitation Tool |
-| ------ | ------------------ | ---------------- |
-| **Input method** | AI provides all parameters at once | Server prompts user step by step |
-| **User interaction** | Indirect (through AI chat) | Direct (structured forms) |
-| **Validation** | At tool execution time | At each step, before proceeding |
-| **Cancellation** | Not possible mid-execution | User can cancel at any step |
-| **Best for** | Automation, scripting, batch operations | Interactive creation, first-time users |
-| **AI context needed** | AI must know all parameters upfront | AI only needs to decide which tool to call |
+| Aspect                | Parameterized Tool                      | Elicitation Tool                           |
+| --------------------- | --------------------------------------- | ------------------------------------------ |
+| **Input method**      | AI provides all parameters at once      | Server prompts user step by step           |
+| **User interaction**  | Indirect (through AI chat)              | Direct (structured forms)                  |
+| **Validation**        | At tool execution time                  | At each step, before proceeding            |
+| **Cancellation**      | Not possible mid-execution              | User can cancel at any step                |
+| **Best for**          | Automation, scripting, batch operations | Interactive creation, first-time users     |
+| **AI context needed** | AI must know all parameters upfront     | AI only needs to decide which tool to call |
 
 Both types coexist in this server. The regular `gitlab_create_issue` tool accepts all parameters at once (better for automation), while `gitlab_interactive_issue_create` guides the user through each field (better for interactive use).
 

--- a/docs/capabilities/icons.md
+++ b/docs/capabilities/icons.md
@@ -26,22 +26,22 @@ interface Icon {
 
 ### Client MIME Type Support
 
-| MIME Type | Support Level | Notes |
-| --------- | ------------- | ----- |
-| `image/png` | **MUST** support | Universal compatibility |
-| `image/jpeg` | **MUST** support | Universal compatibility |
+| MIME Type       | Support Level      | Notes                          |
+| --------------- | ------------------ | ------------------------------ |
+| `image/png`     | **MUST** support   | Universal compatibility        |
+| `image/jpeg`    | **MUST** support   | Universal compatibility        |
 | `image/svg+xml` | **SHOULD** support | Scalable, used by this project |
-| `image/webp` | **SHOULD** support | Modern efficient format |
+| `image/webp`    | **SHOULD** support | Modern efficient format        |
 
 gitlab-mcp-server uses `image/svg+xml` exclusively. Clients that only implement the MUST-level MIME types (PNG/JPEG) will not render these icons.
 
 ### Client Compatibility
 
-| MCP Client | SVG Icons | Notes |
-| ---------- | --------- | ----- |
-| VS Code (GitHub Copilot) | Yes | Full SVG rendering support |
-| Claude Desktop | No | Does not render tool icons |
-| Continue.dev | Partial | Depends on version |
+| MCP Client               | SVG Icons | Notes                      |
+| ------------------------ | --------- | -------------------------- |
+| VS Code (GitHub Copilot) | Yes       | Full SVG rendering support |
+| Claude Desktop           | No        | Does not render tool icons |
+| Continue.dev             | Partial   | Depends on version         |
 
 ## Implementation Details
 
@@ -102,118 +102,118 @@ All 50 icons with their SVG preview, exported variable name, and the tool packag
 
 ### Source Control
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/branch.svg" width="32" height="32" alt="Branch"> | `IconBranch` | branches, repository, repositorysubmodules |
-| <img src="icons/commit.svg" width="32" height="32" alt="Commit"> | `IconCommit` | commits, mrcontextcommits |
-| <img src="icons/tag.svg" width="32" height="32" alt="Tag"> | `IconTag` | tags |
-| <img src="icons/release.svg" width="32" height="32" alt="Release"> | `IconRelease` | releases |
-| <img src="icons/file.svg" width="32" height="32" alt="File"> | `IconFile` | files, markdown, pages |
+| Preview                                                            | Name          | Packages                                   |
+| ------------------------------------------------------------------ | ------------- | ------------------------------------------ |
+| <img src="icons/branch.svg" width="32" height="32" alt="Branch">   | `IconBranch`  | branches, repository, repositorysubmodules |
+| <img src="icons/commit.svg" width="32" height="32" alt="Commit">   | `IconCommit`  | commits, mrcontextcommits                  |
+| <img src="icons/tag.svg" width="32" height="32" alt="Tag">         | `IconTag`     | tags                                       |
+| <img src="icons/release.svg" width="32" height="32" alt="Release"> | `IconRelease` | releases                                   |
+| <img src="icons/file.svg" width="32" height="32" alt="File">       | `IconFile`    | files, markdown, pages                     |
 
 ### Issues and Planning
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/issue.svg" width="32" height="32" alt="Issue"> | `IconIssue` | issues, workitems |
-| <img src="icons/label.svg" width="32" height="32" alt="Label"> | `IconLabel` | awardemoji, badges, grouplabels, labels, topics |
-| <img src="icons/milestone.svg" width="32" height="32" alt="Milestone"> | `IconMilestone` | groupmilestones, milestones |
-| <img src="icons/board.svg" width="32" height="32" alt="Board"> | `IconBoard` | boards, groupboards |
-| <img src="icons/link.svg" width="32" height="32" alt="Link"> | `IconLink` | issuelinks, releaselinks |
-| <img src="icons/epic.svg" width="32" height="32" alt="Epic"> | `IconEpic` | epicissues, epicnotes, epics |
-| <img src="icons/todo.svg" width="32" height="32" alt="Todo"> | `IconTodo` | todos |
+| Preview                                                                | Name            | Packages                                        |
+| ---------------------------------------------------------------------- | --------------- | ----------------------------------------------- |
+| <img src="icons/issue.svg" width="32" height="32" alt="Issue">         | `IconIssue`     | issues, workitems                               |
+| <img src="icons/label.svg" width="32" height="32" alt="Label">         | `IconLabel`     | awardemoji, badges, grouplabels, labels, topics |
+| <img src="icons/milestone.svg" width="32" height="32" alt="Milestone"> | `IconMilestone` | groupmilestones, milestones                     |
+| <img src="icons/board.svg" width="32" height="32" alt="Board">         | `IconBoard`     | boards, groupboards                             |
+| <img src="icons/link.svg" width="32" height="32" alt="Link">           | `IconLink`      | issuelinks, releaselinks                        |
+| <img src="icons/epic.svg" width="32" height="32" alt="Epic">           | `IconEpic`      | epicissues, epicnotes, epics                    |
+| <img src="icons/todo.svg" width="32" height="32" alt="Todo">           | `IconTodo`      | todos                                           |
 
 ### Merge Requests
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/mr.svg" width="32" height="32" alt="MR"> | `IconMR` | deploymentmergerequests, mergerequests, mrapprovals, mrchanges |
+| Preview                                                                  | Name             | Packages                                                                                                                   |
+| ------------------------------------------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| <img src="icons/mr.svg" width="32" height="32" alt="MR">                 | `IconMR`         | deploymentmergerequests, mergerequests, mrapprovals, mrchanges                                                             |
 | <img src="icons/discussion.svg" width="32" height="32" alt="Discussion"> | `IconDiscussion` | commitdiscussions, epicdiscussions, issuediscussions, issuenotes, mrdiscussions, mrdraftnotes, mrnotes, snippetdiscussions |
 
 ### CI/CD
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/pipeline.svg" width="32" height="32" alt="Pipeline"> | `IconPipeline` | cilint, pipelines, pipelinetriggers |
-| <img src="icons/job.svg" width="32" height="32" alt="Job"> | `IconJob` | jobs, jobtokenscope |
-| <img src="icons/runner.svg" width="32" height="32" alt="Runner"> | `IconRunner` | clusteragents, runners, runnercontrollers, runnercontrollerscopes |
-| <img src="icons/schedule.svg" width="32" height="32" alt="Schedule"> | `IconSchedule` | freezeperiods, pipelineschedules |
-| <img src="icons/variable.svg" width="32" height="32" alt="Variable"> | `IconVariable` | civariables, groupvariables, instancevariables |
+| Preview                                                              | Name           | Packages                                                          |
+| -------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- |
+| <img src="icons/pipeline.svg" width="32" height="32" alt="Pipeline"> | `IconPipeline` | cilint, pipelines, pipelinetriggers                               |
+| <img src="icons/job.svg" width="32" height="32" alt="Job">           | `IconJob`      | jobs, jobtokenscope                                               |
+| <img src="icons/runner.svg" width="32" height="32" alt="Runner">     | `IconRunner`   | clusteragents, runners, runnercontrollers, runnercontrollerscopes |
+| <img src="icons/schedule.svg" width="32" height="32" alt="Schedule"> | `IconSchedule` | freezeperiods, pipelineschedules                                  |
+| <img src="icons/variable.svg" width="32" height="32" alt="Variable"> | `IconVariable` | civariables, groupvariables, instancevariables                    |
 
 ### Environments and Deployments
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/environment.svg" width="32" height="32" alt="Environment"> | `IconEnvironment` | environments |
-| <img src="icons/deploy.svg" width="32" height="32" alt="Deploy"> | `IconDeploy` | deployments |
-| <img src="icons/infra.svg" width="32" height="32" alt="Infra"> | `IconInfra` | terraformstates |
+| Preview                                                                    | Name              | Packages        |
+| -------------------------------------------------------------------------- | ----------------- | --------------- |
+| <img src="icons/environment.svg" width="32" height="32" alt="Environment"> | `IconEnvironment` | environments    |
+| <img src="icons/deploy.svg" width="32" height="32" alt="Deploy">           | `IconDeploy`      | deployments     |
+| <img src="icons/infra.svg" width="32" height="32" alt="Infra">             | `IconInfra`       | terraformstates |
 
 ### Projects and Groups
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/project.svg" width="32" height="32" alt="Project"> | `IconProject` | projectdiscovery, projects |
-| <img src="icons/group.svg" width="32" height="32" alt="Group"> | `IconGroup` | groups, namespaces |
-| <img src="icons/queue.svg" width="32" height="32" alt="Queue"> | `IconQueue` | resourcegroups |
-| <img src="icons/user.svg" width="32" height="32" alt="User"> | `IconUser` | accessrequests, avatar, ffuserlists, groupmembers, invites, members, users |
-| <img src="icons/bot.svg" width="32" height="32" alt="Bot"> | `IconBot` | groupserviceaccounts |
+| Preview                                                            | Name          | Packages                                                                   |
+| ------------------------------------------------------------------ | ------------- | -------------------------------------------------------------------------- |
+| <img src="icons/project.svg" width="32" height="32" alt="Project"> | `IconProject` | projectdiscovery, projects                                                 |
+| <img src="icons/group.svg" width="32" height="32" alt="Group">     | `IconGroup`   | groups, namespaces                                                         |
+| <img src="icons/queue.svg" width="32" height="32" alt="Queue">     | `IconQueue`   | resourcegroups                                                             |
+| <img src="icons/user.svg" width="32" height="32" alt="User">       | `IconUser`    | accessrequests, avatar, ffuserlists, groupmembers, invites, members, users |
+| <img src="icons/bot.svg" width="32" height="32" alt="Bot">         | `IconBot`     | groupserviceaccounts                                                       |
 
 ### Packages and Registry
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/package.svg" width="32" height="32" alt="Package"> | `IconPackage` | dependencyproxy, packages |
-| <img src="icons/container.svg" width="32" height="32" alt="Container"> | `IconContainer` | containerregistry |
+| Preview                                                                | Name            | Packages                  |
+| ---------------------------------------------------------------------- | --------------- | ------------------------- |
+| <img src="icons/package.svg" width="32" height="32" alt="Package">     | `IconPackage`   | dependencyproxy, packages |
+| <img src="icons/container.svg" width="32" height="32" alt="Container"> | `IconContainer` | containerregistry         |
 
 ### Search and Analytics
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/search.svg" width="32" height="32" alt="Search"> | `IconSearch` | search |
+| Preview                                                                | Name            | Packages                                                                    |
+| ---------------------------------------------------------------------- | --------------- | --------------------------------------------------------------------------- |
+| <img src="icons/search.svg" width="32" height="32" alt="Search">       | `IconSearch`    | search                                                                      |
 | <img src="icons/analytics.svg" width="32" height="32" alt="Analytics"> | `IconAnalytics` | appstatistics, issuestatistics, projectstatistics, samplingtools, usagedata |
 
 ### Security and Access
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/security.svg" width="32" height="32" alt="Security"> | `IconSecurity` | externalstatuschecks, groupscim, license, memberroles, securefiles, securityattributes, securitycategories, securitysettings |
-| <img src="icons/shield.svg" width="32" height="32" alt="Shield"> | `IconShield` | groupprotectedbranches, groupprotectedenvs, protectedenvs, protectedpackages |
-| <img src="icons/vulnerability.svg" width="32" height="32" alt="Vulnerability"> | `IconVulnerability` | securityfindings, vulnerabilities |
-| <img src="icons/compliance.svg" width="32" height="32" alt="Compliance"> | `IconCompliance` | attestations, compliancepolicy |
-| <img src="icons/token.svg" width="32" height="32" alt="Token"> | `IconToken` | accesstokens, deploytokens, jobtokenscope, runnercontrollertokens |
-| <img src="icons/key.svg" width="32" height="32" alt="Key"> | `IconKey` | deploykeys, keys |
+| Preview                                                                        | Name                | Packages                                                                                                                     |
+| ------------------------------------------------------------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| <img src="icons/security.svg" width="32" height="32" alt="Security">           | `IconSecurity`      | externalstatuschecks, groupscim, license, memberroles, securefiles, securityattributes, securitycategories, securitysettings |
+| <img src="icons/shield.svg" width="32" height="32" alt="Shield">               | `IconShield`        | groupprotectedbranches, groupprotectedenvs, protectedenvs, protectedpackages                                                 |
+| <img src="icons/vulnerability.svg" width="32" height="32" alt="Vulnerability"> | `IconVulnerability` | securityfindings, vulnerabilities                                                                                            |
+| <img src="icons/compliance.svg" width="32" height="32" alt="Compliance">       | `IconCompliance`    | attestations, compliancepolicy                                                                                               |
+| <img src="icons/token.svg" width="32" height="32" alt="Token">                 | `IconToken`         | accesstokens, deploytokens, jobtokenscope, runnercontrollertokens                                                            |
+| <img src="icons/key.svg" width="32" height="32" alt="Key">                     | `IconKey`           | deploykeys, keys                                                                                                             |
 
 ### Documentation and Content
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/wiki.svg" width="32" height="32" alt="Wiki"> | `IconWiki` | wikis |
+| Preview                                                            | Name          | Packages |
+| ------------------------------------------------------------------ | ------------- | -------- |
+| <img src="icons/wiki.svg" width="32" height="32" alt="Wiki">       | `IconWiki`    | wikis    |
 | <img src="icons/snippet.svg" width="32" height="32" alt="Snippet"> | `IconSnippet` | snippets |
 
 ### Configuration and Administration
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/config.svg" width="32" height="32" alt="Config"> | `IconConfig` | appearance, applications, customattributes, dbmigrations, elicitationtools, featureflags, features, planlimits, settings, sidekiq |
-| <img src="icons/server.svg" width="32" height="32" alt="Server"> | `IconServer` | metadata, serverupdate |
-| <img src="icons/template.svg" width="32" height="32" alt="Template"> | `IconTemplate` | ciyamltemplates, dockerfiletemplates, gitignoretemplates, licensetemplates, projecttemplates |
+| Preview                                                              | Name           | Packages                                                                                                                          |
+| -------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| <img src="icons/config.svg" width="32" height="32" alt="Config">     | `IconConfig`   | appearance, applications, customattributes, dbmigrations, elicitationtools, featureflags, features, planlimits, settings, sidekiq |
+| <img src="icons/server.svg" width="32" height="32" alt="Server">     | `IconServer`   | metadata, serverupdate                                                                                                            |
+| <img src="icons/template.svg" width="32" height="32" alt="Template"> | `IconTemplate` | ciyamltemplates, dockerfiletemplates, gitignoretemplates, licensetemplates, projecttemplates                                      |
 
 ### Notifications and Events
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
+| Preview                                                          | Name         | Packages                         |
+| ---------------------------------------------------------------- | ------------ | -------------------------------- |
 | <img src="icons/notify.svg" width="32" height="32" alt="Notify"> | `IconNotify` | broadcastmessages, notifications |
-| <img src="icons/event.svg" width="32" height="32" alt="Event"> | `IconEvent` | events, resourceevents |
-| <img src="icons/audit.svg" width="32" height="32" alt="Audit"> | `IconAudit` | auditevents |
-| <img src="icons/alert.svg" width="32" height="32" alt="Alert"> | `IconAlert` | alertmanagement, errortracking |
+| <img src="icons/event.svg" width="32" height="32" alt="Event">   | `IconEvent`  | events, resourceevents           |
+| <img src="icons/audit.svg" width="32" height="32" alt="Audit">   | `IconAudit`  | auditevents                      |
+| <img src="icons/alert.svg" width="32" height="32" alt="Alert">   | `IconAlert`  | alertmanagement, errortracking   |
 
 ### Integrations and Operations
 
-| Preview | Name | Packages |
-| ------- | ---- | -------- |
-| <img src="icons/integration.svg" width="32" height="32" alt="Integration"> | `IconIntegration` | integrations, systemhooks |
-| <img src="icons/health.svg" width="32" height="32" alt="Health"> | `IconHealth` | health |
-| <img src="icons/upload.svg" width="32" height="32" alt="Upload"> | `IconUpload` | groupmarkdownuploads, uploads |
-| <img src="icons/import.svg" width="32" height="32" alt="Import"> | `IconImport` | bulkimports, groupimportexport, grouprelationsexport, importservice, projectimportexport |
+| Preview                                                                    | Name              | Packages                                                                                 |
+| -------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| <img src="icons/integration.svg" width="32" height="32" alt="Integration"> | `IconIntegration` | integrations, systemhooks                                                                |
+| <img src="icons/health.svg" width="32" height="32" alt="Health">           | `IconHealth`      | health                                                                                   |
+| <img src="icons/upload.svg" width="32" height="32" alt="Upload">           | `IconUpload`      | groupmarkdownuploads, uploads                                                            |
+| <img src="icons/import.svg" width="32" height="32" alt="Import">           | `IconImport`      | bulkimports, groupimportexport, grouprelationsexport, importservice, projectimportexport |
 
 <!-- markdownlint-enable MD033 -->
 
@@ -221,70 +221,70 @@ All 50 icons with their SVG preview, exported variable name, and the tool packag
 
 Alphabetical listing of all 50 icons and every sub-package that uses each one.
 
-| Icon | Variable | Packages |
-| ---- | -------- | -------- |
-| Alert | `IconAlert` | alertmanagement, errortracking |
-| Analytics | `IconAnalytics` | appstatistics, issuestatistics, projectstatistics, samplingtools, usagedata |
-| Audit | `IconAudit` | auditevents |
-| Board | `IconBoard` | boards, groupboards |
-| Bot | `IconBot` | groupserviceaccounts |
-| Branch | `IconBranch` | branches, repository, repositorysubmodules |
-| Commit | `IconCommit` | commits, mrcontextcommits |
-| Compliance | `IconCompliance` | attestations, compliancepolicy |
-| Config | `IconConfig` | appearance, applications, customattributes, dbmigrations, elicitationtools, featureflags, features, planlimits, settings, sidekiq |
-| Container | `IconContainer` | containerregistry |
-| Deploy | `IconDeploy` | deployments |
-| Discussion | `IconDiscussion` | commitdiscussions, epicdiscussions, issuediscussions, issuenotes, mrdiscussions, mrdraftnotes, mrnotes, snippetdiscussions |
-| Epic | `IconEpic` | epicissues, epicnotes, epics |
-| Environment | `IconEnvironment` | environments |
-| Event | `IconEvent` | events, resourceevents |
-| File | `IconFile` | files, markdown, pages |
-| Group | `IconGroup` | groups, namespaces |
-| Health | `IconHealth` | health |
-| Import | `IconImport` | bulkimports, groupimportexport, grouprelationsexport, importservice, projectimportexport |
-| Infra | `IconInfra` | terraformstates |
-| Integration | `IconIntegration` | integrations, systemhooks |
-| Issue | `IconIssue` | issues, workitems |
-| Job | `IconJob` | jobs, jobtokenscope |
-| Key | `IconKey` | deploykeys, keys |
-| Label | `IconLabel` | awardemoji, badges, grouplabels, labels, topics |
-| Link | `IconLink` | issuelinks, releaselinks |
-| MR | `IconMR` | deploymentmergerequests, mergerequests, mrapprovals, mrchanges |
-| Milestone | `IconMilestone` | groupmilestones, milestones |
-| Notify | `IconNotify` | broadcastmessages, notifications |
-| Package | `IconPackage` | dependencyproxy, packages |
-| Pipeline | `IconPipeline` | cilint, pipelines, pipelinetriggers |
-| Project | `IconProject` | projectdiscovery, projects |
-| Queue | `IconQueue` | resourcegroups |
-| Release | `IconRelease` | releases |
-| Runner | `IconRunner` | clusteragents, runners, runnercontrollers, runnercontrollerscopes |
-| Schedule | `IconSchedule` | freezeperiods, pipelineschedules |
-| Search | `IconSearch` | search |
-| Security | `IconSecurity` | externalstatuschecks, groupscim, license, memberroles, securefiles, securityattributes, securitycategories, securitysettings |
-| Server | `IconServer` | metadata, serverupdate |
-| Shield | `IconShield` | groupprotectedbranches, groupprotectedenvs, protectedenvs, protectedpackages |
-| Snippet | `IconSnippet` | snippets |
-| Tag | `IconTag` | tags |
-| Template | `IconTemplate` | ciyamltemplates, dockerfiletemplates, gitignoretemplates, licensetemplates, projecttemplates |
-| Todo | `IconTodo` | todos |
-| Token | `IconToken` | accesstokens, deploytokens, jobtokenscope, runnercontrollertokens |
-| Upload | `IconUpload` | groupmarkdownuploads, uploads |
-| User | `IconUser` | accessrequests, avatar, ffuserlists, groupmembers, invites, members, users |
-| Variable | `IconVariable` | civariables, groupvariables, instancevariables |
-| Vulnerability | `IconVulnerability` | securityfindings, vulnerabilities |
-| Wiki | `IconWiki` | wikis |
+| Icon          | Variable            | Packages                                                                                                                          |
+| ------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Alert         | `IconAlert`         | alertmanagement, errortracking                                                                                                    |
+| Analytics     | `IconAnalytics`     | appstatistics, issuestatistics, projectstatistics, samplingtools, usagedata                                                       |
+| Audit         | `IconAudit`         | auditevents                                                                                                                       |
+| Board         | `IconBoard`         | boards, groupboards                                                                                                               |
+| Bot           | `IconBot`           | groupserviceaccounts                                                                                                              |
+| Branch        | `IconBranch`        | branches, repository, repositorysubmodules                                                                                        |
+| Commit        | `IconCommit`        | commits, mrcontextcommits                                                                                                         |
+| Compliance    | `IconCompliance`    | attestations, compliancepolicy                                                                                                    |
+| Config        | `IconConfig`        | appearance, applications, customattributes, dbmigrations, elicitationtools, featureflags, features, planlimits, settings, sidekiq |
+| Container     | `IconContainer`     | containerregistry                                                                                                                 |
+| Deploy        | `IconDeploy`        | deployments                                                                                                                       |
+| Discussion    | `IconDiscussion`    | commitdiscussions, epicdiscussions, issuediscussions, issuenotes, mrdiscussions, mrdraftnotes, mrnotes, snippetdiscussions        |
+| Epic          | `IconEpic`          | epicissues, epicnotes, epics                                                                                                      |
+| Environment   | `IconEnvironment`   | environments                                                                                                                      |
+| Event         | `IconEvent`         | events, resourceevents                                                                                                            |
+| File          | `IconFile`          | files, markdown, pages                                                                                                            |
+| Group         | `IconGroup`         | groups, namespaces                                                                                                                |
+| Health        | `IconHealth`        | health                                                                                                                            |
+| Import        | `IconImport`        | bulkimports, groupimportexport, grouprelationsexport, importservice, projectimportexport                                          |
+| Infra         | `IconInfra`         | terraformstates                                                                                                                   |
+| Integration   | `IconIntegration`   | integrations, systemhooks                                                                                                         |
+| Issue         | `IconIssue`         | issues, workitems                                                                                                                 |
+| Job           | `IconJob`           | jobs, jobtokenscope                                                                                                               |
+| Key           | `IconKey`           | deploykeys, keys                                                                                                                  |
+| Label         | `IconLabel`         | awardemoji, badges, grouplabels, labels, topics                                                                                   |
+| Link          | `IconLink`          | issuelinks, releaselinks                                                                                                          |
+| MR            | `IconMR`            | deploymentmergerequests, mergerequests, mrapprovals, mrchanges                                                                    |
+| Milestone     | `IconMilestone`     | groupmilestones, milestones                                                                                                       |
+| Notify        | `IconNotify`        | broadcastmessages, notifications                                                                                                  |
+| Package       | `IconPackage`       | dependencyproxy, packages                                                                                                         |
+| Pipeline      | `IconPipeline`      | cilint, pipelines, pipelinetriggers                                                                                               |
+| Project       | `IconProject`       | projectdiscovery, projects                                                                                                        |
+| Queue         | `IconQueue`         | resourcegroups                                                                                                                    |
+| Release       | `IconRelease`       | releases                                                                                                                          |
+| Runner        | `IconRunner`        | clusteragents, runners, runnercontrollers, runnercontrollerscopes                                                                 |
+| Schedule      | `IconSchedule`      | freezeperiods, pipelineschedules                                                                                                  |
+| Search        | `IconSearch`        | search                                                                                                                            |
+| Security      | `IconSecurity`      | externalstatuschecks, groupscim, license, memberroles, securefiles, securityattributes, securitycategories, securitysettings      |
+| Server        | `IconServer`        | metadata, serverupdate                                                                                                            |
+| Shield        | `IconShield`        | groupprotectedbranches, groupprotectedenvs, protectedenvs, protectedpackages                                                      |
+| Snippet       | `IconSnippet`       | snippets                                                                                                                          |
+| Tag           | `IconTag`           | tags                                                                                                                              |
+| Template      | `IconTemplate`      | ciyamltemplates, dockerfiletemplates, gitignoretemplates, licensetemplates, projecttemplates                                      |
+| Todo          | `IconTodo`          | todos                                                                                                                             |
+| Token         | `IconToken`         | accesstokens, deploytokens, jobtokenscope, runnercontrollertokens                                                                 |
+| Upload        | `IconUpload`        | groupmarkdownuploads, uploads                                                                                                     |
+| User          | `IconUser`          | accessrequests, avatar, ffuserlists, groupmembers, invites, members, users                                                        |
+| Variable      | `IconVariable`      | civariables, groupvariables, instancevariables                                                                                    |
+| Vulnerability | `IconVulnerability` | securityfindings, vulnerabilities                                                                                                 |
+| Wiki          | `IconWiki`          | wikis                                                                                                                             |
 
 ## Testing
 
 Icon integrity is validated by 5 unit tests in [`internal/toolutil/icons_test.go`](../../internal/toolutil/icons_test.go):
 
-| Test | Validates |
-| ---- | --------- |
-| `TestAllIcons_ValidDataURI` | Every icon Source starts with `data:image/svg+xml;base64,` |
-| `TestAllIcons_CorrectMIMEType` | MIME type is `image/svg+xml` |
-| `TestAllIcons_NonEmpty` | Source is not empty |
-| `TestAllIcons_DecodesToSVG` | Base64 payload decodes to a `<svg>...</svg>` document |
-| `TestAllIcons_SizesAny` | `Sizes` field equals `["any"]` (scalable) |
+| Test                           | Validates                                                  |
+| ------------------------------ | ---------------------------------------------------------- |
+| `TestAllIcons_ValidDataURI`    | Every icon Source starts with `data:image/svg+xml;base64,` |
+| `TestAllIcons_CorrectMIMEType` | MIME type is `image/svg+xml`                               |
+| `TestAllIcons_NonEmpty`        | Source is not empty                                        |
+| `TestAllIcons_DecodesToSVG`    | Base64 payload decodes to a `<svg>...</svg>` document      |
+| `TestAllIcons_SizesAny`        | `Sizes` field equals `["any"]` (scalable)                  |
 
 ## Security Considerations
 

--- a/docs/capabilities/logging.md
+++ b/docs/capabilities/logging.md
@@ -83,16 +83,16 @@ logger := logging.NewSessionLogger(session)
 
 ### Log Levels
 
-| Method | MCP Level | Use Case |
-| ------ | --------- | -------- |
-| `Debug(ctx, message, data)` | `debug` | Detailed diagnostic information |
-| `Info(ctx, message, data)` | `info` | Normal operational events |
-| `Notice(ctx, message, data)` | `notice` | Significant but expected events |
-| `Warning(ctx, message, data)` | `warning` | Potential issues that don't block operation |
-| `Error(ctx, message, data)` | `error` | Failed operations |
-| `Critical(ctx, message, data)` | `critical` | Critical conditions requiring attention |
-| `Alert(ctx, message, data)` | `alert` | Action must be taken immediately |
-| `Emergency(ctx, message, data)` | `emergency` | System is unusable |
+| Method                          | MCP Level   | Use Case                                    |
+| ------------------------------- | ----------- | ------------------------------------------- |
+| `Debug(ctx, message, data)`     | `debug`     | Detailed diagnostic information             |
+| `Info(ctx, message, data)`      | `info`      | Normal operational events                   |
+| `Notice(ctx, message, data)`    | `notice`    | Significant but expected events             |
+| `Warning(ctx, message, data)`   | `warning`   | Potential issues that don't block operation |
+| `Error(ctx, message, data)`     | `error`     | Failed operations                           |
+| `Critical(ctx, message, data)`  | `critical`  | Critical conditions requiring attention     |
+| `Alert(ctx, message, data)`     | `alert`     | Action must be taken immediately            |
+| `Emergency(ctx, message, data)` | `emergency` | System is unusable                          |
 
 The server exposes the full set of [RFC 5424 syslog severity levels](https://datatracker.ietf.org/doc/html/rfc5424) required by the MCP 2025-11-25 spec. Catalog-backed tool handlers currently emit at `info` (success) and `error` (failure); the higher-severity helpers are available for callers that need them and for clients to filter via `logging/setLevel`.
 
@@ -119,19 +119,19 @@ On error, the payload includes `"status": "error"` and the error message.
 
 The `data` parameter in log methods controls the structure of the payload sent to the client:
 
-| Input | Result |
-| ----- | ------ |
-| `nil` | The message string becomes the payload |
+| Input            | Result                                           |
+| ---------------- | ------------------------------------------------ |
+| `nil`            | The message string becomes the payload           |
 | `map[string]any` | Message is added as a `"message"` key in the map |
-| Anything else | Wrapped in `{"message": "...", "data": ...}` |
+| Anything else    | Wrapped in `{"message": "...", "data": ...}`     |
 
 ## Configuration
 
-| Setting | Value | Notes |
-| ------- | ----- | ----- |
-| Logger name | `gitlab-mcp-server` | Constant, identifies the server in client logs |
-| Transport | MCP protocol notification | `notifications/message` |
-| Error handling | Silent | Failed sends logged to stderr at debug level |
+| Setting        | Value                     | Notes                                          |
+| -------------- | ------------------------- | ---------------------------------------------- |
+| Logger name    | `gitlab-mcp-server`       | Constant, identifies the server in client logs |
+| Transport      | MCP protocol notification | `notifications/message`                        |
+| Error handling | Silent                    | Failed sends logged to stderr at debug level   |
 
 ## Security
 
@@ -159,14 +159,14 @@ This means **every single tool call** (up to 1022 individual tools on GitLab.com
 
 The server produces two log streams. Understanding when to use each helps diagnose issues effectively.
 
-| Aspect | MCP Protocol Logging | stderr (slog) |
-| ------ | -------------------- | ------------- |
-| **Transport** | MCP `notifications/message` | stderr stream |
-| **Audience** | AI client and user | Server operator |
-| **Availability** | Only when MCP session is active | Always available |
-| **Structured data** | JSON payload with tool/duration/status | Text log lines |
-| **Typical use** | Tool call results, warnings for the user | Startup, shutdown, config issues |
-| **Security concern** | Data sent to client — never include secrets | Local only — less sensitive |
+| Aspect               | MCP Protocol Logging                        | stderr (slog)                    |
+| -------------------- | ------------------------------------------- | -------------------------------- |
+| **Transport**        | MCP `notifications/message`                 | stderr stream                    |
+| **Audience**         | AI client and user                          | Server operator                  |
+| **Availability**     | Only when MCP session is active             | Always available                 |
+| **Structured data**  | JSON payload with tool/duration/status      | Text log lines                   |
+| **Typical use**      | Tool call results, warnings for the user    | Startup, shutdown, config issues |
+| **Security concern** | Data sent to client — never include secrets | Local only — less sensitive      |
 
 In practice, both are always active. MCP logging provides the AI with operational context, while stderr provides the operator with detailed diagnostics (including debug-level messages from failed MCP log sends).
 

--- a/docs/capabilities/progress.md
+++ b/docs/capabilities/progress.md
@@ -76,12 +76,12 @@ Returns a `Tracker` bound to the request's session and progress token. If the re
 
 ### Methods
 
-| Method | Signature | Purpose |
-| ------ | --------- | ------- |
-| `IsActive()` | `() bool` | Check if tracker can send notifications |
+| Method                                  | Signature                                     | Purpose                                                                                  |
+| --------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `IsActive()`                            | `() bool`                                     | Check if tracker can send notifications                                                  |
 | `Update(ctx, progress, total, message)` | `(context.Context, float64, float64, string)` | Send progress with explicit float values. Drops non-monotonic updates (logged at debug). |
-| `Step(ctx, step, total, message)` | `(context.Context, int, int, string)` | Convenience: report 1-based step of N |
-| `Done(ctx, total, message)` | `(context.Context, float64, string)` | Send a final notification with `progress == total` to signal completion |
+| `Step(ctx, step, total, message)`       | `(context.Context, int, int, string)`         | Convenience: report 1-based step of N                                                    |
+| `Done(ctx, total, message)`             | `(context.Context, float64, string)`          | Send a final notification with `progress == total` to signal completion                  |
 
 #### Strictly-monotonic progress
 
@@ -106,11 +106,11 @@ tracker.Step(ctx, 4, 4, "Analysis complete")
 
 ## Configuration
 
-| Setting | Value | Notes |
-| ------- | ----- | ----- |
-| Token source | `CallToolRequest.Params.GetProgressToken()` | Provided by the MCP client |
-| Error handling | Silent | Failed notifications logged at debug level |
-| Context awareness | Yes | Returns early if context is canceled |
+| Setting           | Value                                       | Notes                                      |
+| ----------------- | ------------------------------------------- | ------------------------------------------ |
+| Token source      | `CallToolRequest.Params.GetProgressToken()` | Provided by the MCP client                 |
+| Error handling    | Silent                                      | Failed notifications logged at debug level |
+| Context awareness | Yes                                         | Returns early if context is canceled       |
 
 ## Security
 
@@ -120,16 +120,16 @@ tracker.Step(ctx, 4, 4, "Analysis complete")
 
 ## Tools Using Progress
 
-| Tool | Steps | What Each Step Reports |
-| ---- | ----: | ---------------------- |
-| `gitlab_analyze_mr_changes` | 4 | Check capability → Fetch MR → Fetch diffs → LLM analysis |
-| `gitlab_summarize_issue` | 4 | Check capability → Fetch issue → Fetch notes → LLM summary |
-| `gitlab_generate_release_notes` | 5 | Check capability → Compare refs → Fetch MRs → LLM notes → Done |
-| `gitlab_analyze_pipeline_failure` | 5 | Check capability → Fetch pipeline → Fetch jobs/traces → LLM analysis → Done |
-| `gitlab_interactive_issue_create` | 4 | Collect details → Optional fields → Confirm → Create |
-| `gitlab_interactive_mr_create` | 4 | Collect details → Options → Confirm → Create |
-| `gitlab_interactive_release_create` | 3 | Collect details → Confirm → Create |
-| `gitlab_interactive_project_create` | 4 | Collect details → Options → Confirm → Create |
+| Tool                                | Steps | What Each Step Reports                                                      |
+| ----------------------------------- | ----: | --------------------------------------------------------------------------- |
+| `gitlab_analyze_mr_changes`         |     4 | Check capability → Fetch MR → Fetch diffs → LLM analysis                    |
+| `gitlab_summarize_issue`            |     4 | Check capability → Fetch issue → Fetch notes → LLM summary                  |
+| `gitlab_generate_release_notes`     |     5 | Check capability → Compare refs → Fetch MRs → LLM notes → Done              |
+| `gitlab_analyze_pipeline_failure`   |     5 | Check capability → Fetch pipeline → Fetch jobs/traces → LLM analysis → Done |
+| `gitlab_interactive_issue_create`   |     4 | Collect details → Optional fields → Confirm → Create                        |
+| `gitlab_interactive_mr_create`      |     4 | Collect details → Options → Confirm → Create                                |
+| `gitlab_interactive_release_create` |     3 | Collect details → Confirm → Create                                          |
+| `gitlab_interactive_project_create` |     4 | Collect details → Options → Confirm → Create                                |
 
 Progress is most valuable for **sampling tools** (which make multiple GitLab API calls and then wait for LLM analysis) and **elicitation tools** (which require multiple rounds of user interaction).
 

--- a/docs/capabilities/roots.md
+++ b/docs/capabilities/roots.md
@@ -83,15 +83,15 @@ Roots are fetched eagerly on `notifications/initialized` (immediately after the 
 
 ### Methods
 
-| Method | Signature | Purpose |
-| ------ | --------- | ------- |
-| `NewManager()` | `() *Manager` | Create an empty root manager |
-| `Refresh(ctx, session)` | `(context.Context, *mcp.ServerSession) error` | Query client and cache current roots. No-op if the client did not advertise roots. |
-| `GetRoots()` | `() []*mcp.Root` | Return a copy of cached roots |
-| `FindGitRoot()` | `() (string, bool)` | Scan cached roots for a Git repository |
-| `HasRoot(uri)` | `(string) bool` | Check if a specific URI is in the cache |
-| `ListClientRoots(ctx, session)` | `(context.Context, *mcp.ServerSession) ([]*mcp.Root, error)` | Query roots without caching |
-| `ClientSupportsRoots(session)` | `(*mcp.ServerSession) bool` | Reports whether the client advertised the roots capability during initialization |
+| Method                          | Signature                                                    | Purpose                                                                            |
+| ------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `NewManager()`                  | `() *Manager`                                                | Create an empty root manager                                                       |
+| `Refresh(ctx, session)`         | `(context.Context, *mcp.ServerSession) error`                | Query client and cache current roots. No-op if the client did not advertise roots. |
+| `GetRoots()`                    | `() []*mcp.Root`                                             | Return a copy of cached roots                                                      |
+| `FindGitRoot()`                 | `() (string, bool)`                                          | Scan cached roots for a Git repository                                             |
+| `HasRoot(uri)`                  | `(string) bool`                                              | Check if a specific URI is in the cache                                            |
+| `ListClientRoots(ctx, session)` | `(context.Context, *mcp.ServerSession) ([]*mcp.Root, error)` | Query roots without caching                                                        |
+| `ClientSupportsRoots(session)`  | `(*mcp.ServerSession) bool`                                  | Reports whether the client advertised the roots capability during initialization   |
 
 ### Git Detection Heuristics
 
@@ -105,11 +105,11 @@ This enables auto-detection of the GitLab project from the user's opened workspa
 
 ## Configuration
 
-| Setting | Value | Notes |
-| ------- | ----- | ----- |
-| Thread safety | `sync.RWMutex` | All operations are goroutine-safe |
+| Setting            | Value                                | Notes                             |
+| ------------------ | ------------------------------------ | --------------------------------- |
+| Thread safety      | `sync.RWMutex`                       | All operations are goroutine-safe |
 | Cache invalidation | On `roots/list_changed` notification | Client notifies server of changes |
-| URI scheme | `file://` | Standard scheme for local paths |
+| URI scheme         | `file://`                            | Standard scheme for local paths   |
 
 ## Security
 
@@ -124,20 +124,20 @@ The roots infrastructure is **fully implemented** and operational. The `Manager`
 
 ### Active Consumers
 
-| Consumer | How It Uses Roots |
-| -------- | ----------------- |
-| **`gitlab://workspace/roots` resource** | Exposes cached roots as an MCP resource so LLMs can read workspace directories |
-| **`gitlab_discover_project` tool** | LLMs read `.git/config` from root directories to discover `project_id` automatically |
+| Consumer                                | How It Uses Roots                                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------------------ |
+| **`gitlab://workspace/roots` resource** | Exposes cached roots as an MCP resource so LLMs can read workspace directories       |
+| **`gitlab_discover_project` tool**      | LLMs read `.git/config` from root directories to discover `project_id` automatically |
 
 The **project discovery workflow** chains these components: LLM fetches `gitlab://workspace/roots` → reads `.git/config` from each root → calls `gitlab_discover_project` with the remote URL → obtains `project_id` for all subsequent operations.
 
 ### Future Features
 
-| Feature | How Roots Enables It |
-| ------- | -------------------- |
-| **Workspace-relative file paths** | Resolve file references in tool arguments relative to workspace roots |
-| **Multi-project awareness** | Support workspaces with multiple Git repositories (monorepos, polyrepos) |
-| **Contextual completions** | Prioritize completions from the detected project over global search |
+| Feature                           | How Roots Enables It                                                     |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| **Workspace-relative file paths** | Resolve file references in tool arguments relative to workspace roots    |
+| **Multi-project awareness**       | Support workspaces with multiple Git repositories (monorepos, polyrepos) |
+| **Contextual completions**        | Prioritize completions from the detected project over global search      |
 
 ## How Roots Fit in the MCP Architecture
 

--- a/docs/capabilities/sampling.md
+++ b/docs/capabilities/sampling.md
@@ -94,19 +94,19 @@ The server acts as a **data curator**: it collects, filters, and formats the rig
 
 This capability powers eleven tools that provide LLM-assisted insights directly from GitLab data:
 
-| Tool | Purpose |
-| ---- | ------- |
-| `gitlab_analyze_mr_changes` | Code review: analyzes MR diffs for quality, bugs, improvements |
-| `gitlab_summarize_issue` | Issue summary: key decisions, action items, participants |
-| `gitlab_generate_release_notes` | Release notes: categorized changes from commits and MRs |
-| `gitlab_analyze_pipeline_failure` | Pipeline failure: root cause analysis of failed jobs and traces |
-| `gitlab_summarize_mr_review` | MR review summary: reviewer feedback, unresolved threads, action items |
-| `gitlab_generate_milestone_report` | Milestone report: progress metrics, risks, and recommendations |
-| `gitlab_analyze_ci_configuration` | CI config analysis: best practices, security, performance review |
-| `gitlab_analyze_issue_scope` | Issue scope: complexity assessment, effort estimation, decomposition |
-| `gitlab_review_mr_security` | Security review: OWASP Top 10, injection, auth, secrets in MR diffs |
-| `gitlab_find_technical_debt` | Technical debt: TODO/FIXME/HACK markers categorized and prioritized |
-| `gitlab_analyze_deployment_history` | Deployment analysis: frequency, success rate, rollback patterns |
+| Tool                                | Purpose                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| `gitlab_analyze_mr_changes`         | Code review: analyzes MR diffs for quality, bugs, improvements         |
+| `gitlab_summarize_issue`            | Issue summary: key decisions, action items, participants               |
+| `gitlab_generate_release_notes`     | Release notes: categorized changes from commits and MRs                |
+| `gitlab_analyze_pipeline_failure`   | Pipeline failure: root cause analysis of failed jobs and traces        |
+| `gitlab_summarize_mr_review`        | MR review summary: reviewer feedback, unresolved threads, action items |
+| `gitlab_generate_milestone_report`  | Milestone report: progress metrics, risks, and recommendations         |
+| `gitlab_analyze_ci_configuration`   | CI config analysis: best practices, security, performance review       |
+| `gitlab_analyze_issue_scope`        | Issue scope: complexity assessment, effort estimation, decomposition   |
+| `gitlab_review_mr_security`         | Security review: OWASP Top 10, injection, auth, secrets in MR diffs    |
+| `gitlab_find_technical_debt`        | Technical debt: TODO/FIXME/HACK markers categorized and prioritized    |
+| `gitlab_analyze_deployment_history` | Deployment analysis: frequency, success rate, rollback patterns        |
 
 ## How It Works: Step by Step
 
@@ -198,47 +198,47 @@ result, err := samplingClient.Analyze(ctx, prompt, data,
 
 ### Methods
 
-| Method | Signature | Purpose |
-| ------ | --------- | ------- |
-| `FromRequest(req)` | `(*mcp.CallToolRequest) Client` | Create client from tool request |
-| `IsSupported()` | `() bool` | Check if client has sampling capability |
-| `Analyze(ctx, prompt, data, ...opts)` | `(...) (AnalysisResult, error)` | Send data to LLM for analysis |
+| Method                                                   | Signature                       | Purpose                                    |
+| -------------------------------------------------------- | ------------------------------- | ------------------------------------------ |
+| `FromRequest(req)`                                       | `(*mcp.CallToolRequest) Client` | Create client from tool request            |
+| `IsSupported()`                                          | `() bool`                       | Check if client has sampling capability    |
+| `Analyze(ctx, prompt, data, ...opts)`                    | `(...) (AnalysisResult, error)` | Send data to LLM for analysis              |
 | `AnalyzeWithTools(ctx, prompt, data, executor, ...opts)` | `(...) (AnalysisResult, error)` | Send data to LLM with tool-calling support |
 
 ### Interfaces
 
-| Interface | Method | Purpose |
-| --------- | ------ | ------- |
-| `ToolExecutor` | `ExecuteTool(ctx, name, args) (*CallToolResult, error)` | Dispatches tool calls requested by the LLM |
-| `ServerToolExecutor` | (implements `ToolExecutor`) | Dispatches to registered MCP tool handlers with allow-list |
+| Interface            | Method                                                  | Purpose                                                    |
+| -------------------- | ------------------------------------------------------- | ---------------------------------------------------------- |
+| `ToolExecutor`       | `ExecuteTool(ctx, name, args) (*CallToolResult, error)` | Dispatches tool calls requested by the LLM                 |
+| `ServerToolExecutor` | (implements `ToolExecutor`)                             | Dispatches to registered MCP tool handlers with allow-list |
 
 ### Options
 
-| Option | Default | Purpose |
-| ------ | ------- | ------- |
-| `WithMaxTokens(n)` | 4096 | Maximum tokens for LLM response |
-| `WithModelHints(hints...)` | none | Model preference hints to the client |
-| `WithModelPriorities(cost, speed, intelligence)` | balanced | Cost/speed/intelligence priorities (0..1, clamped). Hints take precedence per the MCP spec; priorities disambiguate between matches and influence model choice when no hint matches. |
-| `WithTemperature(t)` | client default | LLM sampling temperature (0..2, clamped). Lower values produce more deterministic output — recommended for security review, code analysis, release notes. |
-| `WithStopSequences(seqs...)` | none | Stop sequences that cause the LLM to halt generation when matched. Empty strings are filtered. |
-| `WithTools(tools)` | none | Tools available to the LLM during `AnalyzeWithTools` |
-| `WithToolChoice(choice)` | auto | How the LLM should use tools (auto/required/none) |
-| `WithMaxIterations(n)` | 5 | Maximum tool-calling rounds before giving up |
-| `WithIterationTimeout(d)` | 2 min | Per-iteration timeout for `AnalyzeWithTools` loop iterations, preventing indefinite hangs |
+| Option                                           | Default        | Purpose                                                                                                                                                                              |
+| ------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `WithMaxTokens(n)`                               | 4096           | Maximum tokens for LLM response                                                                                                                                                      |
+| `WithModelHints(hints...)`                       | none           | Model preference hints to the client                                                                                                                                                 |
+| `WithModelPriorities(cost, speed, intelligence)` | balanced       | Cost/speed/intelligence priorities (0..1, clamped). Hints take precedence per the MCP spec; priorities disambiguate between matches and influence model choice when no hint matches. |
+| `WithTemperature(t)`                             | client default | LLM sampling temperature (0..2, clamped). Lower values produce more deterministic output — recommended for security review, code analysis, release notes.                            |
+| `WithStopSequences(seqs...)`                     | none           | Stop sequences that cause the LLM to halt generation when matched. Empty strings are filtered.                                                                                       |
+| `WithTools(tools)`                               | none           | Tools available to the LLM during `AnalyzeWithTools`                                                                                                                                 |
+| `WithToolChoice(choice)`                         | auto           | How the LLM should use tools (auto/required/none)                                                                                                                                    |
+| `WithMaxIterations(n)`                           | 5              | Maximum tool-calling rounds before giving up                                                                                                                                         |
+| `WithIterationTimeout(d)`                        | 2 min          | Per-iteration timeout for `AnalyzeWithTools` loop iterations, preventing indefinite hangs                                                                                            |
 
 **Model-priority presets** (actual values used by built-in sampling tools):
 
-| Preset (cost / speed / intelligence) | Used by |
-| ------------------------------------ | ------- |
-| `0.0 / 0.0 / 1.0` | `gitlab_review_mr_security` |
-| `0.2 / 0.2 / 0.8` | `gitlab_analyze_mr_changes` |
-| `0.2 / 0.3 / 0.8` | `gitlab_analyze_pipeline_failure` |
-| `0.3 / 0.3 / 0.7` | `gitlab_analyze_ci_configuration` |
-| `0.3 / 0.4 / 0.6` | `gitlab_analyze_issue_scope` |
-| `0.4 / 0.5 / 0.5` | `gitlab_analyze_deployment_history`, `gitlab_summarize_mr_review`, `gitlab_generate_milestone_report` |
-| `0.4 / 0.6 / 0.4` | `gitlab_summarize_issue` |
-| `0.5 / 0.5 / 0.5` | `gitlab_find_technical_debt` |
-| `0.5 / 0.6 / 0.4` | `gitlab_generate_release_notes` |
+| Preset (cost / speed / intelligence) | Used by                                                                                               |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `0.0 / 0.0 / 1.0`                    | `gitlab_review_mr_security`                                                                           |
+| `0.2 / 0.2 / 0.8`                    | `gitlab_analyze_mr_changes`                                                                           |
+| `0.2 / 0.3 / 0.8`                    | `gitlab_analyze_pipeline_failure`                                                                     |
+| `0.3 / 0.3 / 0.7`                    | `gitlab_analyze_ci_configuration`                                                                     |
+| `0.3 / 0.4 / 0.6`                    | `gitlab_analyze_issue_scope`                                                                          |
+| `0.4 / 0.5 / 0.5`                    | `gitlab_analyze_deployment_history`, `gitlab_summarize_mr_review`, `gitlab_generate_milestone_report` |
+| `0.4 / 0.6 / 0.4`                    | `gitlab_summarize_issue`                                                                              |
+| `0.5 / 0.5 / 0.5`                    | `gitlab_find_technical_debt`                                                                          |
+| `0.5 / 0.6 / 0.4`                    | `gitlab_generate_release_notes`                                                                       |
 
 ### AnalysisResult
 
@@ -284,16 +284,16 @@ Sampling is the most security-sensitive capability because it sends GitLab data 
 
 Before sending data to the LLM, a regex engine scans all content and replaces matches with `[REDACTED]`:
 
-| What Is Detected | Pattern Examples |
-| ---------------- | ---------------- |
-| GitLab tokens | `glpat-xxxx...` |
-| GitHub tokens | `ghp_xxxx`, `gho_xxxx`, `github_pat_xxxx` |
-| Slack tokens | `xoxb-xxxx`, `xoxp-xxxx` |
-| AWS access keys | `AKIA...` (16 alphanumeric chars) |
-| JWT tokens | `eyJ...` (three dot-separated segments) |
+| What Is Detected  | Pattern Examples                              |
+| ----------------- | --------------------------------------------- |
+| GitLab tokens     | `glpat-xxxx...`                               |
+| GitHub tokens     | `ghp_xxxx`, `gho_xxxx`, `github_pat_xxxx`     |
+| Slack tokens      | `xoxb-xxxx`, `xoxp-xxxx`                      |
+| AWS access keys   | `AKIA...` (16 alphanumeric chars)             |
+| JWT tokens        | `eyJ...` (three dot-separated segments)       |
 | Key-value secrets | `password=xxx`, `api_key: xxx`, `secret: xxx` |
-| PEM private keys | `-----BEGIN PRIVATE KEY-----...` blocks |
-| Generic API keys | `sk-xxx`, `pk-xxx`, `rk-xxx` prefixes |
+| PEM private keys  | `-----BEGIN PRIVATE KEY-----...` blocks       |
+| Generic API keys  | `sk-xxx`, `pk-xxx`, `rk-xxx` prefixes         |
 
 ### Layer 2: Prompt Injection Prevention
 
@@ -317,10 +317,10 @@ Data exceeding **100 KB** is truncated. This prevents:
 
 When truncation occurs, a warning is appended: `[WARNING: Data was truncated due to size limits. Analysis may be incomplete.]`
 
-| Limit | Value | Behavior |
-| ----- | ----- | -------- |
-| Max input data | 100 KB | Truncated with warning marker |
-| Default max tokens | 4,096 | Can be overridden with `WithMaxTokens()` |
+| Limit              | Value  | Behavior                                 |
+| ------------------ | ------ | ---------------------------------------- |
+| Max input data     | 100 KB | Truncated with warning marker            |
+| Default max tokens | 4,096  | Can be overridden with `WithMaxTokens()` |
 
 ### Layer 4: Hardened System Prompt
 
@@ -349,9 +349,9 @@ The eleven tools fall into four categories based on what kind of analysis they p
 
 These tools help review code changes for quality, security, and best practices.
 
-| Tool | Input | What It Analyzes |
-| ---- | ----- | ---------------- |
-| `gitlab_analyze_mr_changes` | project + MR IID | Fetches MR diffs and provides a code review: summary of changes, potential bugs, improvement suggestions |
+| Tool                        | Input            | What It Analyzes                                                                                            |
+| --------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `gitlab_analyze_mr_changes` | project + MR IID | Fetches MR diffs and provides a code review: summary of changes, potential bugs, improvement suggestions    |
 | `gitlab_review_mr_security` | project + MR IID | Same diffs, but with a security-focused prompt: OWASP Top 10, injection risks, exposed secrets, auth issues |
 
 **When to use**: Before merging, during code review, or when you want a second opinion on code quality.
@@ -362,11 +362,11 @@ These tools help review code changes for quality, security, and best practices.
 
 These tools summarize discussions and review feedback.
 
-| Tool | Input | What It Analyzes |
-| ---- | ----- | ---------------- |
-| `gitlab_summarize_issue` | project + issue IID | Fetches issue description and all comments, produces a summary with key decisions and action items |
-| `gitlab_summarize_mr_review` | project + MR IID | Fetches MR discussions and approval state, summarizes reviewer feedback and unresolved threads |
-| `gitlab_analyze_issue_scope` | project + issue IID | Fetches issue with time stats, participants, related MRs, suggests decomposition if too large |
+| Tool                         | Input               | What It Analyzes                                                                                   |
+| ---------------------------- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| `gitlab_summarize_issue`     | project + issue IID | Fetches issue description and all comments, produces a summary with key decisions and action items |
+| `gitlab_summarize_mr_review` | project + MR IID    | Fetches MR discussions and approval state, summarizes reviewer feedback and unresolved threads     |
+| `gitlab_analyze_issue_scope` | project + issue IID | Fetches issue with time stats, participants, related MRs, suggests decomposition if too large      |
 
 **When to use**: When joining a long discussion, triaging issues, or preparing a sprint review.
 
@@ -376,10 +376,10 @@ These tools summarize discussions and review feedback.
 
 These tools help diagnose pipeline problems and improve CI configuration.
 
-| Tool | Input | What It Analyzes |
-| ---- | ----- | ---------------- |
-| `gitlab_analyze_pipeline_failure` | project + pipeline ID | Fetches failed jobs and their log traces, identifies root cause and suggests fixes |
-| `gitlab_analyze_ci_configuration` | project | Lints the CI config, fetches the merged YAML, analyzes for best practices and optimization |
+| Tool                              | Input                 | What It Analyzes                                                                           |
+| --------------------------------- | --------------------- | ------------------------------------------------------------------------------------------ |
+| `gitlab_analyze_pipeline_failure` | project + pipeline ID | Fetches failed jobs and their log traces, identifies root cause and suggests fixes         |
+| `gitlab_analyze_ci_configuration` | project               | Lints the CI config, fetches the merged YAML, analyzes for best practices and optimization |
 
 **When to use**: When a pipeline fails and you need a quick diagnosis, or when optimizing CI/CD performance.
 
@@ -389,12 +389,12 @@ These tools help diagnose pipeline problems and improve CI configuration.
 
 These tools provide broader insights about project health and progress.
 
-| Tool | Input | What It Analyzes |
-| ---- | ----- | ---------------- |
-| `gitlab_generate_release_notes` | project + from/to refs | Compares two Git refs, fetches commits and merged MRs with labels, produces categorized release notes |
-| `gitlab_generate_milestone_report` | project + milestone | Fetches milestone details with linked issues and MRs, produces a progress report with metrics and risks |
-| `gitlab_find_technical_debt` | project (+ optional ref) | Searches for TODO/FIXME/HACK/XXX/DEPRECATED markers, categorizes and prioritizes them |
-| `gitlab_analyze_deployment_history` | project (+ optional env) | Fetches recent deployments, analyzes frequency, success rates, and rollback patterns |
+| Tool                                | Input                    | What It Analyzes                                                                                        |
+| ----------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `gitlab_generate_release_notes`     | project + from/to refs   | Compares two Git refs, fetches commits and merged MRs with labels, produces categorized release notes   |
+| `gitlab_generate_milestone_report`  | project + milestone      | Fetches milestone details with linked issues and MRs, produces a progress report with metrics and risks |
+| `gitlab_find_technical_debt`        | project (+ optional ref) | Searches for TODO/FIXME/HACK/XXX/DEPRECATED markers, categorizes and prioritizes them                   |
+| `gitlab_analyze_deployment_history` | project (+ optional env) | Fetches recent deployments, analyzes frequency, success rates, and rollback patterns                    |
 
 **When to use**: Release preparation, sprint reviews, technical debt management, or deployment health checks.
 
@@ -404,10 +404,10 @@ These tools provide broader insights about project health and progress.
 
 #### `gitlab_analyze_mr_changes`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `merge_request_iid` | int | Yes | Merge request IID |
+| Parameter           | Type   | Required | Description        |
+| ------------------- | ------ | :------: | ------------------ |
+| `project_id`        | string |   Yes    | Project ID or path |
+| `merge_request_iid` | int    |   Yes    | Merge request IID  |
 
 **Flow**: Fetch MR details → Fetch diffs → Format as Markdown → LLM analysis
 
@@ -415,10 +415,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_summarize_issue`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `issue_iid` | int | Yes | Issue IID |
+| Parameter    | Type   | Required | Description        |
+| ------------ | ------ | :------: | ------------------ |
+| `project_id` | string |   Yes    | Project ID or path |
+| `issue_iid`  | int    |   Yes    | Issue IID          |
 
 **Flow**: Fetch issue → Fetch all notes (paginated) → Format as Markdown → LLM summary
 
@@ -426,11 +426,11 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_generate_release_notes`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `from` | string | Yes | Starting ref (tag, branch, SHA) |
-| `to` | string | No | Ending ref (defaults to `HEAD`) |
+| Parameter    | Type   | Required | Description                     |
+| ------------ | ------ | :------: | ------------------------------- |
+| `project_id` | string |   Yes    | Project ID or path              |
+| `from`       | string |   Yes    | Starting ref (tag, branch, SHA) |
+| `to`         | string |    No    | Ending ref (defaults to `HEAD`) |
 
 **Flow**: Compare refs → Fetch merged MRs with labels → Format commits + MRs + diffs → LLM categorization
 
@@ -438,10 +438,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_analyze_pipeline_failure`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `pipeline_id` | int | Yes | Pipeline ID |
+| Parameter     | Type   | Required | Description        |
+| ------------- | ------ | :------: | ------------------ |
+| `project_id`  | string |   Yes    | Project ID or path |
+| `pipeline_id` | int    |   Yes    | Pipeline ID        |
 
 **Flow**: Fetch pipeline → Fetch failed jobs with traces → Format as Markdown → LLM root cause analysis
 
@@ -449,10 +449,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_summarize_mr_review`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `merge_request_iid` | int | Yes | Merge request IID |
+| Parameter           | Type   | Required | Description        |
+| ------------------- | ------ | :------: | ------------------ |
+| `project_id`        | string |   Yes    | Project ID or path |
+| `merge_request_iid` | int    |   Yes    | Merge request IID  |
 
 **Flow**: Fetch MR details → Fetch discussions → Fetch approval state → Format as Markdown → LLM summary
 
@@ -460,10 +460,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_generate_milestone_report`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `milestone_id` | string | Yes | Milestone title or IID (auto-resolved) |
+| Parameter      | Type   | Required | Description                            |
+| -------------- | ------ | :------: | -------------------------------------- |
+| `project_id`   | string |   Yes    | Project ID or path                     |
+| `milestone_id` | string |   Yes    | Milestone title or IID (auto-resolved) |
 
 **Flow**: Fetch milestone → Fetch linked issues and MRs → Format as Markdown → LLM progress report
 
@@ -471,9 +471,9 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_analyze_ci_configuration`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
+| Parameter    | Type   | Required | Description        |
+| ------------ | ------ | :------: | ------------------ |
+| `project_id` | string |   Yes    | Project ID or path |
 
 **Flow**: Lint CI config → Fetch merged YAML and includes → Format as Markdown → LLM analysis
 
@@ -481,10 +481,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_analyze_issue_scope`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `issue_iid` | int | Yes | Issue IID |
+| Parameter    | Type   | Required | Description        |
+| ------------ | ------ | :------: | ------------------ |
+| `project_id` | string |   Yes    | Project ID or path |
+| `issue_iid`  | int    |   Yes    | Issue IID          |
 
 **Flow**: Fetch issue → Fetch time stats, participants, related MRs, notes → Format as Markdown → LLM scope analysis
 
@@ -492,10 +492,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_review_mr_security`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `merge_request_iid` | int | Yes | Merge request IID |
+| Parameter           | Type   | Required | Description        |
+| ------------------- | ------ | :------: | ------------------ |
+| `project_id`        | string |   Yes    | Project ID or path |
+| `merge_request_iid` | int    |   Yes    | Merge request IID  |
 
 **Flow**: Fetch MR details → Fetch code diffs → Format as Markdown → LLM security review
 
@@ -503,9 +503,9 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_find_technical_debt`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
+| Parameter    | Type   | Required | Description        |
+| ------------ | ------ | :------: | ------------------ |
+| `project_id` | string |   Yes    | Project ID or path |
 
 **Flow**: Search for TODO/FIXME/HACK/XXX/DEPRECATED markers → Format results → LLM categorization
 
@@ -515,10 +515,10 @@ These tools provide broader insights about project health and progress.
 
 ### `gitlab_analyze_deployment_history`
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string | Yes | Project ID or path |
-| `environment` | string | No | Filter by environment name (e.g., "production") |
+| Parameter     | Type   | Required | Description                                     |
+| ------------- | ------ | :------: | ----------------------------------------------- |
+| `project_id`  | string |   Yes    | Project ID or path                              |
+| `environment` | string |    No    | Filter by environment name (e.g., "production") |
 
 **Flow**: Fetch recent deployments → Format as Markdown with success/failure stats → LLM analysis
 
@@ -591,15 +591,15 @@ You:  "Generate release notes for gitlab-mcp-server between v1.1.6 and v1.1.7."
 
 You might wonder: "Why not just ask the AI to read the diff directly, without sampling?"
 
-| Aspect | Direct AI Analysis | Sampling Tools |
-| ------ | ------------------ | -------------- |
-| **Data access** | AI can only see what's in its context window | Server fetches complete datasets from GitLab API |
-| **Data quality** | Raw API output (JSON), AI must parse | Pre-formatted Markdown with relevant fields only |
-| **Credential safety** | No automatic redaction | Credentials stripped before LLM sees data |
-| **Injection protection** | None — data mixed with instructions | XML delimiters + hardened system prompt |
-| **Consistency** | Varies with prompt phrasing | Same prompt template produces consistent results |
-| **Context efficiency** | Full API response consumes tokens | Server curates only relevant information |
-| **Pagination** | AI must manage page cursors | Server handles multi-page collection automatically |
+| Aspect                   | Direct AI Analysis                           | Sampling Tools                                     |
+| ------------------------ | -------------------------------------------- | -------------------------------------------------- |
+| **Data access**          | AI can only see what's in its context window | Server fetches complete datasets from GitLab API   |
+| **Data quality**         | Raw API output (JSON), AI must parse         | Pre-formatted Markdown with relevant fields only   |
+| **Credential safety**    | No automatic redaction                       | Credentials stripped before LLM sees data          |
+| **Injection protection** | None — data mixed with instructions          | XML delimiters + hardened system prompt            |
+| **Consistency**          | Varies with prompt phrasing                  | Same prompt template produces consistent results   |
+| **Context efficiency**   | Full API response consumes tokens            | Server curates only relevant information           |
+| **Pagination**           | AI must manage page cursors                  | Server handles multi-page collection automatically |
 
 In short, sampling tools provide **safer, more consistent, and more complete analysis** by leveraging the server as a data preparation layer.
 
@@ -618,13 +618,13 @@ Not all MCP clients support sampling. When a client lacks this capability, every
 
 As of the current MCP specification, sampling support varies by client:
 
-| Client | Sampling Support |
-| ------ | ---------------- |
+| Client                      | Sampling Support                       |
+| --------------------------- | -------------------------------------- |
 | VS Code with GitHub Copilot | Partial (depends on extension version) |
-| Copilot CLI | Depends on version |
-| OpenCode | Depends on implementation |
-| Continue.dev | Yes |
-| Custom clients | Depends on implementation |
+| Copilot CLI                 | Depends on version                     |
+| OpenCode                    | Depends on implementation              |
+| Continue.dev                | Yes                                    |
+| Custom clients              | Depends on implementation              |
 
 Check your MCP client's documentation for sampling capability status.
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -13,10 +13,10 @@ How to use gitlab-mcp-server in CI/CD pipelines for automated GitLab operations 
 
 gitlab-mcp-server can run inside CI/CD jobs just like any other CLI tool. Two usage modes are available:
 
-| Mode | LLM Required | Use Case | Determinism |
-| --- | :---: | --- | :---: |
-| **Deterministic** (JSON-RPC) | No | Scripted operations: list issues, post comments, create releases | ✅ Fully deterministic |
-| **LLM-driven** (headless MCP client) | Yes | Intelligent workflows: code review, issue triage, MR analysis | ❌ Non-deterministic |
+| Mode                                 | LLM Required | Use Case                                                         |      Determinism      |
+| ------------------------------------ | :----------: | ---------------------------------------------------------------- | :-------------------: |
+| **Deterministic** (JSON-RPC)         |      No      | Scripted operations: list issues, post comments, create releases | ✅ Fully deterministic |
+| **LLM-driven** (headless MCP client) |     Yes      | Intelligent workflows: code review, issue triage, MR analysis    |  ❌ Non-deterministic  |
 
 Both modes authenticate with a **Personal Access Token** (PAT) or **Project Access Token**. Enterprise/Premium deployments using a token with `api` scope have access to the full tool surface. GitLab.com deployments have access to the core tool set plus additional Orbit-specific tools.
 
@@ -55,8 +55,8 @@ Create a **Project Access Token** (recommended over personal PATs for CI):
 
 **GitLab CI**: Go to **Settings > CI/CD > Variables** and add:
 
-| Variable | Value | Properties |
-| --- | --- | --- |
+| Variable  | Value           | Properties                   |
+| --------- | --------------- | ---------------------------- |
 | `MCP_PAT` | `glpat-xxxx...` | Masked, Protected (optional) |
 
 **GitHub Actions**: Go to **Settings > Secrets and variables > Actions** and add a repository secret named `MCP_PAT`.
@@ -480,24 +480,24 @@ jobs:
 
 ### Token Management
 
-| Practice | Recommendation |
-| --- | --- |
+| Practice   | Recommendation                                                   |
+| ---------- | ---------------------------------------------------------------- |
 | Token type | **Project Access Token** — scoped to a single project, auditable |
-| Scope | `api` for full access, `read_api` for read-only workflows |
-| Expiration | Set to 90 days maximum, rotate before expiry |
-| Storage | **Masked CI/CD variable** — never commit to repository |
-| Visibility | Use "Protected" flag if only needed on protected branches |
+| Scope      | `api` for full access, `read_api` for read-only workflows        |
+| Expiration | Set to 90 days maximum, rotate before expiry                     |
+| Storage    | **Masked CI/CD variable** — never commit to repository           |
+| Visibility | Use "Protected" flag if only needed on protected branches        |
 
 ### Minimal Scope Strategy
 
 Match the token scope to your workflow:
 
-| Workflow | Required Scope |
-| --- | --- |
-| List issues, MRs, pipelines | `read_api` |
-| Post comments, create issues | `api` |
-| Manage releases, packages | `api` |
-| Full MR review workflow | `api` |
+| Workflow                     | Required Scope |
+| ---------------------------- | -------------- |
+| List issues, MRs, pipelines  | `read_api`     |
+| Post comments, create issues | `api`          |
+| Manage releases, packages    | `api`          |
+| Full MR review workflow      | `api`          |
 
 ### Group Access Tokens
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,47 +22,47 @@ When run without flags and a `GITLAB_TOKEN` is set, the server starts in **stdio
 
 ### General
 
-| Flag | Type | Default | Description |
-| --- | --- | --- | --- |
-| `-h` | bool | `false` | Show full help with flags, environment variables, and JSON examples |
-| `-version` | bool | `false` | Print version and commit hash, then exit |
-| `-shutdown` | bool | `false` | Terminate all running instances and exit (used by external updaters) |
-| `-setup` | bool | `false` | Run the interactive Setup Wizard |
-| `-setup-mode` | string | `auto` | Setup UI mode: `auto`, `web`, `tui`, `cli` |
+| Flag          | Type   | Default | Description                                                          |
+| ------------- | ------ | ------- | -------------------------------------------------------------------- |
+| `-h`          | bool   | `false` | Show full help with flags, environment variables, and JSON examples  |
+| `-version`    | bool   | `false` | Print version and commit hash, then exit                             |
+| `-shutdown`   | bool   | `false` | Terminate all running instances and exit (used by external updaters) |
+| `-setup`      | bool   | `false` | Run the interactive Setup Wizard                                     |
+| `-setup-mode` | string | `auto`  | Setup UI mode: `auto`, `web`, `tui`, `cli`                           |
 
 ### HTTP Transport Mode
 
-| Flag | Type | Default | Description |
-| --- | --- | --- | --- |
-| `-http` | bool | `false` | Enable HTTP transport mode (default is stdio) |
-| `-http-addr` | string | `:8080` | HTTP listen address (e.g. `localhost:8080`, `:9090`) |
-| `-gitlab-url` | string | _(optional)_ | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request |
-| `-skip-tls-verify` | bool | `false` | Skip TLS certificate verification for self-signed certs |
-| `-tool-surface` | string | `dynamic` | Canonical tool catalog selector: `meta`, `individual`, or `dynamic` |
-| `-meta-tools` | bool | `true` | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false` |
-| `-capability-surface` | string | `full` | Resource and prompt catalog selector: `full` or `minimal`. Minimal keeps `gitlab://workspace/roots`, disables optional resources, workflow guides, and prompts, and keeps meta-schema resources only for `--tool-surface=meta` |
-| `-meta-param-schema` | string | `opaque` | Meta-tool input-schema strategy: `opaque` (default), `compact`, or `full`. Applies to meta-tool schemas only. See [env-reference.md](env-reference.md) |
-| `-enterprise` | bool | `false` | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
-| `-read-only` | bool | `false` | Read-only mode: disables all mutating tools. Only tools with `ReadOnlyHint=true` remain available |
-| `-safe-mode` | bool | `false` | Safe mode: intercepts mutating tools and returns a JSON preview instead of executing. If `--read-only` is also set, it takes precedence |
-| `-embedded-resources` | bool | `true` | Embed canonical `gitlab://` MCP resource URIs as `EmbeddedResource` content blocks in `gitlab_*_get` tool results. Set `false` to disable for clients that don't tolerate duplicate content blocks |
-| `-max-http-clients` | int | `100` | Maximum concurrent client sessions (upper bound: 10,000) |
-| `-session-timeout` | duration | `30m` | Idle MCP session timeout (upper bound: 24h) |
-| `-revalidate-interval` | duration | `15m` | Token re-validation interval; `0` to disable (upper bound: 24h) |
-| `-auth-mode` | string | `legacy` | Authentication mode: `legacy` (PRIVATE-TOKEN header passthrough) or `oauth` (RFC 9728 Bearer token verification via GitLab API). See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode) |
-| `-oauth-cache-ttl` | duration | `15m` | TTL for verified OAuth token identity cache. Range: 1m–2h. Only applies when `--auth-mode=oauth` |
-| `-trusted-proxy-header` | string | _(empty)_ | HTTP header containing the real client IP when behind a reverse proxy (e.g. `Fly-Client-IP`, `X-Forwarded-For`, `X-Real-IP`). Required for accurate rate limiting behind proxies |
-| `-rate-limit-rps` | float | `0` | Per-server `tools/call` rate limit in requests/second. `0` disables. See [Security — Rate Limiting Model](security.md#rate-limiting-model) |
-| `-rate-limit-burst` | int | `40` | Token-bucket burst size when `--rate-limit-rps > 0`. Must be ≥ 1 |
+| Flag                    | Type     | Default      | Description                                                                                                                                                                                                                    |
+| ----------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-http`                 | bool     | `false`      | Enable HTTP transport mode (default is stdio)                                                                                                                                                                                  |
+| `-http-addr`            | string   | `:8080`      | HTTP listen address (e.g. `localhost:8080`, `:9090`)                                                                                                                                                                           |
+| `-gitlab-url`           | string   | _(optional)_ | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request                                                                                                                                     |
+| `-skip-tls-verify`      | bool     | `false`      | Skip TLS certificate verification for self-signed certs                                                                                                                                                                        |
+| `-tool-surface`         | string   | `dynamic`    | Canonical tool catalog selector: `meta`, `individual`, or `dynamic`                                                                                                                                                            |
+| `-meta-tools`           | bool     | `true`       | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false`                                                                                                                                 |
+| `-capability-surface`   | string   | `full`       | Resource and prompt catalog selector: `full` or `minimal`. Minimal keeps `gitlab://workspace/roots`, disables optional resources, workflow guides, and prompts, and keeps meta-schema resources only for `--tool-surface=meta` |
+| `-meta-param-schema`    | string   | `opaque`     | Meta-tool input-schema strategy: `opaque` (default), `compact`, or `full`. Applies to meta-tool schemas only. See [env-reference.md](env-reference.md)                                                                         |
+| `-enterprise`           | bool     | `false`      | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version`                                            |
+| `-read-only`            | bool     | `false`      | Read-only mode: disables all mutating tools. Only tools with `ReadOnlyHint=true` remain available                                                                                                                              |
+| `-safe-mode`            | bool     | `false`      | Safe mode: intercepts mutating tools and returns a JSON preview instead of executing. If `--read-only` is also set, it takes precedence                                                                                        |
+| `-embedded-resources`   | bool     | `true`       | Embed canonical `gitlab://` MCP resource URIs as `EmbeddedResource` content blocks in `gitlab_*_get` tool results. Set `false` to disable for clients that don't tolerate duplicate content blocks                             |
+| `-max-http-clients`     | int      | `100`        | Maximum concurrent client sessions (upper bound: 10,000)                                                                                                                                                                       |
+| `-session-timeout`      | duration | `30m`        | Idle MCP session timeout (upper bound: 24h)                                                                                                                                                                                    |
+| `-revalidate-interval`  | duration | `15m`        | Token re-validation interval; `0` to disable (upper bound: 24h)                                                                                                                                                                |
+| `-auth-mode`            | string   | `legacy`     | Authentication mode: `legacy` (PRIVATE-TOKEN header passthrough) or `oauth` (RFC 9728 Bearer token verification via GitLab API). See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode)                           |
+| `-oauth-cache-ttl`      | duration | `15m`        | TTL for verified OAuth token identity cache. Range: 1m–2h. Only applies when `--auth-mode=oauth`                                                                                                                               |
+| `-trusted-proxy-header` | string   | _(empty)_    | HTTP header containing the real client IP when behind a reverse proxy (e.g. `Fly-Client-IP`, `X-Forwarded-For`, `X-Real-IP`). Required for accurate rate limiting behind proxies                                               |
+| `-rate-limit-rps`       | float    | `0`          | Per-server `tools/call` rate limit in requests/second. `0` disables. See [Security — Rate Limiting Model](security.md#rate-limiting-model)                                                                                     |
+| `-rate-limit-burst`     | int      | `40`         | Token-bucket burst size when `--rate-limit-rps > 0`. Must be ≥ 1                                                                                                                                                               |
 
 ### Auto-Update
 
-| Flag | Type | Default | Description |
-| --- | --- | --- | --- |
-| `-auto-update` | string | `true` | Auto-update mode: `true` (auto-apply), `check` (log-only), `false` (disabled) |
-| `-auto-update-repo` | string | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for update release assets |
-| `-auto-update-interval` | duration | `1h` | How often to check for new releases (HTTP mode periodic checks) |
-| `-auto-update-timeout` | duration | `60s` | Timeout for pre-start update download (range: 5s–10m) |
+| Flag                    | Type     | Default                      | Description                                                                   |
+| ----------------------- | -------- | ---------------------------- | ----------------------------------------------------------------------------- |
+| `-auto-update`          | string   | `true`                       | Auto-update mode: `true` (auto-apply), `check` (log-only), `false` (disabled) |
+| `-auto-update-repo`     | string   | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for update release assets                 |
+| `-auto-update-interval` | duration | `1h`                         | How often to check for new releases (HTTP mode periodic checks)               |
+| `-auto-update-timeout`  | duration | `60s`                        | Timeout for pre-start update download (range: 5s–10m)                         |
 
 ---
 
@@ -181,10 +181,10 @@ See [Dynamic Tools](dynamic-tools.md) for how `dynamic` relates.
 
 ## Exit Codes
 
-| Code | Meaning |
-| --- | --- |
-| `0` | Normal exit (signal-based shutdown, `-version`, `-h`, or `--shutdown`) |
-| `1` | Configuration error, connection failure, runtime error, or `--shutdown` failure |
+| Code | Meaning                                                                         |
+| ---- | ------------------------------------------------------------------------------- |
+| `0`  | Normal exit (signal-based shutdown, `-version`, `-h`, or `--shutdown`)          |
+| `1`  | Configuration error, connection failure, runtime error, or `--shutdown` failure |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,25 +17,25 @@ These are the settings every user needs to get started.
 
 ### Required Variables
 
-| Variable | Description | Example |
-| --- | --- | --- |
+| Variable       | Description                            | Example                      |
+| -------------- | -------------------------------------- | ---------------------------- |
 | `GITLAB_TOKEN` | Personal Access Token with `api` scope | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ### Common Options
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `GITLAB_URL` | `https://gitlab.com` | GitLab instance base URL. Set this for self-managed instances |
-| `GITLAB_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification for self-signed certs |
-| `TOOL_SURFACE` | `dynamic` | Canonical tool catalog selector: `dynamic`, `meta`, or `individual` |
-| `META_TOOLS` | *(legacy)* | Deprecated compatibility selector. Accepted values map to `TOOL_SURFACE`: `true` -> `meta`, `false` -> `individual`, and `dynamic` -> `dynamic`. Ignored when `TOOL_SURFACE` is set |
-| `CAPABILITY_SURFACE` | `full` | Resource and prompt catalog selector: `full` preserves all resources, meta-schema resources, workflow guides, and prompts; `minimal` keeps `gitlab://workspace/roots` and, in `TOOL_SURFACE=meta`, meta-schema resources |
-| `GITLAB_ENTERPRISE` | `false` | Enable Enterprise/Premium tools in stdio mode. In HTTP mode, `--enterprise` explicitly forces the Enterprise/Premium catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
-| `GITLAB_READ_ONLY` | `false` | Read-only mode: disables all mutating tools at startup |
-| `GITLAB_SAFE_MODE` | `false` | Safe mode: intercepts mutating tools and returns a JSON preview instead of executing. Read-only tools work normally. If `GITLAB_READ_ONLY=true`, it takes precedence |
-| `EXCLUDE_TOOLS` | *(empty)* | Comma-separated list of tool names to exclude from registration |
-| `GITLAB_IGNORE_SCOPES` | `false` | Skip PAT scope detection and register all tools regardless of token permissions |
-| `LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` |
+| Variable                 | Default              | Description                                                                                                                                                                                                                                  |
+| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | `https://gitlab.com` | GitLab instance base URL. Set this for self-managed instances                                                                                                                                                                                |
+| `GITLAB_SKIP_TLS_VERIFY` | `false`              | Skip TLS certificate verification for self-signed certs                                                                                                                                                                                      |
+| `TOOL_SURFACE`           | `dynamic`            | Canonical tool catalog selector: `dynamic`, `meta`, or `individual`                                                                                                                                                                          |
+| `META_TOOLS`             | *(legacy)*           | Deprecated compatibility selector. Accepted values map to `TOOL_SURFACE`: `true` -> `meta`, `false` -> `individual`, and `dynamic` -> `dynamic`. Ignored when `TOOL_SURFACE` is set                                                          |
+| `CAPABILITY_SURFACE`     | `full`               | Resource and prompt catalog selector: `full` preserves all resources, meta-schema resources, workflow guides, and prompts; `minimal` keeps `gitlab://workspace/roots` and, in `TOOL_SURFACE=meta`, meta-schema resources                     |
+| `GITLAB_ENTERPRISE`      | `false`              | Enable Enterprise/Premium tools in stdio mode. In HTTP mode, `--enterprise` explicitly forces the Enterprise/Premium catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
+| `GITLAB_READ_ONLY`       | `false`              | Read-only mode: disables all mutating tools at startup                                                                                                                                                                                       |
+| `GITLAB_SAFE_MODE`       | `false`              | Safe mode: intercepts mutating tools and returns a JSON preview instead of executing. Read-only tools work normally. If `GITLAB_READ_ONLY=true`, it takes precedence                                                                         |
+| `EXCLUDE_TOOLS`          | *(empty)*            | Comma-separated list of tool names to exclude from registration                                                                                                                                                                              |
+| `GITLAB_IGNORE_SCOPES`   | `false`              | Skip PAT scope detection and register all tools regardless of token permissions                                                                                                                                                              |
+| `LOG_LEVEL`              | `info`               | Logging verbosity: `debug`, `info`, `warn`, `error`                                                                                                                                                                                          |
 
 ### .env File Example
 
@@ -179,28 +179,28 @@ These settings are for operators deploying the server for a team or managing adv
 
 ### Advanced Variables
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `AUTO_UPDATE` | `true` | Enable automatic binary updates (`true`/`check`/`false`) |
-| `AUTO_UPDATE_REPO` | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets |
-| `AUTO_UPDATE_INTERVAL` | `1h` | Interval between periodic update checks |
-| `ISSUE_REPORTS` | `false` | Enable automatic issue report generation on unrecoverable errors |
-| `YOLO_MODE` | `false` | Skip destructive action confirmation prompts |
-| `AUTOPILOT` | `false` | Same as `YOLO_MODE` — skip confirmation prompts |
-| `AUTH_MODE` | `legacy` | HTTP mode authentication: `legacy` (per-request header) or `oauth` (RFC 9728 Bearer token verification) |
-| `OAUTH_CACHE_TTL` | `15m` | TTL for verified OAuth token identity cache (min 1m, max 2h) |
-| `RATE_LIMIT_RPS` | `0` | Per-server tools/call rate limit in requests/second (`0` = disabled) |
-| `RATE_LIMIT_BURST` | `40` | Token-bucket burst size when `RATE_LIMIT_RPS` > 0 |
+| Variable               | Default                      | Description                                                                                             |
+| ---------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `AUTO_UPDATE`          | `true`                       | Enable automatic binary updates (`true`/`check`/`false`)                                                |
+| `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets                                                                    |
+| `AUTO_UPDATE_INTERVAL` | `1h`                         | Interval between periodic update checks                                                                 |
+| `ISSUE_REPORTS`        | `false`                      | Enable automatic issue report generation on unrecoverable errors                                        |
+| `YOLO_MODE`            | `false`                      | Skip destructive action confirmation prompts                                                            |
+| `AUTOPILOT`            | `false`                      | Same as `YOLO_MODE` — skip confirmation prompts                                                         |
+| `AUTH_MODE`            | `legacy`                     | HTTP mode authentication: `legacy` (per-request header) or `oauth` (RFC 9728 Bearer token verification) |
+| `OAUTH_CACHE_TTL`      | `15m`                        | TTL for verified OAuth token identity cache (min 1m, max 2h)                                            |
+| `RATE_LIMIT_RPS`       | `0`                          | Per-server tools/call rate limit in requests/second (`0` = disabled)                                    |
+| `RATE_LIMIT_BURST`     | `40`                         | Token-bucket burst size when `RATE_LIMIT_RPS` > 0                                                       |
 
 See [Auto-Update](auto-update.md) for detailed documentation on update modes, MCP tools, release requirements, and troubleshooting.
 
 ### Tool Modes
 
-| Mode | Variable | Tools Exposed | Best For |
-| --- | --- | --- | --- |
-| **Dynamic toolset** (default) | `TOOL_SURFACE=dynamic` | `gitlab_find_action`, `gitlab_execute_tool` | Most users — lowest startup context while retaining full catalog reachability |
-| **Meta-tools** | `TOOL_SURFACE=meta` | 33 base / 49 self-managed enterprise / 50 GitLab.com Enterprise | Clients that prefer consolidated domain dispatchers with `action` parameters |
-| **Individual tools** | `TOOL_SURFACE=individual` | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Clients that need granular tool selection |
+| Mode                          | Variable                  | Tools Exposed                                                      | Best For                                                                      |
+| ----------------------------- | ------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| **Dynamic toolset** (default) | `TOOL_SURFACE=dynamic`    | `gitlab_find_action`, `gitlab_execute_tool`                        | Most users — lowest startup context while retaining full catalog reachability |
+| **Meta-tools**                | `TOOL_SURFACE=meta`       | 33 base / 49 self-managed enterprise / 50 GitLab.com Enterprise    | Clients that prefer consolidated domain dispatchers with `action` parameters  |
+| **Individual tools**          | `TOOL_SURFACE=individual` | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Clients that need granular tool selection                                     |
 
 Use the default dynamic surface for normal low-token deployments. Set `TOOL_SURFACE=meta` only when a client or workflow prefers domain meta-tools. `META_TOOLS` remains accepted for compatibility only and should appear only in migration guidance.
 
@@ -210,11 +210,11 @@ See [Meta-Tools](meta-tools.md) for the complete domain-action mapping and [Dyna
 
 `META_PARAM_SCHEMA` controls only the visible `inputSchema` of meta-tool dispatchers in `tools/list`. It does not change handler validation, execution, dynamic find output, or schema resource contents.
 
-| Tool surface | Visible tool schema impact | Schema resource availability | Dynamic describe behavior | Token impact | Recommended use |
-| --- | --- | --- | --- | --- | --- |
-| `meta` | Applies to every visible domain meta-tool. `opaque` shows `{action, params}`; `compact` and `full` inline per-action `oneOf` schemas | Available when `CAPABILITY_SURFACE=full` or `CAPABILITY_SURFACE=minimal` | Not applicable | `full` is 11.9x larger than `opaque`; `compact` is 6.5x larger | Keep `opaque`; use schema resources for exact params |
-| `dynamic` | Does not change the two dynamic tool schemas | Available when `CAPABILITY_SURFACE=full`; omitted when `minimal` | `gitlab_find_action` returns discovery and schema details inline | No practical startup benefit for Dynamic tool schemas | Keep `opaque`; use find |
-| `individual` | Ignored because individual tools expose one operation per tool with direct typed schemas | Meta-schema resources are not registered in individual mode | Not applicable | None | Leave unset |
+| Tool surface | Visible tool schema impact                                                                                                           | Schema resource availability                                             | Dynamic describe behavior                                        | Token impact                                                   | Recommended use                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| `meta`       | Applies to every visible domain meta-tool. `opaque` shows `{action, params}`; `compact` and `full` inline per-action `oneOf` schemas | Available when `CAPABILITY_SURFACE=full` or `CAPABILITY_SURFACE=minimal` | Not applicable                                                   | `full` is 11.9x larger than `opaque`; `compact` is 6.5x larger | Keep `opaque`; use schema resources for exact params |
+| `dynamic`    | Does not change the two dynamic tool schemas                                                                                         | Available when `CAPABILITY_SURFACE=full`; omitted when `minimal`         | `gitlab_find_action` returns discovery and schema details inline | No practical startup benefit for Dynamic tool schemas          | Keep `opaque`; use find                              |
+| `individual` | Ignored because individual tools expose one operation per tool with direct typed schemas                                             | Meta-schema resources are not registered in individual mode              | Not applicable                                                   | None                                                           | Leave unset                                          |
 
 The evaluated modes remain `opaque`, `compact`, and `full`. The setting name remains valid for the final architecture because it describes the meta-tool dispatcher envelope, while the action catalog remains the source of the underlying per-action schemas.
 
@@ -228,31 +228,31 @@ Measured startup context is the reason this setting keeps only two modes for now
 
 When running the server for multiple users, use HTTP mode. Configuration comes from CLI flags instead of environment variables:
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--http` | *(off)* | Enable HTTP transport mode |
-| `--http-addr` | `:8080` | HTTP listen address |
-| `--gitlab-url` | *(optional)* | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request |
-| `--skip-tls-verify` | `false` | Skip TLS certificate verification |
-| `--tool-surface` | `dynamic` | Canonical tool catalog selector: `dynamic`, `meta`, or `individual` |
-| `--meta-tools` | *(unset)* | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false` |
-| `--capability-surface` | `full` | Resource and prompt catalog selector: `full` or `minimal` |
-| `--enterprise` | `false` | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
-| `--max-http-clients` | `100` | Maximum concurrent client sessions |
-| `--session-timeout` | `30m` | Idle session timeout |
-| `--auth-mode` | `legacy` | Authentication mode: `legacy` (per-request header) or `oauth` (RFC 9728 Bearer token verification) |
-| `--oauth-cache-ttl` | `15m` | TTL for verified OAuth token cache (1m–2h) |
-| `--revalidate-interval` | `15m` | Interval for OAuth token re-validation against GitLab (`0` disables; upper bound 24h) |
-| `--trusted-proxy-header` | *(empty)* | Header containing the real client IP when behind a reverse proxy (e.g. `Fly-Client-IP`, `X-Real-IP`, `X-Forwarded-For`). Used by the per-IP auth rate limiter |
-| `--auto-update` | `true` | Enable automatic binary updates |
-| `--auto-update-repo` | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets |
-| `--auto-update-interval` | `1h` | Interval between periodic update checks |
-| `--read-only` | `false` | Expose only read-only tools |
-| `--safe-mode` | `false` | Intercept mutating tools, return preview |
-| `--rate-limit-rps` | `0` | Per-server tools/call rate limit in req/s (`0` = disabled) |
-| `--rate-limit-burst` | `40` | Token-bucket burst size when `--rate-limit-rps` > 0 |
-| `--exclude-tools` | *(empty)* | Comma-separated tool names to exclude |
-| `--ignore-scopes` | `false` | Skip PAT scope detection |
+| Flag                     | Default                      | Description                                                                                                                                                                         |
+| ------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--http`                 | *(off)*                      | Enable HTTP transport mode                                                                                                                                                          |
+| `--http-addr`            | `:8080`                      | HTTP listen address                                                                                                                                                                 |
+| `--gitlab-url`           | *(optional)*                 | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request                                                                                          |
+| `--skip-tls-verify`      | `false`                      | Skip TLS certificate verification                                                                                                                                                   |
+| `--tool-surface`         | `dynamic`                    | Canonical tool catalog selector: `dynamic`, `meta`, or `individual`                                                                                                                 |
+| `--meta-tools`           | *(unset)*                    | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false`                                                                                      |
+| `--capability-surface`   | `full`                       | Resource and prompt catalog selector: `full` or `minimal`                                                                                                                           |
+| `--enterprise`           | `false`                      | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
+| `--max-http-clients`     | `100`                        | Maximum concurrent client sessions                                                                                                                                                  |
+| `--session-timeout`      | `30m`                        | Idle session timeout                                                                                                                                                                |
+| `--auth-mode`            | `legacy`                     | Authentication mode: `legacy` (per-request header) or `oauth` (RFC 9728 Bearer token verification)                                                                                  |
+| `--oauth-cache-ttl`      | `15m`                        | TTL for verified OAuth token cache (1m–2h)                                                                                                                                          |
+| `--revalidate-interval`  | `15m`                        | Interval for OAuth token re-validation against GitLab (`0` disables; upper bound 24h)                                                                                               |
+| `--trusted-proxy-header` | *(empty)*                    | Header containing the real client IP when behind a reverse proxy (e.g. `Fly-Client-IP`, `X-Real-IP`, `X-Forwarded-For`). Used by the per-IP auth rate limiter                       |
+| `--auto-update`          | `true`                       | Enable automatic binary updates                                                                                                                                                     |
+| `--auto-update-repo`     | `jmrplens/gitlab-mcp-server` | GitHub repository for release assets                                                                                                                                                |
+| `--auto-update-interval` | `1h`                         | Interval between periodic update checks                                                                                                                                             |
+| `--read-only`            | `false`                      | Expose only read-only tools                                                                                                                                                         |
+| `--safe-mode`            | `false`                      | Intercept mutating tools, return preview                                                                                                                                            |
+| `--rate-limit-rps`       | `0`                          | Per-server tools/call rate limit in req/s (`0` = disabled)                                                                                                                          |
+| `--rate-limit-burst`     | `40`                         | Token-bucket burst size when `--rate-limit-rps` > 0                                                                                                                                 |
+| `--exclude-tools`        | *(empty)*                    | Comma-separated tool names to exclude                                                                                                                                               |
+| `--ignore-scopes`        | `false`                      | Skip PAT scope detection                                                                                                                                                            |
 
 No `GITLAB_TOKEN` is needed at startup — each client provides its own token per-request via `PRIVATE-TOKEN` header or `Authorization: Bearer`. Clients can specify a `GITLAB-URL` header only when the server starts without `--gitlab-url`; when `--gitlab-url` is configured, it is authoritative and client-provided `GITLAB-URL` values are ignored and logged.
 
@@ -284,12 +284,12 @@ See [HTTP Server Mode](http-server-mode.md) for architecture and deployment deta
 
 These features are always active and require no configuration:
 
-| Feature | Description |
-| --- | --- |
+| Feature                 | Description                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Content annotations** | All Markdown content is annotated with `audience` and `priority` — `ContentList` (priority 0.4), `ContentDetail` (0.6), `ContentMutate` (0.8). This helps MCP clients optimize display and prevents raw Markdown from duplicating the JSON output |
-| **Clickable links** | List results in 14 domains include `[text](url)` links to GitLab entities (MRs, issues, pipelines, etc.) |
-| **Next-step hints** | Every list/detail/mutation response includes `💡 Next steps` suggestions. In meta-tool mode, these are also injected into the JSON `structuredContent` as a `next_steps` array |
-| **Formatted dates** | All timestamps are displayed in readable format (`2025-01-15 10:30`) instead of raw ISO 8601 |
+| **Clickable links**     | List results in 14 domains include `[text](url)` links to GitLab entities (MRs, issues, pipelines, etc.)                                                                                                                                          |
+| **Next-step hints**     | Every list/detail/mutation response includes `💡 Next steps` suggestions. In meta-tool mode, these are also injected into the JSON `structuredContent` as a `next_steps` array                                                                     |
+| **Formatted dates**     | All timestamps are displayed in readable format (`2025-01-15 10:30`) instead of raw ISO 8601                                                                                                                                                      |
 
 See [Output Format](output-format.md) for details.
 

--- a/docs/development/catalog-first-individual-tools.md
+++ b/docs/development/catalog-first-individual-tools.md
@@ -17,10 +17,10 @@ removing duplicated metadata from hundreds of former registration call sites.
 
 Individual tool registration has two layers:
 
-| Layer | Owner | Policy |
-| --- | --- | --- |
-| Handler behavior | Typed domain handlers and `ActionSpec.Route` | Keep explicit closures for logging, request-aware handlers, not-found conversion, embedded resources, rich results, and compatibility behavior |
-| Visible tool metadata | `ActionSpec` projection | Derive title, description, icons, input/output schemas, annotations, and compatibility metadata from specs |
+| Layer                 | Owner                                        | Policy                                                                                                                                         |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Handler behavior      | Typed domain handlers and `ActionSpec.Route` | Keep explicit closures for logging, request-aware handlers, not-found conversion, embedded resources, rich results, and compatibility behavior |
+| Visible tool metadata | `ActionSpec` projection                      | Derive title, description, icons, input/output schemas, annotations, and compatibility metadata from specs                                     |
 
 `RegisterAll` calls `RegisterIndividualCatalogTools`, which projects eligible
 catalog actions into individual MCP tools. Projection fails fast when an action
@@ -29,9 +29,9 @@ has no individual tool policy or when spec metadata cannot produce a valid
 
 Documented source-level exceptions are intentionally narrow:
 
-| Package | Reason |
-| --- | --- |
-| `internal/tools/dynamic/register.go` | Registers the dynamic find/execute controller surface generated from the canonical catalog, not individual GitLab API tools |
+| Package                                       | Reason                                                                                                                                            |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/tools/dynamic/register.go`          | Registers the dynamic find/execute controller surface generated from the canonical catalog, not individual GitLab API tools                       |
 | `internal/tools/serverupdate/action_specs.go` | Defines updater tool handlers that are registered from catalog surface specs with `*autoupdate.Updater`, outside the GitLab client action catalog |
 
 ## Parity Checklist
@@ -100,14 +100,14 @@ notes, but the runtime mechanics remain in domain code.
 
 The migration is enforced by tests and audits:
 
-| Guardrail | What it proves |
-| --- | --- |
-| `TestRegisterAllDoesNotUseDomainRegisterTools` | Root individual registration cannot regress to per-domain `RegisterTools` loops |
-| `TestIndividualToolMetadata_SourceRegistrationUsesActionSpecProjection` | Source registration files do not reintroduce manual individual `mcp.Tool` metadata outside documented exceptions |
-| `TestIndividualToolProjection_GoldenSnapshotParity` | Projected metadata matches `internal/tools/testdata/tools_individual.json` except explicit, reviewed gaps |
-| `TestIndividualToolMetadata_CatalogBackedCoverage` | Every catalog-backed spec references a registered individual tool, and every individual tool without a spec is an explicit standalone exception |
-| `cmd/audit_action_spec_coverage` | Every source domain is classified across individual, meta, dynamic, and standalone surfaces |
-| `TestActionSpecCoverage_AllCatalogRoutesClassified` | Every GitLab.com Enterprise dynamic catalog route is spec-backed |
+| Guardrail                                                               | What it proves                                                                                                                                  |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TestRegisterAllDoesNotUseDomainRegisterTools`                          | Root individual registration cannot regress to per-domain `RegisterTools` loops                                                                 |
+| `TestIndividualToolMetadata_SourceRegistrationUsesActionSpecProjection` | Source registration files do not reintroduce manual individual `mcp.Tool` metadata outside documented exceptions                                |
+| `TestIndividualToolProjection_GoldenSnapshotParity`                     | Projected metadata matches `internal/tools/testdata/tools_individual.json` except explicit, reviewed gaps                                       |
+| `TestIndividualToolMetadata_CatalogBackedCoverage`                      | Every catalog-backed spec references a registered individual tool, and every individual tool without a spec is an explicit standalone exception |
+| `cmd/audit_action_spec_coverage`                                        | Every source domain is classified across individual, meta, dynamic, and standalone surfaces                                                     |
+| `TestActionSpecCoverage_AllCatalogRoutesClassified`                     | Every GitLab.com Enterprise dynamic catalog route is spec-backed                                                                                |
 
 Run the focused checks before changing individual registration policy:
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -235,11 +235,11 @@ func TestCreate_Success(t *testing.T) {
 
 #### Shared helpers (`internal/testutil/`)
 
-| Helper                                  | Purpose                                      |
-| --------------------------------------- | -------------------------------------------- |
-| `testutil.NewTestClient(t)`             | Creates mock GitLab client + httptest mux     |
-| `testutil.RespondJSON(w, code, body)`   | Writes JSON response with status code         |
-| `testutil.RespondJSONWithPagination()`  | Writes JSON response with pagination headers  |
+| Helper                                 | Purpose                                      |
+| -------------------------------------- | -------------------------------------------- |
+| `testutil.NewTestClient(t)`            | Creates mock GitLab client + httptest mux    |
+| `testutil.RespondJSON(w, code, body)`  | Writes JSON response with status code        |
+| `testutil.RespondJSONWithPagination()` | Writes JSON response with pagination headers |
 
 ### End-to-End Tests
 
@@ -276,11 +276,11 @@ GITLAB_SKIP_TLS_VERIFY=true
 
 #### E2E Test Structure
 
-| File                                 | Description                                                        |
-| ------------------------------------ | ------------------------------------------------------------------ |
-| `test/e2e/suite/setup_test.go`       | Shared state, MCP server setup, helpers, drainSidekiq              |
-| `test/e2e/suite/fixture_test.go`     | Self-contained GitLab resource builders                             |
-| `test/e2e/suite/*_test.go`           | 91 domain-specific test files (individual + meta)                   |
+| File                             | Description                                           |
+| -------------------------------- | ----------------------------------------------------- |
+| `test/e2e/suite/setup_test.go`   | Shared state, MCP server setup, helpers, drainSidekiq |
+| `test/e2e/suite/fixture_test.go` | Self-contained GitLab resource builders               |
+| `test/e2e/suite/*_test.go`       | 91 domain-specific test files (individual + meta)     |
 
 ## MCP Inspector
 
@@ -320,12 +320,12 @@ flowchart TD
 
 ### Quick reference
 
-| Function | When to use | Includes GitLab detail | Includes hint |
-| --- | --- | --- | --- |
-| `WrapErr` | Read-only operations | No | No |
-| `WrapErrWithMessage` | Mutating operations (default) | Yes | No |
-| `WrapErrWithHint` | Specific error with known fix | Yes | Yes |
-| `WrapErrWithStatusHint` | Status-specific hint (combines `IsHTTPStatus` + `WrapErrWithHint`) | Yes | Yes (for matching status) |
+| Function                | When to use                                                        | Includes GitLab detail | Includes hint             |
+| ----------------------- | ------------------------------------------------------------------ | ---------------------- | ------------------------- |
+| `WrapErr`               | Read-only operations                                               | No                     | No                        |
+| `WrapErrWithMessage`    | Mutating operations (default)                                      | Yes                    | No                        |
+| `WrapErrWithHint`       | Specific error with known fix                                      | Yes                    | Yes                       |
+| `WrapErrWithStatusHint` | Status-specific hint (combines `IsHTTPStatus` + `WrapErrWithHint`) | Yes                    | Yes (for matching status) |
 
 ### Pattern: Status-specific hints
 
@@ -461,19 +461,19 @@ Install the Go extension and add to `.vscode/mcp.json`:
 
 ## Dependencies
 
-| Dependency                               | Version | Purpose                          |
-| ---------------------------------------- | ------- | -------------------------------- |
-| `github.com/modelcontextprotocol/go-sdk` | v1.6.0  | MCP server framework             |
-| `gitlab.com/gitlab-org/api/client-go/v2`  | v2.24.1  | Official GitLab REST API client  |
-| `github.com/joho/godotenv`               | v1.5.1  | .env file loading for dev        |
+| Dependency                               | Version | Purpose                         |
+| ---------------------------------------- | ------- | ------------------------------- |
+| `github.com/modelcontextprotocol/go-sdk` | v1.6.0  | MCP server framework            |
+| `gitlab.com/gitlab-org/api/client-go/v2` | v2.24.1 | Official GitLab REST API client |
+| `github.com/joho/godotenv`               | v1.5.1  | .env file loading for dev       |
 
 ## External References
 
-| Resource | URL |
-| --- | --- |
+| Resource                       | URL                                                         |
+| ------------------------------ | ----------------------------------------------------------- |
 | MCP Specification (2025-11-25) | <https://modelcontextprotocol.io/specification/2025-11-25/> |
-| MCP Go SDK (pkg.go.dev) | <https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk> |
-| MCP Go SDK Repository | <https://github.com/modelcontextprotocol/go-sdk> |
-| GitLab REST API v4 | <https://docs.gitlab.com/ee/api/rest/> |
-| GitLab Go Client (pkg.go.dev) | <https://pkg.go.dev/gitlab.com/gitlab-org/api/client-go/v2> |
-| GitLab Go Client Repository | <https://gitlab.com/gitlab-org/api/client-go> |
+| MCP Go SDK (pkg.go.dev)        | <https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk> |
+| MCP Go SDK Repository          | <https://github.com/modelcontextprotocol/go-sdk>            |
+| GitLab REST API v4             | <https://docs.gitlab.com/ee/api/rest/>                      |
+| GitLab Go Client (pkg.go.dev)  | <https://pkg.go.dev/gitlab.com/gitlab-org/api/client-go/v2> |
+| GitLab Go Client Repository    | <https://gitlab.com/gitlab-org/api/client-go>               |

--- a/docs/development/dynamic-search-ranker.md
+++ b/docs/development/dynamic-search-ranker.md
@@ -32,33 +32,33 @@ Fuzzy matching is conservative. It runs when lexical search returns no matches o
 
 ## Ranking Weights
 
-| Signal | Weight |
-| --- | ---: |
-| Exact canonical action ID | 120 |
-| Exact alias | 100 |
-| Exact tag | 90 |
-| Exact domain or action | 80 |
-| Split domain or action word | 65 |
-| Partial canonical ID | 55 |
-| Partial domain or action | 45 |
-| Required param match | 35 |
-| Schema enum match | 28 |
-| Typed field or raw flat-text match | 25 |
-| Optional param match | 22 |
-| Synonym or verb alternative flat-text match | 18 |
-| Schema description match | 12 |
+| Signal                                      | Weight |
+| ------------------------------------------- | -----: |
+| Exact canonical action ID                   |    120 |
+| Exact alias                                 |    100 |
+| Exact tag                                   |     90 |
+| Exact domain or action                      |     80 |
+| Split domain or action word                 |     65 |
+| Partial canonical ID                        |     55 |
+| Partial domain or action                    |     45 |
+| Required param match                        |     35 |
+| Schema enum match                           |     28 |
+| Typed field or raw flat-text match          |     25 |
+| Optional param match                        |     22 |
+| Synonym or verb alternative flat-text match |     18 |
+| Schema description match                    |     12 |
 
 ## Alias Metadata
 
 Dynamic aliases have explicit source metadata:
 
-| Source | Meaning |
-| --- | --- |
-| `catalog` | Native alias supplied by the canonical action catalog. |
-| `compatibility` | Backward-compatible alias maintained by the dynamic registry. |
+| Source              | Meaning                                                       |
+| ------------------- | ------------------------------------------------------------- |
+| `catalog`           | Native alias supplied by the canonical action catalog.        |
+| `compatibility`     | Backward-compatible alias maintained by the dynamic registry. |
 | `provider_observed` | Alias observed in model output and kept for repair tolerance. |
-| `standalone` | Alias associated with standalone dynamic-only actions. |
-| `deprecated` | Alias retained only for temporary migration compatibility. |
+| `standalone`        | Alias associated with standalone dynamic-only actions.        |
+| `deprecated`        | Alias retained only for temporary migration compatibility.    |
 
 Aliases also carry a `Searchable` flag. Searchable aliases influence ranking and appear in the field-aware search document. Non-searchable aliases still canonicalize in `describe` and `execute`, but they do not influence search ranking. This is useful for compatibility aliases such as `repository_tree` that are safe to accept as input but too broad for discovery ranking.
 

--- a/docs/development/godoc.md
+++ b/docs/development/godoc.md
@@ -103,13 +103,13 @@ Prefer one canonical `doc.go` package comment, then remove package-adjacent file
 go run ./cmd/audit_godocs/ [flags]
 ```
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--format` | `markdown` | Report format: `markdown` or `json` |
-| `--output` | stdout | Write the report to a file |
-| `--include-tests` | `false` | Include `Test`, `Benchmark`, `Fuzz`, and `Example` functions |
-| `--fail-on-findings` | `false` | Exit non-zero when findings are present |
-| `--ignore-internal` | `false` | Skip packages whose import path contains `/internal/` |
+| Flag                 | Default    | Description                                                  |
+| -------------------- | ---------- | ------------------------------------------------------------ |
+| `--format`           | `markdown` | Report format: `markdown` or `json`                          |
+| `--output`           | stdout     | Write the report to a file                                   |
+| `--include-tests`    | `false`    | Include `Test`, `Benchmark`, `Fuzz`, and `Example` functions |
+| `--fail-on-findings` | `false`    | Exit non-zero when findings are present                      |
+| `--ignore-internal`  | `false`    | Skip packages whose import path contains `/internal/`        |
 
 The non-failing target is intended for remediation work while a baseline exists. The check target is intended for
 future CI gating once the baseline is cleared.

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -12,17 +12,17 @@ This document describes all static analysis tools used in **gitlab-mcp-server**,
 
 The project uses nine complementary static analysis tools:
 
-| Tool | Purpose | Auto-fix | Config | Docs |
-| --- | --- | --- | --- | --- |
-| `goimports` | Import ordering/grouping + gofmt formatting | Yes (`-w`) | N/A | [pkg.go.dev](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) |
-| `gofmt` | Official Go code formatter (canonical style) | Yes (`-w`) | N/A | [pkg.go.dev](https://pkg.go.dev/cmd/gofmt) |
-| `go vet` | Built-in Go bug detection | No | N/A | [pkg.go.dev](https://pkg.go.dev/cmd/vet) |
-| `modernize` | Modern Go idiom suggestions (Go 1.18–1.26) | Yes (`-fix`) | N/A | [pkg.go.dev](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) |
-| `golangci-lint` | Meta-linter with 100+ checks | Partial | `.golangci.yml` | [golangci-lint.run](https://golangci-lint.run/) |
-| `gosec` | OWASP-oriented security scanner | No | `.golangci.yml` | [github.com](https://github.com/securego/gosec) |
-| `staticcheck` | Advanced bug/deprecation/simplification analysis | No | `.golangci.yml` | [staticcheck.dev](https://staticcheck.dev/) |
-| `govulncheck` | Dependency CVE scanner | No | N/A | [pkg.go.dev](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) |
-| `markdownlint-cli2` | Markdown lint and auto-fix | Yes (`--fix`) | `.markdownlint-cli2.jsonc` | [github.com](https://github.com/DavidAnson/markdownlint-cli2) |
+| Tool                | Purpose                                          | Auto-fix      | Config                     | Docs                                                                             |
+| ------------------- | ------------------------------------------------ | ------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| `goimports`         | Import ordering/grouping + gofmt formatting      | Yes (`-w`)    | N/A                        | [pkg.go.dev](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)                |
+| `gofmt`             | Official Go code formatter (canonical style)     | Yes (`-w`)    | N/A                        | [pkg.go.dev](https://pkg.go.dev/cmd/gofmt)                                       |
+| `go vet`            | Built-in Go bug detection                        | No            | N/A                        | [pkg.go.dev](https://pkg.go.dev/cmd/vet)                                         |
+| `modernize`         | Modern Go idiom suggestions (Go 1.18–1.26)       | Yes (`-fix`)  | N/A                        | [pkg.go.dev](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize) |
+| `golangci-lint`     | Meta-linter with 100+ checks                     | Partial       | `.golangci.yml`            | [golangci-lint.run](https://golangci-lint.run/)                                  |
+| `gosec`             | OWASP-oriented security scanner                  | No            | `.golangci.yml`            | [github.com](https://github.com/securego/gosec)                                  |
+| `staticcheck`       | Advanced bug/deprecation/simplification analysis | No            | `.golangci.yml`            | [staticcheck.dev](https://staticcheck.dev/)                                      |
+| `govulncheck`       | Dependency CVE scanner                           | No            | N/A                        | [pkg.go.dev](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)               |
+| `markdownlint-cli2` | Markdown lint and auto-fix                       | Yes (`--fix`) | `.markdownlint-cli2.jsonc` | [github.com](https://github.com/DavidAnson/markdownlint-cli2)                    |
 
 Go analyzers and formatters are scoped to the project Go source roots: `cmd/`, `internal/`, and `test/`. Analysis targets pass the `e2e` build tag so files under `test/e2e/` are included without running E2E tests. Markdown linting remains repository-wide for Markdown files, excluding `plan/` drafts.
 
@@ -46,6 +46,17 @@ make analyze-report
 make analyze-fix
 ```
 
+## Markdown Table Formatting
+
+Source documentation tables can be normalized with the dedicated formatter:
+
+```bash
+go run ./cmd/format_md_tables/
+go run ./cmd/format_md_tables/ --check
+```
+
+The command scans `README.md` and `docs/` by default, skips fenced code blocks, preserves left/right/center alignment markers, and pads table columns for readable source Markdown. Use `--check` in review or CI contexts when you want a non-writing verification pass.
+
 ## Tool Installation
 
 All tools install into `$GOBIN` (usually `$GOPATH/bin`):
@@ -56,14 +67,14 @@ make install-tools
 
 This installs:
 
-| Tool | Install Command | Version |
-| --- | --- | --- |
-| modernize | `go install golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest` | latest |
-| golangci-lint | `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest` | v2.11+ |
-| gosec | `go install github.com/securego/gosec/v2/cmd/gosec@latest` | v2.24+ |
-| staticcheck | `go install honnef.co/go/tools/cmd/staticcheck@latest` | 2026.1+ |
-| govulncheck | `go install golang.org/x/vuln/cmd/govulncheck@latest` | v1.1+ |
-| goimports | `go install golang.org/x/tools/cmd/goimports@latest` | latest |
+| Tool          | Install Command                                                                   | Version |
+| ------------- | --------------------------------------------------------------------------------- | ------- |
+| modernize     | `go install golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest` | latest  |
+| golangci-lint | `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`        | v2.11+  |
+| gosec         | `go install github.com/securego/gosec/v2/cmd/gosec@latest`                        | v2.24+  |
+| staticcheck   | `go install honnef.co/go/tools/cmd/staticcheck@latest`                            | 2026.1+ |
+| govulncheck   | `go install golang.org/x/vuln/cmd/govulncheck@latest`                             | v1.1+   |
+| goimports     | `go install golang.org/x/tools/cmd/goimports@latest`                              | latest  |
 
 Verify installation:
 
@@ -79,44 +90,44 @@ govulncheck -version
 
 ### Individual Targets
 
-| Target | Description |
-| --- | --- |
-| `make goimports` | Apply goimports formatting to Go files under `cmd/`, `internal/`, and `test/` |
-| `make goimports-check` | Check if goimports formatting is needed (no changes) |
-| `make gofmt-check` | Check if gofmt formatting is needed (no changes) |
-| `make fmt` | Apply gofmt formatting to Go files under `cmd/`, `internal/`, and `test/` |
-| `make vet` | Run `go vet` on `cmd/`, `internal/`, and `test/` packages with the `e2e` build tag |
-| `make modernize` | Report modernization suggestions |
-| `make modernize-fix` | Apply modernization fixes automatically |
-| `make golangci-lint` | Run golangci-lint on `cmd/`, `internal/`, and `test/` packages |
-| `make gosec` | Run security scanner (medium+ severity/confidence) |
-| `make staticcheck` | Run static analysis checks |
-| `make govulncheck` | Scan dependencies for known CVEs |
-| `make mdlint` | Lint all Markdown files (excludes `plan/`) |
-| `make mdlint-fix` | Auto-fix Markdown lint issues |
+| Target                 | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `make goimports`       | Apply goimports formatting to Go files under `cmd/`, `internal/`, and `test/`      |
+| `make goimports-check` | Check if goimports formatting is needed (no changes)                               |
+| `make gofmt-check`     | Check if gofmt formatting is needed (no changes)                                   |
+| `make fmt`             | Apply gofmt formatting to Go files under `cmd/`, `internal/`, and `test/`          |
+| `make vet`             | Run `go vet` on `cmd/`, `internal/`, and `test/` packages with the `e2e` build tag |
+| `make modernize`       | Report modernization suggestions                                                   |
+| `make modernize-fix`   | Apply modernization fixes automatically                                            |
+| `make golangci-lint`   | Run golangci-lint on `cmd/`, `internal/`, and `test/` packages                     |
+| `make gosec`           | Run security scanner (medium+ severity/confidence)                                 |
+| `make staticcheck`     | Run static analysis checks                                                         |
+| `make govulncheck`     | Scan dependencies for known CVEs                                                   |
+| `make mdlint`          | Lint all Markdown files (excludes `plan/`)                                         |
+| `make mdlint-fix`      | Auto-fix Markdown lint issues                                                      |
 
 ### Combined Targets
 
-| Target | Description |
-| --- | --- |
-| `make analyze` | Run ALL 9 tools sequentially and fail if any tool reports findings or exits non-zero |
-| `make analyze-fix` | Apply auto-fixes: goimports + gofmt + modernize + markdownlint |
-| `make analyze-report` | Generate combined report to `dist/analysis/report.txt` |
-| `make lint` | Quick lint (go vet only, backward compatible) |
+| Target                | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `make analyze`        | Run ALL 9 tools sequentially and fail if any tool reports findings or exits non-zero |
+| `make analyze-fix`    | Apply auto-fixes: goimports + gofmt + modernize + markdownlint                       |
+| `make analyze-report` | Generate combined report to `dist/analysis/report.txt`                               |
+| `make lint`           | Quick lint (go vet only, backward compatible)                                        |
 
 ### Project Audit Targets
 
-| Target | Description |
-| --- | --- |
-| `make audit-output` | Run the MCP output quality audit on all tools |
-| `make audit-tokens` | Measure exposed tool token overhead |
-| `make audit-tools` | Audit MCP tool metadata violations |
-| `make audit-metrics` | Report MCP tool/resource/prompt counts |
-| `make audit-action-spec-coverage` | Generate ActionSpec surface coverage inventory in `dist/action-spec-coverage.json` |
-| `make audit-dynamic-aliases` | Audit Dynamic search aliases and canonical action reachability |
-| `make audit-test-names` | Audit test function naming convention compliance |
-| `make audit-godocs` | Generate `dist/analysis/godoc.md` with package, exported symbol, and test documentation findings |
-| `make audit-godocs-check` | Run the same Godoc audit and fail if findings remain |
+| Target                            | Description                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `make audit-output`               | Run the MCP output quality audit on all tools                                                    |
+| `make audit-tokens`               | Measure exposed tool token overhead                                                              |
+| `make audit-tools`                | Audit MCP tool metadata violations                                                               |
+| `make audit-metrics`              | Report MCP tool/resource/prompt counts                                                           |
+| `make audit-action-spec-coverage` | Generate ActionSpec surface coverage inventory in `dist/action-spec-coverage.json`               |
+| `make audit-dynamic-aliases`      | Audit Dynamic search aliases and canonical action reachability                                   |
+| `make audit-test-names`           | Audit test function naming convention compliance                                                 |
+| `make audit-godocs`               | Generate `dist/analysis/godoc.md` with package, exported symbol, and test documentation findings |
+| `make audit-godocs-check`         | Run the same Godoc audit and fail if findings remain                                             |
 
 See [Godoc Compliance](godoc.md) for the detailed policy, categories, and local pkgsite workflow.
 
@@ -300,13 +311,13 @@ Configuration file: [`.golangci.yml`](../../.golangci.yml) (v2 format)
 
 #### Exclusion Rules
 
-| Scope | Relaxed Linters |
-| --- | --- |
-| `_test.go` | errcheck, gosec, bodyclose, gocritic, revive, unparam, perfsprint |
-| `vendor/` | All linters |
-| `cmd/server/main.go` | gosec G114 (os.Exit) |
-| `internal/testutil/` | errcheck, gosec |
-| `test/e2e/` | tparallel, thelper, contextcheck, errchkjson (sequential design with shared GitLab fixtures; cleanups use fresh contexts) |
+| Scope                | Relaxed Linters                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `_test.go`           | errcheck, gosec, bodyclose, gocritic, revive, unparam, perfsprint                                                         |
+| `vendor/`            | All linters                                                                                                               |
+| `cmd/server/main.go` | gosec G114 (os.Exit)                                                                                                      |
+| `internal/testutil/` | errcheck, gosec                                                                                                           |
+| `test/e2e/`          | tparallel, thelper, contextcheck, errchkjson (sequential design with shared GitLab fixtures; cleanups use fresh contexts) |
 
 ### 6. gosec
 
@@ -548,18 +559,18 @@ Runs via `npx` (Node.js required, no global install needed).
 
 #### Key Rules
 
-| Rule | Description |
-| --- | --- |
-| MD001 | Heading levels should only increment by one |
-| MD003 | Heading style should be consistent |
-| MD009 | Trailing spaces |
-| MD010 | Hard tabs |
-| MD012 | Multiple consecutive blank lines |
-| MD022 | Headings should be surrounded by blank lines |
+| Rule  | Description                                            |
+| ----- | ------------------------------------------------------ |
+| MD001 | Heading levels should only increment by one            |
+| MD003 | Heading style should be consistent                     |
+| MD009 | Trailing spaces                                        |
+| MD010 | Hard tabs                                              |
+| MD012 | Multiple consecutive blank lines                       |
+| MD022 | Headings should be surrounded by blank lines           |
 | MD031 | Fenced code blocks should be surrounded by blank lines |
-| MD032 | Lists should be surrounded by blank lines |
-| MD034 | Bare URLs without angle brackets or links |
-| MD047 | Files should end with a single newline character |
+| MD032 | Lists should be surrounded by blank lines              |
+| MD034 | Bare URLs without angle brackets or links              |
+| MD047 | Files should end with a single newline character       |
 
 Full rule list: [markdownlint rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
 
@@ -567,14 +578,14 @@ Full rule list: [markdownlint rules](https://github.com/DavidAnson/markdownlint/
 
 #### Disabled Rules
 
-| Rule | Reason |
-| --- | --- |
-| MD013 | Line length — many tables and code blocks exceed 80 chars |
-| MD024 | Multiple headings with same content — common in changelogs |
+| Rule  | Reason                                                          |
+| ----- | --------------------------------------------------------------- |
+| MD013 | Line length — many tables and code blocks exceed 80 chars       |
+| MD024 | Multiple headings with same content — common in changelogs      |
 | MD025 | Single top-level heading — some docs have multiple H1 by design |
-| MD033 | Inline HTML — Mermaid diagrams, badges, details/summary |
-| MD041 | First line heading — files with front matter |
-| MD060 | Native syntax over HTML — disabled |
+| MD033 | Inline HTML — Mermaid diagrams, badges, details/summary         |
+| MD041 | First line heading — files with front matter                    |
+| MD060 | Native syntax over HTML — disabled                              |
 
 #### Ignored Paths
 

--- a/docs/development/tool-surfaces-and-action-core.md
+++ b/docs/development/tool-surfaces-and-action-core.md
@@ -10,11 +10,11 @@ GitLab business logic.
 
 ## Tool Surfaces
 
-| Surface | Selector | Visible MCP tools | Source of action metadata |
-| --- | --- | ---: | --- |
-| Individual tools | `TOOL_SURFACE=individual` (`META_TOOLS=false` legacy) | One tool per GitLab operation | Canonical action catalog projected by `RegisterIndividualCatalogTools` |
-| Dynamic | default, `TOOL_SURFACE=dynamic` | `gitlab_find_action`, `gitlab_execute_tool` | Canonical action catalog |
-| Meta-tools | `TOOL_SURFACE=meta` | Domain dispatchers with `action` and `params` | Canonical action catalog |
+| Surface          | Selector                                              |                             Visible MCP tools | Source of action metadata                                              |
+| ---------------- | ----------------------------------------------------- | --------------------------------------------: | ---------------------------------------------------------------------- |
+| Individual tools | `TOOL_SURFACE=individual` (`META_TOOLS=false` legacy) |                 One tool per GitLab operation | Canonical action catalog projected by `RegisterIndividualCatalogTools` |
+| Dynamic          | default, `TOOL_SURFACE=dynamic`                       |   `gitlab_find_action`, `gitlab_execute_tool` | Canonical action catalog                                               |
+| Meta-tools       | `TOOL_SURFACE=meta`                                   | Domain dispatchers with `action` and `params` | Canonical action catalog                                               |
 
 Individual tools, meta-tools, and dynamic tools are now catalog-backed surfaces
 over the same action core. Domain packages still own typed handlers,
@@ -59,19 +59,19 @@ flowchart LR
 
 The core pieces are:
 
-| File | Responsibility |
-| --- | --- |
-| `internal/toolutil/action_spec.go` | Canonical per-action metadata model, validation, defensive cloning, compatibility policy, and route/catalog projection |
-| `internal/toolutil/action_spec_individual.go` | `ActionSpec` projection into individual `mcp.Tool` metadata and schema/annotation policy |
-| `internal/toolutil/metatool.go` | Route primitives such as `ActionRoute`, `ActionMap`, schema helpers, destructive confirmation dispatch, and `MakeMetaHandler` |
-| `internal/tools/actioncatalog/catalog.go` | Canonical action catalog data model, deterministic ordering, filters, and `domain.action` IDs |
-| `internal/tools/actioncatalog/group_spec.go` | `CatalogGroupSpec`, `SurfaceKind`, group validation, group option projection, and compatibility alias conflict checks |
-| `internal/tools/action_specs.go` | Deterministic collector for domain `ActionSpec` builders, including Enterprise and GitLab.com gating |
-| `internal/tools/action_catalog.go` | Builds the canonical catalog from collected `ActionSpec` groups and the generated manifest |
-| `internal/tools/meta_catalog.go` | Registers visible meta-tools from catalog groups |
-| `internal/tools/dynamic/register.go` | Builds the dynamic registry, find output, internal search/describe helpers, and execute dispatch from the catalog |
-| `internal/tools/dynamic/standalone.go` | Adds dynamic-only catalog actions that do not fit the normal meta route model |
-| `cmd/audit_action_spec_coverage` | Generates source-discovered ActionSpec coverage inventory across individual, meta, dynamic, and standalone surfaces |
+| File                                          | Responsibility                                                                                                                |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `internal/toolutil/action_spec.go`            | Canonical per-action metadata model, validation, defensive cloning, compatibility policy, and route/catalog projection        |
+| `internal/toolutil/action_spec_individual.go` | `ActionSpec` projection into individual `mcp.Tool` metadata and schema/annotation policy                                      |
+| `internal/toolutil/metatool.go`               | Route primitives such as `ActionRoute`, `ActionMap`, schema helpers, destructive confirmation dispatch, and `MakeMetaHandler` |
+| `internal/tools/actioncatalog/catalog.go`     | Canonical action catalog data model, deterministic ordering, filters, and `domain.action` IDs                                 |
+| `internal/tools/actioncatalog/group_spec.go`  | `CatalogGroupSpec`, `SurfaceKind`, group validation, group option projection, and compatibility alias conflict checks         |
+| `internal/tools/action_specs.go`              | Deterministic collector for domain `ActionSpec` builders, including Enterprise and GitLab.com gating                          |
+| `internal/tools/action_catalog.go`            | Builds the canonical catalog from collected `ActionSpec` groups and the generated manifest                                    |
+| `internal/tools/meta_catalog.go`              | Registers visible meta-tools from catalog groups                                                                              |
+| `internal/tools/dynamic/register.go`          | Builds the dynamic registry, find output, internal search/describe helpers, and execute dispatch from the catalog             |
+| `internal/tools/dynamic/standalone.go`        | Adds dynamic-only catalog actions that do not fit the normal meta route model                                                 |
+| `cmd/audit_action_spec_coverage`              | Generates source-discovered ActionSpec coverage inventory across individual, meta, dynamic, and standalone surfaces           |
 
 The catalog stores executable routes with input schemas, output schemas,
 destructive flags, read-only status, icons, descriptions, aliases, tags, usage
@@ -245,22 +245,22 @@ bridge has now been removed from active runtime registration.
 
 Current baseline for delegated meta ownership:
 
-| Metric | Count |
-| --- | ---: |
-| Package-level `RegisterMeta` definitions under `internal/tools/*` | 0 |
-| Delegated `RegisterMeta` calls referenced from `internal/tools/register_meta.go` | 0 |
-| Apparent legacy `RegisterMeta` definitions requiring verification | 0 |
+| Metric                                                                           | Count |
+| -------------------------------------------------------------------------------- | ----: |
+| Package-level `RegisterMeta` definitions under `internal/tools/*`                |     0 |
+| Delegated `RegisterMeta` calls referenced from `internal/tools/register_meta.go` |     0 |
+| Apparent legacy `RegisterMeta` definitions requiring verification                |     0 |
 
 Historical names still handled as compatibility aliases:
 
-| Historical name | Current visible surface |
-| --- | --- |
-| `gitlab_feature_flag` | `gitlab_feature_flags` |
-| `gitlab_ff_user_list` | `gitlab_feature_flags` |
-| `gitlab_registry` | `gitlab_package` |
-| `gitlab_registry_protection` | `gitlab_package` |
-| `gitlab_access_request` | `gitlab_access` |
-| `gitlab_project_snippet` | `gitlab_snippet` |
+| Historical name              | Current visible surface |
+| ---------------------------- | ----------------------- |
+| `gitlab_feature_flag`        | `gitlab_feature_flags`  |
+| `gitlab_ff_user_list`        | `gitlab_feature_flags`  |
+| `gitlab_registry`            | `gitlab_package`        |
+| `gitlab_registry_protection` | `gitlab_package`        |
+| `gitlab_access_request`      | `gitlab_access`         |
+| `gitlab_project_snippet`     | `gitlab_snippet`        |
 
 Package-level `RegisterMeta` functions are now treated as audit violations.
 Former delegated groups such as `gitlab_search`, `gitlab_runner`,

--- a/docs/dynamic-tools.md
+++ b/docs/dynamic-tools.md
@@ -12,11 +12,11 @@ The dynamic toolset is the low-token operating mode for gitlab-mcp-server. It ex
 
 Use the dynamic toolset when the initial MCP `tools/list` payload is the limiting factor for your AI client. This is common with clients that have small tool-context budgets, strict tool-count limits, or slow tool palette rendering.
 
-| Mode | Visible Tools | Best For |
-| --- | ---: | --- |
-| Dynamic toolset, default | 2 | Low-token clients that can find an action with schema, then execute it |
-| Meta-tools | 33 base / 49 self-managed enterprise / 50 GitLab.com Enterprise | Broad compatibility and predictable domain-level action selection |
-| Individual tools | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Clients that benefit from one tool per GitLab operation |
+| Mode                     |                                                      Visible Tools | Best For                                                               |
+| ------------------------ | -----------------------------------------------------------------: | ---------------------------------------------------------------------- |
+| Dynamic toolset, default |                                                                  2 | Low-token clients that can find an action with schema, then execute it |
+| Meta-tools               |    33 base / 49 self-managed enterprise / 50 GitLab.com Enterprise | Broad compatibility and predictable domain-level action selection      |
+| Individual tools         | 866 CE / 1017 self-managed enterprise / 1022 GitLab.com Enterprise | Clients that benefit from one tool per GitLab operation                |
 
 Dynamic mode keeps the same underlying GitLab coverage as meta-tools. It changes discovery, not business behavior.
 
@@ -24,10 +24,10 @@ Dynamic mode keeps the same underlying GitLab coverage as meta-tools. It changes
 
 `TOOL_SURFACE=dynamic` (or leaving `TOOL_SURFACE` unset) exposes the current two-tool surface:
 
-| Tool | Purpose |
-| --- | --- |
-| `gitlab_find_action` | Search the canonical action catalog and return exact input schemas, examples, safety metadata, and output summaries for matching action IDs |
-| `gitlab_execute_tool` | Execute one selected action by canonical `domain.action` ID with runtime validation and safety checks |
+| Tool                  | Purpose                                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gitlab_find_action`  | Search the canonical action catalog and return exact input schemas, examples, safety metadata, and output summaries for matching action IDs |
+| `gitlab_execute_tool` | Execute one selected action by canonical `domain.action` ID with runtime validation and safety checks                                       |
 
 ## Configuration
 
@@ -198,13 +198,13 @@ The action ID is canonical. Aliases can help discovery, but execution should use
 
 Dynamic mode is designed for repairable failures. Models should treat `isError: true` as feedback, not as a dead end:
 
-| Failure | Server response | Model recovery |
-| --- | --- | --- |
-| Missing find query | Error result with example query terms | Retry `gitlab_find_action` with domain, resource, verb, and filters |
-| Unknown action ID | Error result, often with `Did you mean ...?` canonical IDs | Find the suggested canonical action ID |
-| Ambiguous alias | Error result listing the valid canonical targets | Pick one listed `domain.action` ID and find or describe it |
-| Invalid params | Backing handler validation error | Call `gitlab_find_action` and rebuild `params` from `input_schema` |
-| Destructive action without confirmation | Error result explaining that `confirm=true` is required | Ask the user for explicit approval, then retry with top-level `confirm: true` only if approved |
+| Failure                                 | Server response                                            | Model recovery                                                                                 |
+| --------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Missing find query                      | Error result with example query terms                      | Retry `gitlab_find_action` with domain, resource, verb, and filters                            |
+| Unknown action ID                       | Error result, often with `Did you mean ...?` canonical IDs | Find the suggested canonical action ID                                                         |
+| Ambiguous alias                         | Error result listing the valid canonical targets           | Pick one listed `domain.action` ID and find or describe it                                     |
+| Invalid params                          | Backing handler validation error                           | Call `gitlab_find_action` and rebuild `params` from `input_schema`                             |
+| Destructive action without confirmation | Error result explaining that `confirm=true` is required    | Ask the user for explicit approval, then retry with top-level `confirm: true` only if approved |
 
 ## Destructive Actions
 
@@ -300,15 +300,15 @@ Prefer compact metadata that teaches the distinction rather than broad synonyms 
 
 ## Dynamic vs Meta-Tools
 
-| Concern | Meta-tools | Dynamic toolset |
-| --- | --- | --- |
-| Initial tool count | 33/49/50 | 2 |
-| Model selection | Choose a domain tool and action | Find an action with schema, execute |
-| Schema discovery | `action` enum plus optional schema resources or `META_PARAM_SCHEMA=compact/full` | `gitlab_find_action` returns action schemas inline |
-| Minimal capabilities | Loses meta-schema resources and prompts | Keeps action schema discovery through find |
-| Compatibility | Explicit consolidated-dispatcher mode | Default low-token mode |
-| Failure mode | Wrong domain/action choice | Skipped find or wrong action ID |
-| Rollback | Switch to `TOOL_SURFACE=meta` | Default path |
+| Concern              | Meta-tools                                                                       | Dynamic toolset                                    |
+| -------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Initial tool count   | 33/49/50                                                                         | 2                                                  |
+| Model selection      | Choose a domain tool and action                                                  | Find an action with schema, execute                |
+| Schema discovery     | `action` enum plus optional schema resources or `META_PARAM_SCHEMA=compact/full` | `gitlab_find_action` returns action schemas inline |
+| Minimal capabilities | Loses meta-schema resources and prompts                                          | Keeps action schema discovery through find         |
+| Compatibility        | Explicit consolidated-dispatcher mode                                            | Default low-token mode                             |
+| Failure mode         | Wrong domain/action choice                                                       | Skipped find or wrong action ID                    |
+| Rollback             | Switch to `TOOL_SURFACE=meta`                                                    | Default path                                       |
 
 Dynamic mode is the default for low-token clients, evaluations, and deployments that benefit from compact progressive discovery. Meta-tools remain available for clients that prefer explicit domain dispatchers.
 
@@ -318,19 +318,19 @@ Implementation entry points:
 
 For the broader developer architecture of individual tools, meta-tools, dynamic surfaces, and the canonical action core, see [Tool Surfaces And Canonical Action Core](development/tool-surfaces-and-action-core.md).
 
-| File | Responsibility |
-| --- | --- |
-| `internal/tools/actioncatalog/catalog.go` | Canonical action catalog data model, deterministic action ordering, lookup, and filters |
-| `internal/tools/action_catalog.go` | Builds the canonical catalog from collected `ActionSpec` groups and the generated manifest |
-| `internal/tools/meta_catalog.go` | Registers visible meta-tools from the canonical catalog |
-| `internal/tools/dynamic/register.go` | Public dynamic tools, catalog-backed registry, find, internal search/describe helpers, and execute logic |
-| `internal/tools/dynamic/standalone.go` | Adds standalone actions such as project discovery and interactive creation flows to the canonical action catalog |
-| `internal/tools/actioncompat` | Historical action aliases, parameter aliases, and execute-time compatibility normalizers projected into catalog metadata |
-| `internal/toolutil/action_spec.go` | Canonical per-action metadata model, including aliases, tags, usage hints, related actions, and parameter guidance |
-| `internal/toolutil/metatool.go` | Shared `ActionRoute`, route classification, schema helpers, and execution wrappers |
-| `cmd/server/main.go` | Selects `TOOL_SURFACE` and registers meta, individual, or dynamic surfaces |
-| `cmd/eval_mcp_surfaces` | Evaluates meta and dynamic surfaces against schema-only and Docker-backed tasks |
-| `test/e2e/suite/dynamic_test.go` | E2E coverage for the default dynamic two-tool surface |
+| File                                      | Responsibility                                                                                                           |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `internal/tools/actioncatalog/catalog.go` | Canonical action catalog data model, deterministic action ordering, lookup, and filters                                  |
+| `internal/tools/action_catalog.go`        | Builds the canonical catalog from collected `ActionSpec` groups and the generated manifest                               |
+| `internal/tools/meta_catalog.go`          | Registers visible meta-tools from the canonical catalog                                                                  |
+| `internal/tools/dynamic/register.go`      | Public dynamic tools, catalog-backed registry, find, internal search/describe helpers, and execute logic                 |
+| `internal/tools/dynamic/standalone.go`    | Adds standalone actions such as project discovery and interactive creation flows to the canonical action catalog         |
+| `internal/tools/actioncompat`             | Historical action aliases, parameter aliases, and execute-time compatibility normalizers projected into catalog metadata |
+| `internal/toolutil/action_spec.go`        | Canonical per-action metadata model, including aliases, tags, usage hints, related actions, and parameter guidance       |
+| `internal/toolutil/metatool.go`           | Shared `ActionRoute`, route classification, schema helpers, and execution wrappers                                       |
+| `cmd/server/main.go`                      | Selects `TOOL_SURFACE` and registers meta, individual, or dynamic surfaces                                               |
+| `cmd/eval_mcp_surfaces`                   | Evaluates meta and dynamic surfaces against schema-only and Docker-backed tasks                                          |
+| `test/e2e/suite/dynamic_test.go`          | E2E coverage for the default dynamic two-tool surface                                                                    |
 
 ### Registering New Actions
 
@@ -366,14 +366,14 @@ Use `dynamic` for production-like low-token configuration.
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-| --- | --- | --- |
-| Only two tools appear | Dynamic mode is enabled | This is expected. Use `gitlab_find_action` to discover actions and schemas |
-| Find returns many broad list actions | Query is too generic | Include the domain, resource, verb, and filter terms, such as `merge request list open authored by me` |
-| Execute says the action is unknown | The model invented an action ID or the action was excluded | Find again and execute the canonical action ID from the result |
-| Execute rejects parameters | Params do not match the found schema | Call `gitlab_find_action` for that action and retry with the exact field names and types |
-| Destructive action returns an error | Confirmation is missing or policy blocks mutation | Add top-level `confirm:true` only when intentional, or check `GITLAB_READ_ONLY` and `GITLAB_SAFE_MODE` |
-| Resources and prompts still use context | Capability surface is still full | Set `CAPABILITY_SURFACE=minimal` or `--capability-surface=minimal` |
+| Symptom                                 | Cause                                                      | Fix                                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Only two tools appear                   | Dynamic mode is enabled                                    | This is expected. Use `gitlab_find_action` to discover actions and schemas                             |
+| Find returns many broad list actions    | Query is too generic                                       | Include the domain, resource, verb, and filter terms, such as `merge request list open authored by me` |
+| Execute says the action is unknown      | The model invented an action ID or the action was excluded | Find again and execute the canonical action ID from the result                                         |
+| Execute rejects parameters              | Params do not match the found schema                       | Call `gitlab_find_action` for that action and retry with the exact field names and types               |
+| Destructive action returns an error     | Confirmation is missing or policy blocks mutation          | Add top-level `confirm:true` only when intentional, or check `GITLAB_READ_ONLY` and `GITLAB_SAFE_MODE` |
+| Resources and prompts still use context | Capability surface is still full                           | Set `CAPABILITY_SURFACE=minimal` or `--capability-surface=minimal`                                     |
 
 ## See Also
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -10,45 +10,45 @@
 
 ## Required
 
-| Variable | Description | Example |
-| --- | --- | --- |
+| Variable       | Description                            | Example                      |
+| -------------- | -------------------------------------- | ---------------------------- |
 | `GITLAB_TOKEN` | Personal Access Token with `api` scope | `glpat-xxxxxxxxxxxxxxxxxxxx` |
 
 ---
 
 ## Optional — Connection
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `GITLAB_URL` | `https://gitlab.com` | GitLab instance base URL (must use `http://` or `https://` scheme). Set this for self-managed instances |
-| `GITLAB_SKIP_TLS_VERIFY` | `false` | Skip TLS certificate verification (`true`/`false`). Use for self-signed certs |
+| Variable                 | Default              | Description                                                                                             |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`             | `https://gitlab.com` | GitLab instance base URL (must use `http://` or `https://` scheme). Set this for self-managed instances |
+| `GITLAB_SKIP_TLS_VERIFY` | `false`              | Skip TLS certificate verification (`true`/`false`). Use for self-signed certs                           |
 
 ---
 
 ## Optional — Server Behavior
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `TOOL_SURFACE` | `dynamic` | Canonical tool catalog selector: `dynamic`, `meta`, or `individual`. `dynamic` exposes find/execute |
-| `META_TOOLS` | *(legacy)* | Deprecated compatibility selector. Accepted values map to `TOOL_SURFACE`: `true` -> `meta`, `false` -> `individual`, and `dynamic` -> `dynamic`. Ignored when `TOOL_SURFACE` is set |
-| `CAPABILITY_SURFACE` | `full` | Resource and prompt catalog selector: `full` keeps the complete catalog; `minimal` keeps `gitlab://workspace/roots`, disables optional resources, workflow guides, and prompts, and keeps meta-schema resources only for `TOOL_SURFACE=meta`. Dynamic describe/find still returns action schemas inline with `minimal` |
-| `META_PARAM_SCHEMA` | `opaque` | Meta-tool input-schema strategy: `opaque` (compact `{action, params:any}` envelope, default), `compact` (oneOf with property names + types only, 6.5x opaque size) or `full` (oneOf with full per-action JSON Schemas, 11.9x opaque size). Applies to visible meta-tool schemas in `meta`; has no practical effect on `dynamic` or `individual` tool schemas. Per-action JSON Schemas are discoverable via `gitlab://schema/meta/{tool}/{action}` for meta when `CAPABILITY_SURFACE=full` or `minimal`, and for dynamic catalog-backed surfaces when `CAPABILITY_SURFACE=full` |
-| `GITLAB_ENTERPRISE` | `false` | Enable Enterprise/Premium tools for GitLab Premium/Ultimate features in stdio mode. In HTTP mode, `--enterprise` explicitly forces the Enterprise/Premium catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
-| `LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` |
-| `GITLAB_READ_ONLY` | `false` | Read-only mode: disables all mutating tools at startup. Only tools with `ReadOnlyHint=true` remain available (`true`/`false`) |
-| `GITLAB_SAFE_MODE` | `false` | Safe mode: intercepts mutating tools and returns a structured JSON preview instead of executing. Read-only tools work normally. If `GITLAB_READ_ONLY=true`, it takes precedence (`true`/`false`) |
-| `EMBEDDED_RESOURCES` | `true` | Embed canonical `gitlab://` MCP resource URIs as `EmbeddedResource` content blocks in `gitlab_*_get` tool results. Set to `false` to disable for clients that don't tolerate duplicate content blocks (`true`/`false`) |
-| `EXCLUDE_TOOLS` | *(empty)* | Comma-separated list of tool names to exclude from registration (e.g. `gitlab_admin,gitlab_runner`) |
-| `GITLAB_IGNORE_SCOPES` | `false` | Skip PAT scope detection and register all tools regardless of token permissions (`true`/`false`) |
+| Variable               | Default    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `TOOL_SURFACE`         | `dynamic`  | Canonical tool catalog selector: `dynamic`, `meta`, or `individual`. `dynamic` exposes find/execute                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `META_TOOLS`           | *(legacy)* | Deprecated compatibility selector. Accepted values map to `TOOL_SURFACE`: `true` -> `meta`, `false` -> `individual`, and `dynamic` -> `dynamic`. Ignored when `TOOL_SURFACE` is set                                                                                                                                                                                                                                                                                                                                                                                            |
+| `CAPABILITY_SURFACE`   | `full`     | Resource and prompt catalog selector: `full` keeps the complete catalog; `minimal` keeps `gitlab://workspace/roots`, disables optional resources, workflow guides, and prompts, and keeps meta-schema resources only for `TOOL_SURFACE=meta`. Dynamic describe/find still returns action schemas inline with `minimal`                                                                                                                                                                                                                                                         |
+| `META_PARAM_SCHEMA`    | `opaque`   | Meta-tool input-schema strategy: `opaque` (compact `{action, params:any}` envelope, default), `compact` (oneOf with property names + types only, 6.5x opaque size) or `full` (oneOf with full per-action JSON Schemas, 11.9x opaque size). Applies to visible meta-tool schemas in `meta`; has no practical effect on `dynamic` or `individual` tool schemas. Per-action JSON Schemas are discoverable via `gitlab://schema/meta/{tool}/{action}` for meta when `CAPABILITY_SURFACE=full` or `minimal`, and for dynamic catalog-backed surfaces when `CAPABILITY_SURFACE=full` |
+| `GITLAB_ENTERPRISE`    | `false`    | Enable Enterprise/Premium tools for GitLab Premium/Ultimate features in stdio mode. In HTTP mode, `--enterprise` explicitly forces the Enterprise/Premium catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when GitLab reports edition in `/api/v4/version`                                                                                                                                                                                                                                                                                              |
+| `LOG_LEVEL`            | `info`     | Logging verbosity: `debug`, `info`, `warn`, `error`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `GITLAB_READ_ONLY`     | `false`    | Read-only mode: disables all mutating tools at startup. Only tools with `ReadOnlyHint=true` remain available (`true`/`false`)                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `GITLAB_SAFE_MODE`     | `false`    | Safe mode: intercepts mutating tools and returns a structured JSON preview instead of executing. Read-only tools work normally. If `GITLAB_READ_ONLY=true`, it takes precedence (`true`/`false`)                                                                                                                                                                                                                                                                                                                                                                               |
+| `EMBEDDED_RESOURCES`   | `true`     | Embed canonical `gitlab://` MCP resource URIs as `EmbeddedResource` content blocks in `gitlab_*_get` tool results. Set to `false` to disable for clients that don't tolerate duplicate content blocks (`true`/`false`)                                                                                                                                                                                                                                                                                                                                                         |
+| `EXCLUDE_TOOLS`        | *(empty)*  | Comma-separated list of tool names to exclude from registration (e.g. `gitlab_admin,gitlab_runner`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `GITLAB_IGNORE_SCOPES` | `false`    | Skip PAT scope detection and register all tools regardless of token permissions (`true`/`false`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ---
 
 ## Optional — Destructive Action Confirmation
 
-| Variable | Default | Description |
-| --- | --- | --- |
+| Variable    | Default | Description                                                            |
+| ----------- | ------- | ---------------------------------------------------------------------- |
 | `YOLO_MODE` | `false` | Skip confirmation prompts for destructive actions (delete, force-push) |
-| `AUTOPILOT` | `false` | Same as `YOLO_MODE` — skip all confirmation prompts |
+| `AUTOPILOT` | `false` | Same as `YOLO_MODE` — skip all confirmation prompts                    |
 
 These are checked by the elicitation subsystem. When the MCP client supports elicitation, destructive tools ask for user confirmation unless one of these is `true`.
 
@@ -56,14 +56,14 @@ These are checked by the elicitation subsystem. When the MCP client supports eli
 
 ## Optional — Upload
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `UPLOAD_MAX_FILE_SIZE` | `2GB` | Maximum file size for upload tools. Supports human-friendly suffixes: `KB`, `MB`, `GB` (case-insensitive). Upper bound: 1 TB |
+| Variable               | Default | Description                                                                                                                  |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `UPLOAD_MAX_FILE_SIZE` | `2GB`   | Maximum file size for upload tools. Supports human-friendly suffixes: `KB`, `MB`, `GB` (case-insensitive). Upper bound: 1 TB |
 
 ## Optional — Local Import Files
 
-| Variable | Default | Description |
-| --- | --- | --- |
+| Variable                         | Default   | Description                                                                                                                                                                                                                                                                                                    |
+| -------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GITLAB_MCP_ALLOWED_IMPORT_DIRS` | *(empty)* | Additional OS path-list-separated directories allowed for `file_path`/`file` project and group import archives. The current working directory and OS temp directory are always allowed. Import archives must resolve inside an allowed directory after symlink resolution and must use the `.tar.gz` extension |
 
 ---
@@ -72,26 +72,26 @@ These are checked by the elicitation subsystem. When the MCP client supports eli
 
 These variables configure the HTTP server pool when running in HTTP mode. In stdio mode, they are parsed but only used if the configuration is shared with HTTP mode logic.
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `MAX_HTTP_CLIENTS` | `100` | Maximum concurrent client sessions in the server pool. Upper bound: 10,000 |
-| `SESSION_TIMEOUT` | `30m` | Idle MCP session timeout. Upper bound: 24h |
-| `SESSION_REVALIDATE_INTERVAL` | `15m` | Token re-validation interval; `0` to disable. Upper bound: 24h |
-| `AUTH_MODE` | `legacy` | Authentication mode: `legacy` (PRIVATE-TOKEN header passthrough) or `oauth` (RFC 9728 Bearer token verification via GitLab API) |
-| `OAUTH_CACHE_TTL` | `15m` | TTL for verified OAuth token identity cache. Range: 1m–2h |
-| `RATE_LIMIT_RPS` | `0` | Per-server `tools/call` rate limit in requests/second. `0` disables the limiter (default). See [Security — Rate Limiting Model](security.md#rate-limiting-model) |
-| `RATE_LIMIT_BURST` | `40` | Token-bucket burst size when `RATE_LIMIT_RPS > 0`. Must be ≥ 1 |
+| Variable                      | Default  | Description                                                                                                                                                      |
+| ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MAX_HTTP_CLIENTS`            | `100`    | Maximum concurrent client sessions in the server pool. Upper bound: 10,000                                                                                       |
+| `SESSION_TIMEOUT`             | `30m`    | Idle MCP session timeout. Upper bound: 24h                                                                                                                       |
+| `SESSION_REVALIDATE_INTERVAL` | `15m`    | Token re-validation interval; `0` to disable. Upper bound: 24h                                                                                                   |
+| `AUTH_MODE`                   | `legacy` | Authentication mode: `legacy` (PRIVATE-TOKEN header passthrough) or `oauth` (RFC 9728 Bearer token verification via GitLab API)                                  |
+| `OAUTH_CACHE_TTL`             | `15m`    | TTL for verified OAuth token identity cache. Range: 1m–2h                                                                                                        |
+| `RATE_LIMIT_RPS`              | `0`      | Per-server `tools/call` rate limit in requests/second. `0` disables the limiter (default). See [Security — Rate Limiting Model](security.md#rate-limiting-model) |
+| `RATE_LIMIT_BURST`            | `40`     | Token-bucket burst size when `RATE_LIMIT_RPS > 0`. Must be ≥ 1                                                                                                   |
 
 ---
 
 ## Optional — Auto-Update
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `AUTO_UPDATE` | `true` | Update mode: `true` (download and apply), `check` (log only), `false` (disabled) |
-| `AUTO_UPDATE_REPO` | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets |
-| `AUTO_UPDATE_INTERVAL` | `1h` | Periodic update check interval (HTTP mode background checks) |
-| `AUTO_UPDATE_TIMEOUT` | `60s` | Pre-start download timeout (range: 5s–10m) |
+| Variable               | Default                      | Description                                                                      |
+| ---------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
+| `AUTO_UPDATE`          | `true`                       | Update mode: `true` (download and apply), `check` (log only), `false` (disabled) |
+| `AUTO_UPDATE_REPO`     | `jmrplens/gitlab-mcp-server` | GitHub repository slug (owner/repo) for release assets                           |
+| `AUTO_UPDATE_INTERVAL` | `1h`                         | Periodic update check interval (HTTP mode background checks)                     |
+| `AUTO_UPDATE_TIMEOUT`  | `60s`                        | Pre-start download timeout (range: 5s–10m)                                       |
 
 > **Note**: Auto-update uses the GitHub Releases API via `AUTO_UPDATE_REPO`. See [Auto-Update](auto-update.md) for details.
 
@@ -133,33 +133,33 @@ For self-managed GitLab, add `GITLAB_URL=https://gitlab.example.com`.
 
 In HTTP mode, configuration comes from CLI flags instead of environment variables. See [CLI Reference](cli-reference.md) for the full flag list.
 
-| Environment Variable | CLI Flag | Notes |
-| --- | --- | --- |
-| `GITLAB_URL` | `--gitlab-url` | Optional in stdio mode; defaults to `https://gitlab.com`. Optional in HTTP mode unless `--auth-mode=oauth` is used, which requires a fixed `--gitlab-url`. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
-| `GITLAB_TOKEN` | *(none)* | Not needed in HTTP mode — clients provide tokens per-request |
-| `GITLAB_SKIP_TLS_VERIFY` | `--skip-tls-verify` | |
-| `TOOL_SURFACE` | `--tool-surface` | Canonical selector: `meta`, `individual`, or `dynamic` |
-| `META_TOOLS` | `--meta-tools` | Deprecated compatibility selector. Use `TOOL_SURFACE` or `--tool-surface` for new configs |
-| `CAPABILITY_SURFACE` | `--capability-surface` | Explicit selector: `full` or `minimal` |
-| `META_PARAM_SCHEMA` | `--meta-param-schema` | |
-| `MAX_HTTP_CLIENTS` | `--max-http-clients` | |
-| `SESSION_TIMEOUT` | `--session-timeout` | |
-| `SESSION_REVALIDATE_INTERVAL` | `--revalidate-interval` | |
-| `AUTH_MODE` | `--auth-mode` | |
-| `OAUTH_CACHE_TTL` | `--oauth-cache-ttl` | |
-| `RATE_LIMIT_RPS` | `--rate-limit-rps` | |
-| `RATE_LIMIT_BURST` | `--rate-limit-burst` | |
-| *(none)* | `--trusted-proxy-header` | CLI-only; HTTP header with real client IP for rate limiting behind proxies |
-| `AUTO_UPDATE` | `--auto-update` | |
-| `AUTO_UPDATE_REPO` | `--auto-update-repo` | |
-| `AUTO_UPDATE_INTERVAL` | `--auto-update-interval` | |
-| `AUTO_UPDATE_TIMEOUT` | `--auto-update-timeout` | |
-| `GITLAB_ENTERPRISE` | `--enterprise` | In HTTP mode, an explicit flag forces the configured catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when available |
-| `GITLAB_READ_ONLY` | `--read-only` | |
-| `GITLAB_SAFE_MODE` | `--safe-mode` | |
-| `EMBEDDED_RESOURCES` | `--embedded-resources` | |
-| `EXCLUDE_TOOLS` | `--exclude-tools` | Comma-separated list |
-| `GITLAB_IGNORE_SCOPES` | `--ignore-scopes` | |
+| Environment Variable          | CLI Flag                 | Notes                                                                                                                                                                                                                                                                    |
+| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GITLAB_URL`                  | `--gitlab-url`           | Optional in stdio mode; defaults to `https://gitlab.com`. Optional in HTTP mode unless `--auth-mode=oauth` is used, which requires a fixed `--gitlab-url`. When set in HTTP mode, it fixes the GitLab instance; when omitted, clients must send `GITLAB-URL` per request |
+| `GITLAB_TOKEN`                | *(none)*                 | Not needed in HTTP mode — clients provide tokens per-request                                                                                                                                                                                                             |
+| `GITLAB_SKIP_TLS_VERIFY`      | `--skip-tls-verify`      |                                                                                                                                                                                                                                                                          |
+| `TOOL_SURFACE`                | `--tool-surface`         | Canonical selector: `meta`, `individual`, or `dynamic`                                                                                                                                                                                                                   |
+| `META_TOOLS`                  | `--meta-tools`           | Deprecated compatibility selector. Use `TOOL_SURFACE` or `--tool-surface` for new configs                                                                                                                                                                                |
+| `CAPABILITY_SURFACE`          | `--capability-surface`   | Explicit selector: `full` or `minimal`                                                                                                                                                                                                                                   |
+| `META_PARAM_SCHEMA`           | `--meta-param-schema`    |                                                                                                                                                                                                                                                                          |
+| `MAX_HTTP_CLIENTS`            | `--max-http-clients`     |                                                                                                                                                                                                                                                                          |
+| `SESSION_TIMEOUT`             | `--session-timeout`      |                                                                                                                                                                                                                                                                          |
+| `SESSION_REVALIDATE_INTERVAL` | `--revalidate-interval`  |                                                                                                                                                                                                                                                                          |
+| `AUTH_MODE`                   | `--auth-mode`            |                                                                                                                                                                                                                                                                          |
+| `OAUTH_CACHE_TTL`             | `--oauth-cache-ttl`      |                                                                                                                                                                                                                                                                          |
+| `RATE_LIMIT_RPS`              | `--rate-limit-rps`       |                                                                                                                                                                                                                                                                          |
+| `RATE_LIMIT_BURST`            | `--rate-limit-burst`     |                                                                                                                                                                                                                                                                          |
+| *(none)*                      | `--trusted-proxy-header` | CLI-only; HTTP header with real client IP for rate limiting behind proxies                                                                                                                                                                                               |
+| `AUTO_UPDATE`                 | `--auto-update`          |                                                                                                                                                                                                                                                                          |
+| `AUTO_UPDATE_REPO`            | `--auto-update-repo`     |                                                                                                                                                                                                                                                                          |
+| `AUTO_UPDATE_INTERVAL`        | `--auto-update-interval` |                                                                                                                                                                                                                                                                          |
+| `AUTO_UPDATE_TIMEOUT`         | `--auto-update-timeout`  |                                                                                                                                                                                                                                                                          |
+| `GITLAB_ENTERPRISE`           | `--enterprise`           | In HTTP mode, an explicit flag forces the configured catalog; when omitted, CE/EE is auto-detected per token+URL pool entry when available                                                                                                                               |
+| `GITLAB_READ_ONLY`            | `--read-only`            |                                                                                                                                                                                                                                                                          |
+| `GITLAB_SAFE_MODE`            | `--safe-mode`            |                                                                                                                                                                                                                                                                          |
+| `EMBEDDED_RESOURCES`          | `--embedded-resources`   |                                                                                                                                                                                                                                                                          |
+| `EXCLUDE_TOOLS`               | `--exclude-tools`        | Comma-separated list                                                                                                                                                                                                                                                     |
+| `GITLAB_IGNORE_SCOPES`        | `--ignore-scopes`        |                                                                                                                                                                                                                                                                          |
 
 ---
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -52,32 +52,32 @@ Created via `NewDetailedError(domain, action, err)` which automatically:
 
 Inspects the error chain and returns a diagnostic message:
 
-| Error Type | Example Message |
-| --- | --- |
-| GitLab HTTP response | Delegates to `ClassifyHTTPStatus` |
-| Connection refused | "GitLab server is unreachable (connection refused)" |
-| DNS failure | "GitLab server hostname could not be resolved" |
-| Timeout | "Request to GitLab timed out" |
-| TLS/SSL | "TLS/SSL handshake failed" |
-| URL error | "network error reaching GitLab" |
-| Other | "unexpected error" |
+| Error Type           | Example Message                                     |
+| -------------------- | --------------------------------------------------- |
+| GitLab HTTP response | Delegates to `ClassifyHTTPStatus`                   |
+| Connection refused   | "GitLab server is unreachable (connection refused)" |
+| DNS failure          | "GitLab server hostname could not be resolved"      |
+| Timeout              | "Request to GitLab timed out"                       |
+| TLS/SSL              | "TLS/SSL handshake failed"                          |
+| URL error            | "network error reaching GitLab"                     |
+| Other                | "unexpected error"                                  |
 
 ### ClassifyHTTPStatus
 
 Maps HTTP status codes to actionable guidance:
 
-| Code | Message |
-| --- | --- |
-| 400 | "bad request — check your input parameters" |
-| 401 | "authentication failed — GITLAB_TOKEN may be invalid or expired" |
-| 403 | "access denied — your token lacks the required permissions" |
-| 404 | "not found — the requested resource does not exist or you lack access" |
-| 409 | "conflict — the resource already exists or there is a state conflict" |
-| 422 | "validation failed — GitLab rejected the request due to invalid data" |
-| 429 | "rate limited — too many requests, please wait before retrying" |
-| 500 | "GitLab internal server error" |
-| 502 | "GitLab is temporarily unavailable (bad gateway)" |
-| 503 | "GitLab is under maintenance or overloaded" |
+| Code | Message                                                                |
+| ---- | ---------------------------------------------------------------------- |
+| 400  | "bad request — check your input parameters"                            |
+| 401  | "authentication failed — GITLAB_TOKEN may be invalid or expired"       |
+| 403  | "access denied — your token lacks the required permissions"            |
+| 404  | "not found — the requested resource does not exist or you lack access" |
+| 409  | "conflict — the resource already exists or there is a state conflict"  |
+| 422  | "validation failed — GitLab rejected the request due to invalid data"  |
+| 429  | "rate limited — too many requests, please wait before retrying"        |
+| 500  | "GitLab internal server error"                                         |
+| 502  | "GitLab is temporarily unavailable (bad gateway)"                      |
+| 503  | "GitLab is under maintenance or overloaded"                            |
 
 ## Error Flow in Tool Handlers
 
@@ -153,13 +153,13 @@ For handlers that need different hints per status code, use a `switch` over `IsH
 
 ### Error Function Decision Tree
 
-| Scenario | Function | Example |
-| --- | --- | --- |
-| Read-only operation (list, get, search) | `WrapErr` | `WrapErr("listBranches", err)` |
-| Get operation returning 404 | `NotFoundResult` | `NotFoundResult("Branch", "main in project 42", "Use gitlab_branch_list...")` |
-| Mutating operation (create, update, delete) | `WrapErrWithMessage` | `WrapErrWithMessage("fileCreate", err)` |
-| Specific error with known corrective action | `WrapErrWithHint` | `WrapErrWithHint("branchDelete", err, "use gitlab_branch_unprotect first")` |
-| Single-status hint (the common case) | `WrapErrWithStatusHint` | `WrapErrWithStatusHint("issueGet", err, 404, "verify issue_iid")` |
+| Scenario                                    | Function                | Example                                                                       |
+| ------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| Read-only operation (list, get, search)     | `WrapErr`               | `WrapErr("listBranches", err)`                                                |
+| Get operation returning 404                 | `NotFoundResult`        | `NotFoundResult("Branch", "main in project 42", "Use gitlab_branch_list...")` |
+| Mutating operation (create, update, delete) | `WrapErrWithMessage`    | `WrapErrWithMessage("fileCreate", err)`                                       |
+| Specific error with known corrective action | `WrapErrWithHint`       | `WrapErrWithHint("branchDelete", err, "use gitlab_branch_unprotect first")`   |
+| Single-status hint (the common case)        | `WrapErrWithStatusHint` | `WrapErrWithStatusHint("issueGet", err, 404, "verify issue_iid")`             |
 
 ### NotFoundResult — Informational 404 Responses
 
@@ -210,13 +210,13 @@ result := FormatIssueReport("issues", "create", err, inputParams)
 
 The generated Markdown includes:
 
-| Section | Content |
-| --- | --- |
-| Environment | Server version, Go version, OS/Arch, timestamp |
-| Error Details | Tool, action, error message, HTTP status, request ID |
-| Input (sanitized) | All input parameters with secrets redacted |
-| Steps to Reproduce | Pre-filled reproduction steps |
-| Suggested Labels | `bug`, `mcp-tool`, `automated-report` |
+| Section            | Content                                              |
+| ------------------ | ---------------------------------------------------- |
+| Environment        | Server version, Go version, OS/Arch, timestamp       |
+| Error Details      | Tool, action, error message, HTTP status, request ID |
+| Input (sanitized)  | All input parameters with secrets redacted           |
+| Steps to Reproduce | Pre-filled reproduction steps                        |
+| Suggested Labels   | `bug`, `mcp-tool`, `automated-report`                |
 
 ### Secret Redaction
 
@@ -232,13 +232,13 @@ The report includes the server version, read from the `VERSION` file at package 
 
 Lower-level helpers detect specific network conditions:
 
-| Helper | Detects |
-| --- | --- |
-| `isConnectionRefused` | ECONNREFUSED, "connectex:" |
-| `isDNSError` | `*net.DNSError` in error chain |
-| `isTimeout` | Any error implementing `Timeout() bool` |
-| `isTLSError` | "tls:", "certificate", "x509:" in message |
-| `ContainsAny` | Generic substring match on `err.Error()` |
+| Helper                | Detects                                   |
+| --------------------- | ----------------------------------------- |
+| `isConnectionRefused` | ECONNREFUSED, "connectex:"                |
+| `isDNSError`          | `*net.DNSError` in error chain            |
+| `isTimeout`           | Any error implementing `Timeout() bool`   |
+| `isTLSError`          | "tls:", "certificate", "x509:" in message |
+| `ContainsAny`         | Generic substring match on `err.Error()`  |
 
 ## Parameter-Name Guidance Helpers
 
@@ -257,9 +257,9 @@ actionable errors when LLMs mistype argument names:
    missing required values and emit messages that name the exact documented
    parameter:
 
-| Helper | Use Case | Example Output |
-| --- | --- | --- |
-| `ErrRequiredInt64(op, field)` | Required int64 field is 0 | `"milestoneGet: milestone_iid is required (must be > 0). Ensure you use the exact parameter name 'milestone_iid'..."` |
+| Helper                         | Use Case                       | Example Output                                                                                                          |
+| ------------------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `ErrRequiredInt64(op, field)`  | Required int64 field is 0      | `"milestoneGet: milestone_iid is required (must be > 0). Ensure you use the exact parameter name 'milestone_iid'..."`   |
 | `ErrRequiredString(op, field)` | Required string field is empty | `"branchCreate: branch_name is required (must be non-empty). Ensure you use the exact parameter name 'branch_name'..."` |
 
 Used in `milestones`, `branches`, `mergerequests`, and other domains where LLMs frequently confuse parameter names (e.g., `milestone_id` vs `milestone_iid`, `branch` vs `branch_name`, `iid` vs `merge_request_iid`).
@@ -286,13 +286,13 @@ testutil.RespondJSON(w, http.StatusBadRequest, map[string]string{
 
 ## File Reference
 
-| File | Purpose |
-| --- | --- |
-| `internal/toolutil/errors.go` | ToolError, DetailedError, WrapErr, WrapErrWithMessage, WrapErrWithHint, WrapErrWithStatusHint, ExtractGitLabMessage, ClassifyError, ClassifyHTTPStatus, IsHTTPStatus, ContainsAny |
-| `internal/toolutil/not_found.go` | NotFoundResult — informational 404 pattern for get handlers |
-| `internal/toolutil/issue_report.go` | IssueReport, FormatIssueReport, secret redaction |
-| `internal/toolutil/confirm.go` | Destructive action confirmation flow |
-| `internal/toolutil/output.go` | SuccessResult, ErrorResult helpers |
+| File                                | Purpose                                                                                                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `internal/toolutil/errors.go`       | ToolError, DetailedError, WrapErr, WrapErrWithMessage, WrapErrWithHint, WrapErrWithStatusHint, ExtractGitLabMessage, ClassifyError, ClassifyHTTPStatus, IsHTTPStatus, ContainsAny |
+| `internal/toolutil/not_found.go`    | NotFoundResult — informational 404 pattern for get handlers                                                                                                                       |
+| `internal/toolutil/issue_report.go` | IssueReport, FormatIssueReport, secret redaction                                                                                                                                  |
+| `internal/toolutil/confirm.go`      | Destructive action confirmation flow                                                                                                                                              |
+| `internal/toolutil/output.go`       | SuccessResult, ErrorResult helpers                                                                                                                                                |
 
 ## LLM Ergonomics Hint Rollout
 
@@ -300,15 +300,15 @@ Actionable hints were added across the entire codebase to help LLMs self-correct
 
 ### Coverage
 
-| Metric | Count |
-| --- | --- |
-| `WrapErrWithHint` call sites (GraphQL) | 257 |
-| `WrapErrWithStatusHint` call sites (REST) | 858 |
-| **Total hinted error sites** | **1,115** |
-| `WrapErrWithMessage` (skip-category, retained) | 344 |
-| `NotFoundResult` (informational 404s) | 32 |
-| Domain sub-packages with hints | 153 of 162 |
-| Source files with hints | 171 |
+| Metric                                         | Count      |
+| ---------------------------------------------- | ---------- |
+| `WrapErrWithHint` call sites (GraphQL)         | 257        |
+| `WrapErrWithStatusHint` call sites (REST)      | 858        |
+| **Total hinted error sites**                   | **1,115**  |
+| `WrapErrWithMessage` (skip-category, retained) | 344        |
+| `NotFoundResult` (informational 404s)          | 32         |
+| Domain sub-packages with hints                 | 153 of 162 |
+| Source files with hints                        | 171        |
 
 ### Skip Categories
 

--- a/docs/examples/generate-release-notes-skill.md
+++ b/docs/examples/generate-release-notes-skill.md
@@ -30,11 +30,11 @@ requests, and diffs, then produces polished release notes.
 
 The skill documents three complementary approaches:
 
-| Approach | Tool | Requires | Best For |
-| -------- | ---- | -------- | -------- |
-| **A. LLM-Assisted** | `gitlab_generate_release_notes` | MCP Sampling | Fully automated, categorized notes |
-| **B. Manual** | `gitlab_repository` + `gitlab_merge_request` | Nothing extra | Full control, no LLM needed |
-| **C. Prompt-Based** | `generate_release_notes` prompt | LLM client | Editable LLM-enriched context |
+| Approach            | Tool                                         | Requires      | Best For                           |
+| ------------------- | -------------------------------------------- | ------------- | ---------------------------------- |
+| **A. LLM-Assisted** | `gitlab_generate_release_notes`              | MCP Sampling  | Fully automated, categorized notes |
+| **B. Manual**       | `gitlab_repository` + `gitlab_merge_request` | Nothing extra | Full control, no LLM needed        |
+| **C. Prompt-Based** | `generate_release_notes` prompt              | LLM client    | Editable LLM-enriched context      |
 
 ## Categories
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,8 +23,8 @@ A step-by-step tutorial to get gitlab-mcp-server running and make your first Git
 
 Download the latest release for your platform from the project [Releases](../../releases) page:
 
-| Platform            | Binary                            |
-| ------------------- | --------------------------------- |
+| Platform            | Binary                                |
+| ------------------- | ------------------------------------- |
 | Linux amd64         | `gitlab-mcp-server-linux-amd64`       |
 | Linux arm64         | `gitlab-mcp-server-linux-arm64`       |
 | Windows amd64       | `gitlab-mcp-server-windows-amd64.exe` |
@@ -176,29 +176,29 @@ The bundled `mcp.json` runs the published Docker image `ghcr.io/jmrplens/gitlab-
 
 The host passes these environment variables through to the container:
 
-| Variable                          | Required | Description                                              |
-| --------------------------------- | -------- | -------------------------------------------------------- |
-| `GITLAB_URL`                      | No       | GitLab instance URL. Defaults to `https://gitlab.com`; set for self-managed instances |
-| `GITLAB_TOKEN`                    | Yes      | Personal Access Token                                    |
-| `GITLAB_SKIP_TLS_VERIFY`          | No       | `true` for self-signed certs (default `false`)           |
-| `TOOL_SURFACE`                    | No       | Canonical tool catalog selector: `dynamic`, `meta`, or `individual` (default `dynamic`) |
-| `CAPABILITY_SURFACE`              | No       | Resource and prompt catalog selector: `full` or `minimal` (default `full`) |
-| `META_PARAM_SCHEMA`               | No       | Meta-tool input schema detail: `opaque`, `compact`, or `full` (default `opaque`) |
-| `GITLAB_ENTERPRISE`               | No       | Enable Premium/Ultimate tools (default `false`)          |
-| `GITLAB_READ_ONLY`                | No       | Disable mutating tools (default `false`)                 |
-| `GITLAB_SAFE_MODE`                | No       | Preview mutating tool inputs (default `false`)           |
-| `EMBEDDED_RESOURCES`              | No       | Append embedded MCP resource links to get-style tool results (default `true`) |
-| `EXCLUDE_TOOLS`                   | No       | Comma-separated tool names to exclude from registration  |
-| `GITLAB_IGNORE_SCOPES`            | No       | Skip token scope detection and register all tools (default `false`) |
-| `UPLOAD_MAX_FILE_SIZE`            | No       | Maximum attachment upload size in bytes (default `2147483648`) |
-| `GITLAB_MCP_ALLOWED_IMPORT_DIRS`  | No       | Extra path-list-separated directories allowed for local GitLab import archives |
-| `RATE_LIMIT_RPS`                  | No       | Per-server tools/call rate limit in requests per second; `0` disables it (default `0`) |
-| `RATE_LIMIT_BURST`                | No       | Token-bucket burst size when `RATE_LIMIT_RPS` is greater than `0` (default `40`) |
-| `AUTO_UPDATE`                     | No       | Auto-update mode in the container; default is `false` for Open Plugins installs |
-| `AUTO_UPDATE_REPO`                | No       | GitHub repository slug for release assets (default `jmrplens/gitlab-mcp-server`) |
-| `AUTO_UPDATE_INTERVAL`            | No       | Periodic update check interval in HTTP mode (default `1h`) |
-| `AUTO_UPDATE_TIMEOUT`             | No       | Pre-start download timeout (default `60s`)               |
-| `LOG_LEVEL`                       | No       | `debug`, `info`, `warn`, `error` (default `info`)        |
+| Variable                         | Required | Description                                                                             |
+| -------------------------------- | -------- | --------------------------------------------------------------------------------------- |
+| `GITLAB_URL`                     | No       | GitLab instance URL. Defaults to `https://gitlab.com`; set for self-managed instances   |
+| `GITLAB_TOKEN`                   | Yes      | Personal Access Token                                                                   |
+| `GITLAB_SKIP_TLS_VERIFY`         | No       | `true` for self-signed certs (default `false`)                                          |
+| `TOOL_SURFACE`                   | No       | Canonical tool catalog selector: `dynamic`, `meta`, or `individual` (default `dynamic`) |
+| `CAPABILITY_SURFACE`             | No       | Resource and prompt catalog selector: `full` or `minimal` (default `full`)              |
+| `META_PARAM_SCHEMA`              | No       | Meta-tool input schema detail: `opaque`, `compact`, or `full` (default `opaque`)        |
+| `GITLAB_ENTERPRISE`              | No       | Enable Premium/Ultimate tools (default `false`)                                         |
+| `GITLAB_READ_ONLY`               | No       | Disable mutating tools (default `false`)                                                |
+| `GITLAB_SAFE_MODE`               | No       | Preview mutating tool inputs (default `false`)                                          |
+| `EMBEDDED_RESOURCES`             | No       | Append embedded MCP resource links to get-style tool results (default `true`)           |
+| `EXCLUDE_TOOLS`                  | No       | Comma-separated tool names to exclude from registration                                 |
+| `GITLAB_IGNORE_SCOPES`           | No       | Skip token scope detection and register all tools (default `false`)                     |
+| `UPLOAD_MAX_FILE_SIZE`           | No       | Maximum attachment upload size in bytes (default `2147483648`)                          |
+| `GITLAB_MCP_ALLOWED_IMPORT_DIRS` | No       | Extra path-list-separated directories allowed for local GitLab import archives          |
+| `RATE_LIMIT_RPS`                 | No       | Per-server tools/call rate limit in requests per second; `0` disables it (default `0`)  |
+| `RATE_LIMIT_BURST`               | No       | Token-bucket burst size when `RATE_LIMIT_RPS` is greater than `0` (default `40`)        |
+| `AUTO_UPDATE`                    | No       | Auto-update mode in the container; default is `false` for Open Plugins installs         |
+| `AUTO_UPDATE_REPO`               | No       | GitHub repository slug for release assets (default `jmrplens/gitlab-mcp-server`)        |
+| `AUTO_UPDATE_INTERVAL`           | No       | Periodic update check interval in HTTP mode (default `1h`)                              |
+| `AUTO_UPDATE_TIMEOUT`            | No       | Pre-start download timeout (default `60s`)                                              |
+| `LOG_LEVEL`                      | No       | `debug`, `info`, `warn`, `error` (default `info`)                                       |
 
 Prefer `TOOL_SURFACE` for new configurations: `dynamic` is the default two-tool low-token find/execute surface, `meta` exposes consolidated domain dispatchers, and `individual` exposes every tool separately. The server still supports the deprecated `META_TOOLS` selector for compatibility, but the Open Plugins config forwards the explicit `TOOL_SURFACE` variable.
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -17,29 +17,29 @@ This document explains when and how the GraphQL integration is used, the pattern
 
 ## When REST vs GraphQL
 
-| Use REST when | Use GraphQL when |
-| ------------- | ---------------- |
-| client-go has a typed service wrapper | No REST endpoint exists (e.g. CI/CD Catalog, Branch Rules) |
-| The domain is well-served by REST | The REST endpoint is deprecated (e.g. vulnerability findings) |
-| Single-resource CRUD operations | Multiple related resources need to be fetched in one request |
-| The feature is available on all GitLab tiers | The feature is GraphQL-only (e.g. CI/CD Catalog) |
+| Use REST when                                | Use GraphQL when                                              |
+| -------------------------------------------- | ------------------------------------------------------------- |
+| client-go has a typed service wrapper        | No REST endpoint exists (e.g. CI/CD Catalog, Branch Rules)    |
+| The domain is well-served by REST            | The REST endpoint is deprecated (e.g. vulnerability findings) |
+| Single-resource CRUD operations              | Multiple related resources need to be fetched in one request  |
+| The feature is available on all GitLab tiers | The feature is GraphQL-only (e.g. CI/CD Catalog)              |
 
 ### Domains using GraphQL
 
-| Domain | Package | Reason |
-| ------ | ------- | ------ |
-| Epics (6 tools) | `internal/tools/epics/` | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items GraphQL API via client-go `WorkItems` service |
-| Epic Notes (5 tools) | `internal/tools/epicnotes/` | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items notes widgets via client-go `WorkItems` service |
-| Epic Discussions (7 tools) | `internal/tools/epicdiscussions/` | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items discussions widgets via client-go `WorkItems` service |
-| Epic Issues (4 tools) | `internal/tools/epicissues/` | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items children/parent widgets via client-go `WorkItems` service |
-| Vulnerabilities | `internal/tools/vulnerabilities/` | GraphQL provides richer query/mutation capabilities than REST |
-| Security Attributes | `internal/tools/securityattributes/` | GraphQL-only namespace classification feature via client-go `SecurityAttributes` service |
-| Security Categories | `internal/tools/securitycategories/` | GraphQL-only namespace classification feature via client-go `SecurityCategories` service |
-| Security Findings | `internal/tools/securityfindings/` | REST endpoint deprecated; GraphQL `Pipeline.securityReportFindings` is the replacement |
-| CI/CD Catalog | `internal/tools/cicatalog/` | GraphQL-only feature — no REST API exists |
-| Branch Rules | `internal/tools/branchrules/` | GraphQL-only aggregated view of branch protections, approval rules, and status checks |
-| Custom Emoji | `internal/tools/customemoji/` | GraphQL-only — no REST API for custom emoji management |
-| Sampling Tools | `internal/tools/samplingtools/` | GraphQL aggregation replaces 3-6 sequential REST calls with a single request |
+| Domain                     | Package                              | Reason                                                                                                                                 |
+| -------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Epics (6 tools)            | `internal/tools/epics/`              | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items GraphQL API via client-go `WorkItems` service             |
+| Epic Notes (5 tools)       | `internal/tools/epicnotes/`          | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items notes widgets via client-go `WorkItems` service           |
+| Epic Discussions (7 tools) | `internal/tools/epicdiscussions/`    | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items discussions widgets via client-go `WorkItems` service     |
+| Epic Issues (4 tools)      | `internal/tools/epicissues/`         | REST API deprecated since GitLab 17.0 (removal 19.0); migrated to Work Items children/parent widgets via client-go `WorkItems` service |
+| Vulnerabilities            | `internal/tools/vulnerabilities/`    | GraphQL provides richer query/mutation capabilities than REST                                                                          |
+| Security Attributes        | `internal/tools/securityattributes/` | GraphQL-only namespace classification feature via client-go `SecurityAttributes` service                                               |
+| Security Categories        | `internal/tools/securitycategories/` | GraphQL-only namespace classification feature via client-go `SecurityCategories` service                                               |
+| Security Findings          | `internal/tools/securityfindings/`   | REST endpoint deprecated; GraphQL `Pipeline.securityReportFindings` is the replacement                                                 |
+| CI/CD Catalog              | `internal/tools/cicatalog/`          | GraphQL-only feature — no REST API exists                                                                                              |
+| Branch Rules               | `internal/tools/branchrules/`        | GraphQL-only aggregated view of branch protections, approval rules, and status checks                                                  |
+| Custom Emoji               | `internal/tools/customemoji/`        | GraphQL-only — no REST API for custom emoji management                                                                                 |
+| Sampling Tools             | `internal/tools/samplingtools/`      | GraphQL aggregation replaces 3-6 sequential REST calls with a single request                                                           |
 
 ## Architecture
 
@@ -210,12 +210,12 @@ typeName, id, err := toolutil.ParseGID("gid://gitlab/Vulnerability/42")
 
 GraphQL uses cursor-based pagination instead of REST's page/per_page model. The `toolutil.GraphQLPaginationInput` struct provides a consistent interface:
 
-| Parameter | Description |
-| --------- | ----------- |
-| `first` | Number of items to return (default 20, max 100) |
-| `after` | Forward pagination cursor |
-| `last` | Number of items from the end (backward pagination) |
-| `before` | Backward pagination cursor |
+| Parameter | Description                                        |
+| --------- | -------------------------------------------------- |
+| `first`   | Number of items to return (default 20, max 100)    |
+| `after`   | Forward pagination cursor                          |
+| `last`    | Number of items from the end (backward pagination) |
+| `before`  | Backward pagination cursor                         |
 
 The `Variables()` method converts these to a GraphQL variables map, and `PageInfoToOutput()` normalizes the camelCase API response to snake\_case output.
 
@@ -247,16 +247,16 @@ if len(resp.Data.VulnerabilityDismiss.Errors) > 0 {
 
 The `internal/toolutil/graphql.go` module provides shared GraphQL infrastructure:
 
-| Type/Function | Purpose |
-| ------------- | ------- |
-| `GraphQLPaginationInput` | Cursor-based pagination input struct with `Variables()` method |
-| `GraphQLPaginationOutput` | Normalized pagination output for tool responses |
-| `GraphQLRawPageInfo` | Raw camelCase page info from API responses |
-| `PageInfoToOutput()` | Converts raw page info to output format |
-| `FormatGraphQLPagination()` | Renders pagination as Markdown summary |
-| `FormatGID()` | Builds a GitLab GID string |
-| `ParseGID()` | Extracts type and ID from a GID string |
-| `MergeVariables()` | Merges multiple variable maps |
+| Type/Function               | Purpose                                                        |
+| --------------------------- | -------------------------------------------------------------- |
+| `GraphQLPaginationInput`    | Cursor-based pagination input struct with `Variables()` method |
+| `GraphQLPaginationOutput`   | Normalized pagination output for tool responses                |
+| `GraphQLRawPageInfo`        | Raw camelCase page info from API responses                     |
+| `PageInfoToOutput()`        | Converts raw page info to output format                        |
+| `FormatGraphQLPagination()` | Renders pagination as Markdown summary                         |
+| `FormatGID()`               | Builds a GitLab GID string                                     |
+| `ParseGID()`                | Extracts type and ID from a GID string                         |
+| `MergeVariables()`          | Merges multiple variable maps                                  |
 
 ## Testing GraphQL Tools
 

--- a/docs/http-server-mode.md
+++ b/docs/http-server-mode.md
@@ -17,13 +17,13 @@ By default, gitlab-mcp-server runs in **stdio mode** — each AI client (VS Code
 
 ### When to Use HTTP Mode
 
-| Scenario | Recommended Mode |
-| --- | --- |
-| Single developer, local AI client | stdio |
-| Team sharing one server instance | **HTTP** |
-| Remote/headless server deployment | **HTTP** |
-| CI/CD integration with MCP | **HTTP** (see [CI/CD Usage](ci-cd.md)) |
-| Testing with curl or HTTP clients | **HTTP** |
+| Scenario                          | Recommended Mode                       |
+| --------------------------------- | -------------------------------------- |
+| Single developer, local AI client | stdio                                  |
+| Team sharing one server instance  | **HTTP**                               |
+| Remote/headless server deployment | **HTTP**                               |
+| CI/CD integration with MCP        | **HTTP** (see [CI/CD Usage](ci-cd.md)) |
+| Testing with curl or HTTP clients | **HTTP**                               |
 
 ## Starting the HTTP Server
 
@@ -42,30 +42,30 @@ gitlab-mcp-server --http \
 
 ### CLI Flags
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--http` | _(off)_ | Enable HTTP transport mode |
-| `--gitlab-url` | _(optional)_ | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request |
-| `--http-addr` | `:8080` | HTTP listen address (host:port) |
-| `--skip-tls-verify` | `false` | Skip TLS certificate verification for self-signed certs |
-| `--tool-surface` | `dynamic` | Canonical tool catalog selector; see [Tool and capability surface options](#tool-and-capability-surface-options) |
-| `--meta-tools` | _(unset)_ | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false` |
-| `--capability-surface` | `full` | Resource and prompt selector; see [Tool and capability surface options](#tool-and-capability-surface-options) |
-| `--meta-param-schema` | `opaque` | Meta-tool input schema mode: `opaque`, `compact`, or `full` |
-| `--enterprise` | `false` | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
-| `--read-only` | `false` | Expose only read-only tools |
-| `--safe-mode` | `false` | Intercept mutating tools and return a JSON preview instead of executing them |
-| `--embedded-resources` | `true` | Embed canonical MCP resource URIs in get_* tool results |
-| `--exclude-tools` | _(empty)_ | Comma-separated tool names or patterns to exclude from registration |
-| `--ignore-scopes` | `false` | Skip PAT scope detection and register all tools allowed by the configured catalog |
-| `--max-http-clients` | `100` | Maximum unique token+URL entries in the server pool |
-| `--session-timeout` | `30m` | Idle MCP session timeout |
-| `--auth-mode` | `legacy` | Authentication mode: `legacy` (PRIVATE-TOKEN) or `oauth` (Bearer token verified via GitLab API) |
-| `--oauth-cache-ttl` | `15m` | How long verified OAuth tokens are cached before re-validation (1m–2h) |
-| `--revalidate-interval` | `15m` | Token re-validation interval; `0` to disable (upper bound: 24h) |
-| `--trusted-proxy-header` | _(empty)_ | HTTP header containing the real client IP (e.g. `Fly-Client-IP`, `X-Forwarded-For`). Required for rate limiting behind reverse proxies |
-| `--rate-limit-rps` | `0` | Per-server `tools/call` rate limit in requests per second (`0` = disabled) |
-| `--rate-limit-burst` | `40` | Token-bucket burst size when `--rate-limit-rps` > 0 |
+| Flag                     | Default      | Description                                                                                                                                                                         |
+| ------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--http`                 | _(off)_      | Enable HTTP transport mode                                                                                                                                                          |
+| `--gitlab-url`           | _(optional)_ | Fixed GitLab instance URL. Omit it to require each client to send `GITLAB-URL` per request                                                                                          |
+| `--http-addr`            | `:8080`      | HTTP listen address (host:port)                                                                                                                                                     |
+| `--skip-tls-verify`      | `false`      | Skip TLS certificate verification for self-signed certs                                                                                                                             |
+| `--tool-surface`         | `dynamic`    | Canonical tool catalog selector; see [Tool and capability surface options](#tool-and-capability-surface-options)                                                                    |
+| `--meta-tools`           | _(unset)_    | Deprecated compatibility flag. Use `--tool-surface=individual` instead of `--meta-tools=false`                                                                                      |
+| `--capability-surface`   | `full`       | Resource and prompt selector; see [Tool and capability surface options](#tool-and-capability-surface-options)                                                                       |
+| `--meta-param-schema`    | `opaque`     | Meta-tool input schema mode: `opaque`, `compact`, or `full`                                                                                                                         |
+| `--enterprise`           | `false`      | Force the Enterprise/Premium tool catalog when explicitly set. When omitted, HTTP mode auto-detects CE/EE per token+URL pool entry when GitLab reports edition in `/api/v4/version` |
+| `--read-only`            | `false`      | Expose only read-only tools                                                                                                                                                         |
+| `--safe-mode`            | `false`      | Intercept mutating tools and return a JSON preview instead of executing them                                                                                                        |
+| `--embedded-resources`   | `true`       | Embed canonical MCP resource URIs in get_* tool results                                                                                                                             |
+| `--exclude-tools`        | _(empty)_    | Comma-separated tool names or patterns to exclude from registration                                                                                                                 |
+| `--ignore-scopes`        | `false`      | Skip PAT scope detection and register all tools allowed by the configured catalog                                                                                                   |
+| `--max-http-clients`     | `100`        | Maximum unique token+URL entries in the server pool                                                                                                                                 |
+| `--session-timeout`      | `30m`        | Idle MCP session timeout                                                                                                                                                            |
+| `--auth-mode`            | `legacy`     | Authentication mode: `legacy` (PRIVATE-TOKEN) or `oauth` (Bearer token verified via GitLab API)                                                                                     |
+| `--oauth-cache-ttl`      | `15m`        | How long verified OAuth tokens are cached before re-validation (1m–2h)                                                                                                              |
+| `--revalidate-interval`  | `15m`        | Token re-validation interval; `0` to disable (upper bound: 24h)                                                                                                                     |
+| `--trusted-proxy-header` | _(empty)_    | HTTP header containing the real client IP (e.g. `Fly-Client-IP`, `X-Forwarded-For`). Required for rate limiting behind reverse proxies                                              |
+| `--rate-limit-rps`       | `0`          | Per-server `tools/call` rate limit in requests per second (`0` = disabled)                                                                                                          |
+| `--rate-limit-burst`     | `40`         | Token-bucket burst size when `--rate-limit-rps` > 0                                                                                                                                 |
 
 > **Note**: `--gitlab-url` is optional. When omitted, each client must provide the `GITLAB-URL` header. When set, it is authoritative: any client-provided `GITLAB-URL` header is ignored, the configured URL is used, and the request logs `ignored_options` for that client.
 
@@ -85,14 +85,14 @@ gitlab-mcp-server --http \
 
 HTTP mode has a narrow request-controlled surface. GitLab identity always comes from the request token, and the GitLab instance comes from `GITLAB-URL` only when the server was started without `--gitlab-url`. All other MCP server settings are process policy and cannot be changed per user, per session, or per JSON-RPC request.
 
-| Configuration area | Source of truth | Can a client override it? | Behavior when a client sends a matching header |
-| --- | --- | --- | --- |
-| GitLab token | `PRIVATE-TOKEN` or `Authorization: Bearer` request header | Yes, this is the per-user identity boundary | Accepted and used to select/create the pooled server entry |
-| GitLab URL | `--gitlab-url`, or `GITLAB-URL` only when `--gitlab-url` is omitted | Conditional | If `--gitlab-url` is set, `GITLAB-URL` is ignored and logged in `ignored_options` |
-| Tool catalog and behavior | `--tool-surface`, deprecated `--meta-tools`, `--capability-surface`, `--meta-param-schema`, `--enterprise`, `--read-only`, `--safe-mode`, `--embedded-resources`, `--exclude-tools`, `--ignore-scopes` | No | Ignored and logged in `ignored_options` when sent as config-like headers such as `TOOL-SURFACE`, `META-TOOLS`, `CAPABILITY-SURFACE`, `META-PARAM-SCHEMA`, or `GITLAB-SAFE-MODE`; `META-TOOLS` is also logged in `deprecated_options` |
-| Rate limits and HTTP pool policy | `--rate-limit-rps`, `--rate-limit-burst`, `--max-http-clients`, `--session-timeout`, `--revalidate-interval`, `--trusted-proxy-header` | No | Ignored and logged in `ignored_options` when sent as config-like headers such as `RATE-LIMIT-RPS` |
-| Authentication mode and OAuth cache | `--auth-mode`, `--oauth-cache-ttl` | No | Ignored and logged in `ignored_options` |
-| Update policy and logging | `--auto-update`, `--auto-update-repo`, `--auto-update-interval`, `--auto-update-timeout`, process `LOG_LEVEL` | No | Ignored and logged in `ignored_options` |
+| Configuration area                  | Source of truth                                                                                                                                                                                        | Can a client override it?                   | Behavior when a client sends a matching header                                                                                                                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| GitLab token                        | `PRIVATE-TOKEN` or `Authorization: Bearer` request header                                                                                                                                              | Yes, this is the per-user identity boundary | Accepted and used to select/create the pooled server entry                                                                                                                                                                           |
+| GitLab URL                          | `--gitlab-url`, or `GITLAB-URL` only when `--gitlab-url` is omitted                                                                                                                                    | Conditional                                 | If `--gitlab-url` is set, `GITLAB-URL` is ignored and logged in `ignored_options`                                                                                                                                                    |
+| Tool catalog and behavior           | `--tool-surface`, deprecated `--meta-tools`, `--capability-surface`, `--meta-param-schema`, `--enterprise`, `--read-only`, `--safe-mode`, `--embedded-resources`, `--exclude-tools`, `--ignore-scopes` | No                                          | Ignored and logged in `ignored_options` when sent as config-like headers such as `TOOL-SURFACE`, `META-TOOLS`, `CAPABILITY-SURFACE`, `META-PARAM-SCHEMA`, or `GITLAB-SAFE-MODE`; `META-TOOLS` is also logged in `deprecated_options` |
+| Rate limits and HTTP pool policy    | `--rate-limit-rps`, `--rate-limit-burst`, `--max-http-clients`, `--session-timeout`, `--revalidate-interval`, `--trusted-proxy-header`                                                                 | No                                          | Ignored and logged in `ignored_options` when sent as config-like headers such as `RATE-LIMIT-RPS`                                                                                                                                    |
+| Authentication mode and OAuth cache | `--auth-mode`, `--oauth-cache-ttl`                                                                                                                                                                     | No                                          | Ignored and logged in `ignored_options`                                                                                                                                                                                              |
+| Update policy and logging           | `--auto-update`, `--auto-update-repo`, `--auto-update-interval`, `--auto-update-timeout`, process `LOG_LEVEL`                                                                                          | No                                          | Ignored and logged in `ignored_options`                                                                                                                                                                                              |
 
 This means options that affect the size of MCP schemas, such as `--meta-param-schema`, are fixed when each `*mcp.Server` instance is created. Options that affect throttling, such as `--rate-limit-rps` and `--rate-limit-burst`, are also copied into each pooled server entry; clients cannot increase, disable, or replace those limits through request headers or MCP parameters.
 
@@ -189,15 +189,15 @@ HTTP mode supports two authentication modes controlled by `--auth-mode`:
 
 ### Mode Comparison
 
-| Feature | Legacy (`--auth-mode=legacy`) | OAuth (`--auth-mode=oauth`) |
-| --- | --- | --- |
-| Token headers | `PRIVATE-TOKEN` or `Authorization: Bearer` | `Authorization: Bearer` (auto-converted from `PRIVATE-TOKEN`) |
-| Server-side validation | None — token passed directly to GitLab API | Verified via `GET /api/v4/user` before MCP handler |
-| Token caching | No caching — every API call uses the token directly | SHA-256 hashed cache with configurable TTL (default 15m) |
-| Invalid token handling | Errors appear at GitLab API call time | Rejected immediately with HTTP 401 |
-| RFC 9728 metadata | Not served | Served at `/.well-known/oauth-protected-resource` |
-| MCP client OAuth discovery | Not supported | Supported — clients can discover the GitLab authorization server |
-| Best for | Simple setups, internal networks | Production deployments, MCP clients with OAuth 2.1 support |
+| Feature                    | Legacy (`--auth-mode=legacy`)                       | OAuth (`--auth-mode=oauth`)                                      |
+| -------------------------- | --------------------------------------------------- | ---------------------------------------------------------------- |
+| Token headers              | `PRIVATE-TOKEN` or `Authorization: Bearer`          | `Authorization: Bearer` (auto-converted from `PRIVATE-TOKEN`)    |
+| Server-side validation     | None — token passed directly to GitLab API          | Verified via `GET /api/v4/user` before MCP handler               |
+| Token caching              | No caching — every API call uses the token directly | SHA-256 hashed cache with configurable TTL (default 15m)         |
+| Invalid token handling     | Errors appear at GitLab API call time               | Rejected immediately with HTTP 401                               |
+| RFC 9728 metadata          | Not served                                          | Served at `/.well-known/oauth-protected-resource`                |
+| MCP client OAuth discovery | Not supported                                       | Supported — clients can discover the GitLab authorization server |
+| Best for                   | Simple setups, internal networks                    | Production deployments, MCP clients with OAuth 2.1 support       |
 
 ### Legacy Mode (default)
 
@@ -421,27 +421,27 @@ sequenceDiagram
 
 The following settings are **server-wide** — they apply to all clients regardless of their token or GitLab URL:
 
-| Setting | Source | Description |
-| --- | --- | --- |
-| Fixed GitLab URL | `--gitlab-url` | Authoritative GitLab instance for all clients when set. If omitted, clients must send `GITLAB-URL` |
-| TLS verification | `--skip-tls-verify` | Applied to all GitLab client connections |
+| Setting                     | Source                                                   | Description                                                                                                                                                                            |
+| --------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fixed GitLab URL            | `--gitlab-url`                                           | Authoritative GitLab instance for all clients when set. If omitted, clients must send `GITLAB-URL`                                                                                     |
+| TLS verification            | `--skip-tls-verify`                                      | Applied to all GitLab client connections                                                                                                                                               |
 | Tool and capability surface | `--meta-tools`, `--tool-surface`, `--capability-surface` | Same tool catalog and resource/prompt exposure for all clients (`meta`/`individual`/`dynamic`; `full`/`minimal` capabilities); scope and CE/EE filtering still happen per server entry |
-| Upload limits | Compile-time defaults | Max file size |
+| Upload limits               | Compile-time defaults                                    | Max file size                                                                                                                                                                          |
 
 The **GitLab token** always varies per client. The **GitLab URL** can vary per client only when `--gitlab-url` is omitted. Each unique `(token, URL)` pair creates a separate server-pool entry.
 
 ## Comparison with Stdio Mode
 
-| Aspect | Stdio Mode | HTTP Mode |
-| --- | --- | --- |
-| Configuration source | Environment variables / `.env` | CLI flags |
-| Token required at startup | Yes (`GITLAB_TOKEN`) | No — per-request |
-| Clients per process | 1 | Many (bounded by `--max-http-clients`) |
-| Process lifecycle | AI client spawns/kills | Long-running daemon |
-| Memory per client | ~50 MB (full process) | ~130 KB (pool entry) |
-| Client isolation | Process-level | Pool entry-level (same guarantees) |
-| Network requirement | None (stdio pipes) | TCP/HTTP |
-| Session management | SDK handles | SDK + server pool |
+| Aspect                    | Stdio Mode                     | HTTP Mode                              |
+| ------------------------- | ------------------------------ | -------------------------------------- |
+| Configuration source      | Environment variables / `.env` | CLI flags                              |
+| Token required at startup | Yes (`GITLAB_TOKEN`)           | No — per-request                       |
+| Clients per process       | 1                              | Many (bounded by `--max-http-clients`) |
+| Process lifecycle         | AI client spawns/kills         | Long-running daemon                    |
+| Memory per client         | ~50 MB (full process)          | ~130 KB (pool entry)                   |
+| Client isolation          | Process-level                  | Pool entry-level (same guarantees)     |
+| Network requirement       | None (stdio pipes)             | TCP/HTTP                               |
+| Session management        | SDK handles                    | SDK + server pool                      |
 
 ## Monitoring
 
@@ -482,13 +482,13 @@ curl -s -o /dev/null -w "%{http_code}" \
 
 ## Troubleshooting
 
-| Problem | Cause | Solution |
-| --- | --- | --- |
-| `400 Bad Request` | Missing or empty token header | Ensure `PRIVATE-TOKEN` or `Authorization: Bearer` is set |
-| `400 Bad Request` | Invalid GitLab URL | Verify `--gitlab-url` is correct and reachable |
-| Tool errors after connecting | Invalid or expired token | Verify the token has `api` scope and is not expired |
-| Pool eviction too frequent | Too many unique tokens | Increase `--max-http-clients` |
-| Sessions expiring | Idle timeout | Increase `--session-timeout` |
+| Problem                         | Cause                                             | Solution                                                                                             |
+| ------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `400 Bad Request`               | Missing or empty token header                     | Ensure `PRIVATE-TOKEN` or `Authorization: Bearer` is set                                             |
+| `400 Bad Request`               | Invalid GitLab URL                                | Verify `--gitlab-url` is correct and reachable                                                       |
+| Tool errors after connecting    | Invalid or expired token                          | Verify the token has `api` scope and is not expired                                                  |
+| Pool eviction too frequent      | Too many unique tokens                            | Increase `--max-http-clients`                                                                        |
+| Sessions expiring               | Idle timeout                                      | Increase `--session-timeout`                                                                         |
 | Rate limiter blocks all clients | Behind reverse proxy, all requests share proxy IP | Set `--trusted-proxy-header` to the header your proxy sets (e.g. `X-Forwarded-For`, `Fly-Client-IP`) |
 
 ---

--- a/docs/ide-configuration.md
+++ b/docs/ide-configuration.md
@@ -10,19 +10,19 @@ Per-IDE MCP client configuration examples for gitlab-mcp-server, covering both s
 
 ## OAuth Support Matrix
 
-| IDE / Client | Stdio | HTTP Legacy | HTTP OAuth | Official MCP Docs |
-| --- | :---: | :---: | :---: | --- |
-| VS Code (GitHub Copilot) | ✅ | ✅ | ✅ | [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) |
-| Claude Desktop | ✅ | ✅ | — | [Claude Desktop MCP docs](https://modelcontextprotocol.io/quickstart/user) |
-| Claude Code | ✅ | ✅ | ✅ | [Claude Code MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp) |
-| Cursor | ✅ | ✅ | ✅ | [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) |
-| Windsurf | ✅ | ✅ | — | [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) |
-| JetBrains IDEs | ✅ | ✅ | — | [JetBrains MCP docs](https://www.jetbrains.com/help/ai-assistant/mcp.html) |
-| Zed | ✅ | ✅ | — | [Zed MCP docs](https://zed.dev/docs/ai/mcp) |
-| Kiro | ✅ | ✅ | — | [Kiro MCP docs](https://kiro.dev/docs/mcp/) |
-| OpenCode | ✅ | ✅ | — | [OpenCode GitHub](https://github.com/anomalyco/opencode) |
-| Cline | ✅ | ✅ | — | [Cline MCP docs](https://docs.cline.bot/mcp-servers/overview) |
-| Roo Code | ✅ | ✅ | — | [Roo Code MCP docs](https://docs.roocode.com/features/mcp/using-mcp-in-roo) |
+| IDE / Client             | Stdio | HTTP Legacy | HTTP OAuth | Official MCP Docs                                                               |
+| ------------------------ | :---: | :---------: | :--------: | ------------------------------------------------------------------------------- |
+| VS Code (GitHub Copilot) |   ✅   |      ✅      |     ✅      | [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) |
+| Claude Desktop           |   ✅   |      ✅      |     —      | [Claude Desktop MCP docs](https://modelcontextprotocol.io/quickstart/user)      |
+| Claude Code              |   ✅   |      ✅      |     ✅      | [Claude Code MCP docs](https://docs.anthropic.com/en/docs/claude-code/mcp)      |
+| Cursor                   |   ✅   |      ✅      |     ✅      | [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol)       |
+| Windsurf                 |   ✅   |      ✅      |     —      | [Windsurf MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp)             |
+| JetBrains IDEs           |   ✅   |      ✅      |     —      | [JetBrains MCP docs](https://www.jetbrains.com/help/ai-assistant/mcp.html)      |
+| Zed                      |   ✅   |      ✅      |     —      | [Zed MCP docs](https://zed.dev/docs/ai/mcp)                                     |
+| Kiro                     |   ✅   |      ✅      |     —      | [Kiro MCP docs](https://kiro.dev/docs/mcp/)                                     |
+| OpenCode                 |   ✅   |      ✅      |     —      | [OpenCode GitHub](https://github.com/anomalyco/opencode)                        |
+| Cline                    |   ✅   |      ✅      |     —      | [Cline MCP docs](https://docs.cline.bot/mcp-servers/overview)                   |
+| Roo Code                 |   ✅   |      ✅      |     —      | [Roo Code MCP docs](https://docs.roocode.com/features/mcp/using-mcp-in-roo)     |
 
 > **Note**: "—" indicates the client does not support `clientId` configuration for OAuth. These clients rely on Dynamic Client Registration (DCR), which GitLab assigns the `mcp` scope instead of `api`, making most server operations non-functional. Use stdio or HTTP legacy with `PRIVATE-TOKEN` header for those clients.
 
@@ -30,11 +30,11 @@ Per-IDE MCP client configuration examples for gitlab-mcp-server, covering both s
 
 ## Configuration Modes
 
-| Mode | Transport | Token Management | Best For |
-| --- | --- | --- | --- |
-| **Stdio** | stdin/stdout | `GITLAB_TOKEN` env var or `.env` file | Single user, local development |
-| **HTTP Legacy** | HTTP | `PRIVATE-TOKEN` header per-request | Multi-user, simple setup |
-| **HTTP OAuth** | HTTP | Automatic OAuth 2.1 flow via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery | Multi-user, production, zero-config tokens |
+| Mode            | Transport    | Token Management                                                                                 | Best For                                   |
+| --------------- | ------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| **Stdio**       | stdin/stdout | `GITLAB_TOKEN` env var or `.env` file                                                            | Single user, local development             |
+| **HTTP Legacy** | HTTP         | `PRIVATE-TOKEN` header per-request                                                               | Multi-user, simple setup                   |
+| **HTTP OAuth**  | HTTP         | Automatic OAuth 2.1 flow via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery | Multi-user, production, zero-config tokens |
 
 > **Tip**: In HTTP modes, clients send a `GITLAB-URL` header only when the server was started without `--gitlab-url`. If `--gitlab-url` is configured, it is authoritative and client-provided `GITLAB-URL` values are ignored and logged.
 > **Docker note**: The published Docker image starts in HTTP mode by default. If an IDE launches Docker as a stdio MCP process, pass `--http=false` after the image name and keep `docker run -i`; do not publish port 8080 in that mode.

--- a/docs/meta-tools.md
+++ b/docs/meta-tools.md
@@ -59,10 +59,10 @@ META_TOOLS=false
 
 Meta-tools remain available because they are the most broadly compatible consolidated surface.
 
-| Mode | Tool Count | Best For |
-| --- | ---: | --- |
-| Meta-tools | 33 base / 49 self-managed Enterprise/Premium / 50 GitLab.com Enterprise/Premium | LLM clients that need the complete GitLab surface with a compact tool list |
-| Individual tools | 866 CE / 1017 self-managed Enterprise/Premium / 1022 GitLab.com Enterprise/Premium | Clients that benefit from one MCP tool per GitLab operation |
+| Mode             |                                                                         Tool Count | Best For                                                                   |
+| ---------------- | ---------------------------------------------------------------------------------: | -------------------------------------------------------------------------- |
+| Meta-tools       |    33 base / 49 self-managed Enterprise/Premium / 50 GitLab.com Enterprise/Premium | LLM clients that need the complete GitLab surface with a compact tool list |
+| Individual tools | 866 CE / 1017 self-managed Enterprise/Premium / 1022 GitLab.com Enterprise/Premium | Clients that benefit from one MCP tool per GitLab operation                |
 
 ---
 
@@ -70,76 +70,76 @@ Meta-tools remain available because they are the most broadly compatible consoli
 
 ### Core Inline Meta-Tools (17)
 
-| # | Tool Name               | Actions | Domain                                    |
-|---|-------------------------|---------|-------------------------------------------|
-| 1 | `gitlab_project`        | ~92     | Projects, uploads, hooks, badges, boards, import/export, statistics, pages |
-| 2 | `gitlab_branch`         | 11      | Branches, protected branches, branch rules |
-| 3 | `gitlab_tag`            | 9       | Tags, protected tags                      |
-| 4 | `gitlab_release`        | 11      | Releases, release links                   |
-| 5 | `gitlab_merge_request`  | ~46     | MR CRUD, approvals, context-commits, MR emoji, MR resource events |
-| 6 | `gitlab_mr_review`      | ~22     | MR notes, discussions, drafts, changes    |
-| 7 | `gitlab_repository`     | ~40     | Repository tree/compare, commit discussions, files, submodules, markdown |
-| 8 | `gitlab_group`          | ~64     | Groups, members, labels, milestones, boards, uploads, import/export, epic discussions |
-| 9 | `gitlab_issue`          | ~55     | Issues, notes, discussions, links, statistics, issue emoji, issue resource events |
-| 10 | `gitlab_pipeline`      | ~34     | Pipelines, pipeline triggers, pipeline schedules, wait |
-| 11 | `gitlab_job`           | ~25     | Jobs, job token scope, wait               |
-| 12 | `gitlab_user`          | ~29     | Users, events, notifications, keys, namespaces, avatar |
-| 13 | `gitlab_wiki`          | 6       | Project/group wikis                       |
-| 14 | `gitlab_environment`   | ~23     | Environments, protected envs, freeze periods, deployments |
-| 15 | `gitlab_ci_variable`   | ~15     | CI/CD variables (project, group, instance) |
-| 16 | `gitlab_template`      | 12      | CI/CD, Dockerfile, gitignore templates    |
-| 17 | `gitlab_admin`         | ~82     | Server settings, broadcast messages, features, license, system hooks, error tracking, alert management, secure files, terraform states, cluster agents, dependency proxy, import service |
+| #   | Tool Name              | Actions | Domain                                                                                                                                                                                   |
+| --- | ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `gitlab_project`       | ~92     | Projects, uploads, hooks, badges, boards, import/export, statistics, pages                                                                                                               |
+| 2   | `gitlab_branch`        | 11      | Branches, protected branches, branch rules                                                                                                                                               |
+| 3   | `gitlab_tag`           | 9       | Tags, protected tags                                                                                                                                                                     |
+| 4   | `gitlab_release`       | 11      | Releases, release links                                                                                                                                                                  |
+| 5   | `gitlab_merge_request` | ~46     | MR CRUD, approvals, context-commits, MR emoji, MR resource events                                                                                                                        |
+| 6   | `gitlab_mr_review`     | ~22     | MR notes, discussions, drafts, changes                                                                                                                                                   |
+| 7   | `gitlab_repository`    | ~40     | Repository tree/compare, commit discussions, files, submodules, markdown                                                                                                                 |
+| 8   | `gitlab_group`         | ~64     | Groups, members, labels, milestones, boards, uploads, import/export, epic discussions                                                                                                    |
+| 9   | `gitlab_issue`         | ~55     | Issues, notes, discussions, links, statistics, issue emoji, issue resource events                                                                                                        |
+| 10  | `gitlab_pipeline`      | ~34     | Pipelines, pipeline triggers, pipeline schedules, wait                                                                                                                                   |
+| 11  | `gitlab_job`           | ~25     | Jobs, job token scope, wait                                                                                                                                                              |
+| 12  | `gitlab_user`          | ~29     | Users, events, notifications, keys, namespaces, avatar                                                                                                                                   |
+| 13  | `gitlab_wiki`          | 6       | Project/group wikis                                                                                                                                                                      |
+| 14  | `gitlab_environment`   | ~23     | Environments, protected envs, freeze periods, deployments                                                                                                                                |
+| 15  | `gitlab_ci_variable`   | ~15     | CI/CD variables (project, group, instance)                                                                                                                                               |
+| 16  | `gitlab_template`      | 12      | CI/CD, Dockerfile, gitignore templates                                                                                                                                                   |
+| 17  | `gitlab_admin`         | ~82     | Server settings, broadcast messages, features, license, system hooks, error tracking, alert management, secure files, terraform states, cluster agents, dependency proxy, import service |
 
 ### Consolidated Inline Meta-Tools (4)
 
-| # | Tool Name               | Actions | Sources                                   |
-|---|-------------------------|---------|-------------------------------------------|
-| 18 | `gitlab_access`        | ~48     | Access tokens, deploy tokens, deploy keys, access requests, invites |
-| 19 | `gitlab_package`       | ~20     | Packages, container registry              |
-| 20 | `gitlab_snippet`       | ~30     | Snippets, snippet discussions, snippet emoji |
-| 21 | `gitlab_feature_flags` | ~10     | Feature flags, feature flag user lists    |
+| #   | Tool Name              | Actions | Sources                                                             |
+| --- | ---------------------- | ------- | ------------------------------------------------------------------- |
+| 18  | `gitlab_access`        | ~48     | Access tokens, deploy tokens, deploy keys, access requests, invites |
+| 19  | `gitlab_package`       | ~20     | Packages, container registry                                        |
+| 20  | `gitlab_snippet`       | ~30     | Snippets, snippet discussions, snippet emoji                        |
+| 21  | `gitlab_feature_flags` | ~10     | Feature flags, feature flag user lists                              |
 
 ### Always-Registered Meta-Tools (3)
 
-| # | Tool Name               | Actions | Source                                    |
-|---|-------------------------|---------|-------------------------------------------|
-| 22 | `gitlab_model_registry` | 1      | ML model registry package download        |
-| 23 | `gitlab_ci_catalog`    | 2       | CI/CD Catalog resource discovery (GraphQL) |
-| 24 | `gitlab_custom_emoji`  | 3       | Group-level custom emoji management (GraphQL) |
+| #   | Tool Name               | Actions | Source                                        |
+| --- | ----------------------- | ------- | --------------------------------------------- |
+| 22  | `gitlab_model_registry` | 1       | ML model registry package download            |
+| 23  | `gitlab_ci_catalog`     | 2       | CI/CD Catalog resource discovery (GraphQL)    |
+| 24  | `gitlab_custom_emoji`   | 3       | Group-level custom emoji management (GraphQL) |
 
 ### Delegated Meta-Tools (2)
 
-| # | Tool Name               | Actions | Source                                    |
-|---|-------------------------|---------|-------------------------------------------|
-| 25 | `gitlab_search`        | 10      | Global, project, group search             |
-| 26 | `gitlab_runner`        | 34      | Runners, runner management, runner controllers |
+| #   | Tool Name       | Actions | Source                                         |
+| --- | --------------- | ------- | ---------------------------------------------- |
+| 25  | `gitlab_search` | 10      | Global, project, group search                  |
+| 26  | `gitlab_runner` | 34      | Runners, runner management, runner controllers |
 
 ### Sampling Tools (1)
 
-| # | Tool Name               | Actions | Source                                    |
-|---|-------------------------|---------|-------------------------------------------|
-| 27 | `gitlab_analyze`       | 11      | LLM-powered analysis via MCP sampling (MR changes, issues, pipelines, security, deployments, CI config, milestones, release notes, technical debt) |
+| #   | Tool Name        | Actions | Source                                                                                                                                             |
+| --- | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 27  | `gitlab_analyze` | 11      | LLM-powered analysis via MCP sampling (MR changes, issues, pipelines, security, deployments, CI config, milestones, release notes, technical debt) |
 
 ### Standalone Tools (1)
 
-| # | Tool Name               | Actions | Source                                    |
-|---|-------------------------|---------|-------------------------------------------|
-| 28 | `gitlab_discover_project` | 1 | Git remote URL to GitLab project resolution |
+| #   | Tool Name                 | Actions | Source                                      |
+| --- | ------------------------- | ------- | ------------------------------------------- |
+| 28  | `gitlab_discover_project` | 1       | Git remote URL to GitLab project resolution |
 
 ### Interactive Elicitation Tools (4)
 
-| # | Tool Name | Actions | Domain/Source |
-|---|-----------|---------|---------------|
-| 29 | `gitlab_interactive_issue_create` | Guided prompts for issue fields with final confirmation | GitLab |
-| 30 | `gitlab_interactive_mr_create` | Guided prompts for branch, title, metadata, and confirmation | GitLab |
-| 31 | `gitlab_interactive_project_create` | Guided prompts for name, visibility, initialization, and confirmation | GitLab |
-| 32 | `gitlab_interactive_release_create` | Guided prompts for tag, name, notes, and confirmation | GitLab |
+| #   | Tool Name                           | Actions                                                               | Domain/Source |
+| --- | ----------------------------------- | --------------------------------------------------------------------- | ------------- |
+| 29  | `gitlab_interactive_issue_create`   | Guided prompts for issue fields with final confirmation               | GitLab        |
+| 30  | `gitlab_interactive_mr_create`      | Guided prompts for branch, title, metadata, and confirmation          | GitLab        |
+| 31  | `gitlab_interactive_project_create` | Guided prompts for name, visibility, initialization, and confirmation | GitLab        |
+| 32  | `gitlab_interactive_release_create` | Guided prompts for tag, name, notes, and confirmation                 | GitLab        |
 
 ### GitLab.com Enterprise/Premium Meta-Tools (1)
 
-| # | Tool Name | Actions | Source |
-|---|-----------|---------|--------|
-| 33 | `gitlab_orbit` | 5 | Experimental GitLab.com Orbit Knowledge Graph API (`status`, `schema`, `tools`, `query`, `graph_status`) |
+| #   | Tool Name      | Actions | Source                                                                                                   |
+| --- | -------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| 33  | `gitlab_orbit` | 5       | Experimental GitLab.com Orbit Knowledge Graph API (`status`, `schema`, `tools`, `query`, `graph_status`) |
 
 ---
 

--- a/docs/oauth-app-setup.md
+++ b/docs/oauth-app-setup.md
@@ -90,12 +90,12 @@ Each MCP client has its own redirect URI scheme. Configure **all** redirect URIs
 
 ### Redirect URIs per IDE
 
-| IDE / Client | Redirect URI | Notes |
-| --- | --- | --- |
-| VS Code / GitHub Copilot | `http://localhost` | VS Code opens a local HTTP server on a random port; GitLab matches the host only |
-| VS Code (Codespaces / Remote) | `https://insiders.vscode.dev/redirect` | For remote development environments |
-| Cursor | `http://localhost` | VS Code fork — same redirect URI scheme |
-| Claude Code (CLI) | `http://localhost` | CLI-based OAuth callback (default port configurable via `--callback-port`) |
+| IDE / Client                  | Redirect URI                           | Notes                                                                            |
+| ----------------------------- | -------------------------------------- | -------------------------------------------------------------------------------- |
+| VS Code / GitHub Copilot      | `http://localhost`                     | VS Code opens a local HTTP server on a random port; GitLab matches the host only |
+| VS Code (Codespaces / Remote) | `https://insiders.vscode.dev/redirect` | For remote development environments                                              |
+| Cursor                        | `http://localhost`                     | VS Code fork — same redirect URI scheme                                          |
+| Claude Code (CLI)             | `http://localhost`                     | CLI-based OAuth callback (default port configurable via `--callback-port`)       |
 
 > **Multiple URIs**: GitLab allows multiple redirect URIs separated by newlines in the application form. Add all URIs your team needs.
 
@@ -178,13 +178,13 @@ claude mcp add gitlab \
 
 ## Token Lifecycle
 
-| Event | Behavior |
-| --- | --- |
-| First request | Token verified against GitLab `/api/v4/user`, result cached |
+| Event                            | Behavior                                                    |
+| -------------------------------- | ----------------------------------------------------------- |
+| First request                    | Token verified against GitLab `/api/v4/user`, result cached |
 | Subsequent requests (within TTL) | Token served from SHA-256 hashed cache — no GitLab API call |
-| Cache TTL expires | Token re-verified on next request |
-| Token revoked on GitLab | Next request after cache expiry returns 401 |
-| Background cleanup | Expired cache entries evicted every 30 seconds |
+| Cache TTL expires                | Token re-verified on next request                           |
+| Token revoked on GitLab          | Next request after cache expiry returns 401                 |
+| Background cleanup               | Expired cache entries evicted every 30 seconds              |
 
 ---
 
@@ -200,13 +200,13 @@ claude mcp add gitlab \
 
 ## Troubleshooting
 
-| Issue | Solution |
-| --- | --- |
-| "redirect_uri_mismatch" from GitLab | Add the exact redirect URI used by your IDE to the GitLab OAuth Application. See [Redirect URIs per IDE](#redirect-uris-per-ide) |
-| OAuth flow does not start | Verify `--auth-mode=oauth` is set and `/.well-known/oauth-protected-resource` returns metadata |
-| "invalid_client" error | The `clientId` in MCP client config does not match the GitLab Application ID. Copy the exact value |
-| Token works with curl but not from IDE | The IDE may not be sending the token as `Authorization: Bearer`. Check IDE MCP logs |
-| "access_denied" after authorization | The GitLab OAuth Application may not have the `api` scope. Recreate with correct scopes |
+| Issue                                  | Solution                                                                                                                         |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| "redirect_uri_mismatch" from GitLab    | Add the exact redirect URI used by your IDE to the GitLab OAuth Application. See [Redirect URIs per IDE](#redirect-uris-per-ide) |
+| OAuth flow does not start              | Verify `--auth-mode=oauth` is set and `/.well-known/oauth-protected-resource` returns metadata                                   |
+| "invalid_client" error                 | The `clientId` in MCP client config does not match the GitLab Application ID. Copy the exact value                               |
+| Token works with curl but not from IDE | The IDE may not be sending the token as `Authorization: Bearer`. Check IDE MCP logs                                              |
+| "access_denied" after authorization    | The GitLab OAuth Application may not have the `api` scope. Recreate with correct scopes                                          |
 
 ---
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -71,13 +71,13 @@ These hints are available in both the Markdown and JSON output, so your IDE can 
 
 Different MCP clients read different parts of the response:
 
-| Client | Reads Markdown `content` | Reads `structuredContent` JSON | How hints arrive |
-|--------|--------------------------|-------------------------------|-----------------|
-| **VS Code / Copilot** | ❌ Ignores | ✅ Primary | `next_steps` array in JSON |
-| **Cursor** | ✅ Primary | ✅ Also available | Both `💡 Next steps` in Markdown and `next_steps` in JSON |
-| **Claude Desktop** | ✅ Primary | ✅ Also available | Both formats |
-| **CLI tools** | ✅ Primary | ❌ Often ignored | `💡 Next steps` in Markdown |
-| **Custom HTTP clients** | Depends | Depends | Both available in JSON-RPC response |
+| Client                  | Reads Markdown `content` | Reads `structuredContent` JSON | How hints arrive                                         |
+| ----------------------- | ------------------------ | ------------------------------ | -------------------------------------------------------- |
+| **VS Code / Copilot**   | ❌ Ignores                | ✅ Primary                      | `next_steps` array in JSON                               |
+| **Cursor**              | ✅ Primary                | ✅ Also available               | Both `💡 Next steps` in Markdown and `next_steps` in JSON |
+| **Claude Desktop**      | ✅ Primary                | ✅ Also available               | Both formats                                             |
+| **CLI tools**           | ✅ Primary                | ❌ Often ignored                | `💡 Next steps` in Markdown                               |
+| **Custom HTTP clients** | Depends                  | Depends                        | Both available in JSON-RPC response                      |
 
 The server ensures hints appear in **both** formats so no client misses them.
 
@@ -85,14 +85,14 @@ The server ensures hints appear in **both** formats so no client misses them.
 
 Every Markdown response includes [MCP annotations](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/annotations) that tell the client who the content is for and how important it is:
 
-| Annotation | Audience | Priority | Used For |
-|-----------|----------|----------|----------|
-| `ContentList` | `assistant` | 0.4 | List and search results |
-| `ContentDetail` | `assistant` | 0.6 | Single-entity details (get, show) |
-| `ContentMutate` | `assistant` | 0.8 | Create, update, delete confirmations |
-| `ContentAssistant` | `assistant` | 0.7 | General assistant-targeted content |
-| `ContentUser` | `user` | 0.8 | Content for direct user display |
-| `ContentBoth` | `user`, `assistant` | 0.5 | Content for both audiences |
+| Annotation         | Audience            | Priority | Used For                             |
+| ------------------ | ------------------- | -------- | ------------------------------------ |
+| `ContentList`      | `assistant`         | 0.4      | List and search results              |
+| `ContentDetail`    | `assistant`         | 0.6      | Single-entity details (get, show)    |
+| `ContentMutate`    | `assistant`         | 0.8      | Create, update, delete confirmations |
+| `ContentAssistant` | `assistant`         | 0.7      | General assistant-targeted content   |
+| `ContentUser`      | `user`              | 0.8      | Content for direct user display      |
+| `ContentBoth`      | `user`, `assistant` | 0.5      | Content for both audiences           |
 
 ### What Does `audience: ["assistant"]` Mean?
 
@@ -106,12 +106,12 @@ The `priority` value (0.0 to 1.0) hints to the client how important the content 
 
 Separate from content annotations, every **tool** has behavioral annotations that describe what it does:
 
-| Annotation | Type | Meaning |
-|-----------|------|---------|
-| `readOnlyHint` | `bool` | The tool only reads data, never modifies anything |
-| `destructiveHint` | `*bool` | The tool may perform irreversible operations (delete, drop) |
-| `idempotentHint` | `bool` | Calling the tool multiple times with the same input produces the same result |
-| `openWorldHint` | `*bool` | The tool interacts with external systems (GitLab API) |
+| Annotation        | Type    | Meaning                                                                      |
+| ----------------- | ------- | ---------------------------------------------------------------------------- |
+| `readOnlyHint`    | `bool`  | The tool only reads data, never modifies anything                            |
+| `destructiveHint` | `*bool` | The tool may perform irreversible operations (delete, drop)                  |
+| `idempotentHint`  | `bool`  | Calling the tool multiple times with the same input produces the same result |
+| `openWorldHint`   | `*bool` | The tool interacts with external systems (GitLab API)                        |
 
 These annotations help your AI assistant and IDE make safety decisions:
 
@@ -230,30 +230,30 @@ Selected `gitlab_*_get` tools attach an additional content block of type `resour
 
 Currently embedded by 22 `gitlab_*_get` handlers:
 
-| Tool                          | Canonical URI                                            |
-| ----------------------------- | -------------------------------------------------------- |
-| `gitlab_board_get`            | `gitlab://project/{project_id}/board/{board_id}`         |
-| `gitlab_branch_get`           | `gitlab://project/{project_id}/branch/{branch_name}`     |
-| `gitlab_commit_get`           | `gitlab://project/{project_id}/commit/{sha}`             |
-| `gitlab_deploy_key_get`       | `gitlab://project/{project_id}/deploy_key/{key_id}`      |
-| `gitlab_deployment_get`       | `gitlab://project/{project_id}/deployment/{deployment_id}` |
-| `gitlab_environment_get`      | `gitlab://project/{project_id}/environment/{environment_id}` |
-| `gitlab_feature_flag_get`     | `gitlab://project/{project_id}/feature_flag/{name}`      |
-| `gitlab_group_get`            | `gitlab://group/{group_id}`                              |
-| `gitlab_group_label_get`      | `gitlab://group/{group_id}/label/{label_id}`             |
-| `gitlab_group_milestone_get`  | `gitlab://group/{group_id}/milestone/{milestone_iid}`    |
-| `gitlab_issue_get`            | `gitlab://project/{project_id}/issue/{issue_iid}`        |
-| `gitlab_job_get`              | `gitlab://project/{project_id}/job/{job_id}`             |
-| `gitlab_label_get`            | `gitlab://project/{project_id}/label/{label_id}`         |
-| `gitlab_milestone_get`        | `gitlab://project/{project_id}/milestone/{milestone_iid}`|
-| `gitlab_mr_get`               | `gitlab://project/{project_id}/mr/{merge_request_iid}`              |
-| `gitlab_pipeline_get`         | `gitlab://project/{project_id}/pipeline/{pipeline_id}`   |
-| `gitlab_project_get`          | `gitlab://project/{project_id}`                          |
-| `gitlab_project_snippet_get`  | `gitlab://project/{project_id}/snippet/{snippet_id}`     |
-| `gitlab_release_get`          | `gitlab://project/{project_id}/release/{tag_name}`       |
-| `gitlab_snippet_get`          | `gitlab://snippet/{snippet_id}`                          |
-| `gitlab_tag_get`              | `gitlab://project/{project_id}/tag/{tag_name}`           |
-| `gitlab_wiki_get`             | `gitlab://project/{project_id}/wiki/{slug}`              |
+| Tool                         | Canonical URI                                                |
+| ---------------------------- | ------------------------------------------------------------ |
+| `gitlab_board_get`           | `gitlab://project/{project_id}/board/{board_id}`             |
+| `gitlab_branch_get`          | `gitlab://project/{project_id}/branch/{branch_name}`         |
+| `gitlab_commit_get`          | `gitlab://project/{project_id}/commit/{sha}`                 |
+| `gitlab_deploy_key_get`      | `gitlab://project/{project_id}/deploy_key/{key_id}`          |
+| `gitlab_deployment_get`      | `gitlab://project/{project_id}/deployment/{deployment_id}`   |
+| `gitlab_environment_get`     | `gitlab://project/{project_id}/environment/{environment_id}` |
+| `gitlab_feature_flag_get`    | `gitlab://project/{project_id}/feature_flag/{name}`          |
+| `gitlab_group_get`           | `gitlab://group/{group_id}`                                  |
+| `gitlab_group_label_get`     | `gitlab://group/{group_id}/label/{label_id}`                 |
+| `gitlab_group_milestone_get` | `gitlab://group/{group_id}/milestone/{milestone_iid}`        |
+| `gitlab_issue_get`           | `gitlab://project/{project_id}/issue/{issue_iid}`            |
+| `gitlab_job_get`             | `gitlab://project/{project_id}/job/{job_id}`                 |
+| `gitlab_label_get`           | `gitlab://project/{project_id}/label/{label_id}`             |
+| `gitlab_milestone_get`       | `gitlab://project/{project_id}/milestone/{milestone_iid}`    |
+| `gitlab_mr_get`              | `gitlab://project/{project_id}/mr/{merge_request_iid}`       |
+| `gitlab_pipeline_get`        | `gitlab://project/{project_id}/pipeline/{pipeline_id}`       |
+| `gitlab_project_get`         | `gitlab://project/{project_id}`                              |
+| `gitlab_project_snippet_get` | `gitlab://project/{project_id}/snippet/{snippet_id}`         |
+| `gitlab_release_get`         | `gitlab://project/{project_id}/release/{tag_name}`           |
+| `gitlab_snippet_get`         | `gitlab://snippet/{snippet_id}`                              |
+| `gitlab_tag_get`             | `gitlab://project/{project_id}/tag/{tag_name}`               |
+| `gitlab_wiki_get`            | `gitlab://project/{project_id}/wiki/{slug}`                  |
 
 The embedded resource carries `MIMEType: "application/json"` and a `Text` payload equal to the JSON-marshaled output struct — duplicating `StructuredContent` so simpler clients lose nothing. Not-found responses do **not** embed (the entity does not exist).
 

--- a/docs/prompts-reference.md
+++ b/docs/prompts-reference.md
@@ -14,30 +14,30 @@ These prompts are registered directly in `internal/prompts/prompts.go`.
 
 ### Merge Request Analysis
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 1 | `summarize_mr_changes` | `project_id`*, `merge_request_iid`* | Summarize the changed files and key modifications in a merge request. Lists each file with its change type (new/modified/deleted/renamed). |
-| 2 | `review_mr` | `project_id`*, `merge_request_iid`* | Generate a structured code review for a merge request. Files are categorized by risk (high-risk, business logic, tests, documentation) with per-file metrics and a review plan. Full diffs included. |
-| 3 | `suggest_mr_reviewers` | `project_id`*, `merge_request_iid`* | Suggest suitable merge request reviewers based on the files changed and active project members. Excludes the MR author. |
-| 4 | `mr_risk_assessment` | `project_id`*, `merge_request_iid`* | Assess the risk level (LOW/MEDIUM/HIGH/CRITICAL) of a merge request based on size, changed files, sensitive patterns, and conflict status. |
+| #   | Name                   | Arguments                           | Description                                                                                                                                                                                          |
+| --- | ---------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `summarize_mr_changes` | `project_id`*, `merge_request_iid`* | Summarize the changed files and key modifications in a merge request. Lists each file with its change type (new/modified/deleted/renamed).                                                           |
+| 2   | `review_mr`            | `project_id`*, `merge_request_iid`* | Generate a structured code review for a merge request. Files are categorized by risk (high-risk, business logic, tests, documentation) with per-file metrics and a review plan. Full diffs included. |
+| 3   | `suggest_mr_reviewers` | `project_id`*, `merge_request_iid`* | Suggest suitable merge request reviewers based on the files changed and active project members. Excludes the MR author.                                                                              |
+| 4   | `mr_risk_assessment`   | `project_id`*, `merge_request_iid`* | Assess the risk level (LOW/MEDIUM/HIGH/CRITICAL) of a merge request based on size, changed files, sensitive patterns, and conflict status.                                                           |
 
 ### Project Overview
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 5 | `summarize_pipeline_status` | `project_id`* | Summarize the latest CI/CD pipeline status. Groups jobs by outcome (failed/passed/other) and includes failure reasons for debugging. |
-| 6 | `summarize_open_mrs` | `project_id`* | Summarize all open merge requests including title, author, branches, age in days, and merge status. Highlights stale MRs (>7 days). |
-| 7 | `project_health_check` | `project_id`* | Comprehensive project health assessment combining latest pipeline status, open MRs, and branch hygiene (merged/stale branch counts). |
-| 8 | `generate_release_notes` | `project_id`*, `from`*, `to` | Generate release notes from commits and file changes between two Git refs (tags, branches, or SHAs). |
-| 9 | `compare_branches` | `project_id`*, `from`*, `to`* | Compare two Git branches or refs showing commit differences and file changes between them. |
+| #   | Name                        | Arguments                     | Description                                                                                                                          |
+| --- | --------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 5   | `summarize_pipeline_status` | `project_id`*                 | Summarize the latest CI/CD pipeline status. Groups jobs by outcome (failed/passed/other) and includes failure reasons for debugging. |
+| 6   | `summarize_open_mrs`        | `project_id`*                 | Summarize all open merge requests including title, author, branches, age in days, and merge status. Highlights stale MRs (>7 days).  |
+| 7   | `project_health_check`      | `project_id`*                 | Comprehensive project health assessment combining latest pipeline status, open MRs, and branch hygiene (merged/stale branch counts). |
+| 8   | `generate_release_notes`    | `project_id`*, `from`*, `to`  | Generate release notes from commits and file changes between two Git refs (tags, branches, or SHAs).                                 |
+| 9   | `compare_branches`          | `project_id`*, `from`*, `to`* | Compare two Git branches or refs showing commit differences and file changes between them.                                           |
 
 ### Personal Productivity
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 10 | `daily_standup` | `project_id`*, `username` | Generate a daily standup summary based on the user's GitLab activity in the last 24 hours. Includes done/planned/blockers sections. |
-| 11 | `team_member_workload` | `project_id`*, `username`*, `days` | Generate a comprehensive workload summary for a specific team member over a configurable time period. |
-| 12 | `user_stats` | `project_id`*, `username`, `days` | Generate comprehensive user statistics: contribution events, MR stats, issue stats, daily activity trends, and Mermaid activity chart. |
+| #   | Name                   | Arguments                          | Description                                                                                                                            |
+| --- | ---------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 10  | `daily_standup`        | `project_id`*, `username`          | Generate a daily standup summary based on the user's GitLab activity in the last 24 hours. Includes done/planned/blockers sections.    |
+| 11  | `team_member_workload` | `project_id`*, `username`*, `days` | Generate a comprehensive workload summary for a specific team member over a configurable time period.                                  |
+| 12  | `user_stats`           | `project_id`*, `username`, `days`  | Generate comprehensive user statistics: contribution events, MR stats, issue stats, daily activity trends, and Mermaid activity chart. |
 
 > `*` = required argument
 
@@ -45,107 +45,107 @@ These prompts are registered directly in `internal/prompts/prompts.go`.
 
 Personal dashboard prompts that aggregate across all projects. Registered in `internal/prompts/prompt_cross_project.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 13 | `my_open_mrs` | — | Show all open MRs where you are author or assignee across all projects. Grouped by project. |
-| 14 | `my_pending_reviews` | — | Show all open MRs where you are assigned as reviewer across all projects. Grouped by project. |
-| 15 | `my_issues` | — | Show all issues assigned to you across all projects. Includes overdue detection and project grouping. |
-| 16 | `my_activity_summary` | `days` | Generate a personal activity summary for a configurable time period across all projects. Includes daily activity chart. |
+| #   | Name                  | Arguments | Description                                                                                                             |
+| --- | --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 13  | `my_open_mrs`         | —         | Show all open MRs where you are author or assignee across all projects. Grouped by project.                             |
+| 14  | `my_pending_reviews`  | —         | Show all open MRs where you are assigned as reviewer across all projects. Grouped by project.                           |
+| 15  | `my_issues`           | —         | Show all issues assigned to you across all projects. Includes overdue detection and project grouping.                   |
+| 16  | `my_activity_summary` | `days`    | Generate a personal activity summary for a configurable time period across all projects. Includes daily activity chart. |
 
 ## Team Management Prompts (4)
 
 Group-level team management prompts. Registered in `internal/prompts/prompt_team.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 17 | `user_activity_report` | `group_id`*, `username`*, `days` | Generate a detailed activity report for a specific user. Designed for managers to review team member productivity. |
-| 18 | `team_overview` | `group_id`* | Generate a team dashboard showing all group members with their open MR counts and recently merged MRs. Includes workload pie chart. |
-| 19 | `group_mr_dashboard` | `group_id`*, `state`, `target_branch` | List merge requests across a GitLab group with optional state and target branch filters. Grouped by project with blocker and readiness summary statistics. |
-| 20 | `reviewer_workload` | `group_id`* | Analyze review distribution across group members. Shows how many open MRs each member is reviewing and identifies imbalances. |
+| #   | Name                   | Arguments                             | Description                                                                                                                                                |
+| --- | ---------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 17  | `user_activity_report` | `group_id`*, `username`*, `days`      | Generate a detailed activity report for a specific user. Designed for managers to review team member productivity.                                         |
+| 18  | `team_overview`        | `group_id`*                           | Generate a team dashboard showing all group members with their open MR counts and recently merged MRs. Includes workload pie chart.                        |
+| 19  | `group_mr_dashboard`   | `group_id`*, `state`, `target_branch` | List merge requests across a GitLab group with optional state and target branch filters. Grouped by project with blocker and readiness summary statistics. |
+| 20  | `reviewer_workload`    | `group_id`*                           | Analyze review distribution across group members. Shows how many open MRs each member is reviewing and identifies imbalances.                              |
 
 ## Project Report Prompts (5)
 
 Project-level analysis prompts. Registered in `internal/prompts/prompt_project_reports.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 21 | `branch_mr_summary` | `project_id`*, `target_branch`* | List all MRs targeting a specific branch. Shows readiness summary with conflict/draft/approval counts. |
-| 22 | `project_activity_report` | `project_id`*, `days` | Generate a project activity report including recent events, merged MRs, and open issues. Shows daily activity chart. |
-| 23 | `mr_discussion_health` | `project_id`* | Analyze unresolved discussion threads across open MRs. Use for review follow-up and merge-readiness cleanup, not approval-rule status. |
-| 24 | `unassigned_items` | `project_id`* | Find open MRs and issues that have no assignee. Helps identify ownership gaps. |
-| 25 | `stale_items_report` | `project_id`*, `stale_days` | Find MRs and issues that haven't been updated for a configurable number of days. Default: 14 days. |
+| #   | Name                      | Arguments                       | Description                                                                                                                            |
+| --- | ------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 21  | `branch_mr_summary`       | `project_id`*, `target_branch`* | List all MRs targeting a specific branch. Shows readiness summary with conflict/draft/approval counts.                                 |
+| 22  | `project_activity_report` | `project_id`*, `days`           | Generate a project activity report including recent events, merged MRs, and open issues. Shows daily activity chart.                   |
+| 23  | `mr_discussion_health`    | `project_id`*                   | Analyze unresolved discussion threads across open MRs. Use for review follow-up and merge-readiness cleanup, not approval-rule status. |
+| 24  | `unassigned_items`        | `project_id`*                   | Find open MRs and issues that have no assignee. Helps identify ownership gaps.                                                         |
+| 25  | `stale_items_report`      | `project_id`*, `stale_days`     | Find MRs and issues that haven't been updated for a configurable number of days. Default: 14 days.                                     |
 
 ## Analytics Prompts (4)
 
 Velocity and release analytics prompts. Registered in `internal/prompts/prompt_analytics.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 26 | `merge_velocity` | `project_id`*, `days` | Analyze MR throughput metrics. Shows merge rate, average time-to-merge, and daily merged count chart. |
-| 27 | `release_readiness` | `project_id`*, `branch` | Check readiness of a release branch by analyzing open MRs targeting it, draft/conflict counts, and unresolved discussion threads. |
-| 28 | `release_cadence` | `project_id`* | Analyze release frequency. Shows time between releases, average cadence, and release history chart. |
-| 29 | `weekly_team_recap` | `group_id`*, `days` | Generate a comprehensive weekly recap for a team. Combines merged MRs, open MRs, issues activity, and events into a single summary. |
+| #   | Name                | Arguments               | Description                                                                                                                         |
+| --- | ------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 26  | `merge_velocity`    | `project_id`*, `days`   | Analyze MR throughput metrics. Shows merge rate, average time-to-merge, and daily merged count chart.                               |
+| 27  | `release_readiness` | `project_id`*, `branch` | Check readiness of a release branch by analyzing open MRs targeting it, draft/conflict counts, and unresolved discussion threads.   |
+| 28  | `release_cadence`   | `project_id`*           | Analyze release frequency. Shows time between releases, average cadence, and release history chart.                                 |
+| 29  | `weekly_team_recap` | `group_id`*, `days`     | Generate a comprehensive weekly recap for a team. Combines merged MRs, open MRs, issues activity, and events into a single summary. |
 
 ## Milestone & Label Prompts (4)
 
 Milestone tracking, label analysis, and contributor ranking. Registered in `internal/prompts/prompt_milestone_label.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 30 | `milestone_progress` | `project_id`*, `milestone` | Track milestone progress for a project. Shows issue/MR completion, progress bar, and due date risk. Omit milestone for all active milestones. |
-| 31 | `label_distribution` | `project_id`* | Analyze label usage distribution. Shows open/closed issue counts and open MR counts per label. |
-| 32 | `group_milestone_progress` | `group_id`* | Track milestone progress across all projects in a group. Shows issue/MR completion per milestone with progress bars. |
-| 33 | `project_contributors` | `project_id`* | Rank project contributors by commits, additions, and deletions using the repository contributors API. |
+| #   | Name                       | Arguments                  | Description                                                                                                                                   |
+| --- | -------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 30  | `milestone_progress`       | `project_id`*, `milestone` | Track milestone progress for a project. Shows issue/MR completion, progress bar, and due date risk. Omit milestone for all active milestones. |
+| 31  | `label_distribution`       | `project_id`*              | Analyze label usage distribution. Shows open/closed issue counts and open MR counts per label.                                                |
+| 32  | `group_milestone_progress` | `group_id`*                | Track milestone progress across all projects in a group. Shows issue/MR completion per milestone with progress bars.                          |
+| 33  | `project_contributors`     | `project_id`*              | Rank project contributors by commits, additions, and deletions using the repository contributors API.                                         |
 
 ## Git Workflow Prompts (2)
 
 Commit history and MR authoring quality prompts. Registered in `internal/prompts/prompt_git_workflow.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 34 | `audit_commit_hygiene` | `project_id`*, `from`*, `to` | Audit commit message quality between two refs. Scores Conventional Commit usage, merge commits, breaking-change markers, body/detail quality, and linked work references for release and contribution readiness. |
-| 35 | `mr_description_quality` | `project_id`*, `merge_request_iid`* | Score a merge request description for reviewer readiness. Checks context, linked work, test evidence, rollout/risk notes, checklists, and changed-file cues for missing screenshots or migration notes. |
+| #   | Name                     | Arguments                           | Description                                                                                                                                                                                                      |
+| --- | ------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 34  | `audit_commit_hygiene`   | `project_id`*, `from`*, `to`        | Audit commit message quality between two refs. Scores Conventional Commit usage, merge commits, breaking-change markers, body/detail quality, and linked work references for release and contribution readiness. |
+| 35  | `mr_description_quality` | `project_id`*, `merge_request_iid`* | Score a merge request description for reviewer readiness. Checks context, linked work, test evidence, rollout/risk notes, checklists, and changed-file cues for missing screenshots or migration notes.          |
 
 ## Project Audit Prompts (2)
 
 Project configuration audit prompts. Registered in `internal/prompts/prompt_audit.go`.
 
-| # | Name | Arguments | Description |
-|---|------|-----------|-------------|
-| 36 | `audit_project_workflow` | `project_id`* | Audit workflow configuration: labels (with description gaps), milestones (active/closed, due dates), issue and MR templates. |
-| 37 | `audit_project_full` | `project_id`* | Comprehensive project audit combining settings, branch protection, access, labels, milestones, templates, webhooks, and push rules with a quick scorecard. |
+| #   | Name                     | Arguments     | Description                                                                                                                                                |
+| --- | ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 36  | `audit_project_workflow` | `project_id`* | Audit workflow configuration: labels (with description gaps), milestones (active/closed, due dates), issue and MR templates.                               |
+| 37  | `audit_project_full`     | `project_id`* | Comprehensive project audit combining settings, branch protection, access, labels, milestones, templates, webhooks, and push rules with a quick scorecard. |
 
 ## Prompt Selection Guide
 
-| Goal | Use |
-|------|-----|
-| Review code changes deeply | `review_mr` |
+| Goal                                                   | Use                      |
+| ------------------------------------------------------ | ------------------------ |
+| Review code changes deeply                             | `review_mr`              |
 | Check whether an MR description is ready for reviewers | `mr_description_quality` |
-| Find suitable reviewers | `suggest_mr_reviewers` |
-| Track unresolved MR review threads | `mr_discussion_health` |
-| Summarize all project MRs | `summarize_open_mrs` |
-| Summarize MRs for one target branch | `branch_mr_summary` |
-| Review group-wide MR status | `group_mr_dashboard` |
-| Generate release notes | `generate_release_notes` |
-| Check commit message/history quality before release | `audit_commit_hygiene` |
-| Audit project governance comprehensively | `audit_project_full` |
-| Audit labels, milestones, and templates only | `audit_project_workflow` |
+| Find suitable reviewers                                | `suggest_mr_reviewers`   |
+| Track unresolved MR review threads                     | `mr_discussion_health`   |
+| Summarize all project MRs                              | `summarize_open_mrs`     |
+| Summarize MRs for one target branch                    | `branch_mr_summary`      |
+| Review group-wide MR status                            | `group_mr_dashboard`     |
+| Generate release notes                                 | `generate_release_notes` |
+| Check commit message/history quality before release    | `audit_commit_hygiene`   |
+| Audit project governance comprehensively               | `audit_project_full`     |
+| Audit labels, milestones, and templates only           | `audit_project_workflow` |
 
 ## Common Arguments
 
-| Argument | Type | Description |
-|----------|------|-------------|
-| `project_id` | string (required) | Project ID (numeric) or URL-encoded path (e.g. `group/project`) |
+| Argument            | Type              | Description                                                              |
+| ------------------- | ----------------- | ------------------------------------------------------------------------ |
+| `project_id`        | string (required) | Project ID (numeric) or URL-encoded path (e.g. `group/project`)          |
 | `merge_request_iid` | string (required) | Merge request IID (project-scoped numeric ID, visible as `!N` in GitLab) |
-| `group_id` | string (required) | Group ID (numeric) or URL-encoded path |
-| `username` | string | GitLab username (defaults to authenticated user when omitted) |
-| `days` | string | Number of days to look back (default varies by prompt: 7 or 30) |
-| `from` / `to` | string | Git refs: tag name, branch name, or commit SHA |
-| `branch` | string | Target branch name (default: `main`) |
-| `target_branch` | string | Target branch for MR filtering |
-| `state` | string | MR/issue state filter (default: `opened`) |
-| `milestone` | string | Specific milestone title |
-| `stale_days` | string | Days without update to consider stale (default: 14) |
+| `group_id`          | string (required) | Group ID (numeric) or URL-encoded path                                   |
+| `username`          | string            | GitLab username (defaults to authenticated user when omitted)            |
+| `days`              | string            | Number of days to look back (default varies by prompt: 7 or 30)          |
+| `from` / `to`       | string            | Git refs: tag name, branch name, or commit SHA                           |
+| `branch`            | string            | Target branch name (default: `main`)                                     |
+| `target_branch`     | string            | Target branch for MR filtering                                           |
+| `state`             | string            | MR/issue state filter (default: `opened`)                                |
+| `milestone`         | string            | Specific milestone title                                                 |
+| `stale_days`        | string            | Days without update to consider stale (default: 14)                      |
 
 ## Autocomplete Support
 
@@ -153,13 +153,13 @@ All prompt arguments support intelligent autocomplete via the completions handle
 
 ## Source Files
 
-| File | Prompts |
-|------|---------|
-| [`prompts.go`](../internal/prompts/prompts.go) | 12 core prompts |
-| [`prompt_cross_project.go`](../internal/prompts/prompt_cross_project.go) | 4 cross-project prompts |
-| [`prompt_team.go`](../internal/prompts/prompt_team.go) | 4 team management prompts |
-| [`prompt_project_reports.go`](../internal/prompts/prompt_project_reports.go) | 5 project report prompts |
-| [`prompt_analytics.go`](../internal/prompts/prompt_analytics.go) | 4 analytics prompts (incl. `weekly_team_recap`) |
-| [`prompt_milestone_label.go`](../internal/prompts/prompt_milestone_label.go) | 4 milestone & label prompts |
-| [`prompt_git_workflow.go`](../internal/prompts/prompt_git_workflow.go) | 2 Git workflow quality prompts |
-| [`prompt_audit.go`](../internal/prompts/prompt_audit.go) | 2 project audit prompts |
+| File                                                                         | Prompts                                         |
+| ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| [`prompts.go`](../internal/prompts/prompts.go)                               | 12 core prompts                                 |
+| [`prompt_cross_project.go`](../internal/prompts/prompt_cross_project.go)     | 4 cross-project prompts                         |
+| [`prompt_team.go`](../internal/prompts/prompt_team.go)                       | 4 team management prompts                       |
+| [`prompt_project_reports.go`](../internal/prompts/prompt_project_reports.go) | 5 project report prompts                        |
+| [`prompt_analytics.go`](../internal/prompts/prompt_analytics.go)             | 4 analytics prompts (incl. `weekly_team_recap`) |
+| [`prompt_milestone_label.go`](../internal/prompts/prompt_milestone_label.go) | 4 milestone & label prompts                     |
+| [`prompt_git_workflow.go`](../internal/prompts/prompt_git_workflow.go)       | 2 Git workflow quality prompts                  |
+| [`prompt_audit.go`](../internal/prompts/prompt_audit.go)                     | 2 project audit prompts                         |

--- a/docs/resource-consumption.md
+++ b/docs/resource-consumption.md
@@ -12,23 +12,23 @@ This document provides memory and CPU estimates for gitlab-mcp-server in both st
 
 The gitlab-mcp-server binary is a statically compiled Go executable:
 
-| Metric | Value |
-| --- | --- |
-| Binary size (stripped) | ~25 MB |
+| Metric                         | Value      |
+| ------------------------------ | ---------- |
+| Binary size (stripped)         | ~25 MB     |
 | Go runtime overhead at startup | ~15 MB RSS |
-| Initial heap after config load | ~20 MB |
+| Initial heap after config load | ~20 MB     |
 
 ## Stdio Mode
 
 In stdio mode, each AI client (VS Code, Cursor, Copilot CLI, OpenCode) spawns its own server process. The resource footprint is straightforward:
 
-| Component | Memory |
-| --- | --- |
-| Go runtime + binary | ~20 MB |
-| Config + GitLab client | ~2 MB |
-| MCP server + registered tools | ~25 MB |
-| Tool execution working memory | ~5 MB |
-| **Total per process** | **~50 MB** |
+| Component                     | Memory     |
+| ----------------------------- | ---------- |
+| Go runtime + binary           | ~20 MB     |
+| Config + GitLab client        | ~2 MB      |
+| MCP server + registered tools | ~25 MB     |
+| Tool execution working memory | ~5 MB      |
+| **Total per process**         | **~50 MB** |
 
 ## HTTP Mode
 
@@ -36,47 +36,47 @@ In HTTP mode, a single process serves all clients. The base process uses ~50 MB 
 
 ### Per-Token Pool Entry Cost
 
-| Component | Approximate Size |
-| --- | --- |
-| `*mcp.Server` instance (struct + options + session map) | ~40 KB |
-| `*gitlabclient.Client` via `gl.NewClient()` (HTTP client + auth) | ~8 KB |
-| Tool registrations (866/1017/1022 individual or 33/49/50 meta) | ~80 KB |
-| Resource registrations (46) | ~8 KB |
-| Prompt registrations (38) | ~5 KB |
-| **Total per unique token** | **~130 KB** |
+| Component                                                        | Approximate Size |
+| ---------------------------------------------------------------- | ---------------- |
+| `*mcp.Server` instance (struct + options + session map)          | ~40 KB           |
+| `*gitlabclient.Client` via `gl.NewClient()` (HTTP client + auth) | ~8 KB            |
+| Tool registrations (866/1017/1022 individual or 33/49/50 meta)   | ~80 KB           |
+| Resource registrations (46)                                      | ~8 KB            |
+| Prompt registrations (38)                                        | ~5 KB            |
+| **Total per unique token**                                       | **~130 KB**      |
 
 ### Scaling in HTTP Mode
 
-| Unique Tokens | Pool Memory | Total Process Memory | Notes |
-| --- | --- | --- | --- |
-| 1 | ~130 KB | ~50 MB | Equivalent to stdio |
-| 10 | ~1.3 MB | ~51 MB | Minimal overhead |
-| 50 | ~6.5 MB | ~57 MB | Comfortable for a team |
-| 100 (default max) | ~13 MB | ~63 MB | Default `--max-http-clients` |
-| 500 | ~65 MB | ~115 MB | Requires `--max-http-clients=500` |
-| 1000 | ~130 MB | ~180 MB | Large deployment |
+| Unique Tokens     | Pool Memory | Total Process Memory | Notes                             |
+| ----------------- | ----------- | -------------------- | --------------------------------- |
+| 1                 | ~130 KB     | ~50 MB               | Equivalent to stdio               |
+| 10                | ~1.3 MB     | ~51 MB               | Minimal overhead                  |
+| 50                | ~6.5 MB     | ~57 MB               | Comfortable for a team            |
+| 100 (default max) | ~13 MB      | ~63 MB               | Default `--max-http-clients`      |
+| 500               | ~65 MB      | ~115 MB              | Requires `--max-http-clients=500` |
+| 1000              | ~130 MB     | ~180 MB              | Large deployment                  |
 
 ### CPU Usage
 
 CPU usage depends on request throughput, not pool size:
 
-| Scenario | CPU Impact |
-| --- | --- |
-| Idle pool entries | Zero — no goroutines, no timers |
+| Scenario                        | CPU Impact                                |
+| ------------------------------- | ----------------------------------------- |
+| Idle pool entries               | Zero — no goroutines, no timers           |
 | Active MCP session (per client) | ~2 goroutines (read + write on transport) |
-| Tool execution | 1 goroutine per concurrent tool call |
-| GitLab API calls | Blocked on network I/O, minimal CPU |
+| Tool execution                  | 1 goroutine per concurrent tool call      |
+| GitLab API calls                | Blocked on network I/O, minimal CPU       |
 
 100 active sessions ≈ 200 goroutines — negligible for the Go runtime.
 
 ### Goroutine Count
 
-| Component | Goroutines |
-| --- | --- |
-| Go runtime (GC, scheduler, etc.) | ~5 |
-| HTTP server listener | 1 |
-| Per active MCP session | ~2 |
-| Per concurrent tool call | 1 |
+| Component                        | Goroutines |
+| -------------------------------- | ---------- |
+| Go runtime (GC, scheduler, etc.) | ~5         |
+| HTTP server listener             | 1          |
+| Per active MCP session           | ~2         |
+| Per concurrent tool call         | 1          |
 
 A server with 100 active sessions and 10 concurrent tool calls: ~220 goroutines total.
 
@@ -84,13 +84,13 @@ A server with 100 active sessions and 10 concurrent tool calls: ~220 goroutines 
 
 Understanding the terminology is important for capacity planning:
 
-| Term | Definition | Resource Impact |
-| --- | --- | --- |
+| Term                  | Definition                                                           | Resource Impact                  |
+| --------------------- | -------------------------------------------------------------------- | -------------------------------- |
 | **Configured client** | User has the MCP server in their IDE config but hasn't sent requests | Zero — no session, no pool entry |
-| **Connected client** | Client has sent a POST and received a `Mcp-Session-Id` | 1 session (~2 goroutines) |
-| **Active client** | Connected client currently executing tool calls | Session + tool goroutines |
-| **Idle client** | Connected but no recent requests | Session goroutines only |
-| **Unique token** | Distinct GitLab PAT in the pool | 1 pool entry (~130 KB) |
+| **Connected client**  | Client has sent a POST and received a `Mcp-Session-Id`               | 1 session (~2 goroutines)        |
+| **Active client**     | Connected client currently executing tool calls                      | Session + tool goroutines        |
+| **Idle client**       | Connected but no recent requests                                     | Session goroutines only          |
+| **Unique token**      | Distinct GitLab PAT in the pool                                      | 1 pool entry (~130 KB)           |
 
 **Key insight**: Multiple sessions from the same token share one pool entry. A user with 3 IDE windows using the same token = 3 sessions, 1 pool entry.
 
@@ -109,11 +109,11 @@ The pool is the only source of **persistent** memory growth, and it is bounded.
 
 Each token has its own rate limit on the GitLab side:
 
-| Token Type | Rate Limit (Default) |
-| --- | --- |
-| Personal Access Token | 300 requests/minute |
-| Project Access Token | 300 requests/minute |
-| Group Access Token | 300 requests/minute |
+| Token Type            | Rate Limit (Default) |
+| --------------------- | -------------------- |
+| Personal Access Token | 300 requests/minute  |
+| Project Access Token  | 300 requests/minute  |
+| Group Access Token    | 300 requests/minute  |
 
 The server pool does NOT aggregate tokens — each client is independently rate-limited by GitLab. A server with 100 unique tokens can collectively make up to 30,000 requests/minute to GitLab.
 

--- a/docs/resources-reference.md
+++ b/docs/resources-reference.md
@@ -16,12 +16,12 @@ MCP separates fixed resources from URI templates. In full mode, `resources/list`
 
 Static resources have a fixed URI and require no parameters.
 
-| # | Name | URI | Description |
-|---|------|-----|-------------|
-| 1 | `current_user` | `gitlab://user/current` | Get the currently authenticated GitLab user profile. Returns username, display name, email, state (active/blocked), admin status, and web URL. |
-| 2 | `groups` | `gitlab://groups` | List all GitLab groups accessible to the authenticated user. Returns each group's ID, name, full path, description, visibility level, and web URL. |
-| 3 | `workspace_roots` | `gitlab://workspace/roots` | List workspace root directories provided by the MCP client. Use these paths to locate .git/config files and extract git remote URLs for project discovery via `gitlab_discover_project`. |
-| 4 | `meta_schema_index` | `gitlab://schema/meta/` | Catalog of every registered meta-tool and its actions. Available for meta and dynamic surfaces when `CAPABILITY_SURFACE=full`. Use the `gitlab://schema/meta/{tool}/{action}` template to fetch the JSON Schema for a specific action's `params`. |
+| #   | Name                | URI                        | Description                                                                                                                                                                                                                                       |
+| --- | ------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `current_user`      | `gitlab://user/current`    | Get the currently authenticated GitLab user profile. Returns username, display name, email, state (active/blocked), admin status, and web URL.                                                                                                    |
+| 2   | `groups`            | `gitlab://groups`          | List all GitLab groups accessible to the authenticated user. Returns each group's ID, name, full path, description, visibility level, and web URL.                                                                                                |
+| 3   | `workspace_roots`   | `gitlab://workspace/roots` | List workspace root directories provided by the MCP client. Use these paths to locate .git/config files and extract git remote URLs for project discovery via `gitlab_discover_project`.                                                          |
+| 4   | `meta_schema_index` | `gitlab://schema/meta/`    | Catalog of every registered meta-tool and its actions. Available for meta and dynamic surfaces when `CAPABILITY_SURFACE=full`. Use the `gitlab://schema/meta/{tool}/{action}` template to fetch the JSON Schema for a specific action's `params`. |
 
 ## Resource Templates (37)
 
@@ -29,70 +29,70 @@ Resource templates use URI variables (e.g., `{project_id}`) that the client fill
 
 ### Project Resources
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 5 | `project` | `gitlab://project/{project_id}` | Get basic metadata for a GitLab project by numeric ID or URL-encoded path. Returns name, namespace path, visibility, web URL, description, and default branch. |
-| 6 | `project_members` | `gitlab://project/{project_id}/members` | List all members of a GitLab project with their access levels (10=guest, 20=reporter, 30=developer, 40=maintainer, 50=owner). Includes inherited members from parent groups. |
-| 7 | `project_labels` | `gitlab://project/{project_id}/labels` | List all labels defined in a GitLab project. Returns each label's name, color, description, and counts of open issues and merge requests using the label. |
-| 8 | `project_milestones` | `gitlab://project/{project_id}/milestones` | List all milestones in a GitLab project. Returns each milestone's title, description, state (active/closed), due date, and web URL. |
-| 9 | `project_branches` | `gitlab://project/{project_id}/branches` | List all branches in a GitLab project. Returns each branch's name, protection status, merge status, default flag, and web URL. |
-| 10 | `project_issues` | `gitlab://project/{project_id}/issues` | List open issues for a GitLab project. Returns each issue's IID, title, state, labels, assignees, author, web URL, and creation date. |
-| 11 | `project_releases` | `gitlab://project/{project_id}/releases` | List all releases for a GitLab project. Returns each release's tag name, name, description, author, and creation/release dates. |
-| 12 | `project_tags` | `gitlab://project/{project_id}/tags` | List all repository tags for a GitLab project. Returns each tag's name, message, target commit SHA, protection status, and creation date. |
-| 13 | `commit` | `gitlab://project/{project_id}/commit/{sha}` | Get details for a single commit by SHA. Returns short_id, title, message, author, committer, authored/committed dates, parent commits, web URL, and stats (additions/deletions/total). |
-| 14 | `file_blob` | `gitlab://project/{project_id}/file/{ref}/{+path}` | Get the contents of a repository file at a specific ref (branch, tag, or SHA). Path may include slashes. Files over 1 MiB return metadata only with `truncated=true`. Binary files return metadata with empty content. |
-| 15 | `wiki_page` | `gitlab://project/{project_id}/wiki/{slug}` | Get a wiki page by slug. Returns title, slug, format (markdown/rdoc/asciidoc/org), and raw content. Slugs are case-sensitive and use hyphens for spaces. |
-| 16 | `branch` | `gitlab://project/{project_id}/branch/{branch}` | Get a single branch by name. Returns name, protected/default flags, merge status, last commit, and web URL. |
-| 17 | `tag` | `gitlab://project/{project_id}/tag/{tag_name}` | Get a single repository tag by name. Returns name, message, target SHA, protection flag, and creation date. |
-| 18 | `release` | `gitlab://project/{project_id}/release/{tag_name}` | Get release details by tag name. Returns name, description, author, dates, and asset summary. |
-| 19 | `label` | `gitlab://project/{project_id}/label/{label_id}` | Get a single project label. Returns name, color, description, and open issue/MR counts. |
-| 20 | `milestone` | `gitlab://project/{project_id}/milestone/{milestone_iid}` | Get a single project milestone by IID. Returns title, description, state, due date, and web URL. |
-| 21 | `board` | `gitlab://project/{project_id}/board/{board_id}` | Get a single issue board by ID. Returns name and lists. |
-| 22 | `deployment` | `gitlab://project/{project_id}/deployment/{deployment_id}` | Get a deployment by ID. Returns ref, sha, status, and target environment. |
-| 23 | `environment` | `gitlab://project/{project_id}/environment/{environment_id}` | Get an environment by ID. Returns name, slug, state, and tier. |
-| 24 | `job` | `gitlab://project/{project_id}/job/{job_id}` | Get a single CI/CD job by ID. Returns name, stage, status, ref, duration, and web URL. |
-| 25 | `feature_flag` | `gitlab://project/{project_id}/feature_flag/{name}` | Get a feature flag by name. Returns description, active flag, and version. |
-| 26 | `deploy_key` | `gitlab://project/{project_id}/deploy_key/{deploy_key_id}` | Get a project deploy key by ID. Returns title, key, and fingerprint. |
-| 27 | `project_snippet` | `gitlab://project/{project_id}/snippet/{snippet_id}` | Get a project-scoped snippet. Returns title, file name, visibility, and web URL. |
+| #   | Name                 | URI Template                                                 | Description                                                                                                                                                                                                            |
+| --- | -------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 5   | `project`            | `gitlab://project/{project_id}`                              | Get basic metadata for a GitLab project by numeric ID or URL-encoded path. Returns name, namespace path, visibility, web URL, description, and default branch.                                                         |
+| 6   | `project_members`    | `gitlab://project/{project_id}/members`                      | List all members of a GitLab project with their access levels (10=guest, 20=reporter, 30=developer, 40=maintainer, 50=owner). Includes inherited members from parent groups.                                           |
+| 7   | `project_labels`     | `gitlab://project/{project_id}/labels`                       | List all labels defined in a GitLab project. Returns each label's name, color, description, and counts of open issues and merge requests using the label.                                                              |
+| 8   | `project_milestones` | `gitlab://project/{project_id}/milestones`                   | List all milestones in a GitLab project. Returns each milestone's title, description, state (active/closed), due date, and web URL.                                                                                    |
+| 9   | `project_branches`   | `gitlab://project/{project_id}/branches`                     | List all branches in a GitLab project. Returns each branch's name, protection status, merge status, default flag, and web URL.                                                                                         |
+| 10  | `project_issues`     | `gitlab://project/{project_id}/issues`                       | List open issues for a GitLab project. Returns each issue's IID, title, state, labels, assignees, author, web URL, and creation date.                                                                                  |
+| 11  | `project_releases`   | `gitlab://project/{project_id}/releases`                     | List all releases for a GitLab project. Returns each release's tag name, name, description, author, and creation/release dates.                                                                                        |
+| 12  | `project_tags`       | `gitlab://project/{project_id}/tags`                         | List all repository tags for a GitLab project. Returns each tag's name, message, target commit SHA, protection status, and creation date.                                                                              |
+| 13  | `commit`             | `gitlab://project/{project_id}/commit/{sha}`                 | Get details for a single commit by SHA. Returns short_id, title, message, author, committer, authored/committed dates, parent commits, web URL, and stats (additions/deletions/total).                                 |
+| 14  | `file_blob`          | `gitlab://project/{project_id}/file/{ref}/{+path}`           | Get the contents of a repository file at a specific ref (branch, tag, or SHA). Path may include slashes. Files over 1 MiB return metadata only with `truncated=true`. Binary files return metadata with empty content. |
+| 15  | `wiki_page`          | `gitlab://project/{project_id}/wiki/{slug}`                  | Get a wiki page by slug. Returns title, slug, format (markdown/rdoc/asciidoc/org), and raw content. Slugs are case-sensitive and use hyphens for spaces.                                                               |
+| 16  | `branch`             | `gitlab://project/{project_id}/branch/{branch}`              | Get a single branch by name. Returns name, protected/default flags, merge status, last commit, and web URL.                                                                                                            |
+| 17  | `tag`                | `gitlab://project/{project_id}/tag/{tag_name}`               | Get a single repository tag by name. Returns name, message, target SHA, protection flag, and creation date.                                                                                                            |
+| 18  | `release`            | `gitlab://project/{project_id}/release/{tag_name}`           | Get release details by tag name. Returns name, description, author, dates, and asset summary.                                                                                                                          |
+| 19  | `label`              | `gitlab://project/{project_id}/label/{label_id}`             | Get a single project label. Returns name, color, description, and open issue/MR counts.                                                                                                                                |
+| 20  | `milestone`          | `gitlab://project/{project_id}/milestone/{milestone_iid}`    | Get a single project milestone by IID. Returns title, description, state, due date, and web URL.                                                                                                                       |
+| 21  | `board`              | `gitlab://project/{project_id}/board/{board_id}`             | Get a single issue board by ID. Returns name and lists.                                                                                                                                                                |
+| 22  | `deployment`         | `gitlab://project/{project_id}/deployment/{deployment_id}`   | Get a deployment by ID. Returns ref, sha, status, and target environment.                                                                                                                                              |
+| 23  | `environment`        | `gitlab://project/{project_id}/environment/{environment_id}` | Get an environment by ID. Returns name, slug, state, and tier.                                                                                                                                                         |
+| 24  | `job`                | `gitlab://project/{project_id}/job/{job_id}`                 | Get a single CI/CD job by ID. Returns name, stage, status, ref, duration, and web URL.                                                                                                                                 |
+| 25  | `feature_flag`       | `gitlab://project/{project_id}/feature_flag/{name}`          | Get a feature flag by name. Returns description, active flag, and version.                                                                                                                                             |
+| 26  | `deploy_key`         | `gitlab://project/{project_id}/deploy_key/{deploy_key_id}`   | Get a project deploy key by ID. Returns title, key, and fingerprint.                                                                                                                                                   |
+| 27  | `project_snippet`    | `gitlab://project/{project_id}/snippet/{snippet_id}`         | Get a project-scoped snippet. Returns title, file name, visibility, and web URL.                                                                                                                                       |
 
 ### Issue & Merge Request Resources
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 28 | `issue` | `gitlab://project/{project_id}/issue/{issue_iid}` | Get details of a specific issue by its IID (project-scoped ID). Returns title, state, labels, assignees, author, web URL, and creation date. |
-| 29 | `merge_request` | `gitlab://project/{project_id}/mr/{merge_request_iid}` | Get details of a specific merge request by its IID (project-scoped ID). Returns title, state, source/target branches, author, merge status, and web URL. |
-| 30 | `merge_request_notes` | `gitlab://project/{project_id}/mr/{merge_request_iid}/notes` | List notes (comments) on a merge request. Returns each note's id, author username, body, system flag, resolvable/resolved flags, and timestamps. |
-| 31 | `merge_request_discussions` | `gitlab://project/{project_id}/mr/{merge_request_iid}/discussions` | List discussion threads on a merge request. Each discussion has an id, individual_note flag, and an array of notes (id, author, body, system, resolved/resolvable, created_at). |
+| #   | Name                        | URI Template                                                       | Description                                                                                                                                                                     |
+| --- | --------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 28  | `issue`                     | `gitlab://project/{project_id}/issue/{issue_iid}`                  | Get details of a specific issue by its IID (project-scoped ID). Returns title, state, labels, assignees, author, web URL, and creation date.                                    |
+| 29  | `merge_request`             | `gitlab://project/{project_id}/mr/{merge_request_iid}`             | Get details of a specific merge request by its IID (project-scoped ID). Returns title, state, source/target branches, author, merge status, and web URL.                        |
+| 30  | `merge_request_notes`       | `gitlab://project/{project_id}/mr/{merge_request_iid}/notes`       | List notes (comments) on a merge request. Returns each note's id, author username, body, system flag, resolvable/resolved flags, and timestamps.                                |
+| 31  | `merge_request_discussions` | `gitlab://project/{project_id}/mr/{merge_request_iid}/discussions` | List discussion threads on a merge request. Each discussion has an id, individual_note flag, and an array of notes (id, author, body, system, resolved/resolvable, created_at). |
 
 ### CI/CD Resources
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 32 | `latest_pipeline` | `gitlab://project/{project_id}/pipelines/latest` | Get the most recent CI/CD pipeline for a GitLab project. Returns pipeline ID, status (running/pending/success/failed/canceled), ref, SHA, source, and web URL. |
-| 33 | `pipeline` | `gitlab://project/{project_id}/pipeline/{pipeline_id}` | Get details of a specific CI/CD pipeline by its numeric ID. Returns pipeline status, ref, SHA, source, and web URL. |
-| 34 | `pipeline_jobs` | `gitlab://project/{project_id}/pipeline/{pipeline_id}/jobs` | List all jobs for a specific CI/CD pipeline including each job's name, stage, status, duration, failure reason (if failed), and web URL. |
+| #   | Name              | URI Template                                                | Description                                                                                                                                                    |
+| --- | ----------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 32  | `latest_pipeline` | `gitlab://project/{project_id}/pipelines/latest`            | Get the most recent CI/CD pipeline for a GitLab project. Returns pipeline ID, status (running/pending/success/failed/canceled), ref, SHA, source, and web URL. |
+| 33  | `pipeline`        | `gitlab://project/{project_id}/pipeline/{pipeline_id}`      | Get details of a specific CI/CD pipeline by its numeric ID. Returns pipeline status, ref, SHA, source, and web URL.                                            |
+| 34  | `pipeline_jobs`   | `gitlab://project/{project_id}/pipeline/{pipeline_id}/jobs` | List all jobs for a specific CI/CD pipeline including each job's name, stage, status, duration, failure reason (if failed), and web URL.                       |
 
 ### Group Resources
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 35 | `group` | `gitlab://group/{group_id}` | Get details for a specific GitLab group by numeric ID or URL-encoded path. Returns name, full path, description, visibility, and web URL. |
-| 36 | `group_members` | `gitlab://group/{group_id}/members` | List all members of a GitLab group with their access levels (10=guest, 20=reporter, 30=developer, 40=maintainer, 50=owner). Includes inherited members. |
-| 37 | `group_projects` | `gitlab://group/{group_id}/projects` | List all projects within a GitLab group. Returns each project's ID, name, namespace path, visibility, web URL, description, and default branch. |
-| 38 | `group_label` | `gitlab://group/{group_id}/label/{label_id}` | Get a single group label. Returns name, color, description, and open issue/MR counts. |
-| 39 | `group_milestone` | `gitlab://group/{group_id}/milestone/{milestone_iid}` | Get a single group milestone by IID. Returns title, description, state, due date, and web URL. |
+| #   | Name              | URI Template                                          | Description                                                                                                                                             |
+| --- | ----------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 35  | `group`           | `gitlab://group/{group_id}`                           | Get details for a specific GitLab group by numeric ID or URL-encoded path. Returns name, full path, description, visibility, and web URL.               |
+| 36  | `group_members`   | `gitlab://group/{group_id}/members`                   | List all members of a GitLab group with their access levels (10=guest, 20=reporter, 30=developer, 40=maintainer, 50=owner). Includes inherited members. |
+| 37  | `group_projects`  | `gitlab://group/{group_id}/projects`                  | List all projects within a GitLab group. Returns each project's ID, name, namespace path, visibility, web URL, description, and default branch.         |
+| 38  | `group_label`     | `gitlab://group/{group_id}/label/{label_id}`          | Get a single group label. Returns name, color, description, and open issue/MR counts.                                                                   |
+| 39  | `group_milestone` | `gitlab://group/{group_id}/milestone/{milestone_iid}` | Get a single group milestone by IID. Returns title, description, state, due date, and web URL.                                                          |
 
 ### Personal Snippet
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 40 | `snippet` | `gitlab://snippet/{snippet_id}` | Get a personal (user-scoped) snippet. Returns title, file name, visibility, and web URL. |
+| #   | Name      | URI Template                    | Description                                                                              |
+| --- | --------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| 40  | `snippet` | `gitlab://snippet/{snippet_id}` | Get a personal (user-scoped) snippet. Returns title, file name, visibility, and web URL. |
 
 ### Meta-Tool Schema
 
-| # | Name | URI Template | Description |
-|---|------|--------------|-------------|
-| 41 | `meta_action_schema` | `gitlab://schema/meta/{tool}/{action}` | JSON Schema for the `params` property of a specific meta-tool action. Replace `{tool}` with a meta-tool name (e.g. `gitlab_merge_request`) and `{action}` with one of its actions (e.g. `create`). Use the `gitlab://schema/meta/` index resource to enumerate valid combinations. Available for meta surfaces when `CAPABILITY_SURFACE=full` or `minimal`, and for dynamic surfaces when `CAPABILITY_SURFACE=full`, regardless of `META_PARAM_SCHEMA` mode. |
+| #   | Name                 | URI Template                           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | -------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 41  | `meta_action_schema` | `gitlab://schema/meta/{tool}/{action}` | JSON Schema for the `params` property of a specific meta-tool action. Replace `{tool}` with a meta-tool name (e.g. `gitlab_merge_request`) and `{action}` with one of its actions (e.g. `create`). Use the `gitlab://schema/meta/` index resource to enumerate valid combinations. Available for meta surfaces when `CAPABILITY_SURFACE=full` or `minimal`, and for dynamic surfaces when `CAPABILITY_SURFACE=full`, regardless of `META_PARAM_SCHEMA` mode. |
 
 The schema resources are designed for meta-tool clients that keep the default compact schema mode (`META_PARAM_SCHEMA=opaque`). They remain available to `TOOL_SURFACE=meta` even when `CAPABILITY_SURFACE=minimal`; dynamic clients in minimal mode should use `gitlab_find_action` for inline schemas instead. The normal schema-resource discovery flow is:
 
@@ -106,27 +106,27 @@ For example, `gitlab://schema/meta/gitlab_merge_request/create` returns the para
 
 Static best-practice guides that provide AI assistants with GitLab workflow knowledge without requiring API calls.
 
-| # | Name | URI | Description |
-|---|------|-----|-------------|
-| 42 | `guide_git_workflow` | `gitlab://guides/git-workflow` | Git branching strategy, commit hygiene, and merge best practices for GitLab projects. |
-| 43 | `guide_merge_request_hygiene` | `gitlab://guides/merge-request-hygiene` | MR best practices: sizing, descriptions, review workflow, and merge strategies. |
-| 44 | `guide_conventional_commits` | `gitlab://guides/conventional-commits` | Conventional Commits specification with GitLab-specific examples and automation tips. |
-| 45 | `guide_code_review` | `gitlab://guides/code-review` | Structured code review checklist covering quality, security, testing, and architecture. |
-| 46 | `guide_pipeline_troubleshooting` | `gitlab://guides/pipeline-troubleshooting` | CI/CD pipeline debugging guide: common failures, job logs, retry strategies, and caching issues. |
+| #   | Name                             | URI                                        | Description                                                                                      |
+| --- | -------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| 42  | `guide_git_workflow`             | `gitlab://guides/git-workflow`             | Git branching strategy, commit hygiene, and merge best practices for GitLab projects.            |
+| 43  | `guide_merge_request_hygiene`    | `gitlab://guides/merge-request-hygiene`    | MR best practices: sizing, descriptions, review workflow, and merge strategies.                  |
+| 44  | `guide_conventional_commits`     | `gitlab://guides/conventional-commits`     | Conventional Commits specification with GitLab-specific examples and automation tips.            |
+| 45  | `guide_code_review`              | `gitlab://guides/code-review`              | Structured code review checklist covering quality, security, testing, and architecture.          |
+| 46  | `guide_pipeline_troubleshooting` | `gitlab://guides/pipeline-troubleshooting` | CI/CD pipeline debugging guide: common failures, job logs, retry strategies, and caching issues. |
 
 ## URI Parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `project_id` | string | Numeric project ID or URL-encoded path (e.g., `group%2Fproject`) |
-| `group_id` | string | Numeric group ID or URL-encoded path |
-| `pipeline_id` | integer | Numeric pipeline ID |
-| `merge_request_iid` | integer | Merge request IID (project-scoped numeric ID, visible as `!N` in GitLab) |
-| `issue_iid` | integer | Issue IID (project-scoped numeric ID, visible as `#N` in GitLab) |
-| `sha` | string | Commit SHA (full or short) |
-| `ref` | string | Branch name, tag name, or commit SHA |
-| `path` | string | Repository file path (may contain slashes; uses RFC 6570 reserved expansion `{+path}`) |
-| `slug` | string | Wiki page slug (case-sensitive; spaces are replaced with hyphens) |
+| Parameter           | Type    | Description                                                                            |
+| ------------------- | ------- | -------------------------------------------------------------------------------------- |
+| `project_id`        | string  | Numeric project ID or URL-encoded path (e.g., `group%2Fproject`)                       |
+| `group_id`          | string  | Numeric group ID or URL-encoded path                                                   |
+| `pipeline_id`       | integer | Numeric pipeline ID                                                                    |
+| `merge_request_iid` | integer | Merge request IID (project-scoped numeric ID, visible as `!N` in GitLab)               |
+| `issue_iid`         | integer | Issue IID (project-scoped numeric ID, visible as `#N` in GitLab)                       |
+| `sha`               | string  | Commit SHA (full or short)                                                             |
+| `ref`               | string  | Branch name, tag name, or commit SHA                                                   |
+| `path`              | string  | Repository file path (may contain slashes; uses RFC 6570 reserved expansion `{+path}`) |
+| `slug`              | string  | Wiki page slug (case-sensitive; spaces are replaced with hyphens)                      |
 
 ## Autocomplete Support
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,12 +79,12 @@ When running with `--auth-mode=oauth`, the server validates every request's Bear
 
 See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode) for the full architecture and flow diagram, and [OAuth App Setup](oauth-app-setup.md) for creating GitLab OAuth applications.
 
-| Threat | Mitigation |
-| --- | --- |
-| Token replay | TTL-based expiration; tokens re-verified after cache expires |
-| Cache key leakage | SHA-256 hashing of raw tokens; original tokens never stored |
-| Brute force | GitLab API rate limiting applies to verification requests |
-| Memory dump | Only SHA-256 hashes and user metadata stored; no raw tokens in cache |
+| Threat            | Mitigation                                                           |
+| ----------------- | -------------------------------------------------------------------- |
+| Token replay      | TTL-based expiration; tokens re-verified after cache expires         |
+| Cache key leakage | SHA-256 hashing of raw tokens; original tokens never stored          |
+| Brute force       | GitLab API rate limiting applies to verification requests            |
+| Memory dump       | Only SHA-256 hashes and user metadata stored; no raw tokens in cache |
 
 ## PAT Scope-Based Tool Filtering
 
@@ -105,12 +105,12 @@ MCP tool output contains user-generated content (UGC) from GitLab — issue desc
 
 All Markdown formatters apply context-appropriate escaping to UGC fields:
 
-| Context | Escape Function | Purpose |
-| --- | --- | --- |
-| Table cells | `EscapeMdTableCell()` | Prevents pipe characters from breaking table structure |
-| Headings | `EscapeMdHeading()` | Prevents `#` injection that would break heading hierarchy |
-| Multi-line body content | `WrapGFMBody()` | Wraps in blockquote (`>`) to contain structural Markdown |
-| List items (single-line) | `EscapeMdTableCell()` | Strips newlines and pipes from inline values |
+| Context                  | Escape Function       | Purpose                                                   |
+| ------------------------ | --------------------- | --------------------------------------------------------- |
+| Table cells              | `EscapeMdTableCell()` | Prevents pipe characters from breaking table structure    |
+| Headings                 | `EscapeMdHeading()`   | Prevents `#` injection that would break heading hierarchy |
+| Multi-line body content  | `WrapGFMBody()`       | Wraps in blockquote (`>`) to contain structural Markdown  |
+| List items (single-line) | `EscapeMdTableCell()` | Strips newlines and pipes from inline values              |
 
 ### UGC Boundary Markers
 
@@ -140,11 +140,11 @@ The error handling system is designed to be informative for LLMs while avoiding 
 
 ## Dependencies
 
-| Dependency | Security Notes |
-| --- | --- |
+| Dependency                               | Security Notes                                                        |
+| ---------------------------------------- | --------------------------------------------------------------------- |
 | `gitlab.com/gitlab-org/api/client-go/v2` | Official GitLab client; uses `retryablehttp` with exponential backoff |
-| `github.com/modelcontextprotocol/go-sdk` | Official MCP SDK; handles JSON-RPC transport |
-| `github.com/joho/godotenv` | Loads `.env` files (CWD and `~/.gitlab-mcp-server.env` fallback) |
+| `github.com/modelcontextprotocol/go-sdk` | Official MCP SDK; handles JSON-RPC transport                          |
+| `github.com/joho/godotenv`               | Loads `.env` files (CWD and `~/.gitlab-mcp-server.env` fallback)      |
 
 Run `go list -m all` to see all transitive dependencies. Use `govulncheck` for vulnerability scanning:
 
@@ -160,17 +160,17 @@ govulncheck ./...
 The auto-update subsystem embeds a GitHub API token in the
 compiled binary to check for and download new releases. Attack vectors:
 
-| Vector | Description | Mitigation |
-|--------|-------------|------------|
-| Traffic capture (HTTP) | Intercept token on the wire | HTTPS enforcement in `NewUpdater()` |
-| Proxy interception (`HTTPS_PROXY`) | Token sent through attacker proxy | `Proxy: nil` in HTTP transport |
-| HTTP redirect to external host | GitHub redirects to S3/CDN leaking token | `CheckRedirect` strips `Authorization` on cross-host |
-| Protocol downgrade (HTTPS→HTTP) | Redirect from HTTPS to HTTP exposes token | `CheckRedirect` refuses HTTPS→HTTP redirects |
-| Redirect chain abuse | Infinite redirects / open redirect exploitation | Max 10 redirects enforced |
-| Token to external hosts | Asset URL points to non-GitHub host | `sameHost()` check before attaching header |
-| Memory dump (`gcore`, `/proc/PID/mem`) | Read token from process memory | Intermediate `[]byte` zeroed; globals zeroed after first use |
-| Accidental logging (`%v`, panic) | Token printed in logs or stack traces | `Config.String()` / `GoString()` redact to `***` |
-| `GetConfig()` API | Token exposed via MCP tool | Returns copy with `Token: "***"` |
+| Vector                                 | Description                                     | Mitigation                                                   |
+| -------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------ |
+| Traffic capture (HTTP)                 | Intercept token on the wire                     | HTTPS enforcement in `NewUpdater()`                          |
+| Proxy interception (`HTTPS_PROXY`)     | Token sent through attacker proxy               | `Proxy: nil` in HTTP transport                               |
+| HTTP redirect to external host         | GitHub redirects to S3/CDN leaking token        | `CheckRedirect` strips `Authorization` on cross-host         |
+| Protocol downgrade (HTTPS→HTTP)        | Redirect from HTTPS to HTTP exposes token       | `CheckRedirect` refuses HTTPS→HTTP redirects                 |
+| Redirect chain abuse                   | Infinite redirects / open redirect exploitation | Max 10 redirects enforced                                    |
+| Token to external hosts                | Asset URL points to non-GitHub host             | `sameHost()` check before attaching header                   |
+| Memory dump (`gcore`, `/proc/PID/mem`) | Read token from process memory                  | Intermediate `[]byte` zeroed; globals zeroed after first use |
+| Accidental logging (`%v`, panic)       | Token printed in logs or stack traces           | `Config.String()` / `GoString()` redact to `***`             |
+| `GetConfig()` API                      | Token exposed via MCP tool                      | Returns copy with `Token: "***"`                             |
 
 ### Network Hardening
 
@@ -186,11 +186,11 @@ The `newGitHubSource` HTTP client (`internal/autoupdate/github_source.go`):
 
 ### File Reference
 
-| File | Purpose |
-|------|---------|
-| `internal/autoupdate/github_source.go` | `newGitHubSource` with hardened HTTP client |
-| `internal/autoupdate/autoupdate.go` | HTTPS enforcement, `Config.String()`/`GoString()` |
-| `cmd/server/main.go` | Update initialization |
+| File                                   | Purpose                                           |
+| -------------------------------------- | ------------------------------------------------- |
+| `internal/autoupdate/github_source.go` | `newGitHubSource` with hardened HTTP client       |
+| `internal/autoupdate/autoupdate.go`    | HTTPS enforcement, `Config.String()`/`GoString()` |
+| `cmd/server/main.go`                   | Update initialization                             |
 
 ---
 
@@ -203,10 +203,10 @@ agents and noisy clients, not to replace upstream throttling.
 
 ### Configuration
 
-| Setting | Env var | Flag (HTTP mode) | Default |
-| --- | --- | --- | --- |
-| Requests/second | `RATE_LIMIT_RPS` | `--rate-limit-rps` | `0` (disabled) |
-| Burst capacity | `RATE_LIMIT_BURST` | `--rate-limit-burst` | `40` |
+| Setting         | Env var            | Flag (HTTP mode)     | Default        |
+| --------------- | ------------------ | -------------------- | -------------- |
+| Requests/second | `RATE_LIMIT_RPS`   | `--rate-limit-rps`   | `0` (disabled) |
+| Burst capacity  | `RATE_LIMIT_BURST` | `--rate-limit-burst` | `40`           |
 
 When `RATE_LIMIT_RPS = 0` the middleware is not attached and there is zero
 overhead on the hot path. Setting any value `> 0` activates a `golang.org/x/time/rate`
@@ -219,12 +219,12 @@ limiter scoped to **one MCP server instance**:
 
 ### Recommended values
 
-| Deployment | `--rate-limit-rps` | Rationale |
-| --- | --- | --- |
-| GitLab.com (authenticated user) | `20` | Stays well under the published ~33 rps authenticated quota with headroom for pagination loops. |
-| Self-hosted (default config) | `8` | Matches the typical 600 req/min default in `application_settings`. |
-| CI / batch automation | `2`–`4` | Conservative; pipelines that invoke many tools per job. |
-| Disabled (default) | `0` | Trust GitLab's own throttle; useful when you have not measured traffic patterns yet. |
+| Deployment                      | `--rate-limit-rps` | Rationale                                                                                      |
+| ------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| GitLab.com (authenticated user) | `20`               | Stays well under the published ~33 rps authenticated quota with headroom for pagination loops. |
+| Self-hosted (default config)    | `8`                | Matches the typical 600 req/min default in `application_settings`.                             |
+| CI / batch automation           | `2`–`4`            | Conservative; pipelines that invoke many tools per job.                                        |
+| Disabled (default)              | `0`                | Trust GitLab's own throttle; useful when you have not measured traffic patterns yet.           |
 
 ### Behavior on excess
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,21 +11,21 @@ correctly.
 
 ## Documents
 
-| Document | Audience | Purpose |
-| --- | --- | --- |
-| [Testing Reference](testing.md) | Contributors | Generated unit, integration, E2E, coverage, and package test reference. |
-| [AI Model Evaluation](model-evaluation.md) | Users and evaluators | Explains what AI model evaluations prove, how schema and Docker modes differ, and how to interpret the metrics. |
-| [AI Model Evaluation Developer Guide](model-evaluation-developer.md) | Maintainers | Operational guide for running schema and Docker model evaluations, adding cases, reading traces, and updating results. |
-| [AI Model Evaluation Results](model-results.md) | Users and maintainers | Current published benchmark result selected from generated reports. |
+| Document                                                             | Audience              | Purpose                                                                                                                |
+| -------------------------------------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [Testing Reference](testing.md)                                      | Contributors          | Generated unit, integration, E2E, coverage, and package test reference.                                                |
+| [AI Model Evaluation](model-evaluation.md)                           | Users and evaluators  | Explains what AI model evaluations prove, how schema and Docker modes differ, and how to interpret the metrics.        |
+| [AI Model Evaluation Developer Guide](model-evaluation-developer.md) | Maintainers           | Operational guide for running schema and Docker model evaluations, adding cases, reading traces, and updating results. |
+| [AI Model Evaluation Results](model-results.md)                      | Users and maintainers | Current published benchmark result selected from generated reports.                                                    |
 
 ## Validation Layers
 
-| Layer | Runner | GitLab backend | What it proves |
-| --- | --- | --- | --- |
-| Unit tests | `go test ./internal/... ./cmd/...` | Mock `httptest` servers | Handler logic, schema validation, formatting, routing, and error handling. |
-| E2E tests | `go test -tags e2e ./test/e2e/suite/` | Real GitLab, self-hosted or Docker | The MCP server can execute registered tools against GitLab APIs. |
-| Schema model evaluation | `cmd/eval_mcp_surfaces --preset schema-enterprise` | Mock catalog | Models can select tools/actions and shape arguments from the MCP schema and descriptions. |
-| Docker model evaluation | `cmd/eval_mcp_surfaces --preset docker-* --execute-tools` | Docker GitLab CE | Models can drive real MCP calls against a populated GitLab instance, including safe mutations. |
+| Layer                   | Runner                                                    | GitLab backend                     | What it proves                                                                                 |
+| ----------------------- | --------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Unit tests              | `go test ./internal/... ./cmd/...`                        | Mock `httptest` servers            | Handler logic, schema validation, formatting, routing, and error handling.                     |
+| E2E tests               | `go test -tags e2e ./test/e2e/suite/`                     | Real GitLab, self-hosted or Docker | The MCP server can execute registered tools against GitLab APIs.                               |
+| Schema model evaluation | `cmd/eval_mcp_surfaces --preset schema-enterprise`        | Mock catalog                       | Models can select tools/actions and shape arguments from the MCP schema and descriptions.      |
+| Docker model evaluation | `cmd/eval_mcp_surfaces --preset docker-* --execute-tools` | Docker GitLab CE                   | Models can drive real MCP calls against a populated GitLab instance, including safe mutations. |
 
 ## When To Use Each Layer
 

--- a/docs/testing/model-evaluation-developer.md
+++ b/docs/testing/model-evaluation-developer.md
@@ -9,25 +9,25 @@ around `cmd/eval_mcp_surfaces`.
 
 ## Source Map
 
-| Path | Purpose |
-| --- | --- |
-| `cmd/eval_mcp_surfaces/main.go` | Evaluation runner, task filtering, MCP execution, report writing, trace writing. |
-| `cmd/eval_mcp_surfaces/providers.go` | Provider adapters for Anthropic, Google, OpenAI, and Qwen-compatible APIs. |
-| `cmd/eval_mcp_surfaces/fixtures.go` | Docker GitLab fixture preparation and placeholder replacement. |
-| `cmd/eval_mcp_surfaces/testdata/automated-mcp-surface-cases.md` | Canonical task corpus. |
-| `dist/evaluation/mcp-surfaces/` | Generated reports, traces, and fixture state; ignored by Git. |
-| `docs/testing/model-results.md` | Current published benchmark result copied from generated reports. |
+| Path                                                            | Purpose                                                                          |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `cmd/eval_mcp_surfaces/main.go`                                 | Evaluation runner, task filtering, MCP execution, report writing, trace writing. |
+| `cmd/eval_mcp_surfaces/providers.go`                            | Provider adapters for Anthropic, Google, OpenAI, and Qwen-compatible APIs.       |
+| `cmd/eval_mcp_surfaces/fixtures.go`                             | Docker GitLab fixture preparation and placeholder replacement.                   |
+| `cmd/eval_mcp_surfaces/testdata/automated-mcp-surface-cases.md` | Canonical task corpus.                                                           |
+| `dist/evaluation/mcp-surfaces/`                                 | Generated reports, traces, and fixture state; ignored by Git.                    |
+| `docs/testing/model-results.md`                                 | Current published benchmark result copied from generated reports.                |
 
 ## Environment
 
 The evaluator reads model provider keys from environment variables:
 
-| Provider | Environment variable |
-| --- | --- |
-| Anthropic | `ANTHROPIC_API_KEY` |
-| Google | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
-| OpenAI | `OPENAI_API_KEY` |
-| Qwen | `QWEN_API_KEY` |
+| Provider  | Environment variable                 |
+| --------- | ------------------------------------ |
+| Anthropic | `ANTHROPIC_API_KEY`                  |
+| Google    | `GOOGLE_API_KEY` or `GEMINI_API_KEY` |
+| OpenAI    | `OPENAI_API_KEY`                     |
+| Qwen      | `QWEN_API_KEY`                       |
 
 Docker mode also needs `test/e2e/.env.docker`, created by the E2E provisioning
 scripts. Never print or commit `.env`, `.env.docker`, provider keys, raw traces,
@@ -164,41 +164,41 @@ timeout 1800s "$GO_BIN" run ./cmd/eval_mcp_surfaces \
 
 ## Important Flags
 
-| Flag | Meaning |
-| --- | --- |
-| `--preset schema-enterprise` | Schema-only Enterprise/Premium route coverage; dry-run by default. |
-| `--preset docker-read` | Docker read-only partition. |
-| `--preset docker-mutating-safe` | Docker safe mutation partition. |
-| `--preset docker-destructive-safe` | Docker safe destructive partition. |
-| `--model` | One provider/model pair. Overrides `--models`. |
-| `--models` | Comma-separated provider/model list. |
-| `--backend=gitlab` | Build the catalog against the real GitLab backend. |
-| `--gitlab-env-file` | Load Docker GitLab credentials from `test/e2e/.env.docker`. |
-| `--prepare-fixtures` | Create or refresh Docker GitLab resources used by evaluation tasks. |
-| `--use-fixtures` | Replace placeholder IDs in prompts with fixture state. |
-| `--execute-tools` | Execute validated model tool calls through MCP. |
-| `--skip-unavailable` | Skip routes not available in the current catalog or GitLab edition. |
-| `--task` | Comma-separated task IDs for targeted runs. |
-| `--out` | Markdown report path. Trace directory defaults to `<report>.traces/`. |
-| `--terminal-log` | File receiving progress and terminal output. Defaults beside `--out`, or under `dist/evaluation/mcp-surfaces/terminal/` when no report path is known yet. |
-| `--print-output` | Also echo progress/output to the terminal. Without this flag, the command writes terminal output only to `--terminal-log`. |
-| `--publish-docs` | Publish reviewed evaluation reports into the managed docs blocks. |
-| `--publish-from` | Reviewed Markdown report path to publish; repeat once per report. |
-| `--publish-label` | Human-readable label for the published snapshot. |
-| `--check-docs` | Verify committed docs match the selected `--publish-from` reports without writing files. |
+| Flag                               | Meaning                                                                                                                                                   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--preset schema-enterprise`       | Schema-only Enterprise/Premium route coverage; dry-run by default.                                                                                        |
+| `--preset docker-read`             | Docker read-only partition.                                                                                                                               |
+| `--preset docker-mutating-safe`    | Docker safe mutation partition.                                                                                                                           |
+| `--preset docker-destructive-safe` | Docker safe destructive partition.                                                                                                                        |
+| `--model`                          | One provider/model pair. Overrides `--models`.                                                                                                            |
+| `--models`                         | Comma-separated provider/model list.                                                                                                                      |
+| `--backend=gitlab`                 | Build the catalog against the real GitLab backend.                                                                                                        |
+| `--gitlab-env-file`                | Load Docker GitLab credentials from `test/e2e/.env.docker`.                                                                                               |
+| `--prepare-fixtures`               | Create or refresh Docker GitLab resources used by evaluation tasks.                                                                                       |
+| `--use-fixtures`                   | Replace placeholder IDs in prompts with fixture state.                                                                                                    |
+| `--execute-tools`                  | Execute validated model tool calls through MCP.                                                                                                           |
+| `--skip-unavailable`               | Skip routes not available in the current catalog or GitLab edition.                                                                                       |
+| `--task`                           | Comma-separated task IDs for targeted runs.                                                                                                               |
+| `--out`                            | Markdown report path. Trace directory defaults to `<report>.traces/`.                                                                                     |
+| `--terminal-log`                   | File receiving progress and terminal output. Defaults beside `--out`, or under `dist/evaluation/mcp-surfaces/terminal/` when no report path is known yet. |
+| `--print-output`                   | Also echo progress/output to the terminal. Without this flag, the command writes terminal output only to `--terminal-log`.                                |
+| `--publish-docs`                   | Publish reviewed evaluation reports into the managed docs blocks.                                                                                         |
+| `--publish-from`                   | Reviewed Markdown report path to publish; repeat once per report.                                                                                         |
+| `--publish-label`                  | Human-readable label for the published snapshot.                                                                                                          |
+| `--check-docs`                     | Verify committed docs match the selected `--publish-from` reports without writing files.                                                                  |
 
 ## Outputs
 
 Each model-backed run writes:
 
-| Output | Purpose |
-| --- | --- |
-| `*.md` report | Startup placeholder, then final summary metrics, task results, API usage, and failure triage. If the run stops before final metrics, the file is replaced with a failure report. |
-| `*.log` terminal log | Progress lines, report-write notifications, provider warnings, and command errors. The evaluator writes this by default and stays silent on the terminal unless `--print-output` is set. |
-| `*.traces/index.md` | Trace index. |
-| `*.traces/*.json` | Per-task trace with prompts, tool calls, validation, MCP results, and repairs. |
-| `*.traces/traces.jsonl` | JSONL stream for programmatic analysis. |
-| `e2e-fixtures.json` | Docker model-evaluation fixture IDs; generated and ignored. |
+| Output                  | Purpose                                                                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `*.md` report           | Startup placeholder, then final summary metrics, task results, API usage, and failure triage. If the run stops before final metrics, the file is replaced with a failure report.         |
+| `*.log` terminal log    | Progress lines, report-write notifications, provider warnings, and command errors. The evaluator writes this by default and stays silent on the terminal unless `--print-output` is set. |
+| `*.traces/index.md`     | Trace index.                                                                                                                                                                             |
+| `*.traces/*.json`       | Per-task trace with prompts, tool calls, validation, MCP results, and repairs.                                                                                                           |
+| `*.traces/traces.jsonl` | JSONL stream for programmatic analysis.                                                                                                                                                  |
+| `e2e-fixtures.json`     | Docker model-evaluation fixture IDs; generated and ignored.                                                                                                                              |
 
 For long runs, always pass an explicit `--out` path so the terminal log defaults
 to a sibling `.log` file. The Markdown report is the review artifact; terminal

--- a/docs/testing/model-evaluation.md
+++ b/docs/testing/model-evaluation.md
@@ -22,22 +22,22 @@ The evaluator uses natural-language tasks from
 the expected tool, action, required parameters, whether the task is destructive,
 and the success condition.
 
-| Case type | Prefix | Purpose |
-| --- | --- | --- |
-| Single operation | `MT-` | One clear user task should usually require one model call and one MCP tool call. |
-| Multi-step workflow | `MS-` | The model must sequence multiple MCP calls in the requested order. |
-| Failure simulation | `MF-` | The model must recover from injected failures or unsafe output. |
+| Case type           | Prefix | Purpose                                                                          |
+| ------------------- | ------ | -------------------------------------------------------------------------------- |
+| Single operation    | `MT-`  | One clear user task should usually require one model call and one MCP tool call. |
+| Multi-step workflow | `MS-`  | The model must sequence multiple MCP calls in the requested order.               |
+| Failure simulation  | `MF-`  | The model must recover from injected failures or unsafe output.                  |
 
 The current automated corpus contains 159 cases and 300 expected tool
 operations:
 
-| Area | Count |
-| --- | ---: |
-| Single-operation cases | 117 |
-| Multi-step workflow scenarios | 37 |
-| Failure simulation scenarios | 5 |
-| Total cases | 159 |
-| Expected tool operations | 300 |
+| Area                          | Count |
+| ----------------------------- | ----: |
+| Single-operation cases        |   117 |
+| Multi-step workflow scenarios |    37 |
+| Failure simulation scenarios  |     5 |
+| Total cases                   |   159 |
+| Expected tool operations      |   300 |
 
 ## Evaluation Modes
 
@@ -69,10 +69,10 @@ state, permissions, or fixture gaps.
 
 Docker evaluation is split into safe presets:
 
-| Preset | Scope | Mutation policy |
-| --- | --- | --- |
-| `docker-read` | Read-only tasks | No mutating or destructive operations. |
-| `docker-mutating-safe` | Safe create/update tasks | Mutates disposable Docker fixtures. |
+| Preset                    | Scope                     | Mutation policy                                                              |
+| ------------------------- | ------------------------- | ---------------------------------------------------------------------------- |
+| `docker-read`             | Read-only tasks           | No mutating or destructive operations.                                       |
+| `docker-mutating-safe`    | Safe create/update tasks  | Mutates disposable Docker fixtures.                                          |
 | `docker-destructive-safe` | Safe delete/archive tasks | Uses disposable or just-in-time fixtures and requires confirmation metadata. |
 
 The Docker fixture base must contain all resources needed by successful tasks.
@@ -81,17 +81,17 @@ as harness noise and should be fixed in fixtures before judging the model.
 
 ## Core Metrics
 
-| Metric | Meaning |
-| --- | --- |
-| Tool-selection accuracy | The first or final model call selected the expected MCP tool name. |
-| Action-selection accuracy | The selected action matched the expected action inside an action-based meta-tool. |
-| First-call validation pass rate | The first emitted tool call matched schema, required params, and destructive-safety requirements. |
-| Schema lookup use rate | Percentage of attempts where the model used schema lookup before or during the task. Low is better for clear single-operation tasks. |
-| Repair success rate | Percentage of invalid first calls that were corrected after the tool returned an error. |
-| Destructive safety | Destructive calls included the required confirmation and used the expected destructive route. |
-| Final task success proxy | The evaluator's final success signal after validation and optional MCP execution. |
-| Model requests | Number of provider calls made by the evaluator. |
-| Tool calls emitted | Number of tool calls emitted by the model. |
+| Metric                          | Meaning                                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Tool-selection accuracy         | The first or final model call selected the expected MCP tool name.                                                                   |
+| Action-selection accuracy       | The selected action matched the expected action inside an action-based meta-tool.                                                    |
+| First-call validation pass rate | The first emitted tool call matched schema, required params, and destructive-safety requirements.                                    |
+| Schema lookup use rate          | Percentage of attempts where the model used schema lookup before or during the task. Low is better for clear single-operation tasks. |
+| Repair success rate             | Percentage of invalid first calls that were corrected after the tool returned an error.                                              |
+| Destructive safety              | Destructive calls included the required confirmation and used the expected destructive route.                                        |
+| Final task success proxy        | The evaluator's final success signal after validation and optional MCP execution.                                                    |
+| Model requests                  | Number of provider calls made by the evaluator.                                                                                      |
+| Tool calls emitted              | Number of tool calls emitted by the model.                                                                                           |
 
 For clear single-operation tasks, the target is `model_calls=1` and
 `tool_calls=1`. Extra calls are acceptable only when the prompt is genuinely
@@ -102,15 +102,15 @@ ambiguous, the task is multi-step, or a real GitLab error requires recovery.
 Failures are useful only after separating model behavior from harness noise.
 Use these categories when triaging traces:
 
-| Category | Meaning | Typical fix |
-| --- | --- | --- |
-| Model route miss | The model chose the wrong tool or action. | Improve descriptions, action names, examples, or aliases. |
-| Model parameter shape miss | The model chose the right route but emitted invalid params. | Strengthen schema descriptions or add safe alias normalization. |
-| Provider adapter issue | The provider API transformed or rejected a valid MCP schema. | Fix the provider adapter without changing the global MCP contract. |
-| Sampling unsupported | The evaluator client did not advertise MCP sampling. | Add a deterministic `CreateMessageHandler` for evaluator clients. |
-| Fixture gap | Docker GitLab lacks a resource the task expects. | Add initial or just-in-time fixture setup. |
-| GitLab limitation | The Docker GitLab edition does not support the API. | Filter or mark the route unavailable for that edition. |
-| MCP implementation bug | The MCP handler fails despite valid model input and valid fixture state. | Fix the handler and add unit/E2E coverage. |
+| Category                   | Meaning                                                                  | Typical fix                                                        |
+| -------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Model route miss           | The model chose the wrong tool or action.                                | Improve descriptions, action names, examples, or aliases.          |
+| Model parameter shape miss | The model chose the right route but emitted invalid params.              | Strengthen schema descriptions or add safe alias normalization.    |
+| Provider adapter issue     | The provider API transformed or rejected a valid MCP schema.             | Fix the provider adapter without changing the global MCP contract. |
+| Sampling unsupported       | The evaluator client did not advertise MCP sampling.                     | Add a deterministic `CreateMessageHandler` for evaluator clients.  |
+| Fixture gap                | Docker GitLab lacks a resource the task expects.                         | Add initial or just-in-time fixture setup.                         |
+| GitLab limitation          | The Docker GitLab edition does not support the API.                      | Filter or mark the route unavailable for that edition.             |
+| MCP implementation bug     | The MCP handler fails despite valid model input and valid fixture state. | Fix the handler and add unit/E2E coverage.                         |
 
 ## Compatibility Expectations
 
@@ -118,14 +118,14 @@ The evaluator supports several provider families through adapters. A model is
 compatible when it can receive the tool catalog, emit tool calls, preserve tool
 call IDs across repair turns, and accept MCP-shaped JSON Schema.
 
-| Provider | Example model | Compatibility expectation |
-| --- | --- | --- |
-| Anthropic | `anthropic:claude-sonnet-4-6` | Supported. |
-| Anthropic | `anthropic:claude-haiku-4-5-20251001` | Supported. |
-| Google | `google:gemini-3.1-flash-lite-preview` | Supported with validated function-calling mode. |
-| OpenAI | `openai:gpt-5.4-mini` | Supported. |
-| OpenAI | `openai:gpt-5.4-nano` | Supported. |
-| Qwen | `qwen:qwen3.6-flash` | Supported through the OpenAI-compatible adapter using `QWEN_API_KEY`. |
+| Provider  | Example model                          | Compatibility expectation                                             |
+| --------- | -------------------------------------- | --------------------------------------------------------------------- |
+| Anthropic | `anthropic:claude-sonnet-4-6`          | Supported.                                                            |
+| Anthropic | `anthropic:claude-haiku-4-5-20251001`  | Supported.                                                            |
+| Google    | `google:gemini-3.1-flash-lite-preview` | Supported with validated function-calling mode.                       |
+| OpenAI    | `openai:gpt-5.4-mini`                  | Supported.                                                            |
+| OpenAI    | `openai:gpt-5.4-nano`                  | Supported.                                                            |
+| Qwen      | `qwen:qwen3.6-flash`                   | Supported through the OpenAI-compatible adapter using `QWEN_API_KEY`. |
 
 Published percentages belong in [AI Model Evaluation Results](model-results.md),
 not in this conceptual guide.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -616,11 +616,11 @@ Docker mode enables pipeline and job tests that require a CI runner. It also sta
 
 Both `make test-e2e` and `make test-e2e-docker` use [gotestsum](https://github.com/gotestyourself/gotestsum) to produce structured test reports in `dist/e2e-reports/`:
 
-| File                        | Format    | Purpose                                      |
-| --------------------------- | --------- | -------------------------------------------- |
-| `e2e-junit.xml`             | JUnit XML | CI/CD integration (GitHub Actions, SonarQube) |
-| `e2e-log.json`              | JSON      | Programmatic analysis, filtering              |
-| `e2e-output.txt`            | Plain     | Human-readable console output (`testdox`)     |
+| File             | Format    | Purpose                                       |
+| ---------------- | --------- | --------------------------------------------- |
+| `e2e-junit.xml`  | JUnit XML | CI/CD integration (GitHub Actions, SonarQube) |
+| `e2e-log.json`   | JSON      | Programmatic analysis, filtering              |
+| `e2e-output.txt` | Plain     | Human-readable console output (`testdox`)     |
 
 Docker mode files use the `e2e-docker-` prefix. Reports are written to `dist/e2e-reports/` (gitignored via `dist/`).
 
@@ -632,22 +632,22 @@ Install gotestsum via `make install-tools` or `go install gotest.tools/gotestsum
 
 The suite uses five MCP server/client pairs via `mcp.NewInMemoryTransports()`:
 
-| Session       | Purpose                                    |
-| ------------- | ------------------------------------------ |
-| `individual`  | Individual GitLab tools                    |
-| `meta`        | Domain meta-tools and action dispatch      |
-| `sampling`    | Sampling tools with mock LLM handler       |
-| `elicitation` | Elicitation tools with mock user handler   |
+| Session       | Purpose                                      |
+| ------------- | -------------------------------------------- |
+| `individual`  | Individual GitLab tools                      |
+| `meta`        | Domain meta-tools and action dispatch        |
+| `sampling`    | Sampling tools with mock LLM handler         |
+| `elicitation` | Elicitation tools with mock user handler     |
 | `safeMode`    | Mutating tools wrapped as safe-mode previews |
 
 **Workflows:**
 
-| Area                 | Description                                               |
-| -------------------- | --------------------------------------------------------- |
-| Individual tools     | Exercises domain tools directly against real GitLab       |
-| Meta-tools           | Exercises domain action dispatch through meta-tools       |
-| MCP capabilities     | Verifies logging, progress, roots, completions, sampling, elicitation, and safe mode |
-| Docker-only runner   | Exercises CI pipeline and job behavior with a registered runner |
+| Area               | Description                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| Individual tools   | Exercises domain tools directly against real GitLab                                  |
+| Meta-tools         | Exercises domain action dispatch through meta-tools                                  |
+| MCP capabilities   | Verifies logging, progress, roots, completions, sampling, elicitation, and safe mode |
+| Docker-only runner | Exercises CI pipeline and job behavior with a registered runner                      |
 
 Docker validation snapshots are written under `dist/e2e-reports/` after `make test-e2e-docker`. The generated metrics above count E2E `Test*` entry points statically; they do not replace the runtime report produced by gotestsum.
 
@@ -712,12 +712,12 @@ go test -v -tags e2e -timeout 300s -run '^TestMeta_' ./test/e2e/suite/
 
 Validation tests in `internal/tools/register_validation_test.go` ensure structural integrity across all sub-packages:
 
-| Test                                   | Purpose                                                                                     |
-| -------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `TestRegisterAllDoesNotUseDomainRegisterTools` | Verifies root individual registration stays catalog-backed and cannot regress to per-domain `RegisterTools` loops |
-| `TestActionSpecCoverage_AllCatalogRoutesClassified` | Builds the GitLab.com Enterprise dynamic catalog and verifies every catalog action is spec-backed |
-| `TestAllMarkdownFormattersRegistered`  | Verifies all ~266 output types across 76 sub-packages have registered markdown formatters via `toolutil.RegisterMarkdown[T]` |
-| `TestAllHintReferencesValid`           | Validates all `action 'xxx'` and backtick-quoted `` `gitlab_xxx` `` references in WriteHints across all markdown.go files match registered tools/actions |
+| Test                                                | Purpose                                                                                                                                                  |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TestRegisterAllDoesNotUseDomainRegisterTools`      | Verifies root individual registration stays catalog-backed and cannot regress to per-domain `RegisterTools` loops                                        |
+| `TestActionSpecCoverage_AllCatalogRoutesClassified` | Builds the GitLab.com Enterprise dynamic catalog and verifies every catalog action is spec-backed                                                        |
+| `TestAllMarkdownFormattersRegistered`               | Verifies all ~266 output types across 76 sub-packages have registered markdown formatters via `toolutil.RegisterMarkdown[T]`                             |
+| `TestAllHintReferencesValid`                        | Validates all `action 'xxx'` and backtick-quoted `` `gitlab_xxx` `` references in WriteHints across all markdown.go files match registered tools/actions |
 
 ```bash
 # Run validation tests
@@ -800,11 +800,11 @@ make inspector-stop # Stop Inspector and clean up temp binary
 
 ### Shared Helpers (`internal/testutil/`)
 
-| Helper                          | Purpose                                    |
-| ------------------------------- | ------------------------------------------ |
-| `NewTestClient()`               | Creates mock GitLab client + httptest server |
-| `RespondJSON()`                 | Writes JSON response body                  |
-| `RespondJSONWithPagination()`   | Writes JSON + pagination headers           |
+| Helper                        | Purpose                                      |
+| ----------------------------- | -------------------------------------------- |
+| `NewTestClient()`             | Creates mock GitLab client + httptest server |
+| `RespondJSON()`               | Writes JSON response body                    |
+| `RespondJSONWithPagination()` | Writes JSON + pagination headers             |
 
 ### Test File Organization
 
@@ -862,19 +862,19 @@ variables** overridden in tests with `t.Cleanup` to restore originals.
 
 **Function variables** (defined in source files, overridden in tests):
 
-| Variable          | Source file     | Real function    | Purpose                    |
-| ----------------- | --------------- | ---------------- | -------------------------- |
-| `allClientsFn`    | `clients.go`    | `AllClients()`   | Returns MCP client configs |
-| `openBrowserFn`   | `browser.go`    | `openBrowser()`  | Launches default browser   |
-| `pickDirectoryFn` | `dirpicker.go`  | `pickDirectory()`| Opens OS directory picker  |
+| Variable          | Source file    | Real function     | Purpose                    |
+| ----------------- | -------------- | ----------------- | -------------------------- |
+| `allClientsFn`    | `clients.go`   | `AllClients()`    | Returns MCP client configs |
+| `openBrowserFn`   | `browser.go`   | `openBrowser()`   | Launches default browser   |
+| `pickDirectoryFn` | `dirpicker.go` | `pickDirectory()` | Opens OS directory picker  |
 
 **Test helpers** (`testhelpers_test.go`):
 
-| Helper                          | Purpose                                                  |
-| ------------------------------- | -------------------------------------------------------- |
-| `useFakeClients(t)`             | Overrides `allClientsFn` with clients using temp dir paths — prevents writing to real `mcp.json` files |
-| `stubPickDirectory(t, path, err)` | Overrides `pickDirectoryFn` — prevents OS directory dialog |
-| `stubOpenBrowser(t)`            | Overrides `openBrowserFn` — prevents browser launch       |
+| Helper                            | Purpose                                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `useFakeClients(t)`               | Overrides `allClientsFn` with clients using temp dir paths — prevents writing to real `mcp.json` files |
+| `stubPickDirectory(t, path, err)` | Overrides `pickDirectoryFn` — prevents OS directory dialog                                             |
+| `stubOpenBrowser(t)`              | Overrides `openBrowserFn` — prevents browser launch                                                    |
 
 **File organization** (12 test files, 159 test functions):
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -10,50 +10,50 @@ The [dynamic toolset](../dynamic-tools.md) reuses the same canonical action cata
 
 ## Domains
 
-| Domain | Tools | Meta-tool | Document |
-| --- | ---: | --- | --- |
-| Projects | 42 | `gitlab_project` | [projects.md](projects.md) |
-| Repository & Files | 41 | `gitlab_repository` | [repository.md](repository.md) |
-| Branches | 10 | `gitlab_branch` | [branches.md](branches.md) |
-| Tags | 9 | `gitlab_tag` | [tags.md](tags.md) |
-| Merge Requests | 54 | `gitlab_merge_request` | [merge-requests.md](merge-requests.md) |
-| MR Review | 23 | `gitlab_mr_review` | [mr-review.md](mr-review.md) |
-| Issues | 44 | `gitlab_issue` | [issues.md](issues.md) |
-| CI/CD | 58 | `gitlab_pipeline`, `gitlab_job`, etc. | [ci-cd.md](ci-cd.md) |
-| Releases | 12 | `gitlab_release` | [releases.md](releases.md) |
-| Environments & Deployments | 24 | `gitlab_environment` | [environments.md](environments.md) |
-| Groups | 69 | `gitlab_group` | [groups.md](groups.md) |
-| Users & Todos | 27 | `gitlab_user` | [users.md](users.md) |
-| Access & Tokens | 68 | various | [access.md](access.md) |
-| Boards, Labels & Milestones | 26 | `gitlab_project`, `gitlab_group` | [boards.md](boards.md) |
-| Search | 11 | `gitlab_search` | [search.md](search.md) |
-| Orbit (GitLab.com Enterprise/Premium) | 5 | `gitlab_orbit` | [orbit.md](orbit.md) |
-| Wikis | 6 | `gitlab_wiki` | [wikis.md](wikis.md) |
-| Snippets | 24 | `gitlab_snippet` | [snippets.md](snippets.md) |
-| Packages & Registry | 28 | `gitlab_package` | [packages.md](packages.md) |
-| Mirrors | 7 | `gitlab_project` (enterprise routes) | [mirrors.md](mirrors.md) |
-| Runners & Resource Groups | 24 | `gitlab_runner` | [runners.md](runners.md) |
-| Security & Feature Flags | 28 | various | [security.md](security.md) |
-| Notifications & Events | 48 | various | [notifications.md](notifications.md) |
-| Admin & Instance | 77 | `gitlab_admin` | [admin.md](admin.md) |
-| Templates | 10 | `gitlab_template` | [templates.md](templates.md) |
-| Integrations & Misc | 34 | various | [integrations.md](integrations.md) |
-| MCP Capabilities | 16 | `gitlab_server`, `gitlab_analyze` (plus individually-registered elicitation tools) | [capabilities.md](capabilities.md) |
-| Project Discovery | 1 | `gitlab_discover_project` (individual tool) | [project-discovery.md](project-discovery.md) |
-| Analysis (LLM-assisted) | 11 | `gitlab_analyze` | [capabilities.md](capabilities.md) |
-| Identity & Security | 28 | `gitlab_group_scim`, `gitlab_member_role`, etc. | [identity-security.md](identity-security.md) |
-| Enterprise Users & Attestations | 6 | `gitlab_enterprise_user`, `gitlab_attestation` | [enterprise-attestations.md](enterprise-attestations.md) |
-| Analytics & Compliance | 12 | `gitlab_group` (enterprise routes), `gitlab_compliance_policy`, `gitlab_project_alias` | [analytics-compliance.md](analytics-compliance.md) |
-| Geo & Model Registry | 9 | `gitlab_geo`, `gitlab_model_registry` | [geo-model-registry.md](geo-model-registry.md) |
-| Repository Storage Moves | 18 | `gitlab_storage_move` | [storage-moves.md](storage-moves.md) |
-| Epics | 17 | `gitlab_epic` | [epics.md](epics.md) |
-| Vulnerabilities | 8 | `gitlab_vulnerability` | [vulnerabilities.md](vulnerabilities.md) |
-| Security Attributes | 5 | `gitlab_security_attribute` | [security-attributes.md](security-attributes.md) |
-| Security Categories | 3 | `gitlab_security_category` | [security-categories.md](security-categories.md) |
-| Security Findings | 1 | `gitlab_security_finding` | [security-findings.md](security-findings.md) |
-| CI/CD Catalog | 2 | `gitlab_ci_catalog` | [ci-catalog.md](ci-catalog.md) |
-| Branch Rules | 1 | `gitlab_branch` (routed) | [branch-rules.md](branch-rules.md) |
-| Custom Emoji | 3 | `gitlab_custom_emoji` | [custom-emoji.md](custom-emoji.md) |
+| Domain                                | Tools | Meta-tool                                                                              | Document                                                 |
+| ------------------------------------- | ----: | -------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Projects                              |    42 | `gitlab_project`                                                                       | [projects.md](projects.md)                               |
+| Repository & Files                    |    41 | `gitlab_repository`                                                                    | [repository.md](repository.md)                           |
+| Branches                              |    10 | `gitlab_branch`                                                                        | [branches.md](branches.md)                               |
+| Tags                                  |     9 | `gitlab_tag`                                                                           | [tags.md](tags.md)                                       |
+| Merge Requests                        |    54 | `gitlab_merge_request`                                                                 | [merge-requests.md](merge-requests.md)                   |
+| MR Review                             |    23 | `gitlab_mr_review`                                                                     | [mr-review.md](mr-review.md)                             |
+| Issues                                |    44 | `gitlab_issue`                                                                         | [issues.md](issues.md)                                   |
+| CI/CD                                 |    58 | `gitlab_pipeline`, `gitlab_job`, etc.                                                  | [ci-cd.md](ci-cd.md)                                     |
+| Releases                              |    12 | `gitlab_release`                                                                       | [releases.md](releases.md)                               |
+| Environments & Deployments            |    24 | `gitlab_environment`                                                                   | [environments.md](environments.md)                       |
+| Groups                                |    69 | `gitlab_group`                                                                         | [groups.md](groups.md)                                   |
+| Users & Todos                         |    27 | `gitlab_user`                                                                          | [users.md](users.md)                                     |
+| Access & Tokens                       |    68 | various                                                                                | [access.md](access.md)                                   |
+| Boards, Labels & Milestones           |    26 | `gitlab_project`, `gitlab_group`                                                       | [boards.md](boards.md)                                   |
+| Search                                |    11 | `gitlab_search`                                                                        | [search.md](search.md)                                   |
+| Orbit (GitLab.com Enterprise/Premium) |     5 | `gitlab_orbit`                                                                         | [orbit.md](orbit.md)                                     |
+| Wikis                                 |     6 | `gitlab_wiki`                                                                          | [wikis.md](wikis.md)                                     |
+| Snippets                              |    24 | `gitlab_snippet`                                                                       | [snippets.md](snippets.md)                               |
+| Packages & Registry                   |    28 | `gitlab_package`                                                                       | [packages.md](packages.md)                               |
+| Mirrors                               |     7 | `gitlab_project` (enterprise routes)                                                   | [mirrors.md](mirrors.md)                                 |
+| Runners & Resource Groups             |    24 | `gitlab_runner`                                                                        | [runners.md](runners.md)                                 |
+| Security & Feature Flags              |    28 | various                                                                                | [security.md](security.md)                               |
+| Notifications & Events                |    48 | various                                                                                | [notifications.md](notifications.md)                     |
+| Admin & Instance                      |    77 | `gitlab_admin`                                                                         | [admin.md](admin.md)                                     |
+| Templates                             |    10 | `gitlab_template`                                                                      | [templates.md](templates.md)                             |
+| Integrations & Misc                   |    34 | various                                                                                | [integrations.md](integrations.md)                       |
+| MCP Capabilities                      |    16 | `gitlab_server`, `gitlab_analyze` (plus individually-registered elicitation tools)     | [capabilities.md](capabilities.md)                       |
+| Project Discovery                     |     1 | `gitlab_discover_project` (individual tool)                                            | [project-discovery.md](project-discovery.md)             |
+| Analysis (LLM-assisted)               |    11 | `gitlab_analyze`                                                                       | [capabilities.md](capabilities.md)                       |
+| Identity & Security                   |    28 | `gitlab_group_scim`, `gitlab_member_role`, etc.                                        | [identity-security.md](identity-security.md)             |
+| Enterprise Users & Attestations       |     6 | `gitlab_enterprise_user`, `gitlab_attestation`                                         | [enterprise-attestations.md](enterprise-attestations.md) |
+| Analytics & Compliance                |    12 | `gitlab_group` (enterprise routes), `gitlab_compliance_policy`, `gitlab_project_alias` | [analytics-compliance.md](analytics-compliance.md)       |
+| Geo & Model Registry                  |     9 | `gitlab_geo`, `gitlab_model_registry`                                                  | [geo-model-registry.md](geo-model-registry.md)           |
+| Repository Storage Moves              |    18 | `gitlab_storage_move`                                                                  | [storage-moves.md](storage-moves.md)                     |
+| Epics                                 |    17 | `gitlab_epic`                                                                          | [epics.md](epics.md)                                     |
+| Vulnerabilities                       |     8 | `gitlab_vulnerability`                                                                 | [vulnerabilities.md](vulnerabilities.md)                 |
+| Security Attributes                   |     5 | `gitlab_security_attribute`                                                            | [security-attributes.md](security-attributes.md)         |
+| Security Categories                   |     3 | `gitlab_security_category`                                                             | [security-categories.md](security-categories.md)         |
+| Security Findings                     |     1 | `gitlab_security_finding`                                                              | [security-findings.md](security-findings.md)             |
+| CI/CD Catalog                         |     2 | `gitlab_ci_catalog`                                                                    | [ci-catalog.md](ci-catalog.md)                           |
+| Branch Rules                          |     1 | `gitlab_branch` (routed)                                                               | [branch-rules.md](branch-rules.md)                       |
+| Custom Emoji                          |     3 | `gitlab_custom_emoji`                                                                  | [custom-emoji.md](custom-emoji.md)                       |
 
 > **Note**: The `events` sub-package (3 tools) is referenced by both Users & Todos and Notifications & Events domains. Four sub-packages (`projectimportexport`, `projectstatistics`, `uploads`, `deploymentmergerequests` — 12 tools) are covered by their parent domain docs (Projects, Environments). Orbit is registered only for `https://gitlab.com` connections with the Enterprise/Premium catalog enabled. Seven GraphQL-only domains (Vulnerabilities, Security Attributes, Security Categories, Security Findings, CI/CD Catalog, Branch Rules, Custom Emoji) use the GitLab GraphQL API instead of REST — see [GraphQL Integration](../graphql.md) for details.
 

--- a/docs/tools/access.md
+++ b/docs/tools/access.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the 62 individual tools below are consolidated into th
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/admin.md
+++ b/docs/tools/admin.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the smaller sub-packages (settings through bulk import
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/analytics-compliance.md
+++ b/docs/tools/analytics-compliance.md
@@ -9,11 +9,11 @@ Retrieve counts of recently created issues, merge requests, and new members for 
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_get_recently_created_issues_count` | Get count of recently created issues (last 90 days) | Read-only |
-| `gitlab_get_recently_created_mr_count` | Get count of recently created merge requests (last 90 days) | Read-only |
-| `gitlab_get_recently_added_members_count` | Get count of recently added members (last 90 days) | Read-only |
+| Tool                                       | Description                                                 | Annotations |
+| ------------------------------------------ | ----------------------------------------------------------- | ----------- |
+| `gitlab_get_recently_created_issues_count` | Get count of recently created issues (last 90 days)         | Read-only   |
+| `gitlab_get_recently_created_mr_count`     | Get count of recently created merge requests (last 90 days) | Read-only   |
+| `gitlab_get_recently_added_members_count`  | Get count of recently added members (last 90 days)          | Read-only   |
 
 ### Meta-tool
 
@@ -54,9 +54,9 @@ Get recently added members count:
 
 All three tools share the same parameter:
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `group_path` | string | Yes | Full path of the group (e.g. `my-group` or `parent/child`) |
+| Parameter    | Type   | Required | Description                                                |
+| ------------ | ------ | -------- | ---------------------------------------------------------- |
+| `group_path` | string | Yes      | Full path of the group (e.g. `my-group` or `parent/child`) |
 
 ---
 
@@ -67,10 +67,10 @@ instance-wide settings that control the compliance security policy project names
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_get_compliance_policy_settings` | Get compliance policy settings | Read-only |
-| `gitlab_update_compliance_policy_settings` | Update compliance policy settings | Update |
+| Tool                                       | Description                       | Annotations |
+| ------------------------------------------ | --------------------------------- | ----------- |
+| `gitlab_get_compliance_policy_settings`    | Get compliance policy settings    | Read-only   |
+| `gitlab_update_compliance_policy_settings` | Update compliance policy settings | Update      |
 
 ### Meta-tool
 
@@ -105,9 +105,9 @@ No parameters required.
 
 #### Update
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `csp_namespace_id` | int | No | Namespace ID for the compliance security policy project |
+| Parameter          | Type | Required | Description                                             |
+| ------------------ | ---- | -------- | ------------------------------------------------------- |
+| `csp_namespace_id` | int  | No       | Namespace ID for the compliance security policy project |
 
 ---
 
@@ -118,12 +118,12 @@ alternative names, providing a convenient shortcut. All operations require admin
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_list_project_aliases` | List all project aliases | Read-only |
-| `gitlab_get_project_alias` | Get a specific project alias by name | Read-only |
-| `gitlab_create_project_alias` | Create a new project alias | Create |
-| `gitlab_delete_project_alias` | Delete a project alias by name | Destructive |
+| Tool                          | Description                          | Annotations |
+| ----------------------------- | ------------------------------------ | ----------- |
+| `gitlab_list_project_aliases` | List all project aliases             | Read-only   |
+| `gitlab_get_project_alias`    | Get a specific project alias by name | Read-only   |
+| `gitlab_create_project_alias` | Create a new project alias           | Create      |
+| `gitlab_delete_project_alias` | Delete a project alias by name       | Destructive |
 
 ### Meta-tool
 
@@ -177,16 +177,16 @@ No parameters required.
 
 #### Get / Delete
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `name` | string | Yes | The alias name |
+| Parameter | Type   | Required | Description    |
+| --------- | ------ | -------- | -------------- |
+| `name`    | string | Yes      | The alias name |
 
 #### Create
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `name` | string | Yes | The alias name to create |
-| `project_id` | int | Yes | The numeric project ID to alias |
+| Parameter    | Type   | Required | Description                     |
+| ------------ | ------ | -------- | ------------------------------- |
+| `name`       | string | Yes      | The alias name to create        |
+| `project_id` | int    | Yes      | The numeric project ID to alias |
 
 ---
 
@@ -198,10 +198,10 @@ restore service, and change failure rate. Requires GitLab Premium / Ultimate.
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_get_project_dora_metrics` | Get DORA metrics for a project | Read-only |
-| `gitlab_get_group_dora_metrics` | Get DORA metrics for a group | Read-only |
+| Tool                              | Description                    | Annotations |
+| --------------------------------- | ------------------------------ | ----------- |
+| `gitlab_get_project_dora_metrics` | Get DORA metrics for a project | Read-only   |
+| `gitlab_get_group_dora_metrics`   | Get DORA metrics for a group   | Read-only   |
 
 ### Meta-tool
 
@@ -211,14 +211,14 @@ Actions: `project`, `group`
 
 ### Parameters
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `project_id` / `group_id` | string | Yes | Project or group ID / URL-encoded path |
-| `metric` | string | Yes | `deployment_frequency`, `lead_time_for_changes`, `time_to_restore_service`, `change_failure_rate` |
-| `start_date` | string | No | Start date (`YYYY-MM-DD`) |
-| `end_date` | string | No | End date (`YYYY-MM-DD`) |
-| `interval` | string | No | Aggregation: `daily`, `monthly`, `all` (default: `daily`) |
-| `environment_tiers` | []string | No | Filter by tiers (e.g. `production`, `staging`) |
+| Parameter                 | Type     | Required | Description                                                                                       |
+| ------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `project_id` / `group_id` | string   | Yes      | Project or group ID / URL-encoded path                                                            |
+| `metric`                  | string   | Yes      | `deployment_frequency`, `lead_time_for_changes`, `time_to_restore_service`, `change_failure_rate` |
+| `start_date`              | string   | No       | Start date (`YYYY-MM-DD`)                                                                         |
+| `end_date`                | string   | No       | End date (`YYYY-MM-DD`)                                                                           |
+| `interval`                | string   | No       | Aggregation: `daily`, `monthly`, `all` (default: `daily`)                                         |
+| `environment_tiers`       | []string | No       | Filter by tiers (e.g. `production`, `staging`)                                                    |
 
 ---
 
@@ -226,12 +226,12 @@ Actions: `project`, `group`
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_get_project_statistics` | Get project fetch statistics for the last 30 days | Read-only |
+| Tool                            | Description                                       | Annotations |
+| ------------------------------- | ------------------------------------------------- | ----------- |
+| `gitlab_get_project_statistics` | Get project fetch statistics for the last 30 days | Read-only   |
 
 ### Parameters
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `project_id` | string | Yes | Project ID or URL-encoded path |
+| Parameter    | Type   | Required | Description                    |
+| ------------ | ------ | -------- | ------------------------------ |
+| `project_id` | string | Yes      | Project ID or URL-encoded path |

--- a/docs/tools/boards.md
+++ b/docs/tools/boards.md
@@ -22,12 +22,12 @@ With `TOOL_SURFACE=meta`, the 10 board tools are consolidated into a single `git
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/branch-rules.md
+++ b/docs/tools/branch-rules.md
@@ -24,9 +24,9 @@ This tool complements the existing REST-based branch protection tools (`gitlab_b
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 ---
 
@@ -39,48 +39,48 @@ List branch rules for a project. Returns a paginated list of all branch rules wi
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_path` | string | Yes | Full path of the project (e.g. `my-group/my-project`) |
-| `first` | int | No | Number of items per page (default: 20) |
-| `after` | string | No | Cursor for forward pagination |
+| Parameter      | Type   | Required | Description                                           |
+| -------------- | ------ | :------: | ----------------------------------------------------- |
+| `project_path` | string |   Yes    | Full path of the project (e.g. `my-group/my-project`) |
+| `first`        | int    |    No    | Number of items per page (default: 20)                |
+| `after`        | string |    No    | Cursor for forward pagination                         |
 
 ### Output fields
 
 Each branch rule includes:
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Branch name or pattern (e.g. `main`, `release/*`) |
-| `is_default` | bool | Whether this is the default branch |
-| `is_protected` | bool | Whether the branch is protected |
-| `matching_branches_count` | int | Number of branches matching this rule |
-| `created_at` | string | Rule creation timestamp |
-| `updated_at` | string | Rule last update timestamp |
-| `branch_protection` | object | Protection settings (see below) |
-| `approval_rules` | array | Associated approval rules (see below) |
-| `external_status_checks` | array | External status checks (see below) |
+| Field                     | Type   | Description                                       |
+| ------------------------- | ------ | ------------------------------------------------- |
+| `name`                    | string | Branch name or pattern (e.g. `main`, `release/*`) |
+| `is_default`              | bool   | Whether this is the default branch                |
+| `is_protected`            | bool   | Whether the branch is protected                   |
+| `matching_branches_count` | int    | Number of branches matching this rule             |
+| `created_at`              | string | Rule creation timestamp                           |
+| `updated_at`              | string | Rule last update timestamp                        |
+| `branch_protection`       | object | Protection settings (see below)                   |
+| `approval_rules`          | array  | Associated approval rules (see below)             |
+| `external_status_checks`  | array  | External status checks (see below)                |
 
 ### Branch protection settings
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `allow_force_push` | bool | Whether force push is allowed |
+| Field                          | Type | Description                             |
+| ------------------------------ | ---- | --------------------------------------- |
+| `allow_force_push`             | bool | Whether force push is allowed           |
 | `code_owner_approval_required` | bool | Whether code owner approval is required |
 
 ### Approval rules
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Approval rule name |
-| `approvals_required` | int | Number of required approvals |
-| `type` | string | Rule type (e.g. `REGULAR`, `CODE_OWNER`) |
+| Field                | Type   | Description                              |
+| -------------------- | ------ | ---------------------------------------- |
+| `name`               | string | Approval rule name                       |
+| `approvals_required` | int    | Number of required approvals             |
+| `type`               | string | Rule type (e.g. `REGULAR`, `CODE_OWNER`) |
 
 ### External status checks
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Check name |
+| Field          | Type   | Description                 |
+| -------------- | ------ | --------------------------- |
+| `name`         | string | Check name                  |
 | `external_url` | string | URL of the external service |
 
 ---

--- a/docs/tools/branches.md
+++ b/docs/tools/branches.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, all 10 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/capabilities.md
+++ b/docs/tools/capabilities.md
@@ -22,10 +22,10 @@ Sampling tools require the MCP client to support the sampling capability. Elicit
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
+| **Create** |    —     |     No      |     —      | Creates a new resource   |
 
 ---
 
@@ -176,24 +176,24 @@ Check MCP server health and GitLab connectivity. Returns server version, author,
 
 ### Capability Requirements
 
-| Tool | Required MCP Capability | Fallback Behavior |
-| ---- | ----------------------- | ----------------- |
-| `gitlab_analyze_mr_changes` | Sampling | Returns informational message if unsupported |
-| `gitlab_summarize_issue` | Sampling | Returns informational message if unsupported |
-| `gitlab_generate_release_notes` | Sampling | Returns informational message if unsupported |
-| `gitlab_analyze_pipeline_failure` | Sampling | Returns informational message if unsupported |
-| `gitlab_summarize_mr_review` | Sampling | Returns informational message if unsupported |
-| `gitlab_generate_milestone_report` | Sampling | Returns informational message if unsupported |
-| `gitlab_analyze_ci_configuration` | Sampling | Returns informational message if unsupported |
-| `gitlab_analyze_issue_scope` | Sampling | Returns informational message if unsupported |
-| `gitlab_review_mr_security` | Sampling | Returns informational message if unsupported |
-| `gitlab_find_technical_debt` | Sampling | Returns informational message if unsupported |
-| `gitlab_analyze_deployment_history` | Sampling | Returns informational message if unsupported |
-| `gitlab_interactive_issue_create` | Elicitation | Returns informational message if unsupported |
-| `gitlab_interactive_mr_create` | Elicitation | Returns informational message if unsupported |
-| `gitlab_interactive_release_create` | Elicitation | Returns informational message if unsupported |
-| `gitlab_interactive_project_create` | Elicitation | Returns informational message if unsupported |
-| `gitlab_server_status` | None | Always available |
+| Tool                                | Required MCP Capability | Fallback Behavior                            |
+| ----------------------------------- | ----------------------- | -------------------------------------------- |
+| `gitlab_analyze_mr_changes`         | Sampling                | Returns informational message if unsupported |
+| `gitlab_summarize_issue`            | Sampling                | Returns informational message if unsupported |
+| `gitlab_generate_release_notes`     | Sampling                | Returns informational message if unsupported |
+| `gitlab_analyze_pipeline_failure`   | Sampling                | Returns informational message if unsupported |
+| `gitlab_summarize_mr_review`        | Sampling                | Returns informational message if unsupported |
+| `gitlab_generate_milestone_report`  | Sampling                | Returns informational message if unsupported |
+| `gitlab_analyze_ci_configuration`   | Sampling                | Returns informational message if unsupported |
+| `gitlab_analyze_issue_scope`        | Sampling                | Returns informational message if unsupported |
+| `gitlab_review_mr_security`         | Sampling                | Returns informational message if unsupported |
+| `gitlab_find_technical_debt`        | Sampling                | Returns informational message if unsupported |
+| `gitlab_analyze_deployment_history` | Sampling                | Returns informational message if unsupported |
+| `gitlab_interactive_issue_create`   | Elicitation             | Returns informational message if unsupported |
+| `gitlab_interactive_mr_create`      | Elicitation             | Returns informational message if unsupported |
+| `gitlab_interactive_release_create` | Elicitation             | Returns informational message if unsupported |
+| `gitlab_interactive_project_create` | Elicitation             | Returns informational message if unsupported |
+| `gitlab_server_status`              | None                    | Always available                             |
 
 ---
 

--- a/docs/tools/ci-catalog.md
+++ b/docs/tools/ci-catalog.md
@@ -24,9 +24,9 @@ With `TOOL_SURFACE=meta`, both individual tools below are consolidated into a si
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 ---
 
@@ -39,13 +39,13 @@ Search and list CI/CD Catalog resources. Supports text search, scope filtering, 
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `search` | string | No | Search resources by name or description |
-| `scope` | string | No | Filter scope: `ALL` (default) or `NAMESPACED` |
-| `sort` | string | No | Sort order: `NAME_ASC` (default), `NAME_DESC`, `LATEST_RELEASED_AT_ASC`, `LATEST_RELEASED_AT_DESC`, `STAR_COUNT_ASC`, `STAR_COUNT_DESC` |
-| `first` | int | No | Number of items per page (default: 20) |
-| `after` | string | No | Cursor for forward pagination |
+| Parameter | Type   | Required | Description                                                                                                                             |
+| --------- | ------ | :------: | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `search`  | string |    No    | Search resources by name or description                                                                                                 |
+| `scope`   | string |    No    | Filter scope: `ALL` (default) or `NAMESPACED`                                                                                           |
+| `sort`    | string |    No    | Sort order: `NAME_ASC` (default), `NAME_DESC`, `LATEST_RELEASED_AT_ASC`, `LATEST_RELEASED_AT_DESC`, `STAR_COUNT_ASC`, `STAR_COUNT_DESC` |
+| `first`   | int    |    No    | Number of items per page (default: 20)                                                                                                  |
+| `after`   | string |    No    | Cursor for forward pagination                                                                                                           |
 
 ### `gitlab_get_catalog_resource`
 
@@ -54,42 +54,42 @@ Get full details of a CI/CD Catalog resource by GID or project full path. Return
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | No | Resource GID (e.g. `gid://gitlab/Ci::Catalog::Resource/1`) |
-| `full_path` | string | No | Project full path (e.g. `my-group/my-catalog-project`) |
+| Parameter   | Type   | Required | Description                                                |
+| ----------- | ------ | :------: | ---------------------------------------------------------- |
+| `id`        | string |    No    | Resource GID (e.g. `gid://gitlab/Ci::Catalog::Resource/1`) |
+| `full_path` | string |    No    | Project full path (e.g. `my-group/my-catalog-project`)     |
 
 > **Note**: At least one of `id` or `full_path` must be provided.
 
 ### Output fields (detail)
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | string | Resource GID |
-| `name` | string | Resource name |
-| `description` | string | Resource description |
-| `icon` | string | Resource icon |
-| `full_path` | string | Project full path |
-| `web_url` | string | URL to the resource in GitLab |
-| `star_count` | int | Number of stars |
-| `forks_count` | int | Number of forks |
-| `open_issues_count` | int | Open issue count |
-| `open_merge_requests_count` | int | Open MR count |
-| `latest_released_at` | string | Date of latest release |
-| `readme_html` | string | Rendered README content |
-| `versions` | array | Released versions with components |
-| `components` | array | Components in the latest version |
+| Field                       | Type   | Description                       |
+| --------------------------- | ------ | --------------------------------- |
+| `id`                        | string | Resource GID                      |
+| `name`                      | string | Resource name                     |
+| `description`               | string | Resource description              |
+| `icon`                      | string | Resource icon                     |
+| `full_path`                 | string | Project full path                 |
+| `web_url`                   | string | URL to the resource in GitLab     |
+| `star_count`                | int    | Number of stars                   |
+| `forks_count`               | int    | Number of forks                   |
+| `open_issues_count`         | int    | Open issue count                  |
+| `open_merge_requests_count` | int    | Open MR count                     |
+| `latest_released_at`        | string | Date of latest release            |
+| `readme_html`               | string | Rendered README content           |
+| `versions`                  | array  | Released versions with components |
+| `components`                | array  | Components in the latest version  |
 
 ### Component structure
 
 Each component includes:
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Component name |
-| `description` | string | Component description |
-| `include_path` | string | Path to include in `.gitlab-ci.yml` |
-| `inputs` | array | Input parameters (name, type, required, default, description) |
+| Field          | Type   | Description                                                   |
+| -------------- | ------ | ------------------------------------------------------------- |
+| `name`         | string | Component name                                                |
+| `description`  | string | Component description                                         |
+| `include_path` | string | Path to include in `.gitlab-ci.yml`                           |
+| `inputs`       | array  | Input parameters (name, type, required, default, description) |
 
 ---
 

--- a/docs/tools/ci-cd.md
+++ b/docs/tools/ci-cd.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, the 57 individual tools below are consolidated into si
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 
@@ -138,13 +138,13 @@ Get the latest pipeline for a project, optionally filtered by branch/tag ref. Re
 
 Wait for a pipeline to reach a terminal state (success, failed, canceled, skipped, manual). Polls the pipeline status at a configurable interval and sends progress notifications. Returns the final pipeline details when done or when the timeout is reached.
 
-| Parameter           | Required | Default | Description                                    |
-| ------------------- | -------- | ------- | ---------------------------------------------- |
-| `project_id`        | Yes      | —       | Project ID or URL-encoded path                 |
-| `pipeline_id`       | Yes      | —       | Pipeline ID to wait for                        |
-| `interval_seconds`  | No       | 10      | Polling interval in seconds (5–60)             |
-| `timeout_seconds`   | No       | 300     | Maximum wait time in seconds (1–3600)          |
-| `fail_on_error`     | No       | true    | Return error if pipeline reaches a failed state |
+| Parameter          | Required | Default | Description                                     |
+| ------------------ | -------- | ------- | ----------------------------------------------- |
+| `project_id`       | Yes      | —       | Project ID or URL-encoded path                  |
+| `pipeline_id`      | Yes      | —       | Pipeline ID to wait for                         |
+| `interval_seconds` | No       | 10      | Polling interval in seconds (5–60)              |
+| `timeout_seconds`  | No       | 300     | Maximum wait time in seconds (1–3600)           |
+| `fail_on_error`    | No       | true    | Return error if pipeline reaches a failed state |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -275,13 +275,13 @@ Delete all artifacts across an entire project. This is a destructive operation.
 
 Wait for a CI/CD job to reach a terminal state (success, failed, canceled, skipped, manual). Polls the job status at a configurable interval and sends progress notifications. Returns the final job details when done or when the timeout is reached.
 
-| Parameter           | Required | Default | Description                                 |
-| ------------------- | -------- | ------- | ------------------------------------------- |
-| `project_id`        | Yes      | —       | Project ID or URL-encoded path              |
-| `job_id`            | Yes      | —       | Job ID to wait for                          |
-| `interval_seconds`  | No       | 10      | Polling interval in seconds (5–60)          |
-| `timeout_seconds`   | No       | 300     | Maximum wait time in seconds (1–3600)       |
-| `fail_on_error`     | No       | true    | Return error if job reaches a failed state  |
+| Parameter          | Required | Default | Description                                |
+| ------------------ | -------- | ------- | ------------------------------------------ |
+| `project_id`       | Yes      | —       | Project ID or URL-encoded path             |
+| `job_id`           | Yes      | —       | Job ID to wait for                         |
+| `interval_seconds` | No       | 10      | Polling interval in seconds (5–60)         |
+| `timeout_seconds`  | No       | 300     | Maximum wait time in seconds (1–3600)      |
+| `fail_on_error`    | No       | true    | Return error if job reaches a failed state |
 
 | Annotation | **Read** |
 | ---------- | -------- |

--- a/docs/tools/custom-emoji.md
+++ b/docs/tools/custom-emoji.md
@@ -23,11 +23,11 @@ With `TOOL_SURFACE=meta`, all 3 individual tools below are consolidated into a s
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 
@@ -42,11 +42,11 @@ List all custom emoji for a GitLab group. Returns a paginated list with ID, name
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_path` | string | Yes | Group full path (e.g. `my-group`) |
-| `first` | int | No | Number of items per page (default: 20) |
-| `after` | string | No | Cursor for forward pagination |
+| Parameter    | Type   | Required | Description                            |
+| ------------ | ------ | :------: | -------------------------------------- |
+| `group_path` | string |   Yes    | Group full path (e.g. `my-group`)      |
+| `first`      | int    |    No    | Number of items per page (default: 20) |
+| `after`      | string |    No    | Cursor for forward pagination          |
 
 ### `gitlab_create_custom_emoji`
 
@@ -55,11 +55,11 @@ Create a custom emoji in a GitLab group. Requires the group path, emoji name (wi
 | Annotation | **Create** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_path` | string | Yes | Group full path (e.g. `my-group`) |
-| `name` | string | Yes | Emoji name without colons (e.g. `party_parrot`) |
-| `url` | string | Yes | URL to the emoji image (PNG or GIF recommended) |
+| Parameter    | Type   | Required | Description                                     |
+| ------------ | ------ | :------: | ----------------------------------------------- |
+| `group_path` | string |   Yes    | Group full path (e.g. `my-group`)               |
+| `name`       | string |   Yes    | Emoji name without colons (e.g. `party_parrot`) |
+| `url`        | string |   Yes    | URL to the emoji image (PNG or GIF recommended) |
 
 ### `gitlab_delete_custom_emoji`
 
@@ -68,9 +68,9 @@ Delete a custom emoji from a GitLab group. Requires the emoji GID.
 | Annotation | **Delete** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Custom emoji GID (e.g. `gid://gitlab/CustomEmoji/1`) |
+| Parameter | Type   | Required | Description                                          |
+| --------- | ------ | :------: | ---------------------------------------------------- |
+| `id`      | string |   Yes    | Custom emoji GID (e.g. `gid://gitlab/CustomEmoji/1`) |
 
 > **Destructive**: Requires user confirmation before execution. The emoji will be removed from all projects in the group.
 

--- a/docs/tools/enterprise-attestations.md
+++ b/docs/tools/enterprise-attestations.md
@@ -9,12 +9,12 @@ or direct group management.
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_list_enterprise_users` | List all enterprise users for a group | Read-only |
-| `gitlab_get_enterprise_user` | Get details of a specific enterprise user | Read-only |
-| `gitlab_disable_2fa_enterprise_user` | Disable two-factor authentication for a user | Update |
-| `gitlab_delete_enterprise_user` | Delete an enterprise user (soft or hard delete) | Destructive |
+| Tool                                 | Description                                     | Annotations |
+| ------------------------------------ | ----------------------------------------------- | ----------- |
+| `gitlab_list_enterprise_users`       | List all enterprise users for a group           | Read-only   |
+| `gitlab_get_enterprise_user`         | Get details of a specific enterprise user       | Read-only   |
+| `gitlab_disable_2fa_enterprise_user` | Disable two-factor authentication for a user    | Update      |
+| `gitlab_delete_enterprise_user`      | Delete an enterprise user (soft or hard delete) | Destructive |
 
 ### Meta-tool
 
@@ -70,26 +70,26 @@ Hard delete a user:
 
 #### List
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `username` | string | No | Filter by exact username |
-| `search` | string | No | Search by name, username, or email |
-| `active` | bool | No | Filter for active users |
-| `blocked` | bool | No | Filter for blocked users |
-| `created_after` | string | No | ISO 8601 date filter |
-| `created_before` | string | No | ISO 8601 date filter |
-| `two_factor` | string | No | Filter by 2FA: `enabled` or `disabled` |
-| `page` | int | No | Page number |
-| `per_page` | int | No | Items per page (max 100) |
+| Parameter        | Type       | Required | Description                            |
+| ---------------- | ---------- | -------- | -------------------------------------- |
+| `group_id`       | string/int | Yes      | Group ID or URL-encoded path           |
+| `username`       | string     | No       | Filter by exact username               |
+| `search`         | string     | No       | Search by name, username, or email     |
+| `active`         | bool       | No       | Filter for active users                |
+| `blocked`        | bool       | No       | Filter for blocked users               |
+| `created_after`  | string     | No       | ISO 8601 date filter                   |
+| `created_before` | string     | No       | ISO 8601 date filter                   |
+| `two_factor`     | string     | No       | Filter by 2FA: `enabled` or `disabled` |
+| `page`           | int        | No       | Page number                            |
+| `per_page`       | int        | No       | Items per page (max 100)               |
 
 #### Get / Disable 2FA / Delete
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `user_id` | int | Yes | User ID |
-| `hard_delete` | bool | No | Permanently delete (delete only) |
+| Parameter     | Type       | Required | Description                      |
+| ------------- | ---------- | -------- | -------------------------------- |
+| `group_id`    | string/int | Yes      | Group ID or URL-encoded path     |
+| `user_id`     | int        | Yes      | User ID                          |
+| `hard_delete` | bool       | No       | Permanently delete (delete only) |
 
 ---
 
@@ -100,10 +100,10 @@ information for CI/CD builds. They are scoped to a project and identified by sub
 
 ### Tools
 
-| Tool | Description | Annotations |
-| --- | --- | --- |
-| `gitlab_list_attestations` | List attestations matching a subject digest | Read-only |
-| `gitlab_download_attestation` | Download attestation content (base64-encoded) | Read-only |
+| Tool                          | Description                                   | Annotations |
+| ----------------------------- | --------------------------------------------- | ----------- |
+| `gitlab_list_attestations`    | List attestations matching a subject digest   | Read-only   |
+| `gitlab_download_attestation` | Download attestation content (base64-encoded) | Read-only   |
 
 ### Meta-tool
 
@@ -137,24 +137,24 @@ Download an attestation:
 
 #### List
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `project_id` | string/int | Yes | Project ID or URL-encoded path |
-| `subject_digest` | string | Yes | Subject digest hash to filter attestations |
+| Parameter        | Type       | Required | Description                                |
+| ---------------- | ---------- | -------- | ------------------------------------------ |
+| `project_id`     | string/int | Yes      | Project ID or URL-encoded path             |
+| `subject_digest` | string     | Yes      | Subject digest hash to filter attestations |
 
 #### Download
 
-| Parameter | Type | Required | Description |
-| --- | --- | --- | --- |
-| `project_id` | string/int | Yes | Project ID or URL-encoded path |
-| `attestation_iid` | int | Yes | Attestation IID (project-scoped) |
+| Parameter         | Type       | Required | Description                      |
+| ----------------- | ---------- | -------- | -------------------------------- |
+| `project_id`      | string/int | Yes      | Project ID or URL-encoded path   |
+| `attestation_iid` | int        | Yes      | Attestation IID (project-scoped) |
 
 ### Response
 
 The download tool returns:
 
-| Field | Description |
-| --- | --- |
+| Field             | Description                           |
+| ----------------- | ------------------------------------- |
 | `attestation_iid` | The IID of the downloaded attestation |
-| `size` | Size in bytes |
-| `content_base64` | Base64-encoded binary content |
+| `size`            | Size in bytes                         |
+| `content_base64`  | Base64-encoded binary content         |

--- a/docs/tools/environments.md
+++ b/docs/tools/environments.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the 23 individual tools below are consolidated into on
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/epics.md
+++ b/docs/tools/epics.md
@@ -35,12 +35,12 @@ Epics require GitLab Premium or Ultimate and are always scoped to a group.
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 ---
 

--- a/docs/tools/geo-model-registry.md
+++ b/docs/tools/geo-model-registry.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the individual tools below are consolidated into two m
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 ---
 
@@ -36,39 +36,39 @@ With `TOOL_SURFACE=meta`, the individual tools below are consolidated into two m
 
 ### gitlab_create_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Create |
+| Property      | Value                             |
+| ------------- | --------------------------------- |
+| **Action**    | Create                            |
 | **Meta-tool** | `gitlab_geo` → `action: "create"` |
 
 Create a new Geo replication site.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `name` | string | — | Unique name of the Geo site |
-| `url` | string | — | External URL of the Geo site |
-| `primary` | bool | — | Whether this is a primary site |
-| `enabled` | bool | — | Whether the site is enabled |
-| `internal_url` | string | — | Internal URL of the Geo site |
-| `files_max_capacity` | int64 | — | Max LFS/attachment backfill downloads |
-| `repos_max_capacity` | int64 | — | Max concurrent repository backfill syncs |
-| `verification_max_capacity` | int64 | — | Max concurrent verification jobs |
-| `container_repositories_max_capacity` | int64 | — | Max concurrent container repository syncs |
-| `sync_object_storage` | bool | — | Whether to sync object-stored data |
-| `selective_sync_type` | string | — | Selective sync type: `namespaces` or `shards` |
-| `selective_sync_shards` | []string | — | Storage shards to sync |
-| `selective_sync_namespace_ids` | []int64 | — | Namespace IDs to sync |
-| `minimum_reverification_interval` | int64 | — | Minimum interval (days) before re-verification |
+| Name                                  | Type     | Required | Description                                    |
+| ------------------------------------- | -------- | :------: | ---------------------------------------------- |
+| `name`                                | string   |    —     | Unique name of the Geo site                    |
+| `url`                                 | string   |    —     | External URL of the Geo site                   |
+| `primary`                             | bool     |    —     | Whether this is a primary site                 |
+| `enabled`                             | bool     |    —     | Whether the site is enabled                    |
+| `internal_url`                        | string   |    —     | Internal URL of the Geo site                   |
+| `files_max_capacity`                  | int64    |    —     | Max LFS/attachment backfill downloads          |
+| `repos_max_capacity`                  | int64    |    —     | Max concurrent repository backfill syncs       |
+| `verification_max_capacity`           | int64    |    —     | Max concurrent verification jobs               |
+| `container_repositories_max_capacity` | int64    |    —     | Max concurrent container repository syncs      |
+| `sync_object_storage`                 | bool     |    —     | Whether to sync object-stored data             |
+| `selective_sync_type`                 | string   |    —     | Selective sync type: `namespaces` or `shards`  |
+| `selective_sync_shards`               | []string |    —     | Storage shards to sync                         |
+| `selective_sync_namespace_ids`        | []int64  |    —     | Namespace IDs to sync                          |
+| `minimum_reverification_interval`     | int64    |    —     | Minimum interval (days) before re-verification |
 
 ---
 
 ### gitlab_list_geo_sites
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Read |
+| Property      | Value                           |
+| ------------- | ------------------------------- |
+| **Action**    | Read                            |
 | **Meta-tool** | `gitlab_geo` → `action: "list"` |
 
 List all Geo replication sites with pagination.
@@ -79,81 +79,81 @@ List all Geo replication sites with pagination.
 
 ### gitlab_get_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Read |
+| Property      | Value                          |
+| ------------- | ------------------------------ |
+| **Action**    | Read                           |
 | **Meta-tool** | `gitlab_geo` → `action: "get"` |
 
 Get configuration of a specific Geo site by ID.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `id` | int64 | ✅ | Numeric ID of the Geo site |
+| Name | Type  | Required | Description                |
+| ---- | ----- | :------: | -------------------------- |
+| `id` | int64 |    ✅     | Numeric ID of the Geo site |
 
 ---
 
 ### gitlab_edit_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Update |
+| Property      | Value                           |
+| ------------- | ------------------------------- |
+| **Action**    | Update                          |
 | **Meta-tool** | `gitlab_geo` → `action: "edit"` |
 
 Update configuration of an existing Geo site.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `id` | int64 | ✅ | Numeric ID of the Geo site |
-| `name` | string | — | Unique name of the Geo site |
-| `url` | string | — | External URL |
-| `enabled` | bool | — | Whether the site is enabled |
-| _(plus other fields from create, except `primary` and `sync_object_storage`)_ | | | |
+| Name                                                                          | Type   | Required | Description                 |
+| ----------------------------------------------------------------------------- | ------ | :------: | --------------------------- |
+| `id`                                                                          | int64  |    ✅     | Numeric ID of the Geo site  |
+| `name`                                                                        | string |    —     | Unique name of the Geo site |
+| `url`                                                                         | string |    —     | External URL                |
+| `enabled`                                                                     | bool   |    —     | Whether the site is enabled |
+| _(plus other fields from create, except `primary` and `sync_object_storage`)_ |        |          |                             |
 
 ---
 
 ### gitlab_delete_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Delete |
+| Property      | Value                             |
+| ------------- | --------------------------------- |
+| **Action**    | Delete                            |
 | **Meta-tool** | `gitlab_geo` → `action: "delete"` |
 
 Delete a Geo replication site. Protected by confirmation prompt.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `id` | int64 | ✅ | Numeric ID of the Geo site |
+| Name | Type  | Required | Description                |
+| ---- | ----- | :------: | -------------------------- |
+| `id` | int64 |    ✅     | Numeric ID of the Geo site |
 
 ---
 
 ### gitlab_repair_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Update |
+| Property      | Value                             |
+| ------------- | --------------------------------- |
+| **Action**    | Update                            |
 | **Meta-tool** | `gitlab_geo` → `action: "repair"` |
 
 Repair the OAuth authentication of a Geo site.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `id` | int64 | ✅ | Numeric ID of the Geo site |
+| Name | Type  | Required | Description                |
+| ---- | ----- | :------: | -------------------------- |
+| `id` | int64 |    ✅     | Numeric ID of the Geo site |
 
 ---
 
 ### gitlab_list_status_all_geo_sites
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Read |
+| Property      | Value                                  |
+| ------------- | -------------------------------------- |
+| **Action**    | Read                                   |
 | **Meta-tool** | `gitlab_geo` → `action: "list_status"` |
 
 Retrieve replication status of all Geo sites.
@@ -164,18 +164,18 @@ Retrieve replication status of all Geo sites.
 
 ### gitlab_get_status_geo_site
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Read |
+| Property      | Value                                 |
+| ------------- | ------------------------------------- |
+| **Action**    | Read                                  |
 | **Meta-tool** | `gitlab_geo` → `action: "get_status"` |
 
 Retrieve replication status of a specific Geo site.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `id` | int64 | ✅ | Numeric ID of the Geo site |
+| Name | Type  | Required | Description                |
+| ---- | ----- | :------: | -------------------------- |
+| `id` | int64 |    ✅     | Numeric ID of the Geo site |
 
 ---
 
@@ -183,18 +183,18 @@ Retrieve replication status of a specific Geo site.
 
 ### gitlab_download_ml_model_package
 
-| Property | Value |
-| -------- | ----- |
-| **Action** | Read |
+| Property      | Value                                          |
+| ------------- | ---------------------------------------------- |
+| **Action**    | Read                                           |
 | **Meta-tool** | `gitlab_model_registry` → `action: "download"` |
 
 Download a machine learning model package file. Returns the file content as base64-encoded data.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| ---- | ---- | :------: | ----------- |
-| `project_id` | string/int | ✅ | Project ID or URL-encoded path |
-| `model_version_id` | string/int | ✅ | Model version ID (numeric or string like `candidate:5`) |
-| `path` | string | ✅ | Path within the model package |
-| `filename` | string | ✅ | Name of the file to download |
+| Name               | Type       | Required | Description                                             |
+| ------------------ | ---------- | :------: | ------------------------------------------------------- |
+| `project_id`       | string/int |    ✅     | Project ID or URL-encoded path                          |
+| `model_version_id` | string/int |    ✅     | Model version ID (numeric or string like `candidate:5`) |
+| `path`             | string     |    ✅     | Path within the model package                           |
+| `filename`         | string     |    ✅     | Name of the file to download                            |

--- a/docs/tools/groups.md
+++ b/docs/tools/groups.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the 61 individual tools below are consolidated into do
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/identity-security.md
+++ b/docs/tools/identity-security.md
@@ -25,12 +25,12 @@ With `TOOL_SURFACE=meta` and the Enterprise/Premium catalog enabled, the 20 indi
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 
@@ -42,9 +42,9 @@ Tools marked **Delete** require user confirmation before execution.
 
 List all SCIM identities for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -52,10 +52,10 @@ List all SCIM identities for a group.
 
 Get a single SCIM identity by external UID.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `uid` | string | Yes | SCIM external UID |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `uid`      | string     |   Yes    | SCIM external UID            |
 
 **Annotation**: Read
 
@@ -63,11 +63,11 @@ Get a single SCIM identity by external UID.
 
 Update a SCIM identity's external UID.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `uid` | string | Yes | Current SCIM external UID |
-| `extern_uid` | string | Yes | New external UID value |
+| Parameter    | Type       | Required | Description                  |
+| ------------ | ---------- | :------: | ---------------------------- |
+| `group_id`   | string/int |   Yes    | Group ID or URL-encoded path |
+| `uid`        | string     |   Yes    | Current SCIM external UID    |
+| `extern_uid` | string     |   Yes    | New external UID value       |
 
 **Annotation**: Update
 
@@ -75,10 +75,10 @@ Update a SCIM identity's external UID.
 
 Delete a SCIM identity from a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `uid` | string | Yes | SCIM external UID |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `uid`      | string     |   Yes    | SCIM external UID            |
 
 **Annotation**: Delete
 
@@ -90,9 +90,9 @@ Delete a SCIM identity from a group.
 
 List SSH certificates for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -100,11 +100,11 @@ List SSH certificates for a group.
 
 Create an SSH certificate for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `key` | string | Yes | SSH public key |
-| `title` | string | Yes | Certificate title |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `key`      | string     |   Yes    | SSH public key               |
+| `title`    | string     |   Yes    | Certificate title            |
 
 **Annotation**: Create
 
@@ -112,10 +112,10 @@ Create an SSH certificate for a group.
 
 Delete an SSH certificate from a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `certificate_id` | int | Yes | SSH certificate ID |
+| Parameter        | Type       | Required | Description                  |
+| ---------------- | ---------- | :------: | ---------------------------- |
+| `group_id`       | string/int |   Yes    | Group ID or URL-encoded path |
+| `certificate_id` | int        |   Yes    | SSH certificate ID           |
 
 **Annotation**: Delete
 
@@ -127,9 +127,9 @@ Delete an SSH certificate from a group.
 
 Get all security settings for a project (secret push protection, pre-receive, etc.).
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string/int | Yes | Project ID or URL-encoded path |
+| Parameter    | Type       | Required | Description                    |
+| ------------ | ---------- | :------: | ------------------------------ |
+| `project_id` | string/int |   Yes    | Project ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -137,10 +137,10 @@ Get all security settings for a project (secret push protection, pre-receive, et
 
 Enable or disable secret push protection for a project.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | string/int | Yes | Project ID or URL-encoded path |
-| `secret_push_protection_enabled` | bool | Yes | Whether to enable secret push protection |
+| Parameter                        | Type       | Required | Description                              |
+| -------------------------------- | ---------- | :------: | ---------------------------------------- |
+| `project_id`                     | string/int |   Yes    | Project ID or URL-encoded path           |
+| `secret_push_protection_enabled` | bool       |   Yes    | Whether to enable secret push protection |
 
 **Annotation**: Update
 
@@ -148,11 +148,11 @@ Enable or disable secret push protection for a project.
 
 Enable or disable secret push protection for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `secret_push_protection_enabled` | bool | Yes | Whether to enable secret push protection |
-| `projects_to_exclude` | []int | No | Project IDs to exclude from the setting |
+| Parameter                        | Type       | Required | Description                              |
+| -------------------------------- | ---------- | :------: | ---------------------------------------- |
+| `group_id`                       | string/int |   Yes    | Group ID or URL-encoded path             |
+| `secret_push_protection_enabled` | bool       |   Yes    | Whether to enable secret push protection |
+| `projects_to_exclude`            | []int      |    No    | Project IDs to exclude from the setting  |
 
 **Annotation**: Update
 
@@ -172,12 +172,12 @@ No parameters required.
 
 Create a custom member role at instance level.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `name` | string | Yes | Role name |
-| `base_access_level` | int | Yes | Base access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
-| `description` | string | No | Role description |
-| `permissions` | object | No | Permission overrides (20 boolean fields) |
+| Parameter           | Type   | Required | Description                                                                      |
+| ------------------- | ------ | :------: | -------------------------------------------------------------------------------- |
+| `name`              | string |   Yes    | Role name                                                                        |
+| `base_access_level` | int    |   Yes    | Base access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
+| `description`       | string |    No    | Role description                                                                 |
+| `permissions`       | object |    No    | Permission overrides (20 boolean fields)                                         |
 
 **Annotation**: Create
 
@@ -185,9 +185,9 @@ Create a custom member role at instance level.
 
 Delete a custom member role at instance level.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `member_role_id` | int | Yes | Member role ID |
+| Parameter        | Type | Required | Description    |
+| ---------------- | ---- | :------: | -------------- |
+| `member_role_id` | int  |   Yes    | Member role ID |
 
 **Annotation**: Delete
 
@@ -195,9 +195,9 @@ Delete a custom member role at instance level.
 
 List custom member roles for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -205,13 +205,13 @@ List custom member roles for a group.
 
 Create a custom member role for a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `name` | string | Yes | Role name |
-| `base_access_level` | int | Yes | Base access level |
-| `description` | string | No | Role description |
-| `permissions` | object | No | Permission overrides |
+| Parameter           | Type       | Required | Description                  |
+| ------------------- | ---------- | :------: | ---------------------------- |
+| `group_id`          | string/int |   Yes    | Group ID or URL-encoded path |
+| `name`              | string     |   Yes    | Role name                    |
+| `base_access_level` | int        |   Yes    | Base access level            |
+| `description`       | string     |    No    | Role description             |
+| `permissions`       | object     |    No    | Permission overrides         |
 
 **Annotation**: Create
 
@@ -219,10 +219,10 @@ Create a custom member role for a group.
 
 Delete a custom member role from a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `member_role_id` | int | Yes | Member role ID |
+| Parameter        | Type       | Required | Description                  |
+| ---------------- | ---------- | :------: | ---------------------------- |
+| `group_id`       | string/int |   Yes    | Group ID or URL-encoded path |
+| `member_role_id` | int        |   Yes    | Member role ID               |
 
 **Annotation**: Delete
 
@@ -234,14 +234,14 @@ Delete a custom member role from a group.
 
 List personal access tokens managed by a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `search` | string | No | Filter tokens by name |
-| `state` | string | No | Filter by state (`active`/`inactive`) |
-| `revoked` | bool | No | Filter by revoked status |
-| `page` | int | No | Page number |
-| `per_page` | int | No | Items per page |
+| Parameter  | Type       | Required | Description                           |
+| ---------- | ---------- | :------: | ------------------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path          |
+| `search`   | string     |    No    | Filter tokens by name                 |
+| `state`    | string     |    No    | Filter by state (`active`/`inactive`) |
+| `revoked`  | bool       |    No    | Filter by revoked status              |
+| `page`     | int        |    No    | Page number                           |
+| `per_page` | int        |    No    | Items per page                        |
 
 **Annotation**: Read
 
@@ -249,11 +249,11 @@ List personal access tokens managed by a group.
 
 List SSH keys managed by a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `page` | int | No | Page number |
-| `per_page` | int | No | Items per page |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `page`     | int        |    No    | Page number                  |
+| `per_page` | int        |    No    | Items per page               |
 
 **Annotation**: Read
 
@@ -261,10 +261,10 @@ List SSH keys managed by a group.
 
 Revoke a personal access token managed by a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `token_id` | int | Yes | Token ID to revoke |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `token_id` | int        |   Yes    | Token ID to revoke           |
 
 **Annotation**: Delete
 
@@ -272,10 +272,10 @@ Revoke a personal access token managed by a group.
 
 Delete an SSH key managed by a group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `key_id` | int | Yes | SSH key ID to delete |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `key_id`   | int        |   Yes    | SSH key ID to delete         |
 
 **Annotation**: Delete
 
@@ -287,9 +287,9 @@ Delete an SSH key managed by a group.
 
 List all LDAP group links for a GitLab group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -297,14 +297,14 @@ List all LDAP group links for a GitLab group.
 
 Add an LDAP group link to a GitLab group (by CN or filter).
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `cn` | string | No | LDAP Common Name (CN) |
-| `filter` | string | No | LDAP filter |
-| `group_access` | int | Yes | Access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
-| `provider` | string | Yes | LDAP provider name |
-| `member_role_id` | int | No | Custom member role ID |
+| Parameter        | Type       | Required | Description                                                                 |
+| ---------------- | ---------- | :------: | --------------------------------------------------------------------------- |
+| `group_id`       | string/int |   Yes    | Group ID or URL-encoded path                                                |
+| `cn`             | string     |    No    | LDAP Common Name (CN)                                                       |
+| `filter`         | string     |    No    | LDAP filter                                                                 |
+| `group_access`   | int        |   Yes    | Access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
+| `provider`       | string     |   Yes    | LDAP provider name                                                          |
+| `member_role_id` | int        |    No    | Custom member role ID                                                       |
 
 **Annotation**: Create
 
@@ -312,12 +312,12 @@ Add an LDAP group link to a GitLab group (by CN or filter).
 
 Delete a group LDAP link by CN or filter.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `cn` | string | No | LDAP Common Name to delete |
-| `filter` | string | No | LDAP filter to delete |
-| `provider` | string | No | LDAP provider name |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `cn`       | string     |    No    | LDAP Common Name to delete   |
+| `filter`   | string     |    No    | LDAP filter to delete        |
+| `provider` | string     |    No    | LDAP provider name           |
 
 **Annotation**: Delete
 
@@ -325,11 +325,11 @@ Delete a group LDAP link by CN or filter.
 
 Delete a group LDAP link for a specific provider.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `provider` | string | Yes | LDAP provider name |
-| `cn` | string | Yes | LDAP Common Name |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
+| `provider` | string     |   Yes    | LDAP provider name           |
+| `cn`       | string     |   Yes    | LDAP Common Name             |
 
 **Annotation**: Delete
 
@@ -341,9 +341,9 @@ Delete a group LDAP link for a specific provider.
 
 List all SAML group links for a GitLab group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
+| Parameter  | Type       | Required | Description                  |
+| ---------- | ---------- | :------: | ---------------------------- |
+| `group_id` | string/int |   Yes    | Group ID or URL-encoded path |
 
 **Annotation**: Read
 
@@ -351,10 +351,10 @@ List all SAML group links for a GitLab group.
 
 Get a single SAML group link by name.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `saml_group_name` | string | Yes | Name of the SAML group |
+| Parameter         | Type       | Required | Description                  |
+| ----------------- | ---------- | :------: | ---------------------------- |
+| `group_id`        | string/int |   Yes    | Group ID or URL-encoded path |
+| `saml_group_name` | string     |   Yes    | Name of the SAML group       |
 
 **Annotation**: Read
 
@@ -362,13 +362,13 @@ Get a single SAML group link by name.
 
 Add a SAML group link to a GitLab group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `saml_group_name` | string | Yes | Name of the SAML group |
-| `access_level` | int | Yes | Access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
-| `member_role_id` | int | No | Custom member role ID |
-| `provider` | string | No | SAML provider name |
+| Parameter         | Type       | Required | Description                                                                 |
+| ----------------- | ---------- | :------: | --------------------------------------------------------------------------- |
+| `group_id`        | string/int |   Yes    | Group ID or URL-encoded path                                                |
+| `saml_group_name` | string     |   Yes    | Name of the SAML group                                                      |
+| `access_level`    | int        |   Yes    | Access level (10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner) |
+| `member_role_id`  | int        |    No    | Custom member role ID                                                       |
+| `provider`        | string     |    No    | SAML provider name                                                          |
 
 **Annotation**: Create
 
@@ -376,10 +376,10 @@ Add a SAML group link to a GitLab group.
 
 Delete a SAML group link from a GitLab group.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_id` | string/int | Yes | Group ID or URL-encoded path |
-| `saml_group_name` | string | Yes | Name of the SAML group to delete |
+| Parameter         | Type       | Required | Description                      |
+| ----------------- | ---------- | :------: | -------------------------------- |
+| `group_id`        | string/int |   Yes    | Group ID or URL-encoded path     |
+| `saml_group_name` | string     |   Yes    | Name of the SAML group to delete |
 
 **Annotation**: Delete
 

--- a/docs/tools/integrations.md
+++ b/docs/tools/integrations.md
@@ -22,12 +22,12 @@ With `TOOL_SURFACE=meta`, integration and badge tools are consolidated into `git
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/issues.md
+++ b/docs/tools/issues.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, core issue tools (including notes, links, and work ite
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/merge-requests.md
+++ b/docs/tools/merge-requests.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, all 44 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/mirrors.md
+++ b/docs/tools/mirrors.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta` and the Enterprise/Premium catalog enabled, the 7 indiv
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/mr-review.md
+++ b/docs/tools/mr-review.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, all 19 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/notifications.md
+++ b/docs/tools/notifications.md
@@ -22,12 +22,12 @@ With `TOOL_SURFACE=meta`, the individual tools below are consolidated into four 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/orbit.md
+++ b/docs/tools/orbit.md
@@ -18,13 +18,13 @@ The upstream Orbit API is moving quickly. This MCP surface follows the latest Gi
 
 With `TOOL_SURFACE=meta`, all five individual tools below are consolidated into the `gitlab_orbit` meta-tool with an `action` parameter.
 
-| Meta-tool Action | Individual Tool | Purpose |
-| --- | --- | --- |
-| `status` | `gitlab_orbit_status` | Check Orbit service health and backend components |
-| `schema` | `gitlab_orbit_schema` | Inspect the graph ontology and optionally expand node definitions |
-| `tools` | `gitlab_orbit_tools` | Discover the live Orbit query manifest |
-| `query` | `gitlab_orbit_query` | Run a read-only Knowledge Graph query object |
-| `graph_status` | `gitlab_orbit_graph_status` | Inspect indexing status for one namespace, project, or full path |
+| Meta-tool Action | Individual Tool             | Purpose                                                           |
+| ---------------- | --------------------------- | ----------------------------------------------------------------- |
+| `status`         | `gitlab_orbit_status`       | Check Orbit service health and backend components                 |
+| `schema`         | `gitlab_orbit_schema`       | Inspect the graph ontology and optionally expand node definitions |
+| `tools`          | `gitlab_orbit_tools`        | Discover the live Orbit query manifest                            |
+| `query`          | `gitlab_orbit_query`        | Run a read-only Knowledge Graph query object                      |
+| `graph_status`   | `gitlab_orbit_graph_status` | Inspect indexing status for one namespace, project, or full path  |
 
 ### Common Questions
 
@@ -34,9 +34,9 @@ With `TOOL_SURFACE=meta`, all five individual tools below are consolidated into 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 All Orbit tools are read-only.
 

--- a/docs/tools/packages.md
+++ b/docs/tools/packages.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the package-domain tools below are consolidated into t
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/project-discovery.md
+++ b/docs/tools/project-discovery.md
@@ -20,9 +20,9 @@ The project discovery domain provides a utility tool that resolves git remote UR
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 ---
 
@@ -43,9 +43,9 @@ Supports both HTTPS and SSH remote URL formats:
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-| --- | --- | :---: | --- |
-| `remote_url` | string | Yes | Git remote URL from `.git/config` (e.g., `https://gitlab.example.com/group/project.git` or `git@gitlab.example.com:group/project.git`) |
+| Name         | Type   | Required | Description                                                                                                                            |
+| ------------ | ------ | :------: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `remote_url` | string |   Yes    | Git remote URL from `.git/config` (e.g., `https://gitlab.example.com/group/project.git` or `git@gitlab.example.com:group/project.git`) |
 
 **Returns**: Project ID, name, path, `path_with_namespace`, web URL, default branch, description, visibility, clone URLs, and the extracted path.
 
@@ -62,10 +62,10 @@ Supports both HTTPS and SSH remote URL formats:
 
 ## Related Resources
 
-| Resource | URI | Description |
-| --- | --- | --- |
+| Resource          | URI                        | Description                                                                         |
+| ----------------- | -------------------------- | ----------------------------------------------------------------------------------- |
 | `workspace_roots` | `gitlab://workspace/roots` | List workspace root directories from the MCP client to find `.git/config` locations |
-| `current_user` | `gitlab://user/current` | Confirm authentication before project discovery |
+| `current_user`    | `gitlab://user/current`    | Confirm authentication before project discovery                                     |
 
 ## Project Discovery Workflow
 

--- a/docs/tools/projects.md
+++ b/docs/tools/projects.md
@@ -24,12 +24,12 @@ With `TOOL_SURFACE=meta`, all 33 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/releases.md
+++ b/docs/tools/releases.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, all 11 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/repository.md
+++ b/docs/tools/repository.md
@@ -25,12 +25,12 @@ With `TOOL_SURFACE=meta`, all 38 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/runners.md
+++ b/docs/tools/runners.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the 22 individual tools below are consolidated into tw
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/search.md
+++ b/docs/tools/search.md
@@ -23,9 +23,9 @@ With `TOOL_SURFACE=meta`, all 10 individual tools below are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 All search tools are read-only.
 

--- a/docs/tools/security-attributes.md
+++ b/docs/tools/security-attributes.md
@@ -24,12 +24,12 @@ This domain is distinct from security findings and vulnerabilities: security att
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Create** | — | No | No | Creates one or more new attributes |
-| **Update** | — | No | Yes | Modifies metadata or project assignments |
-| **Delete** | — | Yes | Yes | Destroys an attribute; protected by confirmation |
-| **Bulk** | — | Yes | Yes | Applies, removes, or replaces assignments at scale; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                                                   |
+| ---------- | :------: | :---------: | :--------: | ----------------------------------------------------------------------------- |
+| **Create** |    —     |     No      |     No     | Creates one or more new attributes                                            |
+| **Update** |    —     |     No      |    Yes     | Modifies metadata or project assignments                                      |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys an attribute; protected by confirmation                              |
+| **Bulk**   |    —     |     Yes     |    Yes     | Applies, removes, or replaces assignments at scale; protected by confirmation |
 
 Tools marked **Delete** or **Bulk** require confirmation before execution.
 
@@ -44,11 +44,11 @@ Create one or more security attributes under an existing security category.
 | Annotation | **Create** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `namespace_id` | int | Yes | Numeric namespace ID |
-| `category_id` | int | Yes | Numeric security category ID |
-| `attributes` | array | Yes | Attributes to create; each item has `name`, `description`, and `color` |
+| Parameter      | Type  | Required | Description                                                            |
+| -------------- | ----- | :------: | ---------------------------------------------------------------------- |
+| `namespace_id` | int   |   Yes    | Numeric namespace ID                                                   |
+| `category_id`  | int   |   Yes    | Numeric security category ID                                           |
+| `attributes`   | array |   Yes    | Attributes to create; each item has `name`, `description`, and `color` |
 
 ### `gitlab_update_security_attribute`
 
@@ -57,12 +57,12 @@ Update a security attribute name, description, or color.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `attribute_id` | int | Yes | Numeric security attribute ID |
-| `name` | string | No | New attribute name |
-| `description` | string | No | New attribute description |
-| `color` | string | No | New color as a hex code, such as `#FF0000` |
+| Parameter      | Type   | Required | Description                                |
+| -------------- | ------ | :------: | ------------------------------------------ |
+| `attribute_id` | int    |   Yes    | Numeric security attribute ID              |
+| `name`         | string |    No    | New attribute name                         |
+| `description`  | string |    No    | New attribute description                  |
+| `color`        | string |    No    | New color as a hex code, such as `#FF0000` |
 
 At least one of `name`, `description`, or `color` must be provided.
 
@@ -73,9 +73,9 @@ Delete a custom security attribute.
 | Annotation | **Delete** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `attribute_id` | int | Yes | Numeric security attribute ID |
+| Parameter      | Type | Required | Description                   |
+| -------------- | ---- | :------: | ----------------------------- |
+| `attribute_id` | int  |   Yes    | Numeric security attribute ID |
 
 > **Destructive**: Protected by confirmation prompt.
 
@@ -86,11 +86,11 @@ Add or remove security attributes on a project.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_id` | int | Yes | Numeric project ID |
-| `add_attribute_ids` | int[] | No | Security attribute IDs to add |
-| `remove_attribute_ids` | int[] | No | Security attribute IDs to remove |
+| Parameter              | Type  | Required | Description                      |
+| ---------------------- | ----- | :------: | -------------------------------- |
+| `project_id`           | int   |   Yes    | Numeric project ID               |
+| `add_attribute_ids`    | int[] |    No    | Security attribute IDs to add    |
+| `remove_attribute_ids` | int[] |    No    | Security attribute IDs to remove |
 
 At least one of `add_attribute_ids` or `remove_attribute_ids` must be provided.
 
@@ -101,12 +101,12 @@ Add, remove, or replace security attributes across multiple groups and projects.
 | Annotation | **Bulk** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `group_ids` | int[] | No | Numeric group IDs to update |
-| `project_ids` | int[] | No | Numeric project IDs to update |
-| `attribute_ids` | int[] | Yes | Security attribute IDs to apply |
-| `mode` | string | Yes | Bulk mode: `ADD`, `REMOVE`, or `REPLACE` |
+| Parameter       | Type   | Required | Description                              |
+| --------------- | ------ | :------: | ---------------------------------------- |
+| `group_ids`     | int[]  |    No    | Numeric group IDs to update              |
+| `project_ids`   | int[]  |    No    | Numeric project IDs to update            |
+| `attribute_ids` | int[]  |   Yes    | Security attribute IDs to apply          |
+| `mode`          | string |   Yes    | Bulk mode: `ADD`, `REMOVE`, or `REPLACE` |
 
 At least one of `group_ids` or `project_ids` must be provided.
 

--- a/docs/tools/security-categories.md
+++ b/docs/tools/security-categories.md
@@ -24,11 +24,11 @@ Use security categories before creating security attributes. Use security attrib
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Create** | — | No | No | Creates a new category |
-| **Update** | — | No | Yes | Modifies an existing category |
-| **Delete** | — | Yes | Yes | Destroys a category and its attributes; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                                       |
+| ---------- | :------: | :---------: | :--------: | ----------------------------------------------------------------- |
+| **Create** |    —     |     No      |     No     | Creates a new category                                            |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing category                                     |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a category and its attributes; protected by confirmation |
 
 Tools marked **Delete** require confirmation before execution.
 
@@ -43,12 +43,12 @@ Create a security category in a namespace.
 | Annotation | **Create** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `namespace_id` | int | Yes | Numeric namespace ID |
-| `name` | string | Yes | Category name |
-| `description` | string | No | Category description |
-| `multiple_selection` | bool | No | Whether multiple attributes can be selected for the category |
+| Parameter            | Type   | Required | Description                                                  |
+| -------------------- | ------ | :------: | ------------------------------------------------------------ |
+| `namespace_id`       | int    |   Yes    | Numeric namespace ID                                         |
+| `name`               | string |   Yes    | Category name                                                |
+| `description`        | string |    No    | Category description                                         |
+| `multiple_selection` | bool   |    No    | Whether multiple attributes can be selected for the category |
 
 ### `gitlab_update_security_category`
 
@@ -57,12 +57,12 @@ Update a security category name or description.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `category_id` | int | Yes | Numeric security category ID |
-| `namespace_id` | int | Yes | Numeric namespace ID |
-| `name` | string | No | New category name |
-| `description` | string | No | New category description |
+| Parameter      | Type   | Required | Description                  |
+| -------------- | ------ | :------: | ---------------------------- |
+| `category_id`  | int    |   Yes    | Numeric security category ID |
+| `namespace_id` | int    |   Yes    | Numeric namespace ID         |
+| `name`         | string |    No    | New category name            |
+| `description`  | string |    No    | New category description     |
 
 At least one of `name` or `description` must be provided.
 
@@ -73,9 +73,9 @@ Delete a custom security category and its associated security attributes.
 | Annotation | **Delete** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `category_id` | int | Yes | Numeric security category ID |
+| Parameter     | Type | Required | Description                  |
+| ------------- | ---- | :------: | ---------------------------- |
+| `category_id` | int  |   Yes    | Numeric security category ID |
 
 > **Destructive**: Protected by confirmation prompt because associated security attributes are also deleted.
 

--- a/docs/tools/security-findings.md
+++ b/docs/tools/security-findings.md
@@ -24,9 +24,9 @@ Security findings differ from vulnerabilities: findings are raw scan results fro
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 ---
 
@@ -39,38 +39,38 @@ List security report findings for a specific pipeline run. Supports filtering by
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_path` | string | Yes | Full path of the project (e.g. `my-group/my-project`) |
-| `pipeline_iid` | string | Yes | Pipeline IID (internal ID within the project) |
-| `severity` | string[] | No | Filter by severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`, `UNKNOWN` |
-| `confidence` | string[] | No | Filter by confidence: `CONFIRMED`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`, `EXPERIMENTAL`, `IGNORE` |
-| `scanner` | string[] | No | Filter by scanner external IDs |
-| `report_type` | string[] | No | Filter by report type: `SAST`, `DAST`, `DEPENDENCY_SCANNING`, `CONTAINER_SCANNING`, `SECRET_DETECTION`, `COVERAGE_FUZZING`, `API_FUZZING`, `CLUSTER_IMAGE_SCANNING` |
-| `first` | int | No | Number of items per page (default: 20) |
-| `after` | string | No | Cursor for forward pagination |
+| Parameter      | Type     | Required | Description                                                                                                                                                         |
+| -------------- | -------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_path` | string   |   Yes    | Full path of the project (e.g. `my-group/my-project`)                                                                                                               |
+| `pipeline_iid` | string   |   Yes    | Pipeline IID (internal ID within the project)                                                                                                                       |
+| `severity`     | string[] |    No    | Filter by severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`, `UNKNOWN`                                                                                          |
+| `confidence`   | string[] |    No    | Filter by confidence: `CONFIRMED`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`, `EXPERIMENTAL`, `IGNORE`                                                                     |
+| `scanner`      | string[] |    No    | Filter by scanner external IDs                                                                                                                                      |
+| `report_type`  | string[] |    No    | Filter by report type: `SAST`, `DAST`, `DEPENDENCY_SCANNING`, `CONTAINER_SCANNING`, `SECRET_DETECTION`, `COVERAGE_FUZZING`, `API_FUZZING`, `CLUSTER_IMAGE_SCANNING` |
+| `first`        | int      |    No    | Number of items per page (default: 20)                                                                                                                              |
+| `after`        | string   |    No    | Cursor for forward pagination                                                                                                                                       |
 
 ### Output fields
 
 Each finding includes:
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `uuid` | string | Unique identifier for the finding |
-| `name` | string | Finding name |
-| `title` | string | Human-readable title |
-| `severity` | string | Severity level |
-| `confidence` | string | Confidence level |
-| `report_type` | string | Scanner report type |
-| `scanner` | object | Scanner name, vendor, and external ID |
-| `description` | string | Detailed description |
-| `solution` | string | Recommended remediation |
-| `identifiers` | array | CVE, CWE, OWASP identifiers with URLs |
-| `location` | object | File path, line numbers (scanner-specific) |
-| `state` | string | Finding state |
-| `evidence` | object | Supporting evidence data |
-| `vulnerability_id` | string | Linked vulnerability GID (if tracked) |
-| `vulnerability_state` | string | Current state of the linked vulnerability |
+| Field                 | Type   | Description                                |
+| --------------------- | ------ | ------------------------------------------ |
+| `uuid`                | string | Unique identifier for the finding          |
+| `name`                | string | Finding name                               |
+| `title`               | string | Human-readable title                       |
+| `severity`            | string | Severity level                             |
+| `confidence`          | string | Confidence level                           |
+| `report_type`         | string | Scanner report type                        |
+| `scanner`             | object | Scanner name, vendor, and external ID      |
+| `description`         | string | Detailed description                       |
+| `solution`            | string | Recommended remediation                    |
+| `identifiers`         | array  | CVE, CWE, OWASP identifiers with URLs      |
+| `location`            | object | File path, line numbers (scanner-specific) |
+| `state`               | string | Finding state                              |
+| `evidence`            | object | Supporting evidence data                   |
+| `vulnerability_id`    | string | Linked vulnerability GID (if tracked)      |
+| `vulnerability_state` | string | Current state of the linked vulnerability  |
 
 ---
 

--- a/docs/tools/security.md
+++ b/docs/tools/security.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, feature flag and feature-flag user-list actions are co
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 
@@ -231,12 +231,12 @@ Delete a metric image from a GitLab alert.
 
 List all impersonation tokens for a GitLab user by user ID. Optionally filter by state.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `user_id` | int | Yes | GitLab user ID |
-| `state` | string | No | Filter by state: `all`/`active`/`inactive` |
-| `page` | int | No | Page number for pagination |
-| `per_page` | int | No | Items per page (max 100) |
+| Parameter  | Type   | Required | Description                                |
+| ---------- | ------ | :------: | ------------------------------------------ |
+| `user_id`  | int    |   Yes    | GitLab user ID                             |
+| `state`    | string |    No    | Filter by state: `all`/`active`/`inactive` |
+| `page`     | int    |    No    | Page number for pagination                 |
+| `per_page` | int    |    No    | Items per page (max 100)                   |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -245,10 +245,10 @@ List all impersonation tokens for a GitLab user by user ID. Optionally filter by
 
 Retrieve a specific impersonation token by user ID and token ID.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `user_id` | int | Yes | GitLab user ID |
-| `token_id` | int | Yes | Impersonation token ID |
+| Parameter  | Type | Required | Description            |
+| ---------- | ---- | :------: | ---------------------- |
+| `user_id`  | int  |   Yes    | GitLab user ID         |
+| `token_id` | int  |   Yes    | Impersonation token ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -257,12 +257,12 @@ Retrieve a specific impersonation token by user ID and token ID.
 
 Create an impersonation token for a GitLab user (admin only). Requires user ID, token name, and scopes.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `user_id` | int | Yes | GitLab user ID |
-| `name` | string | Yes | Name of the impersonation token |
-| `scopes` | []string | Yes | Array of scopes (api, read_user, read_api, read_repository, write_repository, etc.) |
-| `expires_at` | string | No | Token expiration date (YYYY-MM-DD) |
+| Parameter    | Type     | Required | Description                                                                         |
+| ------------ | -------- | :------: | ----------------------------------------------------------------------------------- |
+| `user_id`    | int      |   Yes    | GitLab user ID                                                                      |
+| `name`       | string   |   Yes    | Name of the impersonation token                                                     |
+| `scopes`     | []string |   Yes    | Array of scopes (api, read_user, read_api, read_repository, write_repository, etc.) |
+| `expires_at` | string   |    No    | Token expiration date (YYYY-MM-DD)                                                  |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -271,10 +271,10 @@ Create an impersonation token for a GitLab user (admin only). Requires user ID, 
 
 Revoke an impersonation token for a GitLab user (admin only).
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `user_id` | int | Yes | GitLab user ID |
-| `token_id` | int | Yes | Impersonation token ID to revoke |
+| Parameter  | Type | Required | Description                      |
+| ---------- | ---- | :------: | -------------------------------- |
+| `user_id`  | int  |   Yes    | GitLab user ID                   |
+| `token_id` | int  |   Yes    | Impersonation token ID to revoke |
 
 | Annotation | **Delete** |
 | ---------- | ---------- |
@@ -285,13 +285,13 @@ Revoke an impersonation token for a GitLab user (admin only).
 
 Create a personal access token for a specific GitLab user (admin only). Requires user ID, token name, and scopes.
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `user_id` | int | Yes | GitLab user ID |
-| `name` | string | Yes | Name of the personal access token |
-| `scopes` | []string | Yes | Array of scopes |
-| `description` | string | No | Description for the token |
-| `expires_at` | string | No | Token expiration date (YYYY-MM-DD) |
+| Parameter     | Type     | Required | Description                        |
+| ------------- | -------- | :------: | ---------------------------------- |
+| `user_id`     | int      |   Yes    | GitLab user ID                     |
+| `name`        | string   |   Yes    | Name of the personal access token  |
+| `scopes`      | []string |   Yes    | Array of scopes                    |
+| `description` | string   |    No    | Description for the token          |
+| `expires_at`  | string   |    No    | Token expiration date (YYYY-MM-DD) |
 
 | Annotation | **Create** |
 | ---------- | ---------- |

--- a/docs/tools/snippets.md
+++ b/docs/tools/snippets.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the 26 individual tools below are consolidated into th
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/storage-moves.md
+++ b/docs/tools/storage-moves.md
@@ -25,10 +25,10 @@ With `TOOL_SURFACE=meta`, repository storage move tools are consolidated into a 
 
 ### Annotation Legend
 
-| Annotation   | ReadOnly | Destructive | Idempotent | Description                     |
-| ------------ | :------: | :---------: | :--------: | ------------------------------- |
-| **Read**     |   Yes    |     No      |    Yes     | Safe read-only operation        |
-| **Create**   |    —     |     No      |     —      | Schedules a new storage move    |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                  |
+| ---------- | :------: | :---------: | :--------: | ---------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation     |
+| **Create** |    —     |     No      |     —      | Schedules a new storage move |
 
 ---
 
@@ -38,10 +38,10 @@ With `TOOL_SURFACE=meta`, repository storage move tools are consolidated into a 
 
 Retrieve all project repository storage moves (admin only). Returns a paginated list of all project storage moves across the instance.
 
-| Parameter  | Type | Required | Description          |
-| ---------- | ---- | :------: | -------------------- |
-| `page`     | int  |    —     | Page number          |
-| `per_page` | int  |    —     | Results per page     |
+| Parameter  | Type | Required | Description      |
+| ---------- | ---- | :------: | ---------------- |
+| `page`     | int  |    —     | Page number      |
+| `per_page` | int  |    —     | Results per page |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -63,9 +63,9 @@ Retrieve all repository storage moves for a specific project (admin only).
 
 Get a single project repository storage move by ID (admin only).
 
-| Parameter | Type | Required | Description       |
-| --------- | ---- | :------: | ----------------- |
-| `id`      | int  |   Yes    | Storage move ID   |
+| Parameter | Type | Required | Description     |
+| --------- | ---- | :------: | --------------- |
+| `id`      | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -74,10 +74,10 @@ Get a single project repository storage move by ID (admin only).
 
 Get a single repository storage move for a specific project (admin only).
 
-| Parameter    | Type | Required | Description      |
-| ------------ | ---- | :------: | ---------------- |
-| `project_id` | int  |   Yes    | Project ID       |
-| `id`         | int  |   Yes    | Storage move ID  |
+| Parameter    | Type | Required | Description     |
+| ------------ | ---- | :------: | --------------- |
+| `project_id` | int  |   Yes    | Project ID      |
+| `id`         | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -86,10 +86,10 @@ Get a single repository storage move for a specific project (admin only).
 
 Schedule a repository storage move for a project (admin only). Optionally specify a destination storage name.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `project_id`                 | int    |   Yes    | Project ID                     |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `project_id`               | int    |   Yes    | Project ID                |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -98,10 +98,10 @@ Schedule a repository storage move for a project (admin only). Optionally specif
 
 Schedule repository storage moves for all projects (admin only). Migrates all projects from one storage shard to another.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `source_storage_name`        | string |    —     | Source storage shard name      |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `source_storage_name`      | string |    —     | Source storage shard name |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -114,10 +114,10 @@ Schedule repository storage moves for all projects (admin only). Migrates all pr
 
 Retrieve all group repository storage moves (admin only). Returns a paginated list of all group storage moves across the instance.
 
-| Parameter  | Type | Required | Description          |
-| ---------- | ---- | :------: | -------------------- |
-| `page`     | int  |    —     | Page number          |
-| `per_page` | int  |    —     | Results per page     |
+| Parameter  | Type | Required | Description      |
+| ---------- | ---- | :------: | ---------------- |
+| `page`     | int  |    —     | Page number      |
+| `per_page` | int  |    —     | Results per page |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -139,9 +139,9 @@ Retrieve all repository storage moves for a specific group (admin only).
 
 Get a single group repository storage move by ID (admin only).
 
-| Parameter | Type | Required | Description       |
-| --------- | ---- | :------: | ----------------- |
-| `id`      | int  |   Yes    | Storage move ID   |
+| Parameter | Type | Required | Description     |
+| --------- | ---- | :------: | --------------- |
+| `id`      | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -150,10 +150,10 @@ Get a single group repository storage move by ID (admin only).
 
 Get a single repository storage move for a specific group (admin only).
 
-| Parameter  | Type | Required | Description      |
-| ---------- | ---- | :------: | ---------------- |
-| `group_id` | int  |   Yes    | Group ID         |
-| `id`       | int  |   Yes    | Storage move ID  |
+| Parameter  | Type | Required | Description     |
+| ---------- | ---- | :------: | --------------- |
+| `group_id` | int  |   Yes    | Group ID        |
+| `id`       | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -162,10 +162,10 @@ Get a single repository storage move for a specific group (admin only).
 
 Schedule a repository storage move for a group (admin only). Optionally specify a destination storage name.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `group_id`                   | int    |   Yes    | Group ID                       |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `group_id`                 | int    |   Yes    | Group ID                  |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -174,10 +174,10 @@ Schedule a repository storage move for a group (admin only). Optionally specify 
 
 Schedule repository storage moves for all groups (admin only). Migrates all groups from one storage shard to another.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `source_storage_name`        | string |    —     | Source storage shard name      |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `source_storage_name`      | string |    —     | Source storage shard name |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -190,10 +190,10 @@ Schedule repository storage moves for all groups (admin only). Migrates all grou
 
 Retrieve all snippet repository storage moves (admin only). Returns a paginated list of all snippet storage moves across the instance.
 
-| Parameter  | Type | Required | Description          |
-| ---------- | ---- | :------: | -------------------- |
-| `page`     | int  |    —     | Page number          |
-| `per_page` | int  |    —     | Results per page     |
+| Parameter  | Type | Required | Description      |
+| ---------- | ---- | :------: | ---------------- |
+| `page`     | int  |    —     | Page number      |
+| `per_page` | int  |    —     | Results per page |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -215,9 +215,9 @@ Retrieve all repository storage moves for a specific snippet (admin only).
 
 Get a single snippet repository storage move by ID (admin only).
 
-| Parameter | Type | Required | Description       |
-| --------- | ---- | :------: | ----------------- |
-| `id`      | int  |   Yes    | Storage move ID   |
+| Parameter | Type | Required | Description     |
+| --------- | ---- | :------: | --------------- |
+| `id`      | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -226,10 +226,10 @@ Get a single snippet repository storage move by ID (admin only).
 
 Get a single repository storage move for a specific snippet (admin only).
 
-| Parameter    | Type | Required | Description      |
-| ------------ | ---- | :------: | ---------------- |
-| `snippet_id` | int  |   Yes    | Snippet ID       |
-| `id`         | int  |   Yes    | Storage move ID  |
+| Parameter    | Type | Required | Description     |
+| ------------ | ---- | :------: | --------------- |
+| `snippet_id` | int  |   Yes    | Snippet ID      |
+| `id`         | int  |   Yes    | Storage move ID |
 
 | Annotation | **Read** |
 | ---------- | -------- |
@@ -238,10 +238,10 @@ Get a single repository storage move for a specific snippet (admin only).
 
 Schedule a repository storage move for a snippet (admin only). Optionally specify a destination storage name.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `snippet_id`                 | int    |   Yes    | Snippet ID                     |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `snippet_id`               | int    |   Yes    | Snippet ID                |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -250,10 +250,10 @@ Schedule a repository storage move for a snippet (admin only). Optionally specif
 
 Schedule repository storage moves for all snippets (admin only). Migrates all snippets from one storage shard to another.
 
-| Parameter                    | Type   | Required | Description                    |
-| ---------------------------- | ------ | :------: | ------------------------------ |
-| `source_storage_name`        | string |    —     | Source storage shard name      |
-| `destination_storage_name`   | string |    —     | Target storage shard name      |
+| Parameter                  | Type   | Required | Description               |
+| -------------------------- | ------ | :------: | ------------------------- |
+| `source_storage_name`      | string |    —     | Source storage shard name |
+| `destination_storage_name` | string |    —     | Target storage shard name |
 
 | Annotation | **Create** |
 | ---------- | ---------- |
@@ -266,23 +266,23 @@ With `TOOL_SURFACE=meta`, storage move tools are available through a single `git
 
 ### Action Mapping
 
-| Action                     | Equivalent Tool                                    |
-| -------------------------- | -------------------------------------------------- |
-| `retrieve_all_project`     | `gitlab_retrieve_all_project_storage_moves`        |
-| `retrieve_project`         | `gitlab_retrieve_project_storage_moves`            |
-| `get_project`              | `gitlab_get_project_storage_move`                  |
-| `get_project_for_project`  | `gitlab_get_project_storage_move_for_project`      |
-| `schedule_project`         | `gitlab_schedule_project_storage_move`             |
-| `schedule_all_project`     | `gitlab_schedule_all_project_storage_moves`        |
-| `retrieve_all_group`       | `gitlab_retrieve_all_group_storage_moves`          |
-| `retrieve_group`           | `gitlab_retrieve_group_storage_moves`              |
-| `get_group`                | `gitlab_get_group_storage_move`                    |
-| `get_group_for_group`      | `gitlab_get_group_storage_move_for_group`          |
-| `schedule_group`           | `gitlab_schedule_group_storage_move`               |
-| `schedule_all_group`       | `gitlab_schedule_all_group_storage_moves`          |
-| `retrieve_all_snippet`     | `gitlab_retrieve_all_snippet_storage_moves`        |
-| `retrieve_snippet`         | `gitlab_retrieve_snippet_storage_moves`            |
-| `get_snippet`              | `gitlab_get_snippet_storage_move`                  |
-| `get_snippet_for_snippet`  | `gitlab_get_snippet_storage_move_for_snippet`      |
-| `schedule_snippet`         | `gitlab_schedule_snippet_storage_move`             |
-| `schedule_all_snippet`     | `gitlab_schedule_all_snippet_storage_moves`        |
+| Action                    | Equivalent Tool                               |
+| ------------------------- | --------------------------------------------- |
+| `retrieve_all_project`    | `gitlab_retrieve_all_project_storage_moves`   |
+| `retrieve_project`        | `gitlab_retrieve_project_storage_moves`       |
+| `get_project`             | `gitlab_get_project_storage_move`             |
+| `get_project_for_project` | `gitlab_get_project_storage_move_for_project` |
+| `schedule_project`        | `gitlab_schedule_project_storage_move`        |
+| `schedule_all_project`    | `gitlab_schedule_all_project_storage_moves`   |
+| `retrieve_all_group`      | `gitlab_retrieve_all_group_storage_moves`     |
+| `retrieve_group`          | `gitlab_retrieve_group_storage_moves`         |
+| `get_group`               | `gitlab_get_group_storage_move`               |
+| `get_group_for_group`     | `gitlab_get_group_storage_move_for_group`     |
+| `schedule_group`          | `gitlab_schedule_group_storage_move`          |
+| `schedule_all_group`      | `gitlab_schedule_all_group_storage_moves`     |
+| `retrieve_all_snippet`    | `gitlab_retrieve_all_snippet_storage_moves`   |
+| `retrieve_snippet`        | `gitlab_retrieve_snippet_storage_moves`       |
+| `get_snippet`             | `gitlab_get_snippet_storage_move`             |
+| `get_snippet_for_snippet` | `gitlab_get_snippet_storage_move_for_snippet` |
+| `schedule_snippet`        | `gitlab_schedule_snippet_storage_move`        |
+| `schedule_all_snippet`    | `gitlab_schedule_all_snippet_storage_moves`   |

--- a/docs/tools/tags.md
+++ b/docs/tools/tags.md
@@ -23,11 +23,11 @@ With `TOOL_SURFACE=meta`, all 9 individual tools below are consolidated into a s
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/templates.md
+++ b/docs/tools/templates.md
@@ -23,9 +23,9 @@ With `TOOL_SURFACE=meta`, all 10 template tools are consolidated into a single `
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description              |
+| ---------- | :------: | :---------: | :--------: | ------------------------ |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation |
 
 ---
 

--- a/docs/tools/users.md
+++ b/docs/tools/users.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, the individual tools below are consolidated into domai
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/tools/vulnerabilities.md
+++ b/docs/tools/vulnerabilities.md
@@ -26,10 +26,10 @@ With `TOOL_SURFACE=meta`, all 8 individual tools below are consolidated into a s
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Update** | — | No | Yes | Modifies an existing resource |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                   |
+| ---------- | :------: | :---------: | :--------: | ----------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation      |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource |
 
 ---
 
@@ -42,18 +42,18 @@ List project vulnerabilities with extensive filtering support. Returns a paginat
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_path` | string | Yes | Full path of the project (e.g. `my-group/my-project`) |
-| `severity` | string[] | No | Filter by severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`, `UNKNOWN` |
-| `state` | string[] | No | Filter by state: `DETECTED`, `CONFIRMED`, `DISMISSED`, `RESOLVED` |
-| `scanner` | string[] | No | Filter by scanner external IDs |
-| `report_type` | string[] | No | Filter by report type: `SAST`, `DAST`, `DEPENDENCY_SCANNING`, `CONTAINER_SCANNING`, `SECRET_DETECTION`, `COVERAGE_FUZZING`, `API_FUZZING`, `CLUSTER_IMAGE_SCANNING` |
-| `has_issues` | bool | No | Filter by whether a linked issue exists |
-| `has_resolution` | bool | No | Filter by whether a resolution exists |
-| `sort` | string | No | Sort order: `severity_desc`, `severity_asc`, `detected_desc`, `detected_asc` |
-| `first` | int | No | Number of items per page (default: 20) |
-| `after` | string | No | Cursor for forward pagination |
+| Parameter        | Type     | Required | Description                                                                                                                                                         |
+| ---------------- | -------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_path`   | string   |   Yes    | Full path of the project (e.g. `my-group/my-project`)                                                                                                               |
+| `severity`       | string[] |    No    | Filter by severity: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFO`, `UNKNOWN`                                                                                          |
+| `state`          | string[] |    No    | Filter by state: `DETECTED`, `CONFIRMED`, `DISMISSED`, `RESOLVED`                                                                                                   |
+| `scanner`        | string[] |    No    | Filter by scanner external IDs                                                                                                                                      |
+| `report_type`    | string[] |    No    | Filter by report type: `SAST`, `DAST`, `DEPENDENCY_SCANNING`, `CONTAINER_SCANNING`, `SECRET_DETECTION`, `COVERAGE_FUZZING`, `API_FUZZING`, `CLUSTER_IMAGE_SCANNING` |
+| `has_issues`     | bool     |    No    | Filter by whether a linked issue exists                                                                                                                             |
+| `has_resolution` | bool     |    No    | Filter by whether a resolution exists                                                                                                                               |
+| `sort`           | string   |    No    | Sort order: `severity_desc`, `severity_asc`, `detected_desc`, `detected_asc`                                                                                        |
+| `first`          | int      |    No    | Number of items per page (default: 20)                                                                                                                              |
+| `after`          | string   |    No    | Cursor for forward pagination                                                                                                                                       |
 
 ### `gitlab_get_vulnerability`
 
@@ -62,9 +62,9 @@ Get full details of a single vulnerability by its GID. Returns complete vulnerab
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
+| Parameter | Type   | Required | Description                                              |
+| --------- | ------ | :------: | -------------------------------------------------------- |
+| `id`      | string |   Yes    | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
 
 ---
 
@@ -91,11 +91,11 @@ Dismiss a vulnerability with an optional comment and reason. Valid dismissal rea
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
-| `comment` | string | No | Reason for dismissal |
-| `dismissal_reason` | string | No | Structured reason: `ACCEPTABLE_RISK`, `FALSE_POSITIVE`, `MITIGATING_CONTROL`, `USED_IN_TESTS`, `NOT_APPLICABLE` |
+| Parameter          | Type   | Required | Description                                                                                                     |
+| ------------------ | ------ | :------: | --------------------------------------------------------------------------------------------------------------- |
+| `id`               | string |   Yes    | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`)                                                        |
+| `comment`          | string |    No    | Reason for dismissal                                                                                            |
+| `dismissal_reason` | string |    No    | Structured reason: `ACCEPTABLE_RISK`, `FALSE_POSITIVE`, `MITIGATING_CONTROL`, `USED_IN_TESTS`, `NOT_APPLICABLE` |
 
 ### `gitlab_confirm_vulnerability`
 
@@ -104,9 +104,9 @@ Confirm a detected vulnerability. Changes state from `DETECTED` to `CONFIRMED`.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
+| Parameter | Type   | Required | Description                                              |
+| --------- | ------ | :------: | -------------------------------------------------------- |
+| `id`      | string |   Yes    | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
 
 ### `gitlab_resolve_vulnerability`
 
@@ -115,9 +115,9 @@ Resolve a vulnerability. Changes state to `RESOLVED`.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
+| Parameter | Type   | Required | Description                                              |
+| --------- | ------ | :------: | -------------------------------------------------------- |
+| `id`      | string |   Yes    | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
 
 ### `gitlab_revert_vulnerability`
 
@@ -126,9 +126,9 @@ Revert a vulnerability back to `DETECTED` state from any other state.
 | Annotation | **Update** |
 | ---------- | ---------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `id` | string | Yes | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
+| Parameter | Type   | Required | Description                                              |
+| --------- | ------ | :------: | -------------------------------------------------------- |
+| `id`      | string |   Yes    | Vulnerability GID (e.g. `gid://gitlab/Vulnerability/42`) |
 
 ---
 
@@ -141,9 +141,9 @@ Get vulnerability severity counts for a project. Returns counts per severity lev
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_path` | string | Yes | Full path of the project (e.g. `my-group/my-project`) |
+| Parameter      | Type   | Required | Description                                           |
+| -------------- | ------ | :------: | ----------------------------------------------------- |
+| `project_path` | string |   Yes    | Full path of the project (e.g. `my-group/my-project`) |
 
 ### `gitlab_pipeline_security_summary`
 
@@ -152,10 +152,10 @@ Get the security report summary for a specific pipeline. Returns scanner-level b
 | Annotation | **Read** |
 | ---------- | -------- |
 
-| Parameter | Type | Required | Description |
-| --------- | ---- | :------: | ----------- |
-| `project_path` | string | Yes | Full path of the project (e.g. `my-group/my-project`) |
-| `pipeline_iid` | string | Yes | Pipeline IID (internal ID within the project) |
+| Parameter      | Type   | Required | Description                                           |
+| -------------- | ------ | :------: | ----------------------------------------------------- |
+| `project_path` | string |   Yes    | Full path of the project (e.g. `my-group/my-project`) |
+| `pipeline_iid` | string |   Yes    | Pipeline IID (internal ID within the project)         |
 
 ---
 

--- a/docs/tools/wikis.md
+++ b/docs/tools/wikis.md
@@ -23,12 +23,12 @@ With `TOOL_SURFACE=meta`, all 6 individual tools below are consolidated into a s
 
 ### Annotation Legend
 
-| Annotation | ReadOnly | Destructive | Idempotent | Description |
-| ---------- | :------: | :---------: | :--------: | ----------- |
-| **Read**   | Yes | No | Yes | Safe read-only operation |
-| **Create** | — | No | — | Creates a new resource |
-| **Update** | — | No | Yes | Modifies an existing resource |
-| **Delete** | — | Yes | Yes | Destroys a resource; protected by confirmation |
+| Annotation | ReadOnly | Destructive | Idempotent | Description                                    |
+| ---------- | :------: | :---------: | :--------: | ---------------------------------------------- |
+| **Read**   |   Yes    |     No      |    Yes     | Safe read-only operation                       |
+| **Create** |    —     |     No      |     —      | Creates a new resource                         |
+| **Update** |    —     |     No      |    Yes     | Modifies an existing resource                  |
+| **Delete** |    —     |     Yes     |    Yes     | Destroys a resource; protected by confirmation |
 
 Tools marked **Delete** require user confirmation before execution.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,103 +11,103 @@ Common issues and solutions for gitlab-mcp-server.
 
 ## Connection and Authentication
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `GITLAB_TOKEN is required` at startup | Token not set | Set `GITLAB_TOKEN` in `.env` or environment |
-| `401 Unauthorized` from GitLab API | Invalid or expired PAT | Generate a new token with `api` scope in GitLab → User Settings → Access Tokens |
-| `403 Forbidden` on specific operations | Token lacks required scope | Ensure the token has `api` scope (not just `read_api`) |
-| Connection refused or timeout | GitLab instance unreachable | Verify `GITLAB_URL` is reachable: `curl -s $GITLAB_URL/api/v4/version` |
+| Symptom                                | Cause                       | Solution                                                                        |
+| -------------------------------------- | --------------------------- | ------------------------------------------------------------------------------- |
+| `GITLAB_TOKEN is required` at startup  | Token not set               | Set `GITLAB_TOKEN` in `.env` or environment                                     |
+| `401 Unauthorized` from GitLab API     | Invalid or expired PAT      | Generate a new token with `api` scope in GitLab → User Settings → Access Tokens |
+| `403 Forbidden` on specific operations | Token lacks required scope  | Ensure the token has `api` scope (not just `read_api`)                          |
+| Connection refused or timeout          | GitLab instance unreachable | Verify `GITLAB_URL` is reachable: `curl -s $GITLAB_URL/api/v4/version`          |
 
 ## TLS and Certificates
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `x509: certificate signed by unknown authority` | Self-signed certificate on GitLab instance | Set `GITLAB_SKIP_TLS_VERIFY=true` in `.env` (or `--skip-tls-verify` in HTTP mode) |
-| `x509: certificate has expired` | Expired TLS certificate | Renew the certificate on the GitLab server, or use `GITLAB_SKIP_TLS_VERIFY=true` as a temporary workaround |
+| Symptom                                         | Cause                                      | Solution                                                                                                   |
+| ----------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `x509: certificate signed by unknown authority` | Self-signed certificate on GitLab instance | Set `GITLAB_SKIP_TLS_VERIFY=true` in `.env` (or `--skip-tls-verify` in HTTP mode)                          |
+| `x509: certificate has expired`                 | Expired TLS certificate                    | Renew the certificate on the GitLab server, or use `GITLAB_SKIP_TLS_VERIFY=true` as a temporary workaround |
 
 ## Tool Discovery
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| MCP client shows hundreds of individual tools instead of 33 | Individual surface selected | Set `TOOL_SURFACE=meta` to use 33 base meta-tools, 49 self-managed enterprise meta-tools, or 50 GitLab.com Enterprise meta-tools instead of the individual catalog |
-| Tool not found in `tools/list` | Tool not registered, or tool surface mismatch | Check the active tool surface. Use `TOOL_SURFACE=individual` for one tool per operation, `TOOL_SURFACE=meta` for consolidated domain meta-tools, and `TOOL_SURFACE=dynamic` for the supported low-token find/execute surface. `META_TOOLS` remains accepted only as deprecated compatibility. See [Configuration](configuration.md#tool-modes) and [Dynamic Toolset](dynamic-tools.md) for mode selection details |
-| `unknown action` in meta-tool call | Invalid `action` parameter | List valid actions by calling the meta-tool with `action: "list"` or check [Meta-Tools Reference](meta-tools.md) |
-| `json: unknown field "<name>"` from a meta-tool | Misspelled or stale parameter name in `params` | Meta-tools reject unknown keys (`DisallowUnknownFields`). Use the exact parameter names listed for the chosen `action` (e.g. `merge_request_iid`, `issue_iid`, `epic_iid`, `work_item_iid`, `snippet_id`) — see [Meta-Tools Reference](meta-tools.md) |
+| Symptom                                                     | Cause                                          | Solution                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MCP client shows hundreds of individual tools instead of 33 | Individual surface selected                    | Set `TOOL_SURFACE=meta` to use 33 base meta-tools, 49 self-managed enterprise meta-tools, or 50 GitLab.com Enterprise meta-tools instead of the individual catalog                                                                                                                                                                                                                                                |
+| Tool not found in `tools/list`                              | Tool not registered, or tool surface mismatch  | Check the active tool surface. Use `TOOL_SURFACE=individual` for one tool per operation, `TOOL_SURFACE=meta` for consolidated domain meta-tools, and `TOOL_SURFACE=dynamic` for the supported low-token find/execute surface. `META_TOOLS` remains accepted only as deprecated compatibility. See [Configuration](configuration.md#tool-modes) and [Dynamic Toolset](dynamic-tools.md) for mode selection details |
+| `unknown action` in meta-tool call                          | Invalid `action` parameter                     | List valid actions by calling the meta-tool with `action: "list"` or check [Meta-Tools Reference](meta-tools.md)                                                                                                                                                                                                                                                                                                  |
+| `json: unknown field "<name>"` from a meta-tool             | Misspelled or stale parameter name in `params` | Meta-tools reject unknown keys (`DisallowUnknownFields`). Use the exact parameter names listed for the chosen `action` (e.g. `merge_request_iid`, `issue_iid`, `epic_iid`, `work_item_iid`, `snippet_id`) — see [Meta-Tools Reference](meta-tools.md)                                                                                                                                                             |
 
 ## Pagination
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
+| Symptom                                | Cause                    | Solution                                                                    |
+| -------------------------------------- | ------------------------ | --------------------------------------------------------------------------- |
 | List results truncated (missing items) | Default `per_page` limit | Pass `per_page` (max 100) and `page` parameters to paginate through results |
-| `nextPage` field missing in response | You are on the last page | No more results available — this is expected behavior |
+| `nextPage` field missing in response   | You are on the last page | No more results available — this is expected behavior                       |
 
 ## Auto-Update
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `autoupdate: current version is required` | Binary built without version injection | Build with `make build` or add `-ldflags "-X main.version=1.2.0"` |
-| `autoupdate: repository is required` | `AUTO_UPDATE_REPO` is empty | Set `AUTO_UPDATE_REPO` or use the default value |
-| `autoupdate: creating GitHub source` | Network error reaching GitHub API | Verify network connectivity to `github.com` |
-| `autoupdate: detecting latest release` | No releases in repository, or token lacks permissions | Create a release or check token permissions |
-| Update detected but not applied | Mode is `check` only | Set `AUTO_UPDATE=true` to enable automatic application |
-| Server still runs old version after update | Binary replaced but process not restarted | Restart the server process or use `gitlab-mcp-server --shutdown` to terminate all instances |
-| Cannot replace binary (file locked) | Running instances hold the file | Run `gitlab-mcp-server --shutdown` to terminate all instances first |
+| Symptom                                    | Cause                                                 | Solution                                                                                    |
+| ------------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `autoupdate: current version is required`  | Binary built without version injection                | Build with `make build` or add `-ldflags "-X main.version=1.2.0"`                           |
+| `autoupdate: repository is required`       | `AUTO_UPDATE_REPO` is empty                           | Set `AUTO_UPDATE_REPO` or use the default value                                             |
+| `autoupdate: creating GitHub source`       | Network error reaching GitHub API                     | Verify network connectivity to `github.com`                                                 |
+| `autoupdate: detecting latest release`     | No releases in repository, or token lacks permissions | Create a release or check token permissions                                                 |
+| Update detected but not applied            | Mode is `check` only                                  | Set `AUTO_UPDATE=true` to enable automatic application                                      |
+| Server still runs old version after update | Binary replaced but process not restarted             | Restart the server process or use `gitlab-mcp-server --shutdown` to terminate all instances |
+| Cannot replace binary (file locked)        | Running instances hold the file                       | Run `gitlab-mcp-server --shutdown` to terminate all instances first                         |
 
 See [Auto-Update](auto-update.md) for full details on update modes and configuration.
 
 ## HTTP Server Mode
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `400 Bad Request` | Missing or empty token header | Send `PRIVATE-TOKEN` or `Authorization: Bearer <token>` header |
+| Symptom                                                   | Cause                                                                     | Solution                                                                                                                                     |
+| --------------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400 Bad Request`                                         | Missing or empty token header                                             | Send `PRIVATE-TOKEN` or `Authorization: Bearer <token>` header                                                                               |
 | `403 Forbidden` on HTTP POST before MCP JSON-RPC handling | Browser sent a cross-site `Origin` or `Sec-Fetch-Site: cross-site` header | Use a same-origin endpoint, call the server from a non-browser MCP client, or put a trusted same-origin reverse proxy in front of the server |
-| Pool eviction too frequent | Too many unique tokens | Increase `--max-http-clients` (default: 100) |
-| Sessions expiring unexpectedly | Idle timeout too short | Increase `--session-timeout` (default: 30m) |
+| Pool eviction too frequent                                | Too many unique tokens                                                    | Increase `--max-http-clients` (default: 100)                                                                                                 |
+| Sessions expiring unexpectedly                            | Idle timeout too short                                                    | Increase `--session-timeout` (default: 30m)                                                                                                  |
 
 See [HTTP Server Mode](http-server-mode.md) for architecture and configuration details.
 
 ## OAuth Mode (`--auth-mode=oauth`)
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| `401 Unauthorized` immediately on all requests | Token verification failed against GitLab API | Verify the token is valid: `curl -H "Authorization: Bearer $TOKEN" $GITLAB_URL/api/v4/user` |
-| `401` after working for a while | Token expired or revoked after cache entry | Token will be re-verified on next request after cache TTL expires. If persistent, generate a new token |
-| High latency on first request | OAuth cache miss — token verified against GitLab API | Expected on cold start. Subsequent requests within `--oauth-cache-ttl` (default 15m) use cache |
-| Frequent re-verifications despite cache | `--oauth-cache-ttl` set too low | Increase `--oauth-cache-ttl` (default 15m, max 2h). Check that the value was parsed correctly with `LOG_LEVEL=debug` |
-| `/.well-known/oauth-protected-resource` returns 404 | Server not running in OAuth mode | Start the server with `--auth-mode=oauth`. The metadata endpoint is only served in OAuth mode |
-| MCP client does not initiate OAuth flow | Client does not support RFC 9728 discovery, or OAuth app not configured | Configure a GitLab OAuth Application and set `clientId` in the MCP client config. See [OAuth App Setup](oauth-app-setup.md) |
-| Operations fail with insufficient `mcp` scope | DCR fallback assigned `mcp` scope instead of `api` | Configure `clientId` explicitly in the MCP client config so the correct OAuth Application (with `api` scope) is used. See [OAuth App Setup](oauth-app-setup.md) |
-| `PRIVATE-TOKEN` header rejected | Not rejected — it is auto-converted to `Authorization: Bearer` | This is expected behavior. The `NormalizeAuthHeader` middleware handles the conversion transparently |
+| Symptom                                             | Cause                                                                   | Solution                                                                                                                                                        |
+| --------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `401 Unauthorized` immediately on all requests      | Token verification failed against GitLab API                            | Verify the token is valid: `curl -H "Authorization: Bearer $TOKEN" $GITLAB_URL/api/v4/user`                                                                     |
+| `401` after working for a while                     | Token expired or revoked after cache entry                              | Token will be re-verified on next request after cache TTL expires. If persistent, generate a new token                                                          |
+| High latency on first request                       | OAuth cache miss — token verified against GitLab API                    | Expected on cold start. Subsequent requests within `--oauth-cache-ttl` (default 15m) use cache                                                                  |
+| Frequent re-verifications despite cache             | `--oauth-cache-ttl` set too low                                         | Increase `--oauth-cache-ttl` (default 15m, max 2h). Check that the value was parsed correctly with `LOG_LEVEL=debug`                                            |
+| `/.well-known/oauth-protected-resource` returns 404 | Server not running in OAuth mode                                        | Start the server with `--auth-mode=oauth`. The metadata endpoint is only served in OAuth mode                                                                   |
+| MCP client does not initiate OAuth flow             | Client does not support RFC 9728 discovery, or OAuth app not configured | Configure a GitLab OAuth Application and set `clientId` in the MCP client config. See [OAuth App Setup](oauth-app-setup.md)                                     |
+| Operations fail with insufficient `mcp` scope       | DCR fallback assigned `mcp` scope instead of `api`                      | Configure `clientId` explicitly in the MCP client config so the correct OAuth Application (with `api` scope) is used. See [OAuth App Setup](oauth-app-setup.md) |
+| `PRIVATE-TOKEN` header rejected                     | Not rejected — it is auto-converted to `Authorization: Bearer`          | This is expected behavior. The `NormalizeAuthHeader` middleware handles the conversion transparently                                                            |
 
 See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode) for the full OAuth architecture and flow diagram.
 
 ## MCP Transport (Stdio)
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| No output from server | MCP client not sending JSON-RPC to stdin | Verify the client is configured for stdio transport and sends `initialize` as the first message |
-| Garbled output or parse errors | Debug logs mixed with JSON-RPC on stdout | Ensure `LOG_LEVEL` is not `debug` in production; logs go to stderr, JSON-RPC to stdout |
-| Server exits immediately | Stdin closed prematurely | The server exits when stdin is closed — ensure the MCP client keeps the pipe open |
+| Symptom                                                                               | Cause                                                     | Solution                                                                                                                            |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| No output from server                                                                 | MCP client not sending JSON-RPC to stdin                  | Verify the client is configured for stdio transport and sends `initialize` as the first message                                     |
+| Garbled output or parse errors                                                        | Debug logs mixed with JSON-RPC on stdout                  | Ensure `LOG_LEVEL` is not `debug` in production; logs go to stderr, JSON-RPC to stdout                                              |
+| Server exits immediately                                                              | Stdin closed prematurely                                  | The server exits when stdin is closed — ensure the MCP client keeps the pipe open                                                   |
 | VS Code waits on `initialize` and Docker logs show `starting MCP server in HTTP mode` | Docker image HTTP default is running under a stdio client | Add `--http=false` after the image name in the Docker args, or change the client entry to HTTP mode with URL `http://host:8080/mcp` |
 
 ## IDE-Specific Issues
 
 ### VS Code / GitHub Copilot
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| "Tool not found" in Copilot Chat | Server not started or MCP configuration error | Check the Output panel → **MCP Logs** for errors. Verify `.vscode/mcp.json` has the correct `command` path |
-| Server does not appear in MCP status | Configuration not loaded | Run `Ctrl+Shift+P` → **MCP: List Servers** to verify. Check that the binary path is absolute and the file exists |
-| "Permission denied" on startup (Linux/macOS) | Binary not executable | Run `chmod +x /path/to/gitlab-mcp-server` |
-| Token prompt does not appear | `${input:...}` misconfigured | Ensure the `inputs` array is at the top level of `mcp.json`, not inside `servers` |
-| Server restarts repeatedly | Crash loop due to missing env vars | Check Output panel → **MCP Logs** for `GITLAB_TOKEN is required` or other startup errors |
+| Symptom                                      | Cause                                         | Solution                                                                                                         |
+| -------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| "Tool not found" in Copilot Chat             | Server not started or MCP configuration error | Check the Output panel → **MCP Logs** for errors. Verify `.vscode/mcp.json` has the correct `command` path       |
+| Server does not appear in MCP status         | Configuration not loaded                      | Run `Ctrl+Shift+P` → **MCP: List Servers** to verify. Check that the binary path is absolute and the file exists |
+| "Permission denied" on startup (Linux/macOS) | Binary not executable                         | Run `chmod +x /path/to/gitlab-mcp-server`                                                                        |
+| Token prompt does not appear                 | `${input:...}` misconfigured                  | Ensure the `inputs` array is at the top level of `mcp.json`, not inside `servers`                                |
+| Server restarts repeatedly                   | Crash loop due to missing env vars            | Check Output panel → **MCP Logs** for `GITLAB_TOKEN is required` or other startup errors                         |
 
 ### Cursor
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| Tools not listed | Configuration file not found | Verify `.cursor/mcp.json` exists and uses the `mcpServers` key (not `servers`) |
-| `${input:...}` not working | Not supported by Cursor | Use system environment variables or hardcode the token in the config file |
+| Symptom                    | Cause                        | Solution                                                                       |
+| -------------------------- | ---------------------------- | ------------------------------------------------------------------------------ |
+| Tools not listed           | Configuration file not found | Verify `.cursor/mcp.json` exists and uses the `mcpServers` key (not `servers`) |
+| `${input:...}` not working | Not supported by Cursor      | Use system environment variables or hardcode the token in the config file      |
 
 ### General IDE Tips
 
@@ -117,12 +117,12 @@ See [HTTP Server Mode — OAuth Mode](http-server-mode.md#oauth-mode) for the fu
 
 ## Output Format
 
-| Symptom | Cause | Solution |
-| --- | --- | --- |
-| Links not clickable in IDE | Your IDE does not render Markdown links from tool responses | The `next_steps` hints are also available in the JSON `structuredContent`. Your AI assistant reads these and can present clickable links in its response |
-| Raw Markdown displayed alongside formatted output | Client shows both `content` and `structuredContent` | Content is annotated `audience: ["assistant"]` — MCP clients that support annotations will hide the raw Markdown. Update your MCP client to the latest version |
-| No "Next steps" in response | Tool is used in individual or dynamic mode (not meta-tool) | Next steps appear in meta-tool mode (`TOOL_SURFACE=meta`). Individual and dynamic tools include hints in Markdown content only |
-| Error message lacks corrective suggestion | Not all errors have known corrective actions | Errors with known fixes include a `💡 Suggestion` section. The server uses `WrapErrWithHint` / `WrapErrWithStatusHint` for status-specific guidance. See [Error Handling](error-handling.md) |
+| Symptom                                           | Cause                                                       | Solution                                                                                                                                                                                    |
+| ------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Links not clickable in IDE                        | Your IDE does not render Markdown links from tool responses | The `next_steps` hints are also available in the JSON `structuredContent`. Your AI assistant reads these and can present clickable links in its response                                    |
+| Raw Markdown displayed alongside formatted output | Client shows both `content` and `structuredContent`         | Content is annotated `audience: ["assistant"]` — MCP clients that support annotations will hide the raw Markdown. Update your MCP client to the latest version                              |
+| No "Next steps" in response                       | Tool is used in individual or dynamic mode (not meta-tool)  | Next steps appear in meta-tool mode (`TOOL_SURFACE=meta`). Individual and dynamic tools include hints in Markdown content only                                                              |
+| Error message lacks corrective suggestion         | Not all errors have known corrective actions                | Errors with known fixes include a `💡 Suggestion` section. The server uses `WrapErrWithHint` / `WrapErrWithStatusHint` for status-specific guidance. See [Error Handling](error-handling.md) |
 
 See [Output Format](output-format.md) for the complete response format specification.
 

--- a/internal/docgen/markdown_tables.go
+++ b/internal/docgen/markdown_tables.go
@@ -116,9 +116,6 @@ func parseMarkdownTableRow(line string) ([]string, bool) {
 	}
 
 	cells := splitMarkdownTableCells(trimmed)
-	if len(cells) == 0 {
-		return nil, false
-	}
 	return cells, true
 }
 
@@ -126,10 +123,24 @@ func splitMarkdownTableCells(line string) []string {
 	cells := make([]string, 0, strings.Count(line, "|")+1)
 	var cell strings.Builder
 	inCode := false
-	for i := range len(line) {
+	codeDelimiterLen := 0
+	for i := 0; i < len(line); i++ {
 		ch := line[i]
 		if ch == '`' && !isEscapedAt(line, i) {
-			inCode = !inCode
+			run := 1
+			for j := i + 1; j < len(line) && line[j] == '`'; j++ {
+				run++
+			}
+			if !inCode {
+				inCode = true
+				codeDelimiterLen = run
+			} else if run == codeDelimiterLen {
+				inCode = false
+				codeDelimiterLen = 0
+			}
+			cell.WriteString(line[i : i+run])
+			i += run - 1
+			continue
 		}
 		if ch == '|' && !inCode && !isEscapedAt(line, i) {
 			cells = append(cells, strings.TrimSpace(cell.String()))

--- a/internal/docgen/markdown_tables.go
+++ b/internal/docgen/markdown_tables.go
@@ -1,0 +1,227 @@
+package docgen
+
+import (
+	"strings"
+)
+
+type markdownLine struct {
+	Raw  string
+	Text string
+	EOL  string
+}
+
+// FormatMarkdownTables normalizes GitHub-flavored Markdown pipe tables in content.
+// Tables inside fenced code blocks are left unchanged.
+func FormatMarkdownTables(content string) (string, bool) {
+	lines := splitMarkdownLines(content)
+	if len(lines) == 0 {
+		return content, false
+	}
+
+	var b strings.Builder
+	b.Grow(len(content))
+	changed := false
+	inFence := false
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		if isMarkdownFence(line.Text) {
+			inFence = !inFence
+			b.WriteString(line.Raw)
+			i++
+			continue
+		}
+
+		if !inFence && i+1 < len(lines) {
+			headers, headerOK := parseMarkdownTableRow(line.Text)
+			alignments, separatorOK := parseMarkdownTableSeparator(lines[i+1].Text, len(headers))
+			if headerOK && separatorOK {
+				rows := make([][]string, 0)
+				end := i + 2
+				for end < len(lines) {
+					if strings.TrimSpace(lines[end].Text) == "" {
+						break
+					}
+					row, ok := parseMarkdownTableRow(lines[end].Text)
+					if !ok {
+						break
+					}
+					rows = append(rows, normalizeMarkdownTableRow(row, len(headers)))
+					end++
+				}
+
+				rendered := RenderMarkdownTable(headers, alignments, rows)
+				rendered = applyMarkdownTableLineEnding(rendered, lines[i:end])
+				original := joinMarkdownLines(lines[i:end])
+				if rendered != original {
+					changed = true
+				}
+				b.WriteString(rendered)
+				i = end
+				continue
+			}
+		}
+
+		b.WriteString(line.Raw)
+		i++
+	}
+
+	if !changed {
+		return content, false
+	}
+	return b.String(), true
+}
+
+func splitMarkdownLines(content string) []markdownLine {
+	if content == "" {
+		return nil
+	}
+	parts := strings.SplitAfter(content, "\n")
+	if parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+
+	lines := make([]markdownLine, 0, len(parts))
+	for _, part := range parts {
+		line := markdownLine{Raw: part, Text: part}
+		textNoLF, okLF := strings.CutSuffix(line.Text, "\n")
+		if okLF {
+			line.Text = textNoLF
+			line.EOL = "\n"
+			textNoCR, okCR := strings.CutSuffix(line.Text, "\r")
+			if okCR {
+				line.Text = textNoCR
+				line.EOL = "\r\n"
+			}
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func isMarkdownFence(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~")
+}
+
+func parseMarkdownTableRow(line string) ([]string, bool) {
+	if !hasUnescapedPipe(line) {
+		return nil, false
+	}
+
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	if strings.HasSuffix(trimmed, "|") && !isEscapedAt(trimmed, len(trimmed)-1) {
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+
+	cells := splitMarkdownTableCells(trimmed)
+	if len(cells) == 0 {
+		return nil, false
+	}
+	return cells, true
+}
+
+func splitMarkdownTableCells(line string) []string {
+	cells := make([]string, 0, strings.Count(line, "|")+1)
+	var cell strings.Builder
+	inCode := false
+	for i := range len(line) {
+		ch := line[i]
+		if ch == '`' && !isEscapedAt(line, i) {
+			inCode = !inCode
+		}
+		if ch == '|' && !inCode && !isEscapedAt(line, i) {
+			cells = append(cells, strings.TrimSpace(cell.String()))
+			cell.Reset()
+			continue
+		}
+		cell.WriteByte(ch)
+	}
+	cells = append(cells, strings.TrimSpace(cell.String()))
+	return cells
+}
+
+func parseMarkdownTableSeparator(line string, columns int) ([]Alignment, bool) {
+	if columns == 0 {
+		return nil, false
+	}
+	cells, ok := parseMarkdownTableRow(line)
+	if !ok || len(cells) != columns {
+		return nil, false
+	}
+
+	alignments := make([]Alignment, len(cells))
+	for i, cell := range cells {
+		compact := strings.ReplaceAll(strings.TrimSpace(cell), " ", "")
+		if compact == "" {
+			return nil, false
+		}
+		leftColon := strings.HasPrefix(compact, ":")
+		rightColon := strings.HasSuffix(compact, ":")
+		marker := strings.Trim(compact, ":")
+		if len(marker) < 3 || strings.Trim(marker, "-") != "" {
+			return nil, false
+		}
+		switch {
+		case leftColon && rightColon:
+			alignments[i] = AlignCenter
+		case rightColon:
+			alignments[i] = AlignRight
+		default:
+			alignments[i] = AlignLeft
+		}
+	}
+	return alignments, true
+}
+
+func normalizeMarkdownTableRow(row []string, columns int) []string {
+	if len(row) == columns {
+		return row
+	}
+	out := make([]string, columns)
+	copy(out, row)
+	return out
+}
+
+func hasUnescapedPipe(line string) bool {
+	for i := range len(line) {
+		if line[i] == '|' && !isEscapedAt(line, i) {
+			return true
+		}
+	}
+	return false
+}
+
+func isEscapedAt(s string, index int) bool {
+	backslashes := 0
+	for i := index - 1; i >= 0 && s[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+func applyMarkdownTableLineEnding(rendered string, original []markdownLine) string {
+	if len(original) == 0 {
+		return rendered
+	}
+	eol := original[0].EOL
+	if eol == "" {
+		eol = "\n"
+	}
+	if eol != "\n" {
+		rendered = strings.ReplaceAll(rendered, "\n", eol)
+	}
+	if original[len(original)-1].EOL == "" {
+		rendered = strings.TrimSuffix(rendered, eol)
+	}
+	return rendered
+}
+
+func joinMarkdownLines(lines []markdownLine) string {
+	var b strings.Builder
+	for _, line := range lines {
+		b.WriteString(line.Raw)
+	}
+	return b.String()
+}

--- a/internal/docgen/markdown_tables_test.go
+++ b/internal/docgen/markdown_tables_test.go
@@ -1,0 +1,110 @@
+package docgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatMarkdownTables_FormatsPipeTables(t *testing.T) {
+	input := strings.Join([]string{
+		"Before",
+		"",
+		"| Name | Count | Status |",
+		"| --- | ---: | :---: |",
+		"| short | 1 | ok |",
+		"| much longer | 20 | review |",
+		"",
+		"After",
+		"",
+	}, "\n")
+	want := strings.Join([]string{
+		"Before",
+		"",
+		"| Name        | Count | Status |",
+		"| ----------- | ----: | :----: |",
+		"| short       |     1 |   ok   |",
+		"| much longer |    20 | review |",
+		"",
+		"After",
+		"",
+	}, "\n")
+
+	got, changed := FormatMarkdownTables(input)
+	if !changed {
+		t.Fatal("FormatMarkdownTables changed = false, want true")
+	}
+	if got != want {
+		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestFormatMarkdownTables_SkipsFencedCodeBlocks(t *testing.T) {
+	input := strings.Join([]string{
+		"```md",
+		"| A | B |",
+		"| --- | --- |",
+		"| unformatted | value |",
+		"```",
+		"",
+	}, "\n")
+
+	got, changed := FormatMarkdownTables(input)
+	if changed {
+		t.Fatal("FormatMarkdownTables changed fenced code block")
+	}
+	if got != input {
+		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, input)
+	}
+}
+
+func TestFormatMarkdownTables_PreservesEscapedAndCodePipes(t *testing.T) {
+	input := strings.Join([]string{
+		"| Pattern | Meaning |",
+		"| --- | --- |",
+		"| `a|b` | escaped \\| pipe |",
+		"",
+	}, "\n")
+	want := strings.Join([]string{
+		"| Pattern | Meaning         |",
+		"| ------- | --------------- |",
+		"| `a|b`   | escaped \\| pipe |",
+		"",
+	}, "\n")
+
+	got, changed := FormatMarkdownTables(input)
+	if !changed {
+		t.Fatal("FormatMarkdownTables changed = false, want true")
+	}
+	if got != want {
+		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestFormatMarkdownTables_PreservesEOFWithoutNewline(t *testing.T) {
+	input := "| A | B |\n| --- | --- |\n| one | two |"
+	want := "| A   | B   |\n| --- | --- |\n| one | two |"
+
+	got, changed := FormatMarkdownTables(input)
+	if !changed {
+		t.Fatal("FormatMarkdownTables changed = false, want true")
+	}
+	if got != want {
+		t.Fatalf("FormatMarkdownTables() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatMarkdownTables_IdempotentForFormattedTable(t *testing.T) {
+	input := RenderMarkdownTable(
+		[]string{"Name", "Count"},
+		[]Alignment{AlignLeft, AlignRight},
+		[][]string{{"alpha", "10"}},
+	)
+
+	got, changed := FormatMarkdownTables(input)
+	if changed {
+		t.Fatal("FormatMarkdownTables changed already formatted table")
+	}
+	if got != input {
+		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, input)
+	}
+}

--- a/internal/docgen/markdown_tables_test.go
+++ b/internal/docgen/markdown_tables_test.go
@@ -5,106 +5,220 @@ import (
 	"testing"
 )
 
-func TestFormatMarkdownTables_FormatsPipeTables(t *testing.T) {
-	input := strings.Join([]string{
-		"Before",
-		"",
-		"| Name | Count | Status |",
-		"| --- | ---: | :---: |",
-		"| short | 1 | ok |",
-		"| much longer | 20 | review |",
-		"",
-		"After",
-		"",
-	}, "\n")
-	want := strings.Join([]string{
-		"Before",
-		"",
-		"| Name        | Count | Status |",
-		"| ----------- | ----: | :----: |",
-		"| short       |     1 |   ok   |",
-		"| much longer |    20 | review |",
-		"",
-		"After",
-		"",
-	}, "\n")
-
-	got, changed := FormatMarkdownTables(input)
-	if !changed {
-		t.Fatal("FormatMarkdownTables changed = false, want true")
-	}
-	if got != want {
-		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, want)
-	}
-}
-
-func TestFormatMarkdownTables_SkipsFencedCodeBlocks(t *testing.T) {
-	input := strings.Join([]string{
-		"```md",
-		"| A | B |",
-		"| --- | --- |",
-		"| unformatted | value |",
-		"```",
-		"",
-	}, "\n")
-
-	got, changed := FormatMarkdownTables(input)
-	if changed {
-		t.Fatal("FormatMarkdownTables changed fenced code block")
-	}
-	if got != input {
-		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, input)
-	}
-}
-
-func TestFormatMarkdownTables_PreservesEscapedAndCodePipes(t *testing.T) {
-	input := strings.Join([]string{
-		"| Pattern | Meaning |",
-		"| --- | --- |",
-		"| `a|b` | escaped \\| pipe |",
-		"",
-	}, "\n")
-	want := strings.Join([]string{
-		"| Pattern | Meaning         |",
-		"| ------- | --------------- |",
-		"| `a|b`   | escaped \\| pipe |",
-		"",
-	}, "\n")
-
-	got, changed := FormatMarkdownTables(input)
-	if !changed {
-		t.Fatal("FormatMarkdownTables changed = false, want true")
-	}
-	if got != want {
-		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, want)
-	}
-}
-
-func TestFormatMarkdownTables_PreservesEOFWithoutNewline(t *testing.T) {
-	input := "| A | B |\n| --- | --- |\n| one | two |"
-	want := "| A   | B   |\n| --- | --- |\n| one | two |"
-
-	got, changed := FormatMarkdownTables(input)
-	if !changed {
-		t.Fatal("FormatMarkdownTables changed = false, want true")
-	}
-	if got != want {
-		t.Fatalf("FormatMarkdownTables() = %q, want %q", got, want)
-	}
-}
-
-func TestFormatMarkdownTables_IdempotentForFormattedTable(t *testing.T) {
-	input := RenderMarkdownTable(
+func TestFormatMarkdownTables_TableDriven(t *testing.T) {
+	formattedTable := RenderMarkdownTable(
 		[]string{"Name", "Count"},
 		[]Alignment{AlignLeft, AlignRight},
 		[][]string{{"alpha", "10"}},
 	)
 
-	got, changed := FormatMarkdownTables(input)
-	if changed {
-		t.Fatal("FormatMarkdownTables changed already formatted table")
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantChanged bool
+	}{
+		{
+			name: "formats pipe tables",
+			input: strings.Join([]string{
+				"Before",
+				"",
+				"| Name | Count | Status |",
+				"| --- | ---: | :---: |",
+				"| short | 1 | ok |",
+				"| much longer | 20 | review |",
+				"",
+				"After",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"Before",
+				"",
+				"| Name        | Count | Status |",
+				"| ----------- | ----: | :----: |",
+				"| short       |     1 |   ok   |",
+				"| much longer |    20 | review |",
+				"",
+				"After",
+				"",
+			}, "\n"),
+			wantChanged: true,
+		},
+		{
+			name: "skips fenced code blocks",
+			input: strings.Join([]string{
+				"```md",
+				"| A | B |",
+				"| --- | --- |",
+				"| unformatted | value |",
+				"```",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"```md",
+				"| A | B |",
+				"| --- | --- |",
+				"| unformatted | value |",
+				"```",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "preserves escaped and code pipes",
+			input: strings.Join([]string{
+				"| Pattern | Meaning |",
+				"| --- | --- |",
+				"| `a|b` | escaped \\| pipe |",
+				"| ``a|b`` | code span |",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| Pattern | Meaning         |",
+				"| ------- | --------------- |",
+				"| `a|b`   | escaped \\| pipe |",
+				"| ``a|b`` | code span       |",
+				"",
+			}, "\n"),
+			wantChanged: true,
+		},
+		{
+			name:        "preserves eof without newline",
+			input:       "| A | B |\n| --- | --- |\n| one | two |",
+			want:        "| A   | B   |\n| --- | --- |\n| one | two |",
+			wantChanged: true,
+		},
+		{
+			name: "preserves crlf line endings",
+			input: strings.Join([]string{
+				"| A | B |\r",
+				"| --- | ---: |\r",
+				"| one | 2 |\r",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A   |    B |\r",
+				"| --- | ---: |\r",
+				"| one |    2 |\r",
+				"",
+			}, "\n"),
+			wantChanged: true,
+		},
+		{
+			name: "normalizes ragged rows",
+			input: strings.Join([]string{
+				"| A | B | C |",
+				"| --- | --- | --- |",
+				"| one | two |",
+				"| extra | values | ignored | more |",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A     | B      | C       |",
+				"| ----- | ------ | ------- |",
+				"| one   | two    |         |",
+				"| extra | values | ignored |",
+				"",
+			}, "\n"),
+			wantChanged: true,
+		},
+		{
+			name: "stops table at non table content",
+			input: strings.Join([]string{
+				"| A | B |",
+				"| --- | --- |",
+				"| one | two |",
+				"not a table",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A   | B   |",
+				"| --- | --- |",
+				"| one | two |",
+				"not a table",
+				"",
+			}, "\n"),
+			wantChanged: true,
+		},
+		{
+			name:        "idempotent for formatted table",
+			input:       formattedTable,
+			want:        formattedTable,
+			wantChanged: false,
+		},
+		{
+			name:        "empty content",
+			input:       "",
+			want:        "",
+			wantChanged: false,
+		},
+		{
+			name: "leaves invalid short separator unchanged",
+			input: strings.Join([]string{
+				"| A | B |",
+				"| -- | --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A | B |",
+				"| -- | --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "leaves empty separator cell unchanged",
+			input: strings.Join([]string{
+				"| A | B |",
+				"|  | --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A | B |",
+				"|  | --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+		},
+		{
+			name: "leaves separator column mismatch unchanged",
+			input: strings.Join([]string{
+				"| A | B |",
+				"| --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+			want: strings.Join([]string{
+				"| A | B |",
+				"| --- |",
+				"| one | two |",
+				"",
+			}, "\n"),
+		},
 	}
-	if got != input {
-		t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, input)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := FormatMarkdownTables(tt.input)
+			if changed != tt.wantChanged {
+				t.Fatalf("FormatMarkdownTables changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if got != tt.want {
+				t.Fatalf("FormatMarkdownTables() =\n%s\nwant\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarkdownTableHelpers_EdgeCases(t *testing.T) {
+	if _, ok := parseMarkdownTableSeparator("| --- |", 0); ok {
+		t.Fatal("parseMarkdownTableSeparator accepted zero columns")
+	}
+	if got := applyMarkdownTableLineEnding("rendered\n", nil); got != "rendered\n" {
+		t.Fatalf("applyMarkdownTableLineEnding() = %q, want rendered newline", got)
+	}
+	if got := applyMarkdownTableLineEnding("rendered\n", []markdownLine{{Raw: "raw", Text: "raw"}}); got != "rendered" {
+		t.Fatalf("applyMarkdownTableLineEnding() = %q, want trimmed newline", got)
 	}
 }

--- a/internal/docgen/table.go
+++ b/internal/docgen/table.go
@@ -14,6 +14,8 @@ const (
 	AlignLeft Alignment = iota
 	// AlignRight pads cells on the left and uses a right-aligned separator.
 	AlignRight
+	// AlignCenter pads cells on both sides and uses a centered separator.
+	AlignCenter
 )
 
 // RenderMarkdownTable returns a Markdown table padded to the widest cell in
@@ -34,6 +36,14 @@ func RenderMarkdownTable(headers []string, alignments []Alignment, rows [][]stri
 				cell = row[i]
 			}
 			widths[i] = max(widths[i], utf8.RuneCountInString(cell))
+		}
+	}
+	for i := range widths {
+		if alignmentAt(alignments, i) == AlignRight {
+			widths[i] = max(widths[i], 4)
+		}
+		if alignmentAt(alignments, i) == AlignCenter {
+			widths[i] = max(widths[i], 5)
 		}
 	}
 
@@ -77,6 +87,11 @@ func padMarkdownTableCell(cell string, alignment Alignment, width int) string {
 	if alignment == AlignRight {
 		return spaces + cell
 	}
+	if alignment == AlignCenter {
+		left := padding / 2
+		right := padding - left
+		return strings.Repeat(" ", left) + cell + strings.Repeat(" ", right)
+	}
 	return cell + spaces
 }
 
@@ -84,6 +99,9 @@ func markdownTableSeparator(alignment Alignment, width int) string {
 	width = max(width, 3)
 	if alignment == AlignRight {
 		return strings.Repeat("-", width-1) + ":"
+	}
+	if alignment == AlignCenter {
+		return ":" + strings.Repeat("-", width-2) + ":"
 	}
 	return strings.Repeat("-", width)
 }

--- a/site/package.json
+++ b/site/package.json
@@ -25,15 +25,15 @@
   "type": "module",
   "dependencies": {
     "@astrojs/starlight": "^0.39.2",
-    "astro": "^6.3.3",
+    "astro": "^6.3.5",
     "astro-mermaid": "^2.0.1",
     "mermaid": "^11.15.0",
     "sharp": "^0.34.5"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
-    "@typescript-eslint/eslint-plugin": "^8.59.3",
-    "@typescript-eslint/parser": "^8.59.3",
+    "@typescript-eslint/eslint-plugin": "^8.59.4",
+    "@typescript-eslint/parser": "^8.59.4",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-astro": "^1.7.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -15,13 +15,13 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.39.2
-        version: 0.39.2(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)
+        version: 0.39.2(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)
       astro:
-        specifier: ^6.3.3
-        version: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
       astro-mermaid:
         specifier: ^2.0.1
-        version: 2.0.1(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(mermaid@11.15.0)
+        version: 2.0.1(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(mermaid@11.15.0)
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -33,11 +33,11 @@ importers:
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
       '@typescript-eslint/eslint-plugin':
-        specifier: ^8.59.3
-        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
+        specifier: ^8.59.4
+        version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
       '@typescript-eslint/parser':
-        specifier: ^8.59.3
-        version: 8.59.3(eslint@10.4.0)(typescript@6.0.3)
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.4.0)(typescript@6.0.3)
       eslint:
         specifier: ^10.4.0
         version: 10.4.0
@@ -64,7 +64,7 @@ importers:
         version: 14.2.6
       starlight-links-validator:
         specifier: ^0.24.0
-        version: 0.24.0(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
+        version: 0.24.0(@astrojs/starlight@0.39.2(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1001,23 +1001,23 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.59.3':
-    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
+  '@typescript-eslint/eslint-plugin@8.59.4':
+    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.3
+      '@typescript-eslint/parser': ^8.59.4
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.3':
-    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.59.3':
-    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1026,14 +1026,18 @@ packages:
     resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.59.3':
-    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.59.3':
-    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
+  '@typescript-eslint/type-utils@8.59.4':
+    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1043,14 +1047,18 @@ packages:
     resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.59.3':
-    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.3':
-    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1058,6 +1066,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.59.3':
     resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -1204,8 +1216,8 @@ packages:
       '@mermaid-js/layout-elk':
         optional: true
 
-  astro@6.3.3:
-    resolution: {integrity: sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==}
+  astro@6.3.5:
+    resolution: {integrity: sha512-gU+4KedkbTuVgz7YoVAN+9Ftnq0GaYwejxK2NbqDzB0M9dWd0f3kXZBuaM9hzbchRFoRAJfJjFtdX9LK6Ir7ZA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -2459,6 +2471,10 @@ packages:
 
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.4.0:
+    resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
     engines: {node: 20 || >=22}
 
   lru-cache@7.18.3:
@@ -3882,12 +3898,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.6(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3911,17 +3927,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.2(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
-      '@astrojs/mdx': 5.0.6(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.6(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
+      astro: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro-expressive-code: 0.42.0(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -4685,14 +4701,14 @@ snapshots:
       '@types/node': 25.8.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@10.4.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       eslint: 10.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -4701,22 +4717,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       eslint: 10.4.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4727,15 +4743,20 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/visitor-keys': 8.59.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@6.0.3)':
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 10.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -4745,12 +4766,14 @@ snapshots:
 
   '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@8.59.3(typescript@6.0.3)':
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
@@ -4760,12 +4783,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
       eslint: 10.4.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4774,6 +4797,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.59.3':
     dependencies:
       '@typescript-eslint/types': 8.59.3
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -4930,20 +4958,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-expressive-code@0.42.0(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)):
     dependencies:
-      astro: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro-mermaid@2.0.1(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(mermaid@11.15.0):
+  astro-mermaid@2.0.1(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(mermaid@11.15.0):
     dependencies:
-      astro: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.15.0
       unist-util-visit: 5.1.0
 
-  astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0):
+  astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.1
@@ -6411,6 +6439,8 @@ snapshots:
 
   lru-cache@11.3.6: {}
 
+  lru-cache@11.4.0: {}
+
   lru-cache@7.18.3: {}
 
   magic-string@0.30.21:
@@ -7687,11 +7717,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  starlight-links-validator@0.24.0(@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)):
+  starlight-links-validator@0.24.0(@astrojs/starlight@0.39.2(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3))(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)):
     dependencies:
-      '@astrojs/starlight': 0.39.2(astro@6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)
+      '@astrojs/starlight': 0.39.2(astro@6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)
       '@types/picomatch': 4.0.3
-      astro: 6.3.3(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
+      astro: 6.3.5(@types/node@25.8.0)(rollup@4.60.4)(yaml@2.9.0)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0
@@ -7952,7 +7982,7 @@ snapshots:
       chokidar: 5.0.0
       destr: 2.0.5
       h3: 1.15.11
-      lru-cache: 11.3.6
+      lru-cache: 11.4.0
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.4


### PR DESCRIPTION
## Summary

- add `cmd/format_md_tables` to normalize Markdown pipe tables in `README.md` and `docs/`
- extend `internal/docgen` table rendering with center alignment support and table formatting tests
- document the formatter in Copilot/Claude context, documentation agent guidance, and documentation skills so models use it when creating or editing tables
- format existing `README.md` and `docs/` tables with the new utility
- apply the dependency updates from #125 in `site/`: `astro` 6.3.3 -> 6.3.5 and `@typescript-eslint/{eslint-plugin,parser}` 8.59.3 -> 8.59.4

## Validation

- `go test ./internal/docgen ./cmd/format_md_tables -count=1 -cover`
- `go vet ./internal/docgen ./cmd/format_md_tables`
- `golangci-lint run ./internal/docgen ./cmd/format_md_tables`
- `go run ./cmd/format_md_tables/ --check`
- `npx markdownlint-cli2 .github/copilot-instructions.md CLAUDE.md .github/agents/documentation-writer.agent.md .github/skills/update-project-documentation/SKILL.md .github/skills/generate-project-documentation/SKILL.md`
- `cd site && pnpm run lint`
- `cd site && pnpm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Markdown table formatter CLI (includes a --check mode) to standardize README/docs tables.

* **Documentation**
  * Reflowed and normalized Markdown tables across guides, references, ADRs, and tool docs for consistent readability and alignment.

* **Chores**
  * Bumped site tooling and linting packages to newer patch versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->