### PR TITLE
fix(lint): cap golangci-lint concurrency to keep cold runs finishing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,14 @@ run:
   go: "1.26"
   timeout: 15m
   tests: true
+  # golangci-lint defaults to one worker per logical CPU. Across 226 packages
+  # and 55 linters that working set does not fit comfortably in memory on a
+  # many-threaded machine: measured on a cold cache, the default (16 workers on
+  # a 16-thread laptop) peaked at 4.4GB and had not finished after 18 minutes,
+  # while the same run capped at 4 workers peaked at 3.6GB and took 3m01s.
+  # CI runners have 4 vCPUs, so this matches what CI already does implicitly and
+  # only changes behaviour on bigger machines — where it is 6x faster.
+  concurrency: 4
   build-tags:
     - e2e
 

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -269,6 +269,29 @@ The configured timeout is in [`.golangci.yml`](../../.golangci.yml). For one-off
 golangci-lint run --timeout 20m ./...
 ```
 
+If a cold run hits the timeout, suspect concurrency before suspecting the
+timeout. `golangci-lint` defaults to one worker per logical CPU, and across 226
+packages and 55 linters that working set does not fit comfortably in memory on a
+many-threaded machine — it thrashes rather than going faster. Measured on a cold
+cache on the same 16-thread machine:
+
+| Concurrency         | Peak RSS | Cold run    |
+| ------------------- | -------- | ----------- |
+| 16 (former default) | 4.4 GB   | >18m, unfinished |
+| 4 (`run.concurrency`) | 3.6 GB | **3m01s**   |
+
+`run.concurrency: 4` is therefore set in `.golangci.yml`. CI runners have 4 vCPUs
+and were already getting this implicitly, which is why CI completed in ~4 minutes
+while a much larger local machine timed out. Raising it is unlikely to help; if
+you need to experiment, override per-run with `-j`:
+
+```bash
+golangci-lint run -j 8 ./...
+```
+
+The analysis cache matters too — a warm run takes seconds against minutes cold —
+but it is rebuilt automatically and needs no manual warming.
+
 ### Need a standalone tool during investigation
 
 Use standalone commands temporarily for debugging if they provide more focused output, but do not add them back to `make analyze` or CI when the same check is already enforced through `golangci-lint`.


### PR DESCRIPTION
## Description

`golangci-lint` defaults to one worker per logical CPU. Across 226 packages and
55 linters that working set does not fit comfortably in memory, and past a
certain worker count the run stops going faster and starts thrashing.

This sets `run.concurrency: 4` in `.golangci.yml`.

## Related Issue

N/A — found while investigating why a local `make golangci-lint` exceeded the
15m timeout while CI completes the identical command in ~4 minutes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Measurements

Cold cache, same 16-thread machine, same commit:

| Concurrency | Peak RSS | Cold run |
| --- | --- | --- |
| 16 (former default) | 4.4 GB | **>18m, never finished** |
| 4 | 3.6 GB | **3m01s** |

End-to-end check with the committed config (no CLI flags): `make golangci-lint`
on a cold cache takes **3m38s**, exit 0, 0 findings. The extra ~35s over the
bare run is `config verify` plus `fmt --diff`.

## Why this explains the CI/local gap

It looked like a hardware problem, and it wasn't. CI runners have 4 vCPUs, so
they were already getting this cap implicitly — that is why CI finishes in ~4
minutes while a far more capable local machine timed out. Setting it explicitly
changes nothing on CI and makes larger machines behave the same way instead of
worse.

Ruled out along the way, each with evidence: version drift (CI installs
`@latest`, which is v2.12.2, identical to local), config drift (the 15m timeout
comes from `.golangci.yml` and applies to both), and Rosetta (`x86_64` native).

## Changes Made

- `.golangci.yml` — `run.concurrency: 4`, with the measurements in a comment so
  the number is not mistaken for a guess.
- `docs/development/static-analysis.md` — the "golangci-lint timeout" section
  now says to suspect concurrency before the timeout, with the table above.

## How to Test

1. `golangci-lint config verify` — passes.
2. `make golangci-lint` — exits 0.
3. Cold-cache check:
   `CACHE=$(mktemp -d) && GOLANGCI_LINT_CACHE=$CACHE make golangci-lint; rm -rf $CACHE`

## Breaking Changes / Migration Notes

N/A. To override per run: `golangci-lint run -j 8 ./...`

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...` (no Go source changed)
- [x] `make golangci-lint` passes, exit 0, 0 findings
- [x] `golangci-lint config verify` passes

### Testing

- [x] Verified on a cold cache with the committed config, not just a CLI flag
- [x] Peak RSS and wall-clock measured for both concurrency settings
- [ ] N/A — configuration change, no Go test surface

### Documentation

- [x] `docs/development/static-analysis.md` updated
- [x] Rationale and measurements inline in `.golangci.yml`
- [x] Commit message follows Conventional Commits

### Security

- [x] No secrets or credentials
- [x] No new dependencies
- [x] No linters disabled — all 55 still run


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

