### PR TITLE
Improve test speed, Godoc coverage, and duplicate helpers

### DIFF
--- a/cmd/audit_meta_schema/main.go
+++ b/cmd/audit_meta_schema/main.go
@@ -18,15 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
-	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
@@ -44,18 +41,11 @@ func main() {
 // compares the generated action parameter schemas across all supported
 // META_PARAM_SCHEMA modes.
 func run() error {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{GitLabURL: srv.URL, GitLabToken: "spike-token"}
-	client, err := gitlabclient.NewClient(cfg)
+	client, cleanup, err := auditclient.NewMock()
 	if err != nil {
 		return fmt.Errorf("client: %w", err)
 	}
+	defer cleanup()
 
 	// Build the action catalog, then register meta catalog routes on the server.
 	server := mcp.NewServer(&mcp.Implementation{Name: "spike", Version: "0"}, &mcp.ServerOptions{PageSize: 2000})

--- a/cmd/audit_metrics/main.go
+++ b/cmd/audit_metrics/main.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
@@ -23,6 +21,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
@@ -45,29 +44,19 @@ const (
 // main builds the audit client, gathers runtime counts from the registered MCP
 // surface, and prints the metrics report to stdout.
 func main() {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{
-		GitLabURL:   srv.URL,
-		GitLabToken: "audit-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, cleanup, err := auditclient.NewMock()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit
+		os.Exit(1)
 	}
+	defer cleanup()
 	gitLabComClient, err := gitlabclient.NewClient(&config.Config{ //#nosec G101 -- not a real credential, audit-only dummy token
 		GitLabURL:   config.DefaultGitLabURL,
 		GitLabToken: "audit-token",
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create gitlab.com client: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit.
 	}
 
 	individualTools := listServerTools(client, false, false)

--- a/cmd/audit_output/main.go
+++ b/cmd/audit_output/main.go
@@ -11,15 +11,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
@@ -34,22 +32,12 @@ type finding struct {
 
 // main runs the MCP tool output audit and prints a report.
 func main() {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{
-		GitLabURL:   srv.URL,
-		GitLabToken: "audit-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, cleanup, err := auditclient.NewMock()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit
+		os.Exit(1)
 	}
+	defer cleanup()
 
 	individual := listTools(client, false)
 	meta := listTools(client, true)

--- a/cmd/audit_tokens/main.go
+++ b/cmd/audit_tokens/main.go
@@ -12,8 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"sort"
 	"strconv"
@@ -22,6 +20,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
@@ -62,29 +61,19 @@ type resourceRegistrationOptions struct {
 // main creates the mock GitLab-backed client, measures all MCP catalog modes,
 // and prints token overhead comparisons for tools, resources, and prompts.
 func main() {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{
-		GitLabURL:   srv.URL,
-		GitLabToken: "audit-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, cleanup, err := auditclient.NewMock()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit
+		os.Exit(1)
 	}
+	defer cleanup()
 
 	metaBaseRoutes := buildMetaActionMaps(client, false)
 	metaEnterpriseRoutes := buildMetaActionMaps(client, true)
 	dynamicBaseCatalog, err := dynamictools.AddStandaloneCatalog(actioncatalog.FromActionMaps(metaBaseRoutes), client, dynamictools.StandaloneOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add standalone base dynamic catalog: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit.
 	}
 	dynamicEnterpriseCatalog, err := dynamictools.AddStandaloneCatalog(actioncatalog.FromActionMaps(metaEnterpriseRoutes), client, dynamictools.StandaloneOptions{})
 	if err != nil {

--- a/cmd/audit_tools/main.go
+++ b/cmd/audit_tools/main.go
@@ -11,8 +11,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"regexp"
 	"slices"
@@ -21,7 +19,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
@@ -56,22 +54,12 @@ type violation struct {
 
 // main audits MCP tool metadata for violations such as missing annotations.
 func main() {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{
-		GitLabURL:   srv.URL,
-		GitLabToken: "audit-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, cleanup, err := auditclient.NewMock()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
-		os.Exit(1) //nolint:gocritic // CLI tool: OS reclaims resources on exit
+		os.Exit(1)
 	}
+	defer cleanup()
 
 	individualTools := listTools(client, false)
 	metaTools := listTools(client, true)

--- a/cmd/eval_mcp_surfaces/main_test.go
+++ b/cmd/eval_mcp_surfaces/main_test.go
@@ -844,8 +844,8 @@ func TestBuildCatalogSession_DynamicSurfaceExposesExecuteRoutes(t *testing.T) {
 	}
 }
 
-// TestNormalizeEvalToolSurface_AcceptsDynamic verifies that supported surface
-// names accepted by configuration normalize to their canonical values.
+// TestNormalizeEvalToolSurface_AcceptsDynamicCandidates verifies that supported
+// surface names accepted by configuration normalize to their canonical values.
 func TestNormalizeEvalToolSurface_AcceptsDynamicCandidates(t *testing.T) {
 	tests := map[string]string{
 		"":        config.ToolSurfaceDynamic,
@@ -4988,6 +4988,12 @@ func TestConfigureTerminalOutput_WritesLogWithoutEcho(t *testing.T) {
 	requireContainsAll(t, "terminal log", string(data), []string{"eval_mcp_surfaces terminal output", "progress line 1"})
 }
 
+// TestShouldConfigureTerminalOutput_SkipsCheckDocsWithoutExplicitOutput verifies
+// report-checking modes avoid terminal log setup unless output is requested.
+//
+// The test covers check-docs, efficiency checks, and trace comparisons as quiet
+// modes, then asserts that an explicit log path or print flag re-enables terminal
+// output. This keeps validation commands from creating unnecessary artifacts.
 func TestShouldConfigureTerminalOutput_SkipsCheckDocsWithoutExplicitOutput(t *testing.T) {
 	for _, opts := range []options{
 		{CheckDocs: true},
@@ -5136,6 +5142,12 @@ func TestWriteRepairDiagnostics_RecordsRecoveredCategory(t *testing.T) {
 	})
 }
 
+// TestWriteRepairDiagnostics_IgnoresFailedFinalOutcome verifies repair
+// diagnostics omit attempts whose final evaluation result still failed.
+//
+// The task is marked as repaired on the retry but unsuccessful overall. The
+// expected output is empty so reports do not count unrecovered failures as
+// successful repaired categories.
 func TestWriteRepairDiagnostics_IgnoresFailedFinalOutcome(t *testing.T) {
 	var b strings.Builder
 	writeRepairDiagnostics(&b, options{ToolSurface: config.ToolSurfaceMeta}, []taskResult{{

--- a/cmd/format_md_tables/main_test.go
+++ b/cmd/format_md_tables/main_test.go
@@ -9,6 +9,13 @@ import (
 	"testing"
 )
 
+// TestRun_TableDriven verifies the Markdown table formatter CLI handles default
+// discovery, check mode, explicit paths, and invalid arguments.
+//
+// Each subtest builds a temporary repository root, writes only the files needed
+// for the scenario, runs [run], and asserts stdout, file rewrites, or expected
+// errors. This protects both the developer workflow and the non-mutating
+// --check mode used by CI.
 func TestRun_TableDriven(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -123,6 +130,12 @@ func TestRun_TableDriven(t *testing.T) {
 	}
 }
 
+// TestDiscoverMarkdownFiles_SortsMarkdownFiles verifies recursive discovery
+// returns only Markdown files in deterministic order.
+//
+// The test creates two docs files and one ignored text file, then expects the
+// result to contain the .md paths sorted lexically. Stable ordering keeps CLI
+// output and formatting diffs predictable.
 func TestDiscoverMarkdownFiles_SortsMarkdownFiles(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "docs", "b.md"), "# B\n")
@@ -147,6 +160,12 @@ func TestDiscoverMarkdownFiles_SortsMarkdownFiles(t *testing.T) {
 	}
 }
 
+// TestRun_RejectsSymlinkEscapingRoot verifies the formatter refuses symlinked
+// Markdown files that resolve outside the configured repository root.
+//
+// The test creates a docs symlink pointing to a file in another temporary
+// directory and expects [run] to report the escaping link. This guards the
+// command against path traversal through Markdown discovery.
 func TestRun_RejectsSymlinkEscapingRoot(t *testing.T) {
 	root := t.TempDir()
 	outside := t.TempDir()
@@ -169,6 +188,12 @@ func TestRun_RejectsSymlinkEscapingRoot(t *testing.T) {
 	}
 }
 
+// TestRun_ReturnsStdoutWriteErrors verifies CLI status output write failures are
+// returned to the caller.
+//
+// The test uses an [errWriter] after creating an otherwise valid root. The
+// expected error includes "write stdout", proving that output failures are not
+// silently ignored after formatting completes.
 func TestRun_ReturnsStdoutWriteErrors(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "README.md"), "# Title\n")

--- a/cmd/gen_llms/main_test.go
+++ b/cmd/gen_llms/main_test.go
@@ -36,6 +36,12 @@ func newGenLLMSClient(t *testing.T) *gitlabclient.Client {
 	return client
 }
 
+// TestListDynamicTools_ExposesFindAndExecute verifies dynamic llms generation
+// exposes only the find and execute tools in deterministic order.
+//
+// The test builds a mock GitLab-backed client, lists dynamic tools, and checks
+// the execute input schema for action, params, and confirm fields. This protects
+// the low-token dynamic contract consumed by generated LLM discovery files.
 func TestListDynamicTools_ExposesFindAndExecute(t *testing.T) {
 	tools, err := listDynamicTools(newGenLLMSClient(t))
 	if err != nil {
@@ -71,6 +77,12 @@ func TestListDynamicTools_ExposesFindAndExecute(t *testing.T) {
 	}
 }
 
+// TestValidateDynamicToolContract_RejectsDrift verifies the generated dynamic
+// tool contract fails when the expected find/execute pair changes.
+//
+// The happy-path assertion accepts the canonical two-tool list, while the drift
+// assertion removes find and expects validation to fail. This keeps accidental
+// dynamic surface changes visible during llms generation.
 func TestValidateDynamicToolContract_RejectsDrift(t *testing.T) {
 	if err := validateDynamicToolContract([]*mcp.Tool{{Name: dynamicFindToolName}, {Name: dynamicExecuteToolName}}); err != nil {
 		t.Fatalf("validateDynamicToolContract() error = %v", err)
@@ -80,6 +92,12 @@ func TestValidateDynamicToolContract_RejectsDrift(t *testing.T) {
 	}
 }
 
+// TestReadVersion_UsesProjectRoot verifies readVersion reads VERSION from the
+// supplied project root and trims trailing whitespace.
+//
+// The test writes a temporary VERSION file and expects the exact semantic
+// version string. This prevents generation from depending on the process working
+// directory when a root is supplied.
 func TestReadVersion_UsesProjectRoot(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "VERSION"), []byte("2.1.0\n"), 0o600); err != nil {
@@ -109,6 +127,12 @@ func TestListResources_IncludesMetaSchemaTemplate(t *testing.T) {
 	t.Fatalf("listResources() templates missing meta-schema template: %v", templates)
 }
 
+// TestValidateLLMSTxt_AcceptsSpecFileListSections verifies llms.txt validation
+// accepts H2 sections made of Markdown file-list entries.
+//
+// The content includes prose before the generated sections and both linked docs
+// with and without descriptions. The expected result is no error, matching the
+// public llms.txt shape documented by the generator.
 func TestValidateLLMSTxt_AcceptsSpecFileListSections(t *testing.T) {
 	content := strings.Join([]string{
 		"# Example",
@@ -135,6 +159,11 @@ func TestValidateLLMSTxt_AcceptsSpecFileListSections(t *testing.T) {
 	}
 }
 
+// TestValidateLLMSTxt_RejectsNonLinkH2Content verifies llms.txt H2 sections must
+// contain file-list link entries rather than arbitrary prose.
+//
+// The test places plain text under a Docs section and expects validation to
+// fail, keeping generated discovery files machine-readable for model consumers.
 func TestValidateLLMSTxt_RejectsNonLinkH2Content(t *testing.T) {
 	content := strings.Join([]string{
 		"# Example",
@@ -152,6 +181,11 @@ func TestValidateLLMSTxt_RejectsNonLinkH2Content(t *testing.T) {
 	}
 }
 
+// TestValidateLLMSTxt_RejectsEmptyFileListLinkLabel verifies llms.txt validation
+// rejects Markdown links without visible labels.
+//
+// Empty labels produce poor LLM context and broken human navigation, so the test
+// expects a validation error for a file-list entry using [](...).
 func TestValidateLLMSTxt_RejectsEmptyFileListLinkLabel(t *testing.T) {
 	content := strings.Join([]string{
 		"# Example",
@@ -169,6 +203,12 @@ func TestValidateLLMSTxt_RejectsEmptyFileListLinkLabel(t *testing.T) {
 	}
 }
 
+// TestValidateLLMSFullTxt_RequiresGeneratedSections verifies llms-full.txt
+// validation requires all generated catalog sections.
+//
+// The first fixture includes Dynamic Toolset, Meta-Tools, Individual Tools,
+// Resources, and Prompts and should pass. The second fixture omits most sections
+// and should fail so partial generated files are caught before writing.
 func TestValidateLLMSFullTxt_RequiresGeneratedSections(t *testing.T) {
 	content := strings.Join([]string{
 		"# Example Full Reference",
@@ -193,6 +233,12 @@ func TestValidateLLMSFullTxt_RequiresGeneratedSections(t *testing.T) {
 	}
 }
 
+// TestWriteGeneratedFile_RejectsUnexpectedFileName verifies generated llms files
+// can only be written to the supported top-level artifact names.
+//
+// The test attempts README.md, a parent-directory escape, and a docs path in
+// check mode. Each should fail to prevent accidental writes outside the intended
+// llms.txt and llms-full.txt outputs.
 func TestWriteGeneratedFile_RejectsUnexpectedFileName(t *testing.T) {
 	for _, name := range []string{"README.md", "../llms.txt", "docs/llms.txt"} {
 		t.Run(name, func(t *testing.T) {
@@ -203,6 +249,12 @@ func TestWriteGeneratedFile_RejectsUnexpectedFileName(t *testing.T) {
 	}
 }
 
+// TestWriteGeneratedFile_CheckModeAcceptsCRLFLineEndings verifies check mode
+// treats CRLF and LF generated files as equivalent.
+//
+// The test writes llms.txt with Windows line endings, then checks the same
+// content with LF endings. A nil error prevents cross-platform line ending
+// differences from causing false generation drift.
 func TestWriteGeneratedFile_CheckModeAcceptsCRLFLineEndings(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o600); err != nil {
@@ -219,6 +271,12 @@ func TestWriteGeneratedFile_CheckModeAcceptsCRLFLineEndings(t *testing.T) {
 	}
 }
 
+// TestSchemaTypeLabel_ArrayAndNullableTypes verifies schemaTypeLabel summarizes
+// nullable, array, nested-array, object, and untyped schemas.
+//
+// The table covers common JSON Schema shapes emitted for tool inputs. Expected
+// labels are human-readable phrases used in generated llms-full.txt parameter
+// references.
 func TestSchemaTypeLabel_ArrayAndNullableTypes(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1190,6 +1190,13 @@ func TestCreateServer_CapabilitySurfaceParity(t *testing.T) {
 	}
 }
 
+// TestShouldRegisterMetaSchemaResources verifies meta-schema resources are
+// registered only for catalog surfaces that can execute action routes.
+//
+// The table covers full and minimal capability surfaces across meta, dynamic,
+// and individual tool modes. Meta and dynamic modes should expose schema
+// resources when appropriate; individual mode should not because it already has
+// per-tool schemas.
 func TestShouldRegisterMetaSchemaResources(t *testing.T) {
 	testCases := []struct {
 		name              string

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -576,9 +576,10 @@ func TestServeHTTP_PortConflict(t *testing.T) {
 }
 
 // TestRun_GitLabConnectionFailure verifies that [run] returns an error when the
-// GitLab instance is unreachable (connectivity ping failure).
+// GitLab connectivity ping returns a failure status.
 func TestRun_GitLabConnectionFailure(t *testing.T) {
-	t.Setenv("GITLAB_URL", "http://127.0.0.1:1") // unreachable
+	srv := newFailingGitLabServer(t, http.StatusForbidden)
+	t.Setenv("GITLAB_URL", srv.URL)
 	t.Setenv("GITLAB_TOKEN", testToken)
 	t.Setenv("GITLAB_SKIP_TLS_VERIFY", "true")
 
@@ -596,6 +597,21 @@ func newMockGitLabServer(t *testing.T) *httptest.Server {
 		if r.URL.Path == "/api/v4/version" {
 			w.Header().Set(hdrContentType, mimeJSON)
 			_ = json.NewEncoder(w).Encode(map[string]string{"version": "16.0.0", "revision": "test"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newFailingGitLabServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v4/version" {
+			w.Header().Set(hdrContentType, mimeJSON)
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"message":"error"}`))
 			return
 		}
 		http.NotFound(w, r)
@@ -700,9 +716,10 @@ func TestRunWithContext_InvalidConfig(t *testing.T) {
 }
 
 // TestRunWithContext_PingFailure verifies that [runWithContext] returns an error
-// when the GitLab connectivity ping fails due to an unreachable host.
+// when the GitLab connectivity ping returns a failure status.
 func TestRunWithContext_PingFailure(t *testing.T) {
-	t.Setenv("GITLAB_URL", "http://127.0.0.1:1") // unreachable
+	srv := newFailingGitLabServer(t, http.StatusForbidden)
+	t.Setenv("GITLAB_URL", srv.URL)
 	t.Setenv("GITLAB_TOKEN", testToken)
 	t.Setenv("GITLAB_SKIP_TLS_VERIFY", "true")
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 10,230 |
-| Unit test functions                                   |  9,979 |
+| Total test functions                                  | 10,232 |
+| Unit test functions                                   |  9,981 |
 | E2E test functions                                    |    251 |
 | cmd test functions                                    |    535 |
 | Test files (internal/)                                |    426 |
@@ -35,7 +35,7 @@
 
 | Pattern                                | Count |     % |
 | -------------------------------------- | ----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 9,172 | 89.7% |
+| `TestFunc_Scenario` (2-part)           | 9,174 | 89.7% |
 | `TestFunc` (no underscore)             |   768 |  7.5% |
 | `TestFunc_Scenario_Expected` (3+ part) |   290 |  2.8% |
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          1,743 |         83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            284 |         12 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (171) |          7,417 |        331 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (171) |          7,419 |        331 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            251 |        109 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            535 |         23 | server entry point and developer command utilities                                              |
-| **Total**               |     **10,230** |    **558** |                                                                                                 |
+| **Total**               |     **10,232** |    **558** |                                                                                                 |
 
 ### Core Packages
 
@@ -281,10 +281,10 @@
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       186 |          7 |   100.0% |        36 |
 | vulnerabilities         |        57 |          3 |   100.0% |         8 |
-| waitpoll                |        11 |          1 |   100.0% |         0 |
+| waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        59 |          2 |    99.4% |         6 |
 | workitems               |        66 |          2 |   100.0% |         5 |
-| **Total**               | **7,417** |    **331** |          | **1,118** |
+| **Total**               | **7,419** |    **331** |          | **1,118** |
 
 </details>
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,24 +18,24 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 10,206 |
-| Unit test functions                                   |  9,955 |
+| Total test functions                                  | 10,212 |
+| Unit test functions                                   |  9,961 |
 | E2E test functions                                    |    251 |
-| cmd test functions                                    |    531 |
-| Test files (internal/)                                |    422 |
-| Test files (cmd/)                                     |     22 |
+| cmd test functions                                    |    535 |
+| Test files (internal/)                                |    423 |
+| Test files (cmd/)                                     |     23 |
 | Test files (test/e2e/suite/)                          |    109 |
 | Tool sub-packages tested                              |    170 |
 | Core packages tested                                  |     17 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  88.9% |
 | Overall coverage (`go test ./internal/...`)           |  99.0% |
-| Average package coverage                              |  95.6% |
+| Average package coverage                              |  95.5% |
 
 ### Naming Convention Stats
 
 | Pattern                                | Count |     % |
 | -------------------------------------- | ----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 9,148 | 89.6% |
+| `TestFunc_Scenario` (2-part)           | 9,154 | 89.6% |
 | `TestFunc` (no underscore)             |   768 |  7.5% |
 | `TestFunc_Scenario_Expected` (3+ part) |   290 |  2.8% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,734 |         80 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,736 |         81 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            284 |         12 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (170) |          7,406 |        330 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            251 |        109 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |            531 |         22 | server entry point and developer command utilities                                              |
-| **Total**               |     **10,206** |    **553** |                                                                                                 |
+| cmd packages            |            535 |         23 | server entry point and developer command utilities                                              |
+| **Total**               |     **10,212** |    **555** |                                                                                                 |
 
 ### Core Packages
 
@@ -59,9 +59,9 @@
 | autoupdate   |       117 |    93.0% | Package autoupdate provides self-update capability for the gitlab-mcp-server MCP server.                                                                                                                          |
 | completions  |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
 | config       |        69 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
-| docgen       |         6 |   100.0% | Package docgen contains helpers for generated project documentation.                                                                                                                                              |
+| docgen       |         8 |   100.0% | Package docgen contains helpers for generated project documentation.                                                                                                                                              |
 | elicitation  |        78 |    92.0% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
-| gitlab       |        41 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
+| gitlab       |        41 |    99.2% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | logging      |        16 |   100.0% | Package logging provides MCP protocol-level logging via ServerSession.                                                                                                                                            |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
@@ -73,7 +73,7 @@
 | testutil     |        25 |    91.9% | Package testutil provides shared test utilities for MCP tool tests.                                                                                                                                               |
 | toolutil     |       461 |    96.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       252 |    93.1% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,734** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **1,736** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -304,6 +304,7 @@
 | cmd/audit_tools                 |    36.1% |
 | cmd/eval_mcp_surfaces           |    59.4% |
 | cmd/find_dupes                  |    90.1% |
+| cmd/format_md_tables            |    86.7% |
 | cmd/gen_action_catalog_manifest |    50.0% |
 | cmd/gen_docker_tools            |    81.9% |
 | cmd/gen_llms                    |    27.1% |
@@ -320,7 +321,7 @@
 | config      |   100.0% |
 | docgen      |   100.0% |
 | elicitation |    92.0% |
-| gitlab      |   100.0% |
+| gitlab      |    99.2% |
 | logging     |   100.0% |
 | oauth       |    98.6% |
 | progress    |   100.0% |
@@ -528,6 +529,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_meta_schema** (80.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_names** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/format_md_tables** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 
 <!-- END TESTING STATS -->
 

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,24 +18,24 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 10,212 |
-| Unit test functions                                   |  9,961 |
+| Total test functions                                  | 10,225 |
+| Unit test functions                                   |  9,974 |
 | E2E test functions                                    |    251 |
 | cmd test functions                                    |    535 |
-| Test files (internal/)                                |    423 |
+| Test files (internal/)                                |    426 |
 | Test files (cmd/)                                     |     23 |
 | Test files (test/e2e/suite/)                          |    109 |
-| Tool sub-packages tested                              |    170 |
-| Core packages tested                                  |     17 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  88.9% |
+| Tool sub-packages tested                              |    171 |
+| Core packages tested                                  |     18 |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  89.0% |
 | Overall coverage (`go test ./internal/...`)           |  99.0% |
-| Average package coverage                              |  95.5% |
+| Average package coverage                              |  95.6% |
 
 ### Naming Convention Stats
 
 | Pattern                                | Count |     % |
 | -------------------------------------- | ----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 9,154 | 89.6% |
+| `TestFunc_Scenario` (2-part)           | 9,167 | 89.7% |
 | `TestFunc` (no underscore)             |   768 |  7.5% |
 | `TestFunc_Scenario_Expected` (3+ part) |   290 |  2.8% |
 
@@ -45,17 +45,18 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,736 |         81 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,742 |         83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            284 |         12 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (170) |          7,406 |        330 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (171) |          7,413 |        331 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            251 |        109 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            535 |         23 | server entry point and developer command utilities                                              |
-| **Total**               |     **10,212** |    **555** |                                                                                                 |
+| **Total**               |     **10,225** |    **558** |                                                                                                 |
 
 ### Core Packages
 
 | Package      |     Tests | Coverage | Description                                                                                                                                                                                                       |
 | ------------ | --------: | -------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| auditclient  |         2 |   100.0% | Package auditclient creates GitLab clients for command-line audit tools.                                                                                                                                          |
 | autoupdate   |       117 |    93.0% | Package autoupdate provides self-update capability for the gitlab-mcp-server MCP server.                                                                                                                          |
 | completions  |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
 | config       |        69 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
@@ -71,9 +72,9 @@
 | sampling     |        83 |    99.5% | Package sampling provides a client for requesting LLM analysis through MCP sampling and for executing allow-listed tool calls during iterative analysis.                                                          |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        25 |    91.9% | Package testutil provides shared test utilities for MCP tool tests.                                                                                                                                               |
-| toolutil     |       461 |    96.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       465 |    96.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       252 |    93.1% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,736** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **1,742** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -108,7 +109,7 @@
 ### Complete Tool Sub-Package Test Counts
 
 <details>
-<summary>All 170 tested sub-packages (click to expand)</summary>
+<summary>All 171 tested sub-packages (click to expand)</summary>
 
 | Sub-package             |     Tests | Test Files | Coverage |     Tools |
 | ----------------------- | --------: | ---------: | -------: | --------: |
@@ -280,9 +281,10 @@
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       186 |          7 |   100.0% |        36 |
 | vulnerabilities         |        57 |          3 |   100.0% |         8 |
+| waitpoll                |         7 |          1 |   100.0% |         0 |
 | wikis                   |        59 |          2 |    99.4% |         6 |
 | workitems               |        66 |          2 |   100.0% |         5 |
-| **Total**               | **7,406** |    **330** |          | **1,118** |
+| **Total**               | **7,413** |    **331** |          | **1,118** |
 
 </details>
 
@@ -296,12 +298,12 @@
 | cmd/audit_action_spec_coverage  |    76.2% |
 | cmd/audit_dynamic_aliases       |    60.0% |
 | cmd/audit_godocs                |    50.7% |
-| cmd/audit_meta_schema           |    80.2% |
-| cmd/audit_metrics               |    28.4% |
-| cmd/audit_output                |    23.0% |
+| cmd/audit_meta_schema           |    82.6% |
+| cmd/audit_metrics               |    28.8% |
+| cmd/audit_output                |    23.9% |
 | cmd/audit_test_names            |    81.6% |
-| cmd/audit_tokens                |    19.2% |
-| cmd/audit_tools                 |    36.1% |
+| cmd/audit_tokens                |    19.5% |
+| cmd/audit_tools                 |    36.7% |
 | cmd/eval_mcp_surfaces           |    59.4% |
 | cmd/find_dupes                  |    90.1% |
 | cmd/format_md_tables            |    86.7% |
@@ -316,6 +318,7 @@
 
 | Package     | Coverage |
 | ----------- | -------: |
+| auditclient |   100.0% |
 | autoupdate  |    93.0% |
 | completions |   100.0% |
 | config      |   100.0% |
@@ -507,18 +510,19 @@
 | usergpgkeys             |   100.0% |
 | users                   |   100.0% |
 | vulnerabilities         |   100.0% |
+| waitpoll                |   100.0% |
 | wikis                   |    99.4% |
 | workitems               |   100.0% |
 
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
-- **cmd/audit_tokens** (19.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_output** (23.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tokens** (19.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_output** (23.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_llms** (27.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (27.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_metrics** (28.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_metrics** (28.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_readme** (35.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_tools** (36.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tools** (36.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_action_catalog_manifest** (50.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces** (59.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -526,9 +530,9 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/add_docs** (60.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_action_spec_coverage** (76.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/server** (77.9%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
-- **cmd/audit_meta_schema** (80.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_names** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_meta_schema** (82.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/format_md_tables** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 
 <!-- END TESTING STATS -->

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 10,225 |
-| Unit test functions                                   |  9,974 |
+| Total test functions                                  | 10,230 |
+| Unit test functions                                   |  9,979 |
 | E2E test functions                                    |    251 |
 | cmd test functions                                    |    535 |
 | Test files (internal/)                                |    426 |
@@ -35,7 +35,7 @@
 
 | Pattern                                | Count |     % |
 | -------------------------------------- | ----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 9,167 | 89.7% |
+| `TestFunc_Scenario` (2-part)           | 9,172 | 89.7% |
 | `TestFunc` (no underscore)             |   768 |  7.5% |
 | `TestFunc_Scenario_Expected` (3+ part) |   290 |  2.8% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,742 |         83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,743 |         83 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            284 |         12 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (171) |          7,413 |        331 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (171) |          7,417 |        331 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            251 |        109 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            535 |         23 | server entry point and developer command utilities                                              |
-| **Total**               |     **10,225** |    **558** |                                                                                                 |
+| **Total**               |     **10,230** |    **558** |                                                                                                 |
 
 ### Core Packages
 
@@ -72,9 +72,9 @@
 | sampling     |        83 |    99.5% | Package sampling provides a client for requesting LLM analysis through MCP sampling and for executing allow-listed tool calls during iterative analysis.                                                          |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        25 |    91.9% | Package testutil provides shared test utilities for MCP tool tests.                                                                                                                                               |
-| toolutil     |       465 |    96.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       466 |    96.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       252 |    93.1% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,742** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **1,743** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -281,10 +281,10 @@
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       186 |          7 |   100.0% |        36 |
 | vulnerabilities         |        57 |          3 |   100.0% |         8 |
-| waitpoll                |         7 |          1 |   100.0% |         0 |
+| waitpoll                |        11 |          1 |   100.0% |         0 |
 | wikis                   |        59 |          2 |    99.4% |         6 |
 | workitems               |        66 |          2 |   100.0% |         5 |
-| **Total**               | **7,413** |    **331** |          | **1,118** |
+| **Total**               | **7,417** |    **331** |          | **1,118** |
 
 </details>
 
@@ -334,7 +334,7 @@
 | sampling    |    99.5% |
 | serverpool  |    99.6% |
 | testutil    |    91.9% |
-| toolutil    |    96.7% |
+| toolutil    |    96.8% |
 | wizard      |    93.1% |
 
 ### Tool Sub-Packages

--- a/internal/auditclient/auditclient.go
+++ b/internal/auditclient/auditclient.go
@@ -1,0 +1,39 @@
+// Package auditclient creates GitLab clients for command-line audit tools.
+package auditclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+)
+
+const (
+	mockGitLabVersionResponse = `{"version":"17.0.0"}`
+	mockGitLabToken           = "audit-token" // #nosec G101 -- audit-only dummy token.
+)
+
+var newGitLabClient = gitlabclient.NewClient
+
+// NewMock returns a GitLab client backed by a local version endpoint.
+func NewMock() (*gitlabclient.Client, func(), error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockGitLabVersionResponse))
+	}))
+
+	client, err := newGitLabClient(&config.Config{
+		GitLabURL:      server.URL,
+		GitLabToken:    mockGitLabToken,
+		DisableRetries: true,
+	})
+	if err != nil {
+		server.Close()
+		return nil, nil, fmt.Errorf("create mock GitLab client: %w", err)
+	}
+
+	return client, server.Close, nil
+}

--- a/internal/auditclient/auditclient_test.go
+++ b/internal/auditclient/auditclient_test.go
@@ -1,0 +1,54 @@
+package auditclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+)
+
+// TestNewMock_ReturnsPingableClient verifies the audit client helper exposes a
+// local GitLab version endpoint and a cleanup function.
+func TestNewMock_ReturnsPingableClient(t *testing.T) {
+	client, cleanup, err := NewMock()
+	if err != nil {
+		t.Fatalf("NewMock() unexpected error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	version, err := client.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping() unexpected error: %v", err)
+	}
+	if version != "17.0.0" {
+		t.Fatalf("version = %q, want 17.0.0", version)
+	}
+}
+
+// TestNewMock_ClientCreationError verifies the helper closes its local server
+// and reports client construction failures.
+func TestNewMock_ClientCreationError(t *testing.T) {
+	original := newGitLabClient
+	t.Cleanup(func() { newGitLabClient = original })
+
+	wantErr := errors.New("boom")
+	newGitLabClient = func(*config.Config) (*gitlabclient.Client, error) {
+		return nil, wantErr
+	}
+
+	client, cleanup, err := NewMock()
+	if err == nil {
+		t.Fatal("NewMock() expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("NewMock() error = %v, want wrapping %v", err, wantErr)
+	}
+	if client != nil {
+		t.Fatalf("client = %#v, want nil", client)
+	}
+	if cleanup != nil {
+		t.Fatal("cleanup is non-nil, want nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,6 +112,7 @@ type Config struct {
 	GitLabURL            string
 	GitLabToken          string
 	SkipTLSVerify        bool
+	DisableRetries       bool // Disable GitLab client retries for unit tests.
 	MetaTools            bool
 	ToolSurface          string
 	CapabilitySurface    string

--- a/internal/docgen/doc.go
+++ b/internal/docgen/doc.go
@@ -1,0 +1,9 @@
+// Package docgen contains helpers for generated project documentation.
+//
+// The package renders source-readable Markdown tables and normalizes existing
+// GitHub-flavored Markdown pipe tables while preserving fenced code blocks,
+// escaped pipe characters, inline code spans, Unicode cell widths, and original
+// line endings. Command packages use these helpers when refreshing README and
+// docs content so generated files stay stable in diffs and easy to review as
+// plain text.
+package docgen

--- a/internal/docgen/markdown_tables_test.go
+++ b/internal/docgen/markdown_tables_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+// TestFormatMarkdownTables_TableDriven verifies Markdown table normalization
+// across formatting, skip, line-ending, and malformed-input scenarios.
+//
+// The table covers ordinary pipe tables, fenced code blocks, escaped and code
+// pipes, missing trailing newlines, CRLF input, ragged rows, table termination,
+// idempotent formatted content, empty content, and invalid separators. Each
+// case asserts both rendered output and whether a change was reported.
 func TestFormatMarkdownTables_TableDriven(t *testing.T) {
 	formattedTable := RenderMarkdownTable(
 		[]string{"Name", "Count"},
@@ -211,6 +218,12 @@ func TestFormatMarkdownTables_TableDriven(t *testing.T) {
 	}
 }
 
+// TestMarkdownTableHelpers_EdgeCases verifies low-level table helper behavior
+// for invalid separators and line-ending preservation.
+//
+// The test rejects zero-column separators and checks that rendered trailing
+// newlines are kept or trimmed based on the source table metadata, preserving the
+// formatter's exact-file behavior.
 func TestMarkdownTableHelpers_EdgeCases(t *testing.T) {
 	if _, ok := parseMarkdownTableSeparator("| --- |", 0); ok {
 		t.Fatal("parseMarkdownTableSeparator accepted zero columns")

--- a/internal/docgen/table.go
+++ b/internal/docgen/table.go
@@ -1,4 +1,3 @@
-// Package docgen contains helpers for generated project documentation.
 package docgen
 
 import (

--- a/internal/docgen/table_test.go
+++ b/internal/docgen/table_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+// TestRenderMarkdownTable_AlignsPlainTextColumns verifies left and right
+// alignment produce padded Markdown columns for plain ASCII content.
+//
+// The test renders a package coverage table with one long package name and
+// expects right-aligned coverage values. This protects generated documentation
+// tables from drifting into hard-to-read raw pipe output.
 func TestRenderMarkdownTable_AlignsPlainTextColumns(t *testing.T) {
 	got := RenderMarkdownTable(
 		[]string{"Package", "Coverage"},
@@ -26,6 +32,12 @@ func TestRenderMarkdownTable_AlignsPlainTextColumns(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownTable_DefaultsMissingCellsAndAlignments verifies omitted
+// cells and alignments use empty values and left alignment.
+//
+// The rendered table has two headers but a single row value. The expected output
+// pads the missing cell rather than dropping the column, preserving rectangular
+// Markdown tables for generated docs.
 func TestRenderMarkdownTable_DefaultsMissingCellsAndAlignments(t *testing.T) {
 	got := RenderMarkdownTable(
 		[]string{"A", "B"},
@@ -43,6 +55,11 @@ func TestRenderMarkdownTable_DefaultsMissingCellsAndAlignments(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownTable_EmptyHeaders_ReturnsEmptyString verifies a table with
+// no headers renders as no Markdown content.
+//
+// Rows without headers cannot form a valid pipe table, so the expected result is
+// an empty string instead of malformed output.
 func TestRenderMarkdownTable_EmptyHeaders_ReturnsEmptyString(t *testing.T) {
 	got := RenderMarkdownTable(nil, nil, [][]string{{"ignored"}})
 	if got != "" {
@@ -50,6 +67,11 @@ func TestRenderMarkdownTable_EmptyHeaders_ReturnsEmptyString(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownTable_UnicodeContent_UsesRuneWidths verifies Unicode text is
+// padded by rune width rather than byte length.
+//
+// The test renders accented words and expects aligned columns, ensuring generated
+// docs remain readable when labels contain non-ASCII characters.
 func TestRenderMarkdownTable_UnicodeContent_UsesRuneWidths(t *testing.T) {
 	got := RenderMarkdownTable(
 		[]string{"Word", "Meaning"},
@@ -71,6 +93,11 @@ func TestRenderMarkdownTable_UnicodeContent_UsesRuneWidths(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownTable_WideContent_ExpandsColumns verifies cell content wider
+// than the header determines the rendered column width.
+//
+// The single row contains a long value, and the expected table expands the Value
+// column to fit it without truncation.
 func TestRenderMarkdownTable_WideContent_ExpandsColumns(t *testing.T) {
 	got := RenderMarkdownTable(
 		[]string{"Key", "Value"},
@@ -88,6 +115,11 @@ func TestRenderMarkdownTable_WideContent_ExpandsColumns(t *testing.T) {
 	}
 }
 
+// TestRenderMarkdownTable_SingleColumn_RendersTable verifies one-column input
+// still produces a valid Markdown table.
+//
+// The expected output includes header, separator, and both rows, covering the
+// smallest valid table shape used by generated documentation.
 func TestRenderMarkdownTable_SingleColumn_RendersTable(t *testing.T) {
 	got := RenderMarkdownTable(
 		[]string{"Only"},

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -124,10 +124,17 @@ func NewClient(cfg *config.Config) (*Client, error) {
 		},
 	}
 
-	inner, err := gl.NewClient(
-		cfg.GitLabToken,
+	options := []gl.ClientOptionFunc{
 		gl.WithBaseURL(cfg.GitLabURL),
 		gl.WithHTTPClient(sdkHTTPClient),
+	}
+	if cfg.DisableRetries {
+		options = append(options, gl.WithoutRetries())
+	}
+
+	inner, err := gl.NewClient(
+		cfg.GitLabToken,
+		options...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating gitlab client: %w", err)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -212,8 +212,8 @@ func callTestTool(t *testing.T, session *mcp.ClientSession) {
 	}
 }
 
-// drainLogs collects log entries from the channel until the timeout elapses.
-func drainLogs(ch <-chan logEntry, timeout time.Duration) []logEntry {
+// collectLogsUntil collects log entries until done reports success or the timeout elapses.
+func collectLogsUntil(ch <-chan logEntry, timeout time.Duration, done func([]logEntry) bool) []logEntry {
 	var entries []logEntry
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -221,6 +221,9 @@ func drainLogs(ch <-chan logEntry, timeout time.Duration) []logEntry {
 		select {
 		case e := <-ch:
 			entries = append(entries, e)
+			if done(entries) {
+				return entries
+			}
 		case <-timer.C:
 			return entries
 		}
@@ -290,7 +293,9 @@ func TestSessionLogger_LevelsViaIntegration(t *testing.T) {
 			}
 
 			callTestTool(t, session)
-			entries := drainLogs(logs, 2*time.Second)
+			entries := collectLogsUntil(logs, time.Second, func(entries []logEntry) bool {
+				return findLogEntryByLevel(t, entries, tt.level)
+			})
 
 			if len(entries) == 0 {
 				t.Fatal("expected at least one log entry, got none")
@@ -317,7 +322,10 @@ func TestSessionLogger_LogToolCallSuccess(t *testing.T) {
 	}
 
 	callTestTool(t, session)
-	entries := drainLogs(logs, 2*time.Second)
+	entries := collectLogsUntil(logs, time.Second, func(entries []logEntry) bool {
+		_, found := findToolLogEntry(entries, "info", "my_tool")
+		return found
+	})
 
 	if len(entries) == 0 {
 		t.Fatal(errExpLogEntries)
@@ -347,7 +355,10 @@ func TestSessionLogger_LogToolCallError(t *testing.T) {
 	}
 
 	callTestTool(t, session)
-	entries := drainLogs(logs, 2*time.Second)
+	entries := collectLogsUntil(logs, time.Second, func(entries []logEntry) bool {
+		_, found := findToolLogEntry(entries, "error", "failing_tool")
+		return found
+	})
 
 	if len(entries) == 0 {
 		t.Fatal(errExpLogEntries)
@@ -380,7 +391,16 @@ func TestSessionLogger_WithMapData(t *testing.T) {
 	}
 
 	callTestTool(t, session)
-	entries := drainLogs(logs, 2*time.Second)
+	entries := collectLogsUntil(logs, time.Second, func(entries []logEntry) bool {
+		for _, e := range entries {
+			if m, ok := e.Data.(map[string]any); ok {
+				if m["project"] == "test-project" && m["message"] == "structured" {
+					return true
+				}
+			}
+		}
+		return false
+	})
 
 	if len(entries) == 0 {
 		t.Fatal(errExpLogEntries)

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -984,7 +984,7 @@ func TestMergeRequestDiscussionsResource_Success(t *testing.T) {
 // from the discussions endpoint propagates as an error.
 func TestMergeRequestDiscussionsResource_APIError(t *testing.T) {
 	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusForbidden)
 	}))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/mr/7/discussions"})
@@ -2115,7 +2115,7 @@ func noAPICallHandler(t *testing.T) http.HandlerFunc {
 // TestReleaseResource_APIError verifies that the release resource returns an
 // error when the GitLab API responds with a failure status.
 func TestReleaseResource_APIError(t *testing.T) {
-	session := newMCPSession(t, errAPIHandler(http.StatusInternalServerError))
+	session := newMCPSession(t, errAPIHandler(http.StatusForbidden))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/release/v1.0.0"})
 	if err == nil {
 		t.Fatal(msgExpectedAPIErr)
@@ -2155,7 +2155,7 @@ func TestLabelResource_APIError(t *testing.T) {
 // TestMilestoneResource_APIError verifies that the milestone resource
 // returns an error when the GitLab API list call fails.
 func TestMilestoneResource_APIError(t *testing.T) {
-	session := newMCPSession(t, errAPIHandler(http.StatusInternalServerError))
+	session := newMCPSession(t, errAPIHandler(http.StatusForbidden))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/milestone/3"})
 	if err == nil {
 		t.Fatal(msgExpectedAPIErr)
@@ -2275,7 +2275,7 @@ func TestBoardResource_APIError(t *testing.T) {
 // TestGroupMilestoneResource_APIError verifies that the group_milestone
 // resource returns an error when the GitLab API list call fails.
 func TestGroupMilestoneResource_APIError(t *testing.T) {
-	session := newMCPSession(t, errAPIHandler(http.StatusInternalServerError))
+	session := newMCPSession(t, errAPIHandler(http.StatusForbidden))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://group/10/milestone/3"})
 	if err == nil {
 		t.Fatal(msgExpectedAPIErr)

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -90,9 +90,10 @@ func NewTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
 	t.Cleanup(srv.Close)
 
 	cfg := &config.Config{
-		GitLabURL:     srv.URL,
-		GitLabToken:   "test-token",
-		SkipTLSVerify: false,
+		GitLabURL:      srv.URL,
+		GitLabToken:    "test-token",
+		SkipTLSVerify:  false,
+		DisableRetries: true,
 	}
 
 	client, err := gitlabclient.NewClient(cfg)

--- a/internal/tools/catalog_group_metadata_test.go
+++ b/internal/tools/catalog_group_metadata_test.go
@@ -6,6 +6,12 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// TestLoadCatalogMetaToolDescriptions_SkipsIncompleteSnapshots verifies meta
+// tool description loading ignores snapshot rows without names or descriptions.
+//
+// The test temporarily replaces the embedded snapshot JSON and expects only the
+// complete gitlab_project entry to be returned, preserving robust catalog startup
+// when generated snapshot rows are incomplete.
 func TestLoadCatalogMetaToolDescriptions_SkipsIncompleteSnapshots(t *testing.T) {
 	original := metaToolSnapshotJSON
 	t.Cleanup(func() { metaToolSnapshotJSON = original })
@@ -25,6 +31,12 @@ func TestLoadCatalogMetaToolDescriptions_SkipsIncompleteSnapshots(t *testing.T) 
 	}
 }
 
+// TestLoadCatalogIndividualToolDescriptions_SkipsIncompleteSnapshots verifies
+// individual tool description loading ignores incomplete snapshot rows.
+//
+// The test replaces the embedded individual snapshot with one complete entry and
+// two incomplete entries. The loader should return only gitlab_get_project with
+// its stored description.
 func TestLoadCatalogIndividualToolDescriptions_SkipsIncompleteSnapshots(t *testing.T) {
 	original := individualToolSnapshotJSON
 	t.Cleanup(func() { individualToolSnapshotJSON = original })
@@ -44,6 +56,12 @@ func TestLoadCatalogIndividualToolDescriptions_SkipsIncompleteSnapshots(t *testi
 	}
 }
 
+// TestCatalogGroupDescription_StripsStoredMetaPrefix verifies generated meta
+// descriptions do not duplicate the runtime action-envelope preamble.
+//
+// The stored description includes the usage and schema prefix already added at
+// runtime. The expected result keeps only the base domain description so tool
+// help remains concise and avoids repeated instructions.
 func TestCatalogGroupDescription_StripsStoredMetaPrefix(t *testing.T) {
 	original := catalogMetaToolDescriptions
 	t.Cleanup(func() { catalogMetaToolDescriptions = original })
@@ -58,6 +76,12 @@ func TestCatalogGroupDescription_StripsStoredMetaPrefix(t *testing.T) {
 	}
 }
 
+// TestLoadCatalogToolDescriptions_PanicOnInvalidJSON verifies embedded catalog
+// description snapshots fail fast when their JSON is invalid.
+//
+// The meta and individual subtests temporarily corrupt their snapshot bytes and
+// expect the loader to panic, making generated-data corruption visible during
+// tests instead of silently omitting descriptions.
 func TestLoadCatalogToolDescriptions_PanicOnInvalidJSON(t *testing.T) {
 	t.Run("meta", func(t *testing.T) {
 		original := metaToolSnapshotJSON

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -381,10 +382,11 @@ func TestDynamicSearchCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddStandaloneCatalog() error = %v", err)
 	}
+	baseRegistry := NewRegistryFromCatalog(baseCatalog)
 
 	for _, tc := range cases {
 		t.Run(tc.Category, func(t *testing.T) {
-			registry := NewRegistryFromCatalog(baseCatalog)
+			registry := baseRegistry
 			if len(tc.CustomAliases) > 0 {
 				aliases := append([]actionAlias(nil), actionAliases()...)
 				for _, customAlias := range tc.CustomAliases {
@@ -2784,18 +2786,32 @@ func actionDescriptionByID(t *testing.T, output DescribeOutput, id string) Actio
 	return ActionDescription{}
 }
 
+var (
+	realCatalogRegistryOnce  sync.Once
+	realCatalogRegistryValue *Registry
+	errRealCatalogRegistry   error
+)
+
 // realCatalogRegistry supports real catalog registry assertions in dynamic tests.
 func realCatalogRegistry(t *testing.T) *Registry {
 	t.Helper()
-	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
-	if err != nil {
-		t.Fatalf("BuildActionCatalog() error = %v", err)
+	realCatalogRegistryOnce.Do(func() {
+		catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
+		if err != nil {
+			errRealCatalogRegistry = fmt.Errorf("BuildActionCatalog() error = %w", err)
+			return
+		}
+		catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
+		if err != nil {
+			errRealCatalogRegistry = fmt.Errorf("AddStandaloneCatalog() error = %w", err)
+			return
+		}
+		realCatalogRegistryValue = NewRegistryFromCatalog(catalog)
+	})
+	if errRealCatalogRegistry != nil {
+		t.Fatal(errRealCatalogRegistry)
 	}
-	catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
-	if err != nil {
-		t.Fatalf("AddStandaloneCatalog() error = %v", err)
-	}
-	return NewRegistryFromCatalog(catalog)
+	return realCatalogRegistryValue
 }
 
 // gitLabDotComEnterpriseRegistry supports GitLab dot com enterprise registry assertions in dynamic tests.

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -2786,32 +2786,26 @@ func actionDescriptionByID(t *testing.T, output DescribeOutput, id string) Actio
 	return ActionDescription{}
 }
 
-var (
-	realCatalogRegistryOnce  sync.Once
-	realCatalogRegistryValue *Registry
-	errRealCatalogRegistry   error
-)
+var cachedRealCatalogRegistry = sync.OnceValues(func() (*Registry, error) {
+	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
+	if err != nil {
+		return nil, fmt.Errorf("BuildActionCatalog() error = %w", err)
+	}
+	catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("AddStandaloneCatalog() error = %w", err)
+	}
+	return NewRegistryFromCatalog(catalog), nil
+})
 
 // realCatalogRegistry supports real catalog registry assertions in dynamic tests.
 func realCatalogRegistry(t *testing.T) *Registry {
 	t.Helper()
-	realCatalogRegistryOnce.Do(func() {
-		catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
-		if err != nil {
-			errRealCatalogRegistry = fmt.Errorf("BuildActionCatalog() error = %w", err)
-			return
-		}
-		catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
-		if err != nil {
-			errRealCatalogRegistry = fmt.Errorf("AddStandaloneCatalog() error = %w", err)
-			return
-		}
-		realCatalogRegistryValue = NewRegistryFromCatalog(catalog)
-	})
-	if errRealCatalogRegistry != nil {
-		t.Fatal(errRealCatalogRegistry)
+	registry, err := cachedRealCatalogRegistry()
+	if err != nil {
+		t.Fatal(err)
 	}
-	return realCatalogRegistryValue
+	return registry
 }
 
 // gitLabDotComEnterpriseRegistry supports GitLab dot com enterprise registry assertions in dynamic tests.

--- a/internal/tools/elicitationtools/action_specs_test.go
+++ b/internal/tools/elicitationtools/action_specs_test.go
@@ -93,16 +93,32 @@ func contentText(res *mcp.CallToolResult) string {
 	return b.String()
 }
 
+// TestCancelledOutput_SurfaceToolTextOnly verifies cancelledOutput exposes a
+// text-only representation for catalog-backed surface tools.
+//
+// The method has no return value, so the test ensures it remains callable for
+// the formatter path that converts elicitation cancellations into text content.
 func TestCancelledOutput_SurfaceToolTextOnly(t *testing.T) {
 	cancelledOutput{}.SurfaceToolTextOnly()
 }
 
+// TestFormatResult_DefaultUnknown verifies FormatResult ignores unsupported
+// output types.
+//
+// Passing an anonymous struct should return nil, keeping the shared formatter
+// from producing misleading content for unknown elicitation results.
 func TestFormatResult_DefaultUnknown(t *testing.T) {
 	if result := FormatResult(struct{}{}); result != nil {
 		t.Fatalf("FormatResult() = %#v, want nil for unknown type", result)
 	}
 }
 
+// TestElicitationRoute_UnmarshalError verifies catalog-backed elicitation routes
+// return decode errors for malformed input parameters.
+//
+// The test calls the raw route handler with project_id as a string slice instead
+// of a scalar. The expected error proves route decoding happens before the
+// interactive flow begins.
 func TestElicitationRoute_UnmarshalError(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	byTool := elicitationSpecsByTool(t, ActionSpecs(client))

--- a/internal/tools/elicitationtools/elicitationtools_test.go
+++ b/internal/tools/elicitationtools/elicitationtools_test.go
@@ -1569,6 +1569,13 @@ func stepHandlerErrorOnConfirm(accepts []map[string]any, confirmErr error) func(
 	}
 }
 
+// TestInteractiveCreate_FinalConfirmUnexpectedError verifies interactive create
+// flows wrap transport failures from the final confirmation prompt.
+//
+// Each table case accepts all field prompts for one interactive tool, then makes
+// the final confirm elicitation return an unexpected error. The expected handler
+// error includes both the tool-specific confirmation context and the underlying
+// transport error text.
 func TestInteractiveCreate_FinalConfirmUnexpectedError(t *testing.T) {
 	confirmErr := errors.New("elicitation transport failed")
 	tests := []struct {

--- a/internal/tools/epicissues/epic_issues_test.go
+++ b/internal/tools/epicissues/epic_issues_test.go
@@ -353,6 +353,12 @@ func TestList_CancelledContext(t *testing.T) {
 	}
 }
 
+// TestList_SkipsWidgetsWithoutChildren verifies List ignores Work Item widgets
+// that do not contain hierarchy children.
+//
+// The mocked GraphQL response includes one unrelated widget before the children
+// widget. The expected output is an empty issue list, proving the parser selects
+// the hierarchy payload without treating other widgets as errors.
 func TestList_SkipsWidgetsWithoutChildren(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{"WorkItemWidgetHierarchy": func(w http.ResponseWriter, _ *http.Request) {
 		testutil.RespondGraphQL(w, http.StatusOK, `{
@@ -499,6 +505,13 @@ func TestAssign_CancelledContext(t *testing.T) {
 	}
 }
 
+// TestAssign_ChildResolutionAndMutationErrors verifies Assign reports failures
+// after the parent epic resolves but child resolution or mutation execution
+// fails.
+//
+// The table covers a missing child work item GID and an HTTP error from the
+// workItemUpdate mutation. Each case expects the operation-specific error text
+// so callers can distinguish resolution failures from mutation failures.
 func TestAssign_ChildResolutionAndMutationErrors(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -658,6 +671,12 @@ func TestRemove_CancelledContext(t *testing.T) {
 	}
 }
 
+// TestRemove_EpicResolutionAndMutationErrors verifies Remove reports failures
+// from parent epic resolution and mutation execution.
+//
+// The first case returns a null namespace while resolving the epic GID; the
+// second resolves IDs but makes workItemUpdate return HTTP 403. Both paths should
+// surface actionable operation-specific errors.
 func TestRemove_EpicResolutionAndMutationErrors(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -878,6 +897,12 @@ func TestUpdateOrder_CancelledContext(t *testing.T) {
 	}
 }
 
+// TestUpdateOrder_MutationAPIError verifies UpdateOrder wraps HTTP errors from
+// the reorder mutation endpoint.
+//
+// The parent work item resolves successfully, then workItemUpdate returns HTTP
+// 403. The expected error contains epicIssueUpdate so callers can identify the
+// failing reorder operation.
 func TestUpdateOrder_MutationAPIError(t *testing.T) {
 	client := testutil.NewTestClient(t, graphqlMux(map[string]http.HandlerFunc{
 		"workItem(iid": func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/tools/events/markdown.go
+++ b/internal/tools/events/markdown.go
@@ -29,6 +29,16 @@ func formatTarget(targetType string, targetIID int64, targetTitle, targetURL str
 	return " " + label
 }
 
+type markdownEvent struct {
+	ActionName     string
+	TargetType     string
+	TargetIID      int64
+	TargetTitle    string
+	TargetURL      string
+	AuthorUsername string
+	CreatedAt      string
+}
+
 // FormatContributionListMarkdown formats contribution events as a Markdown CallToolResult.
 func FormatContributionListMarkdown(out ListContributionEventsOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatContributionListMarkdownString(out))
@@ -36,23 +46,7 @@ func FormatContributionListMarkdown(out ListContributionEventsOutput) *mcp.CallT
 
 // FormatContributionListMarkdownString renders contribution events as a Markdown string.
 func FormatContributionListMarkdownString(out ListContributionEventsOutput) string {
-	if len(out.Events) == 0 {
-		return "No contribution events found.\n"
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Contribution Events (%d)\n\n", len(out.Events))
-	toolutil.WriteListSummary(&b, len(out.Events), out.Pagination)
-	for _, e := range out.Events {
-		target := formatTarget(e.TargetType, e.TargetIID, e.TargetTitle, e.TargetURL)
-		author := formatAuthor(e.AuthorUsername)
-		fmt.Fprintf(&b, "- **%s**%s by %s — %s\n", e.ActionName, target, author, toolutil.FormatTime(e.CreatedAt))
-	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
-	toolutil.WriteHints(&b,
-		toolutil.HintPreserveLinks,
-		"Filter events using action and target_type parameters",
-	)
-	return b.String()
+	return formatEventListMarkdown("Contribution Events", "No contribution events found.", contributionMarkdownEvents(out.Events), out.Pagination)
 }
 
 // FormatListMarkdown formats project events as a Markdown CallToolResult.
@@ -62,21 +56,57 @@ func FormatListMarkdown(out ListProjectEventsOutput) *mcp.CallToolResult {
 
 // FormatListMarkdownString renders project events as a Markdown string.
 func FormatListMarkdownString(out ListProjectEventsOutput) string {
-	if len(out.Events) == 0 {
-		return "No project events found.\n"
+	return formatEventListMarkdown("Project Events", "No project events found.", projectMarkdownEvents(out.Events), out.Pagination)
+}
+
+func formatEventListMarkdown(title, emptyText string, events []markdownEvent, pagination toolutil.PaginationOutput) string {
+	if len(events) == 0 {
+		return emptyText + "\n"
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Project Events (%d)\n\n", len(out.Events))
-	toolutil.WriteListSummary(&b, len(out.Events), out.Pagination)
-	for _, e := range out.Events {
+	fmt.Fprintf(&b, "## %s (%d)\n\n", title, len(events))
+	toolutil.WriteListSummary(&b, len(events), pagination)
+	for _, e := range events {
 		target := formatTarget(e.TargetType, e.TargetIID, e.TargetTitle, e.TargetURL)
 		author := formatAuthor(e.AuthorUsername)
 		fmt.Fprintf(&b, "- **%s**%s by %s — %s\n", e.ActionName, target, author, toolutil.FormatTime(e.CreatedAt))
 	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	b.WriteString(toolutil.FormatPagination(pagination))
 	toolutil.WriteHints(&b,
 		toolutil.HintPreserveLinks,
 		"Filter events using action and target_type parameters",
 	)
 	return b.String()
+}
+
+func contributionMarkdownEvents(events []ContributionEventOutput) []markdownEvent {
+	items := make([]markdownEvent, len(events))
+	for i, event := range events {
+		items[i] = markdownEvent{
+			ActionName:     event.ActionName,
+			TargetType:     event.TargetType,
+			TargetIID:      event.TargetIID,
+			TargetTitle:    event.TargetTitle,
+			TargetURL:      event.TargetURL,
+			AuthorUsername: event.AuthorUsername,
+			CreatedAt:      event.CreatedAt,
+		}
+	}
+	return items
+}
+
+func projectMarkdownEvents(events []ProjectEventOutput) []markdownEvent {
+	items := make([]markdownEvent, len(events))
+	for i, event := range events {
+		items[i] = markdownEvent{
+			ActionName:     event.ActionName,
+			TargetType:     event.TargetType,
+			TargetIID:      event.TargetIID,
+			TargetTitle:    event.TargetTitle,
+			TargetURL:      event.TargetURL,
+			AuthorUsername: event.AuthorUsername,
+			CreatedAt:      event.CreatedAt,
+		}
+	}
+	return items
 }

--- a/internal/tools/groupimportexport/groupimportexport_test.go
+++ b/internal/tools/groupimportexport/groupimportexport_test.go
@@ -223,6 +223,11 @@ func TestExportDownload_ReadAllError(t *testing.T) {
 	}
 }
 
+// TestExportDownload_HTTPShortBodyError verifies ExportDownload returns an error
+// when GitLab advertises a longer archive body than it sends.
+//
+// The mock sets Content-Length to 10 but writes only five bytes. The expected
+// read error protects callers from receiving truncated base64 archive content.
 func TestExportDownload_HTTPShortBodyError(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v4/groups/1/export/download" && r.Method == http.MethodGet {

--- a/internal/tools/grouplabels/grouplabels.go
+++ b/internal/tools/grouplabels/grouplabels.go
@@ -71,6 +71,7 @@ type Output struct {
 	ClosedIssuesCount      int64  `json:"closed_issues_count"`
 	OpenMergeRequestsCount int64  `json:"open_merge_requests_count"`
 	Priority               int64  `json:"priority"`
+	PrioritySpecified      bool   `json:"-"`
 	IsProjectLabel         bool   `json:"is_project_label"`
 	Subscribed             bool   `json:"subscribed"`
 }
@@ -248,6 +249,7 @@ func Unsubscribe(ctx context.Context, client *gitlabclient.Client, input Subscri
 
 // toOutput converts a GitLab API [gl.GroupLabel] to MCP output format.
 func toOutput(l *gl.GroupLabel) Output {
+	priority, prioritySpecified := priorityFromNullable(l.Priority)
 	return Output{
 		ID:                     l.ID,
 		Name:                   l.Name,
@@ -257,16 +259,17 @@ func toOutput(l *gl.GroupLabel) Output {
 		OpenIssuesCount:        l.OpenIssuesCount,
 		ClosedIssuesCount:      l.ClosedIssuesCount,
 		OpenMergeRequestsCount: l.OpenMergeRequestsCount,
-		Priority:               priorityFromNullable(l.Priority),
+		Priority:               priority,
+		PrioritySpecified:      prioritySpecified,
 		IsProjectLabel:         l.IsProjectLabel,
 		Subscribed:             l.Subscribed,
 	}
 }
 
-// priorityFromNullable extracts the int64 value from a Nullable[int64], returning 0 if unset.
-func priorityFromNullable(n gl.Nullable[int64]) int64 {
+// priorityFromNullable extracts the int64 value and whether GitLab returned priority.
+func priorityFromNullable(n gl.Nullable[int64]) (int64, bool) {
 	if !n.IsSpecified() || n.IsNull() {
-		return 0
+		return 0, false
 	}
-	return n.MustGet()
+	return n.MustGet(), true
 }

--- a/internal/tools/grouplabels/markdown.go
+++ b/internal/tools/grouplabels/markdown.go
@@ -1,63 +1,36 @@
 package grouplabels
 
 import (
-	"fmt"
-	"strings"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// FormatMarkdown renders a single group label as a Markdown summary.
-func FormatMarkdown(l Output) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Group Label: %s\n\n", toolutil.EscapeMdHeading(l.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, l.ID)
-	fmt.Fprintf(&b, "- **Color**: %s\n", l.Color)
-	if l.Description != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdDescription, l.Description)
-	}
-	if l.Priority > 0 {
-		fmt.Fprintf(&b, "- **Priority**: %d\n", l.Priority)
-	}
-	fmt.Fprintf(&b, "- **Project label**: %v\n", l.IsProjectLabel)
-	fmt.Fprintf(&b, "- **Subscribed**: %v\n", l.Subscribed)
-	if l.OpenIssuesCount > 0 || l.ClosedIssuesCount > 0 || l.OpenMergeRequestsCount > 0 {
-		fmt.Fprintf(&b, "- **Issues**: %d open, %d closed\n", l.OpenIssuesCount, l.ClosedIssuesCount)
-		fmt.Fprintf(&b, "- **Open MRs**: %d\n", l.OpenMergeRequestsCount)
-	}
-	toolutil.WriteHints(&b,
+var labelMarkdownOptions = toolutil.LabelMarkdownOptions{
+	DetailTitle:   "Group Label",
+	ListTitle:     "Group Labels",
+	EmptyListText: "No group labels found.",
+	DetailHints: []string{
 		"If the workflow asks to fetch/get before update or delete, use the selected tool surface's group-label get action with the same group_id and this label_id next",
 		"Use the selected tool surface's group-label update action with the same group_id and this label_id to modify this label",
 		"Use the selected tool surface's group-label delete action with the same group_id, this label_id, and explicit confirm=true to remove this label",
 		"Use the selected tool surface's group-label subscribe or unsubscribe actions with the same group_id and this label_id to follow or unfollow",
-	)
-	return b.String()
+	},
+	ListHints: []string{
+		toolutil.HintPreserveLinks,
+		"Use the selected tool surface's group-label get action with the same group_id and label_id for full details before update/delete workflows",
+		"Use the selected tool surface's group-label create action with group_id to add a new group label",
+	},
+}
+
+// FormatMarkdown renders a single group label as a Markdown summary.
+func FormatMarkdown(l Output) string {
+	return toolutil.FormatLabelMarkdown(toLabelMarkdown(l), labelMarkdownOptions)
 }
 
 // FormatListMarkdownString renders a paginated list of group labels as a Markdown table string.
 func FormatListMarkdownString(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Group Labels (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Labels), out.Pagination)
-	if len(out.Labels) == 0 {
-		b.WriteString("No group labels found.\n")
-		return b.String()
-	}
-	b.WriteString("| Name | Color | Open Issues | Closed Issues | Open MRs |\n")
-	b.WriteString("|------|-------|-------------|---------------|----------|\n")
-	for _, l := range out.Labels {
-		fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n",
-			toolutil.EscapeMdTableCell(l.Name), toolutil.EscapeMdTableCell(l.Color), l.OpenIssuesCount, l.ClosedIssuesCount, l.OpenMergeRequestsCount)
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b,
-		toolutil.HintPreserveLinks,
-		"Use the selected tool surface's group-label get action with the same group_id and label_id for full details before update/delete workflows",
-		"Use the selected tool surface's group-label create action with group_id to add a new group label",
-	)
-	return b.String()
+	return toolutil.FormatLabelListMarkdown(toLabelMarkdownSlice(out.Labels), out.Pagination, labelMarkdownOptions)
 }
 
 // FormatListMarkdown renders a paginated list of group labels as an MCP Markdown result.
@@ -68,4 +41,27 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 func init() {
 	toolutil.RegisterMarkdown(FormatMarkdown)
 	toolutil.RegisterMarkdown(FormatListMarkdownString)
+}
+
+func toLabelMarkdown(label Output) toolutil.LabelMarkdown {
+	return toolutil.LabelMarkdown{
+		ID:                     label.ID,
+		Name:                   label.Name,
+		Color:                  label.Color,
+		Description:            label.Description,
+		OpenIssuesCount:        label.OpenIssuesCount,
+		ClosedIssuesCount:      label.ClosedIssuesCount,
+		OpenMergeRequestsCount: label.OpenMergeRequestsCount,
+		Priority:               label.Priority,
+		IsProjectLabel:         label.IsProjectLabel,
+		Subscribed:             label.Subscribed,
+	}
+}
+
+func toLabelMarkdownSlice(labels []Output) []toolutil.LabelMarkdown {
+	items := make([]toolutil.LabelMarkdown, len(labels))
+	for i, label := range labels {
+		items[i] = toLabelMarkdown(label)
+	}
+	return items
 }

--- a/internal/tools/grouplabels/markdown.go
+++ b/internal/tools/grouplabels/markdown.go
@@ -30,7 +30,7 @@ func FormatMarkdown(l Output) string {
 
 // FormatListMarkdownString renders a paginated list of group labels as a Markdown table string.
 func FormatListMarkdownString(out ListOutput) string {
-	return toolutil.FormatLabelListMarkdown(toLabelMarkdownSlice(out.Labels), out.Pagination, labelMarkdownOptions)
+	return toolutil.FormatLabelListMarkdownFunc(out.Labels, out.Pagination, labelMarkdownOptions, toLabelMarkdown)
 }
 
 // FormatListMarkdown renders a paginated list of group labels as an MCP Markdown result.
@@ -44,24 +44,5 @@ func init() {
 }
 
 func toLabelMarkdown(label Output) toolutil.LabelMarkdown {
-	return toolutil.LabelMarkdown{
-		ID:                     label.ID,
-		Name:                   label.Name,
-		Color:                  label.Color,
-		Description:            label.Description,
-		OpenIssuesCount:        label.OpenIssuesCount,
-		ClosedIssuesCount:      label.ClosedIssuesCount,
-		OpenMergeRequestsCount: label.OpenMergeRequestsCount,
-		Priority:               label.Priority,
-		IsProjectLabel:         label.IsProjectLabel,
-		Subscribed:             label.Subscribed,
-	}
-}
-
-func toLabelMarkdownSlice(labels []Output) []toolutil.LabelMarkdown {
-	items := make([]toolutil.LabelMarkdown, len(labels))
-	for i, label := range labels {
-		items[i] = toLabelMarkdown(label)
-	}
-	return items
+	return toolutil.LabelMarkdown{ID: label.ID, Name: label.Name, Color: label.Color, Description: label.Description, OpenIssuesCount: label.OpenIssuesCount, ClosedIssuesCount: label.ClosedIssuesCount, OpenMergeRequestsCount: label.OpenMergeRequestsCount, Priority: label.Priority, PrioritySpecified: label.PrioritySpecified, IsProjectLabel: label.IsProjectLabel, Subscribed: label.Subscribed}
 }

--- a/internal/tools/groups/hooks_test.go
+++ b/internal/tools/groups/hooks_test.go
@@ -369,6 +369,12 @@ func TestGetHook_URLVariables(t *testing.T) {
 	}
 }
 
+// TestFormatHookMarkdown_URLVariablesRedacted verifies group hook markdown shows
+// URL variable names without exposing secret values.
+//
+// The formatter receives a hook with token metadata and one URL variable. The
+// expected output includes hook details and REDACTED variable display, preserving
+// useful diagnostics without leaking sensitive webhook configuration.
 func TestFormatHookMarkdown_URLVariablesRedacted(t *testing.T) {
 	text := FormatHookMarkdown(HookOutput{
 		ID:                  10,
@@ -391,6 +397,12 @@ func TestFormatHookMarkdown_URLVariablesRedacted(t *testing.T) {
 	}
 }
 
+// TestEnabledEvents_AllEvents verifies enabledEvents renders every supported
+// group hook event flag.
+//
+// The hook output enables legacy and newer event fields, including milestone,
+// feature flag, subgroup, member, and vulnerability events. The expected string
+// contains each event name so markdown summaries do not silently omit flags.
 func TestEnabledEvents_AllEvents(t *testing.T) {
 	text := enabledEvents(HookOutput{
 		PushEvents:          true,

--- a/internal/tools/individual_catalog_test.go
+++ b/internal/tools/individual_catalog_test.go
@@ -236,6 +236,13 @@ func TestRegisterIndividualCatalogTools_EditionFilters(t *testing.T) {
 	}
 }
 
+// TestRegisterIndividualCatalogTools_AllowExcludeAndDuplicateTools verifies
+// allow lists, exclude lists, and duplicate individual tool names are resolved
+// deterministically.
+//
+// The catalog contains keep, skip, excluded, and duplicate actions. Registration
+// should include allowed tools, remove explicitly excluded tools, and register a
+// duplicate tool name only once.
 func TestRegisterIndividualCatalogTools_AllowExcludeAndDuplicateTools(t *testing.T) {
 	newSpec := func(actionName, toolName string) toolutil.ActionSpec {
 		return toolutil.NewActionSpec(actionName, toolutil.RouteAction(nil,
@@ -270,6 +277,13 @@ func TestRegisterIndividualCatalogTools_AllowExcludeAndDuplicateTools(t *testing
 	}
 }
 
+// TestRegisterIndividualCatalogTools_SkipsIneligibleGroup verifies individual
+// projection ignores catalog groups that are not eligible for the selected
+// surface.
+//
+// The test builds a runtime utility group without standalone utility opt-in and
+// expects no tools to be registered. This prevents internal maintenance surfaces
+// from leaking into individual mode by default.
 func TestRegisterIndividualCatalogTools_SkipsIneligibleGroup(t *testing.T) {
 	spec := toolutil.NewActionSpec("runtime", toolutil.RouteAction(nil,
 		func(_ context.Context, _ *gitlabclient.Client, _ struct{}) (struct{}, error) {
@@ -301,6 +315,12 @@ func TestRegisterIndividualCatalogTools_SkipsIneligibleGroup(t *testing.T) {
 	}
 }
 
+// TestRegisterIndividualCatalogTools_DestructiveConfirmationDeclined verifies a
+// declined elicitation prevents destructive catalog handlers from executing.
+//
+// The in-memory MCP client always declines the confirmation request. The test
+// expects cancellation text and asserts the destructive handler was never called,
+// preserving the safety guard for individual tool projection.
 func TestRegisterIndividualCatalogTools_DestructiveConfirmationDeclined(t *testing.T) {
 	called := false
 	spec := toolutil.NewActionSpec("delete", toolutil.RouteAction(nil,
@@ -349,6 +369,12 @@ func TestRegisterIndividualCatalogTools_DestructiveConfirmationDeclined(t *testi
 	}
 }
 
+// TestMustIndividualToolFromCatalogAction_DescriptionFallbacks verifies
+// individual tool descriptions use callbacks, usage text, then title fallback.
+//
+// Each table case constructs a catalog action with different description inputs
+// and expects the projected MCP tool description to follow the fallback order
+// used by generated individual tools.
 func TestMustIndividualToolFromCatalogAction_DescriptionFallbacks(t *testing.T) {
 	newAction := func(name, usage string) actioncatalog.Action {
 		return actioncatalog.Action{
@@ -403,6 +429,11 @@ func TestMustIndividualToolFromCatalogAction_DescriptionFallbacks(t *testing.T) 
 	}
 }
 
+// TestMustIndividualToolFromCatalogAction_InvalidActionPanics verifies invalid
+// catalog actions fail during individual tool projection.
+//
+// The action lacks an output schema, so projection should panic instead of
+// registering a malformed MCP tool that would fail later at runtime.
 func TestMustIndividualToolFromCatalogAction_InvalidActionPanics(t *testing.T) {
 	action := actioncatalog.Action{
 		Name: "broken",
@@ -416,6 +447,12 @@ func TestMustIndividualToolFromCatalogAction_InvalidActionPanics(t *testing.T) {
 	assertPanics(t, func() { _ = mustIndividualToolFromCatalogAction(action, nil, IndividualCatalogRegisterOptions{}) })
 }
 
+// TestIndividualCatalogActionReadOnly_AnnotationOverride verifies individual
+// annotation overrides can mark an otherwise mutating action as read-only.
+//
+// The action metadata is mutating, but the individual tool override sets
+// ReadOnly to true. The helper should honor that override because it controls
+// MCP annotations exposed by individual tools.
 func TestIndividualCatalogActionReadOnly_AnnotationOverride(t *testing.T) {
 	readOnly := true
 	action := actioncatalog.Action{

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -207,6 +207,12 @@ func TestJobTrace_Success(t *testing.T) {
 	}
 }
 
+// TestJobTrace_Truncated verifies Trace caps large job logs at maxTraceBytes and
+// marks the output as truncated.
+//
+// The mock returns a trace slightly larger than the configured limit. The test
+// expects the trace length to equal maxTraceBytes and Truncated to be true,
+// protecting clients from unbounded job-log responses.
 func TestJobTrace_Truncated(t *testing.T) {
 	traceContent := strings.Repeat("x", maxTraceBytes+10)
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/jobs/wait.go
+++ b/internal/tools/jobs/wait.go
@@ -12,7 +12,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/progress"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/waitpoll"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -50,60 +50,40 @@ func Wait(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Cl
 		return WaitOutput{}, toolutil.ErrRequiredInt64("jobWait", "job_id")
 	}
 
-	interval := toolutil.ClampPollInterval(input.IntervalSeconds)
-	timeout := toolutil.ClampPollTimeout(input.TimeoutSeconds)
-	failOnError := true
-	if input.FailOnError != nil {
-		failOnError = *input.FailOnError
+	result, err := waitpoll.Poll(ctx, waitpoll.Options[Output]{
+		Request:         req,
+		IntervalSeconds: input.IntervalSeconds,
+		TimeoutSeconds:  input.TimeoutSeconds,
+		FailOnError:     input.FailOnError,
+		PollDuration:    pollDuration,
+		ProgressMessage: func(attempt int) string {
+			return fmt.Sprintf("Polling job #%d (attempt %d, status check)…", input.JobID, attempt)
+		},
+		Poll: func(pollCtx context.Context) (Output, error) {
+			j, _, err := client.GL().Jobs.GetJob(string(input.ProjectID), input.JobID, gl.WithContext(pollCtx))
+			if err != nil {
+				return Output{}, toolutil.WrapErrWithStatusHint("jobWait", err, http.StatusNotFound,
+					"verify project_id and job_id with gitlab_job_list; the job may have been deleted or expired during polling")
+			}
+			return ToOutput(j), nil
+		},
+		Status: func(out Output) string { return out.Status },
+		FailureError: func(out Output) error {
+			return fmt.Errorf("jobWait: job #%d finished with status %q", input.JobID, out.Status)
+		},
+	})
+	if err != nil {
+		return waitOutputFromResult(result), err
 	}
+	return waitOutputFromResult(result), nil
+}
 
-	tracker := progress.FromRequest(req)
-	deadline := time.After(pollDuration(timeout))
-	ticker := time.NewTicker(pollDuration(interval))
-	defer ticker.Stop()
-
-	startTime := time.Now()
-	pollCount := 0
-
-	for {
-		pollCount++
-		tracker.Update(ctx, float64(pollCount), 0, fmt.Sprintf("Polling job #%d (attempt %d, status check)…", input.JobID, pollCount))
-
-		j, _, err := client.GL().Jobs.GetJob(string(input.ProjectID), input.JobID, gl.WithContext(ctx))
-		if err != nil {
-			return WaitOutput{}, toolutil.WrapErrWithStatusHint("jobWait", err, http.StatusNotFound,
-				"verify project_id and job_id with gitlab_job_list; the job may have been deleted or expired during polling")
-		}
-
-		out := ToOutput(j)
-		if toolutil.IsTerminalStatus(out.Status) {
-			elapsed := time.Since(startTime).Round(time.Second)
-			result := WaitOutput{
-				Job:         out,
-				WaitedFor:   elapsed.String(),
-				PollCount:   pollCount,
-				FinalStatus: out.Status,
-			}
-			if failOnError && (out.Status == "failed" || out.Status == "canceled") {
-				return result, fmt.Errorf("jobWait: job #%d finished with status %q", input.JobID, out.Status)
-			}
-			return result, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return WaitOutput{}, ctx.Err()
-		case <-deadline:
-			elapsed := time.Since(startTime).Round(time.Second)
-			return WaitOutput{
-				Job:         out,
-				WaitedFor:   elapsed.String(),
-				PollCount:   pollCount,
-				FinalStatus: out.Status,
-				TimedOut:    true,
-			}, nil
-		case <-ticker.C:
-			// Continue polling
-		}
+func waitOutputFromResult(result waitpoll.Result[Output]) WaitOutput {
+	return WaitOutput{
+		Job:         result.Item,
+		WaitedFor:   result.WaitedFor,
+		PollCount:   result.PollCount,
+		FinalStatus: result.FinalStatus,
+		TimedOut:    result.TimedOut,
 	}
 }

--- a/internal/tools/jobs/wait.go
+++ b/internal/tools/jobs/wait.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+var pollDuration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Second }
+
 // WaitInput defines parameters for waiting on a job to complete.
 type WaitInput struct {
 	ProjectID       toolutil.StringOrInt `json:"project_id"                jsonschema:"Project ID or URL-encoded path,required"`
@@ -56,8 +58,8 @@ func Wait(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Cl
 	}
 
 	tracker := progress.FromRequest(req)
-	deadline := time.After(time.Duration(timeout) * time.Second)
-	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	deadline := time.After(pollDuration(timeout))
+	ticker := time.NewTicker(pollDuration(interval))
 	defer ticker.Stop()
 
 	startTime := time.Now()

--- a/internal/tools/jobs/wait_test.go
+++ b/internal/tools/jobs/wait_test.go
@@ -15,6 +15,13 @@ import (
 
 const pathWaitJob = "/api/v4/projects/42/jobs/100"
 
+func useFastJobPollDuration(t *testing.T) {
+	t.Helper()
+	original := pollDuration
+	pollDuration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Millisecond }
+	t.Cleanup(func() { pollDuration = original })
+}
+
 func jobWithStatus(status string) string {
 	return `{
 		"id":100,"name":"build","stage":"build","status":"` + status + `",
@@ -122,6 +129,8 @@ func TestJobWait_FailedJob_NoFailOnError(t *testing.T) {
 // TestJobWait_Timeout verifies that Wait returns TimedOut=true when the
 // job stays in a running state and the timeout expires.
 func TestJobWait_Timeout(t *testing.T) {
+	useFastJobPollDuration(t)
+
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == pathWaitJob {
 			testutil.RespondJSON(w, http.StatusOK, jobWithStatus("running"))
@@ -150,6 +159,8 @@ func TestJobWait_Timeout(t *testing.T) {
 // TestJobWait_PollingTransition verifies that Wait polls multiple times
 // before the job transitions from running to success.
 func TestJobWait_PollingTransition(t *testing.T) {
+	useFastJobPollDuration(t)
+
 	var callCount atomic.Int32
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == pathWaitJob {
@@ -325,7 +336,9 @@ func TestJobWait_ManualJob(t *testing.T) {
 // Uses a short-lived context that expires after the first poll but before
 // the ticker (5 s min), ensuring the select picks ctx.Done deterministically.
 func TestJobWait_ContextCanceledDuringPoll(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	useFastJobPollDuration(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
 	defer cancel()
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/labels/labels.go
+++ b/internal/tools/labels/labels.go
@@ -75,6 +75,7 @@ type Output struct {
 	ClosedIssuesCount      int64  `json:"closed_issues_count"`
 	OpenMergeRequestsCount int64  `json:"open_merge_requests_count"`
 	Priority               int64  `json:"priority"`
+	PrioritySpecified      bool   `json:"-"`
 	IsProjectLabel         bool   `json:"is_project_label"`
 	Subscribed             bool   `json:"subscribed"`
 }
@@ -272,6 +273,7 @@ func Promote(ctx context.Context, client *gitlabclient.Client, input PromoteInpu
 
 // labelToOutput converts a GitLab API [gl.Label] to MCP output format.
 func toOutput(l *gl.Label) Output {
+	priority, prioritySpecified := priorityFromNullable(l.Priority)
 	return Output{
 		ID:                     l.ID,
 		Name:                   l.Name,
@@ -281,16 +283,17 @@ func toOutput(l *gl.Label) Output {
 		OpenIssuesCount:        l.OpenIssuesCount,
 		ClosedIssuesCount:      l.ClosedIssuesCount,
 		OpenMergeRequestsCount: l.OpenMergeRequestsCount,
-		Priority:               priorityFromNullable(l.Priority),
+		Priority:               priority,
+		PrioritySpecified:      prioritySpecified,
 		IsProjectLabel:         l.IsProjectLabel,
 		Subscribed:             l.Subscribed,
 	}
 }
 
-// priorityFromNullable extracts the int64 value from a Nullable[int64], returning 0 if unset.
-func priorityFromNullable(n gl.Nullable[int64]) int64 {
+// priorityFromNullable extracts the int64 value and whether GitLab returned priority.
+func priorityFromNullable(n gl.Nullable[int64]) (int64, bool) {
 	if !n.IsSpecified() || n.IsNull() {
-		return 0
+		return 0, false
 	}
-	return n.MustGet()
+	return n.MustGet(), true
 }

--- a/internal/tools/labels/markdown.go
+++ b/internal/tools/labels/markdown.go
@@ -1,13 +1,25 @@
 package labels
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
+
+var labelMarkdownOptions = toolutil.LabelMarkdownOptions{
+	DetailTitle:       "Label",
+	ListTitle:         "Labels",
+	EmptyListText:     "No labels found.",
+	EscapeDescription: true,
+	DetailHints: []string{
+		"Use action 'label_update' to change label name, color, or description",
+		"Use action 'label_delete' to remove this label",
+	},
+	ListHints: []string{
+		"Use action 'label_get' with a label_id to see label details",
+		"Use action 'label_create' to create a new label",
+	},
+}
 
 type labelNotFoundOutput struct {
 	Identifier string
@@ -22,50 +34,12 @@ func formatLabelNotFound(out labelNotFoundOutput) *mcp.CallToolResult {
 
 // FormatMarkdown renders a single label as a Markdown summary.
 func FormatMarkdown(l Output) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Label: %s\n\n", toolutil.EscapeMdHeading(l.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, l.ID)
-	fmt.Fprintf(&b, "- **Color**: %s\n", l.Color)
-	if l.Description != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdDescription, toolutil.EscapeMdTableCell(l.Description))
-	}
-	if l.Priority > 0 {
-		fmt.Fprintf(&b, "- **Priority**: %d\n", l.Priority)
-	}
-	fmt.Fprintf(&b, "- **Project label**: %v\n", l.IsProjectLabel)
-	fmt.Fprintf(&b, "- **Subscribed**: %v\n", l.Subscribed)
-	if l.OpenIssuesCount > 0 || l.ClosedIssuesCount > 0 || l.OpenMergeRequestsCount > 0 {
-		fmt.Fprintf(&b, "- **Issues**: %d open, %d closed\n", l.OpenIssuesCount, l.ClosedIssuesCount)
-		fmt.Fprintf(&b, "- **Open MRs**: %d\n", l.OpenMergeRequestsCount)
-	}
-	toolutil.WriteHints(&b,
-		"Use action 'label_update' to change label name, color, or description",
-		"Use action 'label_delete' to remove this label",
-	)
-	return b.String()
+	return toolutil.FormatLabelMarkdown(toLabelMarkdown(l), labelMarkdownOptions)
 }
 
 // FormatListMarkdownString renders a paginated list of labels as a Markdown table string.
 func FormatListMarkdownString(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Labels (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Labels), out.Pagination)
-	if len(out.Labels) == 0 {
-		b.WriteString("No labels found.\n")
-		return b.String()
-	}
-	b.WriteString("| Name | Color | Open Issues | Closed Issues | Open MRs |\n")
-	b.WriteString("|------|-------|-------------|---------------|----------|\n")
-	for _, l := range out.Labels {
-		fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n",
-			toolutil.EscapeMdTableCell(l.Name), toolutil.EscapeMdTableCell(l.Color), l.OpenIssuesCount, l.ClosedIssuesCount, l.OpenMergeRequestsCount)
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b,
-		"Use action 'label_get' with a label_id to see label details",
-		"Use action 'label_create' to create a new label",
-	)
-	return b.String()
+	return toolutil.FormatLabelListMarkdown(toLabelMarkdownSlice(out.Labels), out.Pagination, labelMarkdownOptions)
 }
 
 // FormatListMarkdown renders a paginated list of labels as an MCP Markdown result.
@@ -77,4 +51,27 @@ func init() {
 	toolutil.RegisterMarkdownResult(formatLabelNotFound)
 	toolutil.RegisterMarkdown(FormatMarkdown)
 	toolutil.RegisterMarkdown(FormatListMarkdownString)
+}
+
+func toLabelMarkdown(label Output) toolutil.LabelMarkdown {
+	return toolutil.LabelMarkdown{
+		ID:                     label.ID,
+		Name:                   label.Name,
+		Color:                  label.Color,
+		Description:            label.Description,
+		OpenIssuesCount:        label.OpenIssuesCount,
+		ClosedIssuesCount:      label.ClosedIssuesCount,
+		OpenMergeRequestsCount: label.OpenMergeRequestsCount,
+		Priority:               label.Priority,
+		IsProjectLabel:         label.IsProjectLabel,
+		Subscribed:             label.Subscribed,
+	}
+}
+
+func toLabelMarkdownSlice(labels []Output) []toolutil.LabelMarkdown {
+	items := make([]toolutil.LabelMarkdown, len(labels))
+	for i, label := range labels {
+		items[i] = toLabelMarkdown(label)
+	}
+	return items
 }

--- a/internal/tools/labels/markdown.go
+++ b/internal/tools/labels/markdown.go
@@ -16,6 +16,7 @@ var labelMarkdownOptions = toolutil.LabelMarkdownOptions{
 		"Use action 'label_delete' to remove this label",
 	},
 	ListHints: []string{
+		toolutil.HintPreserveLinks,
 		"Use action 'label_get' with a label_id to see label details",
 		"Use action 'label_create' to create a new label",
 	},
@@ -39,7 +40,7 @@ func FormatMarkdown(l Output) string {
 
 // FormatListMarkdownString renders a paginated list of labels as a Markdown table string.
 func FormatListMarkdownString(out ListOutput) string {
-	return toolutil.FormatLabelListMarkdown(toLabelMarkdownSlice(out.Labels), out.Pagination, labelMarkdownOptions)
+	return toolutil.FormatLabelListMarkdownFunc(out.Labels, out.Pagination, labelMarkdownOptions, toLabelMarkdown)
 }
 
 // FormatListMarkdown renders a paginated list of labels as an MCP Markdown result.
@@ -54,24 +55,5 @@ func init() {
 }
 
 func toLabelMarkdown(label Output) toolutil.LabelMarkdown {
-	return toolutil.LabelMarkdown{
-		ID:                     label.ID,
-		Name:                   label.Name,
-		Color:                  label.Color,
-		Description:            label.Description,
-		OpenIssuesCount:        label.OpenIssuesCount,
-		ClosedIssuesCount:      label.ClosedIssuesCount,
-		OpenMergeRequestsCount: label.OpenMergeRequestsCount,
-		Priority:               label.Priority,
-		IsProjectLabel:         label.IsProjectLabel,
-		Subscribed:             label.Subscribed,
-	}
-}
-
-func toLabelMarkdownSlice(labels []Output) []toolutil.LabelMarkdown {
-	items := make([]toolutil.LabelMarkdown, len(labels))
-	for i, label := range labels {
-		items[i] = toLabelMarkdown(label)
-	}
-	return items
+	return toolutil.LabelMarkdown{ID: label.ID, Name: label.Name, Color: label.Color, Description: label.Description, OpenIssuesCount: label.OpenIssuesCount, ClosedIssuesCount: label.ClosedIssuesCount, OpenMergeRequestsCount: label.OpenMergeRequestsCount, Priority: label.Priority, PrioritySpecified: label.PrioritySpecified, IsProjectLabel: label.IsProjectLabel, Subscribed: label.Subscribed}
 }

--- a/internal/tools/meta_catalog_test.go
+++ b/internal/tools/meta_catalog_test.go
@@ -2,6 +2,11 @@ package tools
 
 import "testing"
 
+// TestRegisterMetaCatalog_NilInputs verifies nil server or catalog inputs are
+// ignored without panicking.
+//
+// Meta catalog registration is called from configurable startup paths; accepting
+// nil inputs keeps defensive tests and partial setup flows from crashing.
 func TestRegisterMetaCatalog_NilInputs(t *testing.T) {
 	RegisterMetaCatalog(nil, nil)
 }

--- a/internal/tools/modelregistry/model_registry_test.go
+++ b/internal/tools/modelregistry/model_registry_test.go
@@ -259,6 +259,11 @@ func TestDownload(t *testing.T) {
 	}
 }
 
+// TestDownloadOutput_ReadError verifies downloadOutput returns reader failures
+// instead of producing partial base64 content.
+//
+// The test injects a reader that always fails and expects a non-nil error,
+// protecting ML model downloads from silently accepting corrupted file streams.
 func TestDownloadOutput_ReadError(t *testing.T) {
 	_, err := downloadOutput(DownloadInput{
 		ProjectID:      toolutil.StringOrInt("42"),

--- a/internal/tools/pipelines/wait.go
+++ b/internal/tools/pipelines/wait.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+var pollDuration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Second }
+
 // WaitInput defines parameters for waiting on a pipeline to complete.
 type WaitInput struct {
 	ProjectID       toolutil.StringOrInt `json:"project_id"                jsonschema:"Project ID or URL-encoded path,required"`
@@ -56,8 +58,8 @@ func Wait(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Cl
 	}
 
 	tracker := progress.FromRequest(req)
-	deadline := time.After(time.Duration(timeout) * time.Second)
-	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	deadline := time.After(pollDuration(timeout))
+	ticker := time.NewTicker(pollDuration(interval))
 	defer ticker.Stop()
 
 	startTime := time.Now()

--- a/internal/tools/pipelines/wait.go
+++ b/internal/tools/pipelines/wait.go
@@ -12,7 +12,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/progress"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/waitpoll"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -50,59 +50,39 @@ func Wait(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Cl
 		return WaitOutput{}, toolutil.ErrRequiredInt64("pipelineWait", "pipeline_id")
 	}
 
-	interval := toolutil.ClampPollInterval(input.IntervalSeconds)
-	timeout := toolutil.ClampPollTimeout(input.TimeoutSeconds)
-	failOnError := true
-	if input.FailOnError != nil {
-		failOnError = *input.FailOnError
+	result, err := waitpoll.Poll(ctx, waitpoll.Options[DetailOutput]{
+		Request:         req,
+		IntervalSeconds: input.IntervalSeconds,
+		TimeoutSeconds:  input.TimeoutSeconds,
+		FailOnError:     input.FailOnError,
+		PollDuration:    pollDuration,
+		ProgressMessage: func(attempt int) string {
+			return fmt.Sprintf("Polling pipeline #%d (attempt %d, status check)…", input.PipelineID, attempt)
+		},
+		Poll: func(pollCtx context.Context) (DetailOutput, error) {
+			p, _, err := client.GL().Pipelines.GetPipeline(string(input.ProjectID), input.PipelineID, gl.WithContext(pollCtx))
+			if err != nil {
+				return DetailOutput{}, toolutil.WrapErrWithStatusHint("pipelineWait", err, http.StatusNotFound, "verify project_id and pipeline_id with gitlab_pipeline_list")
+			}
+			return DetailToOutput(p), nil
+		},
+		Status: func(detail DetailOutput) string { return detail.Status },
+		FailureError: func(detail DetailOutput) error {
+			return fmt.Errorf("pipelineWait: pipeline #%d finished with status %q", input.PipelineID, detail.Status)
+		},
+	})
+	if err != nil {
+		return waitOutputFromResult(result), err
 	}
+	return waitOutputFromResult(result), nil
+}
 
-	tracker := progress.FromRequest(req)
-	deadline := time.After(pollDuration(timeout))
-	ticker := time.NewTicker(pollDuration(interval))
-	defer ticker.Stop()
-
-	startTime := time.Now()
-	pollCount := 0
-
-	for {
-		pollCount++
-		tracker.Update(ctx, float64(pollCount), 0, fmt.Sprintf("Polling pipeline #%d (attempt %d, status check)…", input.PipelineID, pollCount))
-
-		p, _, err := client.GL().Pipelines.GetPipeline(string(input.ProjectID), input.PipelineID, gl.WithContext(ctx))
-		if err != nil {
-			return WaitOutput{}, toolutil.WrapErrWithStatusHint("pipelineWait", err, http.StatusNotFound, "verify project_id and pipeline_id with gitlab_pipeline_list")
-		}
-
-		detail := DetailToOutput(p)
-		if toolutil.IsTerminalStatus(detail.Status) {
-			elapsed := time.Since(startTime).Round(time.Second)
-			out := WaitOutput{
-				Pipeline:    detail,
-				WaitedFor:   elapsed.String(),
-				PollCount:   pollCount,
-				FinalStatus: detail.Status,
-			}
-			if failOnError && (detail.Status == "failed" || detail.Status == "canceled") {
-				return out, fmt.Errorf("pipelineWait: pipeline #%d finished with status %q", input.PipelineID, detail.Status)
-			}
-			return out, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return WaitOutput{}, ctx.Err()
-		case <-deadline:
-			elapsed := time.Since(startTime).Round(time.Second)
-			return WaitOutput{
-				Pipeline:    detail,
-				WaitedFor:   elapsed.String(),
-				PollCount:   pollCount,
-				FinalStatus: detail.Status,
-				TimedOut:    true,
-			}, nil
-		case <-ticker.C:
-			// Continue polling
-		}
+func waitOutputFromResult(result waitpoll.Result[DetailOutput]) WaitOutput {
+	return WaitOutput{
+		Pipeline:    result.Item,
+		WaitedFor:   result.WaitedFor,
+		PollCount:   result.PollCount,
+		FinalStatus: result.FinalStatus,
+		TimedOut:    result.TimedOut,
 	}
 }

--- a/internal/tools/pipelines/wait_test.go
+++ b/internal/tools/pipelines/wait_test.go
@@ -15,6 +15,13 @@ import (
 
 const pathWaitPipeline = "/api/v4/projects/42/pipelines/10"
 
+func useFastPipelinePollDuration(t *testing.T) {
+	t.Helper()
+	original := pollDuration
+	pollDuration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Millisecond }
+	t.Cleanup(func() { pollDuration = original })
+}
+
 func pipelineJSON(status string) string {
 	return `{
 		"id":10,"iid":10,"project_id":42,"status":"` + status + `","source":"push",
@@ -115,6 +122,8 @@ func TestWait_FailedPipeline_NoFailOnError(t *testing.T) {
 // TestWait_Timeout verifies that Wait returns TimedOut=true when the
 // pipeline stays in a running state and the timeout expires.
 func TestWait_Timeout(t *testing.T) {
+	useFastPipelinePollDuration(t)
+
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == pathWaitPipeline {
 			testutil.RespondJSON(w, http.StatusOK, pipelineJSON("running"))
@@ -143,6 +152,8 @@ func TestWait_Timeout(t *testing.T) {
 // TestWait_PollingTransition verifies that Wait polls multiple times
 // before the pipeline transitions from running to success.
 func TestWait_PollingTransition(t *testing.T) {
+	useFastPipelinePollDuration(t)
+
 	var callCount atomic.Int32
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == pathWaitPipeline {
@@ -318,7 +329,9 @@ func TestWait_ManualPipeline(t *testing.T) {
 // Uses a short-lived context that expires after the first poll but before
 // the ticker (5 s min), ensuring the select picks ctx.Done deterministically.
 func TestWait_ContextCanceledDuringPoll(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	useFastPipelinePollDuration(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
 	defer cancel()
 
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -468,6 +468,12 @@ func TestProjectDelete_PermanentlyRemove(t *testing.T) {
 	}
 }
 
+// TestProjectDelete_PermanentlyRemoveTwoStep verifies permanent deletion retries
+// through GitLab's mark-then-remove flow.
+//
+// The first DELETE returns GitLab's "must be marked for deletion first" error;
+// the handler should mark the project, retry permanent removal, and report a
+// permanently removed result after three delete calls.
 func TestProjectDelete_PermanentlyRemoveTwoStep(t *testing.T) {
 	calls := 0
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -639,6 +645,12 @@ func TestProjectCreate_ContextCancelled(t *testing.T) {
 	}
 }
 
+// TestProjectHandlers_ContextCancelled verifies project handlers return context
+// cancellation errors without dispatching HTTP requests.
+//
+// The table covers read, write, hook, approval-rule, fork, avatar,
+// housekeeping, and user-project paths. A failing mock handler ensures each
+// operation observes the cancelled context before touching GitLab.
 func TestProjectHandlers_ContextCancelled(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("API should not be called with canceled context: %s %s", r.Method, r.URL.Path)
@@ -757,6 +769,13 @@ func TestProjectHandlers_ContextCancelled(t *testing.T) {
 	}
 }
 
+// TestProjectHandlers_StatusSpecificErrors verifies project handlers propagate
+// representative GitLab HTTP failures.
+//
+// Each table case returns a status code associated with a specific operation,
+// including forbidden, not found, bad request, conflict, and unprocessable
+// entity responses. The test expects errors for every case, preserving
+// operation-specific wrapping and hints.
 func TestProjectHandlers_StatusSpecificErrors(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -900,6 +919,12 @@ func TestProjectHandlers_StatusSpecificErrors(t *testing.T) {
 	}
 }
 
+// TestProjectHandlers_ValidationErrors verifies project handlers reject missing
+// required inputs before making API calls.
+//
+// The table covers missing project IDs and missing hook key fields. The mock
+// handler fails on any request, proving validation protects GitLab from malformed
+// calls.
 func TestProjectHandlers_ValidationErrors(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("API should not be called for validation errors: %s %s", r.Method, r.URL.Path)
@@ -934,6 +959,12 @@ func TestProjectHandlers_ValidationErrors(t *testing.T) {
 	}
 }
 
+// TestBuildUpdateOpts_MergeRequestTitleRegexOptions verifies project update
+// options include merge request title regex settings.
+//
+// The test builds update options with a regex and description, then checks both
+// pointers are populated with the requested values. This protects Premium push
+// rule metadata from being dropped during option conversion.
 func TestBuildUpdateOpts_MergeRequestTitleRegexOptions(t *testing.T) {
 	opts := buildUpdateOpts(UpdateInput{
 		MergeRequestTitleRegex:            testCommitRegex,
@@ -1660,6 +1691,12 @@ func TestProjectListHooks_Success(t *testing.T) {
 	}
 }
 
+// TestProjectHookCustomHeadersToOutput_SkipsNilEntries verifies custom hook
+// header conversion drops nil entries while preserving real keys.
+//
+// The first assertion keeps a single non-nil header after a nil entry; the second
+// expects nil when every source entry is nil. This prevents empty redacted header
+// rows from appearing in hook output.
 func TestProjectHookCustomHeadersToOutput_SkipsNilEntries(t *testing.T) {
 	headers := projectHookCustomHeadersToOutput([]*gl.HookCustomHeader{
 		nil,

--- a/internal/tools/scope_filter_test.go
+++ b/internal/tools/scope_filter_test.go
@@ -135,6 +135,11 @@ func TestFilterScopeFilteredCatalog_MissingAdminMode(t *testing.T) {
 	})
 }
 
+// TestFilterScopeFilteredCatalog_NilCatalog verifies scope filtering handles a
+// nil source catalog by returning an empty catalog.
+//
+// The test expects no error, a non-nil result, and zero groups or actions. This
+// keeps callers safe when filtering is invoked before catalog construction.
 func TestFilterScopeFilteredCatalog_NilCatalog(t *testing.T) {
 	filtered, err := FilterScopeFilteredCatalog(nil, []string{"read_api"})
 	if err != nil {

--- a/internal/tools/securityattributes/doc.go
+++ b/internal/tools/securityattributes/doc.go
@@ -1,5 +1,16 @@
 // Package securityattributes implements MCP tools for GitLab security attributes.
 //
+// The package exposes catalog-backed actions for creating, updating, deleting,
+// assigning, and bulk-applying attributes that GitLab uses to classify projects
+// and groups for security workflows. Handlers validate numeric identifiers,
+// security category references, hex color values, and bulk update modes before
+// issuing GraphQL mutations through the GitLab client.
+//
+// Security attributes are available only on GitLab tiers and deployments that
+// expose the underlying GraphQL security attribute schema. The package keeps the
+// GraphQL payloads local so the MCP action catalog, dynamic search surface, and
+// Markdown formatters all share the same typed input and output structures.
+//
 // GitLab API docs:
 //   - https://docs.gitlab.com/api/graphql/reference/#securityattribute
 //   - https://docs.gitlab.com/api/graphql/reference/#mutationsecurityattributecreate

--- a/internal/tools/securityattributes/security_attributes.go
+++ b/internal/tools/securityattributes/security_attributes.go
@@ -1,4 +1,3 @@
-// Package securityattributes provides handlers for GitLab security attribute tools.
 package securityattributes
 
 import (

--- a/internal/tools/securityattributes/security_attributes_test.go
+++ b/internal/tools/securityattributes/security_attributes_test.go
@@ -396,13 +396,13 @@ func TestHandlers_WrapTransportErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := attributeGraphQLMux(map[string]http.HandlerFunc{
 				tt.queryKey: func(w http.ResponseWriter, _ *http.Request) {
-					http.Error(w, "boom", http.StatusInternalServerError)
+					http.Error(w, "boom", http.StatusForbidden)
 				},
 			})
 			client := testutil.NewTestClient(t, handler)
 			err := tt.call(client)
-			if err == nil || !strings.Contains(err.Error(), "500") {
-				t.Fatalf("handler error = %v, want HTTP 500", err)
+			if err == nil || !strings.Contains(err.Error(), "403") {
+				t.Fatalf("handler error = %v, want HTTP 403", err)
 			}
 		})
 	}

--- a/internal/tools/securityattributes/security_attributes_test.go
+++ b/internal/tools/securityattributes/security_attributes_test.go
@@ -1,4 +1,8 @@
 // security_attributes_test.go contains unit tests for GitLab security attribute operations.
+//
+// The tests mock GitLab GraphQL mutations with [testutil.GraphQLHandler], then
+// call handlers directly to verify request payloads, validation, error wrapping,
+// output conversion, markdown rendering, and ActionSpec metadata.
 package securityattributes
 
 import (
@@ -31,10 +35,14 @@ const sampleAttribute = `{
 	}
 }`
 
+// attributeGraphQLMux returns a GraphQL test handler for security attribute
+// mutations keyed by operation name.
 func attributeGraphQLMux(handlers map[string]http.HandlerFunc) http.Handler {
 	return testutil.GraphQLHandler(handlers)
 }
 
+// attributeGraphQLInput parses the GraphQL input variables from r and fails the
+// calling test if the request does not contain the expected input object.
 func attributeGraphQLInput(t *testing.T, r *http.Request) map[string]any {
 	t.Helper()
 	vars, err := testutil.ParseGraphQLVariables(r)
@@ -48,6 +56,13 @@ func attributeGraphQLInput(t *testing.T, r *http.Request) map[string]any {
 	return input
 }
 
+// TestCreate_Success verifies that Create sends the expected GraphQL input and
+// converts the returned security attribute and category IDs.
+//
+// The mocked securityAttributeCreate mutation asserts that namespace, category,
+// and attribute fields are normalized before request dispatch, then returns a
+// populated attribute node. The test expects the output to preserve the parsed
+// attribute ID, category ID, and template type.
 func TestCreate_Success(t *testing.T) {
 	handler := attributeGraphQLMux(map[string]http.HandlerFunc{
 		"securityAttributeCreate": func(w http.ResponseWriter, r *http.Request) {
@@ -90,6 +105,11 @@ func TestCreate_Success(t *testing.T) {
 	}
 }
 
+// TestCreate_RequiresAttributes verifies that Create rejects an empty attribute
+// list before it reaches the GraphQL transport.
+//
+// The test uses a not-found handler as a guard: a successful validation failure
+// returns an "attributes is required" error without issuing any HTTP request.
 func TestCreate_RequiresAttributes(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	_, err := Create(context.Background(), client, CreateInput{NamespaceID: 101, CategoryID: 7})
@@ -98,6 +118,12 @@ func TestCreate_RequiresAttributes(t *testing.T) {
 	}
 }
 
+// TestCreate_ValidatesInputBeforeRequest verifies Create validation for IDs and
+// required attribute fields.
+//
+// Each table case uses an invalid input shape and expects the specific
+// validation message for that field. The not-found handler ensures the test
+// fails if validation accidentally allows a network call.
 func TestCreate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	tests := []struct {
@@ -147,6 +173,12 @@ func TestCreate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnContextErrors verifies that all security attribute handlers
+// propagate a cancelled context without masking it as a GitLab API error.
+//
+// The test cancels the context before invoking create, update, delete, project
+// update, and bulk update paths. Each subtest expects [context.Canceled], which
+// preserves caller cancellation semantics.
 func TestHandlers_ReturnContextErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -203,6 +235,12 @@ func TestHandlers_ReturnContextErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapGitLabErrors verifies that GraphQL mutation errors embedded
+// in successful HTTP responses are surfaced to callers.
+//
+// Each subtest returns a domain-level errors array from the corresponding
+// security attribute mutation. The expected result is an error containing the
+// GitLab message instead of a successful zero-value output.
 func TestHandlers_WrapGitLabErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -274,6 +312,12 @@ func TestHandlers_WrapGitLabErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapTopLevelGraphQLErrors verifies that top-level GraphQL errors
+// are returned consistently across security attribute handlers.
+//
+// The mock responds with a GraphQL errors envelope for every mutation route. The
+// test expects each handler to preserve the top-level error text so callers can
+// distinguish transport success from GraphQL execution failure.
 func TestHandlers_WrapTopLevelGraphQLErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -343,6 +387,12 @@ func TestHandlers_WrapTopLevelGraphQLErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapTransportErrors verifies that non-2xx HTTP responses from the
+// GraphQL endpoint are wrapped with the transport status.
+//
+// Each subtest returns HTTP 403 for a different mutation. The expected error
+// includes the status code, protecting the shared error path used by all
+// security attribute operations.
 func TestHandlers_WrapTransportErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -408,6 +458,12 @@ func TestHandlers_WrapTransportErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload verifies that empty mutation
+// payloads are treated as missing GitLab resources.
+//
+// The table covers null payloads and empty node results for create, update,
+// delete, project update, and bulk update. Each case expects a Not Found error
+// instead of silently accepting a partial GraphQL response.
 func TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -498,6 +554,12 @@ func TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnErrorOnMalformedGraphQLIDs verifies that malformed GraphQL
+// global IDs in security attribute responses fail during output conversion.
+//
+// The mock replaces valid category or attribute GIDs with invalid strings and
+// expects parse-specific errors. This protects callers from receiving outputs
+// with ambiguous numeric IDs.
 func TestHandlers_ReturnErrorOnMalformedGraphQLIDs(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -555,6 +617,12 @@ func TestHandlers_ReturnErrorOnMalformedGraphQLIDs(t *testing.T) {
 	}
 }
 
+// TestUpdate_Success verifies that Update sends the selected fields to GraphQL
+// and converts the returned security attribute.
+//
+// The mock checks the attribute GID, name, description, and color values before
+// returning a sample attribute node. The expected output contains the parsed
+// attribute ID and a non-nil category summary.
 func TestUpdate_Success(t *testing.T) {
 	name := "Critical"
 	description := "Critical impact"
@@ -582,6 +650,12 @@ func TestUpdate_Success(t *testing.T) {
 	}
 }
 
+// TestUpdate_ValidatesInputBeforeRequest verifies Update validation for the
+// attribute ID, required change set, name, and color format.
+//
+// The table uses invalid inputs against a not-found handler and expects the
+// specific validation message for each failure, ensuring bad requests are
+// rejected locally before GraphQL execution.
 func TestUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	name := " "
@@ -607,6 +681,11 @@ func TestUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestDelete_Success verifies that Delete sends the attribute GID to the
+// securityAttributeDestroy mutation and reports a successful deletion.
+//
+// The mock asserts the encoded GraphQL ID and returns an empty errors array. The
+// test expects a success status and a message that names the deleted attribute.
 func TestDelete_Success(t *testing.T) {
 	handler := attributeGraphQLMux(map[string]http.HandlerFunc{
 		"securityAttributeDestroy": func(w http.ResponseWriter, r *http.Request) {
@@ -628,6 +707,11 @@ func TestDelete_Success(t *testing.T) {
 	}
 }
 
+// TestDelete_ValidatesInputBeforeRequest verifies that Delete rejects an invalid
+// attribute ID before calling GitLab.
+//
+// A not-found handler guards against accidental transport use; the expected
+// result is the local validation error for attribute_id.
 func TestDelete_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	_, err := Delete(context.Background(), client, DeleteInput{AttributeID: 0})
@@ -636,6 +720,12 @@ func TestDelete_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestProjectUpdate_Success verifies that ProjectUpdate encodes project and
+// attribute IDs as GraphQL global IDs.
+//
+// The mocked mutation checks the projectId, addAttributeIds, and
+// removeAttributeIds fields, then returns added and removed counts. The handler
+// output must preserve those counts for callers.
 func TestProjectUpdate_Success(t *testing.T) {
 	handler := attributeGraphQLMux(map[string]http.HandlerFunc{
 		"securityAttributeProjectUpdate": func(w http.ResponseWriter, r *http.Request) {
@@ -663,6 +753,11 @@ func TestProjectUpdate_Success(t *testing.T) {
 	}
 }
 
+// TestProjectUpdate_ValidatesInputBeforeRequest verifies ProjectUpdate rejects
+// invalid project IDs, empty operations, and invalid attribute IDs locally.
+//
+// Each table case expects a field-specific validation message and uses a
+// not-found handler to prove the request never reaches the GraphQL transport.
 func TestProjectUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	tests := []struct {
@@ -686,6 +781,12 @@ func TestProjectUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestBulkUpdate_Success verifies that BulkUpdate builds the combined item list
+// and requested mutation mode for groups and projects.
+//
+// The mock checks that group and project targets are encoded in order, attribute
+// IDs are encoded as security attribute GIDs, and REPLACE is forwarded as the
+// mutation mode. The output should report success with the same mode.
 func TestBulkUpdate_Success(t *testing.T) {
 	handler := attributeGraphQLMux(map[string]http.HandlerFunc{
 		"bulkUpdateSecurityAttributes": func(w http.ResponseWriter, r *http.Request) {
@@ -720,6 +821,11 @@ func TestBulkUpdate_Success(t *testing.T) {
 	}
 }
 
+// TestBulkUpdate_InvalidMode verifies that BulkUpdate rejects modes outside the
+// GitLab-supported ADD, REMOVE, and REPLACE values.
+//
+// The invalid UPSERT mode should fail validation before any request is sent,
+// keeping unsupported destructive operations away from GitLab.
 func TestBulkUpdate_InvalidMode(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	_, err := BulkUpdate(context.Background(), client, BulkUpdateInput{ProjectIDs: []int64{42}, AttributeIDs: []int64{9}, Mode: "UPSERT"})
@@ -728,6 +834,12 @@ func TestBulkUpdate_InvalidMode(t *testing.T) {
 	}
 }
 
+// TestBulkUpdate_ValidatesInputBeforeRequest verifies BulkUpdate validation for
+// targets, attributes, and positive numeric IDs.
+//
+// Each table case uses a malformed target or attribute set and expects the
+// corresponding validation message. The not-found handler makes an unexpected
+// network call visible as a test failure.
 func TestBulkUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	tests := []struct {
@@ -752,6 +864,11 @@ func TestBulkUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestBulkUpdateSecurityAttributes_ValidatesOptions verifies the lower-level
+// GraphQL bulk update helper requires attributes and mode.
+//
+// The helper receives partially populated client-go options and should return
+// local validation errors before building the mutation request.
 func TestBulkUpdateSecurityAttributes_ValidatesOptions(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	mode := glBulkMode(BulkUpdateModeAdd)
@@ -775,6 +892,12 @@ func TestBulkUpdateSecurityAttributes_ValidatesOptions(t *testing.T) {
 	}
 }
 
+// TestMarkdown_EscapesTableCells_PreservesLinkHint verifies security attribute
+// markdown escapes table separators and preserves link guidance.
+//
+// The test renders values containing pipe characters through create and detail
+// formatters, then asserts escaped cells, editable-state output, and the
+// preserve-link hint used by catalog responses.
 func TestMarkdown_EscapesTableCells_PreservesLinkHint(t *testing.T) {
 	attribute := Output{
 		ID:               9,
@@ -800,6 +923,11 @@ func TestMarkdown_EscapesTableCells_PreservesLinkHint(t *testing.T) {
 	}
 }
 
+// TestFormatCreateMarkdown_Empty verifies that FormatCreateMarkdown reports an
+// empty creation response clearly.
+//
+// The test passes a zero-value CreateOutput and expects the fallback message
+// rather than an empty table, which keeps generated tool output understandable.
 func TestFormatCreateMarkdown_Empty(t *testing.T) {
 	md := FormatCreateMarkdown(CreateOutput{})
 	if !strings.Contains(md, "No security attributes returned.") {
@@ -807,6 +935,12 @@ func TestFormatCreateMarkdown_Empty(t *testing.T) {
 	}
 }
 
+// TestMarkdownFormatsProjectAndBulkUpdates verifies the project and bulk update
+// markdown formatters expose their operational counts and selections.
+//
+// The test checks added and removed project counts, bulk mode, attribute IDs,
+// group IDs, and project IDs so regressions in compact mutation summaries are
+// caught by unit tests.
 func TestMarkdownFormatsProjectAndBulkUpdates(t *testing.T) {
 	projectMarkdown := FormatProjectUpdateMarkdown(ProjectUpdateOutput{AddedCount: 2, RemovedCount: 1})
 	if !strings.Contains(projectMarkdown, "| Added | `2` |") || !strings.Contains(projectMarkdown, "| Removed | `1` |") {
@@ -826,6 +960,11 @@ func TestMarkdownFormatsProjectAndBulkUpdates(t *testing.T) {
 	}
 }
 
+// TestOutputHelpers_HandleNilValues_ReturnZeroValues verifies nil GraphQL nodes
+// convert to zero-value outputs without panicking.
+//
+// The test exercises attribute, category summary, and attribute slice helpers to
+// keep defensive conversion behavior stable for partial GraphQL responses.
 func TestOutputHelpers_HandleNilValues_ReturnZeroValues(t *testing.T) {
 	if out, err := attributeNodeOutput(nil); err != nil || out.ID != 0 || out.SecurityCategory != nil {
 		t.Fatalf("attributeNodeOutput(nil) = %#v", out)
@@ -842,6 +981,13 @@ func glBulkMode(mode BulkUpdateMode) gl.SecurityAttributeBulkUpdateMode {
 	return gl.SecurityAttributeBulkUpdateMode(mode)
 }
 
+// TestActionSpecs_Metadata_ExpectedResult verifies the canonical security
+// attribute ActionSpecs expose expected mutation metadata and schemas.
+//
+// The test checks destructive flags, individual tool names, related actions,
+// description text, schema minItems, color pattern, anyOf target requirements,
+// and mode enum values. This protects dynamic, meta, and individual surfaces
+// from drifting away from the security attribute contract.
 func TestActionSpecs_Metadata_ExpectedResult(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	specs := ActionSpecs(client)

--- a/internal/tools/securitycategories/doc.go
+++ b/internal/tools/securitycategories/doc.go
@@ -1,5 +1,16 @@
 // Package securitycategories implements MCP tools for GitLab security categories.
 //
+// The package exposes catalog-backed actions for creating, updating, and
+// deleting the category records that group GitLab security attributes. Handlers
+// validate namespace and category identifiers, optional update fields, and
+// GraphQL mutation responses before returning MCP-friendly output with nested
+// attribute summaries.
+//
+// Security categories are GraphQL-backed GitLab security taxonomy objects. This
+// package keeps those mutations and conversions together so meta-tools, dynamic
+// discovery, individual tool projection, and Markdown rendering all describe the
+// same behavior.
+//
 // GitLab API docs:
 //   - https://docs.gitlab.com/api/graphql/reference/#securitycategory
 //   - https://docs.gitlab.com/api/graphql/reference/#mutationsecuritycategorycreate

--- a/internal/tools/securitycategories/security_categories.go
+++ b/internal/tools/securitycategories/security_categories.go
@@ -1,4 +1,3 @@
-// Package securitycategories provides handlers for GitLab security category tools.
 package securitycategories
 
 import (

--- a/internal/tools/securitycategories/security_categories_test.go
+++ b/internal/tools/securitycategories/security_categories_test.go
@@ -1,4 +1,8 @@
 // security_categories_test.go contains unit tests for GitLab security category operations.
+//
+// The tests mock GitLab GraphQL mutations with [testutil.GraphQLHandler], then
+// call handlers directly to verify request payloads, validation, error wrapping,
+// output conversion, markdown rendering, and ActionSpec metadata.
 package securitycategories
 
 import (
@@ -29,10 +33,14 @@ const sampleCategory = `{
 	}]
 }`
 
+// categoryGraphQLMux returns a GraphQL test handler for security category
+// mutations keyed by operation name.
 func categoryGraphQLMux(handlers map[string]http.HandlerFunc) http.Handler {
 	return testutil.GraphQLHandler(handlers)
 }
 
+// graphQLInput parses the GraphQL input variables from r and fails the calling
+// test if the request does not contain the expected input object.
 func graphQLInput(t *testing.T, r *http.Request) map[string]any {
 	t.Helper()
 	vars, err := testutil.ParseGraphQLVariables(r)
@@ -46,6 +54,12 @@ func graphQLInput(t *testing.T, r *http.Request) map[string]any {
 	return input
 }
 
+// TestCreate_Success verifies that Create sends the expected GraphQL input and
+// converts the returned security category and attribute IDs.
+//
+// The mocked securityCategoryCreate mutation asserts namespace, name,
+// description, and multiple-selection fields before returning a category with a
+// nested attribute. The expected output preserves parsed IDs and template type.
 func TestCreate_Success(t *testing.T) {
 	description := "Business impact labels"
 	multipleSelection := true
@@ -89,6 +103,12 @@ func TestCreate_Success(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnContextErrors verifies that all security category handlers
+// propagate a cancelled context without masking it as a GitLab API error.
+//
+// The test cancels the context before invoking create, update, and delete paths.
+// Each subtest expects [context.Canceled], preserving caller cancellation
+// semantics across GraphQL mutations.
 func TestHandlers_ReturnContextErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -131,6 +151,12 @@ func TestHandlers_ReturnContextErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapGitLabErrors verifies that GraphQL mutation errors embedded
+// in successful HTTP responses are surfaced to callers.
+//
+// Each subtest returns a domain-level errors array from the corresponding
+// security category mutation. The expected result is an error containing the
+// GitLab message instead of a successful zero-value output.
 func TestHandlers_WrapGitLabErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -184,6 +210,12 @@ func TestHandlers_WrapGitLabErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapTopLevelGraphQLErrors verifies that top-level GraphQL errors
+// are returned consistently across security category handlers.
+//
+// The mock responds with a GraphQL errors envelope for every mutation route. The
+// test expects each handler to preserve the top-level error text so callers can
+// distinguish transport success from GraphQL execution failure.
 func TestHandlers_WrapTopLevelGraphQLErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -233,6 +265,11 @@ func TestHandlers_WrapTopLevelGraphQLErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_WrapTransportErrors verifies that non-2xx HTTP responses from the
+// GraphQL endpoint are wrapped with the transport status.
+//
+// Each subtest returns HTTP 403 for a different mutation. The expected error
+// includes the status code, protecting the shared transport error path.
 func TestHandlers_WrapTransportErrors(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -282,6 +319,12 @@ func TestHandlers_WrapTransportErrors(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload verifies that empty mutation
+// payloads are treated as missing GitLab resources.
+//
+// The table covers null category nodes and null payloads for create, update, and
+// delete. Each case expects a Not Found error instead of silently accepting a
+// partial GraphQL response.
 func TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -354,6 +397,12 @@ func TestHandlers_ReturnNotFoundOnEmptyGraphQLPayload(t *testing.T) {
 	}
 }
 
+// TestHandlers_ReturnErrorOnMalformedGraphQLIDs verifies that malformed GraphQL
+// global IDs in security category responses fail during output conversion.
+//
+// The mock replaces valid category or attribute GIDs with invalid strings and
+// expects parse-specific errors. This protects callers from receiving outputs
+// with ambiguous numeric IDs.
 func TestHandlers_ReturnErrorOnMalformedGraphQLIDs(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -389,6 +438,12 @@ func TestHandlers_ReturnErrorOnMalformedGraphQLIDs(t *testing.T) {
 	}
 }
 
+// TestUpdate_Success verifies that Update sends the selected fields to GraphQL
+// and converts the returned security category.
+//
+// The mock checks the category GID, namespace GID, name, and description before
+// returning a sample category. The expected output contains the parsed category
+// ID from the GraphQL node.
 func TestUpdate_Success(t *testing.T) {
 	name := "Application tier"
 	description := "Updated description"
@@ -421,6 +476,12 @@ func TestUpdate_Success(t *testing.T) {
 	}
 }
 
+// TestUpdate_RequiresChanges verifies that Update rejects requests with no
+// mutable fields before calling GitLab.
+//
+// The input contains valid IDs but no name, description, or multiple-selection
+// change. The expected validation error preserves the contract that update
+// actions must carry at least one mutation.
 func TestUpdate_RequiresChanges(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	_, err := Update(context.Background(), client, UpdateInput{CategoryID: 7, NamespaceID: 101})
@@ -429,6 +490,12 @@ func TestUpdate_RequiresChanges(t *testing.T) {
 	}
 }
 
+// TestCreate_ValidatesInputBeforeRequest verifies Create validation for the
+// namespace ID and required category name.
+//
+// Each table case uses a not-found handler as a guard and expects a local
+// validation error, proving invalid category creation requests do not reach
+// GraphQL.
 func TestCreate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	tests := []struct {
@@ -450,6 +517,12 @@ func TestCreate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestUpdate_ValidatesInputBeforeRequest verifies Update validation for IDs,
+// required changes, and non-blank names.
+//
+// The table covers invalid category and namespace IDs, missing changes, and a
+// blank name. Each case expects the field-specific validation message before any
+// network request is attempted.
 func TestUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	name := " "
@@ -474,6 +547,11 @@ func TestUpdate_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestDelete_Success verifies that Delete sends the category GID to the
+// securityCategoryDestroy mutation and reports a successful deletion.
+//
+// The mock asserts the encoded GraphQL ID and returns an empty errors array. The
+// test expects a success status and a message that names the deleted category.
 func TestDelete_Success(t *testing.T) {
 	handler := categoryGraphQLMux(map[string]http.HandlerFunc{
 		"securityCategoryDestroy": func(w http.ResponseWriter, r *http.Request) {
@@ -495,6 +573,11 @@ func TestDelete_Success(t *testing.T) {
 	}
 }
 
+// TestDelete_ValidatesInputBeforeRequest verifies that Delete rejects an invalid
+// category ID before calling GitLab.
+//
+// A not-found handler guards against accidental transport use; the expected
+// result is the local validation error for category_id.
 func TestDelete_ValidatesInputBeforeRequest(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	_, err := Delete(context.Background(), client, DeleteInput{CategoryID: 0})
@@ -503,6 +586,12 @@ func TestDelete_ValidatesInputBeforeRequest(t *testing.T) {
 	}
 }
 
+// TestFormatOutputMarkdown_WithAttributes_RendersTable verifies security
+// category markdown escapes table cells and includes nested attributes.
+//
+// The rendered output contains pipe characters in category and attribute names.
+// The test expects escaped table cells plus multiple-selection, template type,
+// and attribute rows so pkgsite-visible examples remain stable.
 func TestFormatOutputMarkdown_WithAttributes_RendersTable(t *testing.T) {
 	md := FormatOutputMarkdown(Output{
 		ID:                7,
@@ -525,12 +614,24 @@ func TestFormatOutputMarkdown_WithAttributes_RendersTable(t *testing.T) {
 	}
 }
 
+// TestOutputHelpers_HandleNilValues_ReturnZeroValues verifies nil GraphQL nodes
+// convert to zero-value category outputs without panicking.
+//
+// The helper should return an empty category output and no attributes, keeping
+// defensive conversion behavior stable for partial GraphQL responses.
 func TestOutputHelpers_HandleNilValues_ReturnZeroValues(t *testing.T) {
 	if out, err := categoryNodeOutput(nil); err != nil || out.ID != 0 || len(out.SecurityAttributes) != 0 {
 		t.Fatalf("categoryNodeOutput(nil) = %#v", out)
 	}
 }
 
+// TestActionSpecs_Metadata_ExpectedResult verifies the canonical security
+// category ActionSpecs expose expected mutation metadata and schemas.
+//
+// The test checks destructive flags, individual tool names, create schema
+// constraints, boolean typing, and update anyOf requirements. This protects
+// dynamic, meta, and individual surfaces from drifting away from the security
+// category contract.
 func TestActionSpecs_Metadata_ExpectedResult(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NotFoundHandler())
 	specs := ActionSpecs(client)

--- a/internal/tools/securitycategories/security_categories_test.go
+++ b/internal/tools/securitycategories/security_categories_test.go
@@ -270,13 +270,13 @@ func TestHandlers_WrapTransportErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := categoryGraphQLMux(map[string]http.HandlerFunc{
 				tt.queryKey: func(w http.ResponseWriter, _ *http.Request) {
-					http.Error(w, "boom", http.StatusInternalServerError)
+					http.Error(w, "boom", http.StatusForbidden)
 				},
 			})
 			client := testutil.NewTestClient(t, handler)
 			err := tt.call(client)
-			if err == nil || !strings.Contains(err.Error(), "500") {
-				t.Fatalf("handler error = %v, want HTTP 500", err)
+			if err == nil || !strings.Contains(err.Error(), "403") {
+				t.Fatalf("handler error = %v, want HTTP 403", err)
 			}
 		})
 	}

--- a/internal/tools/surface_tools_test.go
+++ b/internal/tools/surface_tools_test.go
@@ -61,6 +61,11 @@ func TestRegisterServerMaintenanceSurfaceTools_SafeModeWrapsMutatingSpec(t *test
 	}
 }
 
+// TestRegisterSurfaceTools_InvalidSpecPanics verifies malformed surface tool
+// specs are rejected during registration.
+//
+// The test passes a spec with a name but no route or schema metadata and expects
+// a panic. Failing early prevents partial MCP surfaces from being exposed.
 func TestRegisterSurfaceTools_InvalidSpecPanics(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
 	assertPanics(t, func() {

--- a/internal/tools/systemhooks/systemhooks_test.go
+++ b/internal/tools/systemhooks/systemhooks_test.go
@@ -449,6 +449,12 @@ func TestFormatHookMarkdown(t *testing.T) {
 	}
 }
 
+// TestFormatHookMarkdown_URLVariablesRedacted verifies system hook markdown
+// includes URL variable names while redacting their values.
+//
+// The formatter receives a hook with token metadata and one URL variable. The
+// expected output includes hook details plus REDACTED variable text, preserving
+// operational context without leaking webhook secrets.
 func TestFormatHookMarkdown_URLVariablesRedacted(t *testing.T) {
 	result := FormatHookMarkdown(HookItem{
 		ID:           1,

--- a/internal/tools/waitpoll/waitpoll.go
+++ b/internal/tools/waitpoll/waitpoll.go
@@ -1,0 +1,98 @@
+// Package waitpoll provides shared polling loops for wait-style tools.
+package waitpoll
+
+import (
+	"context"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/progress"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// DurationFunc converts user-facing seconds into the duration used by timers.
+type DurationFunc func(seconds int) time.Duration
+
+// Options configures a polling loop for one wait-style tool.
+type Options[T any] struct {
+	Request         *mcp.CallToolRequest
+	IntervalSeconds int
+	TimeoutSeconds  int
+	FailOnError     *bool
+	PollDuration    DurationFunc
+	ProgressMessage func(attempt int) string
+	Poll            func(context.Context) (T, error)
+	Status          func(T) string
+	FailureError    func(T) error
+}
+
+// Result reports the final item and polling metadata.
+type Result[T any] struct {
+	Item        T
+	WaitedFor   string
+	PollCount   int
+	FinalStatus string
+	TimedOut    bool
+}
+
+// Poll polls until the item reaches a terminal status, the context is canceled,
+// or the configured timeout expires.
+func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
+	interval := toolutil.ClampPollInterval(opts.IntervalSeconds)
+	timeout := toolutil.ClampPollTimeout(opts.TimeoutSeconds)
+	failOnError := true
+	if opts.FailOnError != nil {
+		failOnError = *opts.FailOnError
+	}
+	duration := opts.PollDuration
+	if duration == nil {
+		duration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Second }
+	}
+
+	tracker := progress.FromRequest(opts.Request)
+	deadline := time.After(duration(timeout))
+	ticker := time.NewTicker(duration(interval))
+	defer ticker.Stop()
+
+	startTime := time.Now()
+	pollCount := 0
+
+	for {
+		pollCount++
+		tracker.Update(ctx, float64(pollCount), 0, opts.ProgressMessage(pollCount))
+
+		item, err := opts.Poll(ctx)
+		if err != nil {
+			return Result[T]{}, err
+		}
+
+		status := opts.Status(item)
+		if toolutil.IsTerminalStatus(status) {
+			result := Result[T]{
+				Item:        item,
+				WaitedFor:   time.Since(startTime).Round(time.Second).String(),
+				PollCount:   pollCount,
+				FinalStatus: status,
+			}
+			if failOnError && (status == "failed" || status == "canceled") {
+				return result, opts.FailureError(item)
+			}
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return Result[T]{}, ctx.Err()
+		case <-deadline:
+			return Result[T]{
+				Item:        item,
+				WaitedFor:   time.Since(startTime).Round(time.Second).String(),
+				PollCount:   pollCount,
+				FinalStatus: status,
+				TimedOut:    true,
+			}, nil
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/tools/waitpoll/waitpoll.go
+++ b/internal/tools/waitpoll/waitpoll.go
@@ -3,6 +3,8 @@ package waitpoll
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -39,6 +41,13 @@ type Result[T any] struct {
 // Poll polls until the item reaches a terminal status, the context is canceled,
 // or the configured timeout expires.
 func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
+	if opts.Poll == nil {
+		return Result[T]{}, errors.New("waitpoll: poll callback is required")
+	}
+	if opts.Status == nil {
+		return Result[T]{}, errors.New("waitpoll: status callback is required")
+	}
+
 	interval := toolutil.ClampPollInterval(opts.IntervalSeconds)
 	timeout := toolutil.ClampPollTimeout(opts.TimeoutSeconds)
 	failOnError := true
@@ -49,25 +58,57 @@ func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
 	if duration == nil {
 		duration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Second }
 	}
+	progressMessage := opts.ProgressMessage
+	if progressMessage == nil {
+		progressMessage = func(int) string { return "" }
+	}
 
 	tracker := progress.FromRequest(opts.Request)
-	deadline := time.After(duration(timeout))
+	timeoutDuration := duration(timeout)
+	deadlineAt := time.Now().Add(timeoutDuration)
+	deadline := time.NewTimer(timeoutDuration)
+	defer deadline.Stop()
 	ticker := time.NewTicker(duration(interval))
 	defer ticker.Stop()
 
 	startTime := time.Now()
 	pollCount := 0
+	var lastItem T
+	var lastStatus string
 
 	for {
-		pollCount++
-		tracker.Update(ctx, float64(pollCount), 0, opts.ProgressMessage(pollCount))
+		if time.Until(deadlineAt) <= 0 {
+			return Result[T]{
+				Item:        lastItem,
+				WaitedFor:   time.Since(startTime).Round(time.Second).String(),
+				PollCount:   pollCount,
+				FinalStatus: lastStatus,
+				TimedOut:    true,
+			}, nil
+		}
 
-		item, err := opts.Poll(ctx)
+		pollCount++
+		tracker.Update(ctx, float64(pollCount), 0, progressMessage(pollCount))
+
+		pollCtx, cancel := context.WithDeadline(ctx, deadlineAt)
+		item, err := opts.Poll(pollCtx)
+		cancel()
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+				return Result[T]{
+					Item:        lastItem,
+					WaitedFor:   time.Since(startTime).Round(time.Second).String(),
+					PollCount:   pollCount,
+					FinalStatus: lastStatus,
+					TimedOut:    true,
+				}, nil
+			}
 			return Result[T]{}, err
 		}
 
 		status := opts.Status(item)
+		lastItem = item
+		lastStatus = status
 		if toolutil.IsTerminalStatus(status) {
 			result := Result[T]{
 				Item:        item,
@@ -76,6 +117,9 @@ func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
 				FinalStatus: status,
 			}
 			if failOnError && (status == "failed" || status == "canceled") {
+				if opts.FailureError == nil {
+					return result, fmt.Errorf("waitpoll: terminal status %q requires failure error callback", status)
+				}
 				return result, opts.FailureError(item)
 			}
 			return result, nil
@@ -84,7 +128,7 @@ func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
 		select {
 		case <-ctx.Done():
 			return Result[T]{}, ctx.Err()
-		case <-deadline:
+		case <-deadline.C:
 			return Result[T]{
 				Item:        item,
 				WaitedFor:   time.Since(startTime).Round(time.Second).String(),

--- a/internal/tools/waitpoll/waitpoll.go
+++ b/internal/tools/waitpoll/waitpoll.go
@@ -86,6 +86,9 @@ func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
 				TimedOut:    true,
 			}, nil
 		}
+		if err := ctx.Err(); err != nil {
+			return Result[T]{}, err
+		}
 
 		pollCount++
 		tracker.Update(ctx, float64(pollCount), 0, progressMessage(pollCount))
@@ -94,7 +97,7 @@ func Poll[T any](ctx context.Context, opts Options[T]) (Result[T], error) {
 		item, err := opts.Poll(pollCtx)
 		cancel()
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil && !time.Now().Before(deadlineAt) {
 				return Result[T]{
 					Item:        lastItem,
 					WaitedFor:   time.Since(startTime).Round(time.Second).String(),

--- a/internal/tools/waitpoll/waitpoll_test.go
+++ b/internal/tools/waitpoll/waitpoll_test.go
@@ -231,6 +231,31 @@ func TestPoll_PollReceivesTimeoutContext(t *testing.T) {
 	}
 }
 
+// TestPoll_CallbackDeadlineExceededBeforeTimeoutReturnsError verifies a poller
+// owned deadline error is not converted into the global wait timeout.
+func TestPoll_CallbackDeadlineExceededBeforeTimeoutReturnsError(t *testing.T) {
+	opts, _ := pollOptions("running")
+	opts.IntervalSeconds = 60
+	opts.TimeoutSeconds = 1
+	opts.PollDuration = func(seconds int) time.Duration {
+		if seconds == opts.TimeoutSeconds {
+			return 50 * time.Millisecond
+		}
+		return time.Hour
+	}
+	opts.Poll = func(context.Context) (pollItem, error) {
+		return pollItem{}, context.DeadlineExceeded
+	}
+
+	result, err := Poll(context.Background(), opts)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Poll() error = %v, want context.DeadlineExceeded", err)
+	}
+	if result != (Result[pollItem]{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+}
+
 // TestPoll_ContextCanceled verifies context cancellation returns ctx.Err after
 // the first non-terminal poll.
 func TestPoll_ContextCanceled(t *testing.T) {
@@ -239,6 +264,26 @@ func TestPoll_ContextCanceled(t *testing.T) {
 	opts.Poll = func(context.Context) (pollItem, error) {
 		cancel()
 		return pollItem{Status: "running"}, nil
+	}
+
+	result, err := Poll(ctx, opts)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Poll() error = %v, want context.Canceled", err)
+	}
+	if result != (Result[pollItem]{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+}
+
+// TestPoll_ContextCanceledBeforeFirstPoll verifies a pre-canceled context fails
+// before invoking the poll callback.
+func TestPoll_ContextCanceledBeforeFirstPoll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	opts, _ := pollOptions("running")
+	opts.Poll = func(context.Context) (pollItem, error) {
+		t.Fatal("Poll callback should not run with a pre-canceled context")
+		return pollItem{}, nil
 	}
 
 	result, err := Poll(ctx, opts)

--- a/internal/tools/waitpoll/waitpoll_test.go
+++ b/internal/tools/waitpoll/waitpoll_test.go
@@ -1,0 +1,152 @@
+package waitpoll
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type pollItem struct {
+	Status string
+	Value  int
+}
+
+func fastDuration(int) time.Duration { return time.Millisecond }
+
+func pollOptions(statuses ...string) (Options[pollItem], *int) {
+	attempts := 0
+	opts := Options[pollItem]{
+		IntervalSeconds: 1,
+		TimeoutSeconds:  1,
+		PollDuration:    fastDuration,
+		ProgressMessage: func(attempt int) string { return "attempt" },
+		Poll: func(context.Context) (pollItem, error) {
+			status := statuses[min(attempts, len(statuses)-1)]
+			attempts++
+			return pollItem{Status: status, Value: attempts}, nil
+		},
+		Status:       func(item pollItem) string { return item.Status },
+		FailureError: func(item pollItem) error { return errors.New("terminal " + item.Status) },
+	}
+	return opts, &attempts
+}
+
+// TestPoll_TerminalSuccessDefaultDuration verifies immediate terminal success
+// and the default second-based duration path.
+func TestPoll_TerminalSuccessDefaultDuration(t *testing.T) {
+	opts, _ := pollOptions("success")
+	opts.PollDuration = nil
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if result.FinalStatus != "success" || result.PollCount != 1 || result.TimedOut {
+		t.Fatalf("result = %#v, want success on first poll without timeout", result)
+	}
+}
+
+// TestPoll_TerminalFailureReturnsPartialResult verifies failed terminal states
+// return both the partial result and the configured error.
+func TestPoll_TerminalFailureReturnsPartialResult(t *testing.T) {
+	opts, _ := pollOptions("failed")
+
+	result, err := Poll(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Poll() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "terminal failed") {
+		t.Fatalf("error = %q, want terminal failed", err.Error())
+	}
+	if result.FinalStatus != "failed" || result.Item.Status != "failed" {
+		t.Fatalf("result = %#v, want failed partial result", result)
+	}
+}
+
+// TestPoll_TerminalFailureAllowed verifies fail_on_error=false returns normally
+// for failed or canceled terminal states.
+func TestPoll_TerminalFailureAllowed(t *testing.T) {
+	failOnError := false
+	opts, _ := pollOptions("canceled")
+	opts.FailOnError = &failOnError
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if result.FinalStatus != "canceled" {
+		t.Fatalf("FinalStatus = %q, want canceled", result.FinalStatus)
+	}
+}
+
+// TestPoll_PollError verifies poller errors stop the loop immediately.
+func TestPoll_PollError(t *testing.T) {
+	wantErr := errors.New("poll failed")
+	opts, _ := pollOptions("running")
+	opts.Poll = func(context.Context) (pollItem, error) { return pollItem{}, wantErr }
+
+	result, err := Poll(context.Background(), opts)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Poll() error = %v, want %v", err, wantErr)
+	}
+	if result != (Result[pollItem]{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+}
+
+// TestPoll_TickerContinuesUntilTerminal verifies non-terminal states wait for
+// the ticker before polling again.
+func TestPoll_TickerContinuesUntilTerminal(t *testing.T) {
+	opts, attempts := pollOptions("running", "success")
+	opts.PollDuration = func(seconds int) time.Duration {
+		if seconds == opts.TimeoutSeconds {
+			return 50 * time.Millisecond
+		}
+		return time.Millisecond
+	}
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if *attempts != 2 || result.PollCount != 2 || result.FinalStatus != "success" {
+		t.Fatalf("attempts=%d result=%#v, want second-poll success", *attempts, result)
+	}
+}
+
+// TestPoll_TimeoutReturnsLastItem verifies timeout returns the last observed
+// non-terminal item and TimedOut=true.
+func TestPoll_TimeoutReturnsLastItem(t *testing.T) {
+	opts, _ := pollOptions("running")
+	opts.IntervalSeconds = 60
+	opts.TimeoutSeconds = 1
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if !result.TimedOut || result.FinalStatus != "running" || result.Item.Value != 1 {
+		t.Fatalf("result = %#v, want timed out running item", result)
+	}
+}
+
+// TestPoll_ContextCanceled verifies context cancellation returns ctx.Err after
+// the first non-terminal poll.
+func TestPoll_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	opts, _ := pollOptions("running")
+	opts.Poll = func(context.Context) (pollItem, error) {
+		cancel()
+		return pollItem{Status: "running"}, nil
+	}
+
+	result, err := Poll(ctx, opts)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Poll() error = %v, want context.Canceled", err)
+	}
+	if result != (Result[pollItem]{}) {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+}

--- a/internal/tools/waitpoll/waitpoll_test.go
+++ b/internal/tools/waitpoll/waitpoll_test.go
@@ -81,6 +81,61 @@ func TestPoll_TerminalFailureAllowed(t *testing.T) {
 	}
 }
 
+// TestPoll_TerminalFailureWithoutCallbackReturnsDefaultError verifies failed
+// terminal states do not panic when the optional failure callback is omitted.
+func TestPoll_TerminalFailureWithoutCallbackReturnsDefaultError(t *testing.T) {
+	opts, _ := pollOptions("failed")
+	opts.FailureError = nil
+	opts.ProgressMessage = nil
+
+	result, err := Poll(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Poll() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `terminal status "failed"`) {
+		t.Fatalf("error = %q, want default terminal status error", err.Error())
+	}
+	if result.FinalStatus != "failed" {
+		t.Fatalf("FinalStatus = %q, want failed", result.FinalStatus)
+	}
+}
+
+// TestPoll_MissingRequiredCallbacks verifies required callbacks fail fast with
+// clear errors instead of nil function pointer panics.
+func TestPoll_MissingRequiredCallbacks(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Options[pollItem])
+		wantErr string
+	}{
+		{
+			name:    "poll",
+			mutate:  func(opts *Options[pollItem]) { opts.Poll = nil },
+			wantErr: "poll callback is required",
+		},
+		{
+			name:    "status",
+			mutate:  func(opts *Options[pollItem]) { opts.Status = nil },
+			wantErr: "status callback is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, _ := pollOptions("success")
+			tc.mutate(&opts)
+
+			result, err := Poll(context.Background(), opts)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Poll() error = %v, want %q", err, tc.wantErr)
+			}
+			if result != (Result[pollItem]{}) {
+				t.Fatalf("result = %#v, want zero result", result)
+			}
+		})
+	}
+}
+
 // TestPoll_PollError verifies poller errors stop the loop immediately.
 func TestPoll_PollError(t *testing.T) {
 	wantErr := errors.New("poll failed")
@@ -129,6 +184,50 @@ func TestPoll_TimeoutReturnsLastItem(t *testing.T) {
 	}
 	if !result.TimedOut || result.FinalStatus != "running" || result.Item.Value != 1 {
 		t.Fatalf("result = %#v, want timed out running item", result)
+	}
+}
+
+// TestPoll_ImmediateTimeoutReturnsBeforePolling verifies an already expired
+// timeout stops before invoking the poll callback.
+func TestPoll_ImmediateTimeoutReturnsBeforePolling(t *testing.T) {
+	opts, _ := pollOptions("running")
+	opts.IntervalSeconds = 2
+	opts.TimeoutSeconds = 1
+	opts.PollDuration = func(seconds int) time.Duration {
+		if seconds == opts.TimeoutSeconds {
+			return 0
+		}
+		return time.Hour
+	}
+	opts.Poll = func(context.Context) (pollItem, error) {
+		t.Fatal("Poll callback should not run after an immediate timeout")
+		return pollItem{}, nil
+	}
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if !result.TimedOut || result.PollCount != 0 {
+		t.Fatalf("result = %#v, want timeout before polling", result)
+	}
+}
+
+// TestPoll_PollReceivesTimeoutContext verifies a slow poller receives a context
+// bounded by timeout_seconds and Poll returns a timeout result when it expires.
+func TestPoll_PollReceivesTimeoutContext(t *testing.T) {
+	opts, _ := pollOptions("running")
+	opts.Poll = func(ctx context.Context) (pollItem, error) {
+		<-ctx.Done()
+		return pollItem{}, ctx.Err()
+	}
+
+	result, err := Poll(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Poll() unexpected error: %v", err)
+	}
+	if !result.TimedOut || result.PollCount != 1 || result.FinalStatus != "" {
+		t.Fatalf("result = %#v, want timeout during first poll", result)
 	}
 }
 

--- a/internal/toolutil/action_spec_test.go
+++ b/internal/toolutil/action_spec_test.go
@@ -291,6 +291,12 @@ func TestActionSpecValidate_RejectsInvalidInputSchemaOverride(t *testing.T) {
 	}
 }
 
+// TestSchemaAnyOfRequired_RejectsEmptyPropertyNames verifies anyOf schema
+// requirements cannot be created from blank property names.
+//
+// The test builds an update action with an empty SchemaAnyOfRequired override and
+// expects validation to reject it. This prevents generated input schemas from
+// containing impossible required-property alternatives.
 func TestSchemaAnyOfRequired_RejectsEmptyPropertyNames(t *testing.T) {
 	spec := NewActionSpec("update", ActionRoute{InputSchema: testActionSpecSchema("name")}, ActionSpecOptions{
 		InputSchemaOverrides: []InputSchemaOverride{SchemaAnyOfRequired(" ", "")},

--- a/internal/toolutil/graphql_test.go
+++ b/internal/toolutil/graphql_test.go
@@ -117,6 +117,12 @@ func TestParseGID_Roundtrip(t *testing.T) {
 	}
 }
 
+// TestGraphQLTopLevelError verifies top-level GraphQL errors are joined into an
+// operation-specific error message.
+//
+// The test covers nil errors, multiple trimmed messages, and blank messages. It
+// expects nil for no errors and descriptive fallback text when GitLab returns an
+// errors array without useful messages.
 func TestGraphQLTopLevelError(t *testing.T) {
 	if err := GraphQLTopLevelError("securityAttributeCreate", nil); err != nil {
 		t.Fatalf("GraphQLTopLevelError(nil) = %v, want nil", err)
@@ -133,6 +139,12 @@ func TestGraphQLTopLevelError(t *testing.T) {
 	}
 }
 
+// TestGraphQLMutationError verifies mutation-level GraphQL error arrays are
+// joined into an operation-specific error message.
+//
+// The test covers nil mutation errors, multiple trimmed messages, and blank
+// messages. This keeps GraphQL mutation handlers from dropping GitLab-provided
+// diagnostics or returning empty error text.
 func TestGraphQLMutationError(t *testing.T) {
 	if err := GraphQLMutationError("securityAttributeCreate", nil); err != nil {
 		t.Fatalf("GraphQLMutationError(nil) = %v, want nil", err)

--- a/internal/toolutil/label_markdown.go
+++ b/internal/toolutil/label_markdown.go
@@ -1,0 +1,77 @@
+package toolutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LabelMarkdown holds the common fields rendered for project and group labels.
+type LabelMarkdown struct {
+	ID                     int64
+	Name                   string
+	Color                  string
+	Description            string
+	OpenIssuesCount        int64
+	ClosedIssuesCount      int64
+	OpenMergeRequestsCount int64
+	Priority               int64
+	IsProjectLabel         bool
+	Subscribed             bool
+}
+
+// LabelMarkdownOptions controls label detail and list Markdown copy.
+type LabelMarkdownOptions struct {
+	DetailTitle       string
+	ListTitle         string
+	EmptyListText     string
+	DetailHints       []string
+	ListHints         []string
+	EscapeDescription bool
+}
+
+// FormatLabelMarkdown renders a project or group label as a Markdown summary.
+func FormatLabelMarkdown(label LabelMarkdown, opts LabelMarkdownOptions) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s: %s\n\n", opts.DetailTitle, EscapeMdHeading(label.Name))
+	fmt.Fprintf(&b, FmtMdID, label.ID)
+	fmt.Fprintf(&b, "- **Color**: %s\n", label.Color)
+	if label.Description != "" {
+		description := label.Description
+		if opts.EscapeDescription {
+			description = EscapeMdTableCell(description)
+		}
+		fmt.Fprintf(&b, FmtMdDescription, description)
+	}
+	if label.Priority > 0 {
+		fmt.Fprintf(&b, "- **Priority**: %d\n", label.Priority)
+	}
+	fmt.Fprintf(&b, "- **Project label**: %v\n", label.IsProjectLabel)
+	fmt.Fprintf(&b, "- **Subscribed**: %v\n", label.Subscribed)
+	if label.OpenIssuesCount > 0 || label.ClosedIssuesCount > 0 || label.OpenMergeRequestsCount > 0 {
+		fmt.Fprintf(&b, "- **Issues**: %d open, %d closed\n", label.OpenIssuesCount, label.ClosedIssuesCount)
+		fmt.Fprintf(&b, "- **Open MRs**: %d\n", label.OpenMergeRequestsCount)
+	}
+	WriteHints(&b, opts.DetailHints...)
+	return b.String()
+}
+
+// FormatLabelListMarkdown renders project or group labels as a paginated table.
+func FormatLabelListMarkdown(labels []LabelMarkdown, pagination PaginationOutput, opts LabelMarkdownOptions) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s (%d)\n\n", opts.ListTitle, pagination.TotalItems)
+	WriteListSummary(&b, len(labels), pagination)
+	if len(labels) == 0 {
+		b.WriteString(opts.EmptyListText)
+		b.WriteString("\n")
+		return b.String()
+	}
+	b.WriteString("| Name | Color | Open Issues | Closed Issues | Open MRs |\n")
+	b.WriteString("|------|-------|-------------|---------------|----------|\n")
+	for _, label := range labels {
+		fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n",
+			EscapeMdTableCell(label.Name), EscapeMdTableCell(label.Color), label.OpenIssuesCount, label.ClosedIssuesCount, label.OpenMergeRequestsCount)
+	}
+	WritePagination(&b, pagination)
+	WriteHints(&b, opts.ListHints...)
+	return b.String()
+}

--- a/internal/toolutil/label_markdown.go
+++ b/internal/toolutil/label_markdown.go
@@ -15,6 +15,7 @@ type LabelMarkdown struct {
 	ClosedIssuesCount      int64
 	OpenMergeRequestsCount int64
 	Priority               int64
+	PrioritySpecified      bool
 	IsProjectLabel         bool
 	Subscribed             bool
 }
@@ -42,7 +43,7 @@ func FormatLabelMarkdown(label LabelMarkdown, opts LabelMarkdownOptions) string 
 		}
 		fmt.Fprintf(&b, FmtMdDescription, description)
 	}
-	if label.Priority > 0 {
+	if label.PrioritySpecified || label.Priority != 0 {
 		fmt.Fprintf(&b, "- **Priority**: %d\n", label.Priority)
 	}
 	fmt.Fprintf(&b, "- **Project label**: %v\n", label.IsProjectLabel)
@@ -63,6 +64,7 @@ func FormatLabelListMarkdown(labels []LabelMarkdown, pagination PaginationOutput
 	if len(labels) == 0 {
 		b.WriteString(opts.EmptyListText)
 		b.WriteString("\n")
+		WriteHints(&b, opts.ListHints...)
 		return b.String()
 	}
 	b.WriteString("| Name | Color | Open Issues | Closed Issues | Open MRs |\n")
@@ -74,4 +76,13 @@ func FormatLabelListMarkdown(labels []LabelMarkdown, pagination PaginationOutput
 	WritePagination(&b, pagination)
 	WriteHints(&b, opts.ListHints...)
 	return b.String()
+}
+
+// FormatLabelListMarkdownFunc renders labels after mapping domain-specific outputs to the shared Markdown view.
+func FormatLabelListMarkdownFunc[T any](labels []T, pagination PaginationOutput, opts LabelMarkdownOptions, convert func(T) LabelMarkdown) string {
+	items := make([]LabelMarkdown, len(labels))
+	for i, label := range labels {
+		items[i] = convert(label)
+	}
+	return FormatLabelListMarkdown(items, pagination, opts)
 }

--- a/internal/toolutil/label_markdown_test.go
+++ b/internal/toolutil/label_markdown_test.go
@@ -1,0 +1,104 @@
+package toolutil
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatLabelMarkdown_AllBranches verifies label detail Markdown renders
+// optional fields, counters, escaped descriptions, and hints.
+func TestFormatLabelMarkdown_AllBranches(t *testing.T) {
+	got := FormatLabelMarkdown(LabelMarkdown{
+		ID:                     42,
+		Name:                   "bug|fix",
+		Color:                  "#ff0000",
+		Description:            "one|two",
+		OpenIssuesCount:        3,
+		ClosedIssuesCount:      2,
+		OpenMergeRequestsCount: 1,
+		Priority:               7,
+		IsProjectLabel:         true,
+		Subscribed:             true,
+	}, LabelMarkdownOptions{
+		DetailTitle:       "Label",
+		DetailHints:       []string{"Use action 'label_update'"},
+		EscapeDescription: true,
+	})
+
+	for _, want := range []string{
+		"## Label: bug|fix",
+		"- **ID**: 42",
+		"- **Color**: #ff0000",
+		"- **Description**: one&#124;two",
+		"- **Priority**: 7",
+		"- **Project label**: true",
+		"- **Subscribed**: true",
+		"- **Issues**: 3 open, 2 closed",
+		"- **Open MRs**: 1",
+		"Use action 'label_update'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("FormatLabelMarkdown() missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFormatLabelMarkdown_MinimalUnescaped verifies optional fields are omitted
+// and descriptions can be left unchanged for callers that already handle them.
+func TestFormatLabelMarkdown_MinimalUnescaped(t *testing.T) {
+	got := FormatLabelMarkdown(LabelMarkdown{
+		Name:        "docs",
+		Color:       "#00ff00",
+		Description: "plain|pipe",
+	}, LabelMarkdownOptions{DetailTitle: "Group Label"})
+
+	for _, unwanted := range []string{"- **Priority**", "- **Issues**", "- **Open MRs**", "&#124;"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("FormatLabelMarkdown() unexpectedly contains %q in:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "- **Description**: plain|pipe") {
+		t.Fatalf("FormatLabelMarkdown() did not preserve unescaped description:\n%s", got)
+	}
+}
+
+// TestFormatLabelListMarkdown_WithLabels verifies list Markdown renders rows,
+// pagination, escaped table cells, and hints.
+func TestFormatLabelListMarkdown_WithLabels(t *testing.T) {
+	got := FormatLabelListMarkdown([]LabelMarkdown{{
+		Name:                   "bug|fix",
+		Color:                  "#ff0000",
+		OpenIssuesCount:        3,
+		ClosedIssuesCount:      2,
+		OpenMergeRequestsCount: 1,
+	}}, PaginationOutput{Page: 1, PerPage: 20, TotalItems: 1, TotalPages: 1}, LabelMarkdownOptions{
+		ListTitle: "Labels",
+		ListHints: []string{"Use action 'label_get'"},
+	})
+
+	for _, want := range []string{
+		"## Labels (1)",
+		"| Name | Color | Open Issues | Closed Issues | Open MRs |",
+		"| bug&#124;fix | #ff0000 | 3 | 2 | 1 |",
+		"Page 1 of 1",
+		"Use action 'label_get'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("FormatLabelListMarkdown() missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFormatLabelListMarkdown_Empty verifies empty lists return the configured
+// empty text without rendering a table or hints.
+func TestFormatLabelListMarkdown_Empty(t *testing.T) {
+	got := FormatLabelListMarkdown(nil, PaginationOutput{}, LabelMarkdownOptions{
+		ListTitle:     "Group Labels",
+		EmptyListText: "No group labels found.",
+		ListHints:     []string{"should not render"},
+	})
+
+	if got != "## Group Labels (0)\n\nNo group labels found.\n" {
+		t.Fatalf("FormatLabelListMarkdown() = %q", got)
+	}
+}

--- a/internal/toolutil/label_markdown_test.go
+++ b/internal/toolutil/label_markdown_test.go
@@ -17,6 +17,7 @@ func TestFormatLabelMarkdown_AllBranches(t *testing.T) {
 		ClosedIssuesCount:      2,
 		OpenMergeRequestsCount: 1,
 		Priority:               7,
+		PrioritySpecified:      true,
 		IsProjectLabel:         true,
 		Subscribed:             true,
 	}, LabelMarkdownOptions{
@@ -43,6 +44,16 @@ func TestFormatLabelMarkdown_AllBranches(t *testing.T) {
 	}
 }
 
+// TestFormatLabelMarkdown_ZeroPrioritySpecified verifies GitLab priority 0 is
+// rendered when the API explicitly returns it.
+func TestFormatLabelMarkdown_ZeroPrioritySpecified(t *testing.T) {
+	got := FormatLabelMarkdown(LabelMarkdown{ID: 1, Name: "zero", Color: "#111111", PrioritySpecified: true}, LabelMarkdownOptions{DetailTitle: "Label"})
+
+	if !strings.Contains(got, "- **Priority**: 0") {
+		t.Fatalf("FormatLabelMarkdown() did not render explicit zero priority:\n%s", got)
+	}
+}
+
 // TestFormatLabelMarkdown_MinimalUnescaped verifies optional fields are omitted
 // and descriptions can be left unchanged for callers that already handle them.
 func TestFormatLabelMarkdown_MinimalUnescaped(t *testing.T) {
@@ -62,10 +73,17 @@ func TestFormatLabelMarkdown_MinimalUnescaped(t *testing.T) {
 	}
 }
 
-// TestFormatLabelListMarkdown_WithLabels verifies list Markdown renders rows,
-// pagination, escaped table cells, and hints.
-func TestFormatLabelListMarkdown_WithLabels(t *testing.T) {
-	got := FormatLabelListMarkdown([]LabelMarkdown{{
+// TestFormatLabelListMarkdownFunc_WithLabels verifies list Markdown maps domain
+// labels, renders rows, pagination, escaped table cells, and hints.
+func TestFormatLabelListMarkdownFunc_WithLabels(t *testing.T) {
+	type labelOutput struct {
+		Name                   string
+		Color                  string
+		OpenIssuesCount        int64
+		ClosedIssuesCount      int64
+		OpenMergeRequestsCount int64
+	}
+	got := FormatLabelListMarkdownFunc([]labelOutput{{
 		Name:                   "bug|fix",
 		Color:                  "#ff0000",
 		OpenIssuesCount:        3,
@@ -74,6 +92,8 @@ func TestFormatLabelListMarkdown_WithLabels(t *testing.T) {
 	}}, PaginationOutput{Page: 1, PerPage: 20, TotalItems: 1, TotalPages: 1}, LabelMarkdownOptions{
 		ListTitle: "Labels",
 		ListHints: []string{"Use action 'label_get'"},
+	}, func(label labelOutput) LabelMarkdown {
+		return LabelMarkdown{Name: label.Name, Color: label.Color, OpenIssuesCount: label.OpenIssuesCount, ClosedIssuesCount: label.ClosedIssuesCount, OpenMergeRequestsCount: label.OpenMergeRequestsCount}
 	})
 
 	for _, want := range []string{
@@ -90,15 +110,15 @@ func TestFormatLabelListMarkdown_WithLabels(t *testing.T) {
 }
 
 // TestFormatLabelListMarkdown_Empty verifies empty lists return the configured
-// empty text without rendering a table or hints.
+// empty text and keep follow-up hints without rendering a table.
 func TestFormatLabelListMarkdown_Empty(t *testing.T) {
 	got := FormatLabelListMarkdown(nil, PaginationOutput{}, LabelMarkdownOptions{
 		ListTitle:     "Group Labels",
 		EmptyListText: "No group labels found.",
-		ListHints:     []string{"should not render"},
+		ListHints:     []string{"Use action 'group_label_create'"},
 	})
 
-	if got != "## Group Labels (0)\n\nNo group labels found.\n" {
+	if !strings.Contains(got, "No group labels found.\n") || !strings.Contains(got, "Use action 'group_label_create'") {
 		t.Fatalf("FormatLabelListMarkdown() = %q", got)
 	}
 }

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -2919,6 +2919,12 @@ func TestInputSchemaForType_SecretFieldsWriteOnly(t *testing.T) {
 	}
 }
 
+// TestInputSchemaForType_UnsupportedTypeReturnsNil verifies schema generation
+// returns nil for input types that jsonschema cannot represent.
+//
+// The unsupported struct contains a channel field. The expected nil schema keeps
+// callers from registering incomplete MCP input schemas for unsupported Go
+// shapes.
 func TestInputSchemaForType_UnsupportedTypeReturnsNil(t *testing.T) {
 	type unsupportedInput struct {
 		Ch chan int `json:"ch"`
@@ -2929,6 +2935,12 @@ func TestInputSchemaForType_UnsupportedTypeReturnsNil(t *testing.T) {
 	}
 }
 
+// TestInputSchemaForType_PointerInputCacheHit verifies pointer input schemas are
+// cached and still mark secret fields write-only.
+//
+// The same pointer type is requested twice and should return the same cached map
+// instance. The test also checks the token field metadata so cache hits do not
+// bypass secret-field decoration.
 func TestInputSchemaForType_PointerInputCacheHit(t *testing.T) {
 	type pointerSecretInput struct {
 		Token string `json:"token,omitempty"`
@@ -2949,6 +2961,11 @@ func TestInputSchemaForType_PointerInputCacheHit(t *testing.T) {
 	}
 }
 
+// TestMarkWriteOnlySecretFields_IgnoresMissingProperties verifies secret-field
+// marking leaves schemas without a properties map unchanged.
+//
+// The test passes a primitive schema and expects no writeOnly flag to be added,
+// preserving non-object schemas generated for unusual inputs.
 func TestMarkWriteOnlySecretFields_IgnoresMissingProperties(t *testing.T) {
 	schema := map[string]any{"type": "string"}
 	markWriteOnlySecretFields(schema, reflect.TypeFor[string]())
@@ -2958,6 +2975,12 @@ func TestMarkWriteOnlySecretFields_IgnoresMissingProperties(t *testing.T) {
 	}
 }
 
+// TestMarkWriteOnlySecretFields_IgnoresNonSchemaProperties verifies secret-field
+// marking skips properties that are not schema maps.
+//
+// The token property is intentionally a string value. The helper should not
+// mutate it, avoiding panics or type corruption when schema generation returns
+// unexpected property metadata.
 func TestMarkWriteOnlySecretFields_IgnoresNonSchemaProperties(t *testing.T) {
 	type secretInput struct {
 		Token string `json:"token,omitempty"`
@@ -2971,6 +2994,12 @@ func TestMarkWriteOnlySecretFields_IgnoresNonSchemaProperties(t *testing.T) {
 	}
 }
 
+// TestSecretJSONFieldNames_EdgeCases verifies secret JSON field discovery handles
+// pointers, embedded structs, ignored tags, and unexported fields.
+//
+// The test expects no fields for a non-struct pointer and only signing_token plus
+// token for the struct with an embedded pointer. Ignored and private fields must
+// not be reported as schema secrets.
 func TestSecretJSONFieldNames_EdgeCases(t *testing.T) {
 	type embeddedSecret struct {
 		SigningToken string `json:"signing_token,omitempty"`


### PR DESCRIPTION
## Summary

This branch completes the first pass of the test-speed, Godoc, and duplication-reduction work:

- speeds up slow unit tests by replacing fixed waits and retry delays with deterministic polling/cached fixtures
- improves Go package and test documentation so the Godoc audit passes cleanly
- reduces obvious duplicated helper logic across audit commands, label Markdown rendering, event Markdown rendering, and wait-style tools
- adds focused coverage for the new helper code, including 100% function coverage for the newly introduced helpers

## Validation

- `go test` targeted changed packages and commands
- `go vet` targeted changed packages and commands
- `golangci-lint run` targeted changed packages and commands
- `go run ./cmd/audit_godocs/ --include-tests --fail-on-findings`
- `go run ./cmd/gen_testing_docs/ --check`
- `go run ./cmd/format_md_tables/ --check`
- `npx markdownlint-cli2 docs/testing/testing.md`

## Notes

This intentionally reduces the clearest low-risk duplication first rather than trying to drive Sonar duplication to zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitLab security-attributes tooling: create/update/delete/project/bulk operations.
  * Shared label Markdown formatting helpers for richer label output.

* **Refactor**
  * Shared polling abstraction adopted by wait-style tools.
  * Audit CLI tools switched to an in-process mock client.
  * Added configuration to disable client retries; label outputs now indicate if priority was provided.

* **Bug Fixes**
  * Test mocks switched to use HTTP 403 for simulated GitLab failures.

* **Documentation**
  * Expanded package and test documentation and regenerated test coverage snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/gitlab-mcp-server/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->