### PR TITLE
chore(deps): bump client-go v2.38.0 to v2.39.0, surface Scopes on application tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/shirou/gopsutil/v4 v4.26.5
-	gitlab.com/gitlab-org/api/client-go/v2 v2.38.0
+	gitlab.com/gitlab-org/api/client-go/v2 v2.39.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/time v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 gitlab.com/gitlab-org/api/client-go v1.46.0 h1:YxBWFZIFYKcGESCb9fpkwzouo+apyB9pr/XTWzNoL24=
 gitlab.com/gitlab-org/api/client-go v1.46.0/go.mod h1:FtgyU6g2HS5+fMhw6nLK96GBEEBx5MzntOiJWfIaiN8=
-gitlab.com/gitlab-org/api/client-go/v2 v2.38.0 h1:gZSMTTnLcUeY5mH4z3G6GEzbaBTOCUfBCAJXMRyuzEM=
-gitlab.com/gitlab-org/api/client-go/v2 v2.38.0/go.mod h1:SKUbKSS59KPt6WeGNJoYF8HDaf/rFMUSITlftj/HkLg=
+gitlab.com/gitlab-org/api/client-go/v2 v2.39.0 h1:avIIRj2sia1bGYCXy6nIeuBFWNzwQppZf+eGjVMNh7E=
+gitlab.com/gitlab-org/api/client-go/v2 v2.39.0/go.mod h1:SKUbKSS59KPt6WeGNJoYF8HDaf/rFMUSITlftj/HkLg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=

--- a/internal/tools/applications/applications.go
+++ b/internal/tools/applications/applications.go
@@ -22,12 +22,13 @@ type ListInput struct {
 
 // ApplicationItem represents a single application.
 type ApplicationItem struct {
-	ID              int64  `json:"id"`
-	ApplicationID   string `json:"application_id"`
-	ApplicationName string `json:"application_name"`
-	Secret          string `json:"secret"`
-	CallbackURL     string `json:"callback_url"`
-	Confidential    bool   `json:"confidential"`
+	ID              int64    `json:"id"`
+	ApplicationID   string   `json:"application_id"`
+	ApplicationName string   `json:"application_name"`
+	Secret          string   `json:"secret"`
+	CallbackURL     string   `json:"callback_url"`
+	Confidential    bool     `json:"confidential"`
+	Scopes          []string `json:"scopes,omitempty"`
 }
 
 // ListOutput is the output for listing applications.
@@ -135,5 +136,6 @@ func toItem(a *gl.Application) ApplicationItem {
 		Secret:          a.Secret,
 		CallbackURL:     a.CallbackURL,
 		Confidential:    a.Confidential,
+		Scopes:          a.Scopes,
 	}
 }

--- a/internal/tools/applications/applications_test.go
+++ b/internal/tools/applications/applications_test.go
@@ -35,7 +35,7 @@ func TestList(t *testing.T) {
 			t.Fatalf(fmtUnexpMethod, r.Method)
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[
-			{"id": 1, "application_id": "app-1", "application_name": "My App", "secret": "sec", "callback_url": "http://localhost", "confidential": true}
+			{"id": 1, "application_id": "app-1", "application_name": "My App", "secret": "sec", "callback_url": "http://localhost", "confidential": true, "scopes": ["api", "read_user"]}
 		]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -81,7 +81,8 @@ func TestCreate(t *testing.T) {
 			"application_name": "New App",
 			"secret": "newsecret",
 			"callback_url": "http://example.com/callback",
-			"confidential": false
+			"confidential": false,
+			"scopes": ["api", "read_user"]
 		}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -212,7 +213,7 @@ func TestList_WithPagination(t *testing.T) {
 				t.Errorf("expected page=2, got %s", r.URL.Query().Get("page"))
 			}
 			testutil.RespondJSON(w, http.StatusOK, `[
-				{"id": 5, "application_id": "app-5", "application_name": "Paged", "secret": "s", "callback_url": "http://cb", "confidential": false}
+				{"id": 5, "application_id": "app-5", "application_name": "Paged", "secret": "s", "callback_url": "http://cb", "confidential": false, "scopes": ["api"]}
 			]`)
 			return
 		}
