### PR TITLE
docs(site): add personal Wikidata item to Person sameAs and footer

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -145,6 +145,7 @@ const jsonLd = JSON.stringify({
 				"AI assistants",
 			],
 			sameAs: [
+				"https://www.wikidata.org/wiki/Q140455276",
 				"https://github.com/jmrplens",
 				"https://linkedin.com/in/jmrplens",
 				"https://mstdn.jmrp.io/@jmrplens",

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -21,6 +21,7 @@ const links = [
 		href: "https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
 		text: "Google Scholar",
 	},
+	{ href: "https://www.wikidata.org/wiki/Q140455276", text: "Wikidata" },
 ];
 ---
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -12,7 +12,9 @@ const rel = pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
 const isES = rel === "/es" || rel.startsWith("/es/");
 
 const label = isES ? "Mantenido por" : "Maintained by";
-// Visible mirror of the Person `sameAs` set in the site-wide @graph.
+// Curated subset of the Person `sameAs` set in the site-wide @graph — the
+// human-relevant profiles; machine-oriented entries (Matrix, Keyoxide) stay
+// JSON-LD-only.
 const links = [
 	{ href: "https://github.com/jmrplens", text: "GitHub" },
 	{ href: "https://linkedin.com/in/jmrplens", text: "LinkedIn" },


### PR DESCRIPTION
## Summary

Adds the personal Wikidata item ([Q140455276](https://www.wikidata.org/wiki/Q140455276)) to the `Person` node's `sameAs` set in the site-wide JSON-LD `@graph` (`site/astro.config.mjs`) and to the visible maintainer footer (`site/src/components/Footer.astro`) that mirrors it.

The Person JSON-LD predates the creation of the personal Wikidata item, so its `sameAs` only listed GitHub, LinkedIn, Mastodon, Scholar, Matrix, and Keyoxide. Wikidata is the strongest entity-disambiguation signal for AI engines, and the footer mirror keeps the rendered content in agreement with the structured data.

Companion off-site work (done directly on Wikidata/Commons, no repo changes): both logo variants uploaded to Wikimedia Commons and linked as `P154` on the project item Q140389426, plus `P8778` (Docker Hub), `P1401`, `P4945`, `mul` label, and six new language descriptions.

https://claude.ai/code/session_016KQnnNLPVouuFYJqLd6kzv

## Summary by Sourcery

Add the maintainer's Wikidata item to both structured data and visible site footer to keep identity links in sync.

Enhancements:
- Include the maintainer's Wikidata profile in the Person JSON-LD sameAs list for the site.
- Expose the maintainer's Wikidata profile link in the footer links alongside other social profiles.