### PR TITLE
fix(mcpb): point manifest author.url at the GitHub profile

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -9,7 +9,7 @@
   "author": {
     "name": "José M. Requena Plens",
     "email": "jmrplens@gmail.com",
-    "url": "https://jmrp.io"
+    "url": "https://github.com/jmrplens"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [MCPB Desktop Extensions submission form](https://clau.de/desktop-extention-submission) requires the manifest `author` field to point at the author's GitHub profile — it had `https://jmrp.io`.

Manifest re-validated with `make check-mcpb`.

https://claude.ai/code/session_01LJ6D4L6rnms9GqMqqc2tFb

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

