### PR TITLE
docs: add winget install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Or install the native binary first, then register it:
 brew install jmrplens/tap/gitlab-mcp-server
 # Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
+# Windows (winget)
+winget install --id jmrplens.gitlab-mcp-server -e
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,8 @@ claude mcp add gitlab --env GITLAB_TOKEN=glpat-xxxx --transport stdio \
 brew install jmrplens/tap/gitlab-mcp-server
 # Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
+# Windows (winget)
+winget install --id jmrplens.gitlab-mcp-server -e
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
 

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -111,6 +111,8 @@ Instala el binario en tu PATH y lo registra. Las actualizaciones las gestiona el
 brew install jmrplens/tap/gitlab-mcp-server
 # Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
+# Windows (winget)
+winget install --id jmrplens.gitlab-mcp-server -e
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -110,6 +110,8 @@ Installs the binary onto your PATH, then registers it. Updates are handled by th
 brew install jmrplens/tap/gitlab-mcp-server
 # Linux/macOS (script)
 curl -fsSL https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.sh | sh
+# Windows (winget)
+winget install --id jmrplens.gitlab-mcp-server -e
 # Windows (PowerShell)
 irm https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/scripts/install.ps1 | iex
 


### PR DESCRIPTION
## Summary

The winget package `jmrplens.gitlab-mcp-server` is now merged into [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/pull/405735) (v2.5.2) and is auto-updated on every release via `winget-releaser`. This documents it as a Windows install channel.

## Changes

Added `winget install --id jmrplens.gitlab-mcp-server -e` to the native-binary install block in:

- `README.md`
- `docs/getting-started.md`
- `site/src/content/docs/getting-started.mdx` (EN)
- `site/src/content/docs/es/getting-started.mdx` (ES)

## Not changed (deliberately)

The JSON-LD `SoftwareApplication` schema in `site/astro.config.mjs` was left as-is. Its `sameAs` array lists *directory/listing pages* that describe the entity (glama, mcp.so, cursor.directory…), and install *channels* (Homebrew tap, install script) are intentionally not in the schema. winget has no canonical per-package entity page, and `operatingSystem` already includes Windows — so there's nothing schema-appropriate to add.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

