### PR TITLE
ci(pages): make IndexNow non-fatal (403 on GitHub Pages project sites)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -103,7 +103,7 @@ jobs:
             echo "sitemap fetch attempt ${attempt} failed; retrying in 10s…"
             sleep 10
           done
-          if [ -z "$idx" ]; then echo "Could not fetch sitemap after retries; aborting"; exit 1; fi
+          if [ -z "$idx" ]; then echo "::warning title=IndexNow::could not fetch sitemap after retries (non-fatal); skipping submission"; exit 0; fi
           # Collect sub-sitemap URLs, then each sitemap's <loc> entries. A while
           # loop over a here-string (not a pipe) keeps errors from being masked
           # under `set -o pipefail`; a transient sub-sitemap fetch can't abort all.
@@ -123,10 +123,12 @@ jobs:
             --arg keyLocation "$BASE/${INDEXNOW_KEY}.txt" \
             --argjson urlList "$url_json" \
             '{host:$host, key:$key, keyLocation:$keyLocation, urlList:$urlList}')
+          # `|| true` so a transport error (DNS/timeout) can't abort under set -e;
+          # curl writes 000 to the http_code on failure, handled by the case below.
           code=$(curl -sS -o /tmp/indexnow.out -w '%{http_code}' \
             -X POST "https://api.indexnow.org/IndexNow" \
             -H "Content-Type: application/json; charset=utf-8" \
-            --data "$payload")
+            --data "$payload" || true)
           echo "IndexNow responded HTTP $code"; cat /tmp/indexnow.out || true
           # IndexNow is a best-effort ping — never fail the deploy over it.
           # NOTE: host-level verification (host=$HOST) requires the key file at the

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -128,4 +128,14 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$payload")
           echo "IndexNow responded HTTP $code"; cat /tmp/indexnow.out || true
-          case "$code" in 200|202) echo "OK" ;; *) echo "IndexNow submission failed"; exit 1 ;; esac
+          # IndexNow is a best-effort ping — never fail the deploy over it.
+          # NOTE: host-level verification (host=$HOST) requires the key file at the
+          # site host ROOT (https://$HOST/${INDEXNOW_KEY}.txt). A GitHub Pages
+          # PROJECT site can only publish the key under its project subpath, so
+          # Bing returns 403 "UserForbiddedToAccessSite". To make it succeed, host
+          # the key at the ${HOST} root (e.g. add ${INDEXNOW_KEY}.txt to the
+          # ${GITHUB_REPOSITORY_OWNER}.github.io repository).
+          case "$code" in
+            200|202) echo "IndexNow: submitted OK" ;;
+            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal); see the note in pages.yml about hosting the key at the domain root" ;;
+          esac


### PR DESCRIPTION
The IndexNow job started failing the Pages deploy with HTTP 403 `UserForbiddedToAccessSite`. Root cause: IndexNow host verification for `host=<owner>.github.io` requires the key file at the **domain root** (`https://<owner>.github.io/<key>.txt`), but a GitHub Pages **project** site can only publish it under the project subpath (`/gitlab-mcp-server/<key>.txt`) — so Bing rejects host-level authorization. (The earlier local test returned 202 because the aggregator accepts optimistically before Bing verifies.)

IndexNow is a best-effort ping, so it must not fail the deploy. This change emits a `::warning::` instead of `exit 1`, and documents the fix inline: to make IndexNow actually succeed, host `<key>.txt` at the `<owner>.github.io` **root** repository. Everything else (site deploy, llms.txt, sitemap, Bing verification) is unaffected.

https://claude.ai/code/session_01PuVd2s3rFHhCb1HSz5vACK

## Summary by Sourcery

CI:
- Adjust the Pages workflow to treat IndexNow failures as warnings instead of causing the job to exit with an error, and document the required key hosting setup for successful verification.