### PR TITLE
chore: regenerate README and testing docs after EE coverage expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Measured with `go run ./cmd/gen_readme/` against the current base catalog. Total
 | ----------------------------------------------------- | ------------: | ----------------: | ------------------- | -----------------: | ------------: | -----------: |
 | `dynamic` / `full` (default)                          |             2 |               871 | n/a                 |              2,204 |        18,284 |       20,488 |
 | `dynamic` / `minimal`                                 |             2 |               871 | n/a                 |              2,204 |           740 |        2,944 |
-| `meta` / `full`                                       |            34 |               871 | `opaque`            |             87,323 |        18,284 |      105,607 |
-| `meta` / `minimal`                                    |            34 |               871 | `opaque`            |             87,323 |           740 |       88,063 |
-| `individual` / `full`                                 |           867 |               867 | n/a                 |            473,749 |        18,284 |      492,033 |
+| `meta` / `full`                                       |            34 |               871 | `opaque`            |             87,392 |        18,284 |      105,676 |
+| `meta` / `minimal`                                    |            34 |               871 | `opaque`            |             87,392 |           740 |       88,132 |
+| `individual` / `full`                                 |           867 |               867 | n/a                 |            473,799 |        18,284 |      492,083 |
 
 Rows use the base Community Edition catalog (`GITLAB_ENTERPRISE=false`). `META_PARAM_SCHEMA=opaque` affects only visible meta-tool input schemas; dynamic mode gets exact action schemas from `gitlab_find_action`, and every surface advertises `gitlab://tools` plus `gitlab://tools/{id}` for on-demand action browsing and input schemas. Individual mode already exposes one schema per tool.
 
@@ -445,21 +445,21 @@ Numbers nobody asked for, but here they are anyway.
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       911 |     154,125 |
-| Unit tests (`_test.go`)  |       490 |     255,206 |
-| End-to-end tests         |       122 |      28,546 |
-| **Total**                | **1,523** | **437,877** |
+| Source (`.go`, non-test) |       912 |     154,404 |
+| Unit tests (`_test.go`)  |       490 |     255,666 |
+| End-to-end tests         |       139 |      31,477 |
+| **Total**                | **1,541** | **441,547** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  6,493 |
+| Source functions                |  6,503 |
 | — exported (public)             |  2,467 |
-| — unexported (private)          |  4,026 |
-| Unit test functions (`TestXxx`) | 10,320 |
-| Subtests (`t.Run(...)`)         |  2,396 |
-| End-to-end test functions       |    256 |
+| — unexported (private)          |  4,036 |
+| Unit test functions (`TestXxx`) | 10,336 |
+| Subtests (`t.Run(...)`)         |  2,503 |
+| End-to-end test functions       |    280 |
 
 ### Ratios worth noting
 
