### PR TITLE
ci(pages): point IndexNow keyLocation at the domain root (fixes 403)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -123,5 +123,5 @@ jobs:
           # from the ${GITHUB_REPOSITORY_OWNER}.github.io user-site repository.
           case "$code" in
             200|202) echo "IndexNow: submitted OK" ;;
-            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal); ensure ${INDEXNOW_KEY}.txt is served at https://${HOST}/" ;;
+            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal); ensure the IndexNow key file is served at the domain root https://${HOST}/" ;;
           esac

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,20 +41,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
         working-directory: site
 
-      # IndexNow ownership-verification file, generated from the secret so the
-      # key isn't committed. Astro copies site/public/* into the build output,
-      # publishing it at /gitlab-mcp-server/<key>.txt.
-      - name: Write IndexNow key file
-        env:
-          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
-        run: |
-          if [ -n "$INDEXNOW_KEY" ]; then
-            printf '%s' "$INDEXNOW_KEY" > "site/public/${INDEXNOW_KEY}.txt"
-            echo "Wrote site/public/${INDEXNOW_KEY}.txt"
-          else
-            echo "INDEXNOW_KEY not set — skipping IndexNow key file"
-          fi
-
       - run: pnpm run build
         working-directory: site
 
@@ -120,7 +106,7 @@ jobs:
           payload=$(jq -n \
             --arg host "$HOST" \
             --arg key "$INDEXNOW_KEY" \
-            --arg keyLocation "$BASE/${INDEXNOW_KEY}.txt" \
+            --arg keyLocation "https://${HOST}/${INDEXNOW_KEY}.txt" \
             --argjson urlList "$url_json" \
             '{host:$host, key:$key, keyLocation:$keyLocation, urlList:$urlList}')
           # `|| true` so a transport error (DNS/timeout) can't abort under set -e;
@@ -131,13 +117,11 @@ jobs:
             --data "$payload" || true)
           echo "IndexNow responded HTTP $code"; cat /tmp/indexnow.out || true
           # IndexNow is a best-effort ping — never fail the deploy over it.
-          # NOTE: host-level verification (host=$HOST) requires the key file at the
-          # site host ROOT (https://$HOST/${INDEXNOW_KEY}.txt). A GitHub Pages
-          # PROJECT site can only publish the key under its project subpath, so
-          # Bing returns 403 "UserForbiddedToAccessSite". To make it succeed, host
-          # the key at the ${HOST} root (e.g. add ${INDEXNOW_KEY}.txt to the
-          # ${GITHUB_REPOSITORY_OWNER}.github.io repository).
+          # keyLocation points at the host ROOT (https://$HOST/<key>.txt) because
+          # IndexNow verifies ownership at the host level, and a GitHub Pages
+          # PROJECT site can't publish at the domain root. The key file is served
+          # from the ${GITHUB_REPOSITORY_OWNER}.github.io user-site repository.
           case "$code" in
             200|202) echo "IndexNow: submitted OK" ;;
-            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal); see the note in pages.yml about hosting the key at the domain root" ;;
+            *) echo "::warning title=IndexNow::submission returned HTTP $code (non-fatal); ensure ${INDEXNOW_KEY}.txt is served at https://${HOST}/" ;;
           esac


### PR DESCRIPTION
Follow-up to #207. The IndexNow key is now published at the **domain root** by the new `jmrplens.github.io` user-site repo (`https://jmrplens.github.io/<key>.txt`) — which is what IndexNow's host-level verification requires and a GitHub Pages *project* site can't provide.

- `keyLocation` now points at `https://$HOST/<key>.txt` (was the project subpath that Bing rejected with 403 `UserForbiddedToAccessSite`).
- Dropped the now-redundant build step that wrote the key into `site/public` (the root user-site repo is the single source for the key file).

Verified end-to-end: submission now returns **HTTP 202 Accepted** instead of 403.

https://claude.ai/code/session_01PuVd2s3rFHhCb1HSz5vACK

## Summary by Sourcery

Adjust IndexNow configuration in the Pages workflow to use a domain-root key file and remove the redundant build-time key generation step.

Bug Fixes:
- Fix IndexNow submissions failing with HTTP 403 by pointing keyLocation to the key file at the domain root instead of the project subpath.

Enhancements:
- Simplify the Pages CI workflow by dropping the step that writes the IndexNow key file into the project site and clarifying comments and warnings around host-level verification behavior.

CI:
- Update the GitHub Pages workflow IndexNow payload to reference https://$HOST/<key>.txt for keyLocation and refine logging/warnings for deployment pings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the site’s indexing setup so verification and submission now point to the live site address consistently.
  - Updated the publishing flow to better align with the expected host-root location for IndexNow files, helping search engines verify and crawl the site more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->