### PR TITLE
docs(site): remove references to deleted Wikidata items

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -145,7 +145,6 @@ const jsonLd = JSON.stringify({
 				"AI assistants",
 			],
 			sameAs: [
-				"https://www.wikidata.org/wiki/Q140455276",
 				"https://github.com/jmrplens",
 				"https://linkedin.com/in/jmrplens",
 				"https://mstdn.jmrp.io/@jmrplens",
@@ -196,7 +195,6 @@ const jsonLd = JSON.stringify({
 			},
 			author: { "@id": authorId },
 			sameAs: [
-				"https://www.wikidata.org/wiki/Q140389426",
 				"https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server",
 				"https://cursor.directory/plugins/gitlab-mcp-server",
 				"https://smithery.ai/servers/jmrp/gitlab-mcp-server",

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -23,7 +23,6 @@ const links = [
 		href: "https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
 		text: "Google Scholar",
 	},
-	{ href: "https://www.wikidata.org/wiki/Q140455276", text: "Wikidata" },
 ];
 ---
 

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -14,7 +14,7 @@ const BASE = (import.meta.env.BASE_URL ?? "/").replace(/\/$/, "");
 const PERSON_ID = "https://jmrp.io/#person";
 const WEBSITE_ID = `${SITE}${BASE}/#website`;
 // Matches the SoftwareApplication @id in the site-wide @graph (astro.config.mjs),
-// which carries the Wikidata sameAs — so each page's TechArticle ties back to it.
+// which carries the directory-listing sameAs — so each page's TechArticle ties back to it.
 const SOFTWARE_ID = "https://github.com/jmrplens/gitlab-mcp-server#software";
 
 // Minimal typed view of the Starlight route data we consume.


### PR DESCRIPTION
## Summary

The project (Q140389426) and personal (Q140455276) Wikidata items were deleted by a Wikidata admin on 2026-07-07 ("Mass deletion of pages added by Jmrplens", notability policy). `sameAs` entries and the footer link now point at nonexistent entities, which is a negative entity-verification signal for AI engines — worse than no link.

- Remove the Wikidata URL from the `Person` and `SoftwareApplication` `sameAs` sets in `site/astro.config.mjs`
- Remove the Wikidata link from the visible maintainer footer
- Update a stale comment in `Head.astro` that described the sameAs as Wikidata-carrying

Directory-listing `sameAs` entries (glama.ai, smithery.ai, mcp.so, …) are unaffected.

Part of a cross-repo cleanup; companion PRs in jmrplens.github.io, jmrp.io, cs-routeros-bouncer, Cloudflare-DNS-Updater, and phonometry.

https://claude.ai/code/session_016KQnnNLPVouuFYJqLd6kzv

## Summary by Sourcery

Remove outdated Wikidata references from site metadata and footer to avoid linking to deleted entities.

Enhancements:
- Update site JSON-LD configuration to drop Wikidata URLs from Person and SoftwareApplication sameAs lists.

Documentation:
- Adjust head component comment to describe remaining sameAs links as directory listings instead of Wikidata.
- Remove the visible Wikidata link from the site footer links list.