### PR TITLE
ci(pages): submit URLs to IndexNow after deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: site
 
+      # IndexNow ownership-verification file, generated from the secret so the
+      # key isn't committed. Astro copies site/public/* into the build output,
+      # publishing it at /gitlab-mcp-server/<key>.txt.
+      - name: Write IndexNow key file
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: |
+          if [ -n "$INDEXNOW_KEY" ]; then
+            printf '%s' "$INDEXNOW_KEY" > "site/public/${INDEXNOW_KEY}.txt"
+            echo "Wrote site/public/${INDEXNOW_KEY}.txt"
+          else
+            echo "INDEXNOW_KEY not set — skipping IndexNow key file"
+          fi
+
       - run: pnpm run build
         working-directory: site
 
@@ -58,3 +72,40 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5
+
+  indexnow:
+    name: Submit to IndexNow
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify IndexNow of updated URLs
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INDEXNOW_KEY:-}" ]; then
+            echo "INDEXNOW_KEY not set — skipping IndexNow submission"
+            exit 0
+          fi
+          BASE="https://jmrplens.github.io/gitlab-mcp-server"
+          # Let the deploy propagate, then read the live sitemap(s).
+          sleep 20
+          urls=$(curl -fsSL "$BASE/sitemap-index.xml" \
+            | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g' \
+            | while read -r sm; do curl -fsSL "$sm" \
+                | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g'; done)
+          url_json=$(printf '%s\n' "$urls" | grep . | jq -R . | jq -s .)
+          count=$(printf '%s' "$url_json" | jq 'length')
+          echo "Submitting $count URLs to IndexNow"
+          payload=$(jq -n \
+            --arg host "jmrplens.github.io" \
+            --arg key "$INDEXNOW_KEY" \
+            --arg keyLocation "$BASE/${INDEXNOW_KEY}.txt" \
+            --argjson urlList "$url_json" \
+            '{host:$host, key:$key, keyLocation:$keyLocation, urlList:$urlList}')
+          code=$(curl -sS -o /tmp/indexnow.out -w '%{http_code}' \
+            -X POST "https://api.indexnow.org/IndexNow" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload")
+          echo "IndexNow responded HTTP $code"; cat /tmp/indexnow.out || true
+          case "$code" in 200|202) echo "OK" ;; *) echo "IndexNow submission failed"; exit 1 ;; esac

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,6 +69,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
         uses: actions/deploy-pages@v5
@@ -81,18 +83,19 @@ jobs:
       - name: Notify IndexNow of updated URLs
         env:
           INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
         run: |
           set -euo pipefail
           if [ -z "${INDEXNOW_KEY:-}" ]; then
             echo "INDEXNOW_KEY not set — skipping IndexNow submission"
             exit 0
           fi
-          # Derive the public site URL from the GitHub context so a repo rename
-          # or org move needs no edit here.
-          HOST="$(echo "${GITHUB_REPOSITORY_OWNER}.github.io" | tr '[:upper:]' '[:lower:]')"
-          REPO="${GITHUB_REPOSITORY#*/}"
-          BASE="https://${HOST}/${REPO}"
-          echo "Site base: $BASE"
+          # Use the actual deployed Pages URL (tracks a custom domain / CNAME and
+          # any repo/org rename automatically).
+          BASE="${PAGE_URL%/}"
+          if [ -z "$BASE" ]; then echo "No deploy page_url available; aborting"; exit 1; fi
+          HOST="$(printf '%s' "$BASE" | sed -E 's#^https?://([^/]+).*#\1#')"
+          echo "Site base: $BASE (host: $HOST)"
           # Fetch the live sitemap with a short retry/backoff for deploy propagation.
           idx=""
           for attempt in 1 2 3 4 5; do
@@ -101,10 +104,16 @@ jobs:
             sleep 10
           done
           if [ -z "$idx" ]; then echo "Could not fetch sitemap after retries; aborting"; exit 1; fi
-          urls=$(printf '%s' "$idx" \
-            | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g' \
-            | while read -r sm; do curl -fsSL "$sm" \
-                | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g'; done)
+          # Collect sub-sitemap URLs, then each sitemap's <loc> entries. A while
+          # loop over a here-string (not a pipe) keeps errors from being masked
+          # under `set -o pipefail`; a transient sub-sitemap fetch can't abort all.
+          subs=$(printf '%s' "$idx" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')
+          urls=""
+          while IFS= read -r sm; do
+            [ -n "$sm" ] || continue
+            body=$(curl -fsSL "$sm" || true)
+            urls="${urls}$(printf '%s' "$body" | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g')"$'\n'
+          done <<< "$subs"
           url_json=$(printf '%s\n' "$urls" | grep . | jq -R . | jq -s .)
           count=$(printf '%s' "$url_json" | jq 'length')
           echo "Submitting $count URLs to IndexNow"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -87,10 +87,21 @@ jobs:
             echo "INDEXNOW_KEY not set — skipping IndexNow submission"
             exit 0
           fi
-          BASE="https://jmrplens.github.io/gitlab-mcp-server"
-          # Let the deploy propagate, then read the live sitemap(s).
-          sleep 20
-          urls=$(curl -fsSL "$BASE/sitemap-index.xml" \
+          # Derive the public site URL from the GitHub context so a repo rename
+          # or org move needs no edit here.
+          HOST="$(echo "${GITHUB_REPOSITORY_OWNER}.github.io" | tr '[:upper:]' '[:lower:]')"
+          REPO="${GITHUB_REPOSITORY#*/}"
+          BASE="https://${HOST}/${REPO}"
+          echo "Site base: $BASE"
+          # Fetch the live sitemap with a short retry/backoff for deploy propagation.
+          idx=""
+          for attempt in 1 2 3 4 5; do
+            if idx=$(curl -fsSL "$BASE/sitemap-index.xml"); then break; fi
+            echo "sitemap fetch attempt ${attempt} failed; retrying in 10s…"
+            sleep 10
+          done
+          if [ -z "$idx" ]; then echo "Could not fetch sitemap after retries; aborting"; exit 1; fi
+          urls=$(printf '%s' "$idx" \
             | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g' \
             | while read -r sm; do curl -fsSL "$sm" \
                 | grep -oE '<loc>[^<]+</loc>' | sed -E 's#</?loc>##g'; done)
@@ -98,7 +109,7 @@ jobs:
           count=$(printf '%s' "$url_json" | jq 'length')
           echo "Submitting $count URLs to IndexNow"
           payload=$(jq -n \
-            --arg host "jmrplens.github.io" \
+            --arg host "$HOST" \
             --arg key "$INDEXNOW_KEY" \
             --arg keyLocation "$BASE/${INDEXNOW_KEY}.txt" \
             --argjson urlList "$url_json" \

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -156,6 +156,11 @@ const jsonLd = JSON.stringify({
 			sameAs: [
 				"https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server",
 				"https://cursor.directory/plugins/gitlab-mcp-server",
+				"https://smithery.ai/servers/jmrp/gitlab-mcp-server",
+				"https://mcp.so/server/gitlab-mcp-server/jmrplens",
+				"https://www.pulsemcp.com/servers/jmrplens-gitlab",
+				"https://mcpservers.org/servers/jmrplens/gitlab-mcp-server",
+				"https://enterprisedna.co/directories/mcp/jmrplens-gitlab-mcp-server",
 			],
 		},
 		{

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -154,6 +154,7 @@ const jsonLd = JSON.stringify({
 			},
 			author: { "@id": authorId },
 			sameAs: [
+				"https://www.wikidata.org/wiki/Q140389426",
 				"https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server",
 				"https://cursor.directory/plugins/gitlab-mcp-server",
 				"https://smithery.ai/servers/jmrp/gitlab-mcp-server",


### PR DESCRIPTION
## Summary

Adds **IndexNow** submission to the Pages deploy so Bing/Yandex (and, via the Bing index, ChatGPT Web Search + Copilot) re-crawl on every site deploy. This was the remaining in-CI GEO item from the audit follow-up (#204); the site is already verified in Bing Webmaster Tools.

## How it works

- **Key file** — generated at build time from the `INDEXNOW_KEY` Actions secret (not committed) and written to `site/public/<key>.txt`, which Astro publishes at `https://jmrplens.github.io/gitlab-mcp-server/<key>.txt` for ownership verification.
- **`indexnow` job** (`needs: deploy`) — reads the live sitemap, extracts all `<loc>` URLs, builds the `urlList`, and `POST`s to `https://api.indexnow.org/IndexNow` with `keyLocation` pointing at the published key file. Skips cleanly if the secret is absent.

## Local test (before wiring CI)

Reproduced the job logic locally against the live sitemap:

```
sitemap-index.xml → 1 sub-sitemap → 56 URLs
payload: 4094 bytes, 56 URLs
POST https://api.indexnow.org/IndexNow → HTTP 202 Accepted
```

## Note on first run

This PR only touches `.github/workflows/pages.yml`, and the Pages workflow triggers on `site/**` changes — so merging won't auto-deploy. After merge, run the workflow once manually (`gh workflow run Pages` / "Run workflow") to publish the key file and perform the first IndexNow submission. Subsequent site deploys submit automatically.

https://claude.ai/code/session_01PuVd2s3rFHhCb1HSz5vACK

## Summary by Sourcery

Integrate IndexNow URL submission into the Pages deployment workflow to notify search engines of updated site content.

New Features:
- Generate an IndexNow ownership-verification key file at build time based on a GitHub Actions secret and publish it with the site.
- Add a post-deploy CI job that reads the live sitemap and submits all URLs to the IndexNow API when the key secret is configured.

CI:
- Extend the Pages GitHub Actions workflow with steps to create the IndexNow key file and a dependent job that performs IndexNow submissions after each deploy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved site indexing support so updated pages can be discovered more quickly by search engines.
  * Expanded structured metadata with additional public profile links to strengthen site identity and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->