### PR TITLE
docs: audit install paths and directory metadata (markdown + site EN/ES)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,12 @@ When creating a new release and uploading binaries to GitHub Releases:
 
 1. Build cross-platform binaries with `make release` (uses GoReleaser locally, flattens `dist/` to match GitHub Release asset names)
 2. **Release link names MUST be exact filenames** (e.g. `checksums.txt.asc`, `gitlab-mcp-server-linux-amd64`). Never add descriptive suffixes like `(GPG signature)` — `go-selfupdate` matches asset names exactly and will fail to find files with decorated names
+3. The tag-triggered release workflow also publishes derived artifacts automatically:
+   - `gitlab-mcp-server-darwin-all` — macOS universal (fat) binary from GoReleaser `universal_binaries`
+   - `gitlab-mcp-server.mcpb` — Claude Desktop extension built by `scripts/build-mcpb.sh` from `mcpb/manifest.json` (validate with `make check-mcpb`, build locally with `make mcpb`)
+   - Homebrew formula update pushed to `jmrplens/homebrew-tap` by `scripts/update-homebrew-tap.sh` (secret `TAP_DEPLOY_KEY_B64`)
+   - winget version PR to `microsoft/winget-pkgs` via `winget-releaser` (secret `WINGET_TOKEN`)
+   - Version stamping of `server.json`, `.plugin/plugin.json`, and `mcpb/manifest.json` committed back to main by `scripts/update-server-json-sha.sh`
 
 ### Post-implementation verification
 

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -476,10 +476,12 @@ func writeLLMSTxt(version string, catalog llmsCatalog, checkOnly bool) error {
 
 	b.WriteString("## Documentation\n\n")
 	writeLLMSLink(&b, "Getting started", "docs/getting-started.md", "Installation and first-run guide")
+	writeLLMSLink(&b, "Claude Desktop extension", "docs/guides/claude-desktop-extension.md", "One-click .mcpb install for Claude Desktop (macOS universal + Windows)")
 	writeLLMSLink(&b, "Configuration", "docs/reference/configuration.md", "Full configuration reference")
 	writeLLMSLink(&b, "Environment variables", "docs/reference/env.md", "Environment variable reference")
 	writeLLMSLink(&b, "HTTP server mode", "docs/guides/http-server-mode.md", "Remote MCP transport setup")
 	writeLLMSLink(&b, "Security model", "docs/concepts/security.md", "Authentication, read-only mode, safe mode, and security controls")
+	writeLLMSLink(&b, "Privacy policy", "PRIVACY.md", "No telemetry; data flows only to the configured GitLab instance")
 
 	b.WriteString("\n## Tool References\n\n")
 	writeLLMSLink(&b, "Dynamic tools", "docs/concepts/dynamic-tools.md", "Low-token find/execute mode and usage pattern")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,13 +44,22 @@ claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx --transport stdio \
 ### One-line installer (native binary)
 
 ```bash
-# Linux/macOS
+# macOS/Linux (Homebrew)
+brew install jmrplens/tap/gitlab-mcp-server
+# Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
 
 claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx -- gitlab-mcp-server
 ```
+
+### Claude Desktop one-click extension (.mcpb)
+
+Claude Desktop users can skip all of the above: download
+[`gitlab-mcp-server.mcpb`](https://github.com/jmrplens/gitlab-mcp-server/releases/latest/download/gitlab-mcp-server.mcpb)
+and open it with Claude Desktop — see the
+[Claude Desktop Extension guide](guides/claude-desktop-extension.md).
 
 Self-managed GitLab? Add `--env GITLAB_URL=https://gitlab.example.com` (and `--env GITLAB_SKIP_TLS_VERIFY=true` for self-signed certs). Prefer a guided flow with no JSON to edit? Run `gitlab-mcp-server --setup` after installing the binary (see [Step 2](#step-2-run-the-setup-wizard)).
 
@@ -70,6 +79,7 @@ Download the latest release for your platform from the project [Releases](https:
 | Windows arm64       | `gitlab-mcp-server-windows-arm64.exe` |
 | macOS Intel         | `gitlab-mcp-server-darwin-amd64`      |
 | macOS Apple Silicon | `gitlab-mcp-server-darwin-arm64`      |
+| macOS universal     | `gitlab-mcp-server-darwin-all`        |
 
 On Linux/macOS, make it executable:
 

--- a/docs/guides/ide-configuration.md
+++ b/docs/guides/ide-configuration.md
@@ -150,6 +150,9 @@ VS Code discovers the GitLab authorization server automatically via `/.well-know
 
 ## Claude Desktop
 
+> **Easiest path**: install the one-click [.mcpb desktop extension](claude-desktop-extension.md)
+> instead — no JSON editing, token stored in the OS keychain.
+
 ### Stdio Mode
 
 Edit `claude_desktop_config.json`:

--- a/llms.txt
+++ b/llms.txt
@@ -199,10 +199,12 @@ Prompts:
 ## Documentation
 
 - [Getting started](docs/getting-started.md): Installation and first-run guide
+- [Claude Desktop extension](docs/guides/claude-desktop-extension.md): One-click .mcpb install for Claude Desktop (macOS universal + Windows)
 - [Configuration](docs/reference/configuration.md): Full configuration reference
 - [Environment variables](docs/reference/env.md): Environment variable reference
 - [HTTP server mode](docs/guides/http-server-mode.md): Remote MCP transport setup
 - [Security model](docs/concepts/security.md): Authentication, read-only mode, safe mode, and security controls
+- [Privacy policy](PRIVACY.md): No telemetry; data flows only to the configured GitLab instance
 
 ## Tool References
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -202,6 +202,8 @@ const jsonLd = JSON.stringify({
 				"https://www.pulsemcp.com/servers/jmrplens-gitlab",
 				"https://mcpservers.org/servers/jmrplens/gitlab-mcp-server",
 				"https://enterprisedna.co/directories/mcp/jmrplens-gitlab-mcp-server",
+				"https://lobehub.com/mcp/jmrplens-gitlab-mcp-server",
+				"https://mcpmarket.com/server/gitlab-32",
 			],
 		},
 		{

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -104,7 +104,7 @@ claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx --transport stdio \
 
 ### Instalador de una línea (binario nativo)
 
-Instala el binario en tu PATH y lo registra. Las actualizaciones las gestiona el auto-update integrado del binario (o Homebrew, que fija su propia formula con checksums).
+Instala el binario en tu PATH y lo registra. Las actualizaciones las gestiona el auto-update integrado del binario (o Homebrew, que fija su propia fórmula con checksums).
 
 ```bash
 # macOS/Linux (Homebrew)

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -88,6 +88,11 @@ Registran un servidor basado en **Docker** (descarga la imagen en la primera eje
 [![Añadir a LM Studio](https://files.lmstudio.ai/deeplink/mcp-install-dark.svg)](https://lmstudio.ai/install-mcp?name=gitlab&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsIi0tcm0iLCItZSIsIkdJVExBQl9UT0tFTiIsImdoY3IuaW8vam1ycGxlbnMvZ2l0bGFiLW1jcC1zZXJ2ZXI6bGF0ZXN0IiwiLS1odHRwPWZhbHNlIl0sImVudiI6eyJHSVRMQUJfVE9LRU4iOiJZT1VSX0dJVExBQl9UT0tFTiJ9fQ%3D%3D)
 [![Añadir a Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=gitlab&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22GITLAB_TOKEN%22%2C%22ghcr.io%2Fjmrplens%2Fgitlab-mcp-server%3Alatest%22%2C%22--http%3Dfalse%22%5D%2C%22env%22%3A%7B%22GITLAB_TOKEN%22%3A%22YOUR_GITLAB_TOKEN%22%7D%7D)
 
+Para **Claude Desktop**, descarga en su lugar la
+[extensión de escritorio .mcpb](/gitlab-mcp-server/es/claude-desktop/) — una
+instalación nativa en un clic (macOS universal + Windows) sin Docker y con el
+token guardado en el llavero del sistema.
+
 ### Claude Code (`claude mcp add`)
 
 Docker (sin instalar nada — descarga la imagen en la primera ejecución):
@@ -99,10 +104,12 @@ claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx --transport stdio \
 
 ### Instalador de una línea (binario nativo)
 
-Instala el binario en tu PATH y lo registra. Las actualizaciones las gestiona el auto-update integrado del binario.
+Instala el binario en tu PATH y lo registra. Las actualizaciones las gestiona el auto-update integrado del binario (o Homebrew, que fija su propia formula con checksums).
 
 ```bash
-# Linux/macOS
+# macOS/Linux (Homebrew)
+brew install jmrplens/tap/gitlab-mcp-server
+# Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
@@ -124,10 +131,12 @@ El [asistente de configuración](#asistente-de-configuración) integrado recoge 
 | --------------------- | ------------------------------------- |
 | Linux (x86_64)        | `gitlab-mcp-server-linux-amd64`       |
 | Linux (ARM64)         | `gitlab-mcp-server-linux-arm64`       |
+| macOS (universal)     | `gitlab-mcp-server-darwin-all`        |
 | macOS (Intel)         | `gitlab-mcp-server-darwin-amd64`      |
 | macOS (Apple Silicon) | `gitlab-mcp-server-darwin-arm64`      |
 | Windows (x86_64)      | `gitlab-mcp-server-windows-amd64.exe` |
 | Windows (ARM64)       | `gitlab-mcp-server-windows-arm64.exe` |
+| Claude Desktop        | `gitlab-mcp-server.mcpb` — consulta [Extensión para Claude Desktop](/gitlab-mcp-server/es/claude-desktop/) |
 
 ### Hacerlo ejecutable (Linux/macOS)
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -88,6 +88,10 @@ These register a **Docker**-based server (it auto-pulls the image on first run; 
 [![Add to LM Studio](https://files.lmstudio.ai/deeplink/mcp-install-dark.svg)](https://lmstudio.ai/install-mcp?name=gitlab&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsIi0tcm0iLCItZSIsIkdJVExBQl9UT0tFTiIsImdoY3IuaW8vam1ycGxlbnMvZ2l0bGFiLW1jcC1zZXJ2ZXI6bGF0ZXN0IiwiLS1odHRwPWZhbHNlIl0sImVudiI6eyJHSVRMQUJfVE9LRU4iOiJZT1VSX0dJVExBQl9UT0tFTiJ9fQ%3D%3D)
 [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=gitlab&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22GITLAB_TOKEN%22%2C%22ghcr.io%2Fjmrplens%2Fgitlab-mcp-server%3Alatest%22%2C%22--http%3Dfalse%22%5D%2C%22env%22%3A%7B%22GITLAB_TOKEN%22%3A%22YOUR_GITLAB_TOKEN%22%7D%7D)
 
+For **Claude Desktop**, download the [.mcpb desktop extension](/gitlab-mcp-server/claude-desktop/)
+instead — a native one-click install (macOS universal + Windows) with no Docker
+and the token stored in the OS keychain.
+
 ### Claude Code (`claude mcp add`)
 
 Docker (no install — pulls the image on first run):
@@ -99,10 +103,12 @@ claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx --transport stdio \
 
 ### One-line installer (native binary)
 
-Installs the binary onto your PATH, then registers it. Updates are handled by the binary's built-in auto-update.
+Installs the binary onto your PATH, then registers it. Updates are handled by the binary's built-in auto-update (or by Homebrew, which pins its own checksummed formula).
 
 ```bash
-# Linux/macOS
+# macOS/Linux (Homebrew)
+brew install jmrplens/tap/gitlab-mcp-server
+# Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
@@ -124,10 +130,12 @@ Prefer to place the binary yourself? Download the latest binary for your platfor
 | --------------------- | ------------------------------------- |
 | Linux (x86_64)        | `gitlab-mcp-server-linux-amd64`       |
 | Linux (ARM64)         | `gitlab-mcp-server-linux-arm64`       |
+| macOS (universal)     | `gitlab-mcp-server-darwin-all`        |
 | macOS (Intel)         | `gitlab-mcp-server-darwin-amd64`      |
 | macOS (Apple Silicon) | `gitlab-mcp-server-darwin-arm64`      |
 | Windows (x86_64)      | `gitlab-mcp-server-windows-amd64.exe` |
 | Windows (ARM64)       | `gitlab-mcp-server-windows-arm64.exe` |
+| Claude Desktop        | `gitlab-mcp-server.mcpb` — see [Claude Desktop Extension](/gitlab-mcp-server/claude-desktop/) |
 
 ### Make it executable (Linux/macOS)
 


### PR DESCRIPTION
Documentation audit covering everything shipped since v2.4.1 that wasn't yet reflected everywhere:

## New install paths
- **Homebrew** (`brew install jmrplens/tap/gitlab-mcp-server`): added to the one-line installer sections in `docs/getting-started.md` and the site getting-started (EN/ES)
- **Claude Desktop `.mcpb`**: pointer under the one-click buttons + rows in the download tables (EN/ES + dev docs), tip in `docs/guides/ide-configuration.md`
- **macOS universal binary** (`gitlab-mcp-server-darwin-all`): added to all download tables

## Directory metadata
- `SoftwareApplication.sameAs` in `site/astro.config.mjs` gains the [LobeHub](https://lobehub.com/mcp/jmrplens-gitlab-mcp-server) and [MCP Market](https://mcpmarket.com/server/gitlab-32) listings

## Reference surfaces
- `CLAUDE.md`: release process now documents the automated artifacts (universal binary, `.mcpb`, Homebrew tap push, winget PR, manifest stamping)
- `gen_llms`: links the Claude Desktop extension guide and `PRIVACY.md`; `llms.txt`/`llms-full.txt` regenerated and `--check` passes

Verified: site builds clean (61 pages, all internal links valid), markdownlint green, `golangci-lint` green on `cmd/gen_llms`, gen_llms tests pass.

## Summary by Sourcery

Align installation and release documentation with new distribution artifacts (Homebrew formula, macOS universal binary, Claude Desktop .mcpb) and update site metadata and LLM reference surfaces accordingly.

New Features:
- Document Homebrew-based installation as a first-class one-line installer path in CLI and site getting-started guides (EN/ES).
- Add documentation and download table entries for the Claude Desktop .mcpb one-click extension across markdown and site content.
- Expose the macOS universal binary as a documented download option alongside existing platform-specific binaries.

Enhancements:
- Update CLAUDE release process documentation to cover automated artifacts, Homebrew tap updates, winget PRs, and manifest version stamping.
- Highlight the Claude Desktop .mcpb extension as the recommended, keychain-backed setup path in the IDE configuration guide.
- Link the Claude Desktop extension guide and privacy policy from the generated LLM documentation index, regenerating llms.txt metadata accordingly.
- Expand site JSON-LD SoftwareApplication.sameAs metadata with additional directory listings for the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-click Claude Desktop extension option for easier installation.
  * Added Homebrew install instructions for macOS/Linux.
  * Expanded download options with more platform-specific builds, including macOS universal and Windows ARM64.
* **Documentation**
  * Updated getting-started and IDE setup guides with clearer install paths and updated download links.
  * Added privacy policy and Claude Desktop extension links to documentation indexes.
* **Chores**
  * Updated site metadata with additional external references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->