### PR TITLE
docs(readme): refresh badges — drop Go Report Card, add Smithery + Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@
 ![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux%20%7C%20macOS-amd64%20%26%20arm64-lightgrey?style=flat&logo=windows-terminal&logoColor=white)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_gitlab-mcp-server&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_gitlab-mcp-server)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_gitlab-mcp-server&metric=coverage)](https://sonarcloud.io/summary/overall?id=jmrplens_gitlab-mcp-server)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jmrplens/gitlab-mcp-server)](https://goreportcard.com/report/github.com/jmrplens/gitlab-mcp-server)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmrplens/gitlab-mcp-server/v2.svg)](https://pkg.go.dev/github.com/jmrplens/gitlab-mcp-server/v2)
+
+</p>
+
+<p align="center">
+
 [![Glama MCP Score](https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server)
 [![MCP Badge](https://lobehub.com/badge/mcp/jmrplens-gitlab-mcp-server)](https://lobehub.com/mcp/jmrplens-gitlab-mcp-server)
+[![smithery badge](https://smithery.ai/badge/jmrp/gitlab-mcp-server)](https://smithery.ai/servers/jmrp/gitlab-mcp-server)
+[![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-000000?logo=cursor&logoColor=white)](https://cursor.directory/plugins/gitlab-mcp-server)
 
 </p>
 


### PR DESCRIPTION
## Summary

Tidy up the README badge strip:

- **Removed** the Go Report Card badge (no longer working).
- **Split** the MCP-directory listing badges onto their own centered row: **Glama**, **LobeHub**, **Smithery**, **Cursor Directory**.
- **Added** the Smithery badge (`smithery.ai/badge/jmrp/gitlab-mcp-server`) and a Cursor Directory badge linking to `cursor.directory/plugins/gitlab-mcp-server` (shields.io static badge — cursor.directory has no official badge image).

The top row now carries the project/quality badges only: Release, License, Platform, Quality Gate, Coverage, Go Reference.

## Notes

All new badge image URLs return `200 image/svg+xml`. The listing URLs match the canonical entries already in the site's `SoftwareApplication` `sameAs` schema.

## Summary by Sourcery

Refresh README badges layout and content to reflect current MCP directory listings and remove obsolete badges.

Documentation:
- Reorganize README badges into separate rows for project/quality badges and MCP directory listings.
- Remove the broken Go Report Card badge from the README.
- Add Smithery and Cursor Directory listing badges to the README.