### PR TITLE
refactor: reduce SonarCloud duplicated lines via shared toolutil shapes + audit coverage guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,19 +358,19 @@ The published container image is `ghcr.io/jmrplens/gitlab-mcp-server:latest`. Se
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       955 |     192,645 |
-| Unit tests (`_test.go`)  |       521 |     293,146 |
+| Source (`.go`, non-test) |       964 |     191,920 |
+| Unit tests (`_test.go`)  |       527 |     293,739 |
 | End-to-end tests         |       143 |      35,337 |
-| **Total**                | **1,619** | **521,128** |
+| **Total**                | **1,634** | **520,996** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,349 |
-| — exported (public)             |  2,563 |
-| — unexported (private)          |  4,786 |
-| Unit test functions (`TestXxx`) | 11,336 |
+| Source functions                |  7,341 |
+| — exported (public)             |  2,589 |
+| — unexported (private)          |  4,752 |
+| Unit test functions (`TestXxx`) | 11,360 |
 | Subtests (`t.Run(...)`)         |  2,639 |
 | End-to-end test functions       |    287 |
 
@@ -378,19 +378,19 @@ The published container image is `ghcr.io/jmrplens/gitlab-mcp-server:latest`. Se
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.52× more tests than code |
-| Average source file length         |                 ~201 lines |
-| Average test file length           |                 ~562 lines |
-| Comment lines in source            |  20,614 (~10.7% of source) |
+| Test lines vs source lines         | 1.53× more tests than code |
+| Average source file length         |                 ~199 lines |
+| Average test file length           |                 ~557 lines |
+| Comment lines in source            |  20,714 (~10.8% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,569 |
-| `defer` statements                 |   706 |
-| `struct` types defined             | 2,721 |
+| `if err != nil` checks             | 6,558 |
+| `defer` statements                 |   705 |
+| `struct` types defined             | 2,701 |
 | `//nolint` suppressions            |   179 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -398,25 +398,25 @@ The published container image is `ghcr.io/jmrplens/gitlab-mcp-server:latest`. Se
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   225 |
+| Go packages                    |   226 |
 | Direct dependencies (`go.mod`) |    13 |
 | Indirect dependencies          |    50 |
-| Git commits                    |   231 |
+| Git commits                    |   230 |
 | Unique contributors            |     4 |
 
 ### Hall of fame
 
 | Record              | File                                                     |
 | ------------------- | -------------------------------------------------------- |
-| Longest source file | `internal/tools/projects/projects.go` — 3,818 lines      |
+| Longest source file | `internal/tools/projects/projects.go` — 3,795 lines      |
 | Longest test file   | `internal/tools/projects/projects_test.go` — 7,931 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,502 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,457 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,489 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,459 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_1to1/internal/metadata/analyze.go
+++ b/cmd/audit_1to1/internal/metadata/analyze.go
@@ -13,26 +13,17 @@
 package metadata
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
-	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
-
-// genericUsageRe matches placeholder Usage sentences such as
-// "Use to execute branches domain action." or "Use to execute list action.".
-var genericUsageRe = regexp.MustCompile(`(?i)^use to execute\b.*\baction\.?\s*$`)
 
 // actionFinding records the R-META flags raised for one action.
 type actionFinding struct {
@@ -86,7 +77,7 @@ func buildReport(gapsOnly bool) (report, error) {
 	}
 	defer cleanup()
 
-	projected, err := projectIndividualDescriptions(client)
+	projected, err := auditshared.ProjectIndividualDescriptions(client)
 	if err != nil {
 		return report{}, err
 	}
@@ -94,7 +85,7 @@ func buildReport(gapsOnly bool) (report, error) {
 	byPackage := map[string]*packageReport{}
 	for _, group := range tools.CollectActionSpecs(client, true) {
 		for _, spec := range group.Actions {
-			owner := ownerPackage(group, spec)
+			owner := auditshared.OwnerPackage(group, spec)
 			pr := packageFor(byPackage, owner)
 			pr.Actions++
 			if finding, ok := analyzeSpec(spec, projected, gapsOnly); ok {
@@ -123,7 +114,7 @@ func buildReport(gapsOnly bool) (report, error) {
 // the action raises no flags (used to skip clean actions in gaps-only mode).
 func analyzeSpec(spec toolutil.ActionSpec, projected map[string]string, gapsOnly bool) (actionFinding, bool) {
 	var flags []string
-	if isGenericUsage(spec.Usage) {
+	if auditshared.IsGenericUsage(spec.Usage) {
 		flags = append(flags, "generic_usage")
 	}
 	if aliasesOnlyToolname(spec) {
@@ -132,7 +123,7 @@ func analyzeSpec(spec toolutil.ActionSpec, projected map[string]string, gapsOnly
 	if len(spec.RelatedActions) == 0 {
 		flags = append(flags, "empty_related")
 	}
-	if weakIndividualDescription(spec, projected) {
+	if auditshared.WeakIndividualDescription(spec, projected) {
 		flags = append(flags, "weak_individual_description")
 	}
 	if len(flags) == 0 && gapsOnly {
@@ -144,60 +135,6 @@ func analyzeSpec(spec toolutil.ActionSpec, projected map[string]string, gapsOnly
 		Usage:  strings.TrimSpace(spec.Usage),
 		Flags:  flags,
 	}, len(flags) > 0
-}
-
-// weakIndividualDescription reports whether the effective individual-tool
-// description the model sees lacks the norm's "Returns: … See also: …" form.
-// The effective description is the projected mcp.Tool.Description (which already
-// resolves the curated-description fallback chain), so this avoids false
-// positives from specs that omit IndividualTool.Description yet still project a
-// good curated one.
-func weakIndividualDescription(spec toolutil.ActionSpec, projected map[string]string) bool {
-	tool := strings.TrimSpace(spec.IndividualTool.Name)
-	if tool == "" {
-		return false
-	}
-	description, ok := projected[tool]
-	if !ok {
-		return false
-	}
-	return !strings.Contains(description, "Returns:") || !strings.Contains(description, "See also:")
-}
-
-// projectIndividualDescriptions registers the individual-tool surface on an
-// in-memory MCP server and returns the projected description per tool name —
-// the exact text the model consumes.
-func projectIndividualDescriptions(client *gitlabclient.Client) (map[string]string, error) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "audit", Version: "0.0.1"}, nil)
-	tools.RegisterAll(server, client, edition.Ultimate)
-	toolutil.LockdownInputSchemas(server)
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-	ctx := context.Background()
-	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
-		return nil, fmt.Errorf("connect server: %w", err)
-	}
-	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "audit-client", Version: "0.0.1"}, nil)
-	session, err := mcpClient.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		return nil, fmt.Errorf("connect client: %w", err)
-	}
-	defer func() { _ = session.Close() }()
-
-	result, err := session.ListTools(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("list tools: %w", err)
-	}
-	descriptions := make(map[string]string, len(result.Tools))
-	for _, tool := range result.Tools {
-		descriptions[tool.Name] = tool.Description
-	}
-	return descriptions, nil
-}
-
-func isGenericUsage(usage string) bool {
-	trimmed := strings.TrimSpace(usage)
-	return trimmed == "" || genericUsageRe.MatchString(trimmed)
 }
 
 // aliasesOnlyToolname reports whether the action has no natural-language alias
@@ -213,16 +150,6 @@ func aliasesOnlyToolname(spec toolutil.ActionSpec) bool {
 		return false
 	}
 	return true
-}
-
-func ownerPackage(group tools.ActionSpecGroup, spec toolutil.ActionSpec) string {
-	if owner := strings.TrimSpace(spec.OwnerPackage); owner != "" {
-		return owner
-	}
-	if owner := strings.TrimSpace(group.OwnerPackage); owner != "" {
-		return owner
-	}
-	return strings.TrimSpace(group.BaseDomain)
 }
 
 func packageFor(byPackage map[string]*packageReport, owner string) *packageReport {

--- a/cmd/audit_1to1/internal/metadata/analyze_test.go
+++ b/cmd/audit_1to1/internal/metadata/analyze_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -19,7 +20,7 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"use to execute markdown_render action",
 	}
 	for _, usage := range generic {
-		if !isGenericUsage(usage) {
+		if !auditshared.IsGenericUsage(usage) {
 			t.Errorf("isGenericUsage(%q) = false, want true", usage)
 		}
 	}
@@ -28,7 +29,7 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"Create a new branch from a ref. Returns the created branch.",
 	}
 	for _, usage := range specific {
-		if isGenericUsage(usage) {
+		if auditshared.IsGenericUsage(usage) {
 			t.Errorf("isGenericUsage(%q) = true, want false", usage)
 		}
 	}
@@ -62,20 +63,20 @@ func TestAliasesOnlyToolname(t *testing.T) {
 func TestWeakIndividualDescription(t *testing.T) {
 	spec := toolutil.ActionSpec{IndividualTool: toolutil.IndividualToolSpec{Name: "gitlab_branch_get"}}
 	good := map[string]string{"gitlab_branch_get": "Fetch a branch. Returns: branch fields. See also: gitlab_branch_list."}
-	if weakIndividualDescription(spec, good) {
+	if auditshared.WeakIndividualDescription(spec, good) {
 		t.Error("structured description should not be flagged")
 	}
 	weak := map[string]string{"gitlab_branch_get": "Fetch a branch."}
-	if !weakIndividualDescription(spec, weak) {
+	if !auditshared.WeakIndividualDescription(spec, weak) {
 		t.Error("unstructured description should be flagged")
 	}
 	// Meta-only action (no individual tool) is never flagged.
 	metaOnly := toolutil.ActionSpec{Name: "server.health_check"}
-	if weakIndividualDescription(metaOnly, weak) {
+	if auditshared.WeakIndividualDescription(metaOnly, weak) {
 		t.Error("meta-only action should not be flagged")
 	}
 	// Unknown tool name (not projected) is not flagged.
-	if weakIndividualDescription(spec, map[string]string{}) {
+	if auditshared.WeakIndividualDescription(spec, map[string]string{}) {
 		t.Error("unprojected tool should not be flagged")
 	}
 }

--- a/cmd/audit_1to1/internal/structs/analyze.go
+++ b/cmd/audit_1to1/internal/structs/analyze.go
@@ -1135,7 +1135,15 @@ func localOrAliasNamedStruct(pkg *packages.Package, resultExpr ast.Expr, resultT
 	}
 	// Go materializes type aliases as *types.Alias; unwrap to the target named
 	// struct (e.g. Output -> toolutil.MergeRequestOutput) before reading fields.
-	_, st, ok := derefNamedStruct(types.Unalias(resultType))
+	// types.Unalias only unwraps a top-level alias, so a *Alias pointer result
+	// (the thin-wrapper converter shape, e.g. *MemberUserOutput) must be
+	// dereferenced first or the alias inside the pointer stays opaque and the
+	// pair silently falls out of audit coverage.
+	target := resultType
+	if ptr, isPtr := target.(*types.Pointer); isPtr {
+		target = ptr.Elem()
+	}
+	_, st, ok := derefNamedStruct(types.Unalias(target))
 	if !ok {
 		return nil, "", false
 	}

--- a/cmd/audit_1to1/internal/structs/analyze_test.go
+++ b/cmd/audit_1to1/internal/structs/analyze_test.go
@@ -662,3 +662,61 @@ func TestDocGroundedSuppression(t *testing.T) {
 		t.Error("name is documented and must not be treated as doc-omitted")
 	}
 }
+
+// TestBuildReport_AuditedPairFloors pins the number of SDK↔MCP struct pairs
+// the R-OUTPUT/R-INPUT resolver attributes, globally and for every package
+// whose output shapes are shared through internal/toolutil. The pairing is
+// converter-driven: each domain must keep a thin package-local converter
+// (possibly a one-line delegate to the toolutil constructor, returning the
+// local alias type) or its shapes silently fall out of 1:1 audit coverage —
+// exactly the regression this guard exists to catch (output pairs once
+// dropped 323→300 when the dedup pass deleted local converters in favor of
+// direct toolutil.New* calls, and no audit or test noticed).
+//
+// If a floor fails after adding or intentionally removing tools, first check
+// that every shared-shape package still declares its local converter
+// wrappers; only lower a floor when the pair genuinely no longer exists (a
+// removed action/shape), and raise it when new pairs are added so the guard
+// stays tight.
+func TestBuildReport_AuditedPairFloors(t *testing.T) {
+	root, err := cmdutil.RepositoryRoot(".")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	rep, err := buildReport(root, false)
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+
+	const minInputPairs, minOutputPairs = 554, 324
+	if rep.Summary.InputPairs < minInputPairs {
+		t.Errorf("summary input_pairs = %d, want >= %d (resolver or handler-detection regression)", rep.Summary.InputPairs, minInputPairs)
+	}
+	if rep.Summary.OutputPairs < minOutputPairs {
+		t.Errorf("summary output_pairs = %d, want >= %d (converter-detection regression: a shared toolutil shape may have lost its package-local converter wrapper)", rep.Summary.OutputPairs, minOutputPairs)
+	}
+
+	// Output-pair floors for the packages whose shapes are toolutil-shared:
+	// these are the ones that go blind first when a local converter is removed.
+	outputFloors := map[string]int{
+		"boards":              8,
+		"branches":            4,
+		"commits":             6,
+		"enterpriseusers":     2,
+		"groupboards":         7,
+		"groupmembers":        6,
+		"groups":              11,
+		"impersonationtokens": 2,
+		"issuelinks":          14,
+		"members":             3,
+		"mergerequests":       5,
+		"resourceevents":      9,
+		"users":               5,
+	}
+	for name, floor := range outputFloors {
+		pr := findPackage(t, rep, name)
+		if pr.OutputPairs < floor {
+			t.Errorf("%s output_pairs = %d, want >= %d (lost audited pair; check the package-local converter wrappers for its toolutil-shared shapes)", name, pr.OutputPairs, floor)
+		}
+	}
+}

--- a/cmd/audit_catalog_first/main.go
+++ b/cmd/audit_catalog_first/main.go
@@ -9,7 +9,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -23,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/autoupdate"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
@@ -631,7 +631,7 @@ func assertActionCatalogHasNoLegacyReferences(path string) error {
 }
 
 func assertActionSpecManifestCurrent(root string) error {
-	sourceBuilders, err := discoverActionSpecGroupBuilderNames(filepath.Join(root, "internal", "tools"))
+	sourceBuilders, err := auditshared.DiscoverActionSpecGroupBuilders(filepath.Join(root, "internal", "tools"))
 	if err != nil {
 		return err
 	}
@@ -643,53 +643,6 @@ func assertActionSpecManifestCurrent(root string) error {
 		return fmt.Errorf("action spec manifest is stale: source builders %v, manifest builders %v; run go run ./cmd/gen_action_catalog_manifest/", sourceBuilders, manifestBuilders)
 	}
 	return nil
-}
-
-func discoverActionSpecGroupBuilderNames(toolsDir string) ([]string, error) {
-	fileSet := token.NewFileSet()
-	builders := make(map[string]string)
-	err := filepath.WalkDir(toolsDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			if path != toolsDir {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, testGoSuffix) || strings.HasSuffix(name, "_gen.go") {
-			return nil
-		}
-		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
-		if parseErr != nil {
-			return fmt.Errorf(parsePathError, path, parseErr)
-		}
-		for _, declaration := range file.Decls {
-			function, ok := declaration.(*ast.FuncDecl)
-			if !ok || function.Recv != nil || !isActionSpecGroupBuilderName(function.Name.Name) {
-				continue
-			}
-			if previousPath, exists := builders[function.Name.Name]; exists {
-				return fmt.Errorf("duplicate action spec group builder %s in %s and %s", function.Name.Name, previousPath, path)
-			}
-			builders[function.Name.Name] = path
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(builders) == 0 {
-		return nil, errors.New("no action spec group builders found")
-	}
-	names := make([]string, 0, len(builders))
-	for name := range builders {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names, nil
 }
 
 func readManifestActionSpecGroupBuilders(path string) ([]string, error) {
@@ -728,10 +681,6 @@ func manifestBuilderNames(function *ast.FuncDecl) []string {
 		return false
 	})
 	return names
-}
-
-func isActionSpecGroupBuilderName(name string) bool {
-	return strings.HasPrefix(name, "build") && strings.HasSuffix(name, "ActionSpecs") && len(name) > len("buildActionSpecs")
 }
 
 func discoverDomainSources(root string) ([]domainSource, error) {

--- a/cmd/audit_discovery_completeness/main.go
+++ b/cmd/audit_discovery_completeness/main.go
@@ -45,7 +45,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -57,21 +56,15 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
 const schemaVersion = 1
-
-// genericUsageRe matches placeholder Usage sentences such as
-// "Use to execute releaselinks domain action." or empty Usage.
-var genericUsageRe = regexp.MustCompile(`(?i)^use to execute\b.*\baction\.?\s*$`)
 
 // variantSuffixes are stripped from action stems when clustering sibling actions.
 var variantSuffixes = []string{"_batch", "_bulk", "_all", "_directory", "_single"}
@@ -304,7 +297,7 @@ func buildReport(gapsOnly bool, minAliases int) (report, error) {
 	}
 	defer cleanup()
 
-	projected, err := projectIndividualDescriptions(client)
+	projected, err := auditshared.ProjectIndividualDescriptions(client)
 	if err != nil {
 		return report{}, err
 	}
@@ -331,7 +324,7 @@ func collectAllClusters(client *gitlabclient.Client) []clusterRecord {
 	seen := map[string]bool{}
 	for _, group := range tools.CollectActionSpecs(client, true) {
 		for _, spec := range group.Actions {
-			owner := ownerPackage(group, spec)
+			owner := auditshared.OwnerPackage(group, spec)
 			key := owner + "\x00" + spec.Name
 			if seen[key] {
 				continue
@@ -349,7 +342,7 @@ func buildPackageReports(client *gitlabclient.Client, allClusters []clusterRecor
 	byPackage := map[string]*packageReport{}
 	for _, group := range tools.CollectActionSpecs(client, true) {
 		for _, spec := range group.Actions {
-			owner := ownerPackage(group, spec)
+			owner := auditshared.OwnerPackage(group, spec)
 			clusterMembers := clusterMembersFor(allClusters, owner, spec.Name)
 			pr := packageFor(byPackage, owner)
 			pr.Actions++
@@ -408,7 +401,7 @@ func analyzeSpec(spec toolutil.ActionSpec, projected map[string]string, clusterM
 
 	addFlag := func(f string) { flagSet[f] = true }
 
-	if isGenericUsage(spec.Usage) {
+	if auditshared.IsGenericUsage(spec.Usage) {
 		addFlag("generic_usage")
 	}
 	if weakAliases(spec, minAliases) {
@@ -417,7 +410,7 @@ func analyzeSpec(spec toolutil.ActionSpec, projected map[string]string, clusterM
 	if len(spec.RelatedActions) == 0 {
 		addFlag("empty_related")
 	}
-	if weakIndividualDescription(spec, projected) {
+	if auditshared.WeakIndividualDescription(spec, projected) {
 		addFlag("weak_individual_description")
 	}
 
@@ -1082,67 +1075,6 @@ func isEmptyOrBoilerplateDescription(propSchema map[string]any) bool {
 		return true
 	}
 	return false
-}
-
-// weakIndividualDescription reports whether the effective individual-tool
-// description lacks the norm's "Returns: … See also: …" form.
-func weakIndividualDescription(spec toolutil.ActionSpec, projected map[string]string) bool {
-	tool := strings.TrimSpace(spec.IndividualTool.Name)
-	if tool == "" {
-		return false
-	}
-	description, ok := projected[tool]
-	if !ok {
-		return false
-	}
-	return !strings.Contains(description, "Returns:") || !strings.Contains(description, "See also:")
-}
-
-// isGenericUsage reports whether the Usage string is the placeholder template
-// or empty.
-func isGenericUsage(usage string) bool {
-	trimmed := strings.TrimSpace(usage)
-	return trimmed == "" || genericUsageRe.MatchString(trimmed)
-}
-
-// projectIndividualDescriptions registers the individual-tool surface on an
-// in-memory MCP server and returns the projected description per tool name.
-func projectIndividualDescriptions(client *gitlabclient.Client) (map[string]string, error) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "audit", Version: "0.0.1"}, nil)
-	tools.RegisterAll(server, client, edition.Ultimate)
-	toolutil.LockdownInputSchemas(server)
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-	ctx := context.Background()
-	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
-		return nil, fmt.Errorf("connect server: %w", err)
-	}
-	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "audit-client", Version: "0.0.1"}, nil)
-	session, err := mcpClient.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		return nil, fmt.Errorf("connect client: %w", err)
-	}
-	defer func() { _ = session.Close() }()
-
-	result, err := session.ListTools(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("list tools: %w", err)
-	}
-	descriptions := make(map[string]string, len(result.Tools))
-	for _, tool := range result.Tools {
-		descriptions[tool.Name] = tool.Description
-	}
-	return descriptions, nil
-}
-
-func ownerPackage(group tools.ActionSpecGroup, spec toolutil.ActionSpec) string {
-	if owner := strings.TrimSpace(spec.OwnerPackage); owner != "" {
-		return owner
-	}
-	if owner := strings.TrimSpace(group.OwnerPackage); owner != "" {
-		return owner
-	}
-	return strings.TrimSpace(group.BaseDomain)
 }
 
 func packageFor(byPackage map[string]*packageReport, owner string) *packageReport {

--- a/cmd/audit_discovery_completeness/main_test.go
+++ b/cmd/audit_discovery_completeness/main_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/releaselinks"
@@ -30,7 +31,7 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"use to execute markdown_render action",
 	}
 	for _, usage := range generic {
-		if !isGenericUsage(usage) {
+		if !auditshared.IsGenericUsage(usage) {
 			t.Errorf("isGenericUsage(%q) = false, want true", usage)
 		}
 	}
@@ -39,7 +40,7 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"Create MULTIPLE release asset links in one call. Use this instead of repeated link_create.",
 	}
 	for _, usage := range specific {
-		if isGenericUsage(usage) {
+		if auditshared.IsGenericUsage(usage) {
 			t.Errorf("isGenericUsage(%q) = true, want false", usage)
 		}
 	}
@@ -360,14 +361,16 @@ func TestSeverityFor_OnlyEscalatesInNonCRUDClusters(t *testing.T) {
 	}
 	var cases []scenario
 	for _, f := range escalating {
-		cases = append(cases,
+		cases = append(
+			cases,
 			scenario{"pure CRUD cluster stays warning/" + f, f, true, pureCRUD, "warning"},
 			scenario{"base-vs-variant cluster escalates to error/" + f, f, true, withBatch, "error"},
 			scenario{"out-of-cluster stays warning/" + f, f, false, nil, "warning"},
 		)
 	}
 	// Flags that are always error regardless of cluster.
-	cases = append(cases,
+	cases = append(
+		cases,
 		scenario{"generic_usage always error", "generic_usage", false, nil, "error"},
 		scenario{"missing_disambiguation always error", "missing_disambiguation", false, nil, "error"},
 	)

--- a/cmd/gen_action_catalog_manifest/main.go
+++ b/cmd/gen_action_catalog_manifest/main.go
@@ -4,19 +4,13 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"flag"
 	"fmt"
-	"go/ast"
 	"go/format"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 )
 
@@ -47,7 +41,7 @@ func main() {
 	if err != nil {
 		cmdutil.Fatalf("find repository root: %v", err)
 	}
-	builders, err := discoverActionSpecGroupBuilders(filepath.Join(root, *sourceDir))
+	builders, err := auditshared.DiscoverActionSpecGroupBuilders(filepath.Join(root, *sourceDir))
 	if err != nil {
 		cmdutil.Fatalf("discover action spec group builders: %v", err)
 	}
@@ -65,57 +59,6 @@ func main() {
 	if writeErr := os.WriteFile(targetPath, content, 0o600); writeErr != nil {
 		cmdutil.Fatalf("write %s: %v", targetPath, writeErr)
 	}
-}
-
-func discoverActionSpecGroupBuilders(sourceDir string) ([]string, error) {
-	fileSet := token.NewFileSet()
-	builders := make(map[string]string)
-	err := filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			if path != sourceDir {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, "_gen.go") {
-			return nil
-		}
-		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
-		if parseErr != nil {
-			return fmt.Errorf("parse %s: %w", path, parseErr)
-		}
-		for _, declaration := range file.Decls {
-			function, ok := declaration.(*ast.FuncDecl)
-			if !ok || function.Recv != nil || !isActionSpecGroupBuilderName(function.Name.Name) {
-				continue
-			}
-			if previousPath, exists := builders[function.Name.Name]; exists {
-				return fmt.Errorf("duplicate action spec group builder %s in %s and %s", function.Name.Name, previousPath, path)
-			}
-			builders[function.Name.Name] = path
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(builders) == 0 {
-		return nil, errors.New("no action spec group builders found")
-	}
-	names := make([]string, 0, len(builders))
-	for name := range builders {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names, nil
-}
-
-func isActionSpecGroupBuilderName(name string) bool {
-	return strings.HasPrefix(name, "build") && strings.HasSuffix(name, "ActionSpecs") && len(name) > len("buildActionSpecs")
 }
 
 func generateManifest(builders []string) ([]byte, error) {

--- a/cmd/gen_action_catalog_manifest/main_test.go
+++ b/cmd/gen_action_catalog_manifest/main_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 )
 
 // TestDiscoverActionSpecGroupBuilders_SortsBuilders verifies DiscoverActionSpecGroupBuilders sorts builders.
@@ -23,9 +25,9 @@ func helper() {}
 func buildAccessActionSpecs() {}
 `)
 
-	builders, err := discoverActionSpecGroupBuilders(sourceDir)
+	builders, err := auditshared.DiscoverActionSpecGroupBuilders(sourceDir)
 	if err != nil {
-		t.Fatalf("discoverActionSpecGroupBuilders() error = %v", err)
+		t.Fatalf("auditshared.DiscoverActionSpecGroupBuilders() error = %v", err)
 	}
 	want := []string{"buildAccessActionSpecs", "buildWikiActionSpecs"}
 	if strings.Join(builders, ",") != strings.Join(want, ",") {

--- a/cmd/gen_docker_tools/main.go
+++ b/cmd/gen_docker_tools/main.go
@@ -28,16 +28,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"sort"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
-	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 )
 
@@ -82,21 +79,11 @@ func run(args []string, stdout io.Writer) error {
 		return fmt.Errorf("parse flags: %w", err)
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{ //#nosec G101 -- dummy token, no real credential
-		GitLabURL:   srv.URL,
-		GitLabToken: "gen-docker-tools-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, closeStub, err := auditshared.NewStubGitLabClient("gen-docker-tools-token") //#nosec G101 -- dummy token, no real credential
 	if err != nil {
 		return fmt.Errorf("client: %w", err)
 	}
+	defer closeStub()
 
 	opts := &mcp.ServerOptions{PageSize: 2000}
 	server := mcp.NewServer(&mcp.Implementation{Name: "gen-docker-tools", Version: "0.0.1"}, opts)

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -17,8 +17,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -28,6 +26,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
@@ -93,21 +92,11 @@ func run(checkOnly bool) error {
 		return err
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	defer srv.Close()
-
-	cfg := &config.Config{ //#nosec G101 -- not a real credential, test-only dummy token
-		GitLabURL:   srv.URL,
-		GitLabToken: "gen-llms-token",
-	}
-	client, err := gitlabclient.NewClient(cfg)
+	client, closeStub, err := auditshared.NewStubGitLabClient("gen-llms-token") //#nosec G101 -- not a real credential, test-only dummy token
 	if err != nil {
 		return fmt.Errorf("create client: %w", err)
 	}
+	defer closeStub()
 	gitLabComClient, err := gitlabclient.NewClient(&config.Config{ //#nosec G101 -- not a real credential, test-only dummy token
 		GitLabURL:   config.DefaultGitLabURL,
 		GitLabToken: "gen-llms-token",

--- a/cmd/internal/auditshared/actionspec_builders.go
+++ b/cmd/internal/auditshared/actionspec_builders.go
@@ -1,0 +1,71 @@
+package auditshared
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// IsActionSpecGroupBuilderName reports whether a function name follows the
+// buildXxxActionSpecs convention used by the per-domain catalog builders.
+func IsActionSpecGroupBuilderName(name string) bool {
+	return strings.HasPrefix(name, "build") && strings.HasSuffix(name, "ActionSpecs") && len(name) > len("buildActionSpecs")
+}
+
+// DiscoverActionSpecGroupBuilders scans the top-level non-test, non-generated
+// .go files of dir for buildXxxActionSpecs builder functions and returns
+// their sorted names. It fails on duplicate builder names and when no
+// builders are found, so both the manifest generator and the catalog-first
+// auditor agree on the same source of truth.
+func DiscoverActionSpecGroupBuilders(dir string) ([]string, error) {
+	fileSet := token.NewFileSet()
+	builders := make(map[string]string)
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != dir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, "_gen.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv != nil || !IsActionSpecGroupBuilderName(function.Name.Name) {
+				continue
+			}
+			if previousPath, exists := builders[function.Name.Name]; exists {
+				return fmt.Errorf("duplicate action spec group builder %s in %s and %s", function.Name.Name, previousPath, path)
+			}
+			builders[function.Name.Name] = path
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(builders) == 0 {
+		return nil, errors.New("no action spec group builders found")
+	}
+	names := make([]string, 0, len(builders))
+	for name := range builders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/cmd/internal/auditshared/auditshared.go
+++ b/cmd/internal/auditshared/auditshared.go
@@ -7,11 +7,14 @@ package auditshared
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
@@ -88,4 +91,27 @@ func OwnerPackage(group tools.ActionSpecGroup, spec toolutil.ActionSpec) string 
 		return owner
 	}
 	return strings.TrimSpace(group.BaseDomain)
+}
+
+// NewStubGitLabClient builds a GitLab client pointed at an in-process HTTP
+// stub that answers every request with a fixed version payload. Generators
+// and auditors use it to register the tool catalog offline. The returned
+// cleanup func shuts the stub server down.
+func NewStubGitLabClient(token string) (*gitlabclient.Client, func(), error) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"version":"17.0.0"}`)
+	}))
+
+	cfg := &config.Config{
+		GitLabURL:   srv.URL,
+		GitLabToken: token,
+	}
+	client, err := gitlabclient.NewClient(cfg)
+	if err != nil {
+		srv.Close()
+		return nil, nil, fmt.Errorf("create stub gitlab client: %w", err)
+	}
+	return client, srv.Close, nil
 }

--- a/cmd/internal/auditshared/auditshared.go
+++ b/cmd/internal/auditshared/auditshared.go
@@ -1,0 +1,91 @@
+// Package auditshared holds analysis helpers shared by the discovery-metadata
+// auditors (cmd/audit_1to1 R-META and cmd/audit_discovery_completeness): the
+// projected-description probe, owner-package resolution, and the shared
+// usage/description quality checks.
+package auditshared
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// genericUsageRe matches the placeholder Usage template ("Use to execute …
+// action.") that indicates the action has no curated usage text.
+var genericUsageRe = regexp.MustCompile(`(?i)^use to execute\b.*\baction\.?\s*$`)
+
+// IsGenericUsage reports whether the Usage string is the placeholder template
+// or empty.
+func IsGenericUsage(usage string) bool {
+	trimmed := strings.TrimSpace(usage)
+	return trimmed == "" || genericUsageRe.MatchString(trimmed)
+}
+
+// WeakIndividualDescription reports whether the effective individual-tool
+// description the model sees lacks the norm's "Returns: … See also: …" form.
+// The effective description is the projected mcp.Tool.Description (which
+// already resolves the curated-description fallback chain), so this avoids
+// false positives from specs that omit IndividualTool.Description yet still
+// project a good curated one.
+func WeakIndividualDescription(spec toolutil.ActionSpec, projected map[string]string) bool {
+	tool := strings.TrimSpace(spec.IndividualTool.Name)
+	if tool == "" {
+		return false
+	}
+	description, ok := projected[tool]
+	if !ok {
+		return false
+	}
+	return !strings.Contains(description, "Returns:") || !strings.Contains(description, "See also:")
+}
+
+// ProjectIndividualDescriptions registers the individual-tool surface on an
+// in-memory MCP server and returns the projected description per tool name —
+// the exact text the model consumes.
+func ProjectIndividualDescriptions(client *gitlabclient.Client) (map[string]string, error) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "audit", Version: "0.0.1"}, nil)
+	tools.RegisterAll(server, client, edition.Ultimate)
+	toolutil.LockdownInputSchemas(server)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		return nil, fmt.Errorf("connect server: %w", err)
+	}
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "audit-client", Version: "0.0.1"}, nil)
+	session, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		return nil, fmt.Errorf("connect client: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list tools: %w", err)
+	}
+	descriptions := make(map[string]string, len(result.Tools))
+	for _, tool := range result.Tools {
+		descriptions[tool.Name] = tool.Description
+	}
+	return descriptions, nil
+}
+
+// OwnerPackage resolves the owning package for an action: the spec override
+// wins, then the group owner, then the group base domain.
+func OwnerPackage(group tools.ActionSpecGroup, spec toolutil.ActionSpec) string {
+	if owner := strings.TrimSpace(spec.OwnerPackage); owner != "" {
+		return owner
+	}
+	if owner := strings.TrimSpace(group.OwnerPackage); owner != "" {
+		return owner
+	}
+	return strings.TrimSpace(group.BaseDomain)
+}

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,16 +18,16 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,607 |
-| Unit test functions                                   | 11,324 |
+| Total test functions                                  | 11,625 |
+| Unit test functions                                   | 11,342 |
 | E2E test functions                                    |    283 |
 | cmd test functions                                    |    900 |
-| Test files (internal/)                                |    452 |
+| Test files (internal/)                                |    457 |
 | Test files (cmd/)                                     |     69 |
 | Test files (test/e2e/suite/)                          |    140 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     16 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  90.9% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  90.8% |
 | Overall coverage (`go test ./internal/...`)           |  94.6% |
 | Average package coverage                              |  95.4% |
 
@@ -35,8 +35,8 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,335 | 89.0% |
-| `TestFunc` (no underscore)             |    945 |  8.1% |
+| `TestFunc_Scenario` (2-part)           | 10,339 | 88.9% |
+| `TestFunc` (no underscore)             |    959 |  8.2% |
 | `TestFunc_Scenario_Expected` (3+ part) |    327 |  2.8% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,857 |         90 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,875 |         95 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            283 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,284 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            283 |        140 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            900 |         69 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,607** |    **661** |                                                                                                 |
+| **Total**               |     **11,625** |    **666** |                                                                                                 |
 
 ### Core Packages
 
@@ -66,13 +66,13 @@
 | gitlab       |        44 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
-| prompts      |       207 |    96.2% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
+| prompts      |       207 |    96.5% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        28 |    95.9% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       630 |    97.0% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       648 |    97.0% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       287 |    92.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,857** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **1,875** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -125,7 +125,7 @@
 | avatar                  |         9 |          1 |   100.0% |         1 |
 | awardemoji              |       113 |          1 |   100.0% |        24 |
 | badges                  |        56 |          1 |   100.0% |        12 |
-| boards                  |        73 |          2 |    99.3% |        10 |
+| boards                  |        73 |          2 |    99.2% |        10 |
 | branches                |        95 |          1 |   100.0% |        10 |
 | branchrules             |        16 |          1 |   100.0% |         1 |
 | broadcastmessages       |        30 |          2 |   100.0% |         5 |
@@ -170,7 +170,7 @@
 | geo                     |        54 |          2 |   100.0% |         8 |
 | gitignoretemplates      |        15 |          1 |   100.0% |         2 |
 | groupanalytics          |         8 |          2 |   100.0% |         3 |
-| groupboards             |        65 |          2 |    98.6% |        10 |
+| groupboards             |        65 |          2 |    98.5% |        10 |
 | groupcredentials        |        43 |          3 |   100.0% |         4 |
 | groupepicboards         |        15 |          3 |    98.3% |         2 |
 | groupimportexport       |        29 |          1 |   100.0% |         3 |
@@ -299,10 +299,10 @@
 | cmd/audit_1to1                                 |    39.0% |
 | cmd/audit_1to1/internal/actions                |    87.7% |
 | cmd/audit_1to1/internal/merge                  |    85.4% |
-| cmd/audit_1to1/internal/metadata               |    73.5% |
+| cmd/audit_1to1/internal/metadata               |    69.1% |
 | cmd/audit_1to1/internal/structs                |    95.3% |
 | cmd/audit_catalog_first                        |    80.8% |
-| cmd/audit_discovery_completeness               |    78.0% |
+| cmd/audit_discovery_completeness               |    77.9% |
 | cmd/audit_doc_coverage                         |    81.6% |
 | cmd/audit_dynamic_aliases                      |    48.4% |
 | cmd/audit_edition_tier                         |    26.0% |
@@ -340,7 +340,7 @@
 | gitlab      |   100.0% |
 | oauth       |    98.6% |
 | progress    |   100.0% |
-| prompts     |    96.2% |
+| prompts     |    96.5% |
 | resources   |   100.0% |
 | serverpool  |    99.6% |
 | testutil    |    95.9% |
@@ -366,7 +366,7 @@
 | avatar                  |   100.0% |
 | awardemoji              |   100.0% |
 | badges                  |   100.0% |
-| boards                  |    99.3% |
+| boards                  |    99.2% |
 | branches                |   100.0% |
 | branchrules             |   100.0% |
 | broadcastmessages       |   100.0% |
@@ -411,7 +411,7 @@
 | geo                     |   100.0% |
 | gitignoretemplates      |   100.0% |
 | groupanalytics          |   100.0% |
-| groupboards             |    98.6% |
+| groupboards             |    98.5% |
 | groupcredentials        |   100.0% |
 | groupepicboards         |    98.3% |
 | groupimportexport       |   100.0% |
@@ -542,10 +542,10 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/gen_action_catalog_manifest** (58.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tokens** (58.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/godoc_tool** (58.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_1to1/internal/metadata** (69.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evaluator** (69.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_surface_quality** (71.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_1to1/internal/metadata** (73.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_discovery_completeness** (78.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_discovery_completeness** (77.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/server** (78.6%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/audit_catalog_first** (80.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,25 +18,25 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,625 |
-| Unit test functions                                   | 11,342 |
+| Total test functions                                  | 11,631 |
+| Unit test functions                                   | 11,348 |
 | E2E test functions                                    |    283 |
 | cmd test functions                                    |    900 |
-| Test files (internal/)                                |    457 |
+| Test files (internal/)                                |    458 |
 | Test files (cmd/)                                     |     69 |
 | Test files (test/e2e/suite/)                          |    140 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     16 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  90.8% |
-| Overall coverage (`go test ./internal/...`)           |  94.6% |
-| Average package coverage                              |  95.4% |
+| Overall coverage (`go test ./internal/...`)           |  94.5% |
+| Average package coverage                              |  95.3% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,339 | 88.9% |
-| `TestFunc` (no underscore)             |    959 |  8.2% |
+| `TestFunc_Scenario` (2-part)           | 10,342 | 88.9% |
+| `TestFunc` (no underscore)             |    962 |  8.3% |
 | `TestFunc_Scenario_Expected` (3+ part) |    327 |  2.8% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,875 |         95 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,881 |         96 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            283 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,284 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            283 |        140 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            900 |         69 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,625** |    **666** |                                                                                                 |
+| **Total**               |     **11,631** |    **667** |                                                                                                 |
 
 ### Core Packages
 
@@ -70,9 +70,9 @@
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        28 |    95.9% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       648 |    97.0% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       654 |    96.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       287 |    92.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,875** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **1,881** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -80,7 +80,7 @@
 | ----------------- | ----: | -------: | ----: |
 | projects          |   382 |   100.0% |    57 |
 | mergerequests     |   239 |   100.0% |    30 |
-| groups            |   234 |    98.8% |    37 |
+| groups            |   234 |    98.7% |    37 |
 | issues            |   223 |   100.0% |    21 |
 | users             |   208 |   100.0% |    38 |
 | dynamic           |   159 |    99.9% |     2 |
@@ -116,7 +116,7 @@
 | actioncatalog           |        31 |          4 |    99.1% |         0 |
 | actioncompat            |        44 |          2 |   100.0% |         1 |
 | adminspecs              |         6 |          1 |   100.0% |        92 |
-| alertmanagement         |        29 |          2 |    98.9% |         4 |
+| alertmanagement         |        29 |          2 |   100.0% |         4 |
 | appearance              |        10 |          1 |   100.0% |         2 |
 | applications            |        20 |          1 |   100.0% |         4 |
 | appstatistics           |         9 |          1 |    96.8% |         1 |
@@ -184,7 +184,7 @@
 | groupprotectedenvs      |        19 |          2 |   100.0% |         5 |
 | grouprelationsexport    |        26 |          2 |   100.0% |         2 |
 | groupreleases           |        18 |          3 |   100.0% |         1 |
-| groups                  |       234 |          8 |    98.8% |        37 |
+| groups                  |       234 |          8 |    98.7% |        37 |
 | groupsaml               |        33 |          3 |   100.0% |         5 |
 | groupscim               |        28 |          3 |    93.5% |         4 |
 | groupserviceaccounts    |        20 |          2 |   100.0% |         8 |
@@ -258,7 +258,7 @@
 | runnercontrollertokens  |        41 |          2 |   100.0% |         5 |
 | runners                 |       109 |          2 |   100.0% |        19 |
 | search                  |       118 |          1 |   100.0% |        10 |
-| securefiles             |        28 |          2 |    98.9% |         4 |
+| securefiles             |        28 |          2 |   100.0% |         4 |
 | securityattributes      |        24 |          1 |   100.0% |         5 |
 | securitycategories      |        16 |          1 |   100.0% |         3 |
 | securityfindings        |        20 |          1 |   100.0% |         1 |
@@ -277,14 +277,14 @@
 | terraformstates         |        17 |          1 |   100.0% |         6 |
 | todos                   |        33 |          1 |   100.0% |         3 |
 | topics                  |        28 |          2 |    97.0% |         5 |
-| uploads                 |        47 |          2 |    99.3% |         4 |
+| uploads                 |        47 |          2 |   100.0% |         4 |
 | usagedata               |        27 |          1 |   100.0% |         6 |
 | useremails              |        24 |          2 |   100.0% |         6 |
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       208 |          8 |   100.0% |        38 |
 | vulnerabilities         |        61 |          3 |   100.0% |         8 |
 | waitpoll                |        13 |          1 |   100.0% |         0 |
-| wikis                   |        60 |          2 |    99.4% |         6 |
+| wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        80 |          2 |   100.0% |         6 |
 | **Total**               | **8,284** |    **349** |          | **1,169** |
 
@@ -301,7 +301,7 @@
 | cmd/audit_1to1/internal/merge                  |    85.4% |
 | cmd/audit_1to1/internal/metadata               |    69.1% |
 | cmd/audit_1to1/internal/structs                |    95.3% |
-| cmd/audit_catalog_first                        |    80.8% |
+| cmd/audit_catalog_first                        |    80.5% |
 | cmd/audit_discovery_completeness               |    77.9% |
 | cmd/audit_doc_coverage                         |    81.6% |
 | cmd/audit_dynamic_aliases                      |    48.4% |
@@ -316,9 +316,9 @@
 | cmd/eval_mcp_surfaces/internal/evaluator/cases |    99.6% |
 | cmd/eval_mcp_surfaces/internal/termio          |    45.7% |
 | cmd/format_md_tables                           |    92.7% |
-| cmd/gen_action_catalog_manifest                |    58.3% |
-| cmd/gen_docker_tools                           |    83.3% |
-| cmd/gen_llms                                   |    26.5% |
+| cmd/gen_action_catalog_manifest                |    41.0% |
+| cmd/gen_docker_tools                           |    86.6% |
+| cmd/gen_llms                                   |    26.7% |
 | cmd/gen_stats                                  |    51.3% |
 | cmd/gen_testing_docs                           |    27.4% |
 | cmd/godoc_tool                                 |    58.9% |
@@ -344,7 +344,7 @@
 | resources   |   100.0% |
 | serverpool  |    99.6% |
 | testutil    |    95.9% |
-| toolutil    |    97.0% |
+| toolutil    |    96.9% |
 | wizard      |    92.0% |
 
 ### Tool Sub-Packages
@@ -357,7 +357,7 @@
 | actioncatalog           |    99.1% |
 | actioncompat            |   100.0% |
 | adminspecs              |   100.0% |
-| alertmanagement         |    98.9% |
+| alertmanagement         |   100.0% |
 | appearance              |   100.0% |
 | applications            |   100.0% |
 | appstatistics           |    96.8% |
@@ -425,7 +425,7 @@
 | groupprotectedenvs      |   100.0% |
 | grouprelationsexport    |   100.0% |
 | groupreleases           |   100.0% |
-| groups                  |    98.8% |
+| groups                  |    98.7% |
 | groupsaml               |   100.0% |
 | groupscim               |    93.5% |
 | groupserviceaccounts    |   100.0% |
@@ -499,7 +499,7 @@
 | runnercontrollertokens  |   100.0% |
 | runners                 |   100.0% |
 | search                  |   100.0% |
-| securefiles             |    98.9% |
+| securefiles             |   100.0% |
 | securityattributes      |   100.0% |
 | securitycategories      |   100.0% |
 | securityfindings        |   100.0% |
@@ -518,28 +518,28 @@
 | terraformstates         |   100.0% |
 | todos                   |   100.0% |
 | topics                  |    97.0% |
-| uploads                 |    99.3% |
+| uploads                 |   100.0% |
 | usagedata               |   100.0% |
 | useremails              |   100.0% |
 | usergpgkeys             |   100.0% |
 | users                   |   100.0% |
 | vulnerabilities         |   100.0% |
 | waitpoll                |   100.0% |
-| wikis                   |    99.4% |
+| wikis                   |   100.0% |
 | workitems               |   100.0% |
 
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
 - **cmd/audit_edition_tier** (26.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/gen_llms** (26.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_llms** (26.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (27.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1** (39.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_action_catalog_manifest** (41.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/termio** (45.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_names** (48.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (48.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_stats** (51.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (52.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/gen_action_catalog_manifest** (58.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tokens** (58.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/godoc_tool** (58.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/metadata** (69.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -547,11 +547,11 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_surface_quality** (71.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_discovery_completeness** (77.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/server** (78.6%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
-- **cmd/audit_catalog_first** (80.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_catalog_first** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **edition** (82.6%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
-- **cmd/gen_docker_tools** (83.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/internal/prompts/prompt_cross_project.go
+++ b/internal/prompts/prompt_cross_project.go
@@ -260,21 +260,9 @@ func handleMyActivitySummary(ctx context.Context, client *gitlabclient.Client, r
 
 	days := parseDays(args[argDays], 7)
 	since := sinceDate(days)
-	sinceISO := gl.ISOTime(since)
 
 	// Fetch contribution events
-	eventOpts := &gl.ListContributionEventsOptions{
-		After: &sinceISO,
-	}
-	var events []*gl.ContributionEvent
-	if isCurrentUser {
-		events, _, err = client.GL().Events.ListCurrentUserContributionEvents(eventOpts, gl.WithContext(ctx))
-	} else {
-		events, _, err = client.GL().Users.ListUserContributionEvents(userID, eventOpts, gl.WithContext(ctx))
-	}
-	if err != nil {
-		slog.Warn("failed to fetch contribution events", "error", err)
-	}
+	events := fetchContributionEvents(ctx, client, userID, isCurrentUser, since)
 
 	// Merged MRs in period
 	mergedMRs, _, errMerged := client.GL().MergeRequests.ListMergeRequests(

--- a/internal/prompts/prompt_team.go
+++ b/internal/prompts/prompt_team.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -75,16 +74,7 @@ func handleUserActivityReport(ctx context.Context, client *gitlabclient.Client, 
 	since := sinceDate(days)
 
 	// Contribution events
-	eventOpts := &gl.ListContributionEventsOptions{After: new(gl.ISOTime(since))}
-	var events []*gl.ContributionEvent
-	if isSelf {
-		events, _, err = client.GL().Events.ListCurrentUserContributionEvents(eventOpts, gl.WithContext(ctx))
-	} else {
-		events, _, err = client.GL().Users.ListUserContributionEvents(userID, eventOpts, gl.WithContext(ctx))
-	}
-	if err != nil {
-		slog.Warn("failed to fetch events", "error", err)
-	}
+	events := fetchContributionEvents(ctx, client, userID, isSelf, since)
 
 	// Merged MRs in period
 	mergedMRs, _, _ := client.GL().MergeRequests.ListMergeRequests(&gl.ListMergeRequestsOptions{

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -161,24 +161,55 @@ func registerReviewMRPrompt(server *mcp.Server, client *gitlabclient.Client) {
 	})
 }
 
-// handleReviewMR generates a structured code review with files categorized by
-// risk level and full diffs included.
-func handleReviewMR(ctx context.Context, client *gitlabclient.Client, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+// fetchMRWithDiffs validates the project_id/mr_iid prompt arguments and
+// fetches the merge request plus its diffs — the shared prologue of the
+// MR-centric prompt handlers.
+func fetchMRWithDiffs(ctx context.Context, client *gitlabclient.Client, req *mcp.GetPromptRequest) (string, *gl.MergeRequest, []*gl.MergeRequestDiff, error) {
 	projectID := req.Params.Arguments[argProjectID]
 	mrIID := req.Params.Arguments[argMRIID]
 	if projectID == "" || mrIID == "" {
-		return nil, fmt.Errorf(fmtTwoArgsRequired, argProjectID, argMRIID)
+		return "", nil, nil, fmt.Errorf(fmtTwoArgsRequired, argProjectID, argMRIID)
 	}
 
 	iid := parseIID(mrIID)
 	mr, _, err := client.GL().MergeRequests.GetMergeRequest(projectID, iid, &gl.GetMergeRequestsOptions{}, gl.WithContext(ctx))
 	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRFailed, err)
+		return "", nil, nil, fmt.Errorf(fmtGetMRFailed, err)
 	}
 
 	diffs, _, err := client.GL().MergeRequests.ListMergeRequestDiffs(projectID, iid, nil, gl.WithContext(ctx))
 	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRDiffsFailed, err)
+		return "", nil, nil, fmt.Errorf(fmtGetMRDiffsFailed, err)
+	}
+	return projectID, mr, diffs, nil
+}
+
+// fetchContributionEvents returns the user's contribution events since the
+// given time, using the current-user endpoint when possible. Failures are
+// logged and yield an empty slice so the prompt can still render.
+func fetchContributionEvents(ctx context.Context, client *gitlabclient.Client, userID int64, isCurrentUser bool, since time.Time) []*gl.ContributionEvent {
+	eventOpts := &gl.ListContributionEventsOptions{
+		After: new(gl.ISOTime(since)),
+	}
+	var events []*gl.ContributionEvent
+	var err error
+	if isCurrentUser {
+		events, _, err = client.GL().Events.ListCurrentUserContributionEvents(eventOpts, gl.WithContext(ctx))
+	} else {
+		events, _, err = client.GL().Users.ListUserContributionEvents(userID, eventOpts, gl.WithContext(ctx))
+	}
+	if err != nil {
+		slog.Warn("failed to fetch contribution events", "error", err)
+	}
+	return events
+}
+
+// handleReviewMR generates a structured code review with files categorized by
+// risk level and full diffs included.
+func handleReviewMR(ctx context.Context, client *gitlabclient.Client, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	_, mr, diffs, err := fetchMRWithDiffs(ctx, client, req)
+	if err != nil {
+		return nil, err
 	}
 
 	// Categorize files by risk/type
@@ -322,21 +353,9 @@ func registerSuggestMRReviewersPrompt(server *mcp.Server, client *gitlabclient.C
 // handleSuggestMRReviewers identifies potential reviewers based on blame data
 // for files changed in a merge request.
 func handleSuggestMRReviewers(ctx context.Context, client *gitlabclient.Client, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-	projectID := req.Params.Arguments[argProjectID]
-	mrIID := req.Params.Arguments[argMRIID]
-	if projectID == "" || mrIID == "" {
-		return nil, fmt.Errorf(fmtTwoArgsRequired, argProjectID, argMRIID)
-	}
-
-	iid := parseIID(mrIID)
-	mr, _, err := client.GL().MergeRequests.GetMergeRequest(projectID, iid, &gl.GetMergeRequestsOptions{}, gl.WithContext(ctx))
+	projectID, mr, diffs, err := fetchMRWithDiffs(ctx, client, req)
 	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRFailed, err)
-	}
-
-	diffs, _, err := client.GL().MergeRequests.ListMergeRequestDiffs(projectID, iid, nil, gl.WithContext(ctx))
-	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRDiffsFailed, err)
+		return nil, err
 	}
 
 	members, _, err := client.GL().ProjectMembers.ListAllProjectMembers(projectID, &gl.ListProjectMembersOptions{}, gl.WithContext(ctx))
@@ -962,18 +981,7 @@ func handleTeamMemberWorkload(ctx context.Context, client *gitlabclient.Client, 
 	since := time.Now().AddDate(0, 0, -days)
 
 	// Contribution events over the period
-	eventOpts := &gl.ListContributionEventsOptions{
-		After: new(gl.ISOTime(since)),
-	}
-	var events []*gl.ContributionEvent
-	if isCurrentUser {
-		events, _, err = client.GL().Events.ListCurrentUserContributionEvents(eventOpts, gl.WithContext(ctx))
-	} else {
-		events, _, err = client.GL().Users.ListUserContributionEvents(userID, eventOpts, gl.WithContext(ctx))
-	}
-	if err != nil {
-		slog.Warn("failed to fetch contribution events", "error", err)
-	}
+	events := fetchContributionEvents(ctx, client, userID, isCurrentUser, since)
 
 	// Authored MRs (open)
 	openAuthoredMRs, _, errOpenAuthored := client.GL().MergeRequests.ListProjectMergeRequests(projectID, &gl.ListProjectMergeRequestsOptions{
@@ -1114,18 +1122,7 @@ func handleUserStats(ctx context.Context, client *gitlabclient.Client, req *mcp.
 	since := time.Now().AddDate(0, 0, -days)
 
 	// Contribution events
-	eventOpts := &gl.ListContributionEventsOptions{
-		After: new(gl.ISOTime(since)),
-	}
-	var events []*gl.ContributionEvent
-	if isCurrentUser {
-		events, _, err = client.GL().Events.ListCurrentUserContributionEvents(eventOpts, gl.WithContext(ctx))
-	} else {
-		events, _, err = client.GL().Users.ListUserContributionEvents(userID, eventOpts, gl.WithContext(ctx))
-	}
-	if err != nil {
-		slog.Warn("failed to fetch contribution events", "error", err)
-	}
+	events := fetchContributionEvents(ctx, client, userID, isCurrentUser, since)
 
 	// MR stats: open, merged, closed
 	openMRs, _, errOpenMRs := client.GL().MergeRequests.ListProjectMergeRequests(projectID, &gl.ListProjectMergeRequestsOptions{
@@ -1326,21 +1323,9 @@ func registerMRRiskAssessmentPrompt(server *mcp.Server, client *gitlabclient.Cli
 // handleMRRiskAssessment computes diff metrics and identifies sensitive files
 // to produce a merge request risk assessment.
 func handleMRRiskAssessment(ctx context.Context, client *gitlabclient.Client, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-	projectID := req.Params.Arguments[argProjectID]
-	mrIID := req.Params.Arguments[argMRIID]
-	if projectID == "" || mrIID == "" {
-		return nil, fmt.Errorf(fmtTwoArgsRequired, argProjectID, argMRIID)
-	}
-
-	iid := parseIID(mrIID)
-	mr, _, err := client.GL().MergeRequests.GetMergeRequest(projectID, iid, &gl.GetMergeRequestsOptions{}, gl.WithContext(ctx))
+	_, mr, diffs, err := fetchMRWithDiffs(ctx, client, req)
 	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRFailed, err)
-	}
-
-	diffs, _, err := client.GL().MergeRequests.ListMergeRequestDiffs(projectID, iid, nil, gl.WithContext(ctx))
-	if err != nil {
-		return nil, fmt.Errorf(fmtGetMRDiffsFailed, err)
+		return nil, err
 	}
 
 	m := computeDiffMetrics(diffs)

--- a/internal/tools/alertmanagement/alertmanagement.go
+++ b/internal/tools/alertmanagement/alertmanagement.go
@@ -1,12 +1,7 @@
 package alertmanagement
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -137,37 +132,9 @@ func UploadMetricImage(ctx context.Context, client *gitlabclient.Client, input U
 		return MetricImageItem{}, toolutil.ErrRequiredInt64("gitlab_upload_alert_metric_image", "alert_iid")
 	}
 
-	hasFilePath := input.FilePathLocal != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return MetricImageItem{}, errors.New("gitlab_upload_alert_metric_image: provide either file_path or content_base64, not both")
-	}
-	if !hasFilePath && !hasBase64 {
-		return MetricImageItem{}, errors.New("gitlab_upload_alert_metric_image: either file_path or content_base64 is required")
-	}
-
-	var reader *bytes.Reader
-
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, info, err := toolutil.OpenAndValidateFile(input.FilePathLocal, cfg.MaxFileSize)
-		if err != nil {
-			return MetricImageItem{}, fmt.Errorf("gitlab_upload_alert_metric_image: %w", err)
-		}
-		defer f.Close()
-
-		data := make([]byte, info.Size())
-		if _, err = io.ReadFull(f, data); err != nil {
-			return MetricImageItem{}, fmt.Errorf("gitlab_upload_alert_metric_image: reading file: %w", err)
-		}
-		reader = bytes.NewReader(data)
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return MetricImageItem{}, fmt.Errorf("gitlab_upload_alert_metric_image: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
+	reader, err := toolutil.ReadFileOrBase64("gitlab_upload_alert_metric_image", input.FilePathLocal, input.ContentBase64)
+	if err != nil {
+		return MetricImageItem{}, err
 	}
 
 	uploadOpts := &gl.UploadMetricImageOptions{}

--- a/internal/tools/boards/boards.go
+++ b/internal/tools/boards/boards.go
@@ -134,9 +134,9 @@ func convertBoard(b *gl.IssueBoard) BoardOutput {
 		Name:            b.Name,
 		Project:         projectOutput(b.Project),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
+		Assignee:        basicUserOutput(b.Assignee),
 		Weight:          b.Weight,
-		Labels:          toolutil.NewBoardLabelDetailsOutputs(b.Labels),
+		Labels:          labelDetailsOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
 		HideClosedList:  b.HideClosedList,
 	}
@@ -154,9 +154,9 @@ func convertBoardAPI(b *issueBoardAPI) BoardOutput {
 		Name:            b.Name,
 		Project:         projectOutput(b.Project),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
+		Assignee:        basicUserOutput(b.Assignee),
 		Weight:          b.Weight,
-		Labels:          toolutil.NewBoardLabelDetailsOutputs(b.Labels),
+		Labels:          labelDetailsOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
 		HideClosedList:  b.HideClosedList,
 	}
@@ -171,10 +171,10 @@ func convertBoardAPI(b *issueBoardAPI) BoardOutput {
 func convertBoardList(l *gl.BoardList) BoardListOutput {
 	return BoardListOutput{
 		ID:             l.ID,
-		Label:          toolutil.NewBoardLabelOutput(l.Label),
-		Assignee:       toolutil.NewBoardListAssigneeOutput(l.Assignee),
+		Label:          labelOutput(l.Label),
+		Assignee:       boardListAssigneeOutput(l.Assignee),
 		Milestone:      milestoneOutput(l.Milestone),
-		Iteration:      toolutil.NewIterationOutputFromProjectIteration(l.Iteration),
+		Iteration:      iterationOutput(l.Iteration),
 		Position:       l.Position,
 		MaxIssueCount:  l.MaxIssueCount,
 		MaxIssueWeight: l.MaxIssueWeight,

--- a/internal/tools/boards/boards.go
+++ b/internal/tools/boards/boards.go
@@ -134,9 +134,9 @@ func convertBoard(b *gl.IssueBoard) BoardOutput {
 		Name:            b.Name,
 		Project:         projectOutput(b.Project),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        basicUserOutput(b.Assignee),
+		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
 		Weight:          b.Weight,
-		Labels:          labelDetailsOutputs(b.Labels),
+		Labels:          toolutil.NewBoardLabelDetailsOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
 		HideClosedList:  b.HideClosedList,
 	}
@@ -154,9 +154,9 @@ func convertBoardAPI(b *issueBoardAPI) BoardOutput {
 		Name:            b.Name,
 		Project:         projectOutput(b.Project),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        basicUserOutput(b.Assignee),
+		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
 		Weight:          b.Weight,
-		Labels:          labelDetailsOutputs(b.Labels),
+		Labels:          toolutil.NewBoardLabelDetailsOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
 		HideClosedList:  b.HideClosedList,
 	}
@@ -171,10 +171,10 @@ func convertBoardAPI(b *issueBoardAPI) BoardOutput {
 func convertBoardList(l *gl.BoardList) BoardListOutput {
 	return BoardListOutput{
 		ID:             l.ID,
-		Label:          labelOutput(l.Label),
-		Assignee:       boardListAssigneeOutput(l.Assignee),
+		Label:          toolutil.NewBoardLabelOutput(l.Label),
+		Assignee:       toolutil.NewBoardListAssigneeOutput(l.Assignee),
 		Milestone:      milestoneOutput(l.Milestone),
-		Iteration:      iterationOutput(l.Iteration),
+		Iteration:      toolutil.NewIterationOutputFromProjectIteration(l.Iteration),
 		Position:       l.Position,
 		MaxIssueCount:  l.MaxIssueCount,
 		MaxIssueWeight: l.MaxIssueWeight,

--- a/internal/tools/boards/shapes.go
+++ b/internal/tools/boards/shapes.go
@@ -114,3 +114,33 @@ type LabelDetailsOutput = toolutil.BoardLabelDetailsOutput
 // A board list's `iteration` object (Premium/Ultimate iteration list type)
 // mirrors gl.ProjectIteration. Canonical shape shared via toolutil.
 type IterationOutput = toolutil.IterationOutput
+
+// basicUserOutput converts a gl.BasicUser into the documented board assignee
+// subset, or nil.
+func basicUserOutput(u *gl.BasicUser) *BasicUserOutput {
+	return toolutil.NewBoardUserOutput(u)
+}
+
+// boardListAssigneeOutput converts a gl.BoardListAssignee into the shared
+// output shape, or nil.
+func boardListAssigneeOutput(a *gl.BoardListAssignee) *BoardListAssigneeOutput {
+	return toolutil.NewBoardListAssigneeOutput(a)
+}
+
+// labelOutput converts a gl.Label into the documented board-list label
+// subset, or nil.
+func labelOutput(l *gl.Label) *LabelOutput {
+	return toolutil.NewBoardLabelOutput(l)
+}
+
+// labelDetailsOutputs converts a slice of gl.LabelDetails into the documented
+// board label subset.
+func labelDetailsOutputs(details []*gl.LabelDetails) []*LabelDetailsOutput {
+	return toolutil.NewBoardLabelDetailsOutputs(details)
+}
+
+// iterationOutput converts a gl.ProjectIteration into the canonical iteration
+// object, or nil.
+func iterationOutput(it *gl.ProjectIteration) *IterationOutput {
+	return toolutil.NewIterationOutputFromProjectIteration(it)
+}

--- a/internal/tools/boards/shapes.go
+++ b/internal/tools/boards/shapes.go
@@ -91,119 +91,26 @@ func milestoneOutput(m *gl.Milestone) *MilestoneOutput {
 // The board's `assignee` object surfaces only the fields the documented
 // update-board response lists (id, name, username, state, avatar_url, web_url);
 // gl.BasicUser's created_at is not part of the documented board assignee shape.
-type BasicUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url"`
-	WebURL    string `json:"web_url"`
-}
-
-func basicUserOutput(u *gl.BasicUser) *BasicUserOutput {
-	if u == nil {
-		return nil
-	}
-	return &BasicUserOutput{
-		ID: u.ID, Username: u.Username, Name: u.Name, State: u.State,
-		AvatarURL: u.AvatarURL, WebURL: u.WebURL,
-	}
-}
+// Canonical shape shared via toolutil.
+type BasicUserOutput = toolutil.BoardUserOutput
 
 // BoardListAssigneeOutput is a documented reference subset per
 // doc/api/boards.md. A board list's `assignee` object (Premium/Ultimate
 // assignee list type) is surfaced with id, name, and username, matching the
-// compact gl.BoardListAssignee struct. The documented response examples cover
-// only label lists, so this premium list-type sub-object has no fuller
-// documented shape to trim against.
-type BoardListAssigneeOutput struct {
-	ID       int64  `json:"id"`
-	Name     string `json:"name"`
-	Username string `json:"username"`
-}
-
-func boardListAssigneeOutput(a *gl.BoardListAssignee) *BoardListAssigneeOutput {
-	if a == nil {
-		return nil
-	}
-	return &BoardListAssigneeOutput{ID: a.ID, Name: a.Name, Username: a.Username}
-}
+// compact gl.BoardListAssignee struct. Canonical shape shared via toolutil.
+type BoardListAssigneeOutput = toolutil.BoardListAssigneeOutput
 
 // LabelOutput is a documented reference subset per doc/api/boards.md.
 // Every documented board-list response shows the list's `label` object with
-// only name, color, and description; gl.Label's id, text_color, counts,
-// subscribed, priority, is_project_label, and archived fields are not part of
-// the documented board-list label shape.
-type LabelOutput struct {
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
-
-func labelOutput(l *gl.Label) *LabelOutput {
-	if l == nil {
-		return nil
-	}
-	return &LabelOutput{
-		Name: l.Name, Color: l.Color, Description: l.Description,
-	}
-}
+// only name, color, and description. Canonical shape shared via toolutil.
+type LabelOutput = toolutil.BoardLabelOutput
 
 // LabelDetailsOutput is a documented reference subset per doc/api/boards.md.
 // The board's `labels[]` entries in the documented update-board response show
-// only id, name, color, and description; gl.LabelDetails's description_html and
-// text_color are not part of the documented board labels shape.
-type LabelDetailsOutput struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
-
-func labelDetailsOutputs(details []*gl.LabelDetails) []*LabelDetailsOutput {
-	if len(details) == 0 {
-		return nil
-	}
-	out := make([]*LabelDetailsOutput, 0, len(details))
-	for _, d := range details {
-		if d == nil {
-			continue
-		}
-		out = append(out, &LabelDetailsOutput{
-			ID: d.ID, Name: d.Name, Color: d.Color, Description: d.Description,
-		})
-	}
-	return out
-}
+// only id, name, color, and description. Canonical shape shared via toolutil.
+type LabelDetailsOutput = toolutil.BoardLabelDetailsOutput
 
 // IterationOutput is a documented reference subset per doc/api/boards.md.
 // A board list's `iteration` object (Premium/Ultimate iteration list type)
-// mirrors gl.ProjectIteration. The documented response examples cover only
-// label lists, so this premium list-type sub-object has no fuller documented
-// shape to trim against.
-type IterationOutput struct {
-	ID          int64  `json:"id"`
-	IID         int64  `json:"iid"`
-	Sequence    int64  `json:"sequence"`
-	GroupID     int64  `json:"group_id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	State       int64  `json:"state"`
-	WebURL      string `json:"web_url"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
-	StartDate   string `json:"start_date,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-}
-
-func iterationOutput(it *gl.ProjectIteration) *IterationOutput {
-	if it == nil {
-		return nil
-	}
-	return &IterationOutput{
-		ID: it.ID, IID: it.IID, Sequence: it.Sequence, GroupID: it.GroupID,
-		Title: it.Title, Description: it.Description, State: it.State, WebURL: it.WebURL,
-		CreatedAt: toolutil.FormatTimePtr(it.CreatedAt), UpdatedAt: toolutil.FormatTimePtr(it.UpdatedAt),
-		StartDate: toolutil.FormatISOTimePtr(it.StartDate), DueDate: toolutil.FormatISOTimePtr(it.DueDate),
-	}
-}
+// mirrors gl.ProjectIteration. Canonical shape shared via toolutil.
+type IterationOutput = toolutil.IterationOutput

--- a/internal/tools/branches/branches_test.go
+++ b/internal/tools/branches/branches_test.go
@@ -2068,7 +2068,7 @@ func TestProtectedList_SearchKeysetAndOrdering(t *testing.T) {
 // TestShapeConverters_NilAndEmpty exercises nil/empty fast paths of the shape
 // converters that the request flows do not otherwise reach.
 func TestShapeConverters_NilAndEmpty(t *testing.T) {
-	if toolutil.NewLastPipelineOutput(nil) != nil {
+	if pipelineInfoToOutput(nil) != nil {
 		t.Error("pipelineInfoToOutput(nil) should be nil")
 	}
 	if commitToOutput(nil) != nil {

--- a/internal/tools/branches/branches_test.go
+++ b/internal/tools/branches/branches_test.go
@@ -2068,7 +2068,7 @@ func TestProtectedList_SearchKeysetAndOrdering(t *testing.T) {
 // TestShapeConverters_NilAndEmpty exercises nil/empty fast paths of the shape
 // converters that the request flows do not otherwise reach.
 func TestShapeConverters_NilAndEmpty(t *testing.T) {
-	if pipelineInfoToOutput(nil) != nil {
+	if toolutil.NewLastPipelineOutput(nil) != nil {
 		t.Error("pipelineInfoToOutput(nil) should be nil")
 	}
 	if commitToOutput(nil) != nil {

--- a/internal/tools/branches/shapes.go
+++ b/internal/tools/branches/shapes.go
@@ -76,7 +76,7 @@ func commitToOutput(c *gl.Commit) *CommitOutput {
 		ProjectID:        c.ProjectID,
 		Trailers:         c.Trailers,
 		ExtendedTrailers: c.ExtendedTrailers,
-		LastPipeline:     toolutil.NewLastPipelineOutput(c.LastPipeline),
+		LastPipeline:     pipelineInfoToOutput(c.LastPipeline),
 	}
 	if c.AuthoredDate != nil {
 		out.AuthoredDate = c.AuthoredDate.String()
@@ -170,4 +170,10 @@ func branchPermissionOptions(in []BranchPermissionInput) *[]*gl.BranchPermission
 		out = append(out, opt)
 	}
 	return &out
+}
+
+// pipelineInfoToOutput maps gl.PipelineInfo to *LastPipelineOutput, or nil when
+// the commit has no associated pipeline.
+func pipelineInfoToOutput(p *gl.PipelineInfo) *LastPipelineOutput {
+	return toolutil.NewLastPipelineOutput(p)
 }

--- a/internal/tools/branches/shapes.go
+++ b/internal/tools/branches/shapes.go
@@ -2,6 +2,8 @@ package branches
 
 import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
 // Canonical output/input shapes mirrored from client-go sub-objects. Per the
@@ -27,20 +29,8 @@ type CommitStatsOutput struct {
 }
 
 // LastPipelineOutput mirrors gl.PipelineInfo, the pipeline summary embedded in a
-// commit payload as last_pipeline.
-type LastPipelineOutput struct {
-	ID        int64  `json:"id"`
-	IID       int64  `json:"iid,omitempty"`
-	ProjectID int64  `json:"project_id,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Source    string `json:"source,omitempty"`
-	Ref       string `json:"ref,omitempty"`
-	SHA       string `json:"sha,omitempty"`
-	Name      string `json:"name,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-}
+// commit payload as last_pipeline. Canonical shape shared via toolutil.
+type LastPipelineOutput = toolutil.LastPipelineOutput
 
 // CommitOutput mirrors gl.Commit, the full commit object embedded on a branch
 // payload as commit.
@@ -66,32 +56,6 @@ type CommitOutput struct {
 	Stats            *CommitStatsOutput  `json:"stats,omitempty"`
 }
 
-// pipelineInfoToOutput maps gl.PipelineInfo to *LastPipelineOutput, or nil when
-// the commit has no associated pipeline.
-func pipelineInfoToOutput(p *gl.PipelineInfo) *LastPipelineOutput {
-	if p == nil {
-		return nil
-	}
-	out := &LastPipelineOutput{
-		ID:        p.ID,
-		IID:       p.IID,
-		ProjectID: p.ProjectID,
-		Status:    p.Status,
-		Source:    p.Source,
-		Ref:       p.Ref,
-		SHA:       p.SHA,
-		Name:      p.Name,
-		WebURL:    p.WebURL,
-	}
-	if p.CreatedAt != nil {
-		out.CreatedAt = p.CreatedAt.String()
-	}
-	if p.UpdatedAt != nil {
-		out.UpdatedAt = p.UpdatedAt.String()
-	}
-	return out
-}
-
 // commitToOutput maps gl.Commit to *CommitOutput, or nil when the branch has no
 // embedded commit.
 func commitToOutput(c *gl.Commit) *CommitOutput {
@@ -112,7 +76,7 @@ func commitToOutput(c *gl.Commit) *CommitOutput {
 		ProjectID:        c.ProjectID,
 		Trailers:         c.Trailers,
 		ExtendedTrailers: c.ExtendedTrailers,
-		LastPipeline:     pipelineInfoToOutput(c.LastPipeline),
+		LastPipeline:     toolutil.NewLastPipelineOutput(c.LastPipeline),
 	}
 	if c.AuthoredDate != nil {
 		out.AuthoredDate = c.AuthoredDate.String()

--- a/internal/tools/commitdiscussions/action_specs.go
+++ b/internal/tools/commitdiscussions/action_specs.go
@@ -85,23 +85,13 @@ func commitScopeGuidance() map[string]toolutil.ParameterGuidance {
 // discussionIDGuidance returns the parameter guidance for the discussion_id
 // parameter used by discussion-scoped actions.
 func discussionIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "discussion_id",
-		ValueSource:      "Discussion thread id from a prior gitlab_list_commit_discussions response.",
-		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
-		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
-	}
+	return toolutil.DiscussionIDParamGuidance("Discussion thread id from a prior gitlab_list_commit_discussions response.")
 }
 
 // noteIDGuidance returns the parameter guidance for the note_id parameter used
 // by note update/delete actions.
 func noteIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "note_id",
-		ValueSource:      "Numeric note id within the discussion thread, from a prior discussion response.",
-		ExampleBinding:   "params.note_id:300",
-		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
-	}
+	return toolutil.DiscussionNoteIDParamGuidance("Numeric note id within the discussion thread, from a prior discussion response.")
 }
 
 // decorateCommitDiscussionMeta fills in action-specific discovery metadata for

--- a/internal/tools/commits/commits.go
+++ b/internal/tools/commits/commits.go
@@ -75,20 +75,8 @@ type CommitStatsOutput struct {
 }
 
 // LastPipelineOutput mirrors gl.PipelineInfo, the pipeline summary embedded in
-// a commit payload as last_pipeline.
-type LastPipelineOutput struct {
-	ID        int64  `json:"id"`
-	IID       int64  `json:"iid,omitempty"`
-	ProjectID int64  `json:"project_id,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Source    string `json:"source,omitempty"`
-	Ref       string `json:"ref,omitempty"`
-	SHA       string `json:"sha,omitempty"`
-	Name      string `json:"name,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-}
+// a commit payload as last_pipeline. Canonical shape shared via toolutil.
+type LastPipelineOutput = toolutil.LastPipelineOutput
 
 // BasicUserOutput mirrors gl.Author, the user object returned on commit
 // comments and commit statuses.
@@ -100,32 +88,6 @@ type BasicUserOutput struct {
 	State     string `json:"state,omitempty"`
 	Blocked   bool   `json:"blocked,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
-}
-
-// pipelineInfoToOutput maps gl.PipelineInfo to LastPipelineOutput, or nil when
-// the commit has no associated pipeline.
-func pipelineInfoToOutput(p *gl.PipelineInfo) *LastPipelineOutput {
-	if p == nil {
-		return nil
-	}
-	out := &LastPipelineOutput{
-		ID:        p.ID,
-		IID:       p.IID,
-		ProjectID: p.ProjectID,
-		Status:    p.Status,
-		Source:    p.Source,
-		Ref:       p.Ref,
-		SHA:       p.SHA,
-		Name:      p.Name,
-		WebURL:    p.WebURL,
-	}
-	if p.CreatedAt != nil {
-		out.CreatedAt = p.CreatedAt.String()
-	}
-	if p.UpdatedAt != nil {
-		out.UpdatedAt = p.UpdatedAt.String()
-	}
-	return out
 }
 
 // authorToOutput maps gl.Author to *BasicUserOutput, or nil when the author is
@@ -254,7 +216,7 @@ func commitToFields(c *gl.Commit) commitFields {
 		projectID:        c.ProjectID,
 		trailers:         c.Trailers,
 		extendedTrailers: c.ExtendedTrailers,
-		lastPipeline:     pipelineInfoToOutput(c.LastPipeline),
+		lastPipeline:     toolutil.NewLastPipelineOutput(c.LastPipeline),
 	}
 	if c.CommittedDate != nil {
 		f.committedDate = c.CommittedDate.String()

--- a/internal/tools/commits/commits.go
+++ b/internal/tools/commits/commits.go
@@ -216,7 +216,7 @@ func commitToFields(c *gl.Commit) commitFields {
 		projectID:        c.ProjectID,
 		trailers:         c.Trailers,
 		extendedTrailers: c.ExtendedTrailers,
-		lastPipeline:     toolutil.NewLastPipelineOutput(c.LastPipeline),
+		lastPipeline:     pipelineInfoToOutput(c.LastPipeline),
 	}
 	if c.CommittedDate != nil {
 		f.committedDate = c.CommittedDate.String()
@@ -1108,4 +1108,10 @@ func GetGPGSignature(ctx context.Context, client *gitlabclient.Client, input GPG
 		Key:                sig.Key,
 		X509Certificate:    sig.X509Certificate,
 	}, nil
+}
+
+// pipelineInfoToOutput maps gl.PipelineInfo to *LastPipelineOutput, or nil when
+// the commit has no associated pipeline.
+func pipelineInfoToOutput(p *gl.PipelineInfo) *LastPipelineOutput {
+	return toolutil.NewLastPipelineOutput(p)
 }

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -2728,7 +2728,7 @@ func TestAuthorToOutput(t *testing.T) {
 // TestPipelineInfoToOutput_Nil verifies pipelineInfoToOutput returns nil when
 // the commit has no associated pipeline.
 func TestPipelineInfoToOutput_Nil(t *testing.T) {
-	if got := toolutil.NewLastPipelineOutput(nil); got != nil {
+	if got := pipelineInfoToOutput(nil); got != nil {
 		t.Errorf("pipelineInfoToOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -2728,7 +2728,7 @@ func TestAuthorToOutput(t *testing.T) {
 // TestPipelineInfoToOutput_Nil verifies pipelineInfoToOutput returns nil when
 // the commit has no associated pipeline.
 func TestPipelineInfoToOutput_Nil(t *testing.T) {
-	if got := pipelineInfoToOutput(nil); got != nil {
+	if got := toolutil.NewLastPipelineOutput(nil); got != nil {
 		t.Errorf("pipelineInfoToOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/enterpriseusers/enterprise_users.go
+++ b/internal/tools/enterpriseusers/enterprise_users.go
@@ -121,23 +121,12 @@ type SCIMIdentityOutput struct {
 }
 
 // CustomAttributeOutput mirrors gl.CustomAttribute, a key/value custom
-// attribute attached to a user.
-type CustomAttributeOutput struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
+// attribute attached to a user. Canonical shape shared via toolutil.
+type CustomAttributeOutput = toolutil.CustomAttributeOutput
 
 // BasicUserOutput mirrors gl.BasicUser, the compact user object referenced by
-// gl.User.CreatedBy.
-type BasicUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-}
+// gl.User.CreatedBy. Canonical shape shared via toolutil.
+type BasicUserOutput = toolutil.UserRefOutput
 
 // ListOutput holds the list response.
 type ListOutput struct {
@@ -189,8 +178,8 @@ func toOutput(u *gl.User) Output {
 		Locked:                         u.Locked,
 		Identities:                     toIdentityOutputs(u.Identities),
 		SCIMIdentities:                 toSCIMIdentityOutputs(u.SCIMIdentities),
-		CustomAttributes:               toCustomAttributeOutputs(u.CustomAttributes),
-		CreatedBy:                      toBasicUserOutput(u.CreatedBy),
+		CustomAttributes:               toolutil.NewCustomAttributeOutputs(u.CustomAttributes),
+		CreatedBy:                      toolutil.NewUserRefOutput(u.CreatedBy),
 	}
 	if u.CreatedAt != nil {
 		o.CreatedAt = u.CreatedAt.Format(time.RFC3339)
@@ -248,41 +237,6 @@ func toSCIMIdentityOutputs(identities []*gl.SCIMIdentity) []SCIMIdentityOutput {
 		return nil
 	}
 	return out
-}
-
-func toCustomAttributeOutputs(attrs []*gl.CustomAttribute) []CustomAttributeOutput {
-	if len(attrs) == 0 {
-		return nil
-	}
-	out := make([]CustomAttributeOutput, 0, len(attrs))
-	for _, a := range attrs {
-		if a == nil {
-			continue
-		}
-		out = append(out, CustomAttributeOutput{Key: a.Key, Value: a.Value})
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func toBasicUserOutput(u *gl.BasicUser) *BasicUserOutput {
-	if u == nil {
-		return nil
-	}
-	o := &BasicUserOutput{
-		ID:        u.ID,
-		Username:  u.Username,
-		Name:      u.Name,
-		State:     u.State,
-		AvatarURL: u.AvatarURL,
-		WebURL:    u.WebURL,
-	}
-	if u.CreatedAt != nil {
-		o.CreatedAt = u.CreatedAt.Format(time.RFC3339)
-	}
-	return o
 }
 
 // List returns all enterprise users for a group.

--- a/internal/tools/enterpriseusers/enterprise_users.go
+++ b/internal/tools/enterpriseusers/enterprise_users.go
@@ -178,8 +178,8 @@ func toOutput(u *gl.User) Output {
 		Locked:                         u.Locked,
 		Identities:                     toIdentityOutputs(u.Identities),
 		SCIMIdentities:                 toSCIMIdentityOutputs(u.SCIMIdentities),
-		CustomAttributes:               toolutil.NewCustomAttributeOutputs(u.CustomAttributes),
-		CreatedBy:                      toolutil.NewUserRefOutput(u.CreatedBy),
+		CustomAttributes:               toCustomAttributeOutputs(u.CustomAttributes),
+		CreatedBy:                      toBasicUserOutput(u.CreatedBy),
 	}
 	if u.CreatedAt != nil {
 		o.CreatedAt = u.CreatedAt.Format(time.RFC3339)
@@ -237,6 +237,18 @@ func toSCIMIdentityOutputs(identities []*gl.SCIMIdentity) []SCIMIdentityOutput {
 		return nil
 	}
 	return out
+}
+
+// toCustomAttributeOutputs converts a []*gl.CustomAttribute slice into the
+// shared output shape.
+func toCustomAttributeOutputs(attrs []*gl.CustomAttribute) []CustomAttributeOutput {
+	return toolutil.NewCustomAttributeOutputs(attrs)
+}
+
+// toBasicUserOutput converts a *gl.BasicUser into the shared user-reference
+// shape, or nil.
+func toBasicUserOutput(u *gl.BasicUser) *BasicUserOutput {
+	return toolutil.NewUserRefOutput(u)
 }
 
 // List returns all enterprise users for a group.

--- a/internal/tools/enterpriseusers/enterprise_users_test.go
+++ b/internal/tools/enterpriseusers/enterprise_users_test.go
@@ -407,13 +407,13 @@ func TestToOutput_NestedConvertersSkipNilAndEmpty(t *testing.T) {
 	if got := toSCIMIdentityOutputs([]*gl.SCIMIdentity{nil}); got != nil {
 		t.Errorf("toSCIMIdentityOutputs([nil]) = %v, want nil", got)
 	}
-	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
+	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
 		t.Errorf("toCustomAttributeOutputs([nil]) = %v, want nil", got)
 	}
-	if got := toolutil.NewUserRefOutput(nil); got != nil {
+	if got := toBasicUserOutput(nil); got != nil {
 		t.Errorf("toBasicUserOutput(nil) = %v, want nil", got)
 	}
-	if got := toolutil.NewUserRefOutput(&gl.BasicUser{ID: 5}); got == nil || got.CreatedAt != "" {
+	if got := toBasicUserOutput(&gl.BasicUser{ID: 5}); got == nil || got.CreatedAt != "" {
 		t.Errorf("toBasicUserOutput with nil created_at = %+v, want non-nil with empty created_at", got)
 	}
 }

--- a/internal/tools/enterpriseusers/enterprise_users_test.go
+++ b/internal/tools/enterpriseusers/enterprise_users_test.go
@@ -407,13 +407,13 @@ func TestToOutput_NestedConvertersSkipNilAndEmpty(t *testing.T) {
 	if got := toSCIMIdentityOutputs([]*gl.SCIMIdentity{nil}); got != nil {
 		t.Errorf("toSCIMIdentityOutputs([nil]) = %v, want nil", got)
 	}
-	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
+	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
 		t.Errorf("toCustomAttributeOutputs([nil]) = %v, want nil", got)
 	}
-	if got := toBasicUserOutput(nil); got != nil {
+	if got := toolutil.NewUserRefOutput(nil); got != nil {
 		t.Errorf("toBasicUserOutput(nil) = %v, want nil", got)
 	}
-	if got := toBasicUserOutput(&gl.BasicUser{ID: 5}); got == nil || got.CreatedAt != "" {
+	if got := toolutil.NewUserRefOutput(&gl.BasicUser{ID: 5}); got == nil || got.CreatedAt != "" {
 		t.Errorf("toBasicUserOutput with nil created_at = %+v, want non-nil with empty created_at", got)
 	}
 }

--- a/internal/tools/epicdiscussions/action_specs.go
+++ b/internal/tools/epicdiscussions/action_specs.go
@@ -98,23 +98,13 @@ func epicScopeGuidance() map[string]toolutil.ParameterGuidance {
 // discussionIDGuidance returns the parameter guidance for the discussion_id
 // parameter used by discussion-scoped actions.
 func discussionIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "discussion_id",
-		ValueSource:      "Discussion thread id (hex hash or full Discussion GID) from a prior gitlab_list_epic_discussions response.",
-		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
-		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
-	}
+	return toolutil.DiscussionIDParamGuidance("Discussion thread id (hex hash or full Discussion GID) from a prior gitlab_list_epic_discussions response.")
 }
 
 // noteIDGuidance returns the parameter guidance for the note_id parameter used
 // by note update/delete actions.
 func noteIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "note_id",
-		ValueSource:      "Numeric note id within the discussion thread, from a prior epic discussion response.",
-		ExampleBinding:   "params.note_id:300",
-		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
-	}
+	return toolutil.DiscussionNoteIDParamGuidance("Numeric note id within the discussion thread, from a prior epic discussion response.")
 }
 
 // bodyGuidance returns the parameter guidance for the Markdown body parameter

--- a/internal/tools/epicdiscussions/epicdiscussions.go
+++ b/internal/tools/epicdiscussions/epicdiscussions.go
@@ -174,23 +174,6 @@ type gqlDiscussionsResponse struct {
 	} `json:"data"`
 }
 
-// gqlCreateNotePayload is the response payload for creating a note.
-type gqlCreateNotePayload struct {
-	Note   *gqlNoteNode `json:"note"`
-	Errors []string     `json:"errors"`
-}
-
-// gqlUpdateNotePayload is the response payload for updating a note.
-type gqlUpdateNotePayload struct {
-	Note   *gqlNoteNode `json:"note"`
-	Errors []string     `json:"errors"`
-}
-
-// gqlDestroyNotePayload is the response payload for deleting a note.
-type gqlDestroyNotePayload struct {
-	Errors []string `json:"errors"`
-}
-
 // extractDiscussionHex extracts the hex ID from a Discussion GID.
 func extractDiscussionHex(gid string) string {
 	if idx := strings.LastIndex(gid, "/"); idx >= 0 {
@@ -435,36 +418,24 @@ func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput)
 			"failed to resolve epic GID; verify full_path + iid with gitlab_epic_list; requires Reporter role on the group")
 	}
 
-	body := toolutil.NormalizeText(input.Body)
-	var resp struct {
-		Data struct {
-			CreateNote gqlCreateNotePayload `json:"createNote"`
-		} `json:"data"`
-	}
-
-	_, err = client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationCreateNote,
+	created, err := toolutil.ExecGraphQLNoteMutation[gqlNoteNode](ctx, client.GL().GraphQL, toolutil.GraphQLNoteMutation{
+		Op:         "epicDiscussionCreate",
+		Hint:       "body is rendered as GitLab Flavored Markdown; max 1MB; check Premium/Ultimate license; createNote mutation may fail if the work item is locked or confidential without permission",
+		PayloadKey: "createNote",
+		Query:      mutationCreateNote,
 		Variables: map[string]any{
 			"noteableId": workItemGID,
-			"body":       body,
+			"body":       toolutil.NormalizeText(input.Body),
 		},
-	}, &resp, gl.WithContext(ctx))
+	})
 	if err != nil {
-		return Output{}, toolutil.WrapErrWithHint("epicDiscussionCreate", err,
-			"body is rendered as GitLab Flavored Markdown; max 1MB; check Premium/Ultimate license; createNote mutation may fail if the work item is locked or confidential without permission")
+		return Output{}, err
 	}
 
-	if len(resp.Data.CreateNote.Errors) > 0 {
-		return Output{}, fmt.Errorf("epicDiscussionCreate: %s", resp.Data.CreateNote.Errors[0])
-	}
-	if resp.Data.CreateNote.Note == nil {
-		return Output{}, errors.New("epicDiscussionCreate: no note returned")
-	}
-
-	note := nodeToNoteOutput(*resp.Data.CreateNote.Note)
+	note := nodeToNoteOutput(*created)
 	discussionID := ""
-	if resp.Data.CreateNote.Note.Discussion != nil {
-		discussionID = extractDiscussionHex(resp.Data.CreateNote.Note.Discussion.ID)
+	if created.Discussion != nil {
+		discussionID = extractDiscussionHex(created.Discussion.ID)
 	}
 
 	return Output{
@@ -498,36 +469,22 @@ func AddNote(ctx context.Context, client *gitlabclient.Client, input AddNoteInpu
 			"failed to resolve epic GID; verify full_path + iid with gitlab_epic_list; requires Reporter role")
 	}
 
-	body := toolutil.NormalizeText(input.Body)
-	discussionGID := formatDiscussionGID(input.DiscussionID)
-
-	var resp struct {
-		Data struct {
-			CreateNote gqlCreateNotePayload `json:"createNote"`
-		} `json:"data"`
-	}
-
-	_, err = client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationCreateNoteReply,
+	note, err := toolutil.ExecGraphQLNoteMutation[gqlNoteNode](ctx, client.GL().GraphQL, toolutil.GraphQLNoteMutation{
+		Op:         "epicDiscussionAddNote",
+		Hint:       "verify discussion_id with gitlab_list_epic_discussions; cannot reply to a system-generated discussion; body is GFM with 1MB max",
+		PayloadKey: "createNote",
+		Query:      mutationCreateNoteReply,
 		Variables: map[string]any{
 			"noteableId":   workItemGID,
-			"body":         body,
-			"discussionId": discussionGID,
+			"body":         toolutil.NormalizeText(input.Body),
+			"discussionId": formatDiscussionGID(input.DiscussionID),
 		},
-	}, &resp, gl.WithContext(ctx))
+	})
 	if err != nil {
-		return NoteOutput{}, toolutil.WrapErrWithHint("epicDiscussionAddNote", err,
-			"verify discussion_id with gitlab_list_epic_discussions; cannot reply to a system-generated discussion; body is GFM with 1MB max")
+		return NoteOutput{}, err
 	}
 
-	if len(resp.Data.CreateNote.Errors) > 0 {
-		return NoteOutput{}, fmt.Errorf("epicDiscussionAddNote: %s", resp.Data.CreateNote.Errors[0])
-	}
-	if resp.Data.CreateNote.Note == nil {
-		return NoteOutput{}, errors.New("epicDiscussionAddNote: no note returned")
-	}
-
-	return nodeToNoteOutput(*resp.Data.CreateNote.Note), nil
+	return nodeToNoteOutput(*note), nil
 }
 
 // UpdateNote updates an existing epic discussion note via the updateNote
@@ -549,35 +506,21 @@ func UpdateNote(ctx context.Context, client *gitlabclient.Client, input UpdateNo
 		return NoteOutput{}, errors.New("epicDiscussionUpdateNote: body is required")
 	}
 
-	body := toolutil.NormalizeText(input.Body)
-	noteGID := toolutil.FormatGID("Note", input.NoteID)
-
-	var resp struct {
-		Data struct {
-			UpdateNote gqlUpdateNotePayload `json:"updateNote"`
-		} `json:"data"`
-	}
-
-	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationUpdateNote,
+	note, err := toolutil.ExecGraphQLNoteMutation[gqlNoteNode](ctx, client.GL().GraphQL, toolutil.GraphQLNoteMutation{
+		Op:         "epicDiscussionUpdateNote",
+		Hint:       "only the note author or a Maintainer/Owner can edit; verify note_id with gitlab_list_epic_discussions; body is GFM with 1MB max",
+		PayloadKey: "updateNote",
+		Query:      mutationUpdateNote,
 		Variables: map[string]any{
-			"id":   noteGID,
-			"body": body,
+			"id":   toolutil.FormatGID("Note", input.NoteID),
+			"body": toolutil.NormalizeText(input.Body),
 		},
-	}, &resp, gl.WithContext(ctx))
+	})
 	if err != nil {
-		return NoteOutput{}, toolutil.WrapErrWithHint("epicDiscussionUpdateNote", err,
-			"only the note author or a Maintainer/Owner can edit; verify note_id with gitlab_list_epic_discussions; body is GFM with 1MB max")
+		return NoteOutput{}, err
 	}
 
-	if len(resp.Data.UpdateNote.Errors) > 0 {
-		return NoteOutput{}, fmt.Errorf("epicDiscussionUpdateNote: %s", resp.Data.UpdateNote.Errors[0])
-	}
-	if resp.Data.UpdateNote.Note == nil {
-		return NoteOutput{}, errors.New("epicDiscussionUpdateNote: no note returned")
-	}
-
-	return nodeToNoteOutput(*resp.Data.UpdateNote.Note), nil
+	return nodeToNoteOutput(*note), nil
 }
 
 // DeleteNote deletes an epic discussion note via the destroyNote GraphQL mutation.
@@ -595,28 +538,7 @@ func DeleteNote(ctx context.Context, client *gitlabclient.Client, input DeleteNo
 		return toolutil.ErrRequiredInt64("epicDiscussionDeleteNote", "note_id")
 	}
 
-	noteGID := toolutil.FormatGID("Note", input.NoteID)
-
-	var resp struct {
-		Data struct {
-			DestroyNote gqlDestroyNotePayload `json:"destroyNote"`
-		} `json:"data"`
-	}
-
-	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationDestroyNote,
-		Variables: map[string]any{
-			"id": noteGID,
-		},
-	}, &resp, gl.WithContext(ctx))
-	if err != nil {
-		return toolutil.WrapErrWithHint("epicDiscussionDeleteNote", err,
-			"only the note author or a Maintainer/Owner can delete; verify note_id with gitlab_list_epic_discussions; deletion is irreversible \u2014 system-generated notes cannot be removed")
-	}
-
-	if len(resp.Data.DestroyNote.Errors) > 0 {
-		return fmt.Errorf("epicDiscussionDeleteNote: %s", resp.Data.DestroyNote.Errors[0])
-	}
-
-	return nil
+	return toolutil.ExecGraphQLDestroyNote(ctx, client.GL().GraphQL, "epicDiscussionDeleteNote",
+		"only the note author or a Maintainer/Owner can delete; verify note_id with gitlab_list_epic_discussions; deletion is irreversible \u2014 system-generated notes cannot be removed",
+		mutationDestroyNote, toolutil.FormatGID("Note", input.NoteID))
 }

--- a/internal/tools/epicnotes/epic_notes.go
+++ b/internal/tools/epicnotes/epic_notes.go
@@ -152,23 +152,6 @@ type gqlNotesResponse struct {
 	} `json:"data"`
 }
 
-// gqlCreateNotePayload is the response payload for creating a note.
-type gqlCreateNotePayload struct {
-	Note   *gqlNoteNode `json:"note"`
-	Errors []string     `json:"errors"`
-}
-
-// gqlUpdateNotePayload is the response payload for updating a note.
-type gqlUpdateNotePayload struct {
-	Note   *gqlNoteNode `json:"note"`
-	Errors []string     `json:"errors"`
-}
-
-// gqlDestroyNotePayload is the response payload for deleting a note.
-type gqlDestroyNotePayload struct {
-	Errors []string `json:"errors"`
-}
-
 // nodeToOutput converts a GraphQL note node to the MCP output format. Per the
 // locked canonical-key convention it surfaces the full author object on the
 // canonical `author` key.
@@ -376,33 +359,21 @@ func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput)
 			"failed to resolve epic GID; verify full_path + iid with gitlab_epic_list; requires Reporter role on the group")
 	}
 
-	body := toolutil.NormalizeText(input.Body)
-	var resp struct {
-		Data struct {
-			CreateNote gqlCreateNotePayload `json:"createNote"`
-		} `json:"data"`
-	}
-
-	_, err = client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationCreateNote,
+	note, err := toolutil.ExecGraphQLNoteMutation[gqlNoteNode](ctx, client.GL().GraphQL, toolutil.GraphQLNoteMutation{
+		Op:         "epicNoteCreate",
+		Hint:       "body is rendered as GitLab Flavored Markdown; max 1MB; check Premium/Ultimate license; createNote mutation may fail if work item is locked or confidential",
+		PayloadKey: "createNote",
+		Query:      mutationCreateNote,
 		Variables: map[string]any{
 			"noteableId": workItemGID,
-			"body":       body,
+			"body":       toolutil.NormalizeText(input.Body),
 		},
-	}, &resp, gl.WithContext(ctx))
+	})
 	if err != nil {
-		return Output{}, toolutil.WrapErrWithHint("epicNoteCreate", err,
-			"body is rendered as GitLab Flavored Markdown; max 1MB; check Premium/Ultimate license; createNote mutation may fail if work item is locked or confidential")
+		return Output{}, err
 	}
 
-	if len(resp.Data.CreateNote.Errors) > 0 {
-		return Output{}, fmt.Errorf("epicNoteCreate: %s", resp.Data.CreateNote.Errors[0])
-	}
-	if resp.Data.CreateNote.Note == nil {
-		return Output{}, errors.New("epicNoteCreate: no note returned")
-	}
-
-	return nodeToOutput(*resp.Data.CreateNote.Note), nil
+	return nodeToOutput(*note), nil
 }
 
 // Update modifies the body of an existing epic note via the updateNote
@@ -424,35 +395,21 @@ func Update(ctx context.Context, client *gitlabclient.Client, input UpdateInput)
 		return Output{}, errors.New("epicNoteUpdate: body is required")
 	}
 
-	body := toolutil.NormalizeText(input.Body)
-	noteGID := toolutil.FormatGID("Note", input.NoteID)
-
-	var resp struct {
-		Data struct {
-			UpdateNote gqlUpdateNotePayload `json:"updateNote"`
-		} `json:"data"`
-	}
-
-	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationUpdateNote,
+	note, err := toolutil.ExecGraphQLNoteMutation[gqlNoteNode](ctx, client.GL().GraphQL, toolutil.GraphQLNoteMutation{
+		Op:         "epicNoteUpdate",
+		Hint:       "only the note author or a Maintainer/Owner can edit; verify note_id with gitlab_epic_note_list; body is GFM with 1MB max; system notes cannot be edited",
+		PayloadKey: "updateNote",
+		Query:      mutationUpdateNote,
 		Variables: map[string]any{
-			"id":   noteGID,
-			"body": body,
+			"id":   toolutil.FormatGID("Note", input.NoteID),
+			"body": toolutil.NormalizeText(input.Body),
 		},
-	}, &resp, gl.WithContext(ctx))
+	})
 	if err != nil {
-		return Output{}, toolutil.WrapErrWithHint("epicNoteUpdate", err,
-			"only the note author or a Maintainer/Owner can edit; verify note_id with gitlab_epic_note_list; body is GFM with 1MB max; system notes cannot be edited")
+		return Output{}, err
 	}
 
-	if len(resp.Data.UpdateNote.Errors) > 0 {
-		return Output{}, fmt.Errorf("epicNoteUpdate: %s", resp.Data.UpdateNote.Errors[0])
-	}
-	if resp.Data.UpdateNote.Note == nil {
-		return Output{}, errors.New("epicNoteUpdate: no note returned")
-	}
-
-	return nodeToOutput(*resp.Data.UpdateNote.Note), nil
+	return nodeToOutput(*note), nil
 }
 
 // Delete removes a note from an epic via the destroyNote GraphQL mutation.
@@ -470,28 +427,7 @@ func Delete(ctx context.Context, client *gitlabclient.Client, input DeleteInput)
 		return toolutil.ErrRequiredInt64("epicNoteDelete", "note_id")
 	}
 
-	noteGID := toolutil.FormatGID("Note", input.NoteID)
-
-	var resp struct {
-		Data struct {
-			DestroyNote gqlDestroyNotePayload `json:"destroyNote"`
-		} `json:"data"`
-	}
-
-	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
-		Query: mutationDestroyNote,
-		Variables: map[string]any{
-			"id": noteGID,
-		},
-	}, &resp, gl.WithContext(ctx))
-	if err != nil {
-		return toolutil.WrapErrWithHint("epicNoteDelete", err,
-			"only the note author or a Maintainer/Owner can delete; verify note_id with gitlab_epic_note_list; deletion is irreversible \u2014 system-generated notes cannot be removed")
-	}
-
-	if len(resp.Data.DestroyNote.Errors) > 0 {
-		return fmt.Errorf("epicNoteDelete: %s", resp.Data.DestroyNote.Errors[0])
-	}
-
-	return nil
+	return toolutil.ExecGraphQLDestroyNote(ctx, client.GL().GraphQL, "epicNoteDelete",
+		"only the note author or a Maintainer/Owner can delete; verify note_id with gitlab_epic_note_list; deletion is irreversible \u2014 system-generated notes cannot be removed",
+		mutationDestroyNote, toolutil.FormatGID("Note", input.NoteID))
 }

--- a/internal/tools/events/events.go
+++ b/internal/tools/events/events.go
@@ -730,31 +730,13 @@ func formatAuthor(username string) string {
 	return "@" + username
 }
 
-// resolveProjectWebURLs fetches the web URL for each unique project ID.
-// Failures are silently ignored — missing URLs simply produce no links.
-func resolveProjectWebURLs(ctx context.Context, client *gitlabclient.Client, projectIDs []int64) map[int64]string {
-	seen := make(map[int64]string, len(projectIDs))
-	for _, id := range projectIDs {
-		if _, ok := seen[id]; ok || id == 0 {
-			continue
-		}
-		proj, _, err := client.GL().Projects.GetProject(id, &gl.GetProjectOptions{}, gl.WithContext(ctx))
-		if err != nil || proj == nil {
-			seen[id] = ""
-			continue
-		}
-		seen[id] = proj.WebURL
-	}
-	return seen
-}
-
 // enrichContributionEventURLs resolves project web URLs and sets TargetURL on each event.
 func enrichContributionEventURLs(ctx context.Context, client *gitlabclient.Client, events []ContributionEventOutput) {
 	ids := make([]int64, 0, len(events))
 	for i := range events {
 		ids = append(ids, events[i].ProjectID)
 	}
-	urls := resolveProjectWebURLs(ctx, client, ids)
+	urls := toolutil.ResolveProjectWebURLs(ctx, client.GL().Projects, ids)
 	for i := range events {
 		events[i].TargetURL = toolutil.BuildTargetURL(urls[events[i].ProjectID], events[i].TargetType, events[i].TargetIID)
 	}
@@ -766,7 +748,7 @@ func enrichProjectEventURLs(ctx context.Context, client *gitlabclient.Client, ev
 	for i := range events {
 		ids = append(ids, events[i].ProjectID)
 	}
-	urls := resolveProjectWebURLs(ctx, client, ids)
+	urls := toolutil.ResolveProjectWebURLs(ctx, client.GL().Projects, ids)
 	for i := range events {
 		events[i].TargetURL = toolutil.BuildTargetURL(urls[events[i].ProjectID], events[i].TargetType, events[i].TargetIID)
 	}

--- a/internal/tools/events/events_test.go
+++ b/internal/tools/events/events_test.go
@@ -827,7 +827,7 @@ func TestResolveProjectWebURLs_SkipsZeroID(t *testing.T) {
 		apiCalled = true
 		testutil.RespondJSON(w, http.StatusOK, `{"id":1,"web_url":"https://example.com/p"}`)
 	}))
-	urls := resolveProjectWebURLs(t.Context(), client, []int64{0})
+	urls := toolutil.ResolveProjectWebURLs(t.Context(), client.GL().Projects, []int64{0})
 	if apiCalled {
 		t.Error("API should not be called for project ID 0")
 	}
@@ -845,7 +845,7 @@ func TestResolveProjectWebURLs_DeduplicatesIDs(t *testing.T) {
 		callCount++
 		testutil.RespondJSON(w, http.StatusOK, `{"id":5,"web_url":"https://example.com/p/5"}`)
 	}))
-	urls := resolveProjectWebURLs(t.Context(), client, []int64{5, 5, 5})
+	urls := toolutil.ResolveProjectWebURLs(t.Context(), client.GL().Projects, []int64{5, 5, 5})
 	if callCount != 1 {
 		t.Errorf("expected 1 API call, got %d", callCount)
 	}

--- a/internal/tools/groupboards/groupboards.go
+++ b/internal/tools/groupboards/groupboards.go
@@ -159,7 +159,7 @@ func convertGroupBoardAPI(b *groupIssueBoardAPI) GroupBoardOutput {
 		Name:            b.Name,
 		Group:           groupRefOutput(b.Group),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        basicUserOutput(b.Assignee),
+		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
 		Weight:          b.Weight,
 		Labels:          groupLabelOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
@@ -175,9 +175,9 @@ func convertGroupBoardAPI(b *groupIssueBoardAPI) GroupBoardOutput {
 func convertBoardList(l *gl.BoardList) BoardListOutput {
 	return BoardListOutput{
 		ID:             l.ID,
-		Assignee:       boardListAssigneeOutput(l.Assignee),
-		Iteration:      iterationOutput(l.Iteration),
-		Label:          labelOutput(l.Label),
+		Assignee:       toolutil.NewBoardListAssigneeOutput(l.Assignee),
+		Iteration:      toolutil.NewIterationOutputFromProjectIteration(l.Iteration),
+		Label:          toolutil.NewBoardLabelOutput(l.Label),
 		MaxIssueCount:  l.MaxIssueCount,
 		MaxIssueWeight: l.MaxIssueWeight,
 		Milestone:      milestoneOutput(l.Milestone),

--- a/internal/tools/groupboards/groupboards.go
+++ b/internal/tools/groupboards/groupboards.go
@@ -159,7 +159,7 @@ func convertGroupBoardAPI(b *groupIssueBoardAPI) GroupBoardOutput {
 		Name:            b.Name,
 		Group:           groupRefOutput(b.Group),
 		Milestone:       milestoneOutput(b.Milestone),
-		Assignee:        toolutil.NewBoardUserOutput(b.Assignee),
+		Assignee:        basicUserOutput(b.Assignee),
 		Weight:          b.Weight,
 		Labels:          groupLabelOutputs(b.Labels),
 		HideBacklogList: b.HideBacklogList,
@@ -175,9 +175,9 @@ func convertGroupBoardAPI(b *groupIssueBoardAPI) GroupBoardOutput {
 func convertBoardList(l *gl.BoardList) BoardListOutput {
 	return BoardListOutput{
 		ID:             l.ID,
-		Assignee:       toolutil.NewBoardListAssigneeOutput(l.Assignee),
-		Iteration:      toolutil.NewIterationOutputFromProjectIteration(l.Iteration),
-		Label:          toolutil.NewBoardLabelOutput(l.Label),
+		Assignee:       boardListAssigneeOutput(l.Assignee),
+		Iteration:      iterationOutput(l.Iteration),
+		Label:          labelOutput(l.Label),
 		MaxIssueCount:  l.MaxIssueCount,
 		MaxIssueWeight: l.MaxIssueWeight,
 		Milestone:      milestoneOutput(l.Milestone),

--- a/internal/tools/groupboards/groupboards_test.go
+++ b/internal/tools/groupboards/groupboards_test.go
@@ -1074,14 +1074,14 @@ func TestShapeConverters_NilInputs(t *testing.T) {
 	if milestoneOutput(nil) != nil {
 		t.Error("milestoneOutput(nil) != nil")
 	}
-	if labelOutput(nil) != nil {
-		t.Error("labelOutput(nil) != nil")
+	if toolutil.NewBoardLabelOutput(nil) != nil {
+		t.Error("toolutil.NewBoardLabelOutput(nil) != nil")
 	}
-	if boardListAssigneeOutput(nil) != nil {
-		t.Error("boardListAssigneeOutput(nil) != nil")
+	if toolutil.NewBoardListAssigneeOutput(nil) != nil {
+		t.Error("toolutil.NewBoardListAssigneeOutput(nil) != nil")
 	}
-	if iterationOutput(nil) != nil {
-		t.Error("iterationOutput(nil) != nil")
+	if toolutil.NewIterationOutputFromProjectIteration(nil) != nil {
+		t.Error("toolutil.NewIterationOutputFromProjectIteration(nil) != nil")
 	}
 	if groupLabelOutputs(nil) != nil {
 		t.Error("groupLabelOutputs(nil) != nil")
@@ -1220,7 +1220,7 @@ func TestListGroupBoards_SurfacesDocumentedPremiumFields(t *testing.T) {
 // TestBasicUserOutput_Nil verifies the assignee converter returns nil for a nil
 // input (the Free-tier / no-assignee case).
 func TestBasicUserOutput_Nil(t *testing.T) {
-	if got := basicUserOutput(nil); got != nil {
-		t.Errorf("basicUserOutput(nil) = %+v, want nil", got)
+	if got := toolutil.NewBoardUserOutput(nil); got != nil {
+		t.Errorf("toolutil.NewBoardUserOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/groupboards/groupboards_test.go
+++ b/internal/tools/groupboards/groupboards_test.go
@@ -1074,14 +1074,14 @@ func TestShapeConverters_NilInputs(t *testing.T) {
 	if milestoneOutput(nil) != nil {
 		t.Error("milestoneOutput(nil) != nil")
 	}
-	if toolutil.NewBoardLabelOutput(nil) != nil {
-		t.Error("toolutil.NewBoardLabelOutput(nil) != nil")
+	if labelOutput(nil) != nil {
+		t.Error("labelOutput(nil) != nil")
 	}
-	if toolutil.NewBoardListAssigneeOutput(nil) != nil {
-		t.Error("toolutil.NewBoardListAssigneeOutput(nil) != nil")
+	if boardListAssigneeOutput(nil) != nil {
+		t.Error("boardListAssigneeOutput(nil) != nil")
 	}
-	if toolutil.NewIterationOutputFromProjectIteration(nil) != nil {
-		t.Error("toolutil.NewIterationOutputFromProjectIteration(nil) != nil")
+	if iterationOutput(nil) != nil {
+		t.Error("iterationOutput(nil) != nil")
 	}
 	if groupLabelOutputs(nil) != nil {
 		t.Error("groupLabelOutputs(nil) != nil")
@@ -1220,7 +1220,7 @@ func TestListGroupBoards_SurfacesDocumentedPremiumFields(t *testing.T) {
 // TestBasicUserOutput_Nil verifies the assignee converter returns nil for a nil
 // input (the Free-tier / no-assignee case).
 func TestBasicUserOutput_Nil(t *testing.T) {
-	if got := toolutil.NewBoardUserOutput(nil); got != nil {
-		t.Errorf("toolutil.NewBoardUserOutput(nil) = %+v, want nil", got)
+	if got := basicUserOutput(nil); got != nil {
+		t.Errorf("basicUserOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/groupboards/shapes.go
+++ b/internal/tools/groupboards/shapes.go
@@ -70,37 +70,15 @@ func milestoneOutput(m *gl.Milestone) *MilestoneOutput {
 // only id, name, username, state, avatar_url, and web_url; gl.BasicUser's
 // created_at is not part of the documented board assignee shape. The board-level
 // assignee is decoded via the raw-superset fetch path (groupIssueBoardAPI), as
-// gl.GroupIssueBoard omits the assignee field entirely.
-type BasicUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url"`
-	WebURL    string `json:"web_url"`
-}
-
-func basicUserOutput(u *gl.BasicUser) *BasicUserOutput {
-	if u == nil {
-		return nil
-	}
-	return &BasicUserOutput{
-		ID: u.ID, Username: u.Username, Name: u.Name, State: u.State,
-		AvatarURL: u.AvatarURL, WebURL: u.WebURL,
-	}
-}
+// gl.GroupIssueBoard omits the assignee field entirely. Canonical shape shared
+// via toolutil.
+type BasicUserOutput = toolutil.BoardUserOutput
 
 // LabelDetailsOutput is a documented reference subset per
 // doc/api/group_boards.md. The board's `labels[]` entries in the documented
-// update-board response show only id, name, color, and description; gl.Label's
-// text_color, counts, subscribed, priority, is_project_label, and archived
-// fields are not part of the documented board labels shape.
-type LabelDetailsOutput struct {
-	ID          int64  `json:"id"`
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
+// update-board response show only id, name, color, and description. Canonical
+// shape shared via toolutil.
+type LabelDetailsOutput = toolutil.BoardLabelDetailsOutput
 
 // groupLabelOutputs converts a slice of gl.GroupLabel (a defined type aliasing
 // gl.Label) to the documented board label subset, skipping nil elements.
@@ -123,67 +101,16 @@ func groupLabelOutputs(labels []*gl.GroupLabel) []*LabelDetailsOutput {
 // BoardListAssigneeOutput is a documented reference subset per
 // doc/api/group_boards.md. A board list's `assignee` object (Premium/Ultimate
 // assignee list type) is surfaced with id, name, and username, matching the
-// compact gl.BoardListAssignee struct. The documented response examples cover
-// only label and milestone lists, so this premium list-type sub-object has no
-// fuller documented shape to trim against.
-type BoardListAssigneeOutput struct {
-	ID       int64  `json:"id"`
-	Name     string `json:"name"`
-	Username string `json:"username"`
-}
-
-func boardListAssigneeOutput(a *gl.BoardListAssignee) *BoardListAssigneeOutput {
-	if a == nil {
-		return nil
-	}
-	return &BoardListAssigneeOutput{ID: a.ID, Name: a.Name, Username: a.Username}
-}
+// compact gl.BoardListAssignee struct. Canonical shape shared via toolutil.
+type BoardListAssigneeOutput = toolutil.BoardListAssigneeOutput
 
 // LabelOutput is a documented reference subset per doc/api/group_boards.md.
 // Every documented board-list response shows the list's `label` object with
-// only name, color, and description (no id); gl.Label's remaining fields are not
-// part of the documented board-list label shape.
-type LabelOutput struct {
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
-
-func labelOutput(l *gl.Label) *LabelOutput {
-	if l == nil {
-		return nil
-	}
-	return &LabelOutput{Name: l.Name, Color: l.Color, Description: l.Description}
-}
+// only name, color, and description (no id). Canonical shape shared via
+// toolutil.
+type LabelOutput = toolutil.BoardLabelOutput
 
 // IterationOutput is a documented reference subset per doc/api/group_boards.md.
 // A board list's `iteration` object (Premium/Ultimate iteration list type)
-// mirrors gl.ProjectIteration. The documented response examples cover only
-// label and milestone lists, so this premium list-type sub-object has no fuller
-// documented shape to trim against.
-type IterationOutput struct {
-	ID          int64  `json:"id"`
-	IID         int64  `json:"iid"`
-	Sequence    int64  `json:"sequence"`
-	GroupID     int64  `json:"group_id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	State       int64  `json:"state"`
-	WebURL      string `json:"web_url"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
-	StartDate   string `json:"start_date,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-}
-
-func iterationOutput(it *gl.ProjectIteration) *IterationOutput {
-	if it == nil {
-		return nil
-	}
-	return &IterationOutput{
-		ID: it.ID, IID: it.IID, Sequence: it.Sequence, GroupID: it.GroupID,
-		Title: it.Title, Description: it.Description, State: it.State, WebURL: it.WebURL,
-		CreatedAt: toolutil.FormatTimePtr(it.CreatedAt), UpdatedAt: toolutil.FormatTimePtr(it.UpdatedAt),
-		StartDate: toolutil.FormatISOTimePtr(it.StartDate), DueDate: toolutil.FormatISOTimePtr(it.DueDate),
-	}
-}
+// mirrors gl.ProjectIteration. Canonical shape shared via toolutil.
+type IterationOutput = toolutil.IterationOutput

--- a/internal/tools/groupboards/shapes.go
+++ b/internal/tools/groupboards/shapes.go
@@ -114,3 +114,27 @@ type LabelOutput = toolutil.BoardLabelOutput
 // A board list's `iteration` object (Premium/Ultimate iteration list type)
 // mirrors gl.ProjectIteration. Canonical shape shared via toolutil.
 type IterationOutput = toolutil.IterationOutput
+
+// basicUserOutput converts a gl.BasicUser into the documented board assignee
+// subset, or nil.
+func basicUserOutput(u *gl.BasicUser) *BasicUserOutput {
+	return toolutil.NewBoardUserOutput(u)
+}
+
+// boardListAssigneeOutput converts a gl.BoardListAssignee into the shared
+// output shape, or nil.
+func boardListAssigneeOutput(a *gl.BoardListAssignee) *BoardListAssigneeOutput {
+	return toolutil.NewBoardListAssigneeOutput(a)
+}
+
+// labelOutput converts a gl.Label into the documented board-list label
+// subset, or nil.
+func labelOutput(l *gl.Label) *LabelOutput {
+	return toolutil.NewBoardLabelOutput(l)
+}
+
+// iterationOutput converts a gl.ProjectIteration into the canonical iteration
+// object, or nil.
+func iterationOutput(it *gl.ProjectIteration) *IterationOutput {
+	return toolutil.NewIterationOutputFromProjectIteration(it)
+}

--- a/internal/tools/groupmembers/groupmembers.go
+++ b/internal/tools/groupmembers/groupmembers.go
@@ -556,9 +556,9 @@ func convertMember(m *gl.GroupMember) Output {
 		AccessLevel:       int(m.AccessLevel),
 		Email:             m.Email,
 		PublicEmail:       m.PublicEmail,
-		CreatedBy:         toolutil.NewMemberUserOutput(m.CreatedBy),
-		GroupSAMLIdentity: toolutil.NewSAMLIdentityOutput(m.GroupSAMLIdentity),
-		MemberRole:        toolutil.NewMemberRoleOutput(m.MemberRole),
+		CreatedBy:         memberUserOutput(m.CreatedBy),
+		GroupSAMLIdentity: samlIdentityOutput(m.GroupSAMLIdentity),
+		MemberRole:        memberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)
@@ -568,6 +568,22 @@ func convertMember(m *gl.GroupMember) Output {
 	}
 	out.IsUsingSeat = m.IsUsingSeat
 	return out
+}
+
+// memberUserOutput mirrors a gl.MemberCreatedBy into the shared output shape.
+func memberUserOutput(u *gl.MemberCreatedBy) *MemberUserOutput {
+	return toolutil.NewMemberUserOutput(u)
+}
+
+// samlIdentityOutput mirrors a gl.GroupMemberSAMLIdentity into the shared
+// output shape.
+func samlIdentityOutput(s *gl.GroupMemberSAMLIdentity) *SAMLIdentityOutput {
+	return toolutil.NewSAMLIdentityOutput(s)
+}
+
+// memberRoleOutput mirrors a gl.MemberRole into the shared output shape.
+func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
+	return toolutil.NewMemberRoleOutput(r)
 }
 
 // convertBillableMember maps a gl.BillableGroupMember into the MCP output

--- a/internal/tools/groupmembers/groupmembers.go
+++ b/internal/tools/groupmembers/groupmembers.go
@@ -42,54 +42,19 @@ type Output struct {
 	IsUsingSeat       bool                `json:"is_using_seat,omitempty"`
 }
 
-// MemberUserOutput mirrors gl.MemberCreatedBy (the created_by object).
-type MemberUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-}
+// MemberUserOutput mirrors gl.MemberCreatedBy (the created_by object);
+// canonical shape shared via toolutil.
+type MemberUserOutput = toolutil.MemberUserOutput
 
 // SAMLIdentityOutput mirrors gl.GroupMemberSAMLIdentity (the
-// group_saml_identity object).
-type SAMLIdentityOutput struct {
-	ExternUID      string `json:"extern_uid"`
-	Provider       string `json:"provider"`
-	SAMLProviderID int64  `json:"saml_provider_id"`
-}
+// group_saml_identity object); canonical shape shared via toolutil.
+type SAMLIdentityOutput = toolutil.SAMLIdentityOutput
 
 // MemberRoleOutput mirrors gl.MemberRole (the member_role object). Custom
 // member roles are an Enterprise (Premium/Ultimate) feature; the object is nil
-// on instances or members without a custom role.
-type MemberRoleOutput struct {
-	ID                         int64  `json:"id"`
-	Name                       string `json:"name"`
-	Description                string `json:"description,omitempty"`
-	GroupID                    int64  `json:"group_id"`
-	BaseAccessLevel            int    `json:"base_access_level"`
-	AdminCICDVariables         bool   `json:"admin_cicd_variables,omitempty"`
-	AdminComplianceFramework   bool   `json:"admin_compliance_framework,omitempty"`
-	AdminGroupMembers          bool   `json:"admin_group_member,omitempty"`
-	AdminMergeRequests         bool   `json:"admin_merge_request,omitempty"`
-	AdminPushRules             bool   `json:"admin_push_rules,omitempty"`
-	AdminTerraformState        bool   `json:"admin_terraform_state,omitempty"`
-	AdminVulnerability         bool   `json:"admin_vulnerability,omitempty"`
-	AdminWebHook               bool   `json:"admin_web_hook,omitempty"`
-	ArchiveProject             bool   `json:"archive_project,omitempty"`
-	ManageDeployTokens         bool   `json:"manage_deploy_tokens,omitempty"`
-	ManageGroupAccessTokens    bool   `json:"manage_group_access_tokens,omitempty"`
-	ManageMergeRequestSettings bool   `json:"manage_merge_request_settings,omitempty"`
-	ManageProjectAccessTokens  bool   `json:"manage_project_access_tokens,omitempty"`
-	ManageSecurityPolicyLink   bool   `json:"manage_security_policy_link,omitempty"`
-	ReadCode                   bool   `json:"read_code,omitempty"`
-	ReadRunners                bool   `json:"read_runners,omitempty"`
-	ReadDependency             bool   `json:"read_dependency,omitempty"`
-	ReadVulnerability          bool   `json:"read_vulnerability,omitempty"`
-	RemoveGroup                bool   `json:"remove_group,omitempty"`
-	RemoveProject              bool   `json:"remove_project,omitempty"`
-}
+// on instances or members without a custom role. Canonical shape shared via
+// toolutil.
+type MemberRoleOutput = toolutil.MemberRoleOutput
 
 // ShareOutput represents the result of sharing with a group.
 type ShareOutput struct {
@@ -591,9 +556,9 @@ func convertMember(m *gl.GroupMember) Output {
 		AccessLevel:       int(m.AccessLevel),
 		Email:             m.Email,
 		PublicEmail:       m.PublicEmail,
-		CreatedBy:         memberUserOutput(m.CreatedBy),
-		GroupSAMLIdentity: samlIdentityOutput(m.GroupSAMLIdentity),
-		MemberRole:        memberRoleOutput(m.MemberRole),
+		CreatedBy:         toolutil.NewMemberUserOutput(m.CreatedBy),
+		GroupSAMLIdentity: toolutil.NewSAMLIdentityOutput(m.GroupSAMLIdentity),
+		MemberRole:        toolutil.NewMemberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)
@@ -603,68 +568,6 @@ func convertMember(m *gl.GroupMember) Output {
 	}
 	out.IsUsingSeat = m.IsUsingSeat
 	return out
-}
-
-// memberUserOutput mirrors a gl.MemberCreatedBy into the local output shape.
-func memberUserOutput(u *gl.MemberCreatedBy) *MemberUserOutput {
-	if u == nil {
-		return nil
-	}
-	return &MemberUserOutput{
-		ID:        u.ID,
-		Username:  u.Username,
-		Name:      u.Name,
-		State:     u.State,
-		AvatarURL: u.AvatarURL,
-		WebURL:    u.WebURL,
-	}
-}
-
-// samlIdentityOutput mirrors a gl.GroupMemberSAMLIdentity into the local
-// output shape.
-func samlIdentityOutput(s *gl.GroupMemberSAMLIdentity) *SAMLIdentityOutput {
-	if s == nil {
-		return nil
-	}
-	return &SAMLIdentityOutput{
-		ExternUID:      s.ExternUID,
-		Provider:       s.Provider,
-		SAMLProviderID: s.SAMLProviderID,
-	}
-}
-
-// memberRoleOutput mirrors a gl.MemberRole into the local output shape.
-func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
-	if r == nil {
-		return nil
-	}
-	return &MemberRoleOutput{
-		ID:                         r.ID,
-		Name:                       r.Name,
-		Description:                r.Description,
-		GroupID:                    r.GroupID,
-		BaseAccessLevel:            int(r.BaseAccessLevel),
-		AdminCICDVariables:         r.AdminCICDVariables,
-		AdminComplianceFramework:   r.AdminComplianceFramework,
-		AdminGroupMembers:          r.AdminGroupMembers,
-		AdminMergeRequests:         r.AdminMergeRequests,
-		AdminPushRules:             r.AdminPushRules,
-		AdminTerraformState:        r.AdminTerraformState,
-		AdminVulnerability:         r.AdminVulnerability,
-		AdminWebHook:               r.AdminWebHook,
-		ArchiveProject:             r.ArchiveProject,
-		ManageDeployTokens:         r.ManageDeployTokens,
-		ManageGroupAccessTokens:    r.ManageGroupAccessTokens,
-		ManageMergeRequestSettings: r.ManageMergeRequestSettings,
-		ManageProjectAccessTokens:  r.ManageProjectAccessTokens,
-		ManageSecurityPolicyLink:   r.ManageSecurityPolicyLink,
-		ReadCode:                   r.ReadCode,
-		ReadRunners:                r.ReadRunners,
-		ReadDependency:             r.ReadDependency,
-		ReadVulnerability:          r.ReadVulnerability,
-		RemoveGroup:                r.RemoveGroup,
-		RemoveProject:              r.RemoveProject,
-	}
 }
 
 // convertBillableMember maps a gl.BillableGroupMember into the MCP output

--- a/internal/tools/groups/avatar.go
+++ b/internal/tools/groups/avatar.go
@@ -1,12 +1,8 @@
 package groups
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
@@ -45,33 +41,11 @@ func UploadAvatar(ctx context.Context, client *gitlabclient.Client, input Upload
 		return Output{}, errors.New("groupUploadAvatar: filename is required")
 	}
 
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return Output{}, errors.New("groupUploadAvatar: provide either file_path or content_base64, not both")
+	reader, _, cleanup, err := toolutil.OpenFileOrBase64Source("groupUploadAvatar", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return Output{}, err
 	}
-	if !hasFilePath && !hasBase64 {
-		return Output{}, errors.New("groupUploadAvatar: either file_path or content_base64 is required")
-	}
-
-	var reader io.Reader
-
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, _, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return Output{}, fmt.Errorf("groupUploadAvatar: %w", err)
-		}
-		defer f.Close()
-		reader = f
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return Output{}, fmt.Errorf("groupUploadAvatar: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
-	}
+	defer cleanup()
 
 	g, _, err := client.GL().Groups.UploadAvatar(string(input.GroupID), reader, input.Filename, gl.WithContext(ctx))
 	if err != nil {

--- a/internal/tools/groups/groups.go
+++ b/internal/tools/groups/groups.go
@@ -227,54 +227,19 @@ type MemberOutput struct {
 	IsUsingSeat       bool                `json:"is_using_seat,omitempty"`
 }
 
-// MemberUserOutput mirrors gl.MemberCreatedBy (the created_by object).
-type MemberUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-}
+// MemberUserOutput mirrors gl.MemberCreatedBy (the created_by object);
+// canonical shape shared via toolutil.
+type MemberUserOutput = toolutil.MemberUserOutput
 
 // SAMLIdentityOutput mirrors gl.GroupMemberSAMLIdentity (the
-// group_saml_identity object).
-type SAMLIdentityOutput struct {
-	ExternUID      string `json:"extern_uid"`
-	Provider       string `json:"provider"`
-	SAMLProviderID int64  `json:"saml_provider_id"`
-}
+// group_saml_identity object); canonical shape shared via toolutil.
+type SAMLIdentityOutput = toolutil.SAMLIdentityOutput
 
 // MemberRoleOutput mirrors gl.MemberRole (the member_role object). Custom member
 // roles are an Enterprise (Premium/Ultimate) feature; the object is nil on
-// instances or members without a custom role.
-type MemberRoleOutput struct {
-	ID                         int64  `json:"id"`
-	Name                       string `json:"name"`
-	Description                string `json:"description,omitempty"`
-	GroupID                    int64  `json:"group_id"`
-	BaseAccessLevel            int    `json:"base_access_level"`
-	AdminCICDVariables         bool   `json:"admin_cicd_variables,omitempty"`
-	AdminComplianceFramework   bool   `json:"admin_compliance_framework,omitempty"`
-	AdminGroupMembers          bool   `json:"admin_group_member,omitempty"`
-	AdminMergeRequests         bool   `json:"admin_merge_request,omitempty"`
-	AdminPushRules             bool   `json:"admin_push_rules,omitempty"`
-	AdminTerraformState        bool   `json:"admin_terraform_state,omitempty"`
-	AdminVulnerability         bool   `json:"admin_vulnerability,omitempty"`
-	AdminWebHook               bool   `json:"admin_web_hook,omitempty"`
-	ArchiveProject             bool   `json:"archive_project,omitempty"`
-	ManageDeployTokens         bool   `json:"manage_deploy_tokens,omitempty"`
-	ManageGroupAccessTokens    bool   `json:"manage_group_access_tokens,omitempty"`
-	ManageMergeRequestSettings bool   `json:"manage_merge_request_settings,omitempty"`
-	ManageProjectAccessTokens  bool   `json:"manage_project_access_tokens,omitempty"`
-	ManageSecurityPolicyLink   bool   `json:"manage_security_policy_link,omitempty"`
-	ReadCode                   bool   `json:"read_code,omitempty"`
-	ReadRunners                bool   `json:"read_runners,omitempty"`
-	ReadDependency             bool   `json:"read_dependency,omitempty"`
-	ReadVulnerability          bool   `json:"read_vulnerability,omitempty"`
-	RemoveGroup                bool   `json:"remove_group,omitempty"`
-	RemoveProject              bool   `json:"remove_project,omitempty"`
-}
+// instances or members without a custom role. Canonical shape shared via
+// toolutil.
+type MemberRoleOutput = toolutil.MemberRoleOutput
 
 // MemberListOutput holds a paginated list of group members.
 type MemberListOutput struct {
@@ -553,9 +518,9 @@ func MemberToOutput(m *gl.GroupMember) MemberOutput {
 		Email:             m.Email,
 		PublicEmail:       m.PublicEmail,
 		IsUsingSeat:       m.IsUsingSeat,
-		CreatedBy:         memberUserOutput(m.CreatedBy),
-		GroupSAMLIdentity: samlIdentityOutput(m.GroupSAMLIdentity),
-		MemberRole:        memberRoleOutput(m.MemberRole),
+		CreatedBy:         toolutil.NewMemberUserOutput(m.CreatedBy),
+		GroupSAMLIdentity: toolutil.NewSAMLIdentityOutput(m.GroupSAMLIdentity),
+		MemberRole:        toolutil.NewMemberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)
@@ -564,68 +529,6 @@ func MemberToOutput(m *gl.GroupMember) MemberOutput {
 		out.ExpiresAt = m.ExpiresAt.String()
 	}
 	return out
-}
-
-// memberUserOutput mirrors a gl.MemberCreatedBy into the local output shape.
-func memberUserOutput(u *gl.MemberCreatedBy) *MemberUserOutput {
-	if u == nil {
-		return nil
-	}
-	return &MemberUserOutput{
-		ID:        u.ID,
-		Username:  u.Username,
-		Name:      u.Name,
-		State:     u.State,
-		AvatarURL: u.AvatarURL,
-		WebURL:    u.WebURL,
-	}
-}
-
-// samlIdentityOutput mirrors a gl.GroupMemberSAMLIdentity into the local output
-// shape.
-func samlIdentityOutput(s *gl.GroupMemberSAMLIdentity) *SAMLIdentityOutput {
-	if s == nil {
-		return nil
-	}
-	return &SAMLIdentityOutput{
-		ExternUID:      s.ExternUID,
-		Provider:       s.Provider,
-		SAMLProviderID: s.SAMLProviderID,
-	}
-}
-
-// memberRoleOutput mirrors a gl.MemberRole into the local output shape.
-func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
-	if r == nil {
-		return nil
-	}
-	return &MemberRoleOutput{
-		ID:                         r.ID,
-		Name:                       r.Name,
-		Description:                r.Description,
-		GroupID:                    r.GroupID,
-		BaseAccessLevel:            int(r.BaseAccessLevel),
-		AdminCICDVariables:         r.AdminCICDVariables,
-		AdminComplianceFramework:   r.AdminComplianceFramework,
-		AdminGroupMembers:          r.AdminGroupMembers,
-		AdminMergeRequests:         r.AdminMergeRequests,
-		AdminPushRules:             r.AdminPushRules,
-		AdminTerraformState:        r.AdminTerraformState,
-		AdminVulnerability:         r.AdminVulnerability,
-		AdminWebHook:               r.AdminWebHook,
-		ArchiveProject:             r.ArchiveProject,
-		ManageDeployTokens:         r.ManageDeployTokens,
-		ManageGroupAccessTokens:    r.ManageGroupAccessTokens,
-		ManageMergeRequestSettings: r.ManageMergeRequestSettings,
-		ManageProjectAccessTokens:  r.ManageProjectAccessTokens,
-		ManageSecurityPolicyLink:   r.ManageSecurityPolicyLink,
-		ReadCode:                   r.ReadCode,
-		ReadRunners:                r.ReadRunners,
-		ReadDependency:             r.ReadDependency,
-		ReadVulnerability:          r.ReadVulnerability,
-		RemoveGroup:                r.RemoveGroup,
-		RemoveProject:              r.RemoveProject,
-	}
 }
 
 // List retrieves a paginated list of GitLab groups visible to the

--- a/internal/tools/groups/groups.go
+++ b/internal/tools/groups/groups.go
@@ -518,9 +518,9 @@ func MemberToOutput(m *gl.GroupMember) MemberOutput {
 		Email:             m.Email,
 		PublicEmail:       m.PublicEmail,
 		IsUsingSeat:       m.IsUsingSeat,
-		CreatedBy:         toolutil.NewMemberUserOutput(m.CreatedBy),
-		GroupSAMLIdentity: toolutil.NewSAMLIdentityOutput(m.GroupSAMLIdentity),
-		MemberRole:        toolutil.NewMemberRoleOutput(m.MemberRole),
+		CreatedBy:         memberUserOutput(m.CreatedBy),
+		GroupSAMLIdentity: samlIdentityOutput(m.GroupSAMLIdentity),
+		MemberRole:        memberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)
@@ -529,6 +529,22 @@ func MemberToOutput(m *gl.GroupMember) MemberOutput {
 		out.ExpiresAt = m.ExpiresAt.String()
 	}
 	return out
+}
+
+// memberUserOutput mirrors a gl.MemberCreatedBy into the shared output shape.
+func memberUserOutput(u *gl.MemberCreatedBy) *MemberUserOutput {
+	return toolutil.NewMemberUserOutput(u)
+}
+
+// samlIdentityOutput mirrors a gl.GroupMemberSAMLIdentity into the shared
+// output shape.
+func samlIdentityOutput(s *gl.GroupMemberSAMLIdentity) *SAMLIdentityOutput {
+	return toolutil.NewSAMLIdentityOutput(s)
+}
+
+// memberRoleOutput mirrors a gl.MemberRole into the shared output shape.
+func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
+	return toolutil.NewMemberRoleOutput(r)
 }
 
 // List retrieves a paginated list of GitLab groups visible to the

--- a/internal/tools/impersonationtokens/impersonationtokens.go
+++ b/internal/tools/impersonationtokens/impersonationtokens.go
@@ -39,17 +39,7 @@ type ListOutput struct {
 // PATOutput represents a personal access token.
 type PATOutput struct {
 	toolutil.HintableOutput
-	ID          int64    `json:"id"`
-	Name        string   `json:"name"`
-	Active      bool     `json:"active"`
-	Token       string   `json:"token,omitempty"`
-	Scopes      []string `json:"scopes"`
-	Revoked     bool     `json:"revoked"`
-	Description string   `json:"description,omitempty"`
-	UserID      int64    `json:"user_id"`
-	CreatedAt   string   `json:"created_at,omitempty"`
-	ExpiresAt   string   `json:"expires_at,omitempty"`
-	LastUsedAt  string   `json:"last_used_at,omitempty"`
+	toolutil.PersonalTokenOutput
 }
 
 // RevokeOutput confirms a token revocation.
@@ -127,26 +117,7 @@ func toOutput(t *gl.ImpersonationToken) Output {
 }
 
 func toPATOutput(t *gl.PersonalAccessToken) PATOutput {
-	o := PATOutput{
-		ID:          t.ID,
-		Name:        t.Name,
-		Active:      t.Active,
-		Token:       t.Token,
-		Scopes:      t.Scopes,
-		Revoked:     t.Revoked,
-		Description: t.Description,
-		UserID:      t.UserID,
-	}
-	if t.CreatedAt != nil {
-		o.CreatedAt = t.CreatedAt.Format(time.RFC3339)
-	}
-	if t.ExpiresAt != nil {
-		o.ExpiresAt = time.Time(*t.ExpiresAt).Format(toolutil.DateFormatISO)
-	}
-	if t.LastUsedAt != nil {
-		o.LastUsedAt = t.LastUsedAt.Format(time.RFC3339)
-	}
-	return o
+	return PATOutput{PersonalTokenOutput: toolutil.NewPersonalTokenOutput(t)}
 }
 
 // --- Handlers ---.

--- a/internal/tools/impersonationtokens/impersonationtokens_test.go
+++ b/internal/tools/impersonationtokens/impersonationtokens_test.go
@@ -331,7 +331,7 @@ func TestFormatMarkdownString(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatPATMarkdownString(t *testing.T) {
-	md := FormatPATMarkdownString(PATOutput{ID: 1, Name: "test", Scopes: []string{"api"}, UserID: 42})
+	md := FormatPATMarkdownString(PATOutput{PersonalTokenOutput: toolutil.PersonalTokenOutput{ID: 1, Name: "test", Scopes: []string{"api"}, UserID: 42}})
 	if md == "" {
 		t.Fatal("expected non-empty markdown")
 	}
@@ -697,13 +697,13 @@ func TestFormatMarkdownString_MinimalFields(t *testing.T) {
 // TestFormatPATMarkdownString_AllOptionalFields verifies that FormatPATMarkdownString
 // renders Description, ExpiresAt, and Token fields when present.
 func TestFormatPATMarkdownString_AllOptionalFields(t *testing.T) {
-	out := PATOutput{
+	out := PATOutput{PersonalTokenOutput: toolutil.PersonalTokenOutput{
 		ID: 10, Name: "full-pat", Active: true,
 		Scopes: []string{"api"}, UserID: 42,
 		Description: "My important PAT",
 		ExpiresAt:   "2026-12-01",
 		Token:       "glpat-fullpat",
-	}
+	}}
 	md := FormatPATMarkdownString(out)
 
 	checks := []string{
@@ -725,7 +725,7 @@ func TestFormatPATMarkdownString_AllOptionalFields(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatPATMarkdownString_MinimalFields(t *testing.T) {
-	out := PATOutput{ID: 11, Name: "bare", Active: false, Scopes: []string{"read_api"}, UserID: 99}
+	out := PATOutput{PersonalTokenOutput: toolutil.PersonalTokenOutput{ID: 11, Name: "bare", Active: false, Scopes: []string{"read_api"}, UserID: 99}}
 	md := FormatPATMarkdownString(out)
 
 	if strings.Contains(md, "**Description**") {

--- a/internal/tools/invites/action_specs.go
+++ b/internal/tools/invites/action_specs.go
@@ -71,6 +71,40 @@ type inviteActionMetaEntry struct {
 	guidance    map[string]toolutil.ParameterGuidance
 }
 
+// inviteGuidance builds the guidance map for an invite action: the
+// scope-specific entry (project_id or group_id) plus the email, user_id,
+// access_level, and expires_at entries that are identical for the project
+// and group invite surfaces.
+func inviteGuidance(scopeParam string, scope toolutil.ParameterGuidance) map[string]toolutil.ParameterGuidance {
+	return map[string]toolutil.ParameterGuidance{
+		scopeParam: scope,
+		"email": {
+			SemanticRole:     "invite_email",
+			ValueSource:      "Email address of the person to invite when they may not have an account yet.",
+			ExampleBinding:   `params.email:"newhire@example.com"`,
+			CommonConfusions: []string{"Provide either email or user_id; supply email for people who are not yet GitLab users."},
+		},
+		"user_id": {
+			SemanticRole:     "user_id",
+			ValueSource:      "Numeric user ID when inviting an existing GitLab user.",
+			ExampleBinding:   "params.user_id:42",
+			CommonConfusions: []string{"Use user_id for existing accounts and email otherwise; do not pass a username here."},
+		},
+		"access_level": {
+			SemanticRole:     "access_level",
+			ValueSource:      "Role to grant: 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner.",
+			ExampleBinding:   "params.access_level:30",
+			CommonConfusions: []string{"Pass the numeric access level, not a role name like 'developer'."},
+		},
+		"expires_at": {
+			SemanticRole:     "calendar_date",
+			ValueSource:      "Date the invitation should expire, when the user requests one.",
+			ExampleBinding:   `params.expires_at:"2026-12-31"`,
+			CommonConfusions: []string{"Use YYYY-MM-DD date only; this invitation field is not an RFC3339 timestamp."},
+		},
+	}
+}
+
 // inviteActionMeta maps each individual invite tool to its discovery metadata.
 var inviteActionMeta = map[string]inviteActionMetaEntry{
 	"gitlab_project_invite": {
@@ -79,38 +113,12 @@ var inviteActionMeta = map[string]inviteActionMetaEntry{
 		related: []string{actionInviteListProject, "project.member_add", "access.request_project", "project.members"},
 		description: "Invite a user to a project by email or user ID with an access level. Returns: an invitation result with status and per-email messages. " +
 			"See also: gitlab_project_invite_list_pending, gitlab_project_member_add, gitlab_access_request_request_project.",
-		guidance: map[string]toolutil.ParameterGuidance{
-			"project_id": {
-				SemanticRole:     "scope_project",
-				ValueSource:      "Project ID or full namespace path the user is being invited to.",
-				ExampleBinding:   `params.project_id:"group/project"`,
-				CommonConfusions: []string{"Use the target project here; use group_id only with group.invite_group."},
-			},
-			"email": {
-				SemanticRole:     "invite_email",
-				ValueSource:      "Email address of the person to invite when they may not have an account yet.",
-				ExampleBinding:   `params.email:"newhire@example.com"`,
-				CommonConfusions: []string{"Provide either email or user_id; supply email for people who are not yet GitLab users."},
-			},
-			"user_id": {
-				SemanticRole:     "user_id",
-				ValueSource:      "Numeric user ID when inviting an existing GitLab user.",
-				ExampleBinding:   "params.user_id:42",
-				CommonConfusions: []string{"Use user_id for existing accounts and email otherwise; do not pass a username here."},
-			},
-			"access_level": {
-				SemanticRole:     "access_level",
-				ValueSource:      "Role to grant: 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner.",
-				ExampleBinding:   "params.access_level:30",
-				CommonConfusions: []string{"Pass the numeric access level, not a role name like 'developer'."},
-			},
-			"expires_at": {
-				SemanticRole:     "calendar_date",
-				ValueSource:      "Date the invitation should expire, when the user requests one.",
-				ExampleBinding:   `params.expires_at:"2026-12-31"`,
-				CommonConfusions: []string{"Use YYYY-MM-DD date only; this invitation field is not an RFC3339 timestamp."},
-			},
-		},
+		guidance: inviteGuidance("project_id", toolutil.ParameterGuidance{
+			SemanticRole:     "scope_project",
+			ValueSource:      "Project ID or full namespace path the user is being invited to.",
+			ExampleBinding:   `params.project_id:"group/project"`,
+			CommonConfusions: []string{"Use the target project here; use group_id only with group.invite_group."},
+		}),
 	},
 	"gitlab_group_invite": {
 		usage:   "Invite a user to a group by email address or user_id with a chosen access_level. Use when adding someone who is not yet a group member, including external users invited by email; for users who already have an account prefer group.group_member_add.",
@@ -118,38 +126,12 @@ var inviteActionMeta = map[string]inviteActionMetaEntry{
 		related: []string{actionInviteListGroup, "group.group_member_add", "access.request_group", "group.members"},
 		description: "Invite a user to a group by email or user ID with an access level. Returns: an invitation result with status and per-email messages. " +
 			"See also: gitlab_group_invite_list_pending, gitlab_group_member_add, gitlab_access_request_request_group.",
-		guidance: map[string]toolutil.ParameterGuidance{
-			"group_id": {
-				SemanticRole:     "scope_group",
-				ValueSource:      "Group ID or full group path the user is being invited to.",
-				ExampleBinding:   `params.group_id:"platform/backend"`,
-				CommonConfusions: []string{"Use group_id for the group scope; use project_id only with project.invite_project."},
-			},
-			"email": {
-				SemanticRole:     "invite_email",
-				ValueSource:      "Email address of the person to invite when they may not have an account yet.",
-				ExampleBinding:   `params.email:"newhire@example.com"`,
-				CommonConfusions: []string{"Provide either email or user_id; supply email for people who are not yet GitLab users."},
-			},
-			"user_id": {
-				SemanticRole:     "user_id",
-				ValueSource:      "Numeric user ID when inviting an existing GitLab user.",
-				ExampleBinding:   "params.user_id:42",
-				CommonConfusions: []string{"Use user_id for existing accounts and email otherwise; do not pass a username here."},
-			},
-			"access_level": {
-				SemanticRole:     "access_level",
-				ValueSource:      "Role to grant: 10=Guest, 20=Reporter, 30=Developer, 40=Maintainer, 50=Owner.",
-				ExampleBinding:   "params.access_level:30",
-				CommonConfusions: []string{"Pass the numeric access level, not a role name like 'developer'."},
-			},
-			"expires_at": {
-				SemanticRole:     "calendar_date",
-				ValueSource:      "Date the invitation should expire, when the user requests one.",
-				ExampleBinding:   `params.expires_at:"2026-12-31"`,
-				CommonConfusions: []string{"Use YYYY-MM-DD date only; this invitation field is not an RFC3339 timestamp."},
-			},
-		},
+		guidance: inviteGuidance("group_id", toolutil.ParameterGuidance{
+			SemanticRole:     "scope_group",
+			ValueSource:      "Group ID or full group path the user is being invited to.",
+			ExampleBinding:   `params.group_id:"platform/backend"`,
+			CommonConfusions: []string{"Use group_id for the group scope; use project_id only with project.invite_project."},
+		}),
 	},
 	"gitlab_project_invite_list_pending": {
 		usage:   "List the pending (not yet accepted) invitations for a project. Use to audit outstanding email invitations before resending or revoking them; this lists invitations, not current members.",

--- a/internal/tools/issuediscussions/action_specs.go
+++ b/internal/tools/issuediscussions/action_specs.go
@@ -95,23 +95,13 @@ func projectScopeGuidance() map[string]toolutil.ParameterGuidance {
 // discussionIDGuidance returns the parameter guidance for the discussion_id
 // parameter used by discussion-scoped actions.
 func discussionIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "discussion_id",
-		ValueSource:      "Discussion thread id from a prior gitlab_list_issue_discussions response.",
-		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
-		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
-	}
+	return toolutil.DiscussionIDParamGuidance("Discussion thread id from a prior gitlab_list_issue_discussions response.")
 }
 
 // noteIDGuidance returns the parameter guidance for the note_id parameter used
 // by note update/delete actions.
 func noteIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "note_id",
-		ValueSource:      "Numeric note id within the discussion thread, from a prior discussion response.",
-		ExampleBinding:   "params.note_id:300",
-		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
-	}
+	return toolutil.DiscussionNoteIDParamGuidance("Numeric note id within the discussion thread, from a prior discussion response.")
 }
 
 // decorateIssueDiscussionMeta fills in action-specific discovery metadata for

--- a/internal/tools/issuelinks/shapes.go
+++ b/internal/tools/issuelinks/shapes.go
@@ -223,34 +223,13 @@ func labelDetailsOutputs(details []*gitlab.LabelDetails) []*LabelDetailsOutput {
 }
 
 // IterationOutput mirrors gitlab.GroupIteration (the iteration assigned to an
-// issue, EE only).
-type IterationOutput struct {
-	ID          int64  `json:"id"`
-	IID         int64  `json:"iid"`
-	Sequence    int64  `json:"sequence"`
-	GroupID     int64  `json:"group_id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	State       int64  `json:"state"`
-	WebURL      string `json:"web_url"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
-	StartDate   string `json:"start_date,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-}
+// issue, EE only). Canonical shape shared via toolutil.
+type IterationOutput = toolutil.IterationOutput
 
 // iterationOutput converts a *gitlab.GroupIteration to a *IterationOutput, or
 // nil when the SDK value is nil.
 func iterationOutput(it *gitlab.GroupIteration) *IterationOutput {
-	if it == nil {
-		return nil
-	}
-	return &IterationOutput{
-		ID: it.ID, IID: it.IID, Sequence: it.Sequence, GroupID: it.GroupID,
-		Title: it.Title, Description: it.Description, State: it.State, WebURL: it.WebURL,
-		CreatedAt: toolutil.FormatTimePtr(it.CreatedAt), UpdatedAt: toolutil.FormatTimePtr(it.UpdatedAt),
-		StartDate: toolutil.FormatISOTimePtr(it.StartDate), DueDate: toolutil.FormatISOTimePtr(it.DueDate),
-	}
+	return toolutil.NewIterationOutputFromGroupIteration(it)
 }
 
 // EpicOutput mirrors gitlab.Epic (the epic associated with an issue, EE only).

--- a/internal/tools/members/members.go
+++ b/internal/tools/members/members.go
@@ -51,6 +51,16 @@ type CreatedByOutput = toolutil.MemberUserOutput
 // 1:1 SDK fidelity. Canonical shape shared via toolutil.
 type MemberRoleOutput = toolutil.MemberRoleOutput
 
+// createdByOutput converts [gl.MemberCreatedBy] into the shared mirror, or nil.
+func createdByOutput(c *gl.MemberCreatedBy) *CreatedByOutput {
+	return toolutil.NewMemberUserOutput(c)
+}
+
+// memberRoleOutput converts [gl.MemberRole] into the shared mirror, or nil.
+func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
+	return toolutil.NewMemberRoleOutput(r)
+}
+
 // ListOutput holds a paginated list of members.
 type ListOutput struct {
 	toolutil.HintableOutput
@@ -80,8 +90,8 @@ func ToOutput(m *gl.ProjectMember) Output {
 		AccessLevel: int(m.AccessLevel),
 		WebURL:      m.WebURL,
 		Email:       m.Email,
-		CreatedBy:   toolutil.NewMemberUserOutput(m.CreatedBy),
-		MemberRole:  toolutil.NewMemberRoleOutput(m.MemberRole),
+		CreatedBy:   createdByOutput(m.CreatedBy),
+		MemberRole:  memberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)

--- a/internal/tools/members/members.go
+++ b/internal/tools/members/members.go
@@ -43,88 +43,13 @@ type Output struct {
 }
 
 // CreatedByOutput mirrors [gl.MemberCreatedBy], the user who created the
-// membership record (1:1 SDK fidelity).
-type CreatedByOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-}
+// membership record (1:1 SDK fidelity); canonical shape shared via toolutil.
+type CreatedByOutput = toolutil.MemberUserOutput
 
 // MemberRoleOutput mirrors [gl.MemberRole], the custom member role attached
 // to a membership (Premium/Ultimate). All permission flags are surfaced for
-// 1:1 SDK fidelity.
-type MemberRoleOutput struct {
-	ID                         int64  `json:"id"`
-	Name                       string `json:"name"`
-	Description                string `json:"description,omitempty"`
-	GroupID                    int64  `json:"group_id"`
-	BaseAccessLevel            int    `json:"base_access_level"`
-	AdminCICDVariables         bool   `json:"admin_cicd_variables,omitempty"`
-	AdminComplianceFramework   bool   `json:"admin_compliance_framework,omitempty"`
-	AdminGroupMembers          bool   `json:"admin_group_member,omitempty"`
-	AdminMergeRequests         bool   `json:"admin_merge_request,omitempty"`
-	AdminPushRules             bool   `json:"admin_push_rules,omitempty"`
-	AdminTerraformState        bool   `json:"admin_terraform_state,omitempty"`
-	AdminVulnerability         bool   `json:"admin_vulnerability,omitempty"`
-	AdminWebHook               bool   `json:"admin_web_hook,omitempty"`
-	ArchiveProject             bool   `json:"archive_project,omitempty"`
-	ManageDeployTokens         bool   `json:"manage_deploy_tokens,omitempty"`
-	ManageGroupAccessTokens    bool   `json:"manage_group_access_tokens,omitempty"`
-	ManageMergeRequestSettings bool   `json:"manage_merge_request_settings,omitempty"`
-	ManageProjectAccessTokens  bool   `json:"manage_project_access_tokens,omitempty"`
-	ManageSecurityPolicyLink   bool   `json:"manage_security_policy_link,omitempty"`
-	ReadCode                   bool   `json:"read_code,omitempty"`
-	ReadRunners                bool   `json:"read_runners,omitempty"`
-	ReadDependency             bool   `json:"read_dependency,omitempty"`
-	ReadVulnerability          bool   `json:"read_vulnerability,omitempty"`
-	RemoveGroup                bool   `json:"remove_group,omitempty"`
-	RemoveProject              bool   `json:"remove_project,omitempty"`
-}
-
-// createdByOutput converts [gl.MemberCreatedBy] into the local mirror, or nil.
-func createdByOutput(c *gl.MemberCreatedBy) *CreatedByOutput {
-	if c == nil {
-		return nil
-	}
-	return &CreatedByOutput{
-		ID: c.ID, Username: c.Username, Name: c.Name,
-		State: c.State, AvatarURL: c.AvatarURL, WebURL: c.WebURL,
-	}
-}
-
-// memberRoleOutput converts [gl.MemberRole] into the local mirror, or nil.
-func memberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
-	if r == nil {
-		return nil
-	}
-	return &MemberRoleOutput{
-		ID: r.ID, Name: r.Name, Description: r.Description, GroupID: r.GroupID,
-		BaseAccessLevel:            int(r.BaseAccessLevel),
-		AdminCICDVariables:         r.AdminCICDVariables,
-		AdminComplianceFramework:   r.AdminComplianceFramework,
-		AdminGroupMembers:          r.AdminGroupMembers,
-		AdminMergeRequests:         r.AdminMergeRequests,
-		AdminPushRules:             r.AdminPushRules,
-		AdminTerraformState:        r.AdminTerraformState,
-		AdminVulnerability:         r.AdminVulnerability,
-		AdminWebHook:               r.AdminWebHook,
-		ArchiveProject:             r.ArchiveProject,
-		ManageDeployTokens:         r.ManageDeployTokens,
-		ManageGroupAccessTokens:    r.ManageGroupAccessTokens,
-		ManageMergeRequestSettings: r.ManageMergeRequestSettings,
-		ManageProjectAccessTokens:  r.ManageProjectAccessTokens,
-		ManageSecurityPolicyLink:   r.ManageSecurityPolicyLink,
-		ReadCode:                   r.ReadCode,
-		ReadRunners:                r.ReadRunners,
-		ReadDependency:             r.ReadDependency,
-		ReadVulnerability:          r.ReadVulnerability,
-		RemoveGroup:                r.RemoveGroup,
-		RemoveProject:              r.RemoveProject,
-	}
-}
+// 1:1 SDK fidelity. Canonical shape shared via toolutil.
+type MemberRoleOutput = toolutil.MemberRoleOutput
 
 // ListOutput holds a paginated list of members.
 type ListOutput struct {
@@ -155,8 +80,8 @@ func ToOutput(m *gl.ProjectMember) Output {
 		AccessLevel: int(m.AccessLevel),
 		WebURL:      m.WebURL,
 		Email:       m.Email,
-		CreatedBy:   createdByOutput(m.CreatedBy),
-		MemberRole:  memberRoleOutput(m.MemberRole),
+		CreatedBy:   toolutil.NewMemberUserOutput(m.CreatedBy),
+		MemberRole:  toolutil.NewMemberRoleOutput(m.MemberRole),
 	}
 	if m.CreatedAt != nil {
 		out.CreatedAt = m.CreatedAt.Format(time.RFC3339)

--- a/internal/tools/mrdiscussions/action_specs.go
+++ b/internal/tools/mrdiscussions/action_specs.go
@@ -89,23 +89,13 @@ func mrScopeGuidance() map[string]toolutil.ParameterGuidance {
 // discussionIDGuidance returns the parameter guidance for the discussion_id
 // parameter used by discussion-scoped actions.
 func discussionIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "discussion_id",
-		ValueSource:      "Discussion thread id from a prior gitlab_mr_discussion_list response.",
-		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
-		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
-	}
+	return toolutil.DiscussionIDParamGuidance("Discussion thread id from a prior gitlab_mr_discussion_list response.")
 }
 
 // noteIDGuidance returns the parameter guidance for the note_id parameter used
 // by note update/delete actions.
 func noteIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "note_id",
-		ValueSource:      "Numeric note id within the discussion thread, from a prior discussion response.",
-		ExampleBinding:   "params.note_id:300",
-		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
-	}
+	return toolutil.DiscussionNoteIDParamGuidance("Numeric note id within the discussion thread, from a prior discussion response.")
 }
 
 // decorateMRDiscussionMeta fills in action-specific discovery metadata for each

--- a/internal/tools/packages/packages.go
+++ b/internal/tools/packages/packages.go
@@ -1,12 +1,9 @@
 package packages
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -91,27 +88,11 @@ func Publish(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient
 		return PublishOutput{}, err
 	}
 
-	var reader io.Reader
-	var fileSize int64
-
-	if input.FilePath != "" {
-		cfg := toolutil.GetUploadConfig()
-		f, info, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return PublishOutput{}, fmt.Errorf(fmtPkgPublish, err)
-		}
-		fileSize = info.Size()
-
-		defer f.Close()
-		reader = f
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return PublishOutput{}, fmt.Errorf("packagePublish: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
-		fileSize = int64(len(decoded))
+	reader, fileSize, cleanup, err := toolutil.OpenFileOrBase64Source("packagePublish", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return PublishOutput{}, err
 	}
+	defer cleanup()
 
 	tracker := progress.FromRequest(req)
 	if tracker.IsActive() {

--- a/internal/tools/projects/projects.go
+++ b/internal/tools/projects/projects.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -3641,33 +3640,11 @@ func UploadAvatar(ctx context.Context, client *gitlabclient.Client, input Upload
 		return Output{}, errors.New("projectUploadAvatar: filename is required")
 	}
 
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return Output{}, errors.New("projectUploadAvatar: provide either file_path or content_base64, not both")
+	reader, _, cleanup, err := toolutil.OpenFileOrBase64Source("projectUploadAvatar", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return Output{}, err
 	}
-	if !hasFilePath && !hasBase64 {
-		return Output{}, errors.New("projectUploadAvatar: either file_path or content_base64 is required")
-	}
-
-	var reader io.Reader
-
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, _, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return Output{}, fmt.Errorf("projectUploadAvatar: %w", err)
-		}
-		defer f.Close()
-		reader = f
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return Output{}, fmt.Errorf("projectUploadAvatar: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
-	}
+	defer cleanup()
 
 	p, _, err := client.GL().Projects.UploadAvatar(string(input.ProjectID), reader, input.Filename, gl.WithContext(ctx))
 	if err != nil {

--- a/internal/tools/resourceevents/shapes.go
+++ b/internal/tools/resourceevents/shapes.go
@@ -93,32 +93,11 @@ func milestoneOutput(m *gl.Milestone) *MilestoneOutput {
 }
 
 // IterationOutput mirrors gl.Iteration (the iteration object on a resource
-// iteration event).
-type IterationOutput struct {
-	ID          int64  `json:"id"`
-	IID         int64  `json:"iid"`
-	Sequence    int64  `json:"sequence"`
-	GroupID     int64  `json:"group_id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	State       int64  `json:"state"`
-	WebURL      string `json:"web_url"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
-	StartDate   string `json:"start_date,omitempty"`
-	DueDate     string `json:"due_date,omitempty"`
-}
+// iteration event). Canonical shape shared via toolutil.
+type IterationOutput = toolutil.IterationOutput
 
 // iterationOutput converts *gl.Iteration to its output shape, returning nil
 // when the SDK value is nil.
 func iterationOutput(it *gl.Iteration) *IterationOutput {
-	if it == nil {
-		return nil
-	}
-	return &IterationOutput{
-		ID: it.ID, IID: it.IID, Sequence: it.Sequence, GroupID: it.GroupID,
-		Title: it.Title, Description: it.Description, State: it.State, WebURL: it.WebURL,
-		CreatedAt: toolutil.FormatTimePtr(it.CreatedAt), UpdatedAt: toolutil.FormatTimePtr(it.UpdatedAt),
-		StartDate: toolutil.FormatISOTimePtr(it.StartDate), DueDate: toolutil.FormatISOTimePtr(it.DueDate),
-	}
+	return toolutil.NewIterationOutput(it)
 }

--- a/internal/tools/securefiles/securefiles.go
+++ b/internal/tools/securefiles/securefiles.go
@@ -1,12 +1,7 @@
 package securefiles
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -166,37 +161,9 @@ type CreateInput struct {
 
 // Create uploads a new secure file.
 func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput) (SecureFileItem, error) {
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return SecureFileItem{}, errors.New("gitlab_create_secure_file: provide either file_path or content_base64, not both")
-	}
-	if !hasFilePath && !hasBase64 {
-		return SecureFileItem{}, errors.New("gitlab_create_secure_file: either file_path or content_base64 is required")
-	}
-
-	var reader *bytes.Reader
-
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, info, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return SecureFileItem{}, fmt.Errorf("gitlab_create_secure_file: %w", err)
-		}
-		defer f.Close()
-
-		data := make([]byte, info.Size())
-		if _, err = io.ReadFull(f, data); err != nil {
-			return SecureFileItem{}, fmt.Errorf("gitlab_create_secure_file: reading file: %w", err)
-		}
-		reader = bytes.NewReader(data)
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return SecureFileItem{}, fmt.Errorf("gitlab_create_secure_file: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
+	reader, err := toolutil.ReadFileOrBase64("gitlab_create_secure_file", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return SecureFileItem{}, err
 	}
 
 	opts := &gl.CreateSecureFileOptions{

--- a/internal/tools/snippetdiscussions/action_specs.go
+++ b/internal/tools/snippetdiscussions/action_specs.go
@@ -94,23 +94,13 @@ func snippetScopeGuidance() map[string]toolutil.ParameterGuidance {
 // discussionIDGuidance returns the parameter guidance for the discussion_id
 // parameter used by discussion-scoped actions.
 func discussionIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "discussion_id",
-		ValueSource:      "Discussion thread id from a prior gitlab_list_snippet_discussions response.",
-		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
-		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
-	}
+	return toolutil.DiscussionIDParamGuidance("Discussion thread id from a prior gitlab_list_snippet_discussions response.")
 }
 
 // noteIDGuidance returns the parameter guidance for the note_id parameter used
 // by note update/delete actions.
 func noteIDGuidance() toolutil.ParameterGuidance {
-	return toolutil.ParameterGuidance{
-		SemanticRole:     "note_id",
-		ValueSource:      "Numeric note id within the discussion thread, from a prior discussion response.",
-		ExampleBinding:   "params.note_id:300",
-		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
-	}
+	return toolutil.DiscussionNoteIDParamGuidance("Numeric note id within the discussion thread, from a prior discussion response.")
 }
 
 // decorateSnippetDiscussionMeta fills in action-specific discovery metadata for

--- a/internal/tools/uploads/uploads.go
+++ b/internal/tools/uploads/uploads.go
@@ -1,12 +1,9 @@
 package uploads
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -56,37 +53,9 @@ func Upload(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.
 		return UploadOutput{}, errors.New("projectUpload: project_id is required. Use gitlab_project_list to find the ID first, then pass it as project_id")
 	}
 
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return UploadOutput{}, errors.New("projectUpload: provide either file_path or content_base64, not both")
-	}
-	if !hasFilePath && !hasBase64 {
-		return UploadOutput{}, errors.New("projectUpload: either file_path or content_base64 is required")
-	}
-
-	var reader *bytes.Reader
-
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, info, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return UploadOutput{}, fmt.Errorf("projectUpload: %w", err)
-		}
-		defer f.Close()
-
-		data := make([]byte, info.Size())
-		if _, err = io.ReadFull(f, data); err != nil {
-			return UploadOutput{}, fmt.Errorf("projectUpload: reading file: %w", err)
-		}
-		reader = bytes.NewReader(data)
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return UploadOutput{}, fmt.Errorf("invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
+	reader, err := toolutil.ReadFileOrBase64("projectUpload", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return UploadOutput{}, err
 	}
 
 	tracker := progress.FromRequest(req)

--- a/internal/tools/users/user_misc.go
+++ b/internal/tools/users/user_misc.go
@@ -1,12 +1,9 @@
 package users
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -52,32 +49,11 @@ func UploadCurrentUserAvatar(ctx context.Context, client *gitlabclient.Client, i
 		return Output{}, errors.New("upload_user_avatar: filename is required")
 	}
 
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return Output{}, errors.New("upload_user_avatar: provide either file_path or content_base64, not both")
+	reader, _, cleanup, err := toolutil.OpenFileOrBase64Source("upload_user_avatar", input.FilePath, input.ContentBase64)
+	if err != nil {
+		return Output{}, err
 	}
-	if !hasFilePath && !hasBase64 {
-		return Output{}, errors.New("upload_user_avatar: either file_path or content_base64 is required")
-	}
-
-	var reader io.Reader
-	if hasFilePath {
-		cfg := toolutil.GetUploadConfig()
-		f, _, err := toolutil.OpenAndValidateFile(input.FilePath, cfg.MaxFileSize)
-		if err != nil {
-			return Output{}, fmt.Errorf("upload_user_avatar: %w", err)
-		}
-		defer f.Close()
-		reader = f
-	} else {
-		decoded, err := base64.StdEncoding.DecodeString(input.ContentBase64)
-		if err != nil {
-			return Output{}, fmt.Errorf("upload_user_avatar: invalid base64 content: %w", err)
-		}
-		reader = bytes.NewReader(decoded)
-	}
+	defer cleanup()
 
 	u, _, err := client.GL().Users.UploadAvatar(reader, input.Filename, gl.WithContext(ctx))
 	if err != nil {

--- a/internal/tools/users/user_service_accounts.go
+++ b/internal/tools/users/user_service_accounts.go
@@ -176,7 +176,7 @@ func CreateCurrentUserPAT(ctx context.Context, client *gitlabclient.Client, inpu
 		return CurrentUserPATOutput{}, toolutil.WrapErrWithStatusHint("create_personal_access_token_for_current_user", err, http.StatusBadRequest,
 			"name is required; scopes must include valid PAT scopes (e.g. api, read_user, read_repository, write_repository); expires_at format YYYY-MM-DD")
 	}
-	return toolutil.NewPersonalTokenOutput(token), nil
+	return toCurrentUserPATOutput(token), nil
 }
 
 // --- Markdown formatters ---.
@@ -230,4 +230,10 @@ func FormatCurrentUserPATMarkdownString(out CurrentUserPATOutput) string {
 		fmt.Fprintf(&sb, "- **Token**: `%s`\n", out.Token)
 	}
 	return sb.String()
+}
+
+// toCurrentUserPATOutput converts a gl.PersonalAccessToken into the shared
+// output shape.
+func toCurrentUserPATOutput(t *gl.PersonalAccessToken) CurrentUserPATOutput {
+	return toolutil.NewPersonalTokenOutput(t)
 }

--- a/internal/tools/users/user_service_accounts.go
+++ b/internal/tools/users/user_service_accounts.go
@@ -43,20 +43,9 @@ type ListServiceAccountsInput struct {
 	toolutil.KeysetPaginationInput
 }
 
-// CurrentUserPATOutput represents a personal access token.
-type CurrentUserPATOutput struct {
-	ID          int64    `json:"id"`
-	Name        string   `json:"name"`
-	Active      bool     `json:"active"`
-	Token       string   `json:"token,omitempty"`
-	Scopes      []string `json:"scopes"`
-	Revoked     bool     `json:"revoked"`
-	Description string   `json:"description,omitempty"`
-	UserID      int64    `json:"user_id"`
-	CreatedAt   string   `json:"created_at,omitempty"`
-	ExpiresAt   string   `json:"expires_at,omitempty"`
-	LastUsedAt  string   `json:"last_used_at,omitempty"`
-}
+// CurrentUserPATOutput mirrors gl.PersonalAccessToken for the current-user
+// PAT tools. Canonical shape shared via toolutil.
+type CurrentUserPATOutput = toolutil.PersonalTokenOutput
 
 // CreateCurrentUserPATInput holds parameters for creating a PAT for the current user.
 type CreateCurrentUserPATInput struct {
@@ -187,30 +176,7 @@ func CreateCurrentUserPAT(ctx context.Context, client *gitlabclient.Client, inpu
 		return CurrentUserPATOutput{}, toolutil.WrapErrWithStatusHint("create_personal_access_token_for_current_user", err, http.StatusBadRequest,
 			"name is required; scopes must include valid PAT scopes (e.g. api, read_user, read_repository, write_repository); expires_at format YYYY-MM-DD")
 	}
-	return toCurrentUserPATOutput(token), nil
-}
-
-func toCurrentUserPATOutput(t *gl.PersonalAccessToken) CurrentUserPATOutput {
-	o := CurrentUserPATOutput{
-		ID:          t.ID,
-		Name:        t.Name,
-		Active:      t.Active,
-		Token:       t.Token,
-		Scopes:      t.Scopes,
-		Revoked:     t.Revoked,
-		Description: t.Description,
-		UserID:      t.UserID,
-	}
-	if t.CreatedAt != nil {
-		o.CreatedAt = t.CreatedAt.Format(time.RFC3339)
-	}
-	if t.ExpiresAt != nil {
-		o.ExpiresAt = time.Time(*t.ExpiresAt).Format(toolutil.DateFormatISO)
-	}
-	if t.LastUsedAt != nil {
-		o.LastUsedAt = t.LastUsedAt.Format(time.RFC3339)
-	}
-	return o
+	return toolutil.NewPersonalTokenOutput(token), nil
 }
 
 // --- Markdown formatters ---.

--- a/internal/tools/users/users.go
+++ b/internal/tools/users/users.go
@@ -84,23 +84,12 @@ type SCIMIdentityOutput struct {
 }
 
 // CustomAttributeOutput mirrors gl.CustomAttribute, a key/value custom
-// attribute attached to a user.
-type CustomAttributeOutput struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
+// attribute attached to a user. Canonical shape shared via toolutil.
+type CustomAttributeOutput = toolutil.CustomAttributeOutput
 
 // BasicUserOutput mirrors gl.BasicUser, the compact user object referenced by
-// gl.User.CreatedBy.
-type BasicUserOutput struct {
-	ID        int64  `json:"id"`
-	Username  string `json:"username"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	AvatarURL string `json:"avatar_url,omitempty"`
-	WebURL    string `json:"web_url,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-}
+// gl.User.CreatedBy. Canonical shape shared via toolutil.
+type BasicUserOutput = toolutil.UserRefOutput
 
 // CurrentInput is an empty struct for the current user tool (no parameters needed).
 type CurrentInput struct{}
@@ -547,31 +536,13 @@ func GetAssociationsCount(ctx context.Context, client *gitlabclient.Client, inpu
 	}, nil
 }
 
-// resolveProjectWebURLs fetches the web URL for each unique project ID.
-// Failures are silently ignored — missing URLs simply produce no links.
-func resolveProjectWebURLs(ctx context.Context, client *gitlabclient.Client, projectIDs []int64) map[int64]string {
-	seen := make(map[int64]string, len(projectIDs))
-	for _, id := range projectIDs {
-		if _, ok := seen[id]; ok || id == 0 {
-			continue
-		}
-		proj, _, err := client.GL().Projects.GetProject(id, &gl.GetProjectOptions{}, gl.WithContext(ctx))
-		if err != nil || proj == nil {
-			seen[id] = ""
-			continue
-		}
-		seen[id] = proj.WebURL
-	}
-	return seen
-}
-
 // enrichContributionEventURLs resolves project web URLs and sets TargetURL on each event.
 func enrichContributionEventURLs(ctx context.Context, client *gitlabclient.Client, events []ContributionEventOutput) {
 	ids := make([]int64, 0, len(events))
 	for i := range events {
 		ids = append(ids, events[i].ProjectID)
 	}
-	urls := resolveProjectWebURLs(ctx, client, ids)
+	urls := toolutil.ResolveProjectWebURLs(ctx, client.GL().Projects, ids)
 	for i := range events {
 		events[i].TargetURL = toolutil.BuildTargetURL(urls[events[i].ProjectID], events[i].TargetType, events[i].TargetIID)
 	}
@@ -623,8 +594,8 @@ func toOutput(u *gl.User) Output {
 		NamespaceID:                    u.NamespaceID,
 		Identities:                     toIdentityOutputs(u.Identities),
 		SCIMIdentities:                 toSCIMIdentityOutputs(u.SCIMIdentities),
-		CustomAttributes:               toCustomAttributeOutputs(u.CustomAttributes),
-		CreatedBy:                      toBasicUserOutput(u.CreatedBy),
+		CustomAttributes:               toolutil.NewCustomAttributeOutputs(u.CustomAttributes),
+		CreatedBy:                      toolutil.NewUserRefOutput(u.CreatedBy),
 	}
 	if u.CreatedAt != nil {
 		out.CreatedAt = u.CreatedAt.Format(time.RFC3339)
@@ -665,41 +636,6 @@ func toIdentityOutputs(identities []*gl.UserIdentity) []IdentityOutput {
 		return nil
 	}
 	return out
-}
-
-func toCustomAttributeOutputs(attrs []*gl.CustomAttribute) []CustomAttributeOutput {
-	if len(attrs) == 0 {
-		return nil
-	}
-	out := make([]CustomAttributeOutput, 0, len(attrs))
-	for _, a := range attrs {
-		if a == nil {
-			continue
-		}
-		out = append(out, CustomAttributeOutput{Key: a.Key, Value: a.Value})
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func toBasicUserOutput(u *gl.BasicUser) *BasicUserOutput {
-	if u == nil {
-		return nil
-	}
-	o := &BasicUserOutput{
-		ID:        u.ID,
-		Username:  u.Username,
-		Name:      u.Name,
-		State:     u.State,
-		AvatarURL: u.AvatarURL,
-		WebURL:    u.WebURL,
-	}
-	if u.CreatedAt != nil {
-		o.CreatedAt = u.CreatedAt.Format(time.RFC3339)
-	}
-	return o
 }
 
 func toSCIMIdentityOutputs(identities []*gl.SCIMIdentity) []SCIMIdentityOutput {

--- a/internal/tools/users/users.go
+++ b/internal/tools/users/users.go
@@ -550,6 +550,18 @@ func enrichContributionEventURLs(ctx context.Context, client *gitlabclient.Clien
 
 // Conversion helpers.
 
+// toCustomAttributeOutputs converts a []*gl.CustomAttribute slice into the
+// shared output shape.
+func toCustomAttributeOutputs(attrs []*gl.CustomAttribute) []CustomAttributeOutput {
+	return toolutil.NewCustomAttributeOutputs(attrs)
+}
+
+// toBasicUserOutput converts a *gl.BasicUser into the shared user-reference
+// shape, or nil.
+func toBasicUserOutput(u *gl.BasicUser) *BasicUserOutput {
+	return toolutil.NewUserRefOutput(u)
+}
+
 // toOutput converts a GitLab User to our Output type.
 func toOutput(u *gl.User) Output {
 	if u == nil {
@@ -594,8 +606,8 @@ func toOutput(u *gl.User) Output {
 		NamespaceID:                    u.NamespaceID,
 		Identities:                     toIdentityOutputs(u.Identities),
 		SCIMIdentities:                 toSCIMIdentityOutputs(u.SCIMIdentities),
-		CustomAttributes:               toolutil.NewCustomAttributeOutputs(u.CustomAttributes),
-		CreatedBy:                      toolutil.NewUserRefOutput(u.CreatedBy),
+		CustomAttributes:               toCustomAttributeOutputs(u.CustomAttributes),
+		CreatedBy:                      toBasicUserOutput(u.CreatedBy),
 	}
 	if u.CreatedAt != nil {
 		out.CreatedAt = u.CreatedAt.Format(time.RFC3339)

--- a/internal/tools/users/users_audit_test.go
+++ b/internal/tools/users/users_audit_test.go
@@ -126,13 +126,13 @@ func TestToOutput_NilAndEmptySubObjects(t *testing.T) {
 	if got := toIdentityOutputs([]*gl.UserIdentity{nil}); got != nil {
 		t.Errorf("toIdentityOutputs([nil]) = %+v, want nil", got)
 	}
-	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{}); got != nil {
+	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{}); got != nil {
 		t.Errorf("toCustomAttributeOutputs(empty) = %+v, want nil", got)
 	}
-	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
+	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
 		t.Errorf("toCustomAttributeOutputs([nil]) = %+v, want nil", got)
 	}
-	if got := toBasicUserOutput(nil); got != nil {
+	if got := toolutil.NewUserRefOutput(nil); got != nil {
 		t.Errorf("toBasicUserOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/users/users_audit_test.go
+++ b/internal/tools/users/users_audit_test.go
@@ -126,13 +126,13 @@ func TestToOutput_NilAndEmptySubObjects(t *testing.T) {
 	if got := toIdentityOutputs([]*gl.UserIdentity{nil}); got != nil {
 		t.Errorf("toIdentityOutputs([nil]) = %+v, want nil", got)
 	}
-	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{}); got != nil {
+	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{}); got != nil {
 		t.Errorf("toCustomAttributeOutputs(empty) = %+v, want nil", got)
 	}
-	if got := toolutil.NewCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
+	if got := toCustomAttributeOutputs([]*gl.CustomAttribute{nil}); got != nil {
 		t.Errorf("toCustomAttributeOutputs([nil]) = %+v, want nil", got)
 	}
-	if got := toolutil.NewUserRefOutput(nil); got != nil {
+	if got := toBasicUserOutput(nil); got != nil {
 		t.Errorf("toBasicUserOutput(nil) = %+v, want nil", got)
 	}
 }

--- a/internal/tools/users/users_test.go
+++ b/internal/tools/users/users_test.go
@@ -1551,7 +1551,7 @@ func TestResolveProjectWebURLs_Success(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	urls := resolveProjectWebURLs(context.Background(), client, []int64{10})
+	urls := toolutil.ResolveProjectWebURLs(context.Background(), client.GL().Projects, []int64{10})
 	if got := urls[10]; got != "https://gitlab.example.com/group/project" {
 		t.Errorf("urls[10] = %q, want %q", got, "https://gitlab.example.com/group/project")
 	}

--- a/internal/tools/wikis/action_specs_test.go
+++ b/internal/tools/wikis/action_specs_test.go
@@ -98,9 +98,9 @@ func TestWikiCreate_BadRequest(t *testing.T) {
 }
 
 // TestResolveAttachmentReader_InvalidBase64 covers the base64 decode error
-// branch in resolveAttachmentReader.
+// branch of the shared toolutil.ReadFileOrBase64 helper as used by the wiki attachment upload.
 func TestResolveAttachmentReader_InvalidBase64(t *testing.T) {
-	_, err := resolveAttachmentReader("", "!!!not-base64!!!")
+	_, err := toolutil.ReadFileOrBase64("upload_wiki_attachment", "", "!!!not-base64!!!")
 	if err == nil {
 		t.Fatal("expected error for invalid base64, got nil")
 	}
@@ -110,9 +110,9 @@ func TestResolveAttachmentReader_InvalidBase64(t *testing.T) {
 }
 
 // TestResolveAttachmentReader_InvalidFilePath covers the file open error
-// branch in resolveAttachmentReader when the file does not exist.
+// branch of the shared toolutil.ReadFileOrBase64 helper as used by the wiki attachment upload when the file does not exist.
 func TestResolveAttachmentReader_InvalidFilePath(t *testing.T) {
-	_, err := resolveAttachmentReader("/nonexistent/path/to/file.txt", "")
+	_, err := toolutil.ReadFileOrBase64("upload_wiki_attachment", "/nonexistent/path/to/file.txt", "")
 	if err == nil {
 		t.Fatal("expected error for nonexistent file, got nil")
 	}
@@ -126,7 +126,7 @@ func TestResolveAttachmentReader_ValidFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	r, err := resolveAttachmentReader(path, "")
+	r, err := toolutil.ReadFileOrBase64("upload_wiki_attachment", path, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/tools/wikis/wikis.go
+++ b/internal/tools/wikis/wikis.go
@@ -1,12 +1,8 @@
 package wikis
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
@@ -243,30 +239,6 @@ type AttachmentOutput struct {
 	Markdown string `json:"markdown"`
 }
 
-// resolveAttachmentReader builds a bytes.Reader from either a file path or base64 content.
-func resolveAttachmentReader(filePath, contentBase64 string) (*bytes.Reader, error) {
-	if filePath != "" {
-		cfg := toolutil.GetUploadConfig()
-		f, info, err := toolutil.OpenAndValidateFile(filePath, cfg.MaxFileSize)
-		if err != nil {
-			return nil, fmt.Errorf("upload_wiki_attachment: %w", err)
-		}
-		defer f.Close()
-
-		data := make([]byte, info.Size())
-		if _, err = io.ReadFull(f, data); err != nil {
-			return nil, fmt.Errorf("upload_wiki_attachment: reading file: %w", err)
-		}
-		return bytes.NewReader(data), nil
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(contentBase64)
-	if err != nil {
-		return nil, fmt.Errorf("upload_wiki_attachment: invalid base64 content: %w", err)
-	}
-	return bytes.NewReader(decoded), nil
-}
-
 // UploadAttachment uploads a file attachment to a project wiki.
 func UploadAttachment(ctx context.Context, client *gitlabclient.Client, input UploadAttachmentInput) (AttachmentOutput, error) {
 	if input.ProjectID == "" {
@@ -276,17 +248,7 @@ func UploadAttachment(ctx context.Context, client *gitlabclient.Client, input Up
 		return AttachmentOutput{}, errors.New("upload_wiki_attachment: filename is required")
 	}
 
-	hasFilePath := input.FilePath != ""
-	hasBase64 := input.ContentBase64 != ""
-
-	if hasFilePath && hasBase64 {
-		return AttachmentOutput{}, errors.New("upload_wiki_attachment: provide either file_path or content_base64, not both")
-	}
-	if !hasFilePath && !hasBase64 {
-		return AttachmentOutput{}, errors.New("upload_wiki_attachment: either file_path or content_base64 is required")
-	}
-
-	reader, err := resolveAttachmentReader(input.FilePath, input.ContentBase64)
+	reader, err := toolutil.ReadFileOrBase64("upload_wiki_attachment", input.FilePath, input.ContentBase64)
 	if err != nil {
 		return AttachmentOutput{}, err
 	}

--- a/internal/toolutil/boardshapes.go
+++ b/internal/toolutil/boardshapes.go
@@ -80,8 +80,9 @@ type BoardLabelDetailsOutput struct {
 }
 
 // NewBoardLabelDetailsOutputs converts a slice of gl.LabelDetails into the
-// documented board label subset, skipping nil elements and returning nil for
-// an empty input.
+// documented board label subset, skipping nil elements and returning nil
+// when no labels remain (consistent with NewCustomAttributeOutputs, so
+// callers never serialize an empty array for an effectively-empty input).
 func NewBoardLabelDetailsOutputs(details []*gl.LabelDetails) []*BoardLabelDetailsOutput {
 	if len(details) == 0 {
 		return nil
@@ -94,6 +95,9 @@ func NewBoardLabelDetailsOutputs(details []*gl.LabelDetails) []*BoardLabelDetail
 		out = append(out, &BoardLabelDetailsOutput{
 			ID: d.ID, Name: d.Name, Color: d.Color, Description: d.Description,
 		})
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/toolutil/boardshapes.go
+++ b/internal/toolutil/boardshapes.go
@@ -1,0 +1,110 @@
+package toolutil
+
+import (
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// BoardUserOutput is the documented 6-field board assignee object shared by
+// the project boards and group boards APIs (doc/api/boards.md and
+// doc/api/group_boards.md). The documented update-board responses show only
+// id, name, username, state, avatar_url, and web_url; gl.BasicUser's
+// created_at is not part of the documented board assignee shape.
+type BoardUserOutput struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url"`
+	WebURL    string `json:"web_url"`
+}
+
+// NewBoardUserOutput converts a gl.BasicUser into the documented board
+// assignee subset, returning nil when the SDK value is nil.
+func NewBoardUserOutput(u *gl.BasicUser) *BoardUserOutput {
+	if u == nil {
+		return nil
+	}
+	return &BoardUserOutput{
+		ID: u.ID, Username: u.Username, Name: u.Name, State: u.State,
+		AvatarURL: u.AvatarURL, WebURL: u.WebURL,
+	}
+}
+
+// BoardListAssigneeOutput is the compact assignee object on a board list
+// (Premium/Ultimate assignee list type), matching gl.BoardListAssignee. The
+// documented response examples cover only label and milestone lists, so this
+// premium list-type sub-object has no fuller documented shape to trim against.
+type BoardListAssigneeOutput struct {
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+}
+
+// NewBoardListAssigneeOutput converts a gl.BoardListAssignee into the shared
+// output shape, returning nil when the SDK value is nil.
+func NewBoardListAssigneeOutput(a *gl.BoardListAssignee) *BoardListAssigneeOutput {
+	if a == nil {
+		return nil
+	}
+	return &BoardListAssigneeOutput{ID: a.ID, Name: a.Name, Username: a.Username}
+}
+
+// BoardLabelOutput is the documented board-list label object. Every
+// documented board-list response shows the list's `label` object with only
+// name, color, and description; gl.Label's remaining fields are not part of
+// the documented board-list label shape.
+type BoardLabelOutput struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// NewBoardLabelOutput converts a gl.Label into the documented board-list
+// label subset, returning nil when the SDK value is nil.
+func NewBoardLabelOutput(l *gl.Label) *BoardLabelOutput {
+	if l == nil {
+		return nil
+	}
+	return &BoardLabelOutput{Name: l.Name, Color: l.Color, Description: l.Description}
+}
+
+// BoardLabelDetailsOutput is the documented board `labels[]` entry. The
+// documented update-board responses show only id, name, color, and
+// description for each label; the SDK label types' remaining fields are not
+// part of the documented board labels shape.
+type BoardLabelDetailsOutput struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// NewBoardLabelDetailsOutputs converts a slice of gl.LabelDetails into the
+// documented board label subset, skipping nil elements and returning nil for
+// an empty input.
+func NewBoardLabelDetailsOutputs(details []*gl.LabelDetails) []*BoardLabelDetailsOutput {
+	if len(details) == 0 {
+		return nil
+	}
+	out := make([]*BoardLabelDetailsOutput, 0, len(details))
+	for _, d := range details {
+		if d == nil {
+			continue
+		}
+		out = append(out, &BoardLabelDetailsOutput{
+			ID: d.ID, Name: d.Name, Color: d.Color, Description: d.Description,
+		})
+	}
+	return out
+}
+
+// NewIterationOutputFromProjectIteration converts a gl.ProjectIteration
+// pointer (the type surfaced on board lists) into the canonical iteration
+// object. gl.ProjectIteration has the same field layout as gl.Iteration but
+// with a separate type identity for documentation.
+func NewIterationOutputFromProjectIteration(it *gl.ProjectIteration) *IterationOutput {
+	if it == nil {
+		return nil
+	}
+	return NewIterationOutput((*gl.Iteration)(it))
+}

--- a/internal/toolutil/boardshapes_test.go
+++ b/internal/toolutil/boardshapes_test.go
@@ -1,0 +1,106 @@
+package toolutil
+
+import (
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// TestNewBoardUserOutput pins the documented board assignee conversion:
+// nil-on-nil plus a full mirror of the 6 documented fields.
+func TestNewBoardUserOutput(t *testing.T) {
+	if got := NewBoardUserOutput(nil); got != nil {
+		t.Fatalf("NewBoardUserOutput(nil) = %+v, want nil", got)
+	}
+
+	in := &gl.BasicUser{
+		ID: 5, Username: "jdoe", Name: "John Doe", State: "active",
+		AvatarURL: "https://example.com/a.png", WebURL: "https://example.com/jdoe",
+	}
+	got := NewBoardUserOutput(in)
+	if got == nil {
+		t.Fatal("NewBoardUserOutput returned nil for non-nil input")
+	}
+	if got.ID != 5 || got.Username != "jdoe" || got.Name != "John Doe" ||
+		got.State != "active" || got.AvatarURL != in.AvatarURL || got.WebURL != in.WebURL {
+		t.Errorf("NewBoardUserOutput = %+v, want mirror of %+v", got, in)
+	}
+}
+
+// TestNewBoardListAssigneeOutput pins the compact board-list assignee
+// conversion: nil-on-nil plus the 3-field mirror.
+func TestNewBoardListAssigneeOutput(t *testing.T) {
+	if got := NewBoardListAssigneeOutput(nil); got != nil {
+		t.Fatalf("NewBoardListAssigneeOutput(nil) = %+v, want nil", got)
+	}
+
+	got := NewBoardListAssigneeOutput(&gl.BoardListAssignee{ID: 9, Name: "Jane", Username: "jane"})
+	if got == nil || got.ID != 9 || got.Name != "Jane" || got.Username != "jane" {
+		t.Errorf("NewBoardListAssigneeOutput = %+v, want {9 Jane jane}", got)
+	}
+}
+
+// TestNewBoardLabelOutput pins the documented board-list label conversion:
+// nil-on-nil plus the name/color/description mirror.
+func TestNewBoardLabelOutput(t *testing.T) {
+	if got := NewBoardLabelOutput(nil); got != nil {
+		t.Fatalf("NewBoardLabelOutput(nil) = %+v, want nil", got)
+	}
+
+	got := NewBoardLabelOutput(&gl.Label{Name: "bug", Color: "#ff0000", Description: "defects"})
+	if got == nil || got.Name != "bug" || got.Color != "#ff0000" || got.Description != "defects" {
+		t.Errorf("NewBoardLabelOutput = %+v, want {bug #ff0000 defects}", got)
+	}
+}
+
+// TestNewBoardLabelDetailsOutputs pins the board labels[] conversion:
+// nil/empty inputs return nil, nil elements are skipped, and populated
+// entries mirror id, name, color, and description.
+func TestNewBoardLabelDetailsOutputs(t *testing.T) {
+	if got := NewBoardLabelDetailsOutputs(nil); got != nil {
+		t.Fatalf("NewBoardLabelDetailsOutputs(nil) = %+v, want nil", got)
+	}
+	if got := NewBoardLabelDetailsOutputs([]*gl.LabelDetails{}); got != nil {
+		t.Fatalf("NewBoardLabelDetailsOutputs(empty) = %+v, want nil", got)
+	}
+
+	in := []*gl.LabelDetails{
+		{ID: 1, Name: "bug", Color: "#f00", Description: "defects"},
+		nil,
+		{ID: 2, Name: "feat", Color: "#0f0", Description: "features"},
+	}
+	got := NewBoardLabelDetailsOutputs(in)
+	if len(got) != 2 {
+		t.Fatalf("NewBoardLabelDetailsOutputs len = %d, want 2 (nil element skipped)", len(got))
+	}
+	if got[0].ID != 1 || got[0].Name != "bug" || got[1].ID != 2 || got[1].Color != "#0f0" {
+		t.Errorf("NewBoardLabelDetailsOutputs = %+v, want mirrors of input entries", got)
+	}
+}
+
+// TestNewIterationOutputFromProjectIteration pins the ProjectIteration →
+// canonical iteration conversion: nil-on-nil plus a full field mirror
+// including formatted timestamps and ISO dates.
+func TestNewIterationOutputFromProjectIteration(t *testing.T) {
+	if got := NewIterationOutputFromProjectIteration(nil); got != nil {
+		t.Fatalf("NewIterationOutputFromProjectIteration(nil) = %+v, want nil", got)
+	}
+
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	start := gl.ISOTime(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+	got := NewIterationOutputFromProjectIteration(&gl.ProjectIteration{
+		ID: 3, IID: 1, Sequence: 2, GroupID: 42,
+		Title: "Sprint 1", Description: "first", State: 1, WebURL: "https://example.com/it/3",
+		CreatedAt: &created, StartDate: &start,
+	})
+	if got == nil {
+		t.Fatal("NewIterationOutputFromProjectIteration returned nil for non-nil input")
+	}
+	if got.ID != 3 || got.GroupID != 42 || got.Title != "Sprint 1" || got.State != 1 {
+		t.Errorf("NewIterationOutputFromProjectIteration identity fields = %+v", got)
+	}
+	if got.CreatedAt == "" || got.StartDate == "" {
+		t.Errorf("NewIterationOutputFromProjectIteration dates not mapped: %+v", got)
+	}
+}

--- a/internal/toolutil/boardshapes_test.go
+++ b/internal/toolutil/boardshapes_test.go
@@ -64,6 +64,9 @@ func TestNewBoardLabelDetailsOutputs(t *testing.T) {
 	if got := NewBoardLabelDetailsOutputs([]*gl.LabelDetails{}); got != nil {
 		t.Fatalf("NewBoardLabelDetailsOutputs(empty) = %+v, want nil", got)
 	}
+	if got := NewBoardLabelDetailsOutputs([]*gl.LabelDetails{nil, nil}); got != nil {
+		t.Fatalf("NewBoardLabelDetailsOutputs(all nil) = %+v, want nil", got)
+	}
 
 	in := []*gl.LabelDetails{
 		{ID: 1, Name: "bug", Color: "#f00", Description: "defects"},
@@ -94,13 +97,12 @@ func TestNewIterationOutputFromProjectIteration(t *testing.T) {
 		Title: "Sprint 1", Description: "first", State: 1, WebURL: "https://example.com/it/3",
 		CreatedAt: &created, StartDate: &start,
 	})
-	if got == nil {
-		t.Fatal("NewIterationOutputFromProjectIteration returned nil for non-nil input")
+	want := &IterationOutput{
+		ID: 3, IID: 1, Sequence: 2, GroupID: 42,
+		Title: "Sprint 1", Description: "first", State: 1, WebURL: "https://example.com/it/3",
+		CreatedAt: FormatTimePtr(&created), StartDate: FormatISOTimePtr(&start),
 	}
-	if got.ID != 3 || got.GroupID != 42 || got.Title != "Sprint 1" || got.State != 1 {
-		t.Errorf("NewIterationOutputFromProjectIteration identity fields = %+v", got)
-	}
-	if got.CreatedAt == "" || got.StartDate == "" {
-		t.Errorf("NewIterationOutputFromProjectIteration dates not mapped: %+v", got)
+	if got == nil || *got != *want {
+		t.Errorf("NewIterationOutputFromProjectIteration = %+v, want %+v", got, want)
 	}
 }

--- a/internal/toolutil/discussion_guidance.go
+++ b/internal/toolutil/discussion_guidance.go
@@ -1,0 +1,30 @@
+package toolutil
+
+// DiscussionIDParamGuidance returns the canonical parameter guidance for the
+// discussion_id parameter used by discussion-scoped actions across the
+// discussion domains (MR, issue, snippet, commit, epic). valueSource is the
+// domain-specific description of where the thread id comes from; the semantic
+// role, example binding, and thread-vs-note confusion note are identical for
+// every domain.
+func DiscussionIDParamGuidance(valueSource string) ParameterGuidance {
+	return ParameterGuidance{
+		SemanticRole:     "discussion_id",
+		ValueSource:      valueSource,
+		ExampleBinding:   `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"`,
+		CommonConfusions: []string{"The discussion_id is the thread hash, not a note id; pass note_id separately for note actions."},
+	}
+}
+
+// DiscussionNoteIDParamGuidance returns the canonical parameter guidance for
+// the note_id parameter of discussion note update/delete actions. valueSource
+// is the domain-specific description of where the note id comes from; the
+// semantic role, example binding, and note-vs-thread confusion note are
+// identical for every discussion domain.
+func DiscussionNoteIDParamGuidance(valueSource string) ParameterGuidance {
+	return ParameterGuidance{
+		SemanticRole:     "note_id",
+		ValueSource:      valueSource,
+		ExampleBinding:   "params.note_id:300",
+		CommonConfusions: []string{"note_id is the numeric id of a single note; discussion_id is the thread hash."},
+	}
+}

--- a/internal/toolutil/discussion_guidance_test.go
+++ b/internal/toolutil/discussion_guidance_test.go
@@ -1,0 +1,43 @@
+package toolutil
+
+import "testing"
+
+// TestDiscussionIDParamGuidance pins the canonical discussion_id guidance:
+// the caller-supplied value source is passed through verbatim while the
+// semantic role, example binding, and confusion note stay fixed.
+func TestDiscussionIDParamGuidance(t *testing.T) {
+	src := "Discussion thread id from a prior gitlab_mr_discussion_list response."
+	got := DiscussionIDParamGuidance(src)
+	if got.SemanticRole != "discussion_id" {
+		t.Errorf("SemanticRole = %q, want discussion_id", got.SemanticRole)
+	}
+	if got.ValueSource != src {
+		t.Errorf("ValueSource = %q, want %q", got.ValueSource, src)
+	}
+	if got.ExampleBinding != `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"` {
+		t.Errorf("ExampleBinding = %q", got.ExampleBinding)
+	}
+	if len(got.CommonConfusions) != 1 || got.CommonConfusions[0] == "" {
+		t.Errorf("CommonConfusions = %v, want the fixed thread-vs-note note", got.CommonConfusions)
+	}
+}
+
+// TestDiscussionNoteIDParamGuidance pins the canonical note_id guidance for
+// discussion note actions: pass-through value source plus fixed role,
+// example, and confusion note.
+func TestDiscussionNoteIDParamGuidance(t *testing.T) {
+	src := "Numeric note id within the discussion thread, from a prior discussion response."
+	got := DiscussionNoteIDParamGuidance(src)
+	if got.SemanticRole != "note_id" {
+		t.Errorf("SemanticRole = %q, want note_id", got.SemanticRole)
+	}
+	if got.ValueSource != src {
+		t.Errorf("ValueSource = %q, want %q", got.ValueSource, src)
+	}
+	if got.ExampleBinding != "params.note_id:300" {
+		t.Errorf("ExampleBinding = %q, want params.note_id:300", got.ExampleBinding)
+	}
+	if len(got.CommonConfusions) != 1 || got.CommonConfusions[0] == "" {
+		t.Errorf("CommonConfusions = %v, want the fixed note-vs-thread note", got.CommonConfusions)
+	}
+}

--- a/internal/toolutil/discussion_guidance_test.go
+++ b/internal/toolutil/discussion_guidance_test.go
@@ -17,7 +17,8 @@ func TestDiscussionIDParamGuidance(t *testing.T) {
 	if got.ExampleBinding != `params.discussion_id:"6a9c1750b37d513a43987b574953fceb50b03ce7"` {
 		t.Errorf("ExampleBinding = %q", got.ExampleBinding)
 	}
-	if len(got.CommonConfusions) != 1 || got.CommonConfusions[0] == "" {
+	if len(got.CommonConfusions) != 1 ||
+		got.CommonConfusions[0] != "The discussion_id is the thread hash, not a note id; pass note_id separately for note actions." {
 		t.Errorf("CommonConfusions = %v, want the fixed thread-vs-note note", got.CommonConfusions)
 	}
 }
@@ -37,7 +38,8 @@ func TestDiscussionNoteIDParamGuidance(t *testing.T) {
 	if got.ExampleBinding != "params.note_id:300" {
 		t.Errorf("ExampleBinding = %q, want params.note_id:300", got.ExampleBinding)
 	}
-	if len(got.CommonConfusions) != 1 || got.CommonConfusions[0] == "" {
+	if len(got.CommonConfusions) != 1 ||
+		got.CommonConfusions[0] != "note_id is the numeric id of a single note; discussion_id is the thread hash." {
 		t.Errorf("CommonConfusions = %v, want the fixed note-vs-thread note", got.CommonConfusions)
 	}
 }

--- a/internal/toolutil/filesource.go
+++ b/internal/toolutil/filesource.go
@@ -1,0 +1,75 @@
+package toolutil
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// validateFileOrBase64 enforces the mutually-exclusive file_path /
+// content_base64 contract shared by every upload-style tool input.
+func validateFileOrBase64(op, filePath, contentBase64 string) error {
+	hasFilePath := filePath != ""
+	hasBase64 := contentBase64 != ""
+	if hasFilePath && hasBase64 {
+		return fmt.Errorf("%s: provide either file_path or content_base64, not both", op)
+	}
+	if !hasFilePath && !hasBase64 {
+		return fmt.Errorf("%s: either file_path or content_base64 is required", op)
+	}
+	return nil
+}
+
+// OpenFileOrBase64Source resolves the mutually-exclusive file_path /
+// content_base64 upload input pair into a streaming reader plus the source
+// size and a cleanup func the caller must defer. file_path is opened and
+// validated against the configured upload size limit and streamed without
+// buffering; content_base64 is decoded in memory. All errors are prefixed
+// with op, matching the per-tool error convention.
+func OpenFileOrBase64Source(op, filePath, contentBase64 string) (reader io.Reader, size int64, cleanup func(), err error) {
+	if invalidErr := validateFileOrBase64(op, filePath, contentBase64); invalidErr != nil {
+		return nil, 0, nil, invalidErr
+	}
+	if filePath != "" {
+		cfg := GetUploadConfig()
+		f, info, openErr := OpenAndValidateFile(filePath, cfg.MaxFileSize)
+		if openErr != nil {
+			return nil, 0, nil, fmt.Errorf("%s: %w", op, openErr)
+		}
+		return f, info.Size(), func() { _ = f.Close() }, nil
+	}
+	decoded, decodeErr := base64.StdEncoding.DecodeString(contentBase64)
+	if decodeErr != nil {
+		return nil, 0, nil, fmt.Errorf("%s: invalid base64 content: %w", op, decodeErr)
+	}
+	return bytes.NewReader(decoded), int64(len(decoded)), func() {}, nil
+}
+
+// ReadFileOrBase64 resolves the mutually-exclusive file_path / content_base64
+// upload input pair into an in-memory bytes.Reader, for endpoints that need a
+// seekable or length-aware body. All errors are prefixed with op.
+func ReadFileOrBase64(op, filePath, contentBase64 string) (*bytes.Reader, error) {
+	if err := validateFileOrBase64(op, filePath, contentBase64); err != nil {
+		return nil, err
+	}
+	if filePath != "" {
+		cfg := GetUploadConfig()
+		f, info, err := OpenAndValidateFile(filePath, cfg.MaxFileSize)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", op, err)
+		}
+		defer func() { _ = f.Close() }()
+
+		data := make([]byte, info.Size())
+		if _, err = io.ReadFull(f, data); err != nil {
+			return nil, fmt.Errorf("%s: reading file: %w", op, err)
+		}
+		return bytes.NewReader(data), nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(contentBase64)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid base64 content: %w", op, err)
+	}
+	return bytes.NewReader(decoded), nil
+}

--- a/internal/toolutil/filesource.go
+++ b/internal/toolutil/filesource.go
@@ -39,11 +39,26 @@ func OpenFileOrBase64Source(op, filePath, contentBase64 string) (reader io.Reade
 		}
 		return f, info.Size(), func() { _ = f.Close() }, nil
 	}
-	decoded, decodeErr := base64.StdEncoding.DecodeString(contentBase64)
+	decoded, decodeErr := decodeBase64Content(op, contentBase64)
 	if decodeErr != nil {
-		return nil, 0, nil, fmt.Errorf("%s: invalid base64 content: %w", op, decodeErr)
+		return nil, 0, nil, decodeErr
 	}
 	return bytes.NewReader(decoded), int64(len(decoded)), func() {}, nil
+}
+
+// decodeBase64Content decodes an inline content_base64 payload and enforces
+// the same configured upload size limit that OpenAndValidateFile applies to
+// file_path sources, so neither input branch can bypass MaxFileSize.
+func decodeBase64Content(op, contentBase64 string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(contentBase64)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid base64 content: %w", op, err)
+	}
+	if maxSize := GetUploadConfig().MaxFileSize; maxSize > 0 && int64(len(decoded)) > maxSize {
+		return nil, fmt.Errorf("%s: decoded content is %d bytes, exceeds maximum allowed size of %d bytes",
+			op, len(decoded), maxSize)
+	}
+	return decoded, nil
 }
 
 // ReadFileOrBase64 resolves the mutually-exclusive file_path / content_base64
@@ -67,9 +82,9 @@ func ReadFileOrBase64(op, filePath, contentBase64 string) (*bytes.Reader, error)
 		}
 		return bytes.NewReader(data), nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(contentBase64)
+	decoded, err := decodeBase64Content(op, contentBase64)
 	if err != nil {
-		return nil, fmt.Errorf("%s: invalid base64 content: %w", op, err)
+		return nil, err
 	}
 	return bytes.NewReader(decoded), nil
 }

--- a/internal/toolutil/filesource.go
+++ b/internal/toolutil/filesource.go
@@ -43,18 +43,25 @@ func OpenFileOrBase64Source(op, filePath, contentBase64 string) (reader io.Reade
 	if decodeErr != nil {
 		return nil, 0, nil, decodeErr
 	}
-	return bytes.NewReader(decoded), int64(len(decoded)), func() {}, nil
+	return bytes.NewReader(decoded), int64(len(decoded)), func() { /* in-memory reader; nothing to release */ }, nil
 }
 
 // decodeBase64Content decodes an inline content_base64 payload and enforces
 // the same configured upload size limit that OpenAndValidateFile applies to
-// file_path sources, so neither input branch can bypass MaxFileSize.
+// file_path sources, so neither input branch can bypass MaxFileSize. The
+// limit is checked against base64.DecodedLen before decoding, so an
+// oversized payload is rejected without allocating its decoded form; the
+// exact post-decode check covers the padding slack DecodedLen overestimates.
 func decodeBase64Content(op, contentBase64 string) ([]byte, error) {
+	maxSize := GetUploadConfig().MaxFileSize
+	if maxSize > 0 && int64(base64.StdEncoding.DecodedLen(len(contentBase64))) > maxSize+2 {
+		return nil, fmt.Errorf("%s: decoded content would exceed maximum allowed size of %d bytes", op, maxSize)
+	}
 	decoded, err := base64.StdEncoding.DecodeString(contentBase64)
 	if err != nil {
 		return nil, fmt.Errorf("%s: invalid base64 content: %w", op, err)
 	}
-	if maxSize := GetUploadConfig().MaxFileSize; maxSize > 0 && int64(len(decoded)) > maxSize {
+	if maxSize > 0 && int64(len(decoded)) > maxSize {
 		return nil, fmt.Errorf("%s: decoded content is %d bytes, exceeds maximum allowed size of %d bytes",
 			op, len(decoded), maxSize)
 	}

--- a/internal/toolutil/filesource_test.go
+++ b/internal/toolutil/filesource_test.go
@@ -86,8 +86,8 @@ func TestReadFileOrBase64(t *testing.T) {
 		t.Errorf("file branch = len %v err %v, want len 3 nil", r, err)
 	}
 
-	if _, err = ReadFileOrBase64("op", "/nonexistent/file", ""); err == nil {
-		t.Error("missing file err = nil, want op-prefixed error")
+	if _, err = ReadFileOrBase64("op", "/nonexistent/file", ""); err == nil || !strings.HasPrefix(err.Error(), "op: ") {
+		t.Errorf("missing file err = %v, want op-prefixed error", err)
 	}
 
 	r, err = ReadFileOrBase64("op", "", base64.StdEncoding.EncodeToString([]byte("zz")))

--- a/internal/toolutil/filesource_test.go
+++ b/internal/toolutil/filesource_test.go
@@ -1,0 +1,100 @@
+package toolutil
+
+import (
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOpenFileOrBase64Source_Validation pins the mutually-exclusive input
+// contract: both sources set and neither source set fail with the op-prefixed
+// messages shared by every upload tool.
+func TestOpenFileOrBase64Source_Validation(t *testing.T) {
+	_, _, _, err := OpenFileOrBase64Source("myOp", "/tmp/x", "aGk=")
+	if err == nil || err.Error() != "myOp: provide either file_path or content_base64, not both" {
+		t.Errorf("both-set err = %v, want op-prefixed not-both message", err)
+	}
+
+	_, _, _, err = OpenFileOrBase64Source("myOp", "", "")
+	if err == nil || err.Error() != "myOp: either file_path or content_base64 is required" {
+		t.Errorf("neither-set err = %v, want op-prefixed required message", err)
+	}
+}
+
+// TestOpenFileOrBase64Source_File verifies the streaming file branch: the
+// reader yields the file content, size matches, and cleanup closes the file.
+func TestOpenFileOrBase64Source_File(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "src.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, size, cleanup, err := OpenFileOrBase64Source("myOp", path, "")
+	if err != nil {
+		t.Fatalf("file branch err = %v, want nil", err)
+	}
+	defer cleanup()
+	if size != 5 {
+		t.Errorf("size = %d, want 5", size)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil || string(data) != "hello" {
+		t.Errorf("read = %q (err %v), want hello", data, err)
+	}
+}
+
+// TestOpenFileOrBase64Source_Base64 verifies the base64 branch: valid content
+// decodes with the right size, invalid content fails with the op-prefixed
+// base64 message.
+func TestOpenFileOrBase64Source_Base64(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("payload"))
+	reader, size, cleanup, err := OpenFileOrBase64Source("myOp", "", encoded)
+	if err != nil {
+		t.Fatalf("base64 branch err = %v, want nil", err)
+	}
+	defer cleanup()
+	if size != int64(len("payload")) {
+		t.Errorf("size = %d, want %d", size, len("payload"))
+	}
+	data, _ := io.ReadAll(reader)
+	if string(data) != "payload" {
+		t.Errorf("read = %q, want payload", data)
+	}
+
+	_, _, _, err = OpenFileOrBase64Source("myOp", "", "!!!not-base64!!!")
+	if err == nil || !strings.Contains(err.Error(), "myOp: invalid base64 content") {
+		t.Errorf("invalid base64 err = %v, want op-prefixed base64 message", err)
+	}
+}
+
+// TestReadFileOrBase64 covers the in-memory variant: validation errors,
+// file read, missing file, and base64 decode.
+func TestReadFileOrBase64(t *testing.T) {
+	if _, err := ReadFileOrBase64("op", "", ""); err == nil {
+		t.Error("neither-set err = nil, want required message")
+	}
+
+	path := filepath.Join(t.TempDir(), "src.bin")
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := ReadFileOrBase64("op", path, "")
+	if err != nil || r.Len() != 3 {
+		t.Errorf("file branch = len %v err %v, want len 3 nil", r, err)
+	}
+
+	if _, err = ReadFileOrBase64("op", "/nonexistent/file", ""); err == nil {
+		t.Error("missing file err = nil, want op-prefixed error")
+	}
+
+	r, err = ReadFileOrBase64("op", "", base64.StdEncoding.EncodeToString([]byte("zz")))
+	if err != nil || r.Len() != 2 {
+		t.Errorf("base64 branch = len %v err %v, want len 2 nil", r, err)
+	}
+	if _, err = ReadFileOrBase64("op", "", "!!!"); err == nil || !strings.Contains(err.Error(), "invalid base64 content") {
+		t.Errorf("invalid base64 err = %v, want base64 message", err)
+	}
+}

--- a/internal/toolutil/filesource_test.go
+++ b/internal/toolutil/filesource_test.go
@@ -98,3 +98,27 @@ func TestReadFileOrBase64(t *testing.T) {
 		t.Errorf("invalid base64 err = %v, want base64 message", err)
 	}
 }
+
+// TestFileOrBase64_Base64SizeLimit verifies the content_base64 branch honors
+// the configured MaxFileSize, so inline payloads cannot bypass the limit that
+// OpenAndValidateFile enforces on file_path sources.
+func TestFileOrBase64_Base64SizeLimit(t *testing.T) {
+	original := GetUploadConfig()
+	SetUploadConfig(4)
+	t.Cleanup(func() { SetUploadConfig(original.MaxFileSize) })
+
+	oversized := base64.StdEncoding.EncodeToString([]byte("12345"))
+	if _, _, _, err := OpenFileOrBase64Source("op", "", oversized); err == nil ||
+		!strings.Contains(err.Error(), "exceeds maximum allowed size") {
+		t.Errorf("OpenFileOrBase64Source oversized err = %v, want size-limit error", err)
+	}
+	if _, err := ReadFileOrBase64("op", "", oversized); err == nil ||
+		!strings.Contains(err.Error(), "exceeds maximum allowed size") {
+		t.Errorf("ReadFileOrBase64 oversized err = %v, want size-limit error", err)
+	}
+
+	within := base64.StdEncoding.EncodeToString([]byte("1234"))
+	if _, _, _, err := OpenFileOrBase64Source("op", "", within); err != nil {
+		t.Errorf("OpenFileOrBase64Source within-limit err = %v, want nil", err)
+	}
+}

--- a/internal/toolutil/graphql_note_mutation.go
+++ b/internal/toolutil/graphql_note_mutation.go
@@ -1,0 +1,77 @@
+package toolutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// GraphQLNoteMutation describes one work item note mutation call
+// (createNote/updateNote) so the shared executor can apply the error
+// conventions used by every GraphQL note domain (epic notes, epic
+// discussions): transport errors are wrapped with the operation name and
+// corrective hint, the first mutation payload error becomes "op: message",
+// and a missing note node becomes "op: no note returned".
+type GraphQLNoteMutation struct {
+	// Op is the operation name used in wrapped errors (e.g. "epicNoteCreate").
+	Op string
+	// Hint is the corrective hint attached to transport errors.
+	Hint string
+	// PayloadKey is the mutation payload key in the response data object
+	// ("createNote" or "updateNote").
+	PayloadKey string
+	// Query is the GraphQL mutation document.
+	Query string
+	// Variables holds the mutation variables.
+	Variables map[string]any
+}
+
+// graphQLNotePayload is the generic single-note mutation payload: the mutated
+// note node plus mutation errors.
+type graphQLNotePayload[N any] struct {
+	Note   *N       `json:"note"`
+	Errors []string `json:"errors"`
+}
+
+// ExecGraphQLNoteMutation runs a work item note mutation and returns the
+// mutated note node decoded as N, applying the shared error conventions
+// described on GraphQLNoteMutation.
+func ExecGraphQLNoteMutation[N any](ctx context.Context, gql gl.GraphQLInterface, m GraphQLNoteMutation) (*N, error) {
+	var resp struct {
+		Data map[string]graphQLNotePayload[N] `json:"data"`
+	}
+	if _, err := gql.Do(gl.GraphQLQuery{Query: m.Query, Variables: m.Variables}, &resp, gl.WithContext(ctx)); err != nil {
+		return nil, WrapErrWithHint(m.Op, err, m.Hint)
+	}
+	payload := resp.Data[m.PayloadKey]
+	if len(payload.Errors) > 0 {
+		return nil, fmt.Errorf("%s: %s", m.Op, payload.Errors[0])
+	}
+	if payload.Note == nil {
+		return nil, errors.New(m.Op + ": no note returned")
+	}
+	return payload.Note, nil
+}
+
+// ExecGraphQLDestroyNote runs the destroyNote work item mutation, applying
+// the shared error conventions: transport errors are wrapped with op + hint
+// and the first mutation payload error becomes "op: message".
+func ExecGraphQLDestroyNote(ctx context.Context, gql gl.GraphQLInterface, op, hint, query, noteGID string) error {
+	var resp struct {
+		Data map[string]struct {
+			Errors []string `json:"errors"`
+		} `json:"data"`
+	}
+	if _, err := gql.Do(gl.GraphQLQuery{
+		Query:     query,
+		Variables: map[string]any{"id": noteGID},
+	}, &resp, gl.WithContext(ctx)); err != nil {
+		return WrapErrWithHint(op, err, hint)
+	}
+	if payload := resp.Data["destroyNote"]; len(payload.Errors) > 0 {
+		return fmt.Errorf("%s: %s", op, payload.Errors[0])
+	}
+	return nil
+}

--- a/internal/toolutil/graphql_note_mutation_test.go
+++ b/internal/toolutil/graphql_note_mutation_test.go
@@ -1,0 +1,103 @@
+package toolutil
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// fakeGraphQL is a stub gl.GraphQLInterface that either fails with err or
+// unmarshals body into the caller's response struct.
+type fakeGraphQL struct {
+	body string
+	err  error
+}
+
+func (f fakeGraphQL) Do(_ gl.GraphQLQuery, response any, _ ...gl.RequestOptionFunc) (*gl.Response, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return nil, json.Unmarshal([]byte(f.body), response)
+}
+
+// testNote is the note node shape used by the mutation helper tests.
+type testNote struct {
+	ID   string `json:"id"`
+	Body string `json:"body"`
+}
+
+// TestExecGraphQLNoteMutation_Success verifies the happy path: the payload
+// under the configured key is decoded and its note node returned.
+func TestExecGraphQLNoteMutation_Success(t *testing.T) {
+	gql := fakeGraphQL{body: `{"data":{"createNote":{"note":{"id":"gid://gitlab/Note/7","body":"hi"},"errors":[]}}}`}
+	note, err := ExecGraphQLNoteMutation[testNote](context.Background(), gql, GraphQLNoteMutation{
+		Op: "epicNoteCreate", Hint: "hint", PayloadKey: "createNote", Query: "mutation {}",
+	})
+	if err != nil {
+		t.Fatalf("ExecGraphQLNoteMutation error = %v, want nil", err)
+	}
+	if note == nil || note.ID != "gid://gitlab/Note/7" || note.Body != "hi" {
+		t.Errorf("note = %+v, want decoded node", note)
+	}
+}
+
+// TestExecGraphQLNoteMutation_TransportError verifies transport errors are
+// wrapped with the operation name and hint.
+func TestExecGraphQLNoteMutation_TransportError(t *testing.T) {
+	gql := fakeGraphQL{err: errors.New("boom")}
+	_, err := ExecGraphQLNoteMutation[testNote](context.Background(), gql, GraphQLNoteMutation{
+		Op: "epicNoteCreate", Hint: "check the license", PayloadKey: "createNote",
+	})
+	if err == nil || !strings.Contains(err.Error(), "epicNoteCreate") || !strings.Contains(err.Error(), "check the license") {
+		t.Errorf("err = %v, want op + hint wrapped", err)
+	}
+}
+
+// TestExecGraphQLNoteMutation_MutationError verifies the first payload error
+// is surfaced as "op: message".
+func TestExecGraphQLNoteMutation_MutationError(t *testing.T) {
+	gql := fakeGraphQL{body: `{"data":{"updateNote":{"note":null,"errors":["not allowed","second"]}}}`}
+	_, err := ExecGraphQLNoteMutation[testNote](context.Background(), gql, GraphQLNoteMutation{
+		Op: "epicNoteUpdate", PayloadKey: "updateNote",
+	})
+	if err == nil || err.Error() != "epicNoteUpdate: not allowed" {
+		t.Errorf("err = %v, want %q", err, "epicNoteUpdate: not allowed")
+	}
+}
+
+// TestExecGraphQLNoteMutation_NoNote verifies a nil note node with no errors
+// becomes "op: no note returned".
+func TestExecGraphQLNoteMutation_NoNote(t *testing.T) {
+	gql := fakeGraphQL{body: `{"data":{"createNote":{"note":null,"errors":[]}}}`}
+	_, err := ExecGraphQLNoteMutation[testNote](context.Background(), gql, GraphQLNoteMutation{
+		Op: "epicDiscussionCreate", PayloadKey: "createNote",
+	})
+	if err == nil || err.Error() != "epicDiscussionCreate: no note returned" {
+		t.Errorf("err = %v, want no-note error", err)
+	}
+}
+
+// TestExecGraphQLDestroyNote covers the destroy helper: success, transport
+// error wrapping, and mutation payload error surfacing.
+func TestExecGraphQLDestroyNote(t *testing.T) {
+	ok := fakeGraphQL{body: `{"data":{"destroyNote":{"errors":[]}}}`}
+	if err := ExecGraphQLDestroyNote(context.Background(), ok, "epicNoteDelete", "hint", "mutation {}", "gid://gitlab/Note/7"); err != nil {
+		t.Errorf("success case err = %v, want nil", err)
+	}
+
+	boom := fakeGraphQL{err: errors.New("boom")}
+	err := ExecGraphQLDestroyNote(context.Background(), boom, "epicNoteDelete", "verify note_id", "mutation {}", "gid://gitlab/Note/7")
+	if err == nil || !strings.Contains(err.Error(), "epicNoteDelete") || !strings.Contains(err.Error(), "verify note_id") {
+		t.Errorf("transport err = %v, want op + hint wrapped", err)
+	}
+
+	denied := fakeGraphQL{body: `{"data":{"destroyNote":{"errors":["forbidden"]}}}`}
+	err = ExecGraphQLDestroyNote(context.Background(), denied, "epicNoteDelete", "hint", "mutation {}", "gid://gitlab/Note/7")
+	if err == nil || err.Error() != "epicNoteDelete: forbidden" {
+		t.Errorf("mutation err = %v, want %q", err, "epicNoteDelete: forbidden")
+	}
+}

--- a/internal/toolutil/membershapes.go
+++ b/internal/toolutil/membershapes.go
@@ -1,0 +1,119 @@
+package toolutil
+
+import (
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// MemberUserOutput mirrors gl.MemberCreatedBy (the created_by object).
+type MemberUserOutput struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	WebURL    string `json:"web_url,omitempty"`
+}
+
+// NewMemberUserOutput mirrors a gl.MemberCreatedBy into the shared output
+// shape, returning nil when the SDK value is nil.
+func NewMemberUserOutput(u *gl.MemberCreatedBy) *MemberUserOutput {
+	if u == nil {
+		return nil
+	}
+	return &MemberUserOutput{
+		ID:        u.ID,
+		Username:  u.Username,
+		Name:      u.Name,
+		State:     u.State,
+		AvatarURL: u.AvatarURL,
+		WebURL:    u.WebURL,
+	}
+}
+
+// SAMLIdentityOutput mirrors gl.GroupMemberSAMLIdentity (the
+// group_saml_identity object).
+type SAMLIdentityOutput struct {
+	ExternUID      string `json:"extern_uid"`
+	Provider       string `json:"provider"`
+	SAMLProviderID int64  `json:"saml_provider_id"`
+}
+
+// NewSAMLIdentityOutput mirrors a gl.GroupMemberSAMLIdentity into the shared
+// output shape, returning nil when the SDK value is nil.
+func NewSAMLIdentityOutput(s *gl.GroupMemberSAMLIdentity) *SAMLIdentityOutput {
+	if s == nil {
+		return nil
+	}
+	return &SAMLIdentityOutput{
+		ExternUID:      s.ExternUID,
+		Provider:       s.Provider,
+		SAMLProviderID: s.SAMLProviderID,
+	}
+}
+
+// MemberRoleOutput mirrors gl.MemberRole (the member_role object). Custom
+// member roles are an Enterprise (Premium/Ultimate) feature; the object is nil
+// on instances or members without a custom role. All permission flags are
+// surfaced for 1:1 SDK fidelity.
+type MemberRoleOutput struct {
+	ID                         int64  `json:"id"`
+	Name                       string `json:"name"`
+	Description                string `json:"description,omitempty"`
+	GroupID                    int64  `json:"group_id"`
+	BaseAccessLevel            int    `json:"base_access_level"`
+	AdminCICDVariables         bool   `json:"admin_cicd_variables,omitempty"`
+	AdminComplianceFramework   bool   `json:"admin_compliance_framework,omitempty"`
+	AdminGroupMembers          bool   `json:"admin_group_member,omitempty"`
+	AdminMergeRequests         bool   `json:"admin_merge_request,omitempty"`
+	AdminPushRules             bool   `json:"admin_push_rules,omitempty"`
+	AdminTerraformState        bool   `json:"admin_terraform_state,omitempty"`
+	AdminVulnerability         bool   `json:"admin_vulnerability,omitempty"`
+	AdminWebHook               bool   `json:"admin_web_hook,omitempty"`
+	ArchiveProject             bool   `json:"archive_project,omitempty"`
+	ManageDeployTokens         bool   `json:"manage_deploy_tokens,omitempty"`
+	ManageGroupAccessTokens    bool   `json:"manage_group_access_tokens,omitempty"`
+	ManageMergeRequestSettings bool   `json:"manage_merge_request_settings,omitempty"`
+	ManageProjectAccessTokens  bool   `json:"manage_project_access_tokens,omitempty"`
+	ManageSecurityPolicyLink   bool   `json:"manage_security_policy_link,omitempty"`
+	ReadCode                   bool   `json:"read_code,omitempty"`
+	ReadRunners                bool   `json:"read_runners,omitempty"`
+	ReadDependency             bool   `json:"read_dependency,omitempty"`
+	ReadVulnerability          bool   `json:"read_vulnerability,omitempty"`
+	RemoveGroup                bool   `json:"remove_group,omitempty"`
+	RemoveProject              bool   `json:"remove_project,omitempty"`
+}
+
+// NewMemberRoleOutput mirrors a gl.MemberRole into the shared output shape,
+// returning nil when the SDK value is nil.
+func NewMemberRoleOutput(r *gl.MemberRole) *MemberRoleOutput {
+	if r == nil {
+		return nil
+	}
+	return &MemberRoleOutput{
+		ID:                         r.ID,
+		Name:                       r.Name,
+		Description:                r.Description,
+		GroupID:                    r.GroupID,
+		BaseAccessLevel:            int(r.BaseAccessLevel),
+		AdminCICDVariables:         r.AdminCICDVariables,
+		AdminComplianceFramework:   r.AdminComplianceFramework,
+		AdminGroupMembers:          r.AdminGroupMembers,
+		AdminMergeRequests:         r.AdminMergeRequests,
+		AdminPushRules:             r.AdminPushRules,
+		AdminTerraformState:        r.AdminTerraformState,
+		AdminVulnerability:         r.AdminVulnerability,
+		AdminWebHook:               r.AdminWebHook,
+		ArchiveProject:             r.ArchiveProject,
+		ManageDeployTokens:         r.ManageDeployTokens,
+		ManageGroupAccessTokens:    r.ManageGroupAccessTokens,
+		ManageMergeRequestSettings: r.ManageMergeRequestSettings,
+		ManageProjectAccessTokens:  r.ManageProjectAccessTokens,
+		ManageSecurityPolicyLink:   r.ManageSecurityPolicyLink,
+		ReadCode:                   r.ReadCode,
+		ReadRunners:                r.ReadRunners,
+		ReadDependency:             r.ReadDependency,
+		ReadVulnerability:          r.ReadVulnerability,
+		RemoveGroup:                r.RemoveGroup,
+		RemoveProject:              r.RemoveProject,
+	}
+}

--- a/internal/toolutil/membershapes_test.go
+++ b/internal/toolutil/membershapes_test.go
@@ -1,0 +1,92 @@
+package toolutil
+
+import (
+	"testing"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// TestNewMemberUserOutput pins the created_by conversion: nil SDK input maps
+// to nil, and a populated gl.MemberCreatedBy maps every field onto the shared
+// output shape.
+func TestNewMemberUserOutput(t *testing.T) {
+	if got := NewMemberUserOutput(nil); got != nil {
+		t.Fatalf("NewMemberUserOutput(nil) = %+v, want nil", got)
+	}
+
+	in := &gl.MemberCreatedBy{
+		ID:        7,
+		Username:  "jdoe",
+		Name:      "John Doe",
+		State:     "active",
+		AvatarURL: "https://example.com/avatar.png",
+		WebURL:    "https://example.com/jdoe",
+	}
+	got := NewMemberUserOutput(in)
+	if got == nil {
+		t.Fatal("NewMemberUserOutput returned nil for non-nil input")
+	}
+	if got.ID != 7 || got.Username != "jdoe" || got.Name != "John Doe" ||
+		got.State != "active" || got.AvatarURL != in.AvatarURL || got.WebURL != in.WebURL {
+		t.Errorf("NewMemberUserOutput = %+v, want mirror of %+v", got, in)
+	}
+}
+
+// TestNewSAMLIdentityOutput pins the group_saml_identity conversion:
+// nil-on-nil plus a full field mirror for populated input.
+func TestNewSAMLIdentityOutput(t *testing.T) {
+	if got := NewSAMLIdentityOutput(nil); got != nil {
+		t.Fatalf("NewSAMLIdentityOutput(nil) = %+v, want nil", got)
+	}
+
+	in := &gl.GroupMemberSAMLIdentity{
+		ExternUID:      "uid-1",
+		Provider:       "group_saml",
+		SAMLProviderID: 12,
+	}
+	got := NewSAMLIdentityOutput(in)
+	if got == nil {
+		t.Fatal("NewSAMLIdentityOutput returned nil for non-nil input")
+	}
+	if got.ExternUID != "uid-1" || got.Provider != "group_saml" || got.SAMLProviderID != 12 {
+		t.Errorf("NewSAMLIdentityOutput = %+v, want mirror of %+v", got, in)
+	}
+}
+
+// TestNewMemberRoleOutput pins the member_role conversion: nil-on-nil plus a
+// full mirror of the identifying fields and a sample of permission flags
+// (all flags are copied by the same one-line assignments; the sample guards
+// against dropped wiring).
+func TestNewMemberRoleOutput(t *testing.T) {
+	if got := NewMemberRoleOutput(nil); got != nil {
+		t.Fatalf("NewMemberRoleOutput(nil) = %+v, want nil", got)
+	}
+
+	in := &gl.MemberRole{
+		ID:                        3,
+		Name:                      "custom-dev",
+		Description:               "custom role",
+		GroupID:                   42,
+		BaseAccessLevel:           gl.DeveloperPermissions,
+		AdminCICDVariables:        true,
+		AdminMergeRequests:        true,
+		ManageProjectAccessTokens: true,
+		ReadCode:                  true,
+		RemoveProject:             true,
+	}
+	got := NewMemberRoleOutput(in)
+	if got == nil {
+		t.Fatal("NewMemberRoleOutput returned nil for non-nil input")
+	}
+	if got.ID != 3 || got.Name != "custom-dev" || got.Description != "custom role" ||
+		got.GroupID != 42 || got.BaseAccessLevel != int(gl.DeveloperPermissions) {
+		t.Errorf("NewMemberRoleOutput identity fields = %+v, want mirror of %+v", got, in)
+	}
+	if !got.AdminCICDVariables || !got.AdminMergeRequests || !got.ManageProjectAccessTokens ||
+		!got.ReadCode || !got.RemoveProject {
+		t.Errorf("NewMemberRoleOutput permission flags = %+v, want true flags mirrored from %+v", got, in)
+	}
+	if got.AdminPushRules || got.RemoveGroup {
+		t.Errorf("NewMemberRoleOutput unset flags = %+v, want false flags preserved", got)
+	}
+}

--- a/internal/toolutil/pipelineshapes.go
+++ b/internal/toolutil/pipelineshapes.go
@@ -167,3 +167,45 @@ func NewPipelineOutput(p *gl.Pipeline) *PipelineOutput {
 		DetailedStatus: NewPipelineDetailedStatusOutput(p.DetailedStatus),
 	}
 }
+
+// LastPipelineOutput mirrors gl.PipelineInfo, the pipeline summary embedded in
+// a commit payload as last_pipeline (commits, branch head commits).
+type LastPipelineOutput struct {
+	ID        int64  `json:"id"`
+	IID       int64  `json:"iid,omitempty"`
+	ProjectID int64  `json:"project_id,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Ref       string `json:"ref,omitempty"`
+	SHA       string `json:"sha,omitempty"`
+	Name      string `json:"name,omitempty"`
+	WebURL    string `json:"web_url,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// NewLastPipelineOutput maps gl.PipelineInfo to *LastPipelineOutput, or nil
+// when the commit has no associated pipeline.
+func NewLastPipelineOutput(p *gl.PipelineInfo) *LastPipelineOutput {
+	if p == nil {
+		return nil
+	}
+	out := &LastPipelineOutput{
+		ID:        p.ID,
+		IID:       p.IID,
+		ProjectID: p.ProjectID,
+		Status:    p.Status,
+		Source:    p.Source,
+		Ref:       p.Ref,
+		SHA:       p.SHA,
+		Name:      p.Name,
+		WebURL:    p.WebURL,
+	}
+	if p.CreatedAt != nil {
+		out.CreatedAt = p.CreatedAt.String()
+	}
+	if p.UpdatedAt != nil {
+		out.UpdatedAt = p.UpdatedAt.String()
+	}
+	return out
+}

--- a/internal/toolutil/pipelineshapes_test.go
+++ b/internal/toolutil/pipelineshapes_test.go
@@ -147,3 +147,28 @@ func TestPipelineOutputJSONTags(t *testing.T) {
 		}
 	}
 }
+
+// TestNewLastPipelineOutput pins the commit last_pipeline conversion:
+// nil-on-nil, full field mirror, and String()-formatted timestamps only when
+// present (preserving the historical commit-payload format).
+func TestNewLastPipelineOutput(t *testing.T) {
+	if got := NewLastPipelineOutput(nil); got != nil {
+		t.Fatalf("NewLastPipelineOutput(nil) = %+v, want nil", got)
+	}
+
+	created := time.Date(2026, 5, 6, 7, 8, 9, 0, time.UTC)
+	got := NewLastPipelineOutput(&gl.PipelineInfo{
+		ID: 12, IID: 3, ProjectID: 9, Status: "success", Source: "push",
+		Ref: "main", SHA: "abc123", Name: "build", WebURL: "https://example.com/p/12",
+		CreatedAt: &created,
+	})
+	if got == nil || got.ID != 12 || got.Status != "success" || got.Ref != "main" || got.WebURL != "https://example.com/p/12" {
+		t.Errorf("NewLastPipelineOutput = %+v, want full mirror", got)
+	}
+	if got.CreatedAt != created.String() {
+		t.Errorf("CreatedAt = %q, want %q", got.CreatedAt, created.String())
+	}
+	if got.UpdatedAt != "" {
+		t.Errorf("UpdatedAt = %q, want empty for nil source", got.UpdatedAt)
+	}
+}

--- a/internal/toolutil/pipelineshapes_test.go
+++ b/internal/toolutil/pipelineshapes_test.go
@@ -157,18 +157,23 @@ func TestNewLastPipelineOutput(t *testing.T) {
 	}
 
 	created := time.Date(2026, 5, 6, 7, 8, 9, 0, time.UTC)
+	updated := time.Date(2026, 5, 7, 1, 2, 3, 0, time.UTC)
 	got := NewLastPipelineOutput(&gl.PipelineInfo{
 		ID: 12, IID: 3, ProjectID: 9, Status: "success", Source: "push",
 		Ref: "main", SHA: "abc123", Name: "build", WebURL: "https://example.com/p/12",
-		CreatedAt: &created,
+		CreatedAt: &created, UpdatedAt: &updated,
 	})
-	if got == nil || got.ID != 12 || got.Status != "success" || got.Ref != "main" || got.WebURL != "https://example.com/p/12" {
-		t.Errorf("NewLastPipelineOutput = %+v, want full mirror", got)
+	want := &LastPipelineOutput{
+		ID: 12, IID: 3, ProjectID: 9, Status: "success", Source: "push",
+		Ref: "main", SHA: "abc123", Name: "build", WebURL: "https://example.com/p/12",
+		CreatedAt: created.String(), UpdatedAt: updated.String(),
 	}
-	if got.CreatedAt != created.String() {
-		t.Errorf("CreatedAt = %q, want %q", got.CreatedAt, created.String())
+	if got == nil || *got != *want {
+		t.Errorf("NewLastPipelineOutput = %+v, want %+v", got, want)
 	}
-	if got.UpdatedAt != "" {
-		t.Errorf("UpdatedAt = %q, want empty for nil source", got.UpdatedAt)
+
+	noDates := NewLastPipelineOutput(&gl.PipelineInfo{ID: 13})
+	if noDates == nil || noDates.CreatedAt != "" || noDates.UpdatedAt != "" {
+		t.Errorf("NewLastPipelineOutput without timestamps = %+v, want empty created/updated", noDates)
 	}
 }

--- a/internal/toolutil/schema_lockdown.go
+++ b/internal/toolutil/schema_lockdown.go
@@ -1,11 +1,9 @@
 package toolutil
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -37,35 +35,16 @@ import (
 //
 // Concurrency. The MCP Go SDK does not expose a public API to enumerate
 // registered tools at startup, so the transformation runs inside a
-// `tools/list` middleware. To avoid a data race when multiple clients call
-// `tools/list` concurrently (each invocation would otherwise mutate the
-// shared *Tool.InputSchema map), the actual mutation is guarded by a
-// `sync.Once`: the first call performs the lockdown, and concurrent callers
-// block until that mutation completes. Subsequent calls are pure reads on
-// the (now stable) schema maps and run lock-free.
+// `tools/list` middleware via [onFirstToolsList], which guards the mutation
+// with a `sync.Once`.
 func LockdownInputSchemas(server *mcp.Server) {
-	if server == nil {
-		return
-	}
-	var once sync.Once
-	server.AddReceivingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
-		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			result, err := next(ctx, method, req)
-			if err != nil || method != "tools/list" {
-				return result, err
+	onFirstToolsList(server, func(mcpTools []*mcp.Tool) {
+		for _, t := range mcpTools {
+			if schema := schemaMap(t.InputSchema); schema != nil {
+				normalizeSchemaDescriptions(schema)
+				lockdownSchemaNode(schema)
+				t.InputSchema = schema
 			}
-			if listResult, ok := result.(*mcp.ListToolsResult); ok && listResult != nil {
-				once.Do(func() {
-					for _, t := range listResult.Tools {
-						if schema := schemaMap(t.InputSchema); schema != nil {
-							normalizeSchemaDescriptions(schema)
-							lockdownSchemaNode(schema)
-							t.InputSchema = schema
-						}
-					}
-				})
-			}
-			return result, nil
 		}
 	})
 }

--- a/internal/toolutil/schema_middleware.go
+++ b/internal/toolutil/schema_middleware.go
@@ -1,0 +1,32 @@
+package toolutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// onFirstToolsList registers a receiving middleware that runs visit exactly
+// once, over the tools of the first successful tools/list response. The
+// sync.Once guard prevents concurrent tools/list calls from racing on the
+// shared *Tool.InputSchema maps: the first call performs the mutation and
+// later calls are pure reads on the (now stable) schemas.
+func onFirstToolsList(server *mcp.Server, visit func([]*mcp.Tool)) {
+	if server == nil {
+		return
+	}
+	var once sync.Once
+	server.AddReceivingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			result, err := next(ctx, method, req)
+			if err != nil || method != "tools/list" {
+				return result, err
+			}
+			if listResult, ok := result.(*mcp.ListToolsResult); ok && listResult != nil {
+				once.Do(func() { visit(listResult.Tools) })
+			}
+			return result, nil
+		}
+	})
+}

--- a/internal/toolutil/schema_pagination.go
+++ b/internal/toolutil/schema_pagination.go
@@ -1,9 +1,6 @@
 package toolutil
 
 import (
-	"context"
-	"sync"
-
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -27,30 +24,15 @@ import (
 // The transformation runs after LockdownInputSchemas so it sees the same
 // fully-populated schema set every list/tools response carries.
 //
-// Concurrency. As with [LockdownInputSchemas], the mutation is guarded by a
-// `sync.Once` so concurrent `tools/list` calls cannot race on the shared
-// *Tool.InputSchema maps.
+// Concurrency. As with [LockdownInputSchemas], the mutation runs through
+// [onFirstToolsList], whose `sync.Once` guard prevents concurrent
+// `tools/list` calls from racing on the shared *Tool.InputSchema maps.
 func EnrichPaginationConstraints(server *mcp.Server) {
-	if server == nil {
-		return
-	}
-	var once sync.Once
-	server.AddReceivingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
-		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			result, err := next(ctx, method, req)
-			if err != nil || method != "tools/list" {
-				return result, err
+	onFirstToolsList(server, func(mcpTools []*mcp.Tool) {
+		for _, t := range mcpTools {
+			if schema, isMap := t.InputSchema.(map[string]any); isMap {
+				enrichPaginationNode(schema)
 			}
-			if listResult, ok := result.(*mcp.ListToolsResult); ok && listResult != nil {
-				once.Do(func() {
-					for _, t := range listResult.Tools {
-						if schema, isMap := t.InputSchema.(map[string]any); isMap {
-							enrichPaginationNode(schema)
-						}
-					}
-				})
-			}
-			return result, nil
 		}
 	})
 }

--- a/internal/toolutil/usershapes.go
+++ b/internal/toolutil/usershapes.go
@@ -1,0 +1,86 @@
+package toolutil
+
+import (
+	"context"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// CustomAttributeOutput mirrors gl.CustomAttribute, a key/value custom
+// attribute attached to a user.
+type CustomAttributeOutput struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// NewCustomAttributeOutputs converts a []*gl.CustomAttribute slice, skipping
+// nil elements and returning nil when no attributes remain.
+func NewCustomAttributeOutputs(attrs []*gl.CustomAttribute) []CustomAttributeOutput {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make([]CustomAttributeOutput, 0, len(attrs))
+	for _, a := range attrs {
+		if a == nil {
+			continue
+		}
+		out = append(out, CustomAttributeOutput{Key: a.Key, Value: a.Value})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// UserRefOutput mirrors gl.BasicUser as surfaced on user resources (the
+// created_by object): identity fields always present, avatar/web URL and
+// created_at omitted when empty. It differs from BasicUserOutput (pipeline
+// sub-objects), whose avatar_url and web_url are always serialized.
+type UserRefOutput struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	WebURL    string `json:"web_url,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// NewUserRefOutput converts a *gl.BasicUser into the user-resource reference
+// shape, returning nil when the SDK value is nil.
+func NewUserRefOutput(u *gl.BasicUser) *UserRefOutput {
+	if u == nil {
+		return nil
+	}
+	o := &UserRefOutput{
+		ID:        u.ID,
+		Username:  u.Username,
+		Name:      u.Name,
+		State:     u.State,
+		AvatarURL: u.AvatarURL,
+		WebURL:    u.WebURL,
+	}
+	if u.CreatedAt != nil {
+		o.CreatedAt = u.CreatedAt.Format(time.RFC3339)
+	}
+	return o
+}
+
+// ResolveProjectWebURLs fetches the web URL for each unique project ID.
+// Failures are silently ignored — missing URLs simply produce no links.
+func ResolveProjectWebURLs(ctx context.Context, projects gl.ProjectsServiceInterface, projectIDs []int64) map[int64]string {
+	seen := make(map[int64]string, len(projectIDs))
+	for _, id := range projectIDs {
+		if _, ok := seen[id]; ok || id == 0 {
+			continue
+		}
+		proj, _, err := projects.GetProject(id, &gl.GetProjectOptions{}, gl.WithContext(ctx))
+		if err != nil || proj == nil {
+			seen[id] = ""
+			continue
+		}
+		seen[id] = proj.WebURL
+	}
+	return seen
+}

--- a/internal/toolutil/usershapes.go
+++ b/internal/toolutil/usershapes.go
@@ -84,3 +84,47 @@ func ResolveProjectWebURLs(ctx context.Context, projects gl.ProjectsServiceInter
 	}
 	return seen
 }
+
+// PersonalTokenOutput mirrors gl.PersonalAccessToken as surfaced by the
+// impersonation-token and current-user PAT tools: identity, scopes, and
+// RFC3339/ISO-date lifecycle timestamps. The token value is only present on
+// creation responses.
+type PersonalTokenOutput struct {
+	ID          int64    `json:"id"`
+	Name        string   `json:"name"`
+	Active      bool     `json:"active"`
+	Token       string   `json:"token,omitempty"`
+	Scopes      []string `json:"scopes"`
+	Revoked     bool     `json:"revoked"`
+	Description string   `json:"description,omitempty"`
+	UserID      int64    `json:"user_id"`
+	CreatedAt   string   `json:"created_at,omitempty"`
+	ExpiresAt   string   `json:"expires_at,omitempty"`
+	LastUsedAt  string   `json:"last_used_at,omitempty"`
+}
+
+// NewPersonalTokenOutput converts a gl.PersonalAccessToken into the shared
+// output shape, formatting created/last-used as RFC3339 and expiry as an ISO
+// date.
+func NewPersonalTokenOutput(t *gl.PersonalAccessToken) PersonalTokenOutput {
+	o := PersonalTokenOutput{
+		ID:          t.ID,
+		Name:        t.Name,
+		Active:      t.Active,
+		Token:       t.Token,
+		Scopes:      t.Scopes,
+		Revoked:     t.Revoked,
+		Description: t.Description,
+		UserID:      t.UserID,
+	}
+	if t.CreatedAt != nil {
+		o.CreatedAt = t.CreatedAt.Format(time.RFC3339)
+	}
+	if t.ExpiresAt != nil {
+		o.ExpiresAt = time.Time(*t.ExpiresAt).Format(DateFormatISO)
+	}
+	if t.LastUsedAt != nil {
+		o.LastUsedAt = t.LastUsedAt.Format(time.RFC3339)
+	}
+	return o
+}

--- a/internal/toolutil/usershapes_test.go
+++ b/internal/toolutil/usershapes_test.go
@@ -1,0 +1,92 @@
+package toolutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+// TestNewCustomAttributeOutputs pins the custom-attribute conversion:
+// nil/empty and all-nil inputs return nil, nil elements are skipped, and
+// populated entries mirror key and value.
+func TestNewCustomAttributeOutputs(t *testing.T) {
+	if got := NewCustomAttributeOutputs(nil); got != nil {
+		t.Fatalf("NewCustomAttributeOutputs(nil) = %+v, want nil", got)
+	}
+	if got := NewCustomAttributeOutputs([]*gl.CustomAttribute{nil, nil}); got != nil {
+		t.Fatalf("NewCustomAttributeOutputs(all nil) = %+v, want nil", got)
+	}
+
+	got := NewCustomAttributeOutputs([]*gl.CustomAttribute{
+		{Key: "department", Value: "platform"},
+		nil,
+		{Key: "location", Value: "remote"},
+	})
+	if len(got) != 2 || got[0].Key != "department" || got[1].Value != "remote" {
+		t.Errorf("NewCustomAttributeOutputs = %+v, want 2 mirrored entries", got)
+	}
+}
+
+// TestNewUserRefOutput pins the user-resource reference conversion:
+// nil-on-nil, full field mirror, and RFC3339 created_at only when present.
+func TestNewUserRefOutput(t *testing.T) {
+	if got := NewUserRefOutput(nil); got != nil {
+		t.Fatalf("NewUserRefOutput(nil) = %+v, want nil", got)
+	}
+
+	created := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	got := NewUserRefOutput(&gl.BasicUser{
+		ID: 8, Username: "jdoe", Name: "John Doe", State: "active",
+		AvatarURL: "https://example.com/a.png", WebURL: "https://example.com/jdoe",
+		CreatedAt: &created,
+	})
+	if got == nil || got.ID != 8 || got.Username != "jdoe" || got.CreatedAt != created.Format(time.RFC3339) {
+		t.Errorf("NewUserRefOutput = %+v, want full mirror with RFC3339 created_at", got)
+	}
+
+	noDate := NewUserRefOutput(&gl.BasicUser{ID: 9, Username: "x"})
+	if noDate == nil || noDate.CreatedAt != "" {
+		t.Errorf("NewUserRefOutput without CreatedAt = %+v, want empty created_at", noDate)
+	}
+}
+
+// TestResolveProjectWebURLs pins the URL resolution helper: zero IDs are
+// skipped, duplicate IDs are fetched once, lookup failures yield an empty
+// URL, and successful lookups map to the project's web_url.
+func TestResolveProjectWebURLs(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if strings.Contains(r.URL.Path, "/projects/10") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":10,"web_url":"https://gitlab.example.com/group/project"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client, err := gl.NewClient("test-token", gl.WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("gl.NewClient: %v", err)
+	}
+
+	urls := ResolveProjectWebURLs(context.Background(), client.Projects, []int64{0, 10, 10, 404})
+	if got := urls[10]; got != "https://gitlab.example.com/group/project" {
+		t.Errorf("urls[10] = %q, want the project web_url", got)
+	}
+	if got, ok := urls[404]; !ok || got != "" {
+		t.Errorf("urls[404] = %q (present=%v), want empty entry for failed lookup", got, ok)
+	}
+	if _, ok := urls[0]; ok {
+		t.Error("urls[0] present, want zero IDs skipped")
+	}
+	if calls != 2 {
+		t.Errorf("API calls = %d, want 2 (duplicate ID fetched once)", calls)
+	}
+}

--- a/internal/toolutil/usershapes_test.go
+++ b/internal/toolutil/usershapes_test.go
@@ -90,3 +90,29 @@ func TestResolveProjectWebURLs(t *testing.T) {
 		t.Errorf("API calls = %d, want 2 (duplicate ID fetched once)", calls)
 	}
 }
+
+// TestNewPersonalTokenOutput pins the personal-access-token conversion:
+// identity fields mirror the SDK struct, created/last-used format as RFC3339,
+// expiry as an ISO date, and absent timestamps stay empty.
+func TestNewPersonalTokenOutput(t *testing.T) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	expires := gl.ISOTime(time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC))
+	got := NewPersonalTokenOutput(&gl.PersonalAccessToken{
+		ID: 7, Name: "ci-token", Active: true, Token: "glpat-x",
+		Scopes: []string{"api"}, Revoked: false, Description: "ci", UserID: 42,
+		CreatedAt: &created, ExpiresAt: &expires,
+	})
+	if got.ID != 7 || got.Name != "ci-token" || !got.Active || got.Token != "glpat-x" ||
+		len(got.Scopes) != 1 || got.UserID != 42 {
+		t.Errorf("NewPersonalTokenOutput identity fields = %+v, want mirror", got)
+	}
+	if got.CreatedAt != created.Format(time.RFC3339) {
+		t.Errorf("CreatedAt = %q, want RFC3339", got.CreatedAt)
+	}
+	if got.ExpiresAt != "2026-12-01" {
+		t.Errorf("ExpiresAt = %q, want 2026-12-01", got.ExpiresAt)
+	}
+	if got.LastUsedAt != "" {
+		t.Errorf("LastUsedAt = %q, want empty for nil source", got.LastUsedAt)
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -58,7 +58,33 @@ sonar.exclusions=VERSION
 # would add loader+parser complexity (init-time read, error paths, regeneration)
 # without reducing the data's per-doc uniqueness, so the irreducibility is
 # inherent to "data that has to live next to the routing code that consumes it".
-sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/groupsaml/action_specs.go,internal/tools/groupldap/action_specs.go,internal/tools/containerregistry/markdown.go,internal/tools/groups/push_rules.go,internal/tools/issues/issues.go,cmd/audit_doc_coverage/mapping.go
+#
+# internal/tools/*/action_specs.go (glob): per-domain discovery-metadata
+# catalogs (usage/aliases/related/parameter guidance per action) — the same
+# data-table class as mapping.go. SonarCloud CPD normalizes string literals, so
+# two actions whose guidance entries share the {SemanticRole, ValueSource,
+# ExampleBinding, CommonConfusions} struct shape are flagged as duplicates even
+# when every string is unique to the action. The guidance text that CAN be
+# shared verbatim is already extracted into helpers
+# (toolutil.DiscussionIDParamGuidance, toolutil.DiscussionNoteIDParamGuidance,
+# invites' inviteGuidance); what remains is per-action data whose quality is
+# policed by cmd/audit_discovery_completeness and the audit_1to1 R-META
+# auditor, not by copy-paste detection. This glob subsumes the previous
+# groupsaml/groupldap action_specs entries.
+#
+# Additional distinct-SDK-type cases (same class as push_rules.go/issues.go):
+#   - accesstokens/accesstokens.go: identical token converters and list-filter
+#     mapping onto gl.ProjectAccessToken / gl.GroupAccessToken /
+#     gl.PersonalAccessToken and their three distinct list-options structs (the
+#     shared date filters are already extracted into applyAccessTokenDateFilters).
+#   - group/project/snippet storage moves: three parallel REST surfaces over
+#     distinct SDK services (GroupRepositoryStorageMove /
+#     ProjectRepositoryStorageMove / SnippetRepositoryStorageMove) with
+#     per-domain hint strings.
+#   - milestones.go vs groupmilestones.go: identical create/update option
+#     mapping onto gl.CreateMilestoneOptions/gl.UpdateMilestoneOptions vs the
+#     distinct gl.CreateGroupMilestoneOptions/gl.UpdateGroupMilestoneOptions.
+sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/*/action_specs.go,internal/tools/containerregistry/markdown.go,internal/tools/groups/push_rules.go,internal/tools/issues/issues.go,cmd/audit_doc_coverage/mapping.go,internal/tools/accesstokens/accesstokens.go,internal/tools/groupstoragemoves/group_storage_moves.go,internal/tools/projectstoragemoves/project_storage_moves.go,internal/tools/snippetstoragemoves/snippet_storage_moves.go,internal/tools/milestones/milestones.go,internal/tools/groupmilestones/groupmilestones.go
 
 # =============================================================================
 # Rule Exclusions for Test Files

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -72,7 +72,13 @@ sonar.exclusions=VERSION
 # auditor, not by copy-paste detection. This glob subsumes the previous
 # groupsaml/groupldap action_specs entries.
 #
-# Additional distinct-SDK-type cases (same class as push_rules.go/issues.go):
+# Additional distinct-SDK-type cases (same class as push_rules.go/issues.go).
+# Each file below was inspected individually; the verbatim-shareable parts have
+# already been extracted to toolutil (member/board/user shapes, guidance
+# helpers, GraphQL note mutations, file/base64 upload source, last-pipeline
+# shape, PAT shape) and what remains is field-assignment or option mapping
+# onto DISTINCT SDK types, or per-surface input schemas whose jsonschema
+# descriptions legitimately differ:
 #   - accesstokens/accesstokens.go: identical token converters and list-filter
 #     mapping onto gl.ProjectAccessToken / gl.GroupAccessToken /
 #     gl.PersonalAccessToken and their three distinct list-options structs (the
@@ -84,7 +90,29 @@ sonar.exclusions=VERSION
 #   - milestones.go vs groupmilestones.go: identical create/update option
 #     mapping onto gl.CreateMilestoneOptions/gl.UpdateMilestoneOptions vs the
 #     distinct gl.CreateGroupMilestoneOptions/gl.UpdateGroupMilestoneOptions.
-sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/*/action_specs.go,internal/tools/containerregistry/markdown.go,internal/tools/groups/push_rules.go,internal/tools/issues/issues.go,cmd/audit_doc_coverage/mapping.go,internal/tools/accesstokens/accesstokens.go,internal/tools/groupstoragemoves/group_storage_moves.go,internal/tools/projectstoragemoves/project_storage_moves.go,internal/tools/snippetstoragemoves/snippet_storage_moves.go,internal/tools/milestones/milestones.go,internal/tools/groupmilestones/groupmilestones.go
+#   - environments.go / files.go / broadcastmessages.go: identical option
+#     mapping in Create vs Edit/Update handlers onto the distinct Create*/
+#     Edit*/Update* SDK options structs.
+#   - usagedata.go: identical field mirror onto two distinct SDK metadata
+#     structs (service ping / usage data).
+#   - groupvariables.go vs instancevariables.go: identical variable filter and
+#     option mapping onto distinct group/instance SDK options structs.
+#   - users/user_misc.go vs runners/runners.go: identical runner option
+#     mapping onto gl.CreateUserRunnerOptions vs gl.RegisterNewRunnerOptions.
+#   - mrdiscussions/mr_discussions.go vs mrdraftnotes/mr_draft_notes.go (and
+#     the mrnotes/mr_notes.go Update prologue): per-surface DiffPosition input
+#     schemas whose jsonschema descriptions and LineRange semantics differ by
+#     design, plus validation prologues that differ only in op/hint literals
+#     (CPD normalizes string literals, so unique per-tool text still matches).
+#   - epics.go / epicissues/epic_issues.go: converter tails onto distinct epic
+#     SDK types and assign/unassign prologues differing only in op literals.
+#   - issuestatistics.go: group vs project statistics option structs built
+#     from one shared parameter struct (the issues.go class).
+#   - labels.go vs grouplabels.go: list/get scaffolding over the distinct
+#     Labels vs GroupLabels SDK services.
+#   - securityfindings.go vs vulnerabilities.go: identical location
+#     normalization from distinct per-domain GraphQL node types.
+sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/*/action_specs.go,internal/tools/containerregistry/markdown.go,internal/tools/groups/push_rules.go,internal/tools/issues/issues.go,cmd/audit_doc_coverage/mapping.go,internal/tools/accesstokens/accesstokens.go,internal/tools/groupstoragemoves/group_storage_moves.go,internal/tools/projectstoragemoves/project_storage_moves.go,internal/tools/snippetstoragemoves/snippet_storage_moves.go,internal/tools/milestones/milestones.go,internal/tools/groupmilestones/groupmilestones.go,internal/tools/environments/environments.go,internal/tools/files/files.go,internal/tools/broadcastmessages/broadcastmessages.go,internal/tools/usagedata/usagedata.go,internal/tools/groupvariables/groupvariables.go,internal/tools/instancevariables/instancevariables.go,internal/tools/users/user_misc.go,internal/tools/runners/runners.go,internal/tools/mrdiscussions/mr_discussions.go,internal/tools/mrdraftnotes/mr_draft_notes.go,internal/tools/mrnotes/mr_notes.go,internal/tools/epics/epics.go,internal/tools/epicissues/epic_issues.go,internal/tools/issuestatistics/issuestatistics.go,internal/tools/labels/labels.go,internal/tools/grouplabels/grouplabels.go,internal/tools/securityfindings/securityfindings.go,internal/tools/vulnerabilities/vulnerabilities.go
 
 # =============================================================================
 # Rule Exclusions for Test Files


### PR DESCRIPTION
## Summary

Reduces the duplicated lines flagged by SonarCloud (baseline: 95 files, 3,636 duplicated lines, 1.9% density) following the established DEDUP policy: byte-identical shapes/converters move to `internal/toolutil`, genuinely irreducible cases get documented CPD exclusions. Every remaining flagged cluster was inspected individually.

### Round 2 — shared shapes and helpers

- `toolutil/membershapes.go`: shared `created_by` / `group_saml_identity` / `member_role` output shapes + converters (groups, groupmembers, members)
- `toolutil/boardshapes.go`: shared board assignee / list-assignee / label / label-details shapes and a `ProjectIteration` converter; boards, groupboards, resourceevents and issuelinks now alias the canonical `IterationOutput`
- `toolutil/discussion_guidance.go`: parameterized `discussion_id`/`note_id` guidance helpers reused by the five discussion domains (exact model-facing strings preserved); invites builds its project/group guidance from one helper
- `toolutil/graphql_note_mutation.go`: generic `createNote`/`updateNote`/`destroyNote` mutation executor shared by epicnotes and epicdiscussions
- `toolutil/usershapes.go`: shared custom-attribute / user-ref / PAT shapes plus `ResolveProjectWebURLs`
- `cmd/internal/auditshared`: shared analysis helpers for the audit_1to1 R-META and audit_discovery_completeness auditors
- `internal/prompts`: `fetchMRWithDiffs` and `fetchContributionEvents` helpers replace repeated handler prologues

### Round 3 — upload sources, pipeline/PAT shapes, cmd helpers

- `toolutil/filesource.go`: `OpenFileOrBase64Source` / `ReadFileOrBase64` absorb the mutually-exclusive `file_path`/`content_base64` upload prologue duplicated across 8 packages
- `toolutil.LastPipelineOutput` (commits, branches) and `toolutil.PersonalTokenOutput` (impersonationtokens, user service-account PATs)
- `toolutil.onFirstToolsList`: shared once-guarded tools/list middleware (lockdown + pagination enrichment)
- `auditshared.DiscoverActionSpecGroupBuilders` (manifest generator + catalog-first auditor) and `auditshared.NewStubGitLabClient` (gen_llms, gen_docker_tools)

### CPD exclusions (`sonar-project.properties`)

Per-file justified additions for the verified-irreducible classes: identical option/field mapping onto distinct SDK types (environments, files, broadcastmessages, usagedata, group/instance variables, user runners, milestones, storage moves, access tokens, epics/epicissues, issuestatistics, labels, security findings/vulnerabilities), per-surface `DiffPosition` schemas with deliberately different jsonschema text (mr discussions/draft notes/notes), and the `internal/tools/*/action_specs.go` metadata catalogs (CPD normalizes string literals, so unique per-action text still matches; metadata quality is policed by the discovery auditors instead).

### Audit coverage fix + guardrail

Verifying `audit_1to1` with tamper tests exposed that the dedup had silently dropped 23 audited SDK↔MCP output pairs (323→300): the R-OUTPUT stream pairs structs through package-local converters, which the refactor had deleted. Fixed by restoring thin local converter wrappers (3-line delegates) per the documented alias-converter convention, plus an analyzer fix (`localOrAliasNamedStruct` now dereferences `*Alias` pointer results before `types.Unalias`). Coverage is now 324 pairs (≥ main's 323) and `TestBuildReport_AuditedPairFloors` pins global and per-package floors so any future drop fails CI. Tamper tests confirm end-to-end detection: a field removed from a shared toolutil shape is flagged in all three consuming member packages; a blanked Usage raises `generic_usage` in R-META.

## Verification

- Full build, `golangci-lint` clean on every touched package
- Unit tests green across all touched packages; `internal/tools` root guardrail suite (catalog/schema/markdown-registry) passes
- All cmd auditors/generators executed clean: audit_1to1 (backlog byte-identical to baseline), catalog_first, discovery_completeness, doc_coverage, dynamic_aliases, edition_tier, godoc audit, metrics, surface_quality (0 findings), test_names, tokens footprint, string_dupes, format_md_tables, gen_llms/gen_stats/gen_testing_docs/gen_action_catalog_manifest checks, gen_docker_tools
- Net effect: −454 non-test lines (round 2) further reduced in round 3; no model-facing JSON shapes, schemas, or metadata text change (only `uploads.go`'s base64 error gains the standard `projectUpload:` prefix)

https://claude.ai/code/session_016b5FhE71CVYFf8L79pgFzM

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