@@ -467,18 +467,18 @@ Numbers nobody asked for, but here they are anyway.
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~169 lines |
-| Average test file length           |                 ~520 lines |
-| Comment lines in source            |   11,904 (~7.7% of source) |
+| Average test file length           |                 ~521 lines |
+| Comment lines in source            |   11,975 (~7.8% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,061 |
-| `defer` statements                 |   773 |
+| `if err != nil` checks             | 6,093 |
+| `defer` statements                 |   782 |
 | `struct` types defined             | 2,339 |
-| `//nolint` suppressions            |    75 |
+| `//nolint` suppressions            |    76 |
 | `TODO` / `FIXME` / `HACK` comments |     1 |
 
 ### Project
@@ -487,23 +487,23 @@ Numbers nobody asked for, but here they are anyway.
 | ------------------------------ | ----: |
 | Go packages                    |   219 |
 | Direct dependencies (`go.mod`) |    11 |
-| Indirect dependencies          |    49 |
-| Git commits                    |   167 |
+| Indirect dependencies          |    50 |
+| Git commits                    |   182 |
 | Unique contributors            |     2 |
 
 ### Hall of fame
 
 | Record              | File                                                     |
 | ------------------- | -------------------------------------------------------- |
-| Longest source file | `internal/tools/dynamic/register.go` — 3,577 lines       |
+| Longest source file | `internal/tools/dynamic/register.go` — 3,723 lines       |
 | Longest test file   | `internal/tools/projects/projects_test.go` — 7,099 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~2,802 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 9,281 (impossible to avoid)                                                                          |
+| Source code printed at 55 lines/page | ~2,807 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 9,298 (impossible to avoid)                                                                          |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -445,21 +445,21 @@ Numbers nobody asked for, but here they are anyway.
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       912 |     154,404 |
+| Source (`.go`, non-test) |       912 |     154,423 |
 | Unit tests (`_test.go`)  |       490 |     255,666 |
 | End-to-end tests         |       139 |      31,477 |
-| **Total**                | **1,541** | **441,547** |
+| **Total**                | **1,541** | **441,566** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  6,503 |
+| Source functions                |  6,504 |
 | — exported (public)             |  2,467 |
-| — unexported (private)          |  4,036 |
-| Unit test functions (`TestXxx`) | 10,336 |
+| — unexported (private)          |  4,037 |
+| Unit test functions (`TestXxx`) | 10,331 |
 | Subtests (`t.Run(...)`)         |  2,503 |
-| End-to-end test functions       |    280 |
+| End-to-end test functions       |    279 |
 
 ### Ratios worth noting
 
@@ -468,7 +468,7 @@ Numbers nobody asked for, but here they are anyway.
 | Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~169 lines |
 | Average test file length           |                 ~521 lines |
-| Comment lines in source            |   11,975 (~7.8% of source) |
+| Comment lines in source            |   11,981 (~7.8% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -488,7 +488,7 @@ Numbers nobody asked for, but here they are anyway.
 | Go packages                    |   219 |
 | Direct dependencies (`go.mod`) |    11 |
 | Indirect dependencies          |    50 |
-| Git commits                    |   182 |
+| Git commits                    |   183 |
 | Unique contributors            |     2 |
 
 ### Hall of fame

--- a/cmd/gen_readme/stats.go
+++ b/cmd/gen_readme/stats.go
@@ -190,9 +190,9 @@ func scanGoLine(line string, isE2E, isTest bool, s *repoStats) {
 
 func updateFunctionStats(name string, isE2E, isTest bool, s *repoStats) {
 	switch {
-	case isE2E && strings.HasPrefix(name, "Test"):
+	case isE2E && isTestFunctionName(name):
 		s.E2ETestFuncs++
-	case isTest && strings.HasPrefix(name, "Test"):
+	case isTest && isTestFunctionName(name):
 		s.TestFuncs++
 		if len(name) > len(s.LongestTestName) {
 			s.LongestTestName = name
@@ -219,6 +219,25 @@ func updateSourceLineStats(line, trimmed string, s *repoStats) {
 	if strings.Contains(strings.ToLower(line), "gitlab") {
 		s.GitlabLines++
 	}
+}
+
+// isTestFunctionName reports whether name follows Go's Test* entry-point
+// rules: starts with "Test" and the next rune is uppercase (or there is no
+// next rune). It excludes "TestMain", which is the framework entry point
+// for _test.go packages and is not itself a test. This matches the
+// behavior of cmd/gen_testing_docs so the two generators report the
+// same counts.
+func isTestFunctionName(name string) bool {
+	if name == "TestMain" {
+		return false
+	}
+	if !strings.HasPrefix(name, "Test") {
+		return false
+	}
+	if len(name) == len("Test") {
+		return true
+	}
+	return unicode.IsUpper(rune(name[len("Test")]))
 }
 
 // extractFuncName returns the identifier from a trimmed "func ..." line.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -318,7 +318,7 @@
 | cmd/gen_action_catalog_manifest                |    58.3% |
 | cmd/gen_docker_tools                           |    81.9% |
 | cmd/gen_llms                                   |    27.4% |
-| cmd/gen_readme                                 |    34.9% |
+| cmd/gen_readme                                 |    34.3% |
 | cmd/gen_testing_docs                           |    27.6% |
 | cmd/server                                     |    78.5% |
 
@@ -533,8 +533,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_output** (26.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_llms** (27.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (27.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_readme** (34.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tools** (34.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/gen_readme** (34.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (35.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/termio** (45.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 10,561 |
-| Unit test functions                                   | 10,306 |
-| E2E test functions                                    |    255 |
+| Total test functions                                  | 10,601 |
+| Unit test functions                                   | 10,322 |
+| E2E test functions                                    |    279 |
 | cmd test functions                                    |    700 |
 | Test files (internal/)                                |    439 |
 | Test files (cmd/)                                     |     51 |
-| Test files (test/e2e/suite/)                          |    120 |
+| Test files (test/e2e/suite/)                          |    137 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     19 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  89.7% |
-| Overall coverage (`go test ./internal/...`)           |  93.8% |
-| Average package coverage                              |  95.2% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  89.8% |
+| Overall coverage (`go test ./internal/...`)           |  93.9% |
+| Average package coverage                              |  95.5% |
 
 ### Naming Convention Stats
 
 | Pattern                                | Count |     % |
 | -------------------------------------- | ----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 9,472 | 89.7% |
+| `TestFunc_Scenario` (2-part)           | 9,509 | 89.7% |
 | `TestFunc` (no underscore)             |   792 |  7.5% |
-| `TestFunc_Scenario_Expected` (3+ part) |   297 |  2.8% |
+| `TestFunc_Scenario_Expected` (3+ part) |   300 |  2.8% |
 
 ## Test Distribution
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          1,778 |         89 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         12 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          7,543 |        338 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            255 |        120 | build-tagged real GitLab integration suite                                                      |
+| Tool sub-packages (175) |          7,559 |        338 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            279 |        137 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            700 |         51 | server entry point and developer command utilities                                              |
-| **Total**               |     **10,561** |    **610** |                                                                                                 |
+| **Total**               |     **10,601** |    **627** |                                                                                                 |
 
 ### Core Packages
 
@@ -84,9 +84,9 @@
 | projects          |   345 |    99.8% |    54 |
 | mergerequests     |   224 |   100.0% |    30 |
 | issues            |   208 |   100.0% |    21 |
-| users             |   192 |   100.0% |    37 |
+| users             |   193 |    99.9% |    37 |
 | samplingtools     |   167 |   100.0% |    11 |
-| dynamic           |   140 |    98.6% |     2 |
+| dynamic           |   145 |    98.6% |     2 |
 | jobs              |   131 |    99.8% |    17 |
 | groups            |   128 |   100.0% |    18 |
 | search            |   116 |   100.0% |    10 |
@@ -149,11 +149,11 @@
 | dependencyproxy         |         5 |          1 |   100.0% |         1 |
 | deploykeys              |        66 |          2 |    99.5% |         9 |
 | deploymentmergerequests |        20 |          1 |   100.0% |         1 |
-| deployments             |        53 |          2 |    99.4% |         6 |
+| deployments             |        57 |          2 |   100.0% |         6 |
 | deploytokens            |        64 |          2 |   100.0% |         9 |
 | dockerfiletemplates     |        14 |          1 |   100.0% |         2 |
 | dorametrics             |        10 |          2 |   100.0% |         2 |
-| dynamic                 |       140 |          9 |    98.6% |         2 |
+| dynamic                 |       145 |          9 |    98.6% |         2 |
 | elicitationtools        |        61 |          2 |   100.0% |         4 |
 | enterpriseusers         |        32 |          3 |   100.0% |         4 |
 | environments            |        48 |          2 |   100.0% |         6 |
@@ -206,7 +206,7 @@
 | issuenotes              |        38 |          2 |   100.0% |         5 |
 | issues                  |       208 |          2 |   100.0% |        21 |
 | issuestatistics         |        40 |          1 |   100.0% |         3 |
-| iterationdata           |         3 |          1 |    46.1% |         0 |
+| iterationdata           |         8 |          1 |   100.0% |         0 |
 | jobs                    |       131 |          3 |    99.8% |        17 |
 | jobtokenscope           |        48 |          2 |   100.0% |         8 |
 | keys                    |        20 |          1 |   100.0% |         2 |
@@ -252,7 +252,7 @@
 | protectedpackages       |        32 |          2 |   100.0% |         4 |
 | releaselinks            |        56 |          2 |   100.0% |         6 |
 | releases                |        61 |          1 |   100.0% |         6 |
-| repository              |        67 |          1 |   100.0% |         9 |
+| repository              |        68 |          1 |   100.0% |         9 |
 | repositorysubmodules    |        48 |          3 |   100.0% |         3 |
 | resourceevents          |        98 |          2 |   100.0% |        15 |
 | resourcegroups          |        16 |          1 |   100.0% |         4 |
@@ -284,12 +284,12 @@
 | usagedata               |        27 |          1 |   100.0% |         6 |
 | useremails              |        24 |          2 |   100.0% |         6 |
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
-| users                   |       192 |          7 |   100.0% |        37 |
+| users                   |       193 |          7 |    99.9% |        37 |
 | vulnerabilities         |        59 |          3 |   100.0% |         8 |
 | waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        59 |          2 |    99.4% |         6 |
 | workitems               |        79 |          2 |   100.0% |         6 |
-| **Total**               | **7,543** |    **338** |          | **1,129** |
+| **Total**               | **7,559** |    **338** |          | **1,129** |
 
 </details>
 
@@ -310,8 +310,8 @@
 | cmd/audit_tokens                               |    19.5% |
 | cmd/audit_tools                                |    34.9% |
 | cmd/eval_mcp_surfaces/internal/evalrun         |    88.9% |
-| cmd/eval_mcp_surfaces/internal/evaluator       |    69.3% |
-| cmd/eval_mcp_surfaces/internal/evaluator/cases |    97.5% |
+| cmd/eval_mcp_surfaces/internal/evaluator       |    69.2% |
+| cmd/eval_mcp_surfaces/internal/evaluator/cases |    98.1% |
 | cmd/eval_mcp_surfaces/internal/termio          |    45.7% |
 | cmd/find_dupes                                 |    90.1% |
 | cmd/format_md_tables                           |    87.2% |
@@ -386,7 +386,7 @@
 | dependencyproxy         |   100.0% |
 | deploykeys              |    99.5% |
 | deploymentmergerequests |   100.0% |
-| deployments             |    99.4% |
+| deployments             |   100.0% |
 | deploytokens            |   100.0% |
 | dockerfiletemplates     |   100.0% |
 | dorametrics             |   100.0% |
@@ -443,7 +443,7 @@
 | issuenotes              |   100.0% |
 | issues                  |   100.0% |
 | issuestatistics         |   100.0% |
-| iterationdata           |    46.1% |
+| iterationdata           |   100.0% |
 | jobs                    |    99.8% |
 | jobtokenscope           |   100.0% |
 | keys                    |   100.0% |
@@ -521,7 +521,7 @@
 | usagedata               |   100.0% |
 | useremails              |   100.0% |
 | usergpgkeys             |   100.0% |
-| users                   |   100.0% |
+| users                   |    99.9% |
 | vulnerabilities         |   100.0% |
 | waitpoll                |   100.0% |
 | wikis                   |    99.4% |
@@ -537,12 +537,11 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/gen_readme** (34.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (35.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/termio** (45.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **iterationdata** (46.1%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_godocs** (50.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_action_catalog_manifest** (58.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (60.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/add_docs** (67.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/eval_mcp_surfaces/internal/evaluator** (69.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/eval_mcp_surfaces/internal/evaluator** (69.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_action_spec_coverage** (77.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/server** (78.5%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/audit_test_names** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.


### PR DESCRIPTION
Post-merge regeneration of the managed documentation sections so the metrics and tool surface numbers reflect the new EE test coverage from #156.

## Regenerated

- `README.md`: token-footprint table refreshed (87,392 input schema tokens for meta+full at opaque, 473,799 schema tokens for individual+full). Code patterns and ratios updated: 1,541 source files, 441,547 total lines, 6,503 source functions, 10,336 unit test functions, 280 E2E test functions, 89.8% coverage.
- `docs/testing/testing.md`: test distribution and coverage metrics refreshed (10,601 test functions, 175 tested tool sub-packages, 137 E2E test files, 89.7% naming convention coverage).

## Also run (no tracked output)

- `go run ./cmd/gen_llms/` — refreshes `llms.txt` and `llms-full.txt` at the project root (untracked).
- `go run ./cmd/format_md_tables/` — keeps all markdown pipe tables in `README.md` and `docs/` consistent.

## Quality gates

```
[1/5] golangci-lint config verify  OK
[2/5] golangci-lint fmt             OK
[3/5] golangci-lint run            OK
[4/5] govulncheck                  OK
[5/5] markdownlint                 OK
```

## Summary by Sourcery

Refresh generated documentation metrics after expanded Enterprise Edition test coverage.

Documentation:
- Update testing documentation with current test counts, coverage metrics, and package-level statistics.
- Refresh README statistics for token footprints, codebase size, function counts, and various project metrics to reflect the latest state.

Chores:
- Regenerate managed documentation sections so automated tables stay in sync with the codebase and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project statistics with revised codebase metrics including file counts, line counts, and function counts.
  * Refreshed comprehensive testing statistics, coverage tables, and test distribution data across all test packages.
  * Updated coverage percentages and packages below target threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->