### PR TITLE
docs(site): GEO polish — TechArticle entity link, Person image, security lead-with-answer

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -101,7 +101,7 @@ const jsonLd = JSON.stringify({
 			name: "José Manuel Requena Plens",
 			alternateName: "jmrplens",
 			url: authorUrl,
-			image: socialImage,
+			image: "https://github.com/jmrplens.png",
 			knowsAbout: [
 				"Model Context Protocol",
 				"GitLab",

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -101,6 +101,7 @@ const jsonLd = JSON.stringify({
 			name: "José Manuel Requena Plens",
 			alternateName: "jmrplens",
 			url: authorUrl,
+			image: socialImage,
 			knowsAbout: [
 				"Model Context Protocol",
 				"GitLab",

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -13,6 +13,9 @@ const SITE = import.meta.env.SITE ?? "https://jmrplens.github.io";
 const BASE = (import.meta.env.BASE_URL ?? "/").replace(/\/$/, "");
 const PERSON_ID = "https://jmrp.io/#person";
 const WEBSITE_ID = `${SITE}${BASE}/#website`;
+// Matches the SoftwareApplication @id in the site-wide @graph (astro.config.mjs),
+// which carries the Wikidata sameAs — so each page's TechArticle ties back to it.
+const SOFTWARE_ID = "https://github.com/jmrplens/gitlab-mcp-server#software";
 
 // Minimal typed view of the Starlight route data we consume.
 interface RouteData {
@@ -49,6 +52,7 @@ const techArticle = isHome
 			author: { "@id": PERSON_ID },
 			publisher: { "@id": PERSON_ID },
 			isPartOf: { "@id": WEBSITE_ID },
+			about: { "@id": SOFTWARE_ID },
 		};
 
 // BreadcrumbList for every non-home page, with locale-aware labels.

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -50,7 +50,7 @@ head:
 Para la referencia técnica completa, consulta [`docs/security.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/concepts/security.md) en el repositorio.
 :::
 
-GitLab MCP Server está diseñado con una arquitectura que prioriza la seguridad. Esta página cubre el modelo de seguridad, el manejo de credenciales y las mejores prácticas para un despliegue seguro.
+**GitLab MCP Server nunca almacena tu token de GitLab.** En modo stdio lee el token de una variable de entorno al arrancar, lo mantiene solo en memoria durante la vida del proceso y lo envía únicamente a tu instancia de GitLab por TLS — nunca a terceros. El modo solo lectura y el modo seguro (vistas previas en dry-run) añaden salvaguardas opcionales, y cada release incluye checksums y firmas para verificar su integridad. Esta página detalla ese modelo de seguridad, el manejo de credenciales y las mejores prácticas para un despliegue seguro.
 
 ## Descripción general del modelo de seguridad
 

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -50,7 +50,7 @@ head:
 Para la referencia técnica completa, consulta [`docs/security.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/concepts/security.md) en el repositorio.
 :::
 
-**GitLab MCP Server nunca almacena tu token de GitLab.** En modo stdio lee el token de una variable de entorno al arrancar, lo mantiene solo en memoria durante la vida del proceso y lo envía únicamente a tu instancia de GitLab por TLS — nunca a terceros. El modo solo lectura y el modo seguro (vistas previas en dry-run) añaden salvaguardas opcionales, y cada release incluye checksums y firmas para verificar su integridad. Esta página detalla ese modelo de seguridad, el manejo de credenciales y las mejores prácticas para un despliegue seguro.
+**GitLab MCP Server nunca almacena tu token de GitLab.** En modo stdio lee el token de una variable de entorno al arrancar, lo mantiene solo en memoria durante la vida del proceso y lo envía únicamente a tu instancia de GitLab —por TLS cuando `GITLAB_URL` apunta a un endpoint `https://` (el valor por defecto)— nunca a terceros. El modo solo lectura y el modo seguro (vistas previas en dry-run) añaden salvaguardas opcionales, y cada release incluye checksums y firmas para verificar su integridad. Esta página detalla ese modelo de seguridad, el manejo de credenciales y las mejores prácticas para un despliegue seguro.
 
 ## Descripción general del modelo de seguridad
 

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -50,7 +50,7 @@ head:
 For the complete technical reference, see [`docs/security.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/concepts/security.md) in the repository.
 :::
 
-**GitLab MCP Server never persists your GitLab token.** In stdio mode it reads the token from an environment variable at startup, holds it only in memory for the life of the process, and sends it only to your GitLab instance over TLS — never to any third party. Read-only mode and safe mode (dry-run previews) add optional guardrails, and every release ships with checksums and signatures for integrity verification. This page details that security model, credential handling, and best practices for safe deployment.
+**GitLab MCP Server never persists your GitLab token.** In stdio mode it reads the token from an environment variable at startup, holds it only in memory for the life of the process, and sends it only to your GitLab instance — over TLS when `GITLAB_URL` points at an `https://` endpoint (the default) — never to any third party. Read-only mode and safe mode (dry-run previews) add optional guardrails, and every release ships with checksums and signatures for integrity verification. This page details that security model, credential handling, and best practices for safe deployment.
 
 ## Security model overview
 

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -50,7 +50,7 @@ head:
 For the complete technical reference, see [`docs/security.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/docs/concepts/security.md) in the repository.
 :::
 
-GitLab MCP Server is designed with a security-first architecture. This page covers the security model, credential handling, and best practices for safe deployment.
+**GitLab MCP Server never persists your GitLab token.** In stdio mode it reads the token from an environment variable at startup, holds it only in memory for the life of the process, and sends it only to your GitLab instance over TLS — never to any third party. Read-only mode and safe mode (dry-run previews) add optional guardrails, and every release ships with checksums and signatures for integrity verification. This page details that security model, credential handling, and best practices for safe deployment.
 
 ## Security model overview
 


### PR DESCRIPTION
Low-effort GEO polish from the v3 audit (composite 88).

- **TechArticle `about`** → each doc page's `TechArticle` now links to the `SoftwareApplication` `@id` (which carries the Wikidata `sameAs`), reinforcing the software entity site-wide for AI engines.
- **`Person.image`** — adds a publisher image/logo to the author node.
- **Security page lead-with-answer** — the `/operations/security/` intro (EN+ES) now opens with the concrete guarantee (token never persisted, in-memory, TLS-only, read-only/safe modes, signed releases) instead of a generic "this page covers…" — the last page not meeting the house lead-with-answer standard.

Skipped (with reason): `SearchAction` (Starlight uses client-side Pagefind with no query-param URL — a SearchAction would point nowhere), and sitemap `lastmod` (Starlight built-in sitemap limitation; freshness is already covered by per-page `dateModified`).

astro check 0 errors; build + lint + i18n parity green; `about`/`image`/intro verified in dist.

https://claude.ai/code/session_01PuVd2s3rFHhCb1HSz5vACK

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the security documentation with clearer guidance on token handling, including in-memory use, TLS-only transmission, and optional read-only/safe-mode protections.
  * Improved site metadata for richer structured data on pages and author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->