### PR TITLE
chore(deps): bump @astrojs/starlight and astro (2026-06)

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -24,8 +24,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@astrojs/starlight": "^0.39.2",
-    "astro": "^6.4.2",
+    "@astrojs/starlight": "^0.39.3",
+    "astro": "^6.4.3",
     "astro-mermaid": "^2.0.2",
     "mermaid": "^11.15.0",
     "sharp": "^0.34.5"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -14,14 +14,14 @@ importers:
   .:
     dependencies:
       '@astrojs/starlight':
-        specifier: ^0.39.2
-        version: 0.39.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)
+        specifier: ^0.39.3
+        version: 0.39.3(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)
       astro:
-        specifier: ^6.4.2
-        version: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+        specifier: ^6.4.3
+        version: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
       astro-mermaid:
         specifier: ^2.0.2
-        version: 2.0.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(mermaid@11.15.0)
+        version: 2.0.2(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(mermaid@11.15.0)
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -64,7 +64,7 @@ importers:
         version: 14.2.6
       starlight-links-validator:
         specifier: ^0.24.0
-        version: 0.24.0(@astrojs/starlight@0.39.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
+        version: 0.24.0(@astrojs/starlight@0.39.3(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -126,8 +126,8 @@ packages:
   '@astrojs/sitemap@3.7.3':
     resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
-  '@astrojs/starlight@0.39.2':
-    resolution: {integrity: sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA==}
+  '@astrojs/starlight@0.39.3':
+    resolution: {integrity: sha512-uvAweA2DwhmLgFVfBT9NqG38Ey14k1ck3+y78XNJbceT1pMdzxCCX69RoBajb1QzTJviufsXzSc1xswgRxJfig==}
     peerDependencies:
       astro: ^6.0.0
 
@@ -1207,8 +1207,8 @@ packages:
       '@mermaid-js/layout-elk':
         optional: true
 
-  astro@6.4.2:
-    resolution: {integrity: sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==}
+  astro@6.4.3:
+    resolution: {integrity: sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -3918,12 +3918,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.6(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+      astro: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3947,17 +3947,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.3(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)':
     dependencies:
       '@astrojs/markdown-remark': 7.2.0
-      '@astrojs/mdx': 5.0.6(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.6(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
+      astro: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+      astro-expressive-code: 0.42.0(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -4964,20 +4964,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-expressive-code@0.42.0(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)):
     dependencies:
-      astro: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+      astro: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro-mermaid@2.0.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(mermaid@11.15.0):
+  astro-mermaid@2.0.2(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(mermaid@11.15.0):
     dependencies:
-      astro: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+      astro: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.15.0
       unist-util-visit: 5.1.0
 
-  astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0):
+  astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -7721,11 +7721,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  starlight-links-validator@0.24.0(@astrojs/starlight@0.39.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)):
+  starlight-links-validator@0.24.0(@astrojs/starlight@0.39.3(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3))(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)):
     dependencies:
-      '@astrojs/starlight': 0.39.2(astro@6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)
+      '@astrojs/starlight': 0.39.3(astro@6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0))(typescript@6.0.3)
       '@types/picomatch': 4.0.3
-      astro: 6.4.2(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
+      astro: 6.4.3(@types/node@25.9.1)(rollup@4.61.0)(yaml@2.9.0)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0


### PR DESCRIPTION
## Summary

Routine minor/patch updates to the site documentation toolchain.

## Changes

- `@astrojs/starlight`: 0.39.2 -> 0.39.3
  - UI translations: Romanian, Turkish
  - Pagefind v1.5 with diacriticSimilarity and metaWeights advanced ranking options
  - Internal file path handling refactor for content collections
- `astro`: 6.4.2 -> 6.4.3
  - devalue v5.8.1
  - Fix: advancedRouting + astro/hono 404 routes
  - Fix: custom src/app.ts middleware warnings
  - Improve: Fonts API bold fallbacks

## Verification

- `cd site && pnpm run build`: ✅ 65 pages built successfully
- Diff is identical to dependabot PR #154 (which has been closed)

## Summary by Sourcery

Update documentation site dependencies to the latest Astro and Starlight patch versions.

Build:
- Bump @astrojs/starlight from 0.39.2 to 0.39.3 for the docs site.
- Bump astro from 6.4.2 to 6.4.3 for the docs site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest patch versions for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->