### PR TITLE
feat(site): GEO audit improvements — schema, visible authorship, sitemap lastmod

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history so add-sitemap-lastmod.mjs can read per-file commit dates.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           # Full history so add-sitemap-lastmod.mjs can read per-file commit dates.
           fetch-depth: 0
+          # The build runs third-party code (pnpm install); the sitemap script
+          # only reads local git history, so the remote token is not needed.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         with:

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
@@ -93,10 +94,22 @@ const socialImage = {
 };
 
 // Freshness signals for the SoftwareApplication node. `datePublished` is the
-// first public release (v1.0.0, 2026-04-21); `dateModified` tracks the current
-// build so AI engines reading the graph see an accurate last-changed date.
+// first public release (v1.0.0, 2026-04-21) and is intentionally fixed. To avoid
+// stamping a false "modified today" on every rebuild, `dateModified` tracks the
+// last repository change (HEAD commit date), falling back to build time only when
+// git history is unavailable.
 const datePublished = "2026-04-21";
-const dateModified = new Date().toISOString().slice(0, 10);
+const dateModified = (() => {
+	try {
+		return execFileSync("git", ["log", "-1", "--format=%cI"], {
+			encoding: "utf8",
+		})
+			.trim()
+			.slice(0, 10);
+	} catch {
+		return new Date().toISOString().slice(0, 10);
+	}
+})();
 
 // Human-readable capability list and requirements — single-sourced from stats so
 // they never drift from the rest of the site. These feed AI "what can it do?" and

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -92,6 +92,27 @@ const socialImage = {
 	height: 630,
 };
 
+// Freshness signals for the SoftwareApplication node. `datePublished` is the
+// first public release (v1.0.0, 2026-04-21); `dateModified` tracks the current
+// build so AI engines reading the graph see an accurate last-changed date.
+const datePublished = "2026-04-21";
+const dateModified = new Date().toISOString().slice(0, 10);
+
+// Human-readable capability list and requirements — single-sourced from stats so
+// they never drift from the rest of the site. These feed AI "what can it do?" and
+// "what do I need?" queries directly from structured data.
+const featureList = [
+	`Exposes over 1,000 GitLab REST v4 and GraphQL operations as MCP tools (${stats.tools.free} on Community Edition, up to ${stats.tools.gitlab_com} on GitLab.com)`,
+	`Three tool surfaces: a 2-tool dynamic low-token mode, ${stats.meta.base} domain meta-tools, or one tool per operation`,
+	`${stats.resources} MCP resources and ${stats.prompts} prompt templates`,
+	"stdio and multi-user HTTP transport with per-token isolation",
+	"GitLab CE and EE support, including self-hosted instances",
+	"Single cross-platform Go binary (Linux, macOS, Windows; amd64 and arm64)",
+	"Read-only and safe-preview modes, plus built-in auto-update",
+];
+const softwareRequirements =
+	"A GitLab instance (GitLab.com or self-hosted, Community or Enterprise Edition) with REST v4/GraphQL API access and a personal access token.";
+
 const jsonLd = JSON.stringify({
 	"@context": "https://schema.org",
 	"@graph": [
@@ -100,6 +121,7 @@ const jsonLd = JSON.stringify({
 			"@id": authorId,
 			name: "José Manuel Requena Plens",
 			alternateName: "jmrplens",
+			jobTitle: ["R&D Engineer", "Firmware & Software Engineer"],
 			url: authorUrl,
 			image: "https://github.com/jmrplens.png",
 			knowsAbout: [
@@ -135,6 +157,7 @@ const jsonLd = JSON.stringify({
 			name: "GitLab MCP Server",
 			softwareVersion: stats.version,
 			applicationCategory: "DeveloperApplication",
+			applicationSubCategory: "Version Control",
 			operatingSystem: "Windows, Linux, macOS",
 			programmingLanguage: "Go",
 			url: repositoryUrl,
@@ -144,6 +167,10 @@ const jsonLd = JSON.stringify({
 			screenshot: socialImage,
 			license: "https://opensource.org/licenses/MIT",
 			isAccessibleForFree: true,
+			datePublished,
+			dateModified,
+			softwareRequirements,
+			featureList,
 			keywords:
 				"Model Context Protocol, MCP, GitLab, AI assistants, developer tools, Go",
 			description:
@@ -205,6 +232,9 @@ export default defineConfig({
 				// Per-page structured data (TechArticle / BreadcrumbList / HowTo)
 				// and per-page Twitter card tags, layered on the default head.
 				Head: "./src/components/Head.astro",
+				// Adds a human-visible maintainer block below the default footer,
+				// corroborating the Person node in the site-wide @graph.
+				Footer: "./src/components/Footer.astro",
 			},
 			logo: {
 				dark: "./src/assets/logo-dark.svg",
@@ -359,6 +389,14 @@ export default defineConfig({
 					attrs: {
 						name: "msvalidate.01",
 						content: "7574EB3B44624C239F14920DBC34EE25",
+					},
+				},
+				// Google Search Console site verification
+				{
+					tag: "meta",
+					attrs: {
+						name: "google-site-verification",
+						content: "4Hx_PJ1seU_BgKfWpo_FA7_Hkh7GeYVNrvnvzqCjF0Q",
 					},
 				},
 				// JSON-LD structured data

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "node -e \"const fs=require('fs'),path=require('path');function walk(d){for(const e of fs.readdirSync(d,{withFileTypes:true})){const p=path.join(d,e.name);if(e.isDirectory())walk(p);else if(e.isFile()&&e.name.endsWith('.html')){const c=fs.readFileSync(p,'utf8');const t=c.split('\\n').map(l=>l.replace(/[ \\t\\r]+$/,'')).join('\\n');if(t!==c)fs.writeFileSync(p,t);}}}walk('dist');\"",
+    "postbuild": "node -e \"const fs=require('fs'),path=require('path');function walk(d){for(const e of fs.readdirSync(d,{withFileTypes:true})){const p=path.join(d,e.name);if(e.isDirectory())walk(p);else if(e.isFile()&&e.name.endsWith('.html')){const c=fs.readFileSync(p,'utf8');const t=c.split('\\n').map(l=>l.replace(/[ \\t\\r]+$/,'')).join('\\n');if(t!==c)fs.writeFileSync(p,t);}}}walk('dist');\" && node scripts/add-sitemap-lastmod.mjs",
     "preview": "astro preview",
     "check": "astro check",
     "eslint": "eslint .",

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -6,6 +6,8 @@
 
 User-agent: *
 Allow: /
+# Explicit opt-in for AI training, search indexing, and AI retrieval/citation.
+Content-Signal: ai-train=yes, search=yes, ai-retrieval=yes
 
 # AI / generative-engine crawlers (explicitly welcomed for GEO).
 User-agent: GPTBot

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -7,7 +7,7 @@
 User-agent: *
 Allow: /
 # Explicit opt-in for AI training, search indexing, and AI retrieval/citation.
-Content-Signal: ai-train=yes, search=yes, ai-retrieval=yes
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 # AI / generative-engine crawlers (explicitly welcomed for GEO).
 User-agent: GPTBot

--- a/site/scripts/add-sitemap-lastmod.mjs
+++ b/site/scripts/add-sitemap-lastmod.mjs
@@ -1,0 +1,102 @@
+// Injects <lastmod> into the generated sitemap.
+//
+// Starlight's built-in sitemap (via @astrojs/sitemap) emits <loc> entries with
+// no <lastmod>, so crawlers — including AI crawlers — can't tell when a page last
+// changed. This post-build step maps each sitemap URL back to its source content
+// file and stamps the file's last Git commit date as <lastmod>. Runs after
+// `astro build` (see package.json `postbuild`).
+//
+// Date resolution per URL: Git commit date of the source .mdx/.md → file mtime →
+// build time. In a shallow CI checkout Git dates may collapse to the latest
+// commit; the deploy workflow uses fetch-depth: 0 so per-file dates are accurate.
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(here, "..");
+const repoRoot = join(siteRoot, "..");
+const distDir = join(siteRoot, "dist");
+const docsDir = join(siteRoot, "src", "content", "docs");
+
+const SITE = "https://jmrplens.github.io";
+const BASE = "/gitlab-mcp-server";
+const buildDate = new Date().toISOString().slice(0, 10);
+
+// Map a sitemap URL to its source content file, or null if none is found.
+function sourceFileFor(url) {
+	let rel;
+	try {
+		rel = new URL(url).pathname;
+	} catch {
+		return null;
+	}
+	if (rel.startsWith(BASE)) rel = rel.slice(BASE.length);
+	rel = rel.replace(/^\/+|\/+$/g, ""); // trim slashes → "tools/overview" | "es" | ""
+	const base = rel === "" ? "index" : rel === "es" ? "es/index" : rel;
+	for (const ext of [".mdx", ".md"]) {
+		const candidate = join(docsDir, base + ext);
+		if (existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+// Git commit date (YYYY-MM-DD) for a file, or null if unavailable.
+function gitDate(absPath) {
+	try {
+		const out = execFileSync(
+			"git",
+			["log", "-1", "--format=%cI", "--", absPath],
+			{ cwd: repoRoot, encoding: "utf8" },
+		).trim();
+		return out ? out.slice(0, 10) : null;
+	} catch {
+		return null;
+	}
+}
+
+function lastmodFor(url) {
+	const src = sourceFileFor(url);
+	if (!src) return buildDate;
+	return (
+		gitDate(src) ?? statSync(src).mtime.toISOString().slice(0, 10) ?? buildDate
+	);
+}
+
+// Add <lastmod> after each <loc> that lacks one.
+function stampSitemap(file) {
+	const xml = readFileSync(file, "utf8");
+	let changed = 0;
+	const out = xml.replace(/<url>\s*<loc>([^<]+)<\/loc>/g, (match, loc) => {
+		if (match.includes("<lastmod>")) return match;
+		changed++;
+		return `<url><loc>${loc}</loc><lastmod>${lastmodFor(loc)}</lastmod>`;
+	});
+	if (changed > 0) {
+		writeFileSync(file, out);
+		console.log(
+			`[sitemap-lastmod] stamped ${changed} URLs in ${file.replace(distDir, "dist")}`,
+		);
+	}
+}
+
+if (!existsSync(distDir)) {
+	console.warn("[sitemap-lastmod] dist/ not found — skipping");
+	process.exit(0);
+}
+
+const sitemaps = readdirSync(distDir).filter(
+	(f) => /^sitemap-\d+\.xml$/.test(f), // child sitemaps only, not sitemap-index.xml
+);
+if (sitemaps.length === 0) {
+	console.warn("[sitemap-lastmod] no child sitemap found — skipping");
+	process.exit(0);
+}
+for (const f of sitemaps) stampSitemap(join(distDir, f));

--- a/site/scripts/add-sitemap-lastmod.mjs
+++ b/site/scripts/add-sitemap-lastmod.mjs
@@ -30,14 +30,17 @@ const SITE = "https://jmrplens.github.io";
 const BASE = "/gitlab-mcp-server";
 const buildDate = new Date().toISOString().slice(0, 10);
 
-// Map a sitemap URL to its source content file, or null if none is found.
+// Map a sitemap URL to its source content file, or null if none is found or the
+// URL is not on this site's origin (so unrelated URLs are never stamped).
 function sourceFileFor(url) {
-	let rel;
+	let parsed;
 	try {
-		rel = new URL(url).pathname;
+		parsed = new URL(url);
 	} catch {
 		return null;
 	}
+	if (parsed.origin !== SITE) return null;
+	let rel = parsed.pathname;
 	if (rel.startsWith(BASE)) rel = rel.slice(BASE.length);
 	rel = rel.replace(/^\/+|\/+$/g, ""); // trim slashes → "tools/overview" | "es" | ""
 	const base = rel === "" ? "index" : rel === "es" ? "es/index" : rel;
@@ -70,14 +73,18 @@ function lastmodFor(url) {
 	);
 }
 
-// Add <lastmod> after each <loc> that lacks one.
+// Add <lastmod> to each <url> that lacks one. Matching the whole <url>…</url>
+// block (not just <loc>) keeps this idempotent: if an entry already carries a
+// <lastmod>, it is left untouched rather than getting a duplicate.
 function stampSitemap(file) {
 	const xml = readFileSync(file, "utf8");
 	let changed = 0;
-	const out = xml.replace(/<url>\s*<loc>([^<]+)<\/loc>/g, (match, loc) => {
-		if (match.includes("<lastmod>")) return match;
-		changed++;
-		return `<url><loc>${loc}</loc><lastmod>${lastmodFor(loc)}</lastmod>`;
+	const out = xml.replace(/<url>[\s\S]*?<\/url>/g, (block) => {
+		if (block.includes("<lastmod>")) return block;
+		return block.replace(/<loc>([^<]+)<\/loc>/, (locMatch, loc) => {
+			changed++;
+			return `<loc>${loc}</loc><lastmod>${lastmodFor(loc)}</lastmod>`;
+		});
 	});
 	if (changed > 0) {
 		writeFileSync(file, out);
@@ -92,8 +99,9 @@ if (!existsSync(distDir)) {
 	process.exit(0);
 }
 
+// Match sitemap.xml and sitemap-<n>.xml, but never the sitemap index.
 const sitemaps = readdirSync(distDir).filter(
-	(f) => /^sitemap-\d+\.xml$/.test(f), // child sitemaps only, not sitemap-index.xml
+	(f) => /^sitemap(-\d+)?\.xml$/.test(f) && f !== "sitemap-index.xml",
 );
 if (sitemaps.length === 0) {
 	console.warn("[sitemap-lastmod] no child sitemap found — skipping");

--- a/site/scripts/add-sitemap-lastmod.mjs
+++ b/site/scripts/add-sitemap-lastmod.mjs
@@ -51,18 +51,37 @@ function sourceFileFor(url) {
 	return null;
 }
 
-// Git commit date (YYYY-MM-DD) for a file, or null if unavailable.
-function gitDate(absPath) {
+// Absolute-path → last commit date (YYYY-MM-DD), built in a single `git log`
+// pass over the docs tree instead of one subprocess per URL. Output is
+// newest-first, so the first date seen for a file is its last-modified date.
+function buildGitDateMap() {
+	const map = new Map();
 	try {
 		const out = execFileSync(
 			"git",
-			["log", "-1", "--format=%cI", "--", absPath],
-			{ cwd: repoRoot, encoding: "utf8" },
-		).trim();
-		return out ? out.slice(0, 10) : null;
+			["log", "--format=%cI", "--name-only", "--", "site/src/content/docs"],
+			{ cwd: repoRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+		);
+		let current = null;
+		for (const line of out.split("\n")) {
+			if (line === "") continue;
+			if (/^\d{4}-\d{2}-\d{2}T/.test(line)) {
+				current = line.slice(0, 10);
+			} else {
+				const abs = join(repoRoot, line);
+				if (!map.has(abs)) map.set(abs, current);
+			}
+		}
 	} catch {
-		return null;
+		// Leave the map empty; callers fall back to file mtime / build date.
 	}
+	return map;
+}
+const gitDates = buildGitDateMap();
+
+// Last commit date (YYYY-MM-DD) for a file, or null if unavailable.
+function gitDate(absPath) {
+	return gitDates.get(absPath) ?? null;
 }
 
 function lastmodFor(url) {

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,0 +1,69 @@
+---
+// Custom Starlight <Footer> override.
+// Renders Starlight's default footer, then a human-visible maintainer block so
+// the on-page authorship corroborates the Person node in the site-wide @graph
+// (astro.config.mjs). AI engines look for agreement between structured data and
+// rendered content when deciding whether to cite a source; this supplies it.
+import Default from "@astrojs/starlight/components/Footer.astro";
+
+const BASE = (import.meta.env.BASE_URL ?? "/").replace(/\/$/, "");
+const pathname = Astro.url.pathname;
+const rel = pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
+const isES = rel === "/es" || rel.startsWith("/es/");
+
+const label = isES ? "Mantenido por" : "Maintained by";
+// Visible mirror of the Person `sameAs` set in the site-wide @graph.
+const links = [
+	{ href: "https://github.com/jmrplens", text: "GitHub" },
+	{ href: "https://linkedin.com/in/jmrplens", text: "LinkedIn" },
+	{ href: "https://mstdn.jmrp.io/@jmrplens", text: "Mastodon" },
+	{
+		href: "https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
+		text: "Google Scholar",
+	},
+];
+---
+
+<Default />
+<div class="gmcp-maintainer">
+	<span>
+		{label}{" "}
+		<a href="https://jmrp.io" rel="author">José Manuel Requena Plens</a>
+	</span>
+	<span class="gmcp-maintainer-links">
+		{
+			links.map((l) => (
+				<a href={l.href} rel="me noopener" target="_blank">
+					{l.text}
+				</a>
+			))
+		}
+	</span>
+</div>
+
+<style>
+	.gmcp-maintainer {
+		margin-top: 1.5rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--sl-color-hairline);
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem 1rem;
+		align-items: baseline;
+		justify-content: space-between;
+		font-size: var(--sl-text-sm);
+		color: var(--sl-color-gray-3);
+	}
+	.gmcp-maintainer-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+	.gmcp-maintainer a {
+		color: var(--sl-color-text-accent);
+		text-decoration: none;
+	}
+	.gmcp-maintainer a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -33,7 +33,7 @@ const links = [
 	<span class="gmcp-maintainer-links">
 		{
 			links.map((l) => (
-				<a href={l.href} rel="me noopener" target="_blank">
+				<a href={l.href} rel="me noopener noreferrer" target="_blank">
 					{l.text}
 				</a>
 			))

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -48,6 +48,11 @@ const techArticle = isHome
 			inLanguage: lang,
 			url: canonical,
 			mainEntityOfPage: canonical,
+			// Point voice/AI assistants at the page title and lead paragraph.
+			speakable: {
+				"@type": "SpeakableSpecification",
+				cssSelector: ["h1", ".sl-markdown-content > p:first-of-type"],
+			},
 			...(updated ? { datePublished: updated, dateModified: updated } : {}),
 			author: { "@id": PERSON_ID },
 			publisher: { "@id": PERSON_ID },

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -310,3 +310,9 @@ The canonical action catalog is the single internal definition of every ordinary
 ### How does GitLab MCP Server keep my GitLab token secure?
 
 GitLab MCP Server never stores tokens server-side. In stdio mode the token exists only in the process environment and never leaves the local machine. In HTTP mode each user's session is isolated in the server pool by token and URL. All GitLab API calls use HTTPS by default, with opt-in skipping for self-signed certificates, and the server is stateless — no data is persisted between requests. Read-only mode (`GITLAB_READ_ONLY=true`) disables every mutating operation.
+
+## External references
+
+- [Model Context Protocol specification](https://modelcontextprotocol.io/) — the protocol the server speaks to AI clients
+- [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification) — the wire format used over stdio and HTTP
+- [GitLab REST API v4](https://docs.gitlab.com/api/rest/) and [GraphQL API](https://docs.gitlab.com/api/graphql/) — the GitLab surfaces the server translates tool calls into

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -315,4 +315,4 @@ GitLab MCP Server never stores tokens server-side. In stdio mode the token exist
 
 - [Model Context Protocol specification](https://modelcontextprotocol.io/) — the protocol the server speaks to AI clients
 - [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification) — the wire format used over stdio and HTTP
-- [GitLab REST API v4](https://docs.gitlab.com/api/rest/) and [GraphQL API](https://docs.gitlab.com/api/graphql/) — the GitLab surfaces the server translates tool calls into
+- [GitLab REST API v4](https://docs.gitlab.com/api/rest/) and [GraphQL API](https://docs.gitlab.com/api/graphql/) — the GitLab API surfaces the server translates tool calls into

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -314,3 +314,9 @@ El catálogo de acciones canónico es la única definición interna de cada oper
 ### ¿Cómo mantiene GitLab MCP Server seguro mi token de GitLab?
 
 GitLab MCP Server nunca almacena tokens en el servidor. En modo stdio el token existe solo en el entorno del proceso y nunca sale de la máquina local. En modo HTTP la sesión de cada usuario está aislada en el pool del servidor por token y URL. Todas las llamadas a la API de GitLab usan HTTPS por defecto, con la opción de omitirlo para certificados autofirmados, y el servidor no tiene estado — no se almacenan datos entre peticiones. El modo solo lectura (`GITLAB_READ_ONLY=true`) desactiva toda operación de escritura.
+
+## Referencias externas
+
+- [Especificación del Model Context Protocol](https://modelcontextprotocol.io/) — el protocolo con el que el servidor habla con los clientes de IA
+- [Especificación JSON-RPC 2.0](https://www.jsonrpc.org/specification) — el formato de mensajes usado sobre stdio y HTTP
+- [API REST v4 de GitLab](https://docs.gitlab.com/api/rest/) y [API GraphQL](https://docs.gitlab.com/api/graphql/) — las superficies de GitLab a las que el servidor traduce las llamadas a herramientas

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -25,6 +25,10 @@ head:
       {
         "@context": "https://schema.org",
         "@type": "FAQPage",
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": ["h1", ".sl-markdown-content > p:first-of-type"]
+        },
         "mainEntity": [
           {
             "@type": "Question",

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -352,3 +352,9 @@ El **modo solo lectura** (`GITLAB_READ_ONLY=true`) no registra ninguna herramien
 ### ¿Cómo verifico la integridad de un binario descargado?
 
 Cada GitHub Release incluye `checksums.txt` (hashes SHA-256) y `checksums.txt.sigstore.json` (un bundle de firma keyless Cosign/Sigstore con GitHub OIDC). La auto-actualización verifica los binarios contra `checksums.txt` automáticamente. Para instalaciones manuales, ejecuta `cosign verify-blob` con el bundle, anclando la identidad del certificado a este repositorio y el emisor OIDC a GitHub, y luego valida el hash del binario contra el checksum firmado. Si la verificación falla, **no ejecutes el binario**.
+
+## Referencias externas
+
+- [Scopes de tokens de acceso personal de GitLab](https://docs.gitlab.com/user/profile/personal_access_tokens/) — elegir scopes de mínimo privilegio
+- [OAuth 2.0 Protected Resource Metadata (RFC 9728)](https://www.rfc-editor.org/rfc/rfc9728) — el estándar detrás del modo OAuth por HTTP
+- [Documentación de Sigstore / Cosign](https://docs.sigstore.dev/) — verificación de firmas keyless de los binarios de release

--- a/site/src/content/docs/es/tools/overview.mdx
+++ b/site/src/content/docs/es/tools/overview.mdx
@@ -220,3 +220,9 @@ Sí. Las meta-herramientas Enterprise —como merge trains, métricas DORA, vuln
 - [Conjunto dinámico](/gitlab-mcp-server/es/tools/dynamic-tools/) — modo de búsqueda, descripción y ejecución con bajo consumo de tokens
 - [Orbit](/gitlab-mcp-server/es/tools/orbit/) — herramientas Knowledge Graph para GitLab.com Enterprise/Premium
 - [Recursos y prompts](/gitlab-mcp-server/es/tools/resources-prompts/) — contexto de solo lectura y plantillas de prompts
+
+## Referencias externas
+
+- [Especificación del Model Context Protocol](https://modelcontextprotocol.io/) — el protocolo que implementan estas herramientas
+- [API REST v4 de GitLab](https://docs.gitlab.com/api/rest/) — la superficie REST que llama la mayoría de las herramientas
+- [API GraphQL de GitLab](https://docs.gitlab.com/api/graphql/) — la superficie GraphQL que usan el resto de dominios

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -25,6 +25,10 @@ head:
       {
         "@context": "https://schema.org",
         "@type": "FAQPage",
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "cssSelector": ["h1", ".sl-markdown-content > p:first-of-type"]
+        },
         "mainEntity": [
           {
             "@type": "Question",

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -352,3 +352,9 @@ Use the **minimum scopes** for your workflow: `read_api` for read-only operation
 ### How do I verify the integrity of a downloaded binary?
 
 Every GitHub Release ships `checksums.txt` (SHA-256 hashes) and `checksums.txt.sigstore.json` (a keyless Cosign/Sigstore signature bundle using GitHub OIDC). Auto-update verifies binaries against `checksums.txt` automatically. For manual installs, run `cosign verify-blob` with the bundle, pinning the certificate identity to this repository and the OIDC issuer to GitHub, then validate the binary hash against the signed checksum. If verification fails, **do not run the binary**.
+
+## External references
+
+- [GitLab personal access token scopes](https://docs.gitlab.com/user/profile/personal_access_tokens/) — choosing least-privilege token scopes
+- [OAuth 2.0 Protected Resource Metadata (RFC 9728)](https://www.rfc-editor.org/rfc/rfc9728) — the standard behind HTTP OAuth mode
+- [Sigstore / Cosign documentation](https://docs.sigstore.dev/) — keyless signature verification for release binaries

--- a/site/src/content/docs/tools/overview.mdx
+++ b/site/src/content/docs/tools/overview.mdx
@@ -220,3 +220,9 @@ Yes. Enterprise meta-tools — such as merge trains, DORA metrics, vulnerabiliti
 - [Dynamic toolset](/gitlab-mcp-server/tools/dynamic-tools/) — low-token search/describe/execute mode
 - [Orbit](/gitlab-mcp-server/tools/orbit/) — GitLab.com Enterprise/Premium Knowledge Graph tools
 - [Resources & Prompts](/gitlab-mcp-server/tools/resources-prompts/) — read-only context and prompt templates
+
+## External references
+
+- [Model Context Protocol specification](https://modelcontextprotocol.io/) — the protocol these tools implement
+- [GitLab REST API v4](https://docs.gitlab.com/api/rest/) — the REST surface most tools call
+- [GitLab GraphQL API](https://docs.gitlab.com/api/graphql/) — the GraphQL surface used by the remaining domains


### PR DESCRIPTION
## Summary

Implements the actionable, in-repo findings from a full GEO (Generative Engine Optimization) audit of the docs site. On-page/technical GEO was already strong; these changes close the remaining code-addressable gaps (schema richness, on-page authorship, freshness signals) and add the requested Google Search Console verification.

## Changes

- **Google Search Console** verification meta tag (alongside the existing Bing one).
- **`SoftwareApplication` JSON-LD enriched**: `applicationSubCategory`, `featureList`, `softwareRequirements`, `datePublished` (v1.0.0 = 2026-04-21), `dateModified` (build date). `featureList`/counts are single-sourced from `stats.json`.
- **`Person.jobTitle`** (R&D / Firmware & Software Engineer).
- **`speakable`** on every page's `TechArticle` (`Head.astro`) and on the homepage `FAQPage` (EN/ES).
- **Visible maintainer footer** (`Footer.astro` override, bilingual) mirroring the `Person` `@graph` on-page — closes the E-E-A-T authorship gap where author identity was machine-only.
- **Sitemap `<lastmod>`** injected from each page's Git commit date via a `postbuild` script; deploy checkout switched to `fetch-depth: 0` for accurate per-file dates.
- **Authoritative outbound citations** (MCP spec, GitLab REST/GraphQL API, RFC 9728, Sigstore, JSON-RPC) added to Tools Overview, Architecture, Security (EN + ES).
- **`Content-Signal`** opt-in directive in `robots.txt`.

## Off-repo (done separately)

- Wikidata `Q140389426` enriched via API: `P571` inception (2026-04-21), `P2283` uses → Model Context Protocol / GraphQL / GitLab, and `GitLab MCP` aliases (en/es). No person item was created (notability).

## Deliberately skipped (with reason)

- `SearchAction` (Starlight search is a client-side modal with no results-URL endpoint) and `aggregateRating` (requires genuine review data — GitHub stars are not valid). Image WebP/lazy-load: no below-fold content raster images.

## Verification

`astro build`, `astro check` (0 errors), i18n parity, eslint, prettier, html-validate, htmlhint all pass. All 12 sampled JSON-LD blocks parse as valid JSON. Note: the Google verification only confirms once deployed to production.

https://claude.ai/code/session_01AEEZLTeWWao8ffn1AscMVB

## Summary by Sourcery

Strengthen GEO/SEO signals across the docs site with richer structured data, visible authorship, and accurate sitemap freshness metadata.

New Features:
- Expose additional SoftwareApplication schema fields, including capabilities, requirements, and publication/modified dates, sourced from existing stats.
- Add speakable schema to TechArticle pages and the FAQ homepage in both languages to guide voice/AI assistants.
- Render a human-visible maintainer footer that mirrors the site-wide Person graph for on-page authorship.
- Introduce a postbuild step that stamps per-URL <lastmod> into generated sitemaps based on source content dates.

Enhancements:
- Augment the site-wide Person node with job titles to clarify the maintainer’s role.
- Configure Starlight to use a custom footer component while retaining the default footer content.
- Add authoritative external reference sections to architecture, tools overview, and security docs in English and Spanish.

Build:
- Extend the site postbuild pipeline with a sitemap lastmod injection script.
- Adjust the GitHub Pages workflow checkout depth to full history to support per-file commit date extraction.

Chores:
- Add Google Search Console verification meta tag alongside existing search engine verification.
- Prepare robots.txt for Content-Signal integration (file present, directive handled elsewhere if applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer site metadata for search engines and social previews, including updated structured data and site verification.
  * Added page “speakable” metadata to highlight key content for voice/search experiences.
  * Added a custom footer with maintainer attribution and localized labels.

* **Bug Fixes**
  * Improved sitemap freshness by including last-modified dates in generated sitemap entries.
  * Updated build settings to ensure sitemap date generation has full history available.

* **Documentation**
  * Added new “External references” sections to key English and Spanish docs pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->