### PR TITLE
refactor(toolutil): use unmarshal error directly in condition (Sonar S8193)

### DIFF
--- a/internal/toolutil/schema_compile.go
+++ b/internal/toolutil/schema_compile.go
@@ -51,7 +51,7 @@ func compiledSchema(key string, schema map[string]any) any {
 		return schema
 	}
 	compiled := new(jsonschema.Schema)
-	if unmarshalErr := json.Unmarshal(data, compiled); unmarshalErr != nil {
+	if json.Unmarshal(data, compiled) != nil {
 		return schema
 	}
 	actual, _ := compiledSchemaCache.LoadOrStore(key, compiled)


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [AZ82GzeEJb95_0_OmCWp](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=jmrplens_gitlab-mcp-server&open=AZ82GzeEJb95_0_OmCWp) (rule `godre:S8193`, MINOR code smell).

The `unmarshalErr` variable in `compiledSchema`'s `if` short statement was only used in the condition itself, so the declaration was unnecessary. The `json.Unmarshal` result is now compared to `nil` directly in the condition. Behavior is unchanged: the original map schema is still returned when unmarshaling fails.

## Verification

- `go test ./internal/toolutil/ -count=1` passes
- `golangci-lint run --build-tags e2e ./internal/toolutil/` reports no issues
- SonarQube analysis of the modified file reports 0 issues

https://claude.ai/code/session_016KQnnNLPVouuFYJqLd6kzv

## Summary by Sourcery

Refactor compiledSchema to compare json.Unmarshal errors directly in the if condition, eliminating an unnecessary temporary variable while preserving existing behavior.