### PR TITLE
perf: production hot paths (search 7.5x, per-token registration 3.7x) + test suite -51% + coverage 99.74%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ image.png
 /gen_testing_docs
 /godoc_tool
 /gitlab-mcp-server
+/server

--- a/cmd/audit_1to1/internal/structs/analyze_test.go
+++ b/cmd/audit_1to1/internal/structs/analyze_test.go
@@ -5,6 +5,7 @@ import (
 	"go/types"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
@@ -134,19 +135,44 @@ func TestPathHelpers(t *testing.T) {
 	}
 }
 
+// cachedBuildReport runs the full struct analysis once per gapsOnly mode and
+// shares the result across this package's tests: buildReport is a pure
+// (~3-5s) analysis over the working tree, so per-test re-runs only multiplied
+// CPU time. Tests must treat the returned report as read-only.
+// TestBuildReport_Deterministic still performs one fresh run and compares it
+// against the cached one, preserving the two-independent-runs property.
+var (
+	cachedReportOnce [2]sync.Once
+	cachedReports    [2]report
+	cachedReportErrs [2]error
+)
+
+func cachedBuildReport(t *testing.T, gapsOnly bool) report {
+	t.Helper()
+	idx := 0
+	if gapsOnly {
+		idx = 1
+	}
+	cachedReportOnce[idx].Do(func() {
+		root, err := cmdutil.RepositoryRoot(".")
+		if err != nil {
+			cachedReportErrs[idx] = err
+			return
+		}
+		cachedReports[idx], cachedReportErrs[idx] = buildReport(root, gapsOnly)
+	})
+	if cachedReportErrs[idx] != nil {
+		t.Fatalf("buildReport: %v", cachedReportErrs[idx])
+	}
+	return cachedReports[idx]
+}
+
 // TestBuildReport_DetectsKnownBranchGaps runs the auditor against the real
 // repository as a methodology regression guard: it verifies the resolver still
 // attributes a healthy number of SDK↔MCP input/output pairs across the tools tree
 // (a broken resolver would collapse these toward zero).
 func TestBuildReport_DetectsKnownBranchGaps(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, false)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, false)
 	if rep.Summary.Packages == 0 || rep.Summary.InputPairs == 0 || rep.Summary.OutputPairs == 0 {
 		t.Fatalf("summary looks empty: %+v", rep.Summary)
 	}
@@ -174,10 +200,7 @@ func TestBuildReport_Deterministic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("repository root: %v", err)
 	}
-	first, err := buildReport(root, true)
-	if err != nil {
-		t.Fatalf("first buildReport: %v", err)
-	}
+	first := cachedBuildReport(t, true)
 	second, err := buildReport(root, true)
 	if err != nil {
 		t.Fatalf("second buildReport: %v", err)
@@ -237,14 +260,7 @@ func TestExtraOutputFields_FlagsInventedScalars(t *testing.T) {
 func TestExtraOutputFields_DiffPairKindGating(t *testing.T) {
 	// Synthesize via the real diffPair against the repository to confirm input
 	// gaps never carry extras. Output extras are exercised in the unit test above.
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, true)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, true)
 	for _, pr := range rep.Packages {
 		for _, g := range pr.Gaps {
 			if g.Kind == "input" && len(g.ExtraFields) > 0 {
@@ -351,14 +367,7 @@ func TestExtraOutputFields_SuppressesAllowlistedRename(t *testing.T) {
 //   - the issue family (issues, issuenotes, issuediscussions) reports ZERO
 //     extras after the cleanup.
 func TestBuildReport_NoFalsePositiveExtras(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, false)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, false)
 
 	// No output pair may be formed against a non-result SDK struct.
 	for _, pr := range rep.Packages {
@@ -563,14 +572,7 @@ func TestDisjointPhantomInput_SkipsDisjointHelperOptions(t *testing.T) {
 // for FIX B: the mrdiscussions/mrdraftnotes DiffPosition input struct must pair
 // only against gl.PositionOptions, never the list/diff options a helper builds.
 func TestBuildReport_NoDiffPositionPhantomInput(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, false)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, false)
 	for _, name := range []string{"mrdiscussions", "mrdraftnotes"} {
 		pr := findPackage(t, rep, name)
 		for _, g := range pr.Gaps {
@@ -590,14 +592,7 @@ func TestBuildReport_NoDiffPositionPhantomInput(t *testing.T) {
 // MergeRequest) must report a single joined-SDK output gap with no extras and
 // none of the MergeRequest-only fields reported as missing.
 func TestBuildReport_UnionsMultiConverterOutput(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, false)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, false)
 	mr := findPackage(t, rep, "mergerequests")
 	var outputs []gap
 	for _, g := range mr.Gaps {
@@ -679,14 +674,7 @@ func TestDocGroundedSuppression(t *testing.T) {
 // removed action/shape), and raise it when new pairs are added so the guard
 // stays tight.
 func TestBuildReport_AuditedPairFloors(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot(".")
-	if err != nil {
-		t.Fatalf("repository root: %v", err)
-	}
-	rep, err := buildReport(root, false)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedBuildReport(t, false)
 
 	const minInputPairs, minOutputPairs = 554, 324
 	if rep.Summary.InputPairs < minInputPairs {

--- a/cmd/audit_catalog_first/main_test.go
+++ b/cmd/audit_catalog_first/main_test.go
@@ -31,7 +31,7 @@ var coverageReportOnce sync.Once
 
 var (
 	cachedReport    coverageReport
-	cachedReportErr error
+	errCachedReport error
 )
 
 func cachedCoverageReport(t *testing.T) coverageReport {
@@ -39,13 +39,13 @@ func cachedCoverageReport(t *testing.T) coverageReport {
 	coverageReportOnce.Do(func() {
 		root, err := cmdutil.RepositoryRoot("../..")
 		if err != nil {
-			cachedReportErr = err
+			errCachedReport = err
 			return
 		}
-		cachedReport, cachedReportErr = buildCoverageReport(root)
+		cachedReport, errCachedReport = buildCoverageReport(root)
 	})
-	if cachedReportErr != nil {
-		t.Fatalf("buildCoverageReport() error = %v", cachedReportErr)
+	if errCachedReport != nil {
+		t.Fatalf("buildCoverageReport() error = %v", errCachedReport)
 	}
 	return cachedReport
 }

--- a/cmd/audit_catalog_first/main_test.go
+++ b/cmd/audit_catalog_first/main_test.go
@@ -16,22 +16,43 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 )
 
+// cachedCoverageReport builds the repository coverage report once and shares
+// it across the test functions of this package: buildCoverageReport is a pure
+// analysis over the working tree (~3s per run), so re-running it per test only
+// multiplied CPU time. Tests must treat the returned report as read-only.
+var coverageReportOnce sync.Once
+
+var (
+	cachedReport    coverageReport
+	cachedReportErr error
+)
+
+func cachedCoverageReport(t *testing.T) coverageReport {
+	t.Helper()
+	coverageReportOnce.Do(func() {
+		root, err := cmdutil.RepositoryRoot("../..")
+		if err != nil {
+			cachedReportErr = err
+			return
+		}
+		cachedReport, cachedReportErr = buildCoverageReport(root)
+	})
+	if cachedReportErr != nil {
+		t.Fatalf("buildCoverageReport() error = %v", cachedReportErr)
+	}
+	return cachedReport
+}
+
 // TestBuildCoverageReport_ClassifiesKeyDomains verifies BuildCoverageReport classifies key domains.
 func TestBuildCoverageReport_ClassifiesKeyDomains(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 	if report.SchemaVersion != schemaVersion {
 		t.Fatalf("SchemaVersion = %d, want %d", report.SchemaVersion, schemaVersion)
 	}
@@ -189,14 +210,7 @@ func TestCatalogActionsMissingIndividualProjectionPolicy(t *testing.T) {
 
 // TestBuildCoverageReport_CoreSourceDomainsAreSpecBacked verifies BuildCoverageReport when core source domains are spec backed.
 func TestBuildCoverageReport_CoreSourceDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"branches",
@@ -216,14 +230,7 @@ func TestBuildCoverageReport_CoreSourceDomainsAreSpecBacked(t *testing.T) {
 
 // TestBuildCoverageReport_CICDDomainsAreSpecBacked verifies BuildCoverageReport when cicd domains are spec backed.
 func TestBuildCoverageReport_CICDDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"cicatalog",
@@ -245,14 +252,7 @@ func TestBuildCoverageReport_CICDDomainsAreSpecBacked(t *testing.T) {
 
 // TestBuildCoverageReport_CollaborationDomainsAreSpecBacked verifies BuildCoverageReport when collaboration domains are spec backed.
 func TestBuildCoverageReport_CollaborationDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"boards",
@@ -273,14 +273,7 @@ func TestBuildCoverageReport_CollaborationDomainsAreSpecBacked(t *testing.T) {
 
 // TestBuildCoverageReport_NoteAndDiscussionDomainsAreSpecBacked verifies BuildCoverageReport when note and discussion domains are spec backed.
 func TestBuildCoverageReport_NoteAndDiscussionDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"commitdiscussions",
@@ -302,14 +295,7 @@ func TestBuildCoverageReport_NoteAndDiscussionDomainsAreSpecBacked(t *testing.T)
 
 // TestBuildCoverageReport_AccessAndSecurityDomainsAreSpecBacked verifies BuildCoverageReport when access and security domains are spec backed.
 func TestBuildCoverageReport_AccessAndSecurityDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"accessrequests",
@@ -332,14 +318,7 @@ func TestBuildCoverageReport_AccessAndSecurityDomainsAreSpecBacked(t *testing.T)
 
 // TestBuildCoverageReport_AdminPlatformDomainsAreSpecBacked verifies BuildCoverageReport when admin platform domains are spec backed.
 func TestBuildCoverageReport_AdminPlatformDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSourceSpecBackedDomains(t, report, []string{
 		"applications",
@@ -366,14 +345,7 @@ func TestBuildCoverageReport_AdminPlatformDomainsAreSpecBacked(t *testing.T) {
 
 // TestBuildCoverageReport_PackageDeploymentStorageDomainsAreSpecBacked verifies BuildCoverageReport when package deployment storage domains are spec backed.
 func TestBuildCoverageReport_PackageDeploymentStorageDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"containerregistry",
@@ -401,14 +373,7 @@ func TestBuildCoverageReport_PackageDeploymentStorageDomainsAreSpecBacked(t *tes
 
 // TestBuildCoverageReport_GroupProjectEnterpriseDomainsAreSpecBacked verifies BuildCoverageReport when group project enterprise domains are spec backed.
 func TestBuildCoverageReport_GroupProjectEnterpriseDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"epicissues",
@@ -433,14 +398,7 @@ func TestBuildCoverageReport_GroupProjectEnterpriseDomainsAreSpecBacked(t *testi
 
 // TestBuildCoverageReport_UtilityTemplateDomainsAreSpecBacked verifies BuildCoverageReport when utility template domains are spec backed.
 func TestBuildCoverageReport_UtilityTemplateDomainsAreSpecBacked(t *testing.T) {
-	root, err := cmdutil.RepositoryRoot("../..")
-	if err != nil {
-		t.Fatalf("cmdutil.RepositoryRoot() error = %v", err)
-	}
-	report, err := buildCoverageReport(root)
-	if err != nil {
-		t.Fatalf("buildCoverageReport() error = %v", err)
-	}
+	report := cachedCoverageReport(t)
 
 	assertSpecBackedDomains(t, report, []string{
 		"avatar",

--- a/cmd/audit_discovery_completeness/main_test.go
+++ b/cmd/audit_discovery_completeness/main_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
@@ -440,6 +441,28 @@ func TestEmptyParamDescription_FlagsBoilerplate(t *testing.T) {
 	}
 }
 
+// cachedFullReport runs the full discovery analysis (gapsOnly=false,
+// minAliases=3) once under its own mock client and shares the result across
+// this package's tests: buildReport spins an in-memory MCP server over the
+// full catalog (~4s per run). Tests must treat the returned report as
+// read-only.
+var (
+	fullReportOnce sync.Once
+	fullReport     report
+	fullReportErr  error
+)
+
+func cachedFullReport(t *testing.T) report {
+	t.Helper()
+	fullReportOnce.Do(func() {
+		fullReport, fullReportErr = buildReport(false, 3)
+	})
+	if fullReportErr != nil {
+		t.Fatalf("buildReport: %v", fullReportErr)
+	}
+	return fullReport
+}
+
 // TestBuildReport_LinkCreateBatchGoldStandard exercises the auditor against
 // the canonical link_create / link_create_batch cluster using synthetic
 // specs that mirror the BEFORE/AFTER signature from the discovery eval
@@ -530,10 +553,7 @@ func TestBuildReport_LinkCreateBatchGoldStandard(t *testing.T) {
 		t.Fatalf("auditclient.NewMock: %v", err)
 	}
 	defer cleanup2()
-	rep, err := buildReport(false, 3)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedFullReport(t)
 	var liveFlags []string
 	for _, pr := range rep.Packages {
 		if pr.Package != "releaselinks" {
@@ -570,10 +590,7 @@ func TestBuildReport_Deterministic(t *testing.T) {
 
 // TestBuildReport_NonEmptyActions verifies the auditor reports actions.
 func TestBuildReport_NonEmptyActions(t *testing.T) {
-	rep, err := buildReport(false, 3)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedFullReport(t)
 	if rep.Summary.Actions == 0 {
 		t.Fatalf("no actions analyzed: %+v", rep.Summary)
 	}
@@ -598,10 +615,7 @@ func TestBuildReport_NonEmptyActions(t *testing.T) {
 // the work that drives it down to zero. See plan/post-pr190-cleanup.md
 // META-001 §5 (Phases).
 func TestBuildReport_LiveBaseline(t *testing.T) {
-	rep, err := buildReport(false, 3)
-	if err != nil {
-		t.Fatalf("buildReport: %v", err)
-	}
+	rep := cachedFullReport(t)
 	t.Logf("discovery baseline: actions=%d errors=%d warnings=%d packages=%d clusters=%d",
 		rep.Summary.Actions, rep.Summary.Errors, rep.Summary.Warnings,
 		rep.Summary.Packages, len(rep.Clusters))

--- a/cmd/audit_discovery_completeness/main_test.go
+++ b/cmd/audit_discovery_completeness/main_test.go
@@ -449,16 +449,16 @@ func TestEmptyParamDescription_FlagsBoilerplate(t *testing.T) {
 var (
 	fullReportOnce sync.Once
 	fullReport     report
-	fullReportErr  error
+	errFullReport  error
 )
 
 func cachedFullReport(t *testing.T) report {
 	t.Helper()
 	fullReportOnce.Do(func() {
-		fullReport, fullReportErr = buildReport(false, 3)
+		fullReport, errFullReport = buildReport(false, 3)
 	})
-	if fullReportErr != nil {
-		t.Fatalf("buildReport: %v", fullReportErr)
+	if errFullReport != nil {
+		t.Fatalf("buildReport: %v", errFullReport)
 	}
 	return fullReport
 }

--- a/cmd/audit_metrics/site_stats_test.go
+++ b/cmd/audit_metrics/site_stats_test.go
@@ -25,7 +25,7 @@ import (
 var (
 	siteStatsOnce   sync.Once
 	siteStatsShared siteStats
-	siteStatsErr    error
+	errSiteStats    error
 )
 
 func newSiteStats(t *testing.T) siteStats {
@@ -37,13 +37,13 @@ func newSiteStats(t *testing.T) siteStats {
 			GitLabToken: "audit-token", //#nosec G101 -- audit-only dummy token, not a real credential
 		})
 		if err != nil {
-			siteStatsErr = err
+			errSiteStats = err
 			return
 		}
 		siteStatsShared = generateSiteStats(client, gitLabComClient)
 	})
-	if siteStatsErr != nil {
-		t.Fatalf("create gitlab.com client: %v", siteStatsErr)
+	if errSiteStats != nil {
+		t.Fatalf("create gitlab.com client: %v", errSiteStats)
 	}
 	return siteStatsShared
 }

--- a/cmd/audit_metrics/site_stats_test.go
+++ b/cmd/audit_metrics/site_stats_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
@@ -18,18 +19,33 @@ import (
 )
 
 // newSiteStats builds the stats payload from a mock self-managed client and a
-// GitLab.com client, matching how main wires generateSiteStats.
+// GitLab.com client, matching how main wires generateSiteStats. The payload is
+// generated once and shared (generateSiteStats builds the full catalog for
+// every tier, ~12s); tests must treat it as read-only.
+var (
+	siteStatsOnce   sync.Once
+	siteStatsShared siteStats
+	siteStatsErr    error
+)
+
 func newSiteStats(t *testing.T) siteStats {
 	t.Helper()
-	client := newAuditMetricsClient(t)
-	gitLabComClient, err := gitlabclient.NewClient(&config.Config{
-		GitLabURL:   config.DefaultGitLabURL,
-		GitLabToken: "audit-token", //#nosec G101 -- audit-only dummy token, not a real credential
+	siteStatsOnce.Do(func() {
+		client := newAuditMetricsClient(t)
+		gitLabComClient, err := gitlabclient.NewClient(&config.Config{
+			GitLabURL:   config.DefaultGitLabURL,
+			GitLabToken: "audit-token", //#nosec G101 -- audit-only dummy token, not a real credential
+		})
+		if err != nil {
+			siteStatsErr = err
+			return
+		}
+		siteStatsShared = generateSiteStats(client, gitLabComClient)
 	})
-	if err != nil {
-		t.Fatalf("create gitlab.com client: %v", err)
+	if siteStatsErr != nil {
+		t.Fatalf("create gitlab.com client: %v", siteStatsErr)
 	}
-	return generateSiteStats(client, gitLabComClient)
+	return siteStatsShared
 }
 
 // TestSiteStatsTierOrdering verifies the derived counts respect the nested

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -681,6 +681,11 @@ func runStdio(ctx context.Context) error {
 	return serveStdio(ctx, server)
 }
 
+// sharedSchemaCache caches resolved tool schemas across every MCP server
+// created by this process (stdio startup and the per-token servers of the
+// HTTP pool). See mcp.ServerOptions.SchemaCache.
+var sharedSchemaCache = mcp.NewSchemaCache()
+
 // createServer builds a fully configured [*mcp.Server] with all tools,
 // resources, and prompts registered for the given GitLab client.
 // Used both by stdio mode (single call) and by the HTTP server pool factory.
@@ -743,6 +748,11 @@ func createServer(client *gitlabclient.Client, cfg *config.ServerConfig, updater
 			)
 		},
 		KeepAlive: 30 * time.Second,
+		// Shared across every server this process creates: in HTTP mode the
+		// pool builds one MCP server per token+URL, and with the compiled
+		// schema pointers from toolutil.CompileToolSchemas this cache skips
+		// schema resolution on every registration after the first.
+		SchemaCache: sharedSchemaCache,
 	})
 
 	toolSurface := config.EffectiveToolSurface(cfg.MetaTools, cfg.ToolSurface)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -105,20 +106,51 @@ func mustCreateServer(t *testing.T, client *gitlabclient.Client, cfg *config.Ser
 	return server
 }
 
-// newTestMCPServer creates an MCP server with the full individual tool catalog,
-// resources, and prompts registered. HTTP protocol tests use it as a stable
-// handler target for initialize and tools/list requests.
+// newTestMCPServer returns a shared MCP server with the full individual tool
+// catalog, resources, and prompts registered. HTTP protocol tests use it as a
+// stable handler target for initialize and tools/list requests; none of them
+// vary registration-time state, and the mock GitLab backend only answers
+// /api/v4/version, so one registration (which resolves ~1,000 tool schemas in
+// the MCP SDK) safely serves every caller. The backing httptest server lives
+// for the whole test binary.
+var (
+	testMCPServerOnce   sync.Once
+	testMCPServerShared *mcp.Server
+	errTestMCPServer    error
+)
+
 func newTestMCPServer(t *testing.T) *mcp.Server {
 	t.Helper()
-	client := newMockGitLabClient(t)
-	server := mcp.NewServer(&mcp.Implementation{
-		Name:    serverName,
-		Version: "test",
-	}, nil)
-	tools.RegisterAll(server, client, edition.Ultimate)
-	resources.Register(server, client)
-	prompts.Register(server, client)
-	return server
+	testMCPServerOnce.Do(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v4/version" {
+				w.Header().Set(hdrContentType, mimeJSON)
+				_ = json.NewEncoder(w).Encode(map[string]string{"version": "16.0.0", "revision": "test"})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		client, err := gitlabclient.NewClient(&config.Config{
+			GitLabURL:   srv.URL,
+			GitLabToken: testToken,
+		})
+		if err != nil {
+			errTestMCPServer = err
+			return
+		}
+		server := mcp.NewServer(&mcp.Implementation{
+			Name:    serverName,
+			Version: "test",
+		}, nil)
+		tools.RegisterAll(server, client, edition.Ultimate)
+		resources.Register(server, client)
+		prompts.Register(server, client)
+		testMCPServerShared = server
+	})
+	if errTestMCPServer != nil {
+		t.Fatalf("failed to create mock gitlab client: %v", errTestMCPServer)
+	}
+	return testMCPServerShared
 }
 
 // newInMemorySession connects an in-memory MCP client to server and registers

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,631 |
-| Unit test functions                                   | 11,348 |
+| Total test functions                                  | 11,785 |
+| Unit test functions                                   | 11,502 |
 | E2E test functions                                    |    283 |
-| cmd test functions                                    |    900 |
-| Test files (internal/)                                |    458 |
+| cmd test functions                                    |    901 |
+| Test files (internal/)                                |    465 |
 | Test files (cmd/)                                     |     69 |
 | Test files (test/e2e/suite/)                          |    140 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     16 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  90.8% |
-| Overall coverage (`go test ./internal/...`)           |  94.5% |
-| Average package coverage                              |  95.3% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  91.2% |
+| Overall coverage (`go test ./internal/...`)           |  95.0% |
+| Average package coverage                              |  95.5% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,342 | 88.9% |
-| `TestFunc` (no underscore)             |    962 |  8.3% |
-| `TestFunc_Scenario_Expected` (3+ part) |    327 |  2.8% |
+| `TestFunc_Scenario` (2-part)           | 10,449 | 88.7% |
+| `TestFunc` (no underscore)             |    962 |  8.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |    374 |  3.2% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,881 |         96 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
-| Tools orchestration     |            283 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          8,284 |        349 | domain-specific GitLab tool handlers                                                            |
+| Core packages           |          2,021 |        102 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Tools orchestration     |            283 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
+| Tool sub-packages (175) |          8,297 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            283 |        140 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |            900 |         69 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,631** |    **667** |                                                                                                 |
+| cmd packages            |            901 |         69 | server entry point and developer command utilities                                              |
+| **Total**               |     **11,785** |    **674** |                                                                                                 |
 
 ### Core Packages
 
@@ -60,27 +60,27 @@
 | autoupdate   |       122 |    94.7% | Package autoupdate provides self-update capability for the gitlab-mcp-server MCP server.                                                                                                                          |
 | cmdutil      |         5 |   100.0% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                         |
 | completions  |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
-| config       |        72 |    98.6% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
-| edition      |         4 |    82.6% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
+| config       |        74 |    99.7% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
+| edition      |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
 | elicitation  |        79 |    92.5% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
 | gitlab       |        44 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
-| prompts      |       207 |    96.5% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
+| prompts      |       260 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        28 |    95.9% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       654 |    96.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
-| wizard       |       287 |    92.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **1,881** |          |                                                                                                                                                                                                                   |
+| toolutil     |       698 |    98.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
+| **Subtotal** | **2,021** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
 | Sub-package       | Tests | Coverage | Tools |
 | ----------------- | ----: | -------: | ----: |
 | projects          |   382 |   100.0% |    57 |
+| groups            |   239 |    99.7% |    37 |
 | mergerequests     |   239 |   100.0% |    30 |
-| groups            |   234 |    98.7% |    37 |
 | issues            |   223 |   100.0% |    21 |
 | users             |   208 |   100.0% |    38 |
 | dynamic           |   159 |    99.9% |     2 |
@@ -101,8 +101,8 @@
 | mrapprovals       |    85 |   100.0% |     7 |
 | tags              |    83 |   100.0% |     9 |
 | groupmembers      |    82 |   100.0% |    10 |
+| integrations      |    82 |    98.8% |    12 |
 | files             |    80 |   100.0% |     8 |
-| integrations      |    80 |    97.5% |    12 |
 
 ### Complete Tool Sub-Package Test Counts
 
@@ -125,7 +125,7 @@
 | avatar                  |         9 |          1 |   100.0% |         1 |
 | awardemoji              |       113 |          1 |   100.0% |        24 |
 | badges                  |        56 |          1 |   100.0% |        12 |
-| boards                  |        73 |          2 |    99.2% |        10 |
+| boards                  |        73 |          2 |    99.3% |        10 |
 | branches                |        95 |          1 |   100.0% |        10 |
 | branchrules             |        16 |          1 |   100.0% |         1 |
 | broadcastmessages       |        30 |          2 |   100.0% |         5 |
@@ -184,9 +184,9 @@
 | groupprotectedenvs      |        19 |          2 |   100.0% |         5 |
 | grouprelationsexport    |        26 |          2 |   100.0% |         2 |
 | groupreleases           |        18 |          3 |   100.0% |         1 |
-| groups                  |       234 |          8 |    98.7% |        37 |
+| groups                  |       239 |          8 |    99.7% |        37 |
 | groupsaml               |        33 |          3 |   100.0% |         5 |
-| groupscim               |        28 |          3 |    93.5% |         4 |
+| groupscim               |        31 |          3 |   100.0% |         4 |
 | groupserviceaccounts    |        20 |          2 |   100.0% |         8 |
 | groupsshcerts           |        25 |          3 |   100.0% |         3 |
 | groupstoragemoves       |        36 |          2 |   100.0% |         6 |
@@ -194,9 +194,9 @@
 | groupwikis              |        33 |          3 |   100.0% |         5 |
 | health                  |        17 |          1 |   100.0% |         2 |
 | impersonationtokens     |        40 |          2 |   100.0% |         5 |
-| importservice           |        30 |          1 |    96.4% |         5 |
+| importservice           |        31 |          1 |   100.0% |         5 |
 | instancevariables       |        41 |          2 |   100.0% |         5 |
-| integrations            |        80 |          4 |    97.5% |        12 |
+| integrations            |        82 |          4 |    98.8% |        12 |
 | invites                 |        40 |          1 |   100.0% |         4 |
 | issuediscussions        |        44 |          2 |   100.0% |         6 |
 | issuelinks              |        68 |          3 |   100.0% |         4 |
@@ -272,11 +272,11 @@
 | snippets                |        89 |          3 |    99.5% |        15 |
 | snippetstoragemoves     |        41 |          2 |   100.0% |         6 |
 | surfaces                |        10 |          1 |   100.0% |         0 |
-| systemhooks             |        34 |          2 |    98.3% |         8 |
+| systemhooks             |        35 |          2 |   100.0% |         8 |
 | tags                    |        83 |          2 |   100.0% |         9 |
 | terraformstates         |        17 |          1 |   100.0% |         6 |
 | todos                   |        33 |          1 |   100.0% |         3 |
-| topics                  |        28 |          2 |    97.0% |         5 |
+| topics                  |        29 |          2 |   100.0% |         5 |
 | uploads                 |        47 |          2 |   100.0% |         4 |
 | usagedata               |        27 |          1 |   100.0% |         6 |
 | useremails              |        24 |          2 |   100.0% |         6 |
@@ -286,7 +286,7 @@
 | waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        80 |          2 |   100.0% |         6 |
-| **Total**               | **8,284** |    **349** |          | **1,169** |
+| **Total**               | **8,297** |    **349** |          | **1,169** |
 
 </details>
 
@@ -300,7 +300,7 @@
 | cmd/audit_1to1/internal/actions                |    87.7% |
 | cmd/audit_1to1/internal/merge                  |    85.4% |
 | cmd/audit_1to1/internal/metadata               |    69.1% |
-| cmd/audit_1to1/internal/structs                |    95.3% |
+| cmd/audit_1to1/internal/structs                |    95.0% |
 | cmd/audit_catalog_first                        |    80.5% |
 | cmd/audit_discovery_completeness               |    77.9% |
 | cmd/audit_doc_coverage                         |    81.6% |
@@ -334,18 +334,18 @@
 | autoupdate  |    94.7% |
 | cmdutil     |   100.0% |
 | completions |   100.0% |
-| config      |    98.6% |
-| edition     |    82.6% |
+| config      |    99.7% |
+| edition     |    87.0% |
 | elicitation |    92.5% |
 | gitlab      |   100.0% |
 | oauth       |    98.6% |
 | progress    |   100.0% |
-| prompts     |    96.5% |
+| prompts     |   100.0% |
 | resources   |   100.0% |
 | serverpool  |    99.6% |
 | testutil    |    95.9% |
-| toolutil    |    96.9% |
-| wizard      |    92.0% |
+| toolutil    |    98.9% |
+| wizard      |   100.0% |
 
 ### Tool Sub-Packages
 
@@ -366,7 +366,7 @@
 | avatar                  |   100.0% |
 | awardemoji              |   100.0% |
 | badges                  |   100.0% |
-| boards                  |    99.2% |
+| boards                  |    99.3% |
 | branches                |   100.0% |
 | branchrules             |   100.0% |
 | broadcastmessages       |   100.0% |
@@ -425,9 +425,9 @@
 | groupprotectedenvs      |   100.0% |
 | grouprelationsexport    |   100.0% |
 | groupreleases           |   100.0% |
-| groups                  |    98.7% |
+| groups                  |    99.7% |
 | groupsaml               |   100.0% |
-| groupscim               |    93.5% |
+| groupscim               |   100.0% |
 | groupserviceaccounts    |   100.0% |
 | groupsshcerts           |   100.0% |
 | groupstoragemoves       |   100.0% |
@@ -435,9 +435,9 @@
 | groupwikis              |   100.0% |
 | health                  |   100.0% |
 | impersonationtokens     |   100.0% |
-| importservice           |    96.4% |
+| importservice           |   100.0% |
 | instancevariables       |   100.0% |
-| integrations            |    97.5% |
+| integrations            |    98.8% |
 | invites                 |   100.0% |
 | issuediscussions        |   100.0% |
 | issuelinks              |   100.0% |
@@ -513,11 +513,11 @@
 | snippets                |    99.5% |
 | snippetstoragemoves     |   100.0% |
 | surfaces                |   100.0% |
-| systemhooks             |    98.3% |
+| systemhooks             |   100.0% |
 | tags                    |   100.0% |
 | terraformstates         |   100.0% |
 | todos                   |   100.0% |
-| topics                  |    97.0% |
+| topics                  |   100.0% |
 | uploads                 |   100.0% |
 | usagedata               |   100.0% |
 | useremails              |   100.0% |
@@ -549,10 +549,10 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/server** (78.6%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/audit_catalog_first** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **edition** (82.6%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_1to1/internal/actions** (87.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1763,3 +1763,27 @@ func TestValidate_RateLimitBurstRequiredWithRPS(t *testing.T) {
 		t.Fatal("Load() expected error for RPS > 0 with burst = 0, got nil")
 	}
 }
+
+// TestConfigEnterprise_NilReceivers verifies the nil-receiver guards of
+// Config.Enterprise and ServerConfig.Enterprise return false instead of
+// panicking, so callers can probe unset configurations safely.
+func TestConfigEnterprise_NilReceivers(t *testing.T) {
+	var c *Config
+	if c.Enterprise() {
+		t.Error("nil *Config Enterprise() = true, want false")
+	}
+	var s *ServerConfig
+	if s.Enterprise() {
+		t.Error("nil *ServerConfig Enterprise() = true, want false")
+	}
+}
+
+// TestResolveTierEnv_InvalidEnterpriseValue verifies a non-boolean
+// GITLAB_ENTERPRISE value yields the explicit invalid-value error instead of
+// silently defaulting a tier.
+func TestResolveTierEnv_InvalidEnterpriseValue(t *testing.T) {
+	_, _, err := resolveTierEnv("", "maybe")
+	if err == nil || !strings.Contains(err.Error(), "invalid GITLAB_ENTERPRISE value") {
+		t.Errorf("resolveTierEnv err = %v, want invalid GITLAB_ENTERPRISE error", err)
+	}
+}

--- a/internal/edition/tier_test.go
+++ b/internal/edition/tier_test.go
@@ -106,3 +106,14 @@ func TestTierOrderingHelpers(t *testing.T) {
 		t.Errorf("String() mismatch: %q %q %q", Free, Premium, Ultimate)
 	}
 }
+
+// TestTierString_FreeAndUnknown verifies String() maps Free to "free" and
+// coerces unknown tier values to "free" as the safe default branch.
+func TestTierString_FreeAndUnknown(t *testing.T) {
+	if got := Free.String(); got != "free" {
+		t.Errorf("Free.String() = %q, want free", got)
+	}
+	if got := Tier(99).String(); got != "free" {
+		t.Errorf("Tier(99).String() = %q, want free (default branch)", got)
+	}
+}

--- a/internal/prompts/prompt_error_paths_test.go
+++ b/internal/prompts/prompt_error_paths_test.go
@@ -1,0 +1,775 @@
+// prompt_error_paths_test.go contains unit tests for the error and edge
+// branches of the prompt handlers: GitLab API failures, missing arguments,
+// empty results, and warn-and-continue paths that the happy-path tests in
+// the sibling files do not exercise.
+package prompts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+)
+
+const (
+	// notFoundJSON is the canonical GitLab 404 error body used by the
+	// error-branch tests. 404 is used instead of 500 because client-go
+	// retries 5xx responses, which would slow the tests down.
+	notFoundJSON = `{"message":"404 Not Found"}`
+	// basicUserJSON is the current-user payload for resolveUser success paths.
+	basicUserJSON = `{"id":1,"username":"me"}`
+	// aliceLookupJSON is the /users lookup payload resolving username "alice".
+	aliceLookupJSON = `[{"id":42,"username":"alice"}]`
+	// groupProjMRJSON is a minimal BasicMergeRequest list with a project reference.
+	groupProjMRJSON = `[{"iid":1,"project_id":10,"title":"MR1","source_branch":"a","target_branch":"main","references":{"full":"group/proj!1"},"created_at":"2026-01-01T00:00:00Z"}]`
+)
+
+// respondNotFound writes the canonical GitLab 404 JSON error response.
+func respondNotFound(w http.ResponseWriter) {
+	respondJSON(w, http.StatusNotFound, notFoundJSON)
+}
+
+// notFoundHandler returns a handler that answers every request with 404,
+// used to drive the first GitLab API call of a handler into its error branch.
+func notFoundHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+}
+
+// getPromptExpectError issues a GetPrompt call that is expected to fail and
+// fails the test when the prompt handler does not surface an error.
+func getPromptExpectError(t *testing.T, handler http.Handler, name string, args map[string]string) {
+	t.Helper()
+	session := newMCPSession(t, handler)
+	_, err := session.GetPrompt(t.Context(), &mcp.GetPromptParams{Name: name, Arguments: args})
+	if err == nil {
+		t.Errorf("expected error from prompt %q", name)
+	}
+}
+
+// getPromptText issues a GetPrompt call that is expected to succeed and
+// returns the text of the first message.
+func getPromptText(t *testing.T, handler http.Handler, name string, args map[string]string) string {
+	t.Helper()
+	session := newMCPSession(t, handler)
+	result, err := session.GetPrompt(t.Context(), &mcp.GetPromptParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf(fmtUnexpectedErr, err)
+	}
+	return result.Messages[0].Content.(*mcp.TextContent).Text
+}
+
+// prompts.go error branches.
+
+// TestFetchContributionEvents_APIError verifies that fetchContributionEvents
+// logs and returns an empty slice (instead of failing the prompt) when the
+// events API fails, for both the current-user and other-user endpoints.
+func TestFetchContributionEvents_APIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	since := time.Now().Add(-7 * 24 * time.Hour)
+
+	if events := fetchContributionEvents(t.Context(), client, 42, false, since); len(events) != 0 {
+		t.Errorf("expected no events for other-user API error, got %d", len(events))
+	}
+	if events := fetchContributionEvents(t.Context(), client, 1, true, since); len(events) != 0 {
+		t.Errorf("expected no events for current-user API error, got %d", len(events))
+	}
+}
+
+// TestWriteOpenMRsSection_APIError verifies that the open-MRs section of the
+// project health check is silently skipped when the MR list API fails.
+func TestWriteOpenMRsSection_APIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	var b strings.Builder
+	writeOpenMRsSection(t.Context(), &b, client, "42")
+	if b.Len() != 0 {
+		t.Errorf("expected empty section on API error, got: %q", b.String())
+	}
+}
+
+// TestWriteBranchesSection_APIError verifies that the branches section of the
+// project health check is silently skipped when the branch list API fails.
+func TestWriteBranchesSection_APIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	var b strings.Builder
+	writeBranchesSection(t.Context(), &b, client, "42")
+	if b.Len() != 0 {
+		t.Errorf("expected empty section on API error, got: %q", b.String())
+	}
+}
+
+// TestWriteMRSection_FetchError verifies that writeMRSection skips the whole
+// section (warn-and-continue) when the MR fetch that produced the slice failed.
+func TestWriteMRSection_FetchError(t *testing.T) {
+	var b strings.Builder
+	writeMRSection(&b, "Open MRs by", "alice", nil, errors.New("boom"))
+	if b.Len() != 0 {
+		t.Errorf("expected no output for failed fetch, got: %q", b.String())
+	}
+}
+
+// TestTeamMemberWorkload_MissingProjectID verifies that the
+// team_member_workload prompt rejects requests without a project_id.
+func TestTeamMemberWorkload_MissingProjectID(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "team_member_workload", nil)
+}
+
+// prompt_team.go error branches.
+
+// TestUserActivityReport_UserLookupAPIError verifies that the
+// user_activity_report prompt returns an error when the /users lookup fails
+// (covers both the handler branch and resolveUser's lookup-error branch).
+func TestUserActivityReport_UserLookupAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "user_activity_report", map[string]string{"username": "alice"})
+}
+
+// TestUserActivityReport_NoEventsWithMRs verifies the user_activity_report
+// branches for an empty event list combined with non-empty merged and
+// under-review MR lists (the grouped per-project MR tables).
+func TestUserActivityReport_NoEventsWithMRs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/users", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, aliceLookupJSON)
+	})
+	mux.HandleFunc("GET /api/v4/users/42/events", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	mux.HandleFunc("GET /api/v4/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, groupProjMRJSON)
+	})
+
+	text := getPromptText(t, mux, "user_activity_report", map[string]string{"username": "alice"})
+	if !strings.Contains(text, "No contribution events found") {
+		t.Error("expected empty-events message")
+	}
+	if !strings.Contains(text, "### group/proj") {
+		t.Error("expected merged MRs grouped by project")
+	}
+	if !strings.Contains(text, "## MRs Under Review") {
+		t.Error("expected MRs under review section")
+	}
+}
+
+// TestUserActivityReport_MultiDayChart verifies the daily activity chart
+// separator branches when contribution events span more than one day.
+func TestUserActivityReport_MultiDayChart(t *testing.T) {
+	d1 := time.Now().Add(-48 * time.Hour)
+	d2 := time.Now().Add(-24 * time.Hour)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/users", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, aliceLookupJSON)
+	})
+	mux.HandleFunc("GET /api/v4/users/42/events", func(w http.ResponseWriter, _ *http.Request) {
+		events := []*gl.ContributionEvent{
+			{ActionName: "pushed to", CreatedAt: &d1},
+			{ActionName: "opened", CreatedAt: &d2},
+		}
+		data, _ := json.Marshal(events)
+		respondJSON(w, http.StatusOK, string(data))
+	})
+	mux.HandleFunc("GET /api/v4/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+
+	text := getPromptText(t, mux, "user_activity_report", map[string]string{"username": "alice"})
+	if !strings.Contains(text, "## Daily Activity") {
+		t.Error("expected daily activity chart")
+	}
+	if !strings.Contains(text, "bar [1, 1]") {
+		t.Error("expected two comma-separated bar values")
+	}
+}
+
+// TestTeamOverview_MembersAPIError verifies that team_overview returns an
+// error when the group members API fails.
+func TestTeamOverview_MembersAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "team_overview", map[string]string{"group_id": "g1"})
+}
+
+// TestBuildTeamOverviewStats_MergedMRAuthors verifies the merged-MR
+// attribution branches: authors that are active members are counted while
+// unknown or nil authors are ignored.
+func TestBuildTeamOverviewStats_MergedMRAuthors(t *testing.T) {
+	members := []*gl.GroupMember{{Username: "alice", Name: "Alice", State: "active"}}
+	mergedMRs := []*gl.BasicMergeRequest{
+		{Author: &gl.BasicUser{Username: "alice"}},
+		{Author: &gl.BasicUser{Username: "ghost"}},
+		{},
+	}
+
+	stats := buildTeamOverviewStats(members, nil, mergedMRs)
+
+	if stats["alice"].mergedMRs != 1 {
+		t.Errorf("alice mergedMRs = %d, want 1", stats["alice"].mergedMRs)
+	}
+	if _, ok := stats["ghost"]; ok {
+		t.Error("non-member author should not create a stats entry")
+	}
+}
+
+// TestWriteTeamOverviewChart_EmptyStats verifies the chart is omitted when
+// there are no member stats to plot.
+func TestWriteTeamOverviewChart_EmptyStats(t *testing.T) {
+	var b strings.Builder
+	writeTeamOverviewChart(&b, map[string]*teamOverviewMemberStats{})
+	if b.Len() != 0 {
+		t.Errorf("expected no chart for empty stats, got: %q", b.String())
+	}
+}
+
+// TestGroupMRDashboard_MissingGroupID verifies that group_mr_dashboard
+// rejects requests without a group_id.
+func TestGroupMRDashboard_MissingGroupID(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "group_mr_dashboard", nil)
+}
+
+// TestGroupMRDashboard_APIError verifies that group_mr_dashboard returns an
+// error when the group MR list API fails.
+func TestGroupMRDashboard_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "group_mr_dashboard", map[string]string{"group_id": "g1"})
+}
+
+// TestGroupMRDashboard_ConflictCount verifies the conflict-counting branch
+// when an MR in the dashboard has merge conflicts.
+func TestGroupMRDashboard_ConflictCount(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/groups/g1/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":10,"title":"MR1","source_branch":"a","target_branch":"main","has_conflicts":true,"references":{"full":"group/proj!1"},"created_at":"2026-01-01T00:00:00Z"}]`)
+	})
+
+	text := getPromptText(t, mux, "group_mr_dashboard", map[string]string{"group_id": "g1"})
+	if !strings.Contains(text, "| With conflicts | 1 |") {
+		t.Error("expected conflict count of 1")
+	}
+}
+
+// TestReviewerWorkload_MembersAPIError verifies that reviewer_workload
+// returns an error when the group members API fails.
+func TestReviewerWorkload_MembersAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "reviewer_workload", map[string]string{"group_id": "g1"})
+}
+
+// TestRecordReviewerWorkloadMR_UnknownReviewer verifies that a reviewer who
+// is not a group member gets a stats entry created on the fly.
+func TestRecordReviewerWorkloadMR_UnknownReviewer(t *testing.T) {
+	stats := map[string]*reviewerWorkloadStats{}
+	created := time.Now().Add(-24 * time.Hour)
+
+	recordReviewerWorkloadMR(stats, "ghost", &created)
+
+	stat, ok := stats["ghost"]
+	if !ok {
+		t.Fatal("expected stats entry for unknown reviewer")
+	}
+	if stat.count != 1 || stat.name != "ghost" {
+		t.Errorf("stat = {count:%d name:%q}, want {count:1 name:\"ghost\"}", stat.count, stat.name)
+	}
+	if stat.oldestMR == nil || !stat.oldestMR.Equal(created) {
+		t.Errorf("oldestMR = %v, want %v", stat.oldestMR, created)
+	}
+}
+
+// TestWriteReviewerWorkloadChart_NoActiveReviewers verifies the chart is
+// omitted when nobody is reviewing anything.
+func TestWriteReviewerWorkloadChart_NoActiveReviewers(t *testing.T) {
+	var b strings.Builder
+	writeReviewerWorkloadChart(&b, map[string]*reviewerWorkloadStats{"a": {name: "A"}}, 0)
+	if b.Len() != 0 {
+		t.Errorf("expected no chart with zero active reviewers, got: %q", b.String())
+	}
+}
+
+// prompt_audit.go error branches.
+
+// TestAuditBranchProtection_ProjectAPIError verifies the project-fetch error
+// branch of the branch protection audit.
+func TestAuditBranchProtection_ProjectAPIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	_, err := handleAuditBranchProtection(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err == nil {
+		t.Error("expected error when project API fails")
+	}
+}
+
+// TestAuditBranchProtection_BranchesAPIError verifies the protected-branches
+// error branch of the branch protection audit (project fetch succeeds).
+func TestAuditBranchProtection_BranchesAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `{"path_with_namespace":"group/p","default_branch":"main"}`)
+	})
+	mux.HandleFunc(routeProtectedBranches, func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	client := newTestClient(t, mux)
+	_, err := handleAuditBranchProtection(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err == nil {
+		t.Error("expected error when protected branches API fails")
+	}
+}
+
+// TestWriteSharedGroups_WithExpiry verifies the expiry-date branch of the
+// shared-groups table.
+func TestWriteSharedGroups_WithExpiry(t *testing.T) {
+	expires := gl.ISOTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	var b strings.Builder
+	writeSharedGroups(&b, []gl.ProjectSharedWithGroup{
+		{GroupID: 7, GroupName: "team-x", GroupAccessLevel: 30, ExpiresAt: &expires},
+	})
+	if !strings.Contains(b.String(), "2026-01-01") {
+		t.Errorf("expected expiry date in output, got: %s", b.String())
+	}
+}
+
+// TestAuditProjectAccess_MembersAPIError verifies the members-fetch error
+// branch of the project access audit.
+func TestAuditProjectAccess_MembersAPIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	_, err := handleAuditProjectAccess(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err == nil {
+		t.Error("expected error when members API fails")
+	}
+}
+
+// TestAuditProjectAccess_ProjectAPIError verifies the project-fetch error
+// branch of the project access audit (members fetch succeeds).
+func TestAuditProjectAccess_ProjectAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeMembersAll, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	client := newTestClient(t, mux)
+	_, err := handleAuditProjectAccess(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err == nil {
+		t.Error("expected error when project API fails")
+	}
+}
+
+// TestAuditProjectAccess_InactiveAccounts verifies the inactive-accounts
+// section branch when a member is neither active nor blocked.
+func TestAuditProjectAccess_InactiveAccounts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeMembersAll, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[{"id":1,"username":"u1","name":"U One","access_level":30,"state":"awaiting"}]`)
+	})
+	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `{"path_with_namespace":"group/p"}`)
+	})
+
+	client := newTestClient(t, mux)
+	result, err := handleAuditProjectAccess(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err != nil {
+		t.Fatalf(errMsgUnexpected, err)
+	}
+	text := result.Messages[0].Content.(*mcp.TextContent).Text
+	if !strings.Contains(text, "Inactive Accounts") {
+		t.Error("expected inactive accounts section")
+	}
+}
+
+// TestAuditProjectWorkflow_ProjectAPIError verifies the project-fetch error
+// branch of the workflow audit.
+func TestAuditProjectWorkflow_ProjectAPIError(t *testing.T) {
+	client := newTestClient(t, notFoundHandler())
+	_, err := handleAuditProjectWorkflow(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err == nil {
+		t.Error("expected error when project API fails")
+	}
+}
+
+// TestAuditProjectWorkflow_SubResourceAPIErrors verifies that the workflow
+// audit degrades gracefully (warn-and-continue) when the labels and template
+// APIs fail while the project fetch succeeds.
+func TestAuditProjectWorkflow_SubResourceAPIErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `{"path_with_namespace":"group/p"}`)
+	})
+	mux.HandleFunc(routeMilestones, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	// Labels and both template endpoints fall through to 404.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	client := newTestClient(t, mux)
+	result, err := handleAuditProjectWorkflow(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
+	if err != nil {
+		t.Fatalf(errMsgUnexpected, err)
+	}
+	text := result.Messages[0].Content.(*mcp.TextContent).Text
+	if !strings.Contains(text, "No labels configured") {
+		t.Error("expected no-labels warning when labels API fails")
+	}
+	if !strings.Contains(text, "No templates found") {
+		t.Error("expected no-templates warning when template APIs fail")
+	}
+}
+
+// prompt_cross_project.go error branches.
+
+// TestMyOpenMRs_UserAPIError verifies that my_open_mrs returns an error when
+// the current-user lookup fails.
+func TestMyOpenMRs_UserAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "my_open_mrs", nil)
+}
+
+// TestMyOpenMRs_MRListAPIErrors verifies that my_open_mrs degrades to an
+// empty dashboard (warn-and-continue) when both MR list calls fail.
+func TestMyOpenMRs_MRListAPIErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, basicUserJSON)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	text := getPromptText(t, mux, "my_open_mrs", nil)
+	if !strings.Contains(text, "| Total open MRs | 0 |") {
+		t.Error("expected zero MRs when both list calls fail")
+	}
+}
+
+// TestMyPendingReviews_UserAPIError verifies that my_pending_reviews returns
+// an error when the current-user lookup fails.
+func TestMyPendingReviews_UserAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "my_pending_reviews", nil)
+}
+
+// TestMyPendingReviews_ListAPIError verifies that my_pending_reviews returns
+// an error when the reviewer MR list fails.
+func TestMyPendingReviews_ListAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, basicUserJSON)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+	getPromptExpectError(t, mux, "my_pending_reviews", nil)
+}
+
+// TestMyIssues_UserAPIError verifies that my_issues returns an error when the
+// current-user lookup fails.
+func TestMyIssues_UserAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "my_issues", nil)
+}
+
+// TestMyIssues_ListAPIError verifies that my_issues returns an error when the
+// issue list fails.
+func TestMyIssues_ListAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, basicUserJSON)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+	getPromptExpectError(t, mux, "my_issues", nil)
+}
+
+// TestMyActivitySummary_UserAPIError verifies that my_activity_summary
+// returns an error when the current-user lookup fails.
+func TestMyActivitySummary_UserAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "my_activity_summary", nil)
+}
+
+// TestMyActivitySummary_MRListAPIErrors verifies that my_activity_summary
+// renders N/A rows (warn-and-continue) when the merged and reviewed MR list
+// calls fail.
+func TestMyActivitySummary_MRListAPIErrors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, basicUserJSON)
+	})
+	mux.HandleFunc("GET /api/v4/events", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	text := getPromptText(t, mux, "my_activity_summary", nil)
+	if !strings.Contains(text, "| MRs merged | N/A |") {
+		t.Error("expected N/A for merged MRs when list fails")
+	}
+	if !strings.Contains(text, "| MRs reviewed | N/A |") {
+		t.Error("expected N/A for reviewed MRs when list fails")
+	}
+}
+
+// prompt_analytics.go error branches.
+
+// TestMergeVelocity_APIError verifies that merge_velocity returns an error
+// when the MR list API fails.
+func TestMergeVelocity_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "merge_velocity", map[string]string{"project_id": "42"})
+}
+
+// TestWriteDailyMergeChart_NoMergedDates verifies that the daily merge chart
+// is omitted when no MR carries a merged_at timestamp.
+func TestWriteDailyMergeChart_NoMergedDates(t *testing.T) {
+	var b strings.Builder
+	writeDailyMergeChart(&b, []*gl.BasicMergeRequest{{IID: 1}})
+	if b.Len() != 0 {
+		t.Errorf("expected no chart without merge dates, got: %q", b.String())
+	}
+}
+
+// TestReleaseReadiness_APIError verifies that release_readiness returns an
+// error when the MR list API fails.
+func TestReleaseReadiness_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "release_readiness", map[string]string{"project_id": "42"})
+}
+
+// TestReleaseReadiness_DiscussionsAPIError verifies that unresolved-thread
+// counting skips MRs whose discussion API fails (continue branch).
+func TestReleaseReadiness_DiscussionsAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":42,"title":"MR1","source_branch":"a","target_branch":"main"}]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	text := getPromptText(t, mux, "release_readiness", map[string]string{"project_id": "42"})
+	if !strings.Contains(text, "| Unresolved threads | 0 |") {
+		t.Error("expected zero unresolved threads when discussions API fails")
+	}
+}
+
+// TestReleaseCadence_APIError verifies that release_cadence returns an error
+// when the releases API fails.
+func TestReleaseCadence_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "release_cadence", map[string]string{"project_id": "42"})
+}
+
+// TestFilterRecentReleases_CreatedAtFallback verifies that a release without
+// released_at falls back to created_at for the recency filter.
+func TestFilterRecentReleases_CreatedAtFallback(t *testing.T) {
+	created := time.Now().Add(-24 * time.Hour)
+	since := time.Now().Add(-30 * 24 * time.Hour)
+
+	filtered := filterRecentReleases([]*gl.Release{{CreatedAt: &created}}, since)
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 release via created_at fallback, got %d", len(filtered))
+	}
+}
+
+// TestWriteReleaseHistoryTable_TagNameFallback verifies that a release
+// without a name is rendered using its tag name. The slice is built
+// dynamically so gosec does not bounds-propagate a literal length into the
+// production loop (G602 false positive).
+func TestWriteReleaseHistoryTable_TagNameFallback(t *testing.T) {
+	now := time.Now()
+	var releases []*gl.Release
+	releases = append(releases, &gl.Release{TagName: "v1.0.0", ReleasedAt: &now})
+
+	var b strings.Builder
+	writeReleaseHistoryTable(&b, releases)
+	if !strings.Contains(b.String(), "| v1.0.0 | v1.0.0 |") {
+		t.Errorf("expected tag name fallback in table, got: %s", b.String())
+	}
+}
+
+// TestWeeklyTeamRecap_MergedAPIError verifies that weekly_team_recap degrades
+// to a zero-count recap (warn-and-continue) when the group MR API fails.
+func TestWeeklyTeamRecap_MergedAPIError(t *testing.T) {
+	text := getPromptText(t, notFoundHandler(), "weekly_team_recap", map[string]string{"group_id": "g1"})
+	if !strings.Contains(text, "| MRs merged | 0 |") {
+		t.Error("expected zero merged MRs when API fails")
+	}
+}
+
+// TestWeeklyTeamRecap_OpenMRConflicts verifies the open-MR conflict counting
+// branch of weekly_team_recap.
+func TestWeeklyTeamRecap_OpenMRConflicts(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/groups/g1/merge_requests", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") == "merged" {
+			respondJSON(w, http.StatusOK, `[]`)
+			return
+		}
+		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":10,"title":"MR1","source_branch":"a","target_branch":"main","has_conflicts":true,"references":{"full":"group/proj!1"},"created_at":"2026-01-01T00:00:00Z"}]`)
+	})
+	mux.HandleFunc("GET /api/v4/groups/g1/issues", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+
+	text := getPromptText(t, mux, "weekly_team_recap", map[string]string{"group_id": "g1"})
+	if !strings.Contains(text, "## Open MR Health") {
+		t.Error("expected open MR health section")
+	}
+	if !strings.Contains(text, "| With conflicts | 1 |") {
+		t.Error("expected conflict count of 1")
+	}
+}
+
+// prompt_project_reports.go error branches.
+
+// TestBranchMRSummary_APIError verifies that branch_mr_summary returns an
+// error when the MR list API fails.
+func TestBranchMRSummary_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "branch_mr_summary",
+		map[string]string{"project_id": "42", "target_branch": "main"})
+}
+
+// TestProjectActivityReport_EventsAPIErrorWithMergedMRs verifies that
+// project_activity_report tolerates a failing events API (warn-and-continue)
+// and still renders the recently-merged MRs section when merged MRs exist.
+func TestProjectActivityReport_EventsAPIErrorWithMergedMRs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") == "merged" {
+			respondJSON(w, http.StatusOK, groupProjMRJSON)
+			return
+		}
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	mux.HandleFunc(pathIssues, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[]`)
+	})
+	// Project events endpoint falls through to 404.
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	text := getPromptText(t, mux, "project_activity_report", map[string]string{"project_id": "42"})
+	if !strings.Contains(text, "| Events | 0 |") {
+		t.Error("expected zero events when events API fails")
+	}
+	if !strings.Contains(text, "Recently Merged MRs") {
+		t.Error("expected recently merged MRs section")
+	}
+}
+
+// TestMRDiscussionHealth_APIError verifies that mr_discussion_health returns
+// an error when the MR list API fails.
+func TestMRDiscussionHealth_APIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "mr_discussion_health", map[string]string{"project_id": "42"})
+}
+
+// TestMRDiscussionHealth_DiscussionsAPIError verifies that a failing
+// discussion API for a single MR yields a zero-thread row instead of failing
+// the whole prompt (warn-and-continue branch).
+func TestMRDiscussionHealth_DiscussionsAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":42,"title":"MR1","source_branch":"a","target_branch":"main","author":{"username":"alice"}}]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+
+	text := getPromptText(t, mux, "mr_discussion_health", map[string]string{"project_id": "42"})
+	if !strings.Contains(text, "| !1 | MR1 | @alice | 0 | 0 |") {
+		t.Error("expected zero-thread row when discussions API fails")
+	}
+}
+
+// prompt_milestone_label.go edge branch.
+
+// TestProjectContributors_PieChartCap verifies that the contributor pie chart
+// is capped at eight entries while the table still lists everyone.
+func TestProjectContributors_PieChartCap(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 1; i <= 9; i++ {
+		if i > 1 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `{"name":"c%d","commits":%d,"additions":0,"deletions":0}`, i, 10-i)
+	}
+	sb.WriteString("]")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/projects/42/repository/contributors", func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, sb.String())
+	})
+
+	text := getPromptText(t, mux, "project_contributors", map[string]string{"project_id": "42"})
+	if !strings.Contains(text, "| c9 |") {
+		t.Error("expected ninth contributor in the table")
+	}
+	if !strings.Contains(text, `"c8" :`) {
+		t.Error("expected eighth contributor in the pie chart")
+	}
+	if strings.Contains(text, `"c9" :`) {
+		t.Error("pie chart should be capped at eight entries")
+	}
+}
+
+// prompt_git_workflow.go error branches.
+
+// TestAuditCommitHygiene_CompareAPIError verifies that audit_commit_hygiene
+// returns an error when the repository compare API fails.
+func TestAuditCommitHygiene_CompareAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "audit_commit_hygiene",
+		map[string]string{"project_id": "42", "from": "v1.0.0"})
+}
+
+// TestAuditCommitHygiene_SameRef verifies the early-exit branch when both
+// refs point at the same commit and no commits are returned.
+func TestAuditCommitHygiene_SameRef(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathRepoCompare, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `{"compare_same_ref":true,"commits":[],"diffs":[]}`)
+	})
+
+	text := getPromptText(t, mux, "audit_commit_hygiene",
+		map[string]string{"project_id": "42", "from": "v1.0.0", "to": "v1.0.0"})
+	if !strings.Contains(text, "No commits found") {
+		t.Error("expected no-commits message for same ref")
+	}
+}
+
+// TestMRDescriptionQuality_InvalidIID verifies that a non-numeric MR IID is
+// rejected before any API call.
+func TestMRDescriptionQuality_InvalidIID(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "mr_description_quality",
+		map[string]string{"project_id": "42", "merge_request_iid": "abc"})
+}
+
+// TestMRDescriptionQuality_MRAPIError verifies the MR-fetch error branch of
+// mr_description_quality.
+func TestMRDescriptionQuality_MRAPIError(t *testing.T) {
+	getPromptExpectError(t, notFoundHandler(), "mr_description_quality",
+		map[string]string{"project_id": "42", "merge_request_iid": "5"})
+}
+
+// TestMRDescriptionQuality_DiffsAPIError verifies the diff-fetch error branch
+// of mr_description_quality (MR fetch succeeds).
+func TestMRDescriptionQuality_DiffsAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+pathMR5, func(w http.ResponseWriter, _ *http.Request) {
+		respondJSON(w, http.StatusOK, `{"iid":5,"title":"T","source_branch":"a","target_branch":"main","description":""}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		respondNotFound(w)
+	})
+	getPromptExpectError(t, mux, "mr_description_quality",
+		map[string]string{"project_id": "42", "merge_request_iid": "5"})
+}
+
+// TestCommitBody_EmptyMessage verifies that a whitespace-only commit message
+// yields an empty body.
+func TestCommitBody_EmptyMessage(t *testing.T) {
+	if got := commitBody(&gl.Commit{Message: "   "}); got != "" {
+		t.Errorf("commitBody() = %q, want empty", got)
+	}
+}

--- a/internal/tools/dynamic/ranking.go
+++ b/internal/tools/dynamic/ranking.go
@@ -113,6 +113,9 @@ type searchDocument struct {
 	SchemaEnums      []string
 	SchemaDescTerms  []string
 	FlatText         string
+	// WordizedValues maps each searchable multi-word value above to its
+	// precomputed space-joined word form (see wordizeSearchDocument).
+	WordizedValues map[string]string
 }
 
 type searchIndex struct {

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -701,6 +701,8 @@ func buildSearchDocument(id, tool, domain, action string, aliases, tags []string
 		SchemaDescTerms:  schemaPropertyDescriptions(schema),
 	}
 
+	wordizeSearchDocument(&document)
+
 	parts := []string{
 		document.Backend,
 		document.Capability,
@@ -728,6 +730,38 @@ func buildSearchDocument(id, tool, domain, action string, aliases, tags []string
 	parts = append(parts, document.SchemaDescTerms...)
 	document.FlatText = strings.ToLower(strings.Join(parts, " "))
 	return document
+}
+
+// wordizeSearchDocument precomputes the space-joined word form of every value
+// the query-time matcher inspects, so matchedSearchValue never re-normalizes
+// candidate text per comparison (that per-call Replacer/Fields/dedupe work
+// used to account for ~40% of Search CPU on long multi-intent queries).
+func wordizeSearchDocument(document *searchDocument) {
+	fields := [][]string{
+		document.DomainWords,
+		document.ActionWords,
+		document.RequiredParams,
+		document.OptionalParams,
+		document.SchemaProperties,
+		document.SchemaEnums,
+		document.SchemaDescTerms,
+	}
+	total := 0
+	for _, values := range fields {
+		total += len(values)
+	}
+	if total == 0 {
+		return
+	}
+	wordized := make(map[string]string, total)
+	for _, values := range fields {
+		for _, value := range values {
+			if _, ok := wordized[value]; !ok {
+				wordized[value] = strings.Join(splitSearchFieldWords(value), " ")
+			}
+		}
+	}
+	document.WordizedValues = wordized
 }
 
 func inferCapability(domain, action string) string {
@@ -769,8 +803,13 @@ func inferActionScope(domain string, schema map[string]any) string {
 	}
 }
 
+// searchWordReplacer maps the canonical identifier separators to spaces. It is
+// built once: constructing a strings.Replacer per call used to dominate Search
+// CPU when the matcher re-normalized candidate text per comparison.
+var searchWordReplacer = strings.NewReplacer(".", " ", "_", " ", "-", " ")
+
 func splitSearchFieldWords(value string) []string {
-	fields := strings.Fields(strings.ToLower(strings.NewReplacer(".", " ", "_", " ", "-", " ").Replace(value)))
+	fields := strings.Fields(strings.ToLower(searchWordReplacer.Replace(value)))
 	return dedupeStrings(fields)
 }
 
@@ -871,7 +910,7 @@ type searchTerm struct {
 }
 
 func normalizeSearchTerms(query string) []searchTerm {
-	fields := strings.Fields(strings.ToLower(strings.NewReplacer(".", " ", "_", " ", "-", " ").Replace(query)))
+	fields := strings.Fields(strings.ToLower(searchWordReplacer.Replace(query)))
 	terms := make([]searchTerm, 0, len(fields))
 	for _, field := range fields {
 		if _, stop := searchStopWords()[field]; stop {
@@ -2541,11 +2580,11 @@ func scoreRequiredParamSignalValue(entry actionEntry, terms []searchTerm) int {
 	total := 0
 	for _, term := range terms {
 		for _, alternative := range term.Alternatives {
-			if matchedSearchValue(document.RequiredParams, alternative) != "" {
+			if matchedSearchValue(document.WordizedValues, document.RequiredParams, alternative) != "" {
 				total += scoreRequiredParamBoost
 				break
 			}
-			if matchedSearchValue(document.OptionalParams, alternative) != "" {
+			if matchedSearchValue(document.WordizedValues, document.OptionalParams, alternative) != "" {
 				total += scoreRequiredParamBoost / 2
 				break
 			}
@@ -2559,11 +2598,11 @@ func scoreRequiredParamSignals(entry actionEntry, terms []searchTerm) (int, []Ma
 	reasons := make([]MatchReason, 0)
 	for _, term := range terms {
 		for _, alternative := range term.Alternatives {
-			matched := matchedSearchValue(document.RequiredParams, alternative)
+			matched := matchedSearchValue(document.WordizedValues, document.RequiredParams, alternative)
 			field := searchFieldRequiredParam
 			boost := scoreRequiredParamBoost
 			if matched == "" {
-				matched = matchedSearchValue(document.OptionalParams, alternative)
+				matched = matchedSearchValue(document.WordizedValues, document.OptionalParams, alternative)
 				field = searchFieldOptionalParam
 				boost = scoreRequiredParamBoost / 2
 			}
@@ -3113,19 +3152,19 @@ func scoreSearchAlternative(entry actionEntry, raw, alternative string) int {
 		return scoreDomainActionWord
 	case strings.Contains(document.CanonicalID, alternative):
 		return scoreIDContains
-	case containsAnySearchValue(document.DomainWords, alternative) || containsAnySearchValue(document.ActionWords, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.DomainWords, alternative) || containsAnySearchValue(document.WordizedValues, document.ActionWords, alternative):
 		return scoreDomainActionContains
 	case strings.Contains(document.Tool, alternative):
 		return scoreFieldContainsFor(raw, alternative)
-	case containsAnySearchValue(document.RequiredParams, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.RequiredParams, alternative):
 		return scoreParamContainsFor(raw, alternative, scoreRequiredParamMatch)
-	case containsAnySearchValue(document.OptionalParams, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.OptionalParams, alternative):
 		return scoreParamContainsFor(raw, alternative, scoreOptionalParamMatch)
-	case containsAnySearchValue(document.SchemaEnums, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.SchemaEnums, alternative):
 		return scoreParamContainsFor(raw, alternative, scoreSchemaEnumMatch)
-	case containsAnySearchValue(document.SchemaDescTerms, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.SchemaDescTerms, alternative):
 		return scoreParamContainsFor(raw, alternative, scoreSchemaDescMatch)
-	case containsAnySearchValue(document.SchemaProperties, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.SchemaProperties, alternative):
 		return scoreFieldContainsFor(raw, alternative)
 	case strings.Contains(document.FlatText, alternative):
 		if raw == alternative {
@@ -3158,22 +3197,22 @@ func scoreSearchAlternativeWithReason(entry actionEntry, raw, alternative string
 	switch {
 	case strings.Contains(document.CanonicalID, alternative):
 		return reason(searchFieldIDContains, document.CanonicalID, scoreIDContains)
-	case containsAnySearchValue(document.DomainWords, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.DomainWords, alternative):
 		return reason(searchFieldDomainContains, document.Domain, scoreDomainActionContains)
-	case containsAnySearchValue(document.ActionWords, alternative):
+	case containsAnySearchValue(document.WordizedValues, document.ActionWords, alternative):
 		return reason(searchFieldActionContains, document.Action, scoreDomainActionContains)
 	case strings.Contains(document.Tool, alternative):
 		return reason(searchFieldTool, document.Tool, scoreFieldContainsFor(raw, alternative))
-	case containsAnySearchValue(document.RequiredParams, alternative):
-		return reason(searchFieldRequiredParam, matchedSearchValue(document.RequiredParams, alternative), scoreParamContainsFor(raw, alternative, scoreRequiredParamMatch))
-	case containsAnySearchValue(document.OptionalParams, alternative):
-		return reason(searchFieldOptionalParam, matchedSearchValue(document.OptionalParams, alternative), scoreParamContainsFor(raw, alternative, scoreOptionalParamMatch))
-	case containsAnySearchValue(document.SchemaEnums, alternative):
-		return reason(searchFieldSchemaEnum, matchedSearchValue(document.SchemaEnums, alternative), scoreParamContainsFor(raw, alternative, scoreSchemaEnumMatch))
-	case containsAnySearchValue(document.SchemaDescTerms, alternative):
-		return reason(searchFieldSchemaDesc, matchedSearchValue(document.SchemaDescTerms, alternative), scoreParamContainsFor(raw, alternative, scoreSchemaDescMatch))
-	case containsAnySearchValue(document.SchemaProperties, alternative):
-		return reason(searchFieldSchemaProperty, matchedSearchValue(document.SchemaProperties, alternative), scoreFieldContainsFor(raw, alternative))
+	case containsAnySearchValue(document.WordizedValues, document.RequiredParams, alternative):
+		return reason(searchFieldRequiredParam, matchedSearchValue(document.WordizedValues, document.RequiredParams, alternative), scoreParamContainsFor(raw, alternative, scoreRequiredParamMatch))
+	case containsAnySearchValue(document.WordizedValues, document.OptionalParams, alternative):
+		return reason(searchFieldOptionalParam, matchedSearchValue(document.WordizedValues, document.OptionalParams, alternative), scoreParamContainsFor(raw, alternative, scoreOptionalParamMatch))
+	case containsAnySearchValue(document.WordizedValues, document.SchemaEnums, alternative):
+		return reason(searchFieldSchemaEnum, matchedSearchValue(document.WordizedValues, document.SchemaEnums, alternative), scoreParamContainsFor(raw, alternative, scoreSchemaEnumMatch))
+	case containsAnySearchValue(document.WordizedValues, document.SchemaDescTerms, alternative):
+		return reason(searchFieldSchemaDesc, matchedSearchValue(document.WordizedValues, document.SchemaDescTerms, alternative), scoreParamContainsFor(raw, alternative, scoreSchemaDescMatch))
+	case containsAnySearchValue(document.WordizedValues, document.SchemaProperties, alternative):
+		return reason(searchFieldSchemaProperty, matchedSearchValue(document.WordizedValues, document.SchemaProperties, alternative), scoreFieldContainsFor(raw, alternative))
 	case strings.Contains(document.FlatText, alternative):
 		if raw == alternative {
 			return reason(searchFieldFlatText, alternative, scoreFieldContains)
@@ -3216,7 +3255,7 @@ func documentForEntry(entry actionEntry) searchDocument {
 	if entry.Document.CanonicalID != "" || entry.Document.FlatText != "" {
 		return entry.Document
 	}
-	return searchDocument{
+	document := searchDocument{
 		CanonicalID:      strings.ToLower(strings.TrimSpace(entry.ID)),
 		IDWords:          splitSearchFieldWords(entry.ID),
 		Tool:             strings.ToLower(strings.TrimSpace(entry.Tool)),
@@ -3233,19 +3272,31 @@ func documentForEntry(entry actionEntry) searchDocument {
 		SchemaDescTerms:  nil,
 		FlatText:         strings.ToLower(entry.SearchText),
 	}
+	wordizeSearchDocument(&document)
+	return document
 }
 
-func containsAnySearchValue(values []string, alternative string) bool {
-	return matchedSearchValue(values, alternative) != ""
+func containsAnySearchValue(wordized map[string]string, values []string, alternative string) bool {
+	return matchedSearchValue(wordized, values, alternative) != ""
 }
 
-func matchedSearchValue(values []string, alternative string) string {
+func matchedSearchValue(wordized map[string]string, values []string, alternative string) string {
 	for _, value := range values {
-		if value == alternative || strings.Contains(value, alternative) || strings.Contains(strings.Join(splitSearchFieldWords(value), " "), alternative) {
+		if value == alternative || strings.Contains(value, alternative) || strings.Contains(wordizedSearchValue(wordized, value), alternative) {
 			return value
 		}
 	}
 	return ""
+}
+
+// wordizedSearchValue returns the precomputed word form of value, falling back
+// to on-the-fly normalization for values that were not registered at document
+// build time (hand-built test entries), preserving the original semantics.
+func wordizedSearchValue(wordized map[string]string, value string) string {
+	if words, ok := wordized[value]; ok {
+		return words
+	}
+	return strings.Join(splitSearchFieldWords(value), " ")
 }
 
 func scoreFieldContainsFor(raw, alternative string) int {

--- a/internal/tools/groups/hooks_test.go
+++ b/internal/tools/groups/hooks_test.go
@@ -747,3 +747,91 @@ func TestHookSubOps_CanceledContext(t *testing.T) {
 		t.Error("ResendHookEvent: expected context error")
 	}
 }
+
+// TestHookHelpers_APIError_ReturnsWrappedError verifies that every custom
+// header / URL variable / test / resend hook helper wraps a failing GitLab
+// API response into its operation-prefixed error instead of returning nil,
+// covering the error branch of each of the six twin handlers.
+func TestHookHelpers_APIError_ReturnsWrappedError(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	tests := []struct {
+		name   string
+		call   func() error
+		wantOp string
+	}{
+		{name: "set custom header", wantOp: "groupSetHookCustomHeader", call: func() error {
+			return SetHookCustomHeader(t.Context(), client, SetHookCustomHeaderInput{GroupID: "42", HookID: 7, Key: "X-K", Value: "v"})
+		}},
+		{name: "delete custom header", wantOp: "groupDeleteHookCustomHeader", call: func() error {
+			return DeleteHookCustomHeader(t.Context(), client, DeleteHookCustomHeaderInput{GroupID: "42", HookID: 7, Key: "X-K"})
+		}},
+		{name: "set url variable", wantOp: "groupSetHookURLVariable", call: func() error {
+			return SetHookURLVariable(t.Context(), client, SetHookURLVariableInput{GroupID: "42", HookID: 7, Key: "k", Value: "v"})
+		}},
+		{name: "delete url variable", wantOp: "groupDeleteHookURLVariable", call: func() error {
+			return DeleteHookURLVariable(t.Context(), client, DeleteHookURLVariableInput{GroupID: "42", HookID: 7, Key: "k"})
+		}},
+		{name: "test hook", wantOp: "groupTestHook", call: func() error {
+			return TestHook(t.Context(), client, TestHookInput{GroupID: "42", HookID: 7, Trigger: "push_events"})
+		}},
+		{name: "resend hook event", wantOp: "groupResendHookEvent", call: func() error {
+			return ResendHookEvent(t.Context(), client, ResendHookEventInput{GroupID: "42", HookID: 7, HookEventID: 3})
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			if err == nil {
+				t.Fatalf("%s: expected error from failing API, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantOp) {
+				t.Errorf("%s: error %q does not carry op prefix %q", tt.name, err, tt.wantOp)
+			}
+		})
+	}
+}
+
+// TestHookOutputWrappers_APIError_PropagatesError verifies the legacy
+// *Output wrappers propagate the underlying helper error (covering their
+// error pass-through branches) instead of returning a success payload.
+func TestHookOutputWrappers_APIError_PropagatesError(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{name: "set custom header output", call: func() error {
+			_, err := SetHookCustomHeaderOutput(t.Context(), client, SetHookCustomHeaderInput{GroupID: "42", HookID: 7, Key: "X-K", Value: "v"})
+			return err
+		}},
+		{name: "set url variable output", call: func() error {
+			_, err := SetHookURLVariableOutput(t.Context(), client, SetHookURLVariableInput{GroupID: "42", HookID: 7, Key: "k", Value: "v"})
+			return err
+		}},
+		{name: "test hook output", call: func() error {
+			_, err := TestHookOutput(t.Context(), client, TestHookInput{GroupID: "42", HookID: 7, Trigger: "push_events"})
+			return err
+		}},
+		{name: "resend hook event output", call: func() error {
+			_, err := ResendHookEventOutput(t.Context(), client, ResendHookEventInput{GroupID: "42", HookID: 7, HookEventID: 3})
+			return err
+		}},
+		{name: "delete push rule output", call: func() error {
+			_, err := DeletePushRuleOutput(t.Context(), client, DeletePushRuleInput{GroupID: "42"})
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.call(); err == nil {
+				t.Fatalf("%s: expected propagated error from failing API, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/internal/tools/groups/sharing_test.go
+++ b/internal/tools/groups/sharing_test.go
@@ -334,3 +334,54 @@ func TestSharing_CanceledContext(t *testing.T) {
 		t.Error("TransferSubGroup: expected context error")
 	}
 }
+
+// TestShareGroupWithGroup_MemberRoleAndErrorFallthrough verifies the
+// member_role_id option is forwarded when set and that non-422/400 API
+// failures take the NotFound-hint fallthrough branch.
+func TestShareGroupWithGroup_MemberRoleAndErrorFallthrough(t *testing.T) {
+	roleID := int64(9)
+
+	okClient := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "member_role_id") {
+			t.Errorf("request body missing member_role_id: %s", body)
+		}
+		testutil.RespondJSON(w, http.StatusOK, `{"id": 42}`)
+	}))
+	if _, err := ShareGroupWithGroup(t.Context(), okClient, ShareGroupInput{GroupID: "42", SharedGroupID: 7, GroupAccess: 30, MemberRoleID: &roleID}); err != nil {
+		t.Fatalf("ShareGroupWithGroup with member role error = %v", err)
+	}
+
+	failClient := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	_, err := ShareGroupWithGroup(t.Context(), failClient, ShareGroupInput{GroupID: "42", SharedGroupID: 7, GroupAccess: 30})
+	if err == nil || !strings.Contains(err.Error(), "groupShareWithGroup") {
+		t.Errorf("fallthrough err = %v, want groupShareWithGroup-wrapped error", err)
+	}
+}
+
+// TestTransferSubGroup_BadRequestHint verifies an HTTP 400 transfer failure
+// surfaces the invalid-destination hint branch instead of the generic
+// not-found wrap.
+func TestTransferSubGroup_BadRequestHint(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	parentID := int64(7)
+	_, err := TransferSubGroup(t.Context(), client, TransferSubGroupInput{GroupID: "42", ParentID: &parentID})
+	if err == nil || !strings.Contains(err.Error(), "gitlab_group_transfer_locations") {
+		t.Errorf("TransferSubGroup 400 err = %v, want invalid-destination hint", err)
+	}
+}
+
+// TestFormatSharedProjectsListMarkdown_ArchivedRow verifies the shared
+// projects table marks archived projects with "Yes" in the Archived column.
+func TestFormatSharedProjectsListMarkdown_ArchivedRow(t *testing.T) {
+	md := FormatSharedProjectsListMarkdown(SharedProjectsListOutput{Projects: []ProjectItem{
+		{ID: 1, Name: "arch", Archived: true},
+	}})
+	if !strings.Contains(md, "| Yes |") {
+		t.Errorf("markdown missing archived Yes cell:\n%s", md)
+	}
+}

--- a/internal/tools/groupscim/markdown_test.go
+++ b/internal/tools/groupscim/markdown_test.go
@@ -158,3 +158,47 @@ func TestToOutput_Nil(t *testing.T) {
 		t.Error("expected Active false, got true")
 	}
 }
+
+// TestFormatOutputMarkdown_EmptyAndPopulated verifies the single-identity
+// formatter returns an empty string for a zero-value identity (the
+// nothing-to-render guard) and renders UID/UserID/Active for a populated one.
+func TestFormatOutputMarkdown_EmptyAndPopulated(t *testing.T) {
+	if got := FormatOutputMarkdown(Output{}); got != "" {
+		t.Errorf("FormatOutputMarkdown(zero) = %q, want empty", got)
+	}
+	got := FormatOutputMarkdown(Output{ExternalUID: "uid-1", UserID: 7, Active: true})
+	for _, want := range []string{"## SCIM Identity", "`uid-1`", "**User ID**: 7", "**Active**: true"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFormatListMarkdown_EmptyAndRows verifies the list formatter emits the
+// no-identities message for an empty list and a table row per identity plus
+// the count header otherwise.
+func TestFormatListMarkdown_EmptyAndRows(t *testing.T) {
+	if got := FormatListMarkdown(ListOutput{}); got != "No SCIM identities found." {
+		t.Errorf("FormatListMarkdown(empty) = %q", got)
+	}
+	got := FormatListMarkdown(ListOutput{Identities: []Output{
+		{ExternalUID: "a", UserID: 1, Active: true},
+		{ExternalUID: "b", UserID: 2},
+	}})
+	for _, want := range []string{"## SCIM Identities (2)", "| `a` | 1 | true |", "| `b` | 2 | false |"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatListMarkdown missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestFormatUpdateMarkdown_RendersConfirmation verifies the update formatter
+// surfaces the Updated flag and message text.
+func TestFormatUpdateMarkdown_RendersConfirmation(t *testing.T) {
+	got := FormatUpdateMarkdown(UpdateOutput{Updated: true, Message: "ok"})
+	for _, want := range []string{"## SCIM Identity Updated", "**Updated**: true", "**Message**: ok"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatUpdateMarkdown missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -761,3 +761,21 @@ func importServiceSpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[str
 	}
 	return byTool
 }
+
+// TestMarkdownRegistry_PointerOutputFormatters verifies the init-registered
+// value-signature formatter closures render each import output type through
+// the shared Markdown registry (covering the registration lambdas that adapt
+// the pointer-returning handlers to value-type registry keys).
+func TestMarkdownRegistry_PointerOutputFormatters(t *testing.T) {
+	outputs := []any{
+		GitHubImportOutput{},
+		CancelledImportOutput{},
+		BitbucketCloudImportOutput{},
+		BitbucketServerImportOutput{},
+	}
+	for _, out := range outputs {
+		if result := toolutil.MarkdownForResult(out); result == nil || len(result.Content) == 0 {
+			t.Errorf("MarkdownForResult(%T) returned empty result", out)
+		}
+	}
+}

--- a/internal/tools/individual_catalog.go
+++ b/internal/tools/individual_catalog.go
@@ -35,6 +35,12 @@ type IndividualCatalogRegisterOptions struct {
 	AllowedToolNames           []string
 	ExcludeToolNames           []string
 	DescriptionForTool         func(actioncatalog.Action) string
+	// SchemaCacheKey, when non-empty, enables process-wide reuse of compiled
+	// tool schemas across registrations (see toolutil.CompileToolSchemas).
+	// It must uniquely identify the catalog's schema content — RegisterAll
+	// passes the instance tier. Leave empty when the schemas may vary for
+	// the same tier (none of the production surfaces do).
+	SchemaCacheKey string
 }
 
 // individualCatalogRegisterState carries the gating sets and registered
@@ -94,6 +100,9 @@ func registerIndividualCatalogAction(server *mcp.Server, group actioncatalog.Gro
 	tool := mustIndividualToolFromCatalogAction(action, group.Icons, state.opts)
 	if state.opts.ReadOnlyOnly && (tool.Annotations == nil || !tool.Annotations.ReadOnlyHint) {
 		return
+	}
+	if state.opts.SchemaCacheKey != "" {
+		toolutil.CompileToolSchemas(tool, state.opts.SchemaCacheKey+"|"+toolName)
 	}
 	state.registered[toolName] = struct{}{}
 	mcp.AddTool[map[string]any, any](server, tool, individualCatalogHandler(toolName, action, formatResult, state.opts))

--- a/internal/tools/integrations/integrations_test.go
+++ b/internal/tools/integrations/integrations_test.go
@@ -815,3 +815,31 @@ func TestIntegrationFromService_Branches(t *testing.T) {
 		})
 	}
 }
+
+// TestFormatSetJiraMarkdown_RendersUpdateAndHints verifies the Jira upsert
+// formatter renders the integration item plus the write-only credentials
+// hint through the shared Markdown registry.
+func TestFormatSetJiraMarkdown_RendersUpdateAndHints(t *testing.T) {
+	md := formatSetJiraMarkdownString(SetJiraOutput{Integration: IntegrationItem{Slug: "jira", Active: true}})
+	for _, want := range []string{"Jira Integration Updated", "write-only"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("formatSetJiraMarkdownString missing %q in:\n%s", want, md)
+		}
+	}
+}
+
+// TestListGroupIntegrations_SkipsNullElements verifies that a JSON null
+// element inside the integrations array is skipped instead of producing an
+// empty item or a panic (the nil-guard branch of the list loop).
+func TestListGroupIntegrations_SkipsNullElements(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		testutil.RespondJSON(w, http.StatusOK, `[null, {"id": 3, "slug": "datadog", "active": true}]`)
+	}))
+	out, err := ListGroupIntegrations(t.Context(), client, ListGroupIntegrationsInput{GroupID: "42"})
+	if err != nil {
+		t.Fatalf("ListGroupIntegrations error = %v", err)
+	}
+	if len(out.Integrations) != 1 || out.Integrations[0].Slug != "datadog" {
+		t.Errorf("Integrations = %+v, want single datadog item (null skipped)", out.Integrations)
+	}
+}

--- a/internal/tools/metatool_test.go
+++ b/internal/tools/metatool_test.go
@@ -339,12 +339,15 @@ func keysOf(m map[string]any) []string {
 	return out
 }
 
-// metaSession sets the active param-schema mode, registers meta-tools, and
-// resets the mode on cleanup so other tests see the default (opaque).
+// metaSessionWithMode sets the active param-schema mode, registers meta-tools
+// on a FRESH isolated session, and resets the mode on cleanup so other tests
+// see the default (opaque). It must not use the shared meta session: the mode
+// shapes the tool schemas at registration time, so a cached registration
+// would leak one mode's schemas into the other modes' assertions.
 func metaSessionWithMode(t *testing.T, mode string, handler http.Handler) *mcp.ClientSession {
 	t.Helper()
 	t.Cleanup(SetMetaParamSchemaScoped(mode))
-	return newMetaMCPSession(t, handler, false)
+	return newIsolatedMetaMCPSession(t, handler, false)
 }
 
 // TestMetaSchema_DispatchParity verifies that the same {action, params}

--- a/internal/tools/prod_bench_test.go
+++ b/internal/tools/prod_bench_test.go
@@ -1,0 +1,100 @@
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+)
+
+// benchClient builds a GitLab client against a stub version endpoint for the
+// registration benchmarks.
+func benchClient(b *testing.B) *gitlabclient.Client {
+	b.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0"}`))
+	}))
+	b.Cleanup(srv.Close)
+	client, err := gitlabclient.NewClient(&config.Config{GitLabURL: srv.URL, GitLabToken: "bench-token"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return client
+}
+
+// BenchmarkBuildActionCatalog_Ultimate measures the per-server cost of
+// building the full Ultimate action catalog (paid per token+URL in HTTP mode).
+func BenchmarkBuildActionCatalog_Ultimate(b *testing.B) {
+	client := benchClient(b)
+	b.ResetTimer()
+	for range b.N {
+		if _, err := BuildActionCatalog(client, ActionCatalogOptions{Enterprise: true, IncludeMCP: true}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRegisterAll_Ultimate measures a cold individual-surface
+// registration: catalog build plus MCP SDK schema conversion/resolution for
+// every projected tool.
+func BenchmarkRegisterAll_Ultimate(b *testing.B) {
+	client := benchClient(b)
+	b.ResetTimer()
+	for range b.N {
+		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{PageSize: 2000})
+		RegisterAll(server, client, edition.Ultimate)
+	}
+}
+
+// BenchmarkRegisterAllMeta_Ultimate measures a cold meta-surface
+// registration (catalog build dominates; ~50 dispatcher tools).
+func BenchmarkRegisterAllMeta_Ultimate(b *testing.B) {
+	client := benchClient(b)
+	b.ResetTimer()
+	for range b.N {
+		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, nil)
+		if err := RegisterAllMeta(server, client, edition.Ultimate); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRegisterAll_Ultimate_Cached measures the steady-state per-token
+// registration cost in HTTP mode: compiled schema pointers plus a warm
+// mcp.SchemaCache skip the SDK remarshal and resolution.
+func BenchmarkRegisterAll_Ultimate_Cached(b *testing.B) {
+	client := benchClient(b)
+	cache := mcp.NewSchemaCache()
+	// warm-up: first registration pays the one-time schema compilation
+	warm := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: cache})
+	RegisterAll(warm, client, edition.Ultimate)
+	b.ResetTimer()
+	for range b.N {
+		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: cache})
+		RegisterAll(server, client, edition.Ultimate)
+	}
+}
+
+// BenchmarkRegisterAllMeta_Ultimate_Cached is the warm-cache counterpart of
+// BenchmarkRegisterAllMeta_Ultimate.
+func BenchmarkRegisterAllMeta_Ultimate_Cached(b *testing.B) {
+	client := benchClient(b)
+	cache := mcp.NewSchemaCache()
+	warm := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{SchemaCache: cache})
+	if err := RegisterAllMeta(warm, client, edition.Ultimate); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{SchemaCache: cache})
+		if err := RegisterAllMeta(server, client, edition.Ultimate); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -21,6 +21,7 @@ func RegisterAll(server *mcp.Server, client *gitlabclient.Client, tier edition.T
 	}
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{
 		IncludeStandaloneUtilities: true,
+		SchemaCacheKey:             "individual|" + tier.String(),
 	})
 	RegisterMetaStandaloneTools(server, client)
 }

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -94,42 +95,185 @@ func readRegisterMetaSource(t *testing.T) string {
 	return builder.String()
 }
 
-// newMCPSession creates an MCP session with individual tools registered.
-// When enterprise is true, Enterprise/Premium tools are included.
+// sharedSessionSlot holds one fully registered individual-tools MCP session
+// per tier plus a swappable backend handler. Registering the individual
+// surface resolves and validates ~1,000 tool schemas in the MCP SDK (several
+// seconds), and that cost depends only on the tier — not on the HTTP mock a
+// test supplies — so the session is built once and each test swaps its own
+// handler in behind a delegating httptest server. The handler swap is
+// mutex-guarded; the tests using this fixture run serially.
+type sharedSessionSlot struct {
+	once    sync.Once
+	session *mcp.ClientSession
+	err     error
+
+	mu      sync.Mutex
+	handler http.Handler
+}
+
+// sharedIndividualSessions caches the CE (index 0) and enterprise (index 1)
+// individual-surface sessions for the lifetime of the test binary.
+var sharedIndividualSessions [2]sharedSessionSlot
+
+// newMCPSession returns the shared MCP session with individual tools
+// registered for the requested tier (enterprise by default), wiring the
+// given handler as the GitLab backend for the duration of the calling test.
 func newMCPSession(t *testing.T, handler http.Handler, enterprise ...bool) *mcp.ClientSession {
 	t.Helper()
-	client := newTestClient(t, handler)
 
 	ent := true
 	if len(enterprise) > 0 {
 		ent = enterprise[0]
 	}
+	idx := 0
+	if ent {
+		idx = 1
+	}
+	slot := &sharedIndividualSessions[idx]
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
-	RegisterAll(server, client, edition.TierForEnterprise(ent))
-	toolutil.LockdownInputSchemas(server)
+	slot.once.Do(func() {
+		delegate := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			slot.mu.Lock()
+			current := slot.handler
+			slot.mu.Unlock()
+			if current == nil {
+				http.NotFound(w, r)
+				return
+			}
+			current.ServeHTTP(w, r)
+		})
+		// The backing httptest server and session live for the whole test
+		// binary; process teardown reclaims them.
+		srv := httptest.NewServer(delegate)
+		client, err := gitlabclient.NewClient(&config.Config{
+			GitLabURL:     srv.URL,
+			GitLabToken:   "test-token",
+			SkipTLSVerify: false,
+		})
+		if err != nil {
+			slot.err = fmt.Errorf("create test gitlab client: %w", err)
+			return
+		}
 
-	st, ct := mcp.NewInMemoryTransports()
-	ctx := context.Background()
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+		RegisterAll(server, client, edition.TierForEnterprise(ent))
+		toolutil.LockdownInputSchemas(server)
 
-	_, err := server.Connect(ctx, st, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
+		st, ct := mcp.NewInMemoryTransports()
+		ctx := context.Background()
+
+		if _, connectErr := server.Connect(ctx, st, nil); connectErr != nil {
+			slot.err = fmt.Errorf("server connect: %w", connectErr)
+			return
+		}
+
+		mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+		session, connectErr := mcpClient.Connect(ctx, ct, nil)
+		if connectErr != nil {
+			slot.err = fmt.Errorf("client connect: %w", connectErr)
+			return
+		}
+		slot.session = session
+	})
+	if slot.err != nil {
+		t.Fatalf("shared MCP session (enterprise=%v): %v", ent, slot.err)
 	}
 
-	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
-	session, err := mcpClient.Connect(ctx, ct, nil)
-	if err != nil {
-		t.Fatalf("client connect: %v", err)
-	}
-	t.Cleanup(func() { session.Close() })
-	return session
+	slot.mu.Lock()
+	slot.handler = handler
+	slot.mu.Unlock()
+	t.Cleanup(func() {
+		slot.mu.Lock()
+		slot.handler = nil
+		slot.mu.Unlock()
+	})
+	return slot.session
 }
 
-// newMetaMCPSession creates an MCP session with meta-tools registered.
-// When enterprise is true, Enterprise/Premium meta-tools are included.
-// It uses in-memory transports and auto-closes the session via t.Cleanup.
+// sharedMetaSessions caches the CE (index 0) and enterprise (index 1)
+// meta-tools sessions, mirroring sharedIndividualSessions: RegisterAllMeta
+// builds the full action catalog per call, and that cost depends only on the
+// tier, not on the per-test HTTP mock. Tests using this fixture must not run
+// with t.Parallel (concurrent handler swaps would cross-wire backends).
+var sharedMetaSessions [2]sharedSessionSlot
+
+// newMetaMCPSession returns the shared MCP session with meta-tools registered
+// for the requested tier, wiring the given handler as the GitLab backend for
+// the duration of the calling test.
 func newMetaMCPSession(t *testing.T, handler http.Handler, enterprise bool) *mcp.ClientSession {
+	t.Helper()
+
+	idx := 0
+	if enterprise {
+		idx = 1
+	}
+	slot := &sharedMetaSessions[idx]
+
+	slot.once.Do(func() {
+		delegate := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			slot.mu.Lock()
+			current := slot.handler
+			slot.mu.Unlock()
+			if current == nil {
+				http.NotFound(w, r)
+				return
+			}
+			current.ServeHTTP(w, r)
+		})
+		srv := httptest.NewServer(delegate)
+		client, err := gitlabclient.NewClient(&config.Config{
+			GitLabURL:     srv.URL,
+			GitLabToken:   "test-token",
+			SkipTLSVerify: false,
+		})
+		if err != nil {
+			slot.err = fmt.Errorf("create test gitlab client: %w", err)
+			return
+		}
+
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+		if registerErr := RegisterAllMeta(server, client, edition.TierForEnterprise(enterprise)); registerErr != nil {
+			slot.err = fmt.Errorf("RegisterAllMeta() error = %w", registerErr)
+			return
+		}
+		toolutil.LockdownInputSchemas(server)
+
+		st, ct := mcp.NewInMemoryTransports()
+		ctx := context.Background()
+
+		if _, connectErr := server.Connect(ctx, st, nil); connectErr != nil {
+			slot.err = fmt.Errorf("server connect: %w", connectErr)
+			return
+		}
+
+		mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+		session, connectErr := mcpClient.Connect(ctx, ct, nil)
+		if connectErr != nil {
+			slot.err = fmt.Errorf("client connect: %w", connectErr)
+			return
+		}
+		slot.session = session
+	})
+	if slot.err != nil {
+		t.Fatalf("shared meta MCP session (enterprise=%v): %v", enterprise, slot.err)
+	}
+
+	slot.mu.Lock()
+	slot.handler = handler
+	slot.mu.Unlock()
+	t.Cleanup(func() {
+		slot.mu.Lock()
+		slot.handler = nil
+		slot.mu.Unlock()
+	})
+	return slot.session
+}
+
+// newIsolatedMetaMCPSession creates a FRESH meta-tools MCP session (no shared
+// cache). Use it only for tests that vary registration-time state (e.g. the
+// META_PARAM_SCHEMA mode), where the shared per-tier session would leak one
+// configuration's schemas into another's assertions.
+func newIsolatedMetaMCPSession(t *testing.T, handler http.Handler, enterprise bool) *mcp.ClientSession {
 	t.Helper()
 	client := newTestClient(t, handler)
 
@@ -142,8 +286,7 @@ func newMetaMCPSession(t *testing.T, handler http.Handler, enterprise bool) *mcp
 	st, ct := mcp.NewInMemoryTransports()
 	ctx := context.Background()
 
-	_, err := server.Connect(ctx, st, nil)
-	if err != nil {
+	if _, err := server.Connect(ctx, st, nil); err != nil {
 		t.Fatalf("server connect: %v", err)
 	}
 
@@ -4173,7 +4316,8 @@ func TestCommitToOutput_NilDate(t *testing.T) {
 // closure in registerGroupSCIMMeta propagates errors from groupscim.Update
 // back to the caller as an MCP error result.
 func TestGroupSCIMMeta_UpdateAction_ErrorPath(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel: the shared meta MCP session swaps its backend handler
+	// per test, so concurrent tests would cross-wire their HTTP mocks.
 
 	const scimUpdatePath = "/api/v4/groups/mygroup/scim/uid-123"
 
@@ -4225,7 +4369,8 @@ func TestGroupSCIMMeta_UpdateAction_ErrorPath(t *testing.T) {
 // closure in registerGroupSCIMMeta returns the expected UpdateOutput on
 // a successful GitLab SCIM PATCH response.
 func TestGroupSCIMMeta_UpdateAction_SuccessPath(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel: the shared meta MCP session swaps its backend handler
+	// per test, so concurrent tests would cross-wire their HTTP mocks.
 
 	const scimUpdatePath = "/api/v4/groups/mygroup/scim/uid-123"
 

--- a/internal/tools/systemhooks/systemhooks_test.go
+++ b/internal/tools/systemhooks/systemhooks_test.go
@@ -599,3 +599,19 @@ func TestFormatHookMarkdown_WithCreatedAt(t *testing.T) {
 		t.Errorf("expected created_at in output, got: %s", text)
 	}
 }
+
+// TestFormatDelegatorMarkdown_GetAddEdit verifies the thin get/add/edit
+// formatter delegators produce the shared hook Markdown (non-empty result
+// with text content), covering their delegation bodies.
+func TestFormatDelegatorMarkdown_GetAddEdit(t *testing.T) {
+	hook := HookItem{ID: 7, URL: "https://example.com/hook"}
+	for name, result := range map[string]*mcp.CallToolResult{
+		"get":  FormatGetMarkdown(GetOutput{Hook: hook}),
+		"add":  FormatAddMarkdown(AddOutput{Hook: hook}),
+		"edit": FormatEditMarkdown(EditOutput{Hook: hook}),
+	} {
+		if result == nil || len(result.Content) == 0 {
+			t.Errorf("%s delegator returned empty result", name)
+		}
+	}
+}

--- a/internal/tools/topics/topics_test.go
+++ b/internal/tools/topics/topics_test.go
@@ -486,3 +486,19 @@ func TestFormatTopicMarkdown_MinimalFields(t *testing.T) {
 		t.Error("should not contain Avatar for empty avatar URL")
 	}
 }
+
+// TestFormatDelegatorMarkdown_GetCreateUpdate verifies the thin
+// get/create/update formatter delegators produce the shared topic Markdown
+// (non-empty result), covering their delegation bodies.
+func TestFormatDelegatorMarkdown_GetCreateUpdate(t *testing.T) {
+	topic := TopicItem{ID: 3, Name: "go", Title: "Go"}
+	for name, result := range map[string]*mcp.CallToolResult{
+		"get":    FormatGetMarkdown(GetOutput{Topic: topic}),
+		"create": FormatCreateMarkdown(CreateOutput{Topic: topic}),
+		"update": FormatUpdateMarkdown(UpdateOutput{Topic: topic}),
+	} {
+		if result == nil || len(result.Content) == 0 {
+			t.Errorf("%s delegator returned empty result", name)
+		}
+	}
+}

--- a/internal/toolutil/action_spec_guidance_test.go
+++ b/internal/toolutil/action_spec_guidance_test.go
@@ -1,0 +1,86 @@
+// action_spec_guidance_test.go contains unit tests for the scope parameter
+// guidance defaults: the [FillScopeParameterGuidance] batch path and the
+// per-name defaults returned by defaultScopeParameterGuidance, including the
+// zero-value fallback for names outside the scope-suggestive set.
+package toolutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestFillScopeParameterGuidance_NonEmptySpecs_AddsDefaults verifies that
+// [FillScopeParameterGuidance] iterates a non-empty spec slice and adds the
+// default guidance entry for a scope-suggestive input schema parameter that
+// lacks explicit guidance.
+func TestFillScopeParameterGuidance_NonEmptySpecs_AddsDefaults(t *testing.T) {
+	specs := []ActionSpec{{
+		Name: "list",
+		Route: ActionRoute{
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"project_id": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}}
+
+	out := FillScopeParameterGuidance(specs)
+	if len(out) != 1 {
+		t.Fatalf("FillScopeParameterGuidance() returned %d specs, want 1", len(out))
+	}
+	guidance, ok := out[0].ParameterGuidance["project_id"]
+	if !ok {
+		t.Fatal("FillScopeParameterGuidance() did not add project_id guidance")
+	}
+	if guidance.SemanticRole != "scope_project" {
+		t.Errorf("project_id SemanticRole = %q, want %q", guidance.SemanticRole, "scope_project")
+	}
+}
+
+// TestDefaultScopeParameterGuidance_KnownNames_ReturnsGuidance verifies that
+// defaultScopeParameterGuidance returns a populated entry (semantic role and
+// value source) for every scope-suggestive parameter name, so the discovery
+// auditor's missing_parameter_guidance check is satisfied for all of them.
+func TestDefaultScopeParameterGuidance_KnownNames_ReturnsGuidance(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+	}{
+		{name: "project_id", role: "scope_project"},
+		{name: "group_id", role: "scope_group"},
+		{name: "user_id", role: "scope_user"},
+		{name: "instance_id", role: "scope_instance"},
+		{name: "namespace_id", role: "scope_namespace"},
+		{name: "milestone_id", role: "milestone_id"},
+		{name: "epic_id", role: "epic_id"},
+		{name: "ref", role: "branch_or_tag"},
+		{name: "branch", role: "branch_name"},
+		{name: "tag", role: "tag_name"},
+		{name: "sha", role: "commit_sha"},
+		{name: "path", role: "path_component"},
+		{name: "iid", role: "scope_iid"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := defaultScopeParameterGuidance(tc.name)
+			if got.SemanticRole != tc.role {
+				t.Errorf("defaultScopeParameterGuidance(%q).SemanticRole = %q, want %q", tc.name, got.SemanticRole, tc.role)
+			}
+			if got.ValueSource == "" {
+				t.Errorf("defaultScopeParameterGuidance(%q).ValueSource is empty", tc.name)
+			}
+		})
+	}
+}
+
+// TestDefaultScopeParameterGuidance_UnknownName_ReturnsZero verifies the
+// fall-through branch: names outside the scope-suggestive set yield the zero
+// ParameterGuidance so callers never attach fabricated guidance.
+func TestDefaultScopeParameterGuidance_UnknownName_ReturnsZero(t *testing.T) {
+	got := defaultScopeParameterGuidance("definitely_not_a_scope_param")
+	if !reflect.DeepEqual(got, ParameterGuidance{}) {
+		t.Errorf("defaultScopeParameterGuidance(unknown) = %+v, want zero value", got)
+	}
+}

--- a/internal/toolutil/fileutils_errors_test.go
+++ b/internal/toolutil/fileutils_errors_test.go
@@ -1,0 +1,91 @@
+// fileutils_errors_test.go contains unit tests for rare filesystem error
+// branches in fileutils.go: opening an unreadable file after a successful
+// stat, resolving relative paths when the working directory has been
+// deleted (os.Getwd failure), and filepath.Rel errors in pathWithinBase.
+package toolutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestOpenAndValidateFile_UnreadableFile_ReturnsOpenError verifies that
+// [OpenAndValidateFile] surfaces the os.Open error when the file exists and
+// passes the stat/regular/size checks but cannot be opened for reading
+// (mode 0o000). This exercises the open-failure branch that runs after all
+// validations succeed.
+func TestOpenAndValidateFile_UnreadableFile_ReturnsOpenError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission bits are not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission bits are not enforced")
+	}
+
+	path := filepath.Join(t.TempDir(), "secret.bin")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	f, info, err := OpenAndValidateFile(path, 0)
+	if f != nil {
+		f.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenAndValidateFile(unreadable) error = nil, want open error")
+	}
+	if info != nil {
+		t.Errorf("OpenAndValidateFile(unreadable) info = %v, want nil", info)
+	}
+	if !strings.Contains(err.Error(), "open ") {
+		t.Errorf("OpenAndValidateFile(unreadable) error = %q, want it to mention open", err)
+	}
+}
+
+// TestCanonicalImportArchivePath_DeletedCwd_ReturnsResolveError verifies that
+// [CanonicalImportArchivePath] fails cleanly for a relative archive path when
+// the current working directory has been removed. On Linux os.Getwd fails and
+// the filepath.Abs error branch ("resolve archive path") is exercised; on
+// macOS getcwd still succeeds for a deleted cwd (vnode name cache), so the
+// failure surfaces at symlink resolution instead — both are resolve errors.
+// The same deleted-cwd state verifies that canonicalDirPath also fails for a
+// relative allowlist directory.
+func TestCanonicalImportArchivePath_DeletedCwd_ReturnsResolveError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("removing the current working directory is not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.Remove(dir); err != nil {
+		t.Skipf("cannot remove current working directory: %v", err)
+	}
+
+	_, err := CanonicalImportArchivePath("export.tar.gz")
+	if err == nil {
+		t.Fatal("CanonicalImportArchivePath(relative, deleted cwd) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "resolve archive") {
+		t.Errorf("CanonicalImportArchivePath() error = %q, want a 'resolve archive' error", err)
+	}
+
+	if _, dirErr := canonicalDirPath("relative-allowlist-dir"); dirErr == nil {
+		t.Error("canonicalDirPath(relative, deleted cwd) error = nil, want error")
+	}
+}
+
+// TestPathWithinBase_RelError_ReturnsFalse verifies that pathWithinBase
+// returns false when filepath.Rel cannot relate the two paths (an absolute
+// target against a relative base), instead of panicking or misclassifying.
+func TestPathWithinBase_RelError_ReturnsFalse(t *testing.T) {
+	if pathWithinBase("/absolute/target", "relative-base") {
+		t.Error(`pathWithinBase("/absolute/target", "relative-base") = true, want false`)
+	}
+}

--- a/internal/toolutil/mdregistry_query_test.go
+++ b/internal/toolutil/mdregistry_query_test.go
@@ -1,0 +1,101 @@
+// mdregistry_query_test.go contains unit tests for the registry query helpers
+// [HasRegisteredMarkdownFormatter] and [MarkdownFormatterCount], covering the
+// nil/interface guards, the reflect.Type and plain-value lookup paths, pointer
+// dereferencing, and both the string-formatter and result-formatter registries.
+package toolutil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mdQueryUnregistered is a local type that never gets a Markdown formatter,
+// used to exercise the negative lookup path.
+type mdQueryUnregistered struct{ X int }
+
+// mdQueryResultOnly is a local type registered exclusively through
+// [RegisterMarkdownResult], used to exercise the result-formatter branch of
+// [HasRegisteredMarkdownFormatter].
+type mdQueryResultOnly struct{ Y int }
+
+// TestHasRegisteredMarkdownFormatter_NilValue_ReturnsFalse verifies that
+// [HasRegisteredMarkdownFormatter] returns false for a nil input, which has
+// no concrete type to look up in the registries.
+func TestHasRegisteredMarkdownFormatter_NilValue_ReturnsFalse(t *testing.T) {
+	if HasRegisteredMarkdownFormatter(nil) {
+		t.Error("HasRegisteredMarkdownFormatter(nil) = true, want false")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_ReflectType_ReturnsTrue verifies the
+// canonical reflect.Type lookup path: DeleteOutput is registered by the
+// package init, so its reflect.Type must resolve to a formatter.
+func TestHasRegisteredMarkdownFormatter_ReflectType_ReturnsTrue(t *testing.T) {
+	if !HasRegisteredMarkdownFormatter(reflect.TypeFor[DeleteOutput]()) {
+		t.Error("HasRegisteredMarkdownFormatter(reflect.TypeFor[DeleteOutput]()) = false, want true")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_Value_ReturnsTrue verifies the
+// plain-value lookup path (the default switch arm using reflect.TypeOf)
+// for a type with a registered string formatter.
+func TestHasRegisteredMarkdownFormatter_Value_ReturnsTrue(t *testing.T) {
+	if !HasRegisteredMarkdownFormatter(DeleteOutput{Message: "gone"}) {
+		t.Error("HasRegisteredMarkdownFormatter(DeleteOutput{}) = false, want true")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_PointerValue_Dereferenced verifies that
+// pointer types are dereferenced to their element type before the registry
+// lookup, so *DeleteOutput matches the DeleteOutput formatter.
+func TestHasRegisteredMarkdownFormatter_PointerValue_Dereferenced(t *testing.T) {
+	if !HasRegisteredMarkdownFormatter(&DeleteOutput{Message: "gone"}) {
+		t.Error("HasRegisteredMarkdownFormatter(*DeleteOutput) = false, want true")
+	}
+	if !HasRegisteredMarkdownFormatter(reflect.TypeFor[**DeleteOutput]()) {
+		t.Error("HasRegisteredMarkdownFormatter(**DeleteOutput type) = false, want true")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_AnyInterfaceType_ReturnsFalse verifies
+// that the special "any" interface reflect.Type is rejected: it carries no
+// concrete output type and must never match a formatter.
+func TestHasRegisteredMarkdownFormatter_AnyInterfaceType_ReturnsFalse(t *testing.T) {
+	if HasRegisteredMarkdownFormatter(reflect.TypeFor[any]()) {
+		t.Error("HasRegisteredMarkdownFormatter(reflect.TypeFor[any]()) = true, want false")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_UnregisteredType_ReturnsFalse verifies
+// that a type absent from both the string and result registries reports
+// false (the final fall-through return).
+func TestHasRegisteredMarkdownFormatter_UnregisteredType_ReturnsFalse(t *testing.T) {
+	if HasRegisteredMarkdownFormatter(mdQueryUnregistered{X: 1}) {
+		t.Error("HasRegisteredMarkdownFormatter(unregistered type) = true, want false")
+	}
+}
+
+// TestHasRegisteredMarkdownFormatter_ResultFormatter_ReturnsTrue verifies
+// that types registered only via [RegisterMarkdownResult] (custom
+// CallToolResult construction, e.g. image content) are also reported as
+// having a formatter.
+func TestHasRegisteredMarkdownFormatter_ResultFormatter_ReturnsTrue(t *testing.T) {
+	RegisterMarkdownResult(func(mdQueryResultOnly) *mcp.CallToolResult {
+		return SuccessResult("ok")
+	})
+	if !HasRegisteredMarkdownFormatter(mdQueryResultOnly{Y: 2}) {
+		t.Error("HasRegisteredMarkdownFormatter(result-only type) = false, want true")
+	}
+}
+
+// TestMarkdownFormatterCount_IncludesInitRegistrations verifies that
+// [MarkdownFormatterCount] counts both registries and reports at least the
+// two formatters registered by this package's init (DeleteOutput and
+// VoidOutput).
+func TestMarkdownFormatterCount_IncludesInitRegistrations(t *testing.T) {
+	if n := MarkdownFormatterCount(); n < 2 {
+		t.Errorf("MarkdownFormatterCount() = %d, want >= 2", n)
+	}
+}

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -2184,6 +2184,23 @@ func DestructiveVoidActionWithRequest[T any](client *gitlabclient.Client, fn fun
 	}
 }
 
+// metaSchemaCompileKey returns a stable content key for compiling and
+// caching a meta dispatcher's schemas across registrations, or "" (caching
+// disabled) outside the default opaque mode: compact/full schemas embed
+// tier-pruned per-action payloads with no cheap stable identity, while the
+// opaque envelope depends only on the sorted action-name enum.
+func metaSchemaCompileKey(name string, routes ActionMap) string {
+	if currentMetaParamSchemaMode() != MetaParamSchemaOpaque {
+		return ""
+	}
+	actions := make([]string, 0, len(routes))
+	for actionName := range routes {
+		actions = append(actions, actionName)
+	}
+	sort.Strings(actions)
+	return "meta|opaque|" + name + "|" + strings.Join(actions, ",")
+}
+
 // FormatResultFunc converts an action result into an MCP call tool result.
 type FormatResultFunc func(any) *mcp.CallToolResult
 
@@ -2194,7 +2211,7 @@ func AddMetaTool(server *mcp.Server, name, desc string, routes ActionMap, icons 
 	if server == nil {
 		return
 	}
-	mcp.AddTool(server, &mcp.Tool{
+	tool := &mcp.Tool{
 		Name:         name,
 		Title:        TitleFromName(name),
 		Description:  MetaToolDescriptionPrefix(name, routes) + desc,
@@ -2202,7 +2219,9 @@ func AddMetaTool(server *mcp.Server, name, desc string, routes ActionMap, icons 
 		Icons:        icons,
 		InputSchema:  MetaToolSchema(routes),
 		OutputSchema: MetaToolOutputSchema(),
-	}, MakeMetaHandler(name, routes, formatResult))
+	}
+	CompileToolSchemas(tool, metaSchemaCompileKey(name, routes))
+	mcp.AddTool(server, tool, MakeMetaHandler(name, routes, formatResult))
 }
 
 // AddReadOnlyMetaTool registers an action-dispatched meta-tool whose actions
@@ -2211,7 +2230,7 @@ func AddReadOnlyMetaTool(server *mcp.Server, name, desc string, routes ActionMap
 	if server == nil {
 		return
 	}
-	mcp.AddTool(server, &mcp.Tool{
+	tool := &mcp.Tool{
 		Name:         name,
 		Title:        TitleFromName(name),
 		Description:  MetaToolDescriptionPrefix(name, routes) + desc,
@@ -2219,7 +2238,9 @@ func AddReadOnlyMetaTool(server *mcp.Server, name, desc string, routes ActionMap
 		Icons:        icons,
 		InputSchema:  MetaToolSchema(routes),
 		OutputSchema: MetaToolOutputSchema(),
-	}, MakeMetaHandler(name, routes, formatResult))
+	}
+	CompileToolSchemas(tool, metaSchemaCompileKey(name, routes))
+	mcp.AddTool(server, tool, MakeMetaHandler(name, routes, formatResult))
 }
 
 // MakeMetaHandler creates a generic MCP tool handler that dispatches to action routes.

--- a/internal/toolutil/metatool_branches_test.go
+++ b/internal/toolutil/metatool_branches_test.go
@@ -1,0 +1,479 @@
+// metatool_branches_test.go contains unit tests for rarely exercised
+// branches in metatool.go: FieldTiers guards, schema-driven alias
+// explanations (iid/environment_id), encoded-path decoding failures,
+// structured value coercion fallbacks, UnmarshalParams retry paths,
+// schema-based coercion no-ops, destructive-action confirmation in
+// MakeMetaHandler, and enrichWithHints marshal failures.
+package toolutil
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// FieldTiers guards.
+
+// TestFieldTiers_NilType_ReturnsNil verifies that [FieldTiers] returns nil
+// for a nil reflect.Type instead of panicking.
+func TestFieldTiers_NilType_ReturnsNil(t *testing.T) {
+	if got := FieldTiers(nil); got != nil {
+		t.Errorf("FieldTiers(nil) = %v, want nil", got)
+	}
+}
+
+// TestFieldTiers_PointerType_Dereferences verifies that [FieldTiers]
+// dereferences pointer types to their struct element before collecting
+// tier tags.
+func TestFieldTiers_PointerType_Dereferences(t *testing.T) {
+	type tiered struct {
+		Plan string `json:"plan" tier:"premium"`
+	}
+	got := FieldTiers(reflect.TypeFor[*tiered]())
+	if got["plan"] != "premium" {
+		t.Errorf("FieldTiers(*tiered) = %v, want plan:premium", got)
+	}
+}
+
+// TestFieldTiers_NonStructType_ReturnsNil verifies that [FieldTiers] returns
+// nil for non-struct kinds, which carry no field tier metadata.
+func TestFieldTiers_NonStructType_ReturnsNil(t *testing.T) {
+	if got := FieldTiers(reflect.TypeFor[string]()); got != nil {
+		t.Errorf("FieldTiers(string) = %v, want nil", got)
+	}
+}
+
+// TestFieldTiers_UnexportedField_Skipped verifies that unexported,
+// non-anonymous struct fields are skipped while exported tier-tagged fields
+// are still collected.
+func TestFieldTiers_UnexportedField_Skipped(t *testing.T) {
+	got := FieldTiers(reflect.TypeOf(struct {
+		hidden string // present only to exercise the unexported-field skip branch via reflection.
+		Public string `json:"public" tier:"ultimate"`
+	}{}))
+	if len(got) != 1 || got["public"] != "ultimate" {
+		t.Errorf("FieldTiers(unexported+exported) = %v, want only public:ultimate", got)
+	}
+}
+
+// Schema-driven alias explanations.
+
+// TestNormalizeParamAliasesForSchemaWithExplanation_IIDAlias verifies that a
+// bare "iid" parameter is explained as an alias of the schema's single
+// *_iid property when the schema does not accept "iid" directly.
+func TestNormalizeParamAliasesForSchemaWithExplanation_IIDAlias(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"mr_iid": map[string]any{"type": "integer"},
+		},
+	}
+	params := map[string]any{"iid": 5}
+
+	_, explanations := NormalizeParamAliasesForSchemaWithExplanation(params, schema)
+
+	found := false
+	for _, e := range explanations {
+		if e.Alias == "iid" && e.Canonical == "mr_iid" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("explanations = %+v, want iid → mr_iid entry", explanations)
+	}
+}
+
+// TestNormalizeParamAliasesForSchemaWithExplanation_EnvironmentIDAlias
+// verifies that "environment_id" is explained as an alias of the schema's
+// "environment" property when the schema accepts "environment" but not
+// "environment_id".
+func TestNormalizeParamAliasesForSchemaWithExplanation_EnvironmentIDAlias(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"environment": map[string]any{"type": "string"},
+		},
+	}
+	params := map[string]any{"environment_id": 7}
+
+	_, explanations := NormalizeParamAliasesForSchemaWithExplanation(params, schema)
+
+	found := false
+	for _, e := range explanations {
+		if e.Alias == "environment_id" && e.Canonical == "environment" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("explanations = %+v, want environment_id → environment entry", explanations)
+	}
+}
+
+// Encoded path identifiers.
+
+// TestDecodeEncodedPathIdentifier_InvalidEscape_ReturnsFalse verifies that a
+// value containing "%2f" but with a malformed trailing escape sequence is
+// rejected (url.PathUnescape error) instead of being partially decoded.
+func TestDecodeEncodedPathIdentifier_InvalidEscape_ReturnsFalse(t *testing.T) {
+	decoded, ok := decodeEncodedPathIdentifier("group%2fproject%")
+	if ok || decoded != "" {
+		t.Errorf("decodeEncodedPathIdentifier(invalid escape) = (%q, %v), want (\"\", false)", decoded, ok)
+	}
+}
+
+// File path alias normalization.
+
+// TestNormalizeFilePathAlias_ExistingFilename_NoRewrite verifies that
+// normalizeFilePathAlias leaves params untouched when the output already
+// carries a "filename" value, so a caller-provided filename is never
+// overwritten by the file_path split.
+func TestNormalizeFilePathAlias_ExistingFilename_NoRewrite(t *testing.T) {
+	out := map[string]any{"file_path": "docs/readme.md", "filename": "custom.md"}
+	accepts := func(name string) bool { return name == "path" || name == "filename" }
+	cloned := false
+	clone := func() map[string]any {
+		cloned = true
+		return maps.Clone(out)
+	}
+
+	normalizeFilePathAlias(out, accepts, clone)
+
+	if cloned {
+		t.Error("normalizeFilePathAlias cloned params despite existing filename")
+	}
+	if _, hasPath := out["path"]; hasPath {
+		t.Errorf("normalizeFilePathAlias added path key: %v", out)
+	}
+}
+
+// JSON field reflection fallbacks.
+
+// EmbeddedID is a named non-struct type embedded anonymously in test structs
+// to exercise the empty-JSON-name fallback: anonymous fields yield an empty
+// jsonFieldName, and non-struct kinds cannot be flattened, so the collectors
+// must fall back to the Go field name. Exported so the embedded field is not
+// skipped by the unexported-field guard.
+type EmbeddedID int
+
+// TestCollectJSONFieldNames_AnonymousNonStruct_UsesGoFieldName verifies that
+// an anonymous embedded non-struct field (which has no JSON tag name and
+// cannot be flattened) falls back to its Go field name when collecting
+// accepted parameter names.
+func TestCollectJSONFieldNames_AnonymousNonStruct_UsesGoFieldName(t *testing.T) {
+	fields := map[string]struct{}{}
+	collectJSONFieldNames(reflect.TypeOf(struct{ EmbeddedID }{}), fields)
+	if _, ok := fields["EmbeddedID"]; !ok {
+		t.Errorf("collectJSONFieldNames(embedded non-struct) = %v, want EmbeddedID key", fields)
+	}
+}
+
+// TestCollectJSONFieldTypes_AnonymousNonStruct_UsesGoFieldName verifies that
+// jsonFieldTypes falls back to the Go field name for an anonymous embedded
+// non-struct field, mirroring encoding/json field promotion.
+func TestCollectJSONFieldTypes_AnonymousNonStruct_UsesGoFieldName(t *testing.T) {
+	fields := jsonFieldTypes(reflect.TypeOf(struct{ EmbeddedID }{}))
+	if got, ok := fields["EmbeddedID"]; !ok || got.Kind() != reflect.Int {
+		t.Errorf("jsonFieldTypes(embedded non-struct) = %v, want EmbeddedID:int", fields)
+	}
+}
+
+// UnmarshalParams edge cases.
+
+// TestUnmarshalParams_UnmarshalableValue_ReturnsValidationError verifies
+// that a parameter value that cannot be serialized to JSON (a function)
+// produces a ParamValidationError from the initial json.Marshal step.
+func TestUnmarshalParams_UnmarshalableValue_ReturnsValidationError(t *testing.T) {
+	type input struct {
+		X any `json:"x"`
+	}
+	_, err := UnmarshalParams[input](map[string]any{"x": func() {}})
+	if err == nil {
+		t.Fatal("UnmarshalParams(func value) error = nil, want marshal error")
+	}
+	var validationErr *ParamValidationError
+	if !errors.As(err, &validationErr) {
+		t.Errorf("UnmarshalParams(func value) error = %T, want *ParamValidationError", err)
+	}
+}
+
+// TestUnmarshalParams_MapTarget_RetriesWithBroadCoercion verifies the legacy
+// retry path: for a map target (no reflectable JSON fields, so the typed
+// coercion pipeline is skipped) a numeric string fails strict unmarshalling
+// first and then succeeds after coerceNumericStrings converts it.
+func TestUnmarshalParams_MapTarget_RetriesWithBroadCoercion(t *testing.T) {
+	got, err := UnmarshalParams[map[string]int](map[string]any{"n": "5"})
+	if err != nil {
+		t.Fatalf("UnmarshalParams(map target, numeric string) error = %v", err)
+	}
+	if got["n"] != 5 {
+		t.Errorf("UnmarshalParams(map target) = %v, want n:5", got)
+	}
+}
+
+// TestUnmarshalParams_MapTarget_NaNRetryMarshalFails verifies that when the
+// broad numeric coercion retry produces a value JSON cannot encode (the
+// string "NaN" parses to a float64 NaN), the retry marshal fails and the
+// original strict unmarshal error is preserved.
+func TestUnmarshalParams_MapTarget_NaNRetryMarshalFails(t *testing.T) {
+	_, err := UnmarshalParams[map[string]int](map[string]any{"n": "NaN"})
+	if err == nil {
+		t.Fatal("UnmarshalParams(map target, NaN string) error = nil, want error")
+	}
+	var validationErr *ParamValidationError
+	if !errors.As(err, &validationErr) {
+		t.Errorf("UnmarshalParams(NaN string) error = %T, want *ParamValidationError", err)
+	}
+}
+
+// Structured value coercion.
+
+// TestCoerceStructuredValue_PointerSliceElem_WrapsObject verifies that a
+// single JSON object destined for a slice of struct pointers is wrapped in
+// a one-element list after the pointer element type is dereferenced.
+func TestCoerceStructuredValue_PointerSliceElem_WrapsObject(t *testing.T) {
+	type rule struct {
+		A int `json:"a"`
+	}
+	coerced, changed := coerceStructuredValue("rules", map[string]any{"a": 1}, reflect.TypeFor[[]*rule]())
+	if !changed {
+		t.Fatal("coerceStructuredValue(map for []*struct) changed = false, want true")
+	}
+	items, ok := coerced.([]any)
+	if !ok || len(items) != 1 {
+		t.Errorf("coerceStructuredValue(map for []*struct) = %v, want single-item list", coerced)
+	}
+}
+
+// TestCoerceStructuredValue_StringForStructSlice_Unchanged verifies that a
+// scalar string that is neither an object, a role name, nor a list is left
+// untouched for a slice-of-struct field.
+func TestCoerceStructuredValue_StringForStructSlice_Unchanged(t *testing.T) {
+	type rule struct {
+		A int `json:"a"`
+	}
+	coerced, changed := coerceStructuredValue("rules", "hello", reflect.TypeFor[[]rule]())
+	if changed || coerced != "hello" {
+		t.Errorf("coerceStructuredValue(string for []struct) = (%v, %v), want (hello, false)", coerced, changed)
+	}
+}
+
+// TestCoerceStructuredValue_NonRoleScalarItems_Unchanged verifies that list
+// items that are neither objects nor GitLab role names are kept as-is and
+// the overall value is reported unchanged.
+func TestCoerceStructuredValue_NonRoleScalarItems_Unchanged(t *testing.T) {
+	type rule struct {
+		A int `json:"a"`
+	}
+	value := []any{"not-a-role"}
+	coerced, changed := coerceStructuredValue("rules", value, reflect.TypeFor[[]rule]())
+	if changed {
+		t.Errorf("coerceStructuredValue(scalar items) changed = true, want false")
+	}
+	if !reflect.DeepEqual(coerced, value) {
+		t.Errorf("coerceStructuredValue(scalar items) = %v, want %v", coerced, value)
+	}
+}
+
+// TestNormalizeStructuredObjectFields_NoReflectableFields_ReturnsValue
+// verifies that objects targeted at a struct without JSON fields are
+// returned unchanged.
+func TestNormalizeStructuredObjectFields_NoReflectableFields_ReturnsValue(t *testing.T) {
+	value := map[string]any{"x": 1}
+	got := normalizeStructuredObjectFields(value, reflect.TypeFor[struct{}]())
+	if !reflect.DeepEqual(got, value) {
+		t.Errorf("normalizeStructuredObjectFields(empty struct) = %v, want %v", got, value)
+	}
+}
+
+// TestNormalizeStructuredObjectFields_ApprovalCountWithoutPrincipal_DefaultsAccessLevel
+// verifies that an approval-rule object carrying only a required approval
+// count (no access_level/user_id/group_id principal) receives the
+// Maintainer access level 40 default.
+func TestNormalizeStructuredObjectFields_ApprovalCountWithoutPrincipal_DefaultsAccessLevel(t *testing.T) {
+	type approvalRule struct {
+		RequiredApprovals int `json:"required_approvals"`
+		AccessLevel       int `json:"access_level"`
+	}
+	got := normalizeStructuredObjectFields(map[string]any{"required_approvals": 2}, reflect.TypeFor[approvalRule]())
+	if got["access_level"] != 40 {
+		t.Errorf("normalizeStructuredObjectFields(count only)[access_level] = %v, want 40", got["access_level"])
+	}
+}
+
+// Numeric slice coercion.
+
+// TestCoerceSliceValueForTargetType_PointerElem_CoercesStrings verifies that
+// pointer element types are dereferenced before the numeric-kind check so
+// numeric strings inside a []*int value are still coerced.
+func TestCoerceSliceValueForTargetType_PointerElem_CoercesStrings(t *testing.T) {
+	coerced, changed, err := coerceSliceValueForTargetType("ids", []any{"5"}, reflect.TypeFor[*int]())
+	if err != nil {
+		t.Fatalf("coerceSliceValueForTargetType([]*int) error = %v", err)
+	}
+	if !changed {
+		t.Fatal("coerceSliceValueForTargetType([]*int) changed = false, want true")
+	}
+	items, ok := coerced.([]any)
+	if !ok || len(items) != 1 || items[0] != int64(5) {
+		t.Errorf("coerceSliceValueForTargetType([]*int) = %v, want [5]", coerced)
+	}
+}
+
+// TestCoerceSliceValueForTargetType_NonSliceValue_Unchanged verifies that a
+// non-list value for a numeric slice element type is returned unchanged
+// without error.
+func TestCoerceSliceValueForTargetType_NonSliceValue_Unchanged(t *testing.T) {
+	coerced, changed, err := coerceSliceValueForTargetType("ids", 42, reflect.TypeFor[int]())
+	if err != nil || changed || coerced != 42 {
+		t.Errorf("coerceSliceValueForTargetType(non-slice) = (%v, %v, %v), want (42, false, nil)", coerced, changed, err)
+	}
+}
+
+// Schema-driven coercion no-ops.
+
+// TestCoerceSchemaParamValue_NumberProperty_NonNumericString_Unchanged
+// verifies that values for a number-typed schema property that cannot be
+// parsed as floats are passed through unchanged.
+func TestCoerceSchemaParamValue_NumberProperty_NonNumericString_Unchanged(t *testing.T) {
+	property := map[string]any{"type": "number"}
+	got, changed := coerceSchemaParamValue("weight", "abc", property)
+	if changed || got != "abc" {
+		t.Errorf("coerceSchemaParamValue(number, non-numeric) = (%v, %v), want (abc, false)", got, changed)
+	}
+}
+
+// TestCoerceSchemaArrayValue_NonSliceValue_Unchanged verifies that a scalar
+// value for an integer-array schema property is returned unchanged when it
+// cannot be interpreted as a list.
+func TestCoerceSchemaArrayValue_NonSliceValue_Unchanged(t *testing.T) {
+	property := map[string]any{
+		"type":  "array",
+		"items": map[string]any{"type": "integer"},
+	}
+	got, changed := coerceSchemaArrayValue("abc", property)
+	if changed || got != "abc" {
+		t.Errorf("coerceSchemaArrayValue(non-slice) = (%v, %v), want (abc, false)", got, changed)
+	}
+}
+
+// TestCoerceSingleStringArraysForSchema_NonStringValue_Skipped verifies that
+// non-string values for a string-array schema property are not wrapped in a
+// single-element list.
+func TestCoerceSingleStringArraysForSchema_NonStringValue_Skipped(t *testing.T) {
+	schema := map[string]any{
+		"properties": map[string]any{
+			"labels": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+		},
+	}
+	params := map[string]any{"labels": 7}
+	got := coerceSingleStringArraysForSchema(params, schema)
+	if !reflect.DeepEqual(got, params) {
+		t.Errorf("coerceSingleStringArraysForSchema(non-string) = %v, want unchanged %v", got, params)
+	}
+}
+
+// MakeMetaHandler destructive confirmation and error propagation.
+
+// TestMakeMetaHandler_DestructiveDeclined_ReturnsCancelled verifies that a
+// destructive route is intercepted by the elicitation confirmation flow and
+// that a user decline cancels the action without invoking the handler.
+func TestMakeMetaHandler_DestructiveDeclined_ReturnsCancelled(t *testing.T) {
+	t.Setenv("YOLO_MODE", "")
+	t.Setenv("AUTOPILOT", "")
+
+	ss := newConfirmSession(t, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "decline"}, nil
+	})
+
+	executed := false
+	routes := ActionMap{
+		"delete": DestructiveRoute(func(_ context.Context, _ map[string]any) (any, error) {
+			executed = true
+			return map[string]any{"ok": true}, nil
+		}),
+	}
+	handler := MakeMetaHandler("test_tool", routes, nil)
+	req := &mcp.CallToolRequest{Session: ss, Params: &mcp.CallToolParamsRaw{Name: "test_tool"}}
+
+	result, raw, err := handler(context.Background(), req, MetaToolInput{Action: "delete", Params: map[string]any{}})
+	if err != nil {
+		t.Fatalf("handler(destructive declined) error = %v", err)
+	}
+	if executed {
+		t.Error("destructive handler executed despite declined confirmation")
+	}
+	if raw != nil {
+		t.Errorf("handler(destructive declined) raw = %v, want nil", raw)
+	}
+	if result == nil {
+		t.Fatal("handler(destructive declined) result = nil, want cancellation result")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok || !strings.Contains(tc.Text, "canceled") {
+		t.Errorf("handler(destructive declined) content = %+v, want canceled message", result.Content)
+	}
+}
+
+// TestMakeMetaHandler_HandlerError_Propagated verifies that a generic
+// (non-validation) handler error is returned to the MCP framework unchanged
+// instead of being converted into an in-band error result.
+func TestMakeMetaHandler_HandlerError_Propagated(t *testing.T) {
+	wantErr := errors.New("boom")
+	routes := ActionMap{
+		"fail": Route(func(_ context.Context, _ map[string]any) (any, error) {
+			return nil, wantErr
+		}),
+	}
+	handler := MakeMetaHandler("test_tool", routes, nil)
+
+	result, raw, err := handler(context.Background(), &mcp.CallToolRequest{}, MetaToolInput{Action: "fail", Params: map[string]any{}})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("handler(generic error) error = %v, want %v", err, wantErr)
+	}
+	if result != nil || raw != nil {
+		t.Errorf("handler(generic error) result/raw = %v/%v, want nil/nil", result, raw)
+	}
+}
+
+// TestMetaSchemaCompileKey_NonOpaqueMode_ReturnsEmpty verifies that schema
+// compile caching is disabled (empty key) outside the default opaque
+// META_PARAM_SCHEMA mode, where compact/full schemas have no cheap stable
+// identity.
+func TestMetaSchemaCompileKey_NonOpaqueMode_ReturnsEmpty(t *testing.T) {
+	restore := SetMetaParamSchemaModeScoped(MetaParamSchemaCompact)
+	defer restore()
+
+	routes := ActionMap{
+		"list": Route(func(_ context.Context, _ map[string]any) (any, error) { return map[string]any{}, nil }),
+	}
+	if key := metaSchemaCompileKey("gitlab_test", routes); key != "" {
+		t.Errorf("metaSchemaCompileKey(compact mode) = %q, want empty", key)
+	}
+}
+
+// enrichWithHints marshal failure.
+
+// TestEnrichWithHints_UnmarshalableResult_ReturnsOriginal verifies that a
+// result value JSON cannot encode (a channel) is returned unchanged even
+// when the call result carries next-step hints.
+func TestEnrichWithHints_UnmarshalableResult_ReturnsOriginal(t *testing.T) {
+	callResult := &mcp.CallToolResult{Content: []mcp.Content{
+		&mcp.TextContent{Text: "Done.\n\n💡 **Next steps:**\n- Use gitlab_list_projects\n"},
+	}}
+	result := make(chan int)
+
+	got := enrichWithHints(result, callResult)
+
+	gotChan, ok := got.(chan int)
+	if !ok || gotChan != result {
+		t.Errorf("enrichWithHints(chan) = %v, want original channel", got)
+	}
+}

--- a/internal/toolutil/schema_compile.go
+++ b/internal/toolutil/schema_compile.go
@@ -1,0 +1,59 @@
+package toolutil
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// compiledSchemaCache maps a caller-supplied stable cache key to the
+// *jsonschema.Schema compiled from a projected tool's map schema. Keys must
+// uniquely identify the schema content (surface + tool + tier); the schema
+// projection pipeline is a pure function of those inputs.
+var compiledSchemaCache sync.Map
+
+// CompileToolSchemas replaces a projected tool's map-based input and output
+// schemas with process-cached *jsonschema.Schema equivalents. Passing the
+// SDK a stable schema pointer instead of a map removes the per-registration
+// JSON remarshal inside mcp.AddTool and lets a shared [mcp.SchemaCache]
+// (keyed by pointer identity) skip schema resolution on subsequent
+// registrations — the dominant cost when the HTTP server pool builds a new
+// MCP server per token.
+//
+// The conversion is a faithful roundtrip: the maps are produced by
+// marshaling jsonschema output, and jsonschema.Schema preserves non-standard
+// keys such as x_destructive. On any marshal error the original map is kept,
+// preserving current behavior. An empty cacheKey disables compilation, so
+// callers that cannot guarantee a content-stable key keep the map path.
+func CompileToolSchemas(tool *mcp.Tool, cacheKey string) {
+	if tool == nil || cacheKey == "" {
+		return
+	}
+	if m, ok := tool.InputSchema.(map[string]any); ok {
+		tool.InputSchema = compiledSchema(cacheKey+"|in", m)
+	}
+	if m, ok := tool.OutputSchema.(map[string]any); ok {
+		tool.OutputSchema = compiledSchema(cacheKey+"|out", m)
+	}
+}
+
+// compiledSchema returns the cached compiled schema for key, converting and
+// caching the map form on first use. It falls back to the original map when
+// the conversion fails so registration behavior never changes on error.
+func compiledSchema(key string, schema map[string]any) any {
+	if cached, ok := compiledSchemaCache.Load(key); ok {
+		return cached
+	}
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return schema
+	}
+	compiled := new(jsonschema.Schema)
+	if unmarshalErr := json.Unmarshal(data, compiled); unmarshalErr != nil {
+		return schema
+	}
+	actual, _ := compiledSchemaCache.LoadOrStore(key, compiled)
+	return actual
+}

--- a/internal/toolutil/schema_compile_test.go
+++ b/internal/toolutil/schema_compile_test.go
@@ -1,0 +1,73 @@
+package toolutil
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestCompileToolSchemas_RoundTripAndCache pins the three contracts of the
+// compiled-schema cache: the conversion preserves the schema content
+// (including non-standard keys such as x_destructive), the same cache key
+// returns the identical *jsonschema.Schema pointer (what lets the SDK
+// SchemaCache skip re-resolution), and an empty key leaves the maps
+// untouched.
+func TestCompileToolSchemas_RoundTripAndCache(t *testing.T) {
+	input := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"confirm": map[string]any{"type": "boolean", "description": "d"},
+		},
+		"x_destructive": true,
+	}
+	output := map[string]any{"type": "object"}
+
+	tool := &mcp.Tool{InputSchema: input, OutputSchema: output}
+	CompileToolSchemas(tool, "test|roundtrip")
+
+	compiled, ok := tool.InputSchema.(*jsonschema.Schema)
+	if !ok {
+		t.Fatalf("InputSchema = %T, want *jsonschema.Schema", tool.InputSchema)
+	}
+	if _, outOK := tool.OutputSchema.(*jsonschema.Schema); !outOK {
+		t.Fatalf("OutputSchema = %T, want *jsonschema.Schema", tool.OutputSchema)
+	}
+
+	// Content equivalence: marshaling the compiled schema must yield the
+	// same JSON object as the original map, x_destructive included.
+	compiledJSON, err := json.Marshal(compiled)
+	if err != nil {
+		t.Fatalf("marshal compiled: %v", err)
+	}
+	var compiledMap map[string]any
+	if unmarshalErr := json.Unmarshal(compiledJSON, &compiledMap); unmarshalErr != nil {
+		t.Fatalf("unmarshal compiled: %v", unmarshalErr)
+	}
+	if !reflect.DeepEqual(compiledMap, input) {
+		t.Errorf("compiled schema roundtrip = %v, want %v", compiledMap, input)
+	}
+
+	// Pointer stability: a second tool with the same key must receive the
+	// exact same schema pointer.
+	second := &mcp.Tool{InputSchema: map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"confirm": map[string]any{"type": "boolean", "description": "d"},
+		},
+		"x_destructive": true,
+	}}
+	CompileToolSchemas(second, "test|roundtrip")
+	if second.InputSchema != tool.InputSchema {
+		t.Error("same cache key returned a different schema pointer")
+	}
+
+	// Empty key: no-op, maps stay maps.
+	untouched := &mcp.Tool{InputSchema: map[string]any{"type": "object"}}
+	CompileToolSchemas(untouched, "")
+	if _, isMap := untouched.InputSchema.(map[string]any); !isMap {
+		t.Errorf("empty key changed InputSchema to %T, want map", untouched.InputSchema)
+	}
+}

--- a/internal/toolutil/schema_pagination.go
+++ b/internal/toolutil/schema_pagination.go
@@ -30,8 +30,13 @@ import (
 func EnrichPaginationConstraints(server *mcp.Server) {
 	onFirstToolsList(server, func(mcpTools []*mcp.Tool) {
 		for _, t := range mcpTools {
-			if schema, isMap := t.InputSchema.(map[string]any); isMap {
+			// schemaMap also converts compiled *jsonschema.Schema inputs to a
+			// fresh map, so the enrichment works regardless of whether the
+			// lockdown middleware already ran and never mutates a schema
+			// object shared across servers.
+			if schema := schemaMap(t.InputSchema); schema != nil {
 				enrichPaginationNode(schema)
+				t.InputSchema = schema
 			}
 		}
 	})

--- a/internal/toolutil/surface_tool.go
+++ b/internal/toolutil/surface_tool.go
@@ -38,6 +38,9 @@ func RegisterSurfaceToolFromSpec(server *mcp.Server, spec ActionSpec, opts Surfa
 	if formatResult == nil {
 		formatResult = MarkdownForResult
 	}
+	// Standalone utility schemas are static per tool name (no tier pruning
+	// at this layer), so the compiled form is safely shared across servers.
+	CompileToolSchemas(tool, "standalone|"+tool.Name)
 	mcp.AddTool[map[string]any, any](server, tool, surfaceToolHandler(tool.Name, spec.Route, formatResult))
 }
 

--- a/internal/toolutil/time_helpers_test.go
+++ b/internal/toolutil/time_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,22 +133,57 @@ var formatTimePtrFuncDef = regexp.MustCompile(`^func\s+formatTimePtr\b`)
 // formatISOTimePtr (with any return type). Used by the uniqueness guardrail.
 var formatISOTimePtrFuncDef = regexp.MustCompile(`^func\s+formatISOTimePtr\b`)
 
-// findDuplicateTimeHelper walks the repository looking for top-level Go function
-// definitions matching re, excluding the canonical home (this package's source
-// directory) and the test runtime cache. Returns the list of offending
-// "path:lineno" locations.
+// timeHelperScan holds the result of the single shared repository sweep the
+// two DEDUP-003 guardrail tests consume: offending "path:lineno" locations
+// per helper regex. The sweep is repo-wide but runs once (sync.Once) and
+// prunes non-source trees (.git, node_modules, dist, the Astro site), which
+// previously dominated the walk with tens of thousands of irrelevant entries.
+type timeHelperScan struct {
+	formatTimePtr    []string
+	formatISOTimePtr []string
+	err              error
+}
+
+var (
+	timeHelperScanOnce   sync.Once
+	timeHelperScanResult timeHelperScan
+)
+
+// findDuplicateTimeHelper returns the duplicate-definition hits for re,
+// excluding the canonical home (this package's source directory). Both
+// guardrail regexes are matched in one shared walk.
 func findDuplicateTimeHelper(t *testing.T, re *regexp.Regexp, skipDir string) []string {
 	t.Helper()
+	timeHelperScanOnce.Do(func() { timeHelperScanResult = scanRepoForTimeHelpers(t, skipDir) })
+	if timeHelperScanResult.err != nil {
+		t.Fatalf("walk repo: %v", timeHelperScanResult.err)
+	}
+	if re == formatISOTimePtrFuncDef {
+		return timeHelperScanResult.formatISOTimePtr
+	}
+	return timeHelperScanResult.formatTimePtr
+}
+
+// scanRepoForTimeHelpers performs the single repository sweep, collecting the
+// hits for both helper regexes at once.
+func scanRepoForTimeHelpers(t *testing.T, skipDir string) timeHelperScan {
+	t.Helper()
 	repoRoot := findRepoRoot(t)
-	var hits []string
-	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+	prunedDirs := map[string]struct{}{
+		".git": {}, "node_modules": {}, "dist": {}, "site": {},
+	}
+	var scan timeHelperScan
+	scan.err = filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") {
+		if info.IsDir() {
+			if _, pruned := prunedDirs[info.Name()]; pruned {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		if strings.HasSuffix(path, "_test.go") {
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 		if filepath.Dir(path) == skipDir {
@@ -162,17 +198,19 @@ func findDuplicateTimeHelper(t *testing.T, re *regexp.Regexp, skipDir string) []
 		lineNo := 0
 		for scanner.Scan() {
 			lineNo++
-			if re.MatchString(scanner.Text()) {
+			line := scanner.Text()
+			if formatTimePtrFuncDef.MatchString(line) {
 				rel, _ := filepath.Rel(repoRoot, path)
-				hits = append(hits, rel+":"+itoa(lineNo))
+				scan.formatTimePtr = append(scan.formatTimePtr, rel+":"+itoa(lineNo))
+			}
+			if formatISOTimePtrFuncDef.MatchString(line) {
+				rel, _ := filepath.Rel(repoRoot, path)
+				scan.formatISOTimePtr = append(scan.formatISOTimePtr, rel+":"+itoa(lineNo))
 			}
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("walk repo: %v", err)
-	}
-	return hits
+	return scan
 }
 
 // findRepoRoot returns the absolute path to the repository root (the directory

--- a/internal/toolutil/tool_listing_test.go
+++ b/internal/toolutil/tool_listing_test.go
@@ -50,3 +50,27 @@ func TestListRegisteredTools_DefaultClientName(t *testing.T) {
 		t.Fatalf("ListRegisteredTools() = %+v, want gitlab_x", tools)
 	}
 }
+
+// TestListRegisteredTools_NilServerAndCancelledContext verifies the nil-server
+// guard, the default client-name fallback on the happy path, and the connect
+// error branch under an already-cancelled context.
+func TestListRegisteredTools_NilServerAndCancelledContext(t *testing.T) {
+	if _, err := ListRegisteredTools(context.Background(), nil, ""); err == nil {
+		t.Error("nil server: expected error, got nil")
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+	tools, err := ListRegisteredTools(context.Background(), server, "")
+	if err != nil {
+		t.Fatalf("default client name: error = %v", err)
+	}
+	if tools == nil {
+		t.Log("empty server returned no tools (expected)")
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ListRegisteredTools(cancelled, mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil), "x"); err == nil {
+		t.Error("cancelled context: expected connect/list error, got nil")
+	}
+}

--- a/internal/toolutil/tool_listing_test.go
+++ b/internal/toolutil/tool_listing_test.go
@@ -70,7 +70,7 @@ func TestListRegisteredTools_NilServerAndCancelledContext(t *testing.T) {
 
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := ListRegisteredTools(cancelled, mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil), "x"); err == nil {
+	if _, listErr := ListRegisteredTools(cancelled, mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil), "x"); listErr == nil {
 		t.Error("cancelled context: expected connect/list error, got nil")
 	}
 }

--- a/internal/wizard/browser.go
+++ b/internal/wizard/browser.go
@@ -20,9 +20,15 @@ var hasDisplayFn = hasDisplay
 // On Linux/FreeBSD it checks for X11 (DISPLAY) or Wayland (WAYLAND_DISPLAY).
 // macOS and Windows are assumed to always have a desktop.
 func hasDisplay() bool {
-	switch runtime.GOOS {
+	return hasDisplayOn(runtime.GOOS, os.Getenv)
+}
+
+// hasDisplayOn is the platform-parameterized implementation of hasDisplay,
+// extracted so every GOOS branch is testable on any host.
+func hasDisplayOn(goos string, getenv func(string) string) bool {
+	switch goos {
 	case "linux", "freebsd", "openbsd", "netbsd":
-		return os.Getenv("DISPLAY") != "" || os.Getenv("WAYLAND_DISPLAY") != ""
+		return getenv("DISPLAY") != "" || getenv("WAYLAND_DISPLAY") != ""
 	default:
 		return true
 	}
@@ -31,20 +37,24 @@ func hasDisplay() bool {
 // openBrowser opens the given URL in the user's default browser.
 // Only called internally with http://127.0.0.1:<port> URLs.
 func openBrowser(url string) error {
-	var cmd *exec.Cmd
-	ctx := context.Background()
-
-	switch runtime.GOOS {
-	case "windows":
-		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url) // #nosec G204 -- trusted internal URL
-	case "darwin":
-		cmd = exec.CommandContext(ctx, "open", url) // #nosec G204 -- trusted internal URL
-	default: // linux, freebsd, etc.
-		cmd = exec.CommandContext(ctx, "xdg-open", url) // #nosec G204 -- trusted internal URL
-	}
+	cmd := browserCommand(context.Background(), runtime.GOOS, url)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("opening browser: %w", err)
 	}
 	return nil
+}
+
+// browserCommand builds the platform-specific command that opens a URL in the
+// default browser. Extracted from openBrowser so every GOOS branch is
+// testable on any host.
+func browserCommand(ctx context.Context, goos, url string) *exec.Cmd {
+	switch goos {
+	case "windows":
+		return exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url) // #nosec G204 -- trusted internal URL
+	case "darwin":
+		return exec.CommandContext(ctx, "open", url) // #nosec G204 -- trusted internal URL
+	default: // linux, freebsd, etc.
+		return exec.CommandContext(ctx, "xdg-open", url) // #nosec G204 -- trusted internal URL
+	}
 }

--- a/internal/wizard/browser_test.go
+++ b/internal/wizard/browser_test.go
@@ -1,6 +1,7 @@
 package wizard
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -203,5 +204,66 @@ func TestOpenBrowser_NonLinux(t *testing.T) {
 
 	if err := openBrowser("http://127.0.0.1:65535/test"); err != nil {
 		t.Fatalf("openBrowser() error = %v, want nil from stub", err)
+	}
+}
+
+// TestHasDisplayOn_PlatformBranches verifies graphical-environment detection
+// for every GOOS branch with injected environment lookups: Linux/BSD honor
+// DISPLAY and WAYLAND_DISPLAY, all other platforms always report a display.
+// The extracted helper makes each branch testable on any host.
+func TestHasDisplayOn_PlatformBranches(t *testing.T) {
+	env := func(vars map[string]string) func(string) string {
+		return func(key string) string { return vars[key] }
+	}
+
+	tests := []struct {
+		name string
+		goos string
+		vars map[string]string
+		want bool
+	}{
+		{name: "linux without display vars", goos: "linux", vars: map[string]string{}, want: false},
+		{name: "linux with DISPLAY", goos: "linux", vars: map[string]string{"DISPLAY": ":1"}, want: true},
+		{name: "linux with WAYLAND_DISPLAY", goos: "linux", vars: map[string]string{"WAYLAND_DISPLAY": "wayland-1"}, want: true},
+		{name: "freebsd without display vars", goos: "freebsd", vars: map[string]string{}, want: false},
+		{name: "darwin always true", goos: "darwin", vars: map[string]string{}, want: true},
+		{name: "windows always true", goos: "windows", vars: map[string]string{}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasDisplayOn(tt.goos, env(tt.vars)); got != tt.want {
+				t.Errorf("hasDisplayOn(%q, %v) = %v, want %v", tt.goos, tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBrowserCommand_PlatformBranches verifies the browser launch command for
+// every GOOS branch: rundll32 on Windows, open on macOS, xdg-open elsewhere.
+// The extracted builder makes each branch testable on any host without
+// starting a real browser process.
+func TestBrowserCommand_PlatformBranches(t *testing.T) {
+	const url = "http://127.0.0.1:8080"
+	tests := []struct {
+		goos string
+		want []string
+	}{
+		{goos: "windows", want: []string{"rundll32", "url.dll,FileProtocolHandler", url}},
+		{goos: "darwin", want: []string{"open", url}},
+		{goos: "linux", want: []string{"xdg-open", url}},
+		{goos: "freebsd", want: []string{"xdg-open", url}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			cmd := browserCommand(context.Background(), tt.goos, url)
+			if len(cmd.Args) != len(tt.want) {
+				t.Fatalf("browserCommand(%q) args = %v, want %v", tt.goos, cmd.Args, tt.want)
+			}
+			for i, arg := range tt.want {
+				if cmd.Args[i] != arg {
+					t.Fatalf("browserCommand(%q) args = %v, want %v", tt.goos, cmd.Args, tt.want)
+				}
+			}
+		})
 	}
 }

--- a/internal/wizard/cli.go
+++ b/internal/wizard/cli.go
@@ -82,7 +82,7 @@ func printSection(w io.Writer, title string) {
 func stepInstall(p *Prompter, w io.Writer) (string, error) {
 	printSection(w, "Step 1: Binary Installation")
 
-	currentPath, err := os.Executable()
+	currentPath, err := osExecutableFn()
 	if err != nil {
 		return "", fmt.Errorf("getting executable path: %w", err)
 	}

--- a/internal/wizard/cli_test.go
+++ b/internal/wizard/cli_test.go
@@ -677,3 +677,45 @@ func TestPrintSection(t *testing.T) {
 		t.Error("section missing separator")
 	}
 }
+
+// TestRunCLI_StepInstallError_Propagates verifies RunCLI aborts with the
+// step-one error when the install prompt cannot be read (exhausted input),
+// covering the stepInstall error return inside RunCLI.
+func TestRunCLI_StepInstallError_Propagates(t *testing.T) {
+	stubLoadExistingConfig(t)
+
+	var w bytes.Buffer
+	err := RunCLI("1.0.0", strings.NewReader(""), &w)
+	if err == nil || !strings.Contains(err.Error(), "reading input") {
+		t.Fatalf("RunCLI error = %v, want reading input", err)
+	}
+}
+
+// TestStepInstall_ExecutablePathError verifies stepInstall fails with a
+// wrapped error when the running binary path cannot be resolved. The
+// executable hook injects the failure because os.Executable practically
+// never fails on a real host.
+func TestStepInstall_ExecutablePathError(t *testing.T) {
+	stubOsExecutable(t, "", errors.New("no executable"))
+
+	var w bytes.Buffer
+	p := NewPrompter(strings.NewReader("\n"), &w)
+	_, err := stepInstall(p, &w)
+	if err == nil || !strings.Contains(err.Error(), "getting executable path") {
+		t.Fatalf("stepInstall error = %v, want getting executable path", err)
+	}
+}
+
+// TestStepInstall_ExpandPathError verifies stepInstall fails with a wrapped
+// error when the user-provided install directory starts with ~ but no home
+// directory can be resolved from the environment.
+func TestStepInstall_ExpandPathError(t *testing.T) {
+	unsetHomeEnv(t)
+
+	var w bytes.Buffer
+	p := NewPrompter(strings.NewReader("~gitlab-install\n"), &w)
+	_, err := stepInstall(p, &w)
+	if err == nil || !strings.Contains(err.Error(), "expanding path") {
+		t.Fatalf("stepInstall error = %v, want expanding path", err)
+	}
+}

--- a/internal/wizard/dirpicker.go
+++ b/internal/wizard/dirpicker.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+// currentGOOS carries runtime.GOOS through a variable so the GOOS-
+// parameterized helpers below keep varied call sites on every platform
+// (a direct constant argument would trip unparam on single-OS CI runners).
+var currentGOOS = runtime.GOOS
+
 var linuxDialogToolDirs = []string{"/usr/bin", "/bin"}
 
 var findLinuxDialogToolPath = fixedLinuxDialogToolPath
@@ -23,7 +28,7 @@ var pickDirectoryFn = pickDirectory
 // pickDirectory opens a native OS directory picker dialog and returns the selected path.
 // Uses PowerShell FolderBrowserDialog on Windows, osascript on macOS, zenity/kdialog on Linux.
 func pickDirectory(startDir string) (string, error) {
-	return pickDirectoryOn(runtime.GOOS, startDir)
+	return pickDirectoryOn(currentGOOS, startDir)
 }
 
 // pickDirectoryOn is the GOOS-parameterized implementation of pickDirectory,

--- a/internal/wizard/dirpicker.go
+++ b/internal/wizard/dirpicker.go
@@ -23,53 +23,22 @@ var pickDirectoryFn = pickDirectory
 // pickDirectory opens a native OS directory picker dialog and returns the selected path.
 // Uses PowerShell FolderBrowserDialog on Windows, osascript on macOS, zenity/kdialog on Linux.
 func pickDirectory(startDir string) (string, error) {
+	return pickDirectoryOn(runtime.GOOS, startDir)
+}
+
+// pickDirectoryOn is the GOOS-parameterized implementation of pickDirectory,
+// extracted so the per-platform dispatch and dialog output handling are
+// testable on any host.
+func pickDirectoryOn(goos, startDir string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	var cmd *exec.Cmd
-	var err error
-
-	switch runtime.GOOS {
-	case "windows":
-		// PowerShell script to open native Windows FolderBrowserDialog.
-		// -STA is required for WinForms dialogs; a hidden topmost form ensures
-		// the dialog appears in front of the browser window.
-		escaped := strings.ReplaceAll(startDir, "'", "''")
-		ps := fmt.Sprintf(
-			`Add-Type -AssemblyName System.Windows.Forms; `+
-				`$f = New-Object System.Windows.Forms.Form; `+
-				`$f.TopMost = $true; `+
-				`$f.WindowState = 'Minimized'; `+
-				`$f.ShowInTaskbar = $false; `+
-				`$d = New-Object System.Windows.Forms.FolderBrowserDialog; `+
-				`$d.Description = 'Select installation directory'; `+
-				`$d.ShowNewFolderButton = $true; `+
-				`if ('%s' -ne '') { $d.SelectedPath = '%s' }; `+
-				`if ($d.ShowDialog($f) -eq 'OK') { $d.SelectedPath }; `+
-				`$f.Dispose()`,
-			escaped, escaped,
-		)
-		cmd = exec.CommandContext(ctx, "powershell", "-NoProfile", "-STA", "-Command", ps) // #nosec G204 -- trusted internal command with escaped directory path
-
-	case "darwin":
-		script := `POSIX path of (choose folder with prompt "Select installation directory")`
-		if startDir != "" {
-			script = fmt.Sprintf( //nolint:gocritic // AppleScript requires literal double quotes, %q would break syntax
-				`POSIX path of (choose folder with prompt "Select installation directory" default location POSIX file "%s")`,
-				strings.ReplaceAll(startDir, `"`, `\"`),
-			)
-		}
-		cmd = exec.CommandContext(ctx, "osascript", "-e", script) // #nosec G204 -- trusted internal command with escaped directory path
-
-	default: // Linux / FreeBSD
-		cmd, err = linuxDirectoryPickerCommand(ctx, startDir)
-		if err != nil {
-			return "", errors.New("no dialog tool available (install zenity or kdialog)")
-		}
+	cmd, err := directoryPickerCommand(ctx, goos, startDir)
+	if err != nil {
+		return "", errors.New("no dialog tool available (install zenity or kdialog)")
 	}
 
-	var out []byte
-	out, err = cmd.Output()
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("dialog cancelled or failed: %w", err)
 	}
@@ -79,6 +48,56 @@ func pickDirectory(startDir string) (string, error) {
 		return "", errors.New("no directory selected")
 	}
 	return selected, nil
+}
+
+// directoryPickerCommand selects the platform-specific directory picker
+// command builder for the given GOOS.
+func directoryPickerCommand(ctx context.Context, goos, startDir string) (*exec.Cmd, error) {
+	switch goos {
+	case "windows":
+		return windowsDirectoryPickerCommand(ctx, startDir), nil
+	case "darwin":
+		return darwinDirectoryPickerCommand(ctx, startDir), nil
+	default: // Linux / FreeBSD
+		return linuxDirectoryPickerCommand(ctx, startDir)
+	}
+}
+
+// windowsDirectoryPickerCommand builds the PowerShell command that opens the
+// native Windows FolderBrowserDialog.
+func windowsDirectoryPickerCommand(ctx context.Context, startDir string) *exec.Cmd {
+	// PowerShell script to open native Windows FolderBrowserDialog.
+	// -STA is required for WinForms dialogs; a hidden topmost form ensures
+	// the dialog appears in front of the browser window.
+	escaped := strings.ReplaceAll(startDir, "'", "''")
+	ps := fmt.Sprintf(
+		`Add-Type -AssemblyName System.Windows.Forms; `+
+			`$f = New-Object System.Windows.Forms.Form; `+
+			`$f.TopMost = $true; `+
+			`$f.WindowState = 'Minimized'; `+
+			`$f.ShowInTaskbar = $false; `+
+			`$d = New-Object System.Windows.Forms.FolderBrowserDialog; `+
+			`$d.Description = 'Select installation directory'; `+
+			`$d.ShowNewFolderButton = $true; `+
+			`if ('%s' -ne '') { $d.SelectedPath = '%s' }; `+
+			`if ($d.ShowDialog($f) -eq 'OK') { $d.SelectedPath }; `+
+			`$f.Dispose()`,
+		escaped, escaped,
+	)
+	return exec.CommandContext(ctx, "powershell", "-NoProfile", "-STA", "-Command", ps) // #nosec G204 -- trusted internal command with escaped directory path
+}
+
+// darwinDirectoryPickerCommand builds the osascript command that opens the
+// native macOS folder chooser.
+func darwinDirectoryPickerCommand(ctx context.Context, startDir string) *exec.Cmd {
+	script := `POSIX path of (choose folder with prompt "Select installation directory")`
+	if startDir != "" {
+		script = fmt.Sprintf( //nolint:gocritic // AppleScript requires literal double quotes, %q would break syntax
+			`POSIX path of (choose folder with prompt "Select installation directory" default location POSIX file "%s")`,
+			strings.ReplaceAll(startDir, `"`, `\"`),
+		)
+	}
+	return exec.CommandContext(ctx, "osascript", "-e", script) // #nosec G204 -- trusted internal command with escaped directory path
 }
 
 func linuxDirectoryPickerCommand(ctx context.Context, startDir string) (*exec.Cmd, error) {

--- a/internal/wizard/dirpicker_test.go
+++ b/internal/wizard/dirpicker_test.go
@@ -1,6 +1,7 @@
 package wizard
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -207,4 +208,254 @@ func writeFakeDialogTool(t *testing.T, dir, name, script string) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+// TestDirectoryPickerCommand_WindowsBuilder verifies the Windows PowerShell
+// FolderBrowserDialog command construction, including single-quote escaping
+// of the start directory. The extracted builder makes the Windows branch
+// testable on any host without opening a real dialog.
+func TestDirectoryPickerCommand_WindowsBuilder(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("with start directory escapes single quotes", func(t *testing.T) {
+		cmd, err := directoryPickerCommand(ctx, "windows", `C:\it's here`)
+		if err != nil {
+			t.Fatalf("directoryPickerCommand(windows) error = %v", err)
+		}
+		args := cmd.Args
+		if len(args) != 5 || args[0] != "powershell" || args[1] != "-NoProfile" || args[2] != "-STA" || args[3] != "-Command" {
+			t.Fatalf("directoryPickerCommand(windows) args = %v, want powershell -NoProfile -STA -Command <script>", args)
+		}
+		script := args[4]
+		if !strings.Contains(script, `C:\it''s here`) {
+			t.Errorf("script %q does not contain escaped start directory", script)
+		}
+		if !strings.Contains(script, "FolderBrowserDialog") {
+			t.Errorf("script %q does not open FolderBrowserDialog", script)
+		}
+	})
+
+	t.Run("without start directory keeps empty selection guard", func(t *testing.T) {
+		cmd, err := directoryPickerCommand(ctx, "windows", "")
+		if err != nil {
+			t.Fatalf("directoryPickerCommand(windows) error = %v", err)
+		}
+		if !strings.Contains(cmd.Args[4], `if ('' -ne '')`) {
+			t.Errorf("script %q does not guard empty start directory", cmd.Args[4])
+		}
+	})
+}
+
+// TestDirectoryPickerCommand_DarwinBuilder verifies the macOS osascript
+// choose-folder command construction, including double-quote escaping and
+// the default-location clause added only when a start directory is given.
+// The extracted builder makes the darwin branch testable on any host.
+func TestDirectoryPickerCommand_DarwinBuilder(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("without start directory", func(t *testing.T) {
+		cmd, err := directoryPickerCommand(ctx, "darwin", "")
+		if err != nil {
+			t.Fatalf("directoryPickerCommand(darwin) error = %v", err)
+		}
+		want := `POSIX path of (choose folder with prompt "Select installation directory")`
+		if len(cmd.Args) != 3 || cmd.Args[0] != "osascript" || cmd.Args[1] != "-e" || cmd.Args[2] != want {
+			t.Fatalf("directoryPickerCommand(darwin) args = %v, want osascript -e %q", cmd.Args, want)
+		}
+	})
+
+	t.Run("with start directory escapes double quotes", func(t *testing.T) {
+		cmd, err := directoryPickerCommand(ctx, "darwin", `/tmp/"quoted"`)
+		if err != nil {
+			t.Fatalf("directoryPickerCommand(darwin) error = %v", err)
+		}
+		script := cmd.Args[2]
+		if !strings.Contains(script, `default location POSIX file "/tmp/\"quoted\""`) {
+			t.Errorf("script %q does not contain escaped default location", script)
+		}
+	})
+}
+
+// TestPickDirectoryOn_LinuxDispatch verifies the GOOS-parameterized
+// pickDirectoryOn on the Linux code path from any host: missing dialog tools
+// yield the install hint, a fake zenity script's stdout becomes the
+// selection, a failing tool maps to the cancelled error, and empty output
+// maps to the no-selection error. Windows is skipped because the fixtures
+// are shell scripts.
+func TestPickDirectoryOn_LinuxDispatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script dialog fixtures require a Unix host")
+	}
+
+	t.Run("missing dialog tools", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, nil)
+		_, err := pickDirectoryOn("linux", t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "no dialog tool available (install zenity or kdialog)") {
+			t.Fatalf("pickDirectoryOn(linux) error = %v, want missing dialog tool", err)
+		}
+	})
+
+	t.Run("zenity output becomes selection", func(t *testing.T) {
+		binDir := t.TempDir()
+		selected := t.TempDir()
+		zenityPath := writeFakeDialogTool(t, binDir, "zenity", "#!/bin/sh\nprintf '%s\\n' \""+selected+"\"\n")
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": zenityPath})
+
+		got, err := pickDirectoryOn("linux", t.TempDir())
+		if err != nil {
+			t.Fatalf("pickDirectoryOn(linux) error = %v", err)
+		}
+		if got != selected {
+			t.Fatalf("pickDirectoryOn(linux) = %q, want %q", got, selected)
+		}
+	})
+
+	t.Run("dialog failure", func(t *testing.T) {
+		binDir := t.TempDir()
+		zenityPath := writeFakeDialogTool(t, binDir, "zenity", "#!/bin/sh\nexit 1\n")
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": zenityPath})
+
+		_, err := pickDirectoryOn("linux", t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "dialog cancelled or failed") {
+			t.Fatalf("pickDirectoryOn(linux) error = %v, want command failure", err)
+		}
+	})
+
+	t.Run("empty selection", func(t *testing.T) {
+		binDir := t.TempDir()
+		zenityPath := writeFakeDialogTool(t, binDir, "zenity", "#!/bin/sh\nexit 0\n")
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": zenityPath})
+
+		_, err := pickDirectoryOn("linux", t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "no directory selected") {
+			t.Fatalf("pickDirectoryOn(linux) error = %v, want empty selection", err)
+		}
+	})
+}
+
+// TestFixedLinuxDialogToolPath_SkipsNonFixedDirs verifies the search skips
+// candidate directories that are world/group writable (not "fixed") or do
+// not exist, and still finds an executable tool in a later fixed directory.
+// The directory list is swapped for test-controlled temp directories.
+func TestFixedLinuxDialogToolPath_SkipsNonFixedDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission fixtures require a Unix host")
+	}
+
+	writable := t.TempDir()
+	if err := os.Chmod(writable, 0o777); err != nil { //nolint:gosec // world-writable fixture is required to trigger the skip branch
+		t.Fatal(err)
+	}
+	fixed := t.TempDir()
+	if err := os.Chmod(fixed, 0o755); err != nil { //nolint:gosec // non-writable-for-group directory fixture is required for the fixed-dir check
+		t.Fatal(err)
+	}
+	writeFakeDialogTool(t, writable, "zenity", "#!/bin/sh\nexit 0\n")
+	toolPath := writeFakeDialogTool(t, fixed, "zenity", "#!/bin/sh\nexit 0\n")
+
+	original := linuxDialogToolDirs
+	linuxDialogToolDirs = []string{writable, filepath.Join(fixed, "does-not-exist"), fixed}
+	t.Cleanup(func() { linuxDialogToolDirs = original })
+
+	got, ok := fixedLinuxDialogToolPath("zenity")
+	if !ok {
+		t.Fatal("fixedLinuxDialogToolPath(zenity) = false, want tool in fixed directory")
+	}
+	if got != toolPath {
+		t.Fatalf("fixedLinuxDialogToolPath(zenity) = %q, want %q (writable dir must be skipped)", got, toolPath)
+	}
+}
+
+// TestLinuxDirectoryPickerCommand_ArgumentShapes verifies the exact argument
+// lists built for zenity and kdialog, with and without a start directory,
+// plus the error when neither tool is available. The dialog tool lookup is
+// stubbed so every branch runs on any host.
+func TestLinuxDirectoryPickerCommand_ArgumentShapes(t *testing.T) {
+	ctx := context.Background()
+
+	assertArgs := func(t *testing.T, got, want []string) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("args = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("args = %v, want %v", got, want)
+			}
+		}
+	}
+
+	t.Run("zenity with start directory", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": "/fixed/zenity"})
+		cmd, err := linuxDirectoryPickerCommand(ctx, "/srv/data")
+		if err != nil {
+			t.Fatalf("linuxDirectoryPickerCommand error = %v", err)
+		}
+		assertArgs(t, cmd.Args, []string{"/fixed/zenity", "--file-selection", "--directory", "--title=Select installation directory", "--filename=/srv/data/"})
+	})
+
+	t.Run("zenity without start directory", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": "/fixed/zenity"})
+		cmd, err := linuxDirectoryPickerCommand(ctx, "")
+		if err != nil {
+			t.Fatalf("linuxDirectoryPickerCommand error = %v", err)
+		}
+		assertArgs(t, cmd.Args, []string{"/fixed/zenity", "--file-selection", "--directory", "--title=Select installation directory"})
+	})
+
+	t.Run("kdialog with start directory", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, map[string]string{"kdialog": "/fixed/kdialog"})
+		cmd, err := linuxDirectoryPickerCommand(ctx, "/srv/data")
+		if err != nil {
+			t.Fatalf("linuxDirectoryPickerCommand error = %v", err)
+		}
+		assertArgs(t, cmd.Args, []string{"/fixed/kdialog", "--getexistingdirectory", "/srv/data"})
+	})
+
+	t.Run("kdialog without start directory defaults to cwd", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, map[string]string{"kdialog": "/fixed/kdialog"})
+		cmd, err := linuxDirectoryPickerCommand(ctx, "")
+		if err != nil {
+			t.Fatalf("linuxDirectoryPickerCommand error = %v", err)
+		}
+		assertArgs(t, cmd.Args, []string{"/fixed/kdialog", "--getexistingdirectory", "."})
+	})
+
+	t.Run("no tool available", func(t *testing.T) {
+		stubLinuxDialogToolPaths(t, nil)
+		if _, err := linuxDirectoryPickerCommand(ctx, ""); err == nil {
+			t.Fatal("linuxDirectoryPickerCommand error = nil, want no fixed dialog tool found")
+		}
+	})
+}
+
+// TestPickDirectory_UsesRuntimePlatform verifies the thin pickDirectory
+// wrapper dispatches on the real runtime.GOOS. The host's dialog tooling is
+// stubbed per platform (fake zenity lookup on Linux/BSD, fake osascript on
+// PATH for macOS) so no real dialog opens; Windows is skipped because
+// PowerShell cannot be safely shadowed.
+func TestPickDirectory_UsesRuntimePlatform(t *testing.T) {
+	selected := t.TempDir()
+	script := "#!/bin/sh\nprintf '%s\\n' \"" + selected + "\"\n"
+
+	switch runtime.GOOS {
+	case "windows":
+		t.Skip("cannot shadow the PowerShell dialog on Windows")
+	case "darwin":
+		binDir := t.TempDir()
+		writeFakeDialogTool(t, binDir, "osascript", script)
+		t.Setenv("PATH", binDir)
+	default: // linux and BSDs
+		binDir := t.TempDir()
+		zenityPath := writeFakeDialogTool(t, binDir, "zenity", script)
+		stubLinuxDialogToolPaths(t, map[string]string{"zenity": zenityPath})
+	}
+
+	got, err := pickDirectory("")
+	if err != nil {
+		t.Fatalf("pickDirectory() error = %v", err)
+	}
+	if got != selected {
+		t.Fatalf("pickDirectory() = %q, want %q", got, selected)
+	}
 }

--- a/internal/wizard/envfile_test.go
+++ b/internal/wizard/envfile_test.go
@@ -458,3 +458,15 @@ func TestWriteEnvFile_Wrapper(t *testing.T) {
 		t.Error("written file does not contain expected token")
 	}
 }
+
+// TestWriteEnvFileToPath_WriteError verifies writeEnvFileToPath wraps the
+// filesystem error when the env file cannot be written (here: the parent
+// directory does not exist).
+func TestWriteEnvFileToPath_WriteError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-subdir", EnvFileName)
+
+	_, err := writeEnvFileToPath(path, ServerConfig{GitLabURL: "https://gitlab.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "writing env file") {
+		t.Fatalf("writeEnvFileToPath error = %v, want writing env file", err)
+	}
+}

--- a/internal/wizard/install.go
+++ b/internal/wizard/install.go
@@ -22,6 +22,18 @@ var installBinaryFn = installBinaryImpl
 // Tests override it to avoid executing real binaries.
 var getInstalledVersionFn = getInstalledVersionImpl
 
+// osExecutableFn resolves the path of the running binary. Tests override it
+// to exercise executable-resolution error branches deterministically.
+var osExecutableFn = os.Executable
+
+// filepathAbsFn resolves a path to its absolute form. Tests override it to
+// exercise path-resolution error branches deterministically.
+var filepathAbsFn = filepath.Abs
+
+// chmodFn sets file permissions after install. Tests override it to exercise
+// the permission error branch without an unwritable filesystem.
+var chmodFn = os.Chmod
+
 // InstallBinary copies the currently running binary to destDir.
 // Returns the full path of the installed binary. Skips copy if
 // the source and destination resolve to the same path.
@@ -30,7 +42,7 @@ func InstallBinary(destDir string) (string, error) {
 }
 
 func installBinaryImpl(destDir string) (string, error) {
-	srcPath, err := os.Executable()
+	srcPath, err := osExecutableFn()
 	if err != nil {
 		return "", fmt.Errorf("getting executable path: %w", err)
 	}
@@ -40,7 +52,7 @@ func installBinaryImpl(destDir string) (string, error) {
 	}
 
 	// Sanitize destDir to prevent path traversal.
-	cleanDir, err := filepath.Abs(filepath.Clean(destDir)) // #nosec G304 -- wizard install dir chosen by local user via setup UI
+	cleanDir, err := filepathAbsFn(filepath.Clean(destDir)) // #nosec G304 -- wizard install dir chosen by local user via setup UI
 	if err != nil {
 		return "", fmt.Errorf("resolving absolute path for %s: %w", destDir, err)
 	}
@@ -68,7 +80,7 @@ func installBinaryImpl(destDir string) (string, error) {
 	}
 
 	if runtime.GOOS != "windows" {
-		if err = os.Chmod(destPath, 0o700); err != nil { // #nosec G302 -- binary needs owner-only execute permission
+		if err = chmodFn(destPath, 0o700); err != nil { // #nosec G302 -- binary needs owner-only execute permission
 			return "", fmt.Errorf("setting permissions: %w", err)
 		}
 	}

--- a/internal/wizard/install_test.go
+++ b/internal/wizard/install_test.go
@@ -3,6 +3,7 @@
 package wizard
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -269,4 +270,154 @@ func writeFakeVersionBinary(t *testing.T, output string) string {
 		t.Fatal(err)
 	}
 	return p
+}
+
+// stubOsExecutable overrides osExecutableFn to return the given path and
+// error, so executable-resolution branches can be exercised without
+// depending on the real running binary.
+func stubOsExecutable(t *testing.T, path string, err error) {
+	t.Helper()
+	orig := osExecutableFn
+	osExecutableFn = func() (string, error) { return path, err }
+	t.Cleanup(func() { osExecutableFn = orig })
+}
+
+// TestInstallBinaryImpl_ExecutablePathError verifies installBinaryImpl
+// surfaces a wrapped error when the running binary path cannot be resolved.
+func TestInstallBinaryImpl_ExecutablePathError(t *testing.T) {
+	stubOsExecutable(t, "", errors.New("no executable"))
+
+	_, err := installBinaryImpl(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "getting executable path") {
+		t.Fatalf("installBinaryImpl error = %v, want getting executable path", err)
+	}
+}
+
+// TestInstallBinaryImpl_SymlinkResolutionError verifies installBinaryImpl
+// surfaces a wrapped error when the executable path cannot be resolved via
+// EvalSymlinks (e.g. the reported binary no longer exists on disk).
+func TestInstallBinaryImpl_SymlinkResolutionError(t *testing.T) {
+	stubOsExecutable(t, filepath.Join(t.TempDir(), "missing-binary"), nil)
+
+	_, err := installBinaryImpl(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "resolving executable path") {
+		t.Fatalf("installBinaryImpl error = %v, want resolving executable path", err)
+	}
+}
+
+// stubFilepathAbs overrides filepathAbsFn to return the given path and
+// error, so absolute-path resolution branches can be exercised
+// deterministically (filepath.Abs only fails when the working directory is
+// unavailable).
+func stubFilepathAbs(t *testing.T, path string, err error) {
+	t.Helper()
+	orig := filepathAbsFn
+	filepathAbsFn = func(string) (string, error) { return path, err }
+	t.Cleanup(func() { filepathAbsFn = orig })
+}
+
+// TestInstallBinaryImpl_AbsPathError verifies installBinaryImpl surfaces a
+// wrapped error when the destination directory cannot be resolved to an
+// absolute path.
+func TestInstallBinaryImpl_AbsPathError(t *testing.T) {
+	stubFilepathAbs(t, "", errors.New("no working directory"))
+
+	_, err := installBinaryImpl("relative-dir")
+	if err == nil || !strings.Contains(err.Error(), "resolving absolute path for relative-dir") {
+		t.Fatalf("installBinaryImpl error = %v, want resolving absolute path", err)
+	}
+}
+
+// TestInstallBinaryImpl_PathTraversalRejected verifies the defensive
+// traversal guard: if the resolved destination still contains a ".."
+// component, installation is rejected. The Abs hook injects such a path
+// because filepath.Abs normally cleans it away.
+func TestInstallBinaryImpl_PathTraversalRejected(t *testing.T) {
+	stubFilepathAbs(t, filepath.Join(string(filepath.Separator), "opt")+string(filepath.Separator)+".."+string(filepath.Separator)+"bin", nil)
+
+	_, err := installBinaryImpl("ignored")
+	if err == nil || !strings.Contains(err.Error(), "invalid install directory (contains path traversal)") {
+		t.Fatalf("installBinaryImpl error = %v, want path traversal rejection", err)
+	}
+}
+
+// TestInstallBinaryImpl_SourceEqualsDestination_SkipsCopy verifies the
+// short-circuit branch: when the running binary already resides at the
+// destination path, installBinaryImpl returns the destination without
+// copying or modifying anything.
+func TestInstallBinaryImpl_SourceEqualsDestination_SkipsCopy(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, DefaultBinaryName())
+	if err := os.WriteFile(existing, []byte("fake binary"), 0o755); err != nil { //nolint:gosec // executable fixture required for install path comparison
+		t.Fatal(err)
+	}
+	stubOsExecutable(t, existing, nil)
+
+	got, err := installBinaryImpl(dir)
+	if err != nil {
+		t.Fatalf("installBinaryImpl error = %v", err)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(absDir, DefaultBinaryName()); got != want {
+		t.Fatalf("installBinaryImpl = %q, want %q", got, want)
+	}
+	content, err := os.ReadFile(existing) // #nosec G304 -- reading back the fixture path created above
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "fake binary" {
+		t.Fatalf("destination content = %q, want untouched fixture (no copy)", content)
+	}
+}
+
+// TestInstallBinaryImpl_CopyFails_DestinationIsDirectory verifies
+// installBinaryImpl surfaces a wrapped copy error when the destination file
+// path is occupied by a directory, which makes os.Create fail on any
+// platform.
+func TestInstallBinaryImpl_CopyFails_DestinationIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, DefaultBinaryName()), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := installBinaryImpl(dir)
+	if err == nil || !strings.Contains(err.Error(), "copying binary") {
+		t.Fatalf("installBinaryImpl error = %v, want copying binary", err)
+	}
+}
+
+// TestInstallBinaryImpl_ChmodError verifies installBinaryImpl surfaces a
+// wrapped permissions error when the post-copy chmod fails. The chmod hook
+// injects the failure because chmod on a freshly created file cannot fail
+// naturally. Skipped on Windows where the chmod branch is not executed.
+func TestInstallBinaryImpl_ChmodError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod branch is skipped on Windows")
+	}
+	orig := chmodFn
+	chmodFn = func(string, os.FileMode) error { return errors.New("chmod denied") }
+	t.Cleanup(func() { chmodFn = orig })
+
+	_, err := installBinaryImpl(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "setting permissions") {
+		t.Fatalf("installBinaryImpl error = %v, want setting permissions", err)
+	}
+}
+
+// TestCopyFile_SourceIsDirectory_ReturnsCopyError verifies copyFile returns
+// the io.Copy read error when the source path is a directory: opening a
+// directory succeeds on Unix, so the failure surfaces during the copy.
+func TestCopyFile_SourceIsDirectory_ReturnsCopyError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("opening a directory for read behaves differently on Windows")
+	}
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := copyFile(src, dst); err == nil {
+		t.Fatal("copyFile(directory, file) error = nil, want read error")
+	}
 }

--- a/internal/wizard/paths.go
+++ b/internal/wizard/paths.go
@@ -18,22 +18,33 @@ const (
 //   - Windows: %LOCALAPPDATA%\gitlab-mcp-server
 //   - macOS/Linux: ~/.local/bin
 func DefaultInstallDir() string {
-	switch runtime.GOOS {
+	home, _ := os.UserHomeDir()
+	return defaultInstallDirFor(runtime.GOOS, os.Getenv, home)
+}
+
+// defaultInstallDirFor is the platform-parameterized implementation of
+// DefaultInstallDir, extracted so every GOOS branch is testable on any host.
+func defaultInstallDirFor(goos string, getenv func(string) string, home string) string {
+	switch goos {
 	case "windows":
-		if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
+		if dir := getenv("LOCALAPPDATA"); dir != "" {
 			return filepath.Join(dir, appName)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, "AppData", "Local", appName)
 	default:
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, ".local", "bin")
 	}
 }
 
 // DefaultBinaryName returns the binary name for the current platform.
 func DefaultBinaryName() string {
-	if runtime.GOOS == "windows" {
+	return defaultBinaryNameFor(runtime.GOOS)
+}
+
+// defaultBinaryNameFor is the platform-parameterized implementation of
+// DefaultBinaryName, extracted so both GOOS branches are testable on any host.
+func defaultBinaryNameFor(goos string) string {
+	if goos == "windows" {
 		return appName + ".exe"
 	}
 	return appName
@@ -45,29 +56,40 @@ func ExpandPath(path string) (string, error) {
 		return path, nil
 	}
 	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+	return expandPathWithHome(path, home, err)
+}
+
+// expandPathWithHome joins a ~-prefixed path with the resolved home directory,
+// propagating any home-resolution error. Extracted so the error branch is
+// testable without depending on the host environment.
+func expandPathWithHome(path, home string, homeErr error) (string, error) {
+	if homeErr != nil {
+		return "", homeErr
 	}
 	return filepath.Join(home, path[1:]), nil
 }
 
 // configDir returns the platform-specific user config directory for a given app.
 func configDir(app string) string {
-	switch runtime.GOOS {
+	home, _ := os.UserHomeDir()
+	return configDirFor(runtime.GOOS, os.Getenv, home, app)
+}
+
+// configDirFor is the platform-parameterized implementation of configDir,
+// extracted so every GOOS branch is testable on any host.
+func configDirFor(goos string, getenv func(string) string, home, app string) string {
+	switch goos {
 	case "windows":
-		if dir := os.Getenv("APPDATA"); dir != "" {
+		if dir := getenv("APPDATA"); dir != "" {
 			return filepath.Join(dir, app)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, "AppData", "Roaming", app)
 	case "darwin":
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, "Library", "Application Support", app)
 	default:
-		if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		if dir := getenv("XDG_CONFIG_HOME"); dir != "" {
 			return filepath.Join(dir, app)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, configDirXDG, app)
 	}
 }
@@ -113,15 +135,21 @@ func openCodeConfigPath() string {
 
 // crushConfigPath returns the path to Crush (Charm) global config.
 func crushConfigPath() string {
-	switch runtime.GOOS {
+	home, _ := os.UserHomeDir()
+	return crushConfigPathFor(runtime.GOOS, os.Getenv, home)
+}
+
+// crushConfigPathFor is the platform-parameterized implementation of
+// crushConfigPath, extracted so every GOOS branch is testable on any host.
+func crushConfigPathFor(goos string, getenv func(string) string, home string) string {
+	switch goos {
 	case "windows":
-		if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
+		if dir := getenv("LOCALAPPDATA"); dir != "" {
 			return filepath.Join(dir, "crush", crushFile)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, "AppData", "Local", "crush", crushFile)
 	default:
-		return filepath.Join(configDir("crush"), crushFile)
+		return filepath.Join(configDirFor(goos, getenv, home, "crush"), crushFile)
 	}
 }
 
@@ -136,21 +164,25 @@ func EnvFilePath() string {
 
 // zedConfigPath returns the path to Zed's settings file.
 func zedConfigPath() string {
-	switch runtime.GOOS {
+	home, _ := os.UserHomeDir()
+	return zedConfigPathFor(runtime.GOOS, os.Getenv, home)
+}
+
+// zedConfigPathFor is the platform-parameterized implementation of
+// zedConfigPath, extracted so every GOOS branch is testable on any host.
+func zedConfigPathFor(goos string, getenv func(string) string, home string) string {
+	switch goos {
 	case "darwin":
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, configDirXDG, "zed", settingsFile)
 	case "windows":
-		if dir := os.Getenv("APPDATA"); dir != "" {
+		if dir := getenv("APPDATA"); dir != "" {
 			return filepath.Join(dir, "Zed", settingsFile)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, "AppData", "Roaming", "Zed", settingsFile)
 	default:
-		if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		if dir := getenv("XDG_CONFIG_HOME"); dir != "" {
 			return filepath.Join(dir, "zed", settingsFile)
 		}
-		home, _ := os.UserHomeDir()
 		return filepath.Join(home, configDirXDG, "zed", settingsFile)
 	}
 }

--- a/internal/wizard/paths_test.go
+++ b/internal/wizard/paths_test.go
@@ -3,6 +3,7 @@
 package wizard
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -346,5 +347,261 @@ func TestZedConfigPath_WindowsFallback(t *testing.T) {
 	want := filepath.Join(home, "AppData", "Roaming", "Zed", "settings.json")
 	if p != want {
 		t.Errorf("zedConfigPath = %q, want %q", p, want)
+	}
+}
+
+// fakeGetenv returns a getenv function backed by the given map, so
+// platform-parameterized path helpers can be tested with deterministic
+// environment values on any host.
+func fakeGetenv(vars map[string]string) func(string) string {
+	return func(key string) string { return vars[key] }
+}
+
+// unsetHomeEnv clears the environment variables os.UserHomeDir consults on
+// every platform (HOME on Unix, USERPROFILE on Windows, home on Plan 9) so
+// home-directory resolution fails deterministically in error-branch tests.
+func unsetHomeEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("home", "")
+}
+
+// TestDefaultInstallDirFor_PlatformBranches verifies the platform-specific
+// install directory selection for every GOOS branch: Windows prefers
+// %LOCALAPPDATA%, falls back to the home AppData path, and all other
+// platforms use ~/.local/bin. The extracted helper makes each branch
+// testable regardless of the host OS.
+func TestDefaultInstallDirFor_PlatformBranches(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		home string
+		want string
+	}{
+		{
+			name: "windows with LOCALAPPDATA",
+			goos: "windows",
+			env:  map[string]string{"LOCALAPPDATA": filepath.Join("C:", "Users", "u", "AppData", "Local")},
+			home: filepath.Join("C:", "Users", "u"),
+			want: filepath.Join("C:", "Users", "u", "AppData", "Local", appName),
+		},
+		{
+			name: "windows without LOCALAPPDATA falls back to home",
+			goos: "windows",
+			env:  map[string]string{},
+			home: filepath.Join("C:", "Users", "u"),
+			want: filepath.Join("C:", "Users", "u", "AppData", "Local", appName),
+		},
+		{
+			name: "linux uses ~/.local/bin",
+			goos: "linux",
+			env:  map[string]string{},
+			home: filepath.Join("/home", "u"),
+			want: filepath.Join("/home", "u", ".local", "bin"),
+		},
+		{
+			name: "darwin uses ~/.local/bin",
+			goos: "darwin",
+			env:  map[string]string{},
+			home: filepath.Join("/Users", "u"),
+			want: filepath.Join("/Users", "u", ".local", "bin"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultInstallDirFor(tt.goos, fakeGetenv(tt.env), tt.home)
+			if got != tt.want {
+				t.Errorf("defaultInstallDirFor(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefaultBinaryNameFor_PlatformBranches verifies the binary name gets a
+// .exe suffix only on Windows. The extracted helper makes the Windows branch
+// testable on non-Windows hosts.
+func TestDefaultBinaryNameFor_PlatformBranches(t *testing.T) {
+	if got := defaultBinaryNameFor("windows"); got != appName+".exe" {
+		t.Errorf("defaultBinaryNameFor(windows) = %q, want %q", got, appName+".exe")
+	}
+	if got := defaultBinaryNameFor("linux"); got != appName {
+		t.Errorf("defaultBinaryNameFor(linux) = %q, want %q", got, appName)
+	}
+	if got := defaultBinaryNameFor("darwin"); got != appName {
+		t.Errorf("defaultBinaryNameFor(darwin) = %q, want %q", got, appName)
+	}
+}
+
+// TestExpandPath_HomeLookupError verifies ExpandPath surfaces the
+// os.UserHomeDir error when a ~-prefixed path is expanded while no home
+// directory can be resolved from the environment.
+func TestExpandPath_HomeLookupError(t *testing.T) {
+	unsetHomeEnv(t)
+	if _, err := ExpandPath("~" + string(os.PathSeparator) + "sub"); err == nil {
+		t.Fatal("ExpandPath(~/sub) error = nil, want home lookup error")
+	}
+}
+
+// TestExpandPathWithHome_ErrorPropagates verifies the extracted helper
+// returns the home-resolution error verbatim and an empty path, matching the
+// original ExpandPath contract.
+func TestExpandPathWithHome_ErrorPropagates(t *testing.T) {
+	wantErr := os.ErrPermission
+	got, err := expandPathWithHome("~/x", "", wantErr)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expandPathWithHome error = %v, want %v", err, wantErr)
+	}
+	if got != "" {
+		t.Fatalf("expandPathWithHome path = %q, want empty on error", got)
+	}
+}
+
+// TestConfigDirFor_PlatformBranches verifies the per-platform user config
+// directory resolution: Windows prefers %APPDATA% with a home fallback,
+// macOS uses Library/Application Support, and Linux honors XDG_CONFIG_HOME
+// with a ~/.config fallback. The extracted helper makes every branch
+// testable on any host.
+func TestConfigDirFor_PlatformBranches(t *testing.T) {
+	home := filepath.Join("/home", "u")
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "windows with APPDATA",
+			goos: "windows",
+			env:  map[string]string{"APPDATA": filepath.Join("C:", "roaming")},
+			want: filepath.Join("C:", "roaming", "App"),
+		},
+		{
+			name: "windows without APPDATA falls back to home",
+			goos: "windows",
+			env:  map[string]string{},
+			want: filepath.Join(home, "AppData", "Roaming", "App"),
+		},
+		{
+			name: "darwin uses Application Support",
+			goos: "darwin",
+			env:  map[string]string{},
+			want: filepath.Join(home, "Library", "Application Support", "App"),
+		},
+		{
+			name: "linux with XDG_CONFIG_HOME",
+			goos: "linux",
+			env:  map[string]string{"XDG_CONFIG_HOME": "/xdg"},
+			want: filepath.Join("/xdg", "App"),
+		},
+		{
+			name: "linux without XDG_CONFIG_HOME falls back to ~/.config",
+			goos: "linux",
+			env:  map[string]string{},
+			want: filepath.Join(home, configDirXDG, "App"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := configDirFor(tt.goos, fakeGetenv(tt.env), home, "App")
+			if got != tt.want {
+				t.Errorf("configDirFor(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCrushConfigPathFor_PlatformBranches verifies the Crush config path
+// resolution: Windows prefers %LOCALAPPDATA% with a home fallback, all
+// other platforms use the shared config directory. The extracted helper
+// makes the Windows branches testable on any host.
+func TestCrushConfigPathFor_PlatformBranches(t *testing.T) {
+	home := filepath.Join("/home", "u")
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "windows with LOCALAPPDATA",
+			goos: "windows",
+			env:  map[string]string{"LOCALAPPDATA": filepath.Join("C:", "local")},
+			want: filepath.Join("C:", "local", "crush", crushFile),
+		},
+		{
+			name: "windows without LOCALAPPDATA falls back to home",
+			goos: "windows",
+			env:  map[string]string{},
+			want: filepath.Join(home, "AppData", "Local", "crush", crushFile),
+		},
+		{
+			name: "linux delegates to config dir",
+			goos: "linux",
+			env:  map[string]string{},
+			want: filepath.Join(home, configDirXDG, "crush", crushFile),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := crushConfigPathFor(tt.goos, fakeGetenv(tt.env), home)
+			if got != tt.want {
+				t.Errorf("crushConfigPathFor(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestZedConfigPathFor_PlatformBranches verifies the Zed settings path
+// resolution: macOS uses ~/.config/zed, Windows prefers %APPDATA% with a
+// home fallback, and Linux honors XDG_CONFIG_HOME with a ~/.config
+// fallback. The extracted helper makes every branch testable on any host.
+func TestZedConfigPathFor_PlatformBranches(t *testing.T) {
+	home := filepath.Join("/home", "u")
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "darwin uses ~/.config/zed",
+			goos: "darwin",
+			env:  map[string]string{},
+			want: filepath.Join(home, configDirXDG, "zed", settingsFile),
+		},
+		{
+			name: "windows with APPDATA",
+			goos: "windows",
+			env:  map[string]string{"APPDATA": filepath.Join("C:", "roaming")},
+			want: filepath.Join("C:", "roaming", "Zed", settingsFile),
+		},
+		{
+			name: "windows without APPDATA falls back to home",
+			goos: "windows",
+			env:  map[string]string{},
+			want: filepath.Join(home, "AppData", "Roaming", "Zed", settingsFile),
+		},
+		{
+			name: "linux with XDG_CONFIG_HOME",
+			goos: "linux",
+			env:  map[string]string{"XDG_CONFIG_HOME": "/xdg"},
+			want: filepath.Join("/xdg", "zed", settingsFile),
+		},
+		{
+			name: "linux without XDG_CONFIG_HOME falls back to ~/.config",
+			goos: "linux",
+			env:  map[string]string{},
+			want: filepath.Join(home, configDirXDG, "zed", settingsFile),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := zedConfigPathFor(tt.goos, fakeGetenv(tt.env), home)
+			if got != tt.want {
+				t.Errorf("zedConfigPathFor(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/wizard/run.go
+++ b/internal/wizard/run.go
@@ -20,6 +20,11 @@ const (
 	UIModeCLI UIMode = "cli"
 )
 
+// isInteractiveTerminalFn detects an interactive terminal for the auto-mode
+// cascade. Tests override it to exercise the TUI fallback branch without a
+// real TTY.
+var isInteractiveTerminalFn = IsInteractiveTerminal
+
 // Run executes the setup wizard using the selected UI mode.
 // In "auto" mode it cascades: Web UI → Bubble Tea TUI → plain CLI.
 func Run(version string, mode UIMode, r io.Reader, w io.Writer) error {
@@ -50,7 +55,7 @@ func runCascade(version string, r io.Reader, w io.Writer) error {
 	}
 
 	// Try Bubble Tea TUI — requires a real terminal
-	if IsInteractiveTerminal() {
+	if isInteractiveTerminalFn() {
 		if err := RunTUI(version, w); err == nil {
 			return nil
 		}

--- a/internal/wizard/run_test.go
+++ b/internal/wizard/run_test.go
@@ -6,6 +6,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -172,5 +175,223 @@ func TestToolSurfaceHelpers(t *testing.T) {
 	toolSurface, metaTools := toolSurfaceFromEnv(map[string]string{"TOOL_SURFACE": "invalid", "META_TOOLS": "false"})
 	if toolSurface != "individual" || metaTools {
 		t.Fatalf("toolSurfaceFromEnv(invalid,false) = %q/%v, want individual/false", toolSurface, metaTools)
+	}
+}
+
+// stubInteractiveTerminal overrides isInteractiveTerminalFn so the auto-mode
+// cascade can be steered into or away from the TUI branch without a real TTY.
+func stubInteractiveTerminal(t *testing.T, interactive bool) {
+	t.Helper()
+	orig := isInteractiveTerminalFn
+	isInteractiveTerminalFn = func() bool { return interactive }
+	t.Cleanup(func() { isInteractiveTerminalFn = orig })
+}
+
+// stubHasDisplay overrides hasDisplayFn so the auto-mode cascade can be
+// steered into or away from the Web UI branch regardless of the host's
+// graphical environment.
+func stubHasDisplay(t *testing.T, has bool) {
+	t.Helper()
+	orig := hasDisplayFn
+	hasDisplayFn = func() bool { return has }
+	t.Cleanup(func() { hasDisplayFn = orig })
+}
+
+// TestRun_TUIMode_Dispatch verifies Run delegates to RunTUI in TUI mode by
+// swapping stdinFn for a Ctrl+C reader: the TUI starts, aborts cleanly, and
+// Run returns nil after printing the cancellation notice.
+func TestRun_TUIMode_Dispatch(t *testing.T) {
+	stubWriteEnvFile(t)
+	origStdin := stdinFn
+	stdinFn = func() io.Reader { return bytes.NewReader([]byte{0x03}) }
+	t.Cleanup(func() { stdinFn = origStdin })
+
+	var output bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- Run("1.0.0", UIModeTUI, nil, &output) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run(tui) error = %v, want nil from Ctrl+C abort", err)
+		}
+		if !strings.Contains(output.String(), "Setup cancelled") {
+			t.Errorf("Run(tui) output = %q, want cancellation notice", output.String())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run(tui) hung")
+	}
+}
+
+// TestRunCascade_WebSucceeds_ReturnsNil verifies auto mode returns nil right
+// after a successful Web UI session: with a display available, the browser
+// stub posts a valid configuration and the cascade never reaches TUI or CLI.
+func TestRunCascade_WebSucceeds_ReturnsNil(t *testing.T) {
+	useFakeClients(t)
+	stubWriteEnvFile(t)
+	stubInstallBinary(t)
+	stubLoadExistingConfig(t)
+	stubHasDisplay(t, true)
+
+	origOpenBrowser := openBrowserFn
+	openedURL := make(chan string, 1)
+	openBrowserFn = func(url string) error {
+		openedURL <- url
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFn = origOpenBrowser })
+
+	var output bytes.Buffer
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run("1.0.0", UIModeAuto, nil, &output) }()
+
+	var webURL string
+	select {
+	case webURL = <-openedURL:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run(auto) did not open the local wizard URL")
+	}
+
+	reqBody := configureRequest{
+		InstallPath:       filepath.Join(t.TempDir(), "bin"),
+		GitLabURL:         "https://gitlab.example.com",
+		GitLabToken:       "test-token-test123",
+		ToolSurface:       "meta",
+		CapabilitySurface: "full",
+		MetaParamSchema:   "opaque",
+		AutoUpdateMode:    "false",
+		RateLimitRPS:      "0",
+		RateLimitBurst:    "40",
+		LogLevel:          "info",
+		SelectedClients:   []int{0},
+	}
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("marshal configure request: %v", err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, webURL+"/api/configure", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("build POST /api/configure request: %v", err)
+	}
+	req.Header.Set("Content-Type", mimeJSON)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/configure: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /api/configure status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	select {
+	case err = <-errCh:
+		if err != nil {
+			t.Fatalf("Run(auto) error = %v, want nil after web configuration", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run(auto) did not finish after web configuration")
+	}
+}
+
+// TestRunCascade_WebFailsThenTUISucceeds verifies the first cascade fallback:
+// with a display available but the web listener failing, auto mode prints the
+// Web UI fallback notice and completes through the TUI (aborted via Ctrl+C).
+func TestRunCascade_WebFailsThenTUISucceeds(t *testing.T) {
+	stubWriteEnvFile(t)
+	stubHasDisplay(t, true)
+	stubInteractiveTerminal(t, true)
+
+	origListen := listenFn
+	listenFn = func(context.Context, string, string) (net.Listener, error) {
+		return nil, errors.New("bind refused")
+	}
+	t.Cleanup(func() { listenFn = origListen })
+
+	origStdin := stdinFn
+	stdinFn = func() io.Reader { return bytes.NewReader([]byte{0x03}) }
+	t.Cleanup(func() { stdinFn = origStdin })
+
+	var output bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- Run("1.0.0", UIModeAuto, nil, &output) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run(auto) error = %v, want nil from TUI abort", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run(auto) hung")
+	}
+	out := output.String()
+	if !strings.Contains(out, "Web UI unavailable, falling back to terminal UI...") {
+		t.Errorf("output %q missing Web UI fallback notice", out)
+	}
+	if !strings.Contains(out, "Setup cancelled") {
+		t.Errorf("output %q missing TUI cancellation notice", out)
+	}
+}
+
+// TestRunCascade_TUIFailsThenCLI verifies the second cascade fallback: with
+// no display and a TUI whose input reader fails, auto mode prints the TUI
+// fallback notice and continues into the plain CLI (which then fails on the
+// exhausted reader, proving the CLI branch ran).
+func TestRunCascade_TUIFailsThenCLI(t *testing.T) {
+	stubLoadExistingConfig(t)
+	stubHasDisplay(t, false)
+	stubInteractiveTerminal(t, true)
+
+	origStdin := stdinFn
+	stdinFn = func() io.Reader { return failingInputReader{} }
+	t.Cleanup(func() { stdinFn = origStdin })
+
+	var output bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- Run("1.0.0", UIModeAuto, strings.NewReader(""), &output) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run(auto) error = nil, want CLI input error from empty reader")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run(auto) hung")
+	}
+	out := output.String()
+	if !strings.Contains(out, "TUI unavailable, falling back to plain CLI...") {
+		t.Errorf("output %q missing TUI fallback notice", out)
+	}
+	if !strings.Contains(out, "gitlab-mcp-server Setup Wizard") {
+		t.Errorf("output %q missing CLI wizard banner", out)
+	}
+}
+
+// TestRunCascade_NilReaderUsesStdin verifies the final CLI fallback binds to
+// os.Stdin when no reader is supplied: with a non-interactive stdin swapped
+// in, the CLI starts (banner printed) and fails on the empty input, proving
+// the nil-reader branch selected os.Stdin.
+func TestRunCascade_NilReaderUsesStdin(t *testing.T) {
+	stubLoadExistingConfig(t)
+	stubHasDisplay(t, false)
+	stubInteractiveTerminal(t, false)
+
+	originalStdin := os.Stdin
+	emptyStdin, err := os.CreateTemp(t.TempDir(), "stdin-*")
+	if err != nil {
+		t.Fatalf("creating empty stdin: %v", err)
+	}
+	os.Stdin = emptyStdin
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = emptyStdin.Close()
+	})
+
+	var output bytes.Buffer
+	runErr := Run("1.0.0", UIModeAuto, nil, &output)
+	if runErr == nil {
+		t.Fatal("Run(auto) error = nil, want CLI input error from empty stdin")
+	}
+	if !strings.Contains(output.String(), "gitlab-mcp-server Setup Wizard") {
+		t.Errorf("output %q missing CLI wizard banner", output.String())
 	}
 }

--- a/internal/wizard/tui_test.go
+++ b/internal/wizard/tui_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1688,5 +1689,42 @@ func TestUpdate_DefaultStepReturnsModelNil(t *testing.T) {
 	}
 	if final.step != tuiStep(99) {
 		t.Errorf("expected step unchanged, got %d", final.step)
+	}
+}
+
+// failingInputReader is an io.Reader whose Read always fails. Feeding it to
+// Bubble Tea's input makes tea.Program.Run return an error, which is the
+// only way to exercise RunTUI's error branch without a real TTY failure.
+type failingInputReader struct{}
+
+// Read implements io.Reader by always returning an input failure.
+func (failingInputReader) Read([]byte) (int, error) {
+	return 0, errors.New("input read failure")
+}
+
+// TestStdinFn_DefaultReturnsOSStdin verifies the production stdinFn default
+// hands Bubble Tea the real os.Stdin, locking the wiring between RunTUI and
+// the process standard input.
+func TestStdinFn_DefaultReturnsOSStdin(t *testing.T) {
+	if got := stdinFn(); got != io.Reader(os.Stdin) {
+		t.Fatalf("stdinFn() = %v, want os.Stdin", got)
+	}
+}
+
+// TestRunTUIWithInput_InputReadError_ReturnsTUIError verifies RunTUIWithInput
+// wraps a Bubble Tea program failure in a "TUI error" so the auto-mode
+// cascade can detect it and fall back to the plain CLI.
+func TestRunTUIWithInput_InputReadError_ReturnsTUIError(t *testing.T) {
+	var output bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- RunTUIWithInput("1.0.0", failingInputReader{}, &output) }()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "TUI error") {
+			t.Fatalf("RunTUIWithInput error = %v, want wrapped TUI error", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunTUIWithInput hung on failing input reader")
 	}
 }

--- a/internal/wizard/webui.go
+++ b/internal/wizard/webui.go
@@ -30,11 +30,22 @@ const (
 //go:embed webui_assets/index.html
 var webAssets embed.FS
 
+// readWebAssetFn reads embedded web UI assets. Tests override it to exercise
+// the internal-error branch of serveIndex, which is otherwise unreachable
+// with a valid embedded filesystem.
+var readWebAssetFn = webAssets.ReadFile
+
+// listenFn opens the local TCP listener for the web wizard. Tests override it
+// to force listener startup failures or to inject a listener they control.
+var listenFn = func(ctx context.Context, network, address string) (net.Listener, error) {
+	var lc net.ListenConfig
+	return lc.Listen(ctx, network, address)
+}
+
 // RunWebUI starts a local HTTP server and opens the setup wizard in the browser.
 // It blocks until the user completes configuration or the context is cancelled.
 func RunWebUI(version string, w io.Writer) error {
-	var lc net.ListenConfig
-	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	listener, err := listenFn(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("starting web server: %w", err)
 	}
@@ -82,7 +93,7 @@ func RunWebUI(version string, w io.Writer) error {
 
 // serveIndex writes the embedded browser wizard HTML page.
 func serveIndex(rw http.ResponseWriter, _ *http.Request) {
-	data, err := webAssets.ReadFile("webui_assets/index.html")
+	data, err := readWebAssetFn("webui_assets/index.html")
 	if err != nil {
 		http.Error(rw, "Internal error", http.StatusInternalServerError)
 		return

--- a/internal/wizard/webui_test.go
+++ b/internal/wizard/webui_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"maps"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 // jsonTagsFromStruct extracts all JSON field names from a struct type using
@@ -1428,5 +1430,130 @@ func TestWebUI_AdvancedOptions_HaveHelpButtons(t *testing.T) {
 	}
 	if strings.Contains(html, `class="help-btn"`) && strings.Contains(html, `title="`) {
 		t.Error("help buttons should not rely on native title tooltips")
+	}
+}
+
+// TestRunWebUI_ListenError verifies RunWebUI fails fast with a wrapped error
+// when the local TCP listener cannot be opened. The listen hook injects the
+// failure because binding 127.0.0.1:0 practically never fails on a real host.
+func TestRunWebUI_ListenError(t *testing.T) {
+	origListen := listenFn
+	listenFn = func(context.Context, string, string) (net.Listener, error) {
+		return nil, errors.New("bind refused")
+	}
+	t.Cleanup(func() { listenFn = origListen })
+
+	var w bytes.Buffer
+	err := RunWebUI("1.0.0", &w)
+	if err == nil || !strings.Contains(err.Error(), "starting web server") {
+		t.Fatalf("RunWebUI error = %v, want starting web server", err)
+	}
+}
+
+// TestRunWebUI_ServeErrorAndBrowserFailure verifies two error paths in one
+// controlled run: when the browser cannot be opened, RunWebUI prints the
+// manual-URL fallback instead of failing; and when the HTTP server stops
+// serving with a non-ErrServerClosed error (the injected listener is closed
+// under it), that error is delivered through the done channel and returned.
+func TestRunWebUI_ServeErrorAndBrowserFailure(t *testing.T) {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("creating test listener: %v", err)
+	}
+	origListen := listenFn
+	listenFn = func(context.Context, string, string) (net.Listener, error) {
+		return listener, nil
+	}
+	t.Cleanup(func() { listenFn = origListen })
+
+	origOpen := openBrowserFn
+	openBrowserFn = func(string) error {
+		// Kill the listener so server.Serve returns a non-ErrServerClosed
+		// error, then report a browser failure to hit the manual-URL hint.
+		_ = listener.Close()
+		return errors.New("no browser installed")
+	}
+	t.Cleanup(func() { openBrowserFn = origOpen })
+
+	var w bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- RunWebUI("1.0.0", &w) }()
+
+	select {
+	case err = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunWebUI did not return after listener close")
+	}
+	if err == nil {
+		t.Fatal("RunWebUI error = nil, want serve error from closed listener")
+	}
+	out := w.String()
+	if !strings.Contains(out, "Could not open browser") {
+		t.Errorf("output %q missing browser failure notice", out)
+	}
+	if !strings.Contains(out, "manually") {
+		t.Errorf("output %q missing manual URL hint", out)
+	}
+}
+
+// TestServeIndex_AssetReadError verifies serveIndex responds with HTTP 500
+// when the embedded wizard page cannot be read. The asset hook injects the
+// failure because the embedded filesystem is otherwise always readable.
+func TestServeIndex_AssetReadError(t *testing.T) {
+	origRead := readWebAssetFn
+	readWebAssetFn = func(string) ([]byte, error) {
+		return nil, errors.New("corrupt asset")
+	}
+	t.Cleanup(func() { readWebAssetFn = origRead })
+
+	rec := httptest.NewRecorder()
+	serveIndex(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("serveIndex status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+// TestInstallBinaryForConfigure_ExpandPathError verifies the requested path
+// is kept verbatim as both install dir and binary path when tilde expansion
+// fails (no resolvable home directory).
+func TestInstallBinaryForConfigure_ExpandPathError(t *testing.T) {
+	unsetHomeEnv(t)
+
+	var w bytes.Buffer
+	requested := "~" + string(os.PathSeparator) + "gitlab-install"
+	installDir, binaryPath := installBinaryForConfigure(&w, requested)
+
+	if installDir != requested {
+		t.Errorf("installDir = %q, want %q", installDir, requested)
+	}
+	if binaryPath != requested {
+		t.Errorf("binaryPath = %q, want %q", binaryPath, requested)
+	}
+}
+
+// TestInstallBinaryForConfigure_InstallErrorFallsBack verifies that a failed
+// binary installation reports the failure and falls back to the currently
+// running executable path.
+func TestInstallBinaryForConfigure_InstallErrorFallsBack(t *testing.T) {
+	origInstall := installBinaryFn
+	installBinaryFn = func(string) (string, error) {
+		return "", errors.New("disk full")
+	}
+	t.Cleanup(func() { installBinaryFn = origInstall })
+
+	var w bytes.Buffer
+	_, binaryPath := installBinaryForConfigure(&w, t.TempDir())
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binaryPath != exe {
+		t.Errorf("binaryPath = %q, want current executable %q", binaryPath, exe)
+	}
+	if !strings.Contains(w.String(), "Could not install") {
+		t.Errorf("output %q missing install failure notice", w.String())
 	}
 }

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -18,6 +18,11 @@ type Result struct {
 // LogLevelOptions lists the configurable log levels.
 var LogLevelOptions = []string{"debug", "info", "warn", "error"}
 
+// jsonMarshalIndentFn serializes the JetBrains snippet. Tests override it to
+// exercise the marshal error branch, which is otherwise unreachable with the
+// always-serializable snippet map.
+var jsonMarshalIndentFn = json.MarshalIndent
+
 // Apply writes the env file with secrets, then writes MCP configurations
 // for selected clients, and prints a summary.
 // It is called after any UI mode collects user input.
@@ -68,7 +73,7 @@ func printJetBrainsConfig(w io.Writer, cfg ServerConfig) error {
 			ServerEntryName: entry,
 		},
 	}
-	data, err := json.MarshalIndent(snippet, "    ", "  ")
+	data, err := jsonMarshalIndentFn(snippet, "    ", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -616,3 +616,29 @@ func stubGetInstalledVersion(t *testing.T, version string) {
 	getInstalledVersionFn = func() string { return version }
 	t.Cleanup(func() { getInstalledVersionFn = orig })
 }
+
+// TestApply_JetBrainsMarshalError verifies Apply aborts with the underlying
+// error when the JetBrains display-only snippet cannot be serialized. The
+// marshal hook injects the failure because the snippet map is otherwise
+// always serializable.
+func TestApply_JetBrainsMarshalError(t *testing.T) {
+	useFakeClients(t)
+	stubWriteEnvFile(t)
+
+	origMarshal := jsonMarshalIndentFn
+	jsonMarshalIndentFn = func(any, string, string) ([]byte, error) {
+		return nil, errors.New("marshal boom")
+	}
+	t.Cleanup(func() { jsonMarshalIndentFn = origMarshal })
+
+	var w bytes.Buffer
+	result := &Result{
+		Config:          ServerConfig{GitLabURL: "https://gitlab.example.com", GitLabToken: "glpat-test"},
+		SelectedClients: []int{5}, // JetBrains (display-only) in the fake client list
+	}
+
+	err := Apply(&w, result)
+	if err == nil || !strings.Contains(err.Error(), "marshal boom") {
+		t.Fatalf("Apply error = %v, want marshal boom", err)
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,11 @@ sonar.go.coverage.reportPaths=coverage.out
 # are still analyzed for issues, but most are validated through generated
 # artifacts, integration workflows, or direct CLI execution rather than useful
 # unit-level coverage.
-sonar.coverage.exclusions=cmd/**
+# internal/autoupdate/exec_unix.go + exec_windows.go call syscall.Exec /
+# os.StartProcess to replace or relaunch the running binary during
+# self-update activation; executing them under `go test` would replace the
+# test process itself, so they are structurally untestable.
+sonar.coverage.exclusions=cmd/**,internal/autoupdate/exec_unix.go,internal/autoupdate/exec_windows.go
 
 # Exclude non-code files that SonarQube cannot parse (e.g. VERSION triggers
 # the C/C++ analyzer with "Expected unqualified-id").

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -143,7 +143,7 @@ sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/*/acti
 # S3776: "Refactor this method to reduce its Cognitive Complexity"
 # Test helper functions that verify multiple fields of API responses naturally
 # have higher complexity. Splitting them reduces test readability.
-sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7
+sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7,g8,g9
 
 # S1192 — duplicated string literals in tests
 sonar.issue.ignore.multicriteria.t1.ruleKey=go:S1192
@@ -201,3 +201,18 @@ sonar.issue.ignore.multicriteria.g6.resourceKey=**/gitlab/client.go
 
 sonar.issue.ignore.multicriteria.g7.ruleKey=go:S5527
 sonar.issue.ignore.multicriteria.g7.resourceKey=**/gitlab/client.go
+
+# S4036: "Make sure the PATH variable only contains fixed, unwriteable
+# directories". The setup wizard is an interactive local tool that launches
+# the invoking user's own desktop utilities: the browser opener (xdg-open /
+# open / cmd) is intentionally resolved through the user's PATH because that
+# is the platform contract for "open the default browser", and the Linux
+# dialog pickers (zenity/kdialog) are already resolved exclusively from fixed
+# root-owned directories via fixedLinuxDialogToolPath (/usr/bin, /bin with a
+# writability check) — a guarantee the rule cannot see. The wizard runs as
+# the invoking user with no privilege boundary crossed.
+sonar.issue.ignore.multicriteria.g8.ruleKey=go:S4036
+sonar.issue.ignore.multicriteria.g8.resourceKey=**/wizard/browser.go
+
+sonar.issue.ignore.multicriteria.g9.ruleKey=go:S4036
+sonar.issue.ignore.multicriteria.g9.resourceKey=**/wizard/dirpicker.go


### PR DESCRIPTION
## Summary

Three related workstreams on one branch: production performance, unit-test suite time, and coverage of the Sonar-monitored surface.

### Production performance

- **`gitlab_find_action` search** (`internal/tools/dynamic`): `matchedSearchValue` re-normalized candidate text per token × field × action comparison (a fresh `strings.Replacer`, ToLower, Fields, dedupe map and Join on every call — ~40% of Search CPU in allocation/normalization). Word forms of every searchable document value are now precomputed at index build (`searchDocument.WordizedValues`); the matcher only runs `strings.Contains` over prebuilt strings. Worst-case long multi-intent query: **4.85s → 0.65s CPU**. Semantics byte-identical — the golden search corpus passes unchanged.
- **Per-token server registration** (HTTP pool builds one MCP server per token+URL; same cost at stdio startup): profiling showed the SDK remarshaling every map-based tool schema into `*jsonschema.Schema` plus resolution, for ~1,065 tools on every registration. `toolutil.CompileToolSchemas` now converts each projected schema once per stable content key (`individual|<tier>|<tool>`, `meta|opaque|<tool>|<actions>`, `standalone|<tool>`) and `cmd/server` wires a shared `mcp.SchemaCache` (the SDK documents it exactly for per-request server deployments). **1.25s → 0.34s warm per token** (0.81s cold). Model-facing output byte-identical: `audit_tokens -footprint -check` passes over all 27 tier/surface/mode rows.

### Test suite time (−51%)

- Shared pure fixtures via `sync.Once` across test packages: per-tier MCP sessions with a swappable backend handler in `internal/tools`, cached audit reports in `audit_catalog_first`/`audit_1to1/structs`/`audit_discovery_completeness`, cached site stats in `audit_metrics`, shared HTTP-protocol server in `cmd/server`. Registration-time-variant tests (META_PARAM_SCHEMA modes) keep isolated sessions.
- DEDUP-003 repo-sweep guardrails merged into one pruned walk (13.9s → 0.1s).
- Full suite: **690s → 337s CPU**; tests ≥2s: 127 (619s) → 45 (224s), all with a documented inherent reason (determinism double-runs, real token-footprint measurement, per-config registration, full-stack HTTP lifecycle). No test waits on a timeout.

### Coverage (Sonar scope: internal/, CI `-coverpkg` semantics)

**99.18% → 99.74%** (378 → 120 uncovered statements):
- `internal/wizard` 92% → 100%: every `runtime.GOOS` switch extracted into pure goos/getenv/home-parameterized functions with unchanged thin wrappers, so darwin/windows branches are covered from the Linux CI runner; exec/listen boundaries stubbed via function vars. Identical paths, commands and error strings.
- `internal/prompts` 96.5% → 100% (47 error/edge-branch tests) and `internal/toolutil` 96.9% → 98.9% (38 tests).
- Tail sweep across ~15 packages (groups hooks/sharing/push-rules, formatter delegators, config/edition guards, importservice registry closures).
- The remaining 120 statements are classified as unreachable defense-in-depth (SDK-prevalidated elicitation branches with SDK source references, `crypto/rand` post-Go 1.24, GOOS-gated autoupdate fallbacks, TOCTOU-only races); `autoupdate/exec_{unix,windows}.go` are coverage-excluded with justification (`syscall.Exec` replaces the process image).

## Verification

- 221 packages green (`./internal/... ./cmd/...`), `golangci-lint` clean on every touched package
- `audit_tokens -footprint -check` byte-identical across all tiers/surfaces/modes; golden snapshot + response-compliance suites pass; `gen_llms --check` and `gen_testing_docs --check` clean
- New benchmarks (`internal/tools/prod_bench_test.go`) pin the registration baselines for future regressions

https://claude.ai/code/session_016b5FhE71CVYFf8L79pgFzM

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

