### PR TITLE
docs(site): Claude Desktop (.mcpb) guide + privacy policy pages (EN/ES)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -448,6 +448,11 @@ export default defineConfig({
 							translations: { es: "Asistente de configuración" },
 						},
 						{
+							slug: "claude-desktop",
+							label: "Claude Desktop (.mcpb)",
+							translations: { es: "Claude Desktop (.mcpb)" },
+						},
+						{
 							slug: "configuration",
 							label: "Configuration",
 							translations: { es: "Configuración" },
@@ -534,6 +539,11 @@ export default defineConfig({
 							slug: "operations/security",
 							label: "Security",
 							translations: { es: "Seguridad" },
+						},
+						{
+							slug: "operations/privacy",
+							label: "Privacy",
+							translations: { es: "Privacidad" },
 						},
 						{
 							slug: "operations/auto-update",

--- a/site/src/content/docs/claude-desktop.mdx
+++ b/site/src/content/docs/claude-desktop.mdx
@@ -1,0 +1,72 @@
+---
+title: Claude Desktop Extension
+description: Install GitLab MCP Server in Claude Desktop with one click using the .mcpb desktop extension — macOS and Windows, no Docker or runtime required.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+GitLab MCP Server ships as a one-click **desktop extension** (`.mcpb`) for
+Claude Desktop on macOS and Windows. The bundle contains a macOS universal
+binary (Apple Silicon + Intel) and a Windows executable — no Docker, Node.js,
+or Python required.
+
+## Install
+
+<Steps>
+
+1. Download [`gitlab-mcp-server.mcpb`](https://github.com/jmrplens/gitlab-mcp-server/releases/latest/download/gitlab-mcp-server.mcpb)
+   from the latest release.
+
+2. Open the file with Claude Desktop — double-click it, or drag it onto the
+   Claude Desktop Settings window. Claude shows an install dialog with the
+   extension details.
+
+3. Fill in the settings and start chatting.
+
+</Steps>
+
+## Settings
+
+| Setting                      | Required | Default              | Environment variable     |
+| ---------------------------- | -------- | -------------------- | ------------------------ |
+| GitLab URL                   | Yes      | `https://gitlab.com` | `GITLAB_URL`             |
+| GitLab Personal Access Token | Yes      | —                    | `GITLAB_TOKEN`           |
+| Tool surface                 | No       | `dynamic`            | `TOOL_SURFACE`           |
+| GitLab tier                  | No       | auto-detect          | `GITLAB_TIER`            |
+| Read-only mode               | No       | off                  | `GITLAB_READ_ONLY`       |
+| Safe mode                    | No       | off                  | `GITLAB_SAFE_MODE`       |
+| Skip TLS verification        | No       | off                  | `GITLAB_SKIP_TLS_VERIFY` |
+
+:::tip[Token storage]
+Claude Desktop stores the Personal Access Token in the operating system
+keychain, not in a plain-text config file. Create the token with the `api`
+scope under **GitLab → User Settings → Access Tokens**.
+:::
+
+The default `dynamic` tool surface registers just two find/execute tools, so
+the server never crowds Claude's context window. Switch to `meta`
+(~32 consolidated domain tools) or `individual` (one tool per action) in the
+extension settings — see [Tool surfaces](/gitlab-mcp-server/tools/overview/).
+
+## Updates
+
+The extension has the server's [auto-update](/gitlab-mcp-server/operations/auto-update/)
+mechanism disabled: updates arrive as new extension versions published with
+each release instead of in-place binary swaps.
+
+## Verify
+
+Ask Claude something like *"What GitLab user am I authenticated as?"* — it
+should call `gitlab_find_action` and then `gitlab_execute_action` with the
+`user.current` action and return your username.
+
+:::note[Self-managed instances]
+Set your instance URL in the **GitLab URL** setting. If it uses a self-signed
+certificate, enable **Skip TLS verification**.
+:::
+
+## Privacy
+
+The server runs entirely on your machine and has no telemetry — data flows
+only between Claude Desktop and the GitLab instance you configure. See the
+[Privacy Policy](/gitlab-mcp-server/operations/privacy/).

--- a/site/src/content/docs/es/claude-desktop.mdx
+++ b/site/src/content/docs/es/claude-desktop.mdx
@@ -1,0 +1,74 @@
+---
+title: Extensión para Claude Desktop
+description: Instala GitLab MCP Server en Claude Desktop con un clic mediante la extensión de escritorio .mcpb — macOS y Windows, sin Docker ni runtimes.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+GitLab MCP Server se distribuye como **extensión de escritorio** (`.mcpb`) de
+instalación en un clic para Claude Desktop en macOS y Windows. El paquete
+contiene un binario universal de macOS (Apple Silicon + Intel) y un ejecutable
+de Windows — sin Docker, Node.js ni Python.
+
+## Instalación
+
+<Steps>
+
+1. Descarga [`gitlab-mcp-server.mcpb`](https://github.com/jmrplens/gitlab-mcp-server/releases/latest/download/gitlab-mcp-server.mcpb)
+   desde la última release.
+
+2. Abre el archivo con Claude Desktop — doble clic, o arrástralo a la ventana
+   de Ajustes de Claude Desktop. Claude muestra un diálogo de instalación con
+   los detalles de la extensión.
+
+3. Rellena los ajustes y empieza a chatear.
+
+</Steps>
+
+## Ajustes
+
+| Ajuste                           | Obligatorio | Por defecto          | Variable de entorno      |
+| -------------------------------- | ----------- | -------------------- | ------------------------ |
+| GitLab URL                       | Sí          | `https://gitlab.com` | `GITLAB_URL`             |
+| GitLab Personal Access Token     | Sí          | —                    | `GITLAB_TOKEN`           |
+| Tool surface                     | No          | `dynamic`            | `TOOL_SURFACE`           |
+| GitLab tier                      | No          | autodetección        | `GITLAB_TIER`            |
+| Read-only mode                   | No          | desactivado          | `GITLAB_READ_ONLY`       |
+| Safe mode                        | No          | desactivado          | `GITLAB_SAFE_MODE`       |
+| Skip TLS verification            | No          | desactivado          | `GITLAB_SKIP_TLS_VERIFY` |
+
+:::tip[Almacenamiento del token]
+Claude Desktop guarda el Personal Access Token en el llavero del sistema
+operativo, no en un archivo de configuración en texto plano. Crea el token con
+el scope `api` en **GitLab → User Settings → Access Tokens**.
+:::
+
+La superficie de herramientas por defecto, `dynamic`, registra solo dos
+herramientas find/execute, de modo que el servidor nunca satura la ventana de
+contexto de Claude. Cambia a `meta` (~32 herramientas consolidadas por
+dominio) o `individual` (una herramienta por acción) en los ajustes de la
+extensión — consulta [Superficies de herramientas](/gitlab-mcp-server/es/tools/overview/).
+
+## Actualizaciones
+
+La extensión lleva desactivado el mecanismo de
+[auto-actualización](/gitlab-mcp-server/es/operations/auto-update/) del
+servidor: las actualizaciones llegan como nuevas versiones de la extensión
+publicadas con cada release, en lugar de reemplazos del binario in situ.
+
+## Verificación
+
+Pídele a Claude algo como *"¿Con qué usuario de GitLab estoy autenticado?"* —
+debería llamar a `gitlab_find_action` y después a `gitlab_execute_action` con
+la acción `user.current` y devolver tu nombre de usuario.
+
+:::note[Instancias self-managed]
+Configura la URL de tu instancia en el ajuste **GitLab URL**. Si usa un
+certificado autofirmado, activa **Skip TLS verification**.
+:::
+
+## Privacidad
+
+El servidor se ejecuta íntegramente en tu máquina y no tiene telemetría — los
+datos fluyen solo entre Claude Desktop y la instancia de GitLab que
+configures. Consulta la [Política de privacidad](/gitlab-mcp-server/es/operations/privacy/).

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -264,6 +264,12 @@ Usa variables de entrada de VS Code para evitar almacenar el token en texto plan
 </TabItem>
 <TabItem label="Claude Desktop">
 
+:::tip[La vía más fácil]
+Claude Desktop también se instala con un clic mediante la
+[extensión de escritorio .mcpb](/gitlab-mcp-server/es/claude-desktop/) — sin
+editar JSON y con el token guardado en el llavero del sistema.
+:::
+
 Edita `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json

--- a/site/src/content/docs/es/operations/privacy.mdx
+++ b/site/src/content/docs/es/operations/privacy.mdx
@@ -1,0 +1,69 @@
+---
+title: Política de privacidad
+description: Política de privacidad de GitLab MCP Server — sin telemetría, sin analítica, sin backend; los datos fluyen solo entre tu máquina y la instancia de GitLab que configures.
+---
+
+Última actualización: 2026-07-07
+
+GitLab MCP Server es un servidor Model Context Protocol **local**. Se ejecuta
+íntegramente en tu máquina y actúa como puente entre tu cliente MCP (Claude
+Desktop, Claude Code, Cursor, VS Code, …) y la instancia de GitLab que
+configures.
+
+## Qué recopilamos
+
+**Nada.** El servidor no tiene telemetría, ni analítica, ni informes de
+errores, ni backend propio. El mantenedor nunca recibe, almacena ni tiene
+acceso a tus datos, credenciales o información de uso.
+
+## Flujos de datos
+
+- **Tu instancia de GitLab.** Cada llamada a una herramienta genera peticiones
+  a la URL de GitLab que configures (`GITLAB_URL`), autenticadas con tu
+  Personal Access Token (`GITLAB_TOKEN`). Los datos que devuelve GitLab —
+  proyectos, issues, merge requests, logs de pipelines — se entregan
+  directamente a tu cliente MCP y no se envían a ningún otro sitio. El
+  tratamiento de esos datos por GitLab se rige por la
+  [Declaración de privacidad de GitLab](https://about.gitlab.com/privacy/)
+  (en GitLab.com) o por las políticas de tu organización (en instancias
+  self-managed).
+- **GitHub (solo auto-actualización).** Con la
+  [auto-actualización](/gitlab-mcp-server/es/operations/auto-update/)
+  activada (por defecto en los binarios standalone), el servidor consulta
+  periódicamente GitHub Releases y descarga binarios firmados. No se envía
+  ningún dato personal — es una petición HTTPS estándar a `api.github.com`,
+  sujeta a la [Declaración de privacidad de GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+  La [extensión para Claude Desktop](/gitlab-mcp-server/es/claude-desktop/)
+  lleva la auto-actualización **desactivada**; las actualizaciones llegan como
+  nuevas versiones de la extensión.
+
+No existen otros destinos de red.
+
+## Credenciales
+
+Tu Personal Access Token de GitLab lo proporcionas tú mediante variables de
+entorno o la interfaz de configuración de tu cliente MCP. Claude Desktop
+guarda los secretos de las extensiones en el llavero del sistema operativo.
+El servidor mantiene el token solo en la memoria del proceso, lo usa
+únicamente para autenticar las peticiones a tu instancia de GitLab y nunca lo
+escribe en los logs. Consulta [Seguridad](/gitlab-mcp-server/es/operations/security/)
+para el modelo de seguridad completo.
+
+## Almacenamiento local y logs
+
+El servidor escribe logs solo en la salida de error estándar (recogidos, en
+su caso, por tu cliente MCP). No crea bases de datos, cachés ni archivos con
+tus datos de GitLab. En modo HTTP, las identidades de los tokens se cachean en
+memoria durante el TTL configurado y nunca se persisten a disco.
+
+## Retención y compartición de datos
+
+El servidor no retiene nada tras finalizar y no comparte datos con terceros
+más allá de la instancia de GitLab que configures explícitamente.
+
+## Cambios y contacto
+
+Los cambios de esta política se publican en
+[`PRIVACY.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/PRIVACY.md)
+(la versión canónica de esta página) y se recogen en los changelogs de las
+releases. Preguntas: [abre un issue](https://github.com/jmrplens/gitlab-mcp-server/issues).

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -264,6 +264,12 @@ Use VS Code input variables to avoid storing the token in plain text:
 </TabItem>
 <TabItem label="Claude Desktop">
 
+:::tip[Easiest path]
+Claude Desktop also installs with one click via the
+[.mcpb desktop extension](/gitlab-mcp-server/claude-desktop/) — no JSON
+editing, token stored in the OS keychain.
+:::
+
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
 
 ```json

--- a/site/src/content/docs/operations/privacy.mdx
+++ b/site/src/content/docs/operations/privacy.mdx
@@ -1,0 +1,67 @@
+---
+title: Privacy Policy
+description: GitLab MCP Server privacy policy — no telemetry, no analytics, no backend; data flows only between your machine and the GitLab instance you configure.
+---
+
+Last updated: 2026-07-07
+
+GitLab MCP Server is a **local** Model Context Protocol server. It runs
+entirely on your machine and acts as a bridge between your MCP client (Claude
+Desktop, Claude Code, Cursor, VS Code, …) and the GitLab instance you
+configure.
+
+## What we collect
+
+**Nothing.** The server has no telemetry, no analytics, no crash reporting,
+and no backend of its own. The maintainer never receives, stores, or has
+access to any of your data, credentials, or usage information.
+
+## Data flows
+
+- **Your GitLab instance.** Every tool call results in requests to the GitLab
+  URL you configure (`GITLAB_URL`), authenticated with your Personal Access
+  Token (`GITLAB_TOKEN`). Data returned by GitLab — projects, issues, merge
+  requests, pipeline logs — is passed directly to your MCP client and is never
+  sent anywhere else. GitLab's handling of that data is governed by the
+  [GitLab Privacy Statement](https://about.gitlab.com/privacy/) (for
+  GitLab.com) or by your organization's own policies (for self-managed
+  instances).
+- **GitHub (auto-update only).** When [auto-update](/gitlab-mcp-server/operations/auto-update/)
+  is enabled (the default for standalone binaries), the server periodically
+  checks GitHub Releases for new versions and downloads signed binaries. No
+  personal data is sent — it is a standard HTTPS request to `api.github.com`,
+  subject to the [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+  The [Claude Desktop extension](/gitlab-mcp-server/claude-desktop/) ships
+  with auto-update **disabled**; updates arrive through new extension
+  versions instead.
+
+There are no other network destinations.
+
+## Credentials
+
+Your GitLab Personal Access Token is provided by you through environment
+variables or your MCP client's configuration UI. Claude Desktop stores
+extension secrets in the operating system keychain. The server keeps the
+token in process memory only, uses it solely to authenticate requests to your
+configured GitLab instance, and never logs it. See
+[Security](/gitlab-mcp-server/operations/security/) for the full security
+model.
+
+## Local storage and logs
+
+The server writes logs to standard error only (collected, if at all, by your
+MCP client). It does not create databases, caches, or files with your GitLab
+data. In HTTP mode, token identities are cached in memory for the configured
+TTL and are never persisted to disk.
+
+## Data retention and sharing
+
+The server retains nothing after it exits and shares data with no third
+parties beyond the GitLab instance you explicitly configure.
+
+## Changes and contact
+
+Changes to this policy are published in
+[`PRIVACY.md`](https://github.com/jmrplens/gitlab-mcp-server/blob/main/PRIVACY.md)
+(the canonical version of this page) and noted in release changelogs.
+Questions: [open an issue](https://github.com/jmrplens/gitlab-mcp-server/issues).


### PR DESCRIPTION
Syncs the new v2.5.0 user-facing features to the Starlight site, in both locales:

- **`claude-desktop`** (EN/ES): one-click `.mcpb` install guide — download, install dialog, settings table (env var mapping), keychain token storage, update model (extension versions, in-bundle auto-update disabled), verification prompt, self-managed notes
- **`operations/privacy`** (EN/ES): user-facing mirror of [PRIVACY.md](https://github.com/jmrplens/gitlab-mcp-server/blob/main/PRIVACY.md) (canonical), cross-linked with Security, Auto-update, and the extension page
- Sidebar entries: *Claude Desktop (.mcpb)* under **Getting Started**, *Privacy* under **Operations**
- `getting-started` (EN/ES): tip in the Claude Desktop tab pointing at the one-click path

`pnpm run build`: 61 pages, zero errors, all internal links valid.

https://claude.ai/code/session_01LJ6D4L6rnms9GqMqqc2tFb

## Summary by Sourcery

Add documentation for one-click Claude Desktop (.mcpb) setup and a user-facing privacy policy, and surface both in the docs navigation in EN and ES.

Enhancements:
- Expose new Claude Desktop (.mcpb) and Privacy entries in the Getting Started and Operations sections of the docs sidebar navigation.

Documentation:
- Document Claude Desktop .mcpb desktop extension installation, configuration, updates, verification, and privacy behavior for EN and ES locales.
- Add an English and Spanish privacy policy page mirroring the canonical PRIVACY.md, including data flows, credential handling, storage, and retention details.
- Mention the one-click Claude Desktop .mcpb installation path from the existing getting-started guides in both EN and ES.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Claude Desktop extension guide with one-click installation steps, configuration options, update behavior, verification tips, and privacy notes.
  * Added a new privacy policy page in English and Spanish covering local-only operation, data handling, and update behavior.
  * Added Spanish navigation entries for the new Claude Desktop and Privacy pages.

* **Documentation**
  * Updated the Getting Started guides to highlight the easiest way to install via the desktop extension without manual JSON editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->