### PR TITLE
fix: remove stray test log file from version control

### DIFF
--- a/targeted-mt039-040-096-current.log
+++ b/targeted-mt039-040-096-current.log
@@ -1,3 +1,0 @@
-eval_mcp_surfaces terminal output
-terminal_log=targeted-mt039-040-096-current.log
-eval_mcp_surfaces: load gitlab env file .env.docker: open .env.docker: no such file or directory


### PR DESCRIPTION
Remove targeted-mt039-040-096-current.log from version control — a stray test log file that should not have been committed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