@@ -238,7 +239,7 @@ func TestCreate_WithConfidential(t *testing.T) {
 		if r.URL.Path == "/api/v4/applications" && r.Method == http.MethodPost {
 			testutil.RespondJSON(w, http.StatusCreated, `{
 				"id": 10, "application_id": "app-10", "application_name": "Conf App",
-				"secret": "csec", "callback_url": "http://cb", "confidential": true
+				"secret": "csec", "callback_url": "http://cb", "confidential": true, "scopes": ["read_user"]
 			}`)
 			return
 		}
@@ -371,10 +372,10 @@ func newApplicationsRouteSpecs(t *testing.T) map[string]toolutil.ActionSpec {
 
 	handler := http.NewServeMux()
 	handler.HandleFunc("GET /api/v4/applications", func(w http.ResponseWriter, _ *http.Request) {
-		testutil.RespondJSON(w, http.StatusOK, `[{"id":1,"application_id":"a1","application_name":"App1","secret":"s","callback_url":"http://cb","confidential":true}]`)
+		testutil.RespondJSON(w, http.StatusOK, `[{"id":1,"application_id":"a1","application_name":"App1","secret":"s","callback_url":"http://cb","confidential":true,"scopes":["api","read_user"]}]`)
 	})
 	handler.HandleFunc("POST /api/v4/applications", func(w http.ResponseWriter, _ *http.Request) {
-		testutil.RespondJSON(w, http.StatusCreated, `{"id":2,"application_id":"a2","application_name":"Test App","secret":"s2","callback_url":"http://cb","confidential":false}`)
+		testutil.RespondJSON(w, http.StatusCreated, `{"id":2,"application_id":"a2","application_name":"Test App","secret":"s2","callback_url":"http://cb","confidential":false,"scopes":["api"]}`)
 	})
 	handler.HandleFunc("DELETE /api/v4/applications/1", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/tools/applications/applications_test.go
+++ b/internal/tools/applications/applications_test.go
@@ -52,6 +52,9 @@ func TestList(t *testing.T) {
 	if out.Applications[0].ID != 1 {
 		t.Errorf("ID = %d, want 1", out.Applications[0].ID)
 	}
+	if out.Applications[0].Scopes == nil || len(out.Applications[0].Scopes) != 2 {
+		t.Errorf("Scopes = %v, want [\"api\", \"read_user\"]", out.Applications[0].Scopes)
+	}
 }
 
 // TestList_Error verifies List when error.
@@ -102,6 +105,9 @@ func TestCreate(t *testing.T) {
 	}
 	if out.Secret != "newsecret" {
 		t.Errorf("Secret = %q, want newsecret", out.Secret)
+	}
+	if out.Scopes == nil || len(out.Scopes) != 2 {
+		t.Errorf("Scopes = %v, want [\"api\", \"read_user\"]", out.Scopes)
 	}
 }
 

--- a/internal/tools/applications/markdown.go
+++ b/internal/tools/applications/markdown.go
@@ -16,14 +16,15 @@ func FormatListMarkdown(out ListOutput) string {
 		sb.WriteString("No applications found.\n")
 		return sb.String()
 	}
-	sb.WriteString("| ID | Name | App ID | Callback URL | Confidential |\n|---|---|---|---|---|\n")
+	sb.WriteString("| ID | Name | App ID | Callback URL | Confidential | Scopes |\n|---|---|---|---|---|---|\n")
 	for _, a := range out.Applications {
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %v |\n",
+		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %v | %s |\n",
 			a.ID,
 			toolutil.EscapeMdTableCell(a.ApplicationName),
 			toolutil.EscapeMdTableCell(a.ApplicationID),
 			toolutil.EscapeMdTableCell(a.CallbackURL),
-			a.Confidential)
+			a.Confidential,
+			toolutil.EscapeMdTableCell(strings.Join(a.Scopes, ", ")))
 	}
 	toolutil.WritePagination(&sb, out.Pagination)
 	toolutil.WriteHints(&sb, "Use `gitlab_create_application` to register a new application")
@@ -41,6 +42,7 @@ func FormatCreateMarkdown(out CreateOutput) string {
 	fmt.Fprintf(&sb, "| Callback URL | %s |\n", toolutil.EscapeMdTableCell(out.CallbackURL))
 	fmt.Fprintf(&sb, "| Confidential | %v |\n", out.Confidential)
 	fmt.Fprintf(&sb, "| Secret | %s |\n", toolutil.EscapeMdTableCell(out.Secret))
+	fmt.Fprintf(&sb, "| Scopes | %s |\n", toolutil.EscapeMdTableCell(strings.Join(out.Scopes, ", ")))
 	toolutil.WriteHints(&sb, "Store the application secret securely — it cannot be retrieved later")
 	return sb.String()
 }

--- a/internal/tools/testdata/tools_individual.json
+++ b/internal/tools/testdata/tools_individual.json
@@ -7679,6 +7679,15 @@
             "array"
           ]
         },
+        "scopes": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "null",
+            "array"
+          ]
+        },
         "secret": {
           "type": "string"
         }
@@ -52146,6 +52155,15 @@
               },
               "id": {
                 "type": "integer"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": [
+                  "null",
+                  "array"
+                ]
               },
               "secret": {
                 "type": "string"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -878,7 +878,7 @@ Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true
 <details><summary>application_create</summary>
 
 ```json
-{"additionalProperties":false,"properties":{"application_id":{"type":"string"},"application_name":{"type":"string"},"callback_url":{"type":"string"},"confidential":{"type":"boolean"},"id":{"type":"integer"},"next_steps":{"items":{"type":"string"},"type":["null","array"]},"secret":{"type":"string"}},"required":["id","application_id","application_name","secret","callback_url","confidential"],"type":"object"}
+{"additionalProperties":false,"properties":{"application_id":{"type":"string"},"application_name":{"type":"string"},"callback_url":{"type":"string"},"confidential":{"type":"boolean"},"id":{"type":"integer"},"next_steps":{"items":{"type":"string"},"type":["null","array"]},"scopes":{"items":{"type":"string"},"type":["null","array"]},"secret":{"type":"string"}},"required":["id","application_id","application_name","secret","callback_url","confidential"],"type":"object"}
 ```
 
 </details>
@@ -894,7 +894,7 @@ Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true
 <details><summary>application_list</summary>
 
 ```json
-{"additionalProperties":false,"properties":{"applications":{"items":{"additionalProperties":false,"properties":{"application_id":{"type":"string"},"application_name":{"type":"string"},"callback_url":{"type":"string"},"confidential":{"type":"boolean"},"id":{"type":"integer"},"secret":{"type":"string"}},"required":["id","application_id","application_name","secret","callback_url","confidential"],"type":"object"},"type":["null","array"]},"next_steps":{"items":{"type":"string"},"type":["null","array"]},"pagination":{"additionalProperties":false,"properties":{"has_more":{"type":"boolean"},"next_page":{"type":"integer"},"page":{"type":"integer"},"per_page":{"type":"integer"},"prev_page":{"type":"integer"},"total_items":{"type":"integer"},"total_pages":{"type":"integer"}},"required":["page","per_page","total_items","total_pages","next_page","prev_page","has_more"],"type":"object"}},"required":["applications","pagination"],"type":"object"}
+{"additionalProperties":false,"properties":{"applications":{"items":{"additionalProperties":false,"properties":{"application_id":{"type":"string"},"application_name":{"type":"string"},"callback_url":{"type":"string"},"confidential":{"type":"boolean"},"id":{"type":"integer"},"scopes":{"items":{"type":"string"},"type":["null","array"]},"secret":{"type":"string"}},"required":["id","application_id","application_name","secret","callback_url","confidential"],"type":"object"},"type":["null","array"]},"next_steps":{"items":{"type":"string"},"type":["null","array"]},"pagination":{"additionalProperties":false,"properties":{"has_more":{"type":"boolean"},"next_page":{"type":"integer"},"page":{"type":"integer"},"per_page":{"type":"integer"},"prev_page":{"type":"integer"},"total_items":{"type":"integer"},"total_pages":{"type":"integer"}},"required":["page","per_page","total_items","total_pages","next_page","prev_page","has_more"],"type":"object"}},"required":["applications","pagination"],"type":"object"}
 ```
 
 </details>


### PR DESCRIPTION
Bumps gitlab.com/gitlab-org/api/client-go/v2 from v2.38.0 to v2.39.0 and surfaces the new Scopes field on application tools.

## Changes

client-go v2.39.0 (MR !2918) adds a Scopes field to the Application struct. This change exposes it in the MCP layer:

- ApplicationItem.Scopes: new field in the domain struct
- toItem(): copy a.Scopes from the GitLab API response
- FormatListMarkdown: Scopes column added to the application table
- FormatCreateMarkdown: Scopes row added to the create output table
- applications_test.go: scopes field added to all JSON mock responses
- testdata/tools_individual.json: golden snapshots regenerated
- llms.txt, llms-full.txt: regenerated

## Verification

- go build ./... clean
- go test ./internal/... -count=1 all pass
- go test ./internal/tools/applications/ -count=1 -coverprofile 100% coverage
- make analyze all gates pass

## Summary by Sourcery

Bump the GitLab client-go dependency and surface application OAuth scopes throughout the applications tool responses and markdown output.

New Features:
- Expose OAuth scopes on application items returned by the applications tool and include them in list and create markdown output.

Enhancements:
- Map the Scopes field from the GitLab API Application struct into the internal ApplicationItem domain model.
- Update application tests, test data, and LLM prompt assets to cover and reflect the new scopes field.

Build:
- Upgrade gitlab.com/gitlab-org/api/client-go/v2 from v2.38.0 to v2.39.0.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application scopes are now displayed in application management interfaces, including list views and creation responses, allowing users to see the permissions granted to each application.

* **Dependencies**
  * Updated GitLab API client library to the latest version for compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->