### PR TITLE
fix(ci): bump Go to 1.26.4 to clear GO-2026-5037

### DIFF
--- a/.github/agents/go-mcp-expert.agent.md
+++ b/.github/agents/go-mcp-expert.agent.md
@@ -173,7 +173,7 @@ Always write idiomatic Go code that follows the official SDK patterns and Go com
 ## MCP Go SDK v1.6.0 Key Knowledge
 
 - **Protocol version**: 2025-11-25
-- **Project Go requirement**: 1.26.3
+- **Project Go requirement**: 1.26.4
 - **OAuth**: Stabilized — no build tag needed, `auth/` and `auth/extauth/` packages
 - **Sampling with Tools**: `CreateMessageWithTools` / `CreateMessageWithToolsHandler` — allows server to provide tools alongside sampling requests
 - **DNS rebinding protection**: Built-in for HTTP transport (localhost binding)

--- a/.github/agents/plan-expert.agent.md
+++ b/.github/agents/plan-expert.agent.md
@@ -35,7 +35,7 @@ This project is a **Model Context Protocol (MCP) server** in Go exposing GitLab 
 
 | Component          | Technology                                              |
 | ------------------ | ------------------------------------------------------- |
-| Language           | Go 1.26.3                                               |
+| Language           | Go 1.26.4                                               |
 | MCP SDK            | `github.com/modelcontextprotocol/go-sdk/mcp` v1.6.0    |
 | GitLab Client      | `gitlab.com/gitlab-org/api/client-go/v2` v2.29.0        |
 | Self-Update        | `github.com/creativeprojects/go-selfupdate` v1.5.2     |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This project implements a **Model Context Protocol (MCP) server** that exposes G
 
 ## Architecture
 
-- **Language**: Go 1.26.3
+- **Language**: Go 1.26.4
 - **MCP SDK**: `github.com/modelcontextprotocol/go-sdk/mcp` v1.6.0
 - **GitLab Client**: `gitlab.com/gitlab-org/api/client-go/v2` v2.29.0 (official client, migrated from deprecated `xanzy/go-gitlab`)
 - **Transport**: stdio (primary), HTTP (optional)

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -408,7 +408,7 @@ func TestCovListMetricImagesWithPagination(t *testing.T) { ... }
 
 ## Go 1.26 Project Modern Features
 
-This project declares `go 1.26.3`; prefer these modern patterns when they simplify code without reducing clarity:
+This project declares `1.26.4`; prefer these modern patterns when they simplify code without reducing clarity:
 
 ### Range-over-func Iterators (Go 1.23+)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   COVERAGE_MIN: "80"
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   GITLAB_IMAGE: ${{ inputs.gitlab_image || 'gitlab/gitlab-ce:latest' }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   REGISTRY: ghcr.io
   IMAGE_NAME: jmrplens/gitlab-mcp-server
   DOCKERHUB_IMAGE: jmrplens/gitlab-mcp-server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 
 | Attribute     | Value                                               |
 | ------------- | --------------------------------------------------- |
-| Language      | Go 1.26.3                                           |
+| Language      | Go 1.26.4                                           |
 | MCP SDK       | `github.com/modelcontextprotocol/go-sdk/mcp` v1.6.0 |
 | GitLab Client | `gitlab.com/gitlab-org/api/client-go/v2` v2.29.0       |
 | Transport     | stdio (primary), HTTP (optional)                    |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 
 # --- Build stage ---
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.23 AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache git ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmrplens/gitlab-mcp-server/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

CI govulncheck gate was failing on GO-2026-5037 (stdlib `crypto/x509` inefficient hostname parsing), fixed in Go 1.26.4.

## Changes

- `go.mod`: toolchain `1.26.3` → `1.26.4`
- `.github/workflows/ci.yml`, `e2e.yml`, `release.yml`: `GO_VERSION` `1.26.3` → `1.26.4`

## Verification

- `make analyze`: ✅ all gates pass (golangci-lint, govulncheck, markdownlint)
- `govulncheck`: ✅ `No vulnerabilities found.`
- `go test ./internal/...`: ✅ all pass

## Summary by Sourcery

Update Go toolchain and CI workflows to use Go 1.26.4.

Build:
- Bump Go toolchain version in go.mod from 1.26.3 to 1.26.4.

CI:
- Update CI, E2E, and release GitHub Actions workflows to use Go 1.26.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated Go toolchain from version 1.26.3 to 1.26.4 across build, test, and release pipelines to leverage the latest Go improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->