### PR TITLE
feat(release): track lhm.plugin.json and auto-stamp it on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
           git add server.json
           [ -f .plugin/plugin.json ] && git add .plugin/plugin.json
           [ -f mcpb/manifest.json ] && git add mcpb/manifest.json
+          [ -f lhm.plugin.json ] && git add lhm.plugin.json
 
           if git diff --cached --quiet; then
             echo "::notice::No manifest changes to commit"
@@ -220,8 +221,9 @@ jobs:
           git commit -m "chore: update manifests for v${VERSION}
 
           Updates server.json (MCP Registry), .plugin/plugin.json
-          (Open Plugins), and mcpb/manifest.json (Claude Desktop
-          extension) with version ${VERSION} and pinned SHA256 hashes."
+          (Open Plugins), mcpb/manifest.json (Claude Desktop
+          extension), and lhm.plugin.json (LobeHub Marketplace) with
+          version ${VERSION} and pinned SHA256 hashes."
           git push origin main
 
   winget:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,10 +220,10 @@ jobs:
 
           git commit -m "chore: update manifests for v${VERSION}
 
-          Updates server.json (MCP Registry), .plugin/plugin.json
-          (Open Plugins), mcpb/manifest.json (Claude Desktop
-          extension), and lhm.plugin.json (LobeHub Marketplace) with
-          version ${VERSION} and pinned SHA256 hashes."
+          Updates server.json (MCP Registry) with version ${VERSION} and
+          pinned SHA256 hashes, and stamps version ${VERSION} into
+          .plugin/plugin.json (Open Plugins), mcpb/manifest.json (Claude
+          Desktop extension), and lhm.plugin.json (LobeHub Marketplace)."
           git push origin main
 
   winget:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,8 @@ When creating a new release and uploading binaries to GitHub Releases:
    - `gitlab-mcp-server.mcpb` — Claude Desktop extension built by `scripts/build-mcpb.sh` from `mcpb/manifest.json` (validate with `make check-mcpb`, build locally with `make mcpb`)
    - Homebrew formula update pushed to `jmrplens/homebrew-tap` by `scripts/update-homebrew-tap.sh` (secret `TAP_DEPLOY_KEY_B64`)
    - winget version PR to `microsoft/winget-pkgs` via `winget-releaser` (secret `WINGET_TOKEN`)
-   - Version stamping of `server.json`, `.plugin/plugin.json`, and `mcpb/manifest.json` committed back to main by `scripts/update-server-json-sha.sh`
+   - Version stamping of `server.json`, `.plugin/plugin.json`, `mcpb/manifest.json`, and `lhm.plugin.json` (LobeHub Marketplace) committed back to main by `scripts/update-server-json-sha.sh`
+4. **LobeHub Marketplace is a manual publish step.** The stamping script keeps `lhm.plugin.json`'s version current on every release, but the LobeHub CLI (`@lobehub/market-cli`) has no non-interactive publish path (browser OIDC login + GitHub connect are required once), so it cannot run in CI. After a release, run `make publish-lobehub` from a machine with `lhm login` + `lhm github connect` already completed. The listing is `jmrplens-gitlab-mcp-server`.
 
 ### Post-implementation verification
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-validate-docs audit-edition-tier \
 	audit-discovery audit-discovery-check audit-e2e-gaps \
 	audit-doc-coverage audit-doc-coverage-check \
-	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms check-server-json check-openplugin check-mcpb mcpb gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
+	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms check-server-json check-openplugin check-mcpb mcpb publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
 	docs-local-go \
        docker-build docker-push docker-run \
        fly-check fly-deploy fly-deploy-release fly-status fly-logs fly-ssh fly-restart \
@@ -707,6 +707,21 @@ mcpb:
 	lipo -create -output dist/local_darwin_all/gitlab-mcp-server dist/local_darwin_arm64/gitlab-mcp-server dist/local_darwin_amd64/gitlab-mcp-server; \
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -X main.version=$$VER" -o dist/local_windows_amd64/gitlab-mcp-server.exe ./cmd/server; \
 	bash scripts/build-mcpb.sh "$$VER"
+
+## publish-lobehub: publish the current version to the LobeHub Marketplace.
+## Reads lhm.plugin.json (version kept in sync by scripts/update-server-json-sha.sh
+## on each release) and posts it via the @lobehub/market-cli. Requires a one-time
+## interactive `lhm login` + `lhm github connect` first — LobeHub has no
+## non-interactive publish path, so this cannot run in CI. See the release process in CLAUDE.md.
+publish-lobehub:
+	@command -v node >/dev/null || { echo "ERROR: Node.js >= 22 is required"; exit 1; }
+	@VER=$$(tr -d '[:space:]' < VERSION); \
+	MVER=$$(jq -r '.version' lhm.plugin.json); \
+	if [ "$$VER" != "$$MVER" ]; then \
+		echo "ERROR: VERSION ($$VER) != lhm.plugin.json version ($$MVER); run a release stamp first"; exit 1; \
+	fi; \
+	echo "Publishing jmrplens-gitlab-mcp-server v$$VER to LobeHub..."; \
+	npx -y @lobehub/market-cli plugin publish --dir "$(CURDIR)"
 
 ## gen-readme: regenerate all managed README.md sections (token footprint + stats).
 gen-readme: gen-footprint gen-stats

--- a/Makefile
+++ b/Makefile
@@ -715,6 +715,9 @@ mcpb:
 ## non-interactive publish path, so this cannot run in CI. See the release process in CLAUDE.md.
 publish-lobehub:
 	@command -v node >/dev/null || { echo "ERROR: Node.js >= 22 is required"; exit 1; }
+	@NODE_MAJOR=$$(node -v | sed 's/^v\([0-9]*\).*/\1/'); \
+	if [ "$$NODE_MAJOR" -lt 22 ]; then echo "ERROR: Node.js >= 22 is required (found $$(node -v))"; exit 1; fi
+	@command -v jq >/dev/null || { echo "ERROR: jq is required"; exit 1; }
 	@VER=$$(tr -d '[:space:]' < VERSION); \
 	MVER=$$(jq -r '.version' lhm.plugin.json); \
 	if [ "$$VER" != "$$MVER" ]; then \

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,0 +1,20 @@
+{
+  "identifier": "jmrplens-gitlab-mcp-server",
+  "name": "GitLab MCP Server",
+  "version": "2.5.2",
+  "description": "Model Context Protocol server exposing 1000+ GitLab REST + GraphQL operations as AI tools — merge requests, pipelines, issues, releases, milestones, and more. One static Go binary; stdio or HTTP transport, with dynamic/meta/individual tool surfaces.",
+  "author": "José M. Requena Plens",
+  "authorUrl": "https://github.com/jmrplens",
+  "tags": [
+    "gitlab",
+    "mcp",
+    "devops",
+    "ci-cd",
+    "merge-requests",
+    "issues",
+    "pipelines",
+    "git",
+    "go",
+    "graphql"
+  ]
+}

--- a/scripts/update-server-json-sha.sh
+++ b/scripts/update-server-json-sha.sh
@@ -14,6 +14,10 @@
 #
 # Steps for .plugin/plugin.json:
 #   5. Sets top-level .version to the given version (if file exists)
+#
+# Steps for mcpb/manifest.json (Claude Desktop) and lhm.plugin.json
+# (LobeHub Marketplace):
+#   6-7. Sets top-level .version to the given version (if file exists)
 
 set -euo pipefail
 
@@ -97,4 +101,15 @@ if [[ -f "$MCPB_JSON" ]]; then
   echo "$MCPB_JSON version set to $VERSION"
 else
   echo "NOTE: $MCPB_JSON not found, skipping MCPB manifest update"
+fi
+
+# 7. Update LobeHub Marketplace manifest version (if present). The actual
+# publish to LobeHub is a manual step (`make publish-lobehub`) — the CLI has no
+# non-interactive auth — but the version is kept in sync here on every release.
+LHM_JSON="lhm.plugin.json"
+if [[ -f "$LHM_JSON" ]]; then
+  jq --arg v "$VERSION" '.version = $v' "$LHM_JSON" > tmp.$$.json && mv tmp.$$.json "$LHM_JSON"
+  echo "$LHM_JSON version set to $VERSION"
+else
+  echo "NOTE: $LHM_JSON not found, skipping LobeHub manifest update"
 fi


### PR DESCRIPTION
## Summary

Make the LobeHub Marketplace listing (`jmrplens-gitlab-mcp-server`) stay in sync with releases, the same way `server.json`, `.plugin/plugin.json`, and `mcpb/manifest.json` do.

## Changes

- **`lhm.plugin.json`** (new) — the tracked LobeHub manifest (identifier, name, version, description, author, tags). Source of truth for the listing's `en-US` metadata; re-publishing merges these fields.
- **`scripts/update-server-json-sha.sh`** — new step 7 stamps `lhm.plugin.json`'s `.version` to the release version (guarded by a file-exists check, like the other manifests).
- **`.github/workflows/release.yml`** — the manifest-commit step now `git add`s `lhm.plugin.json` and mentions it in the commit message, so the stamped version is committed back to `main` each release.
- **`Makefile`** — new `make publish-lobehub` target: validates `VERSION == lhm.plugin.json.version`, then runs `@lobehub/market-cli plugin publish --dir <repo>`.
- **`CLAUDE.md`** — documents the new stamped file and that LobeHub publish is a **manual** post-release step.

## Why publish stays manual

The LobeHub CLI has **no non-interactive publish path** — `lhm login` (browser OIDC) and `lhm github connect` are required once and there is no token-only publish (per LobeHub's own skill docs). So CI can auto-**stamp** the version but cannot auto-**publish**. `make publish-lobehub` makes the manual step one command from a machine that has logged in.

## Testing

- `bash -n scripts/update-server-json-sha.sh` — OK
- End-to-end run of the stamping script (idempotent, v2.5.2) stamps `lhm.plugin.json` correctly alongside the other manifests
- `make -n publish-lobehub` — target resolves with the version-match guard and absolute `--dir`
- markdownlint clean; `lhm.plugin.json` is valid JSON

The current listing was already published to v2.5.2 manually during this work (1.0.0 → 2.5.2, claimed + validated).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

