### PR TITLE
docs(readme): add the Cline settings paths to the manual JSON section

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Docker variant — replace `"command"`/`"args"` with:
 "args": ["run", "-i", "--rm", "-e", "GITLAB_TOKEN", "ghcr.io/jmrplens/gitlab-mcp-server:latest", "--http=false"]
 ```
 
+Cline (VS Code) — open the Cline sidebar → MCP servers icon → **Edit Global MCP**, or edit the settings file directly:
+
+- **macOS**: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- **Linux**: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- **Windows**: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
+
+Cline uses the `mcpServers` shape shown above for the native binary.
+
 For a shared, long-running HTTP deployment instead of per-user stdio, see [HTTP Server Mode](docs/guides/http-server-mode.md).
 
 </details>


### PR DESCRIPTION
## Description

The Cline marketplace submission ([cline/mcp-marketplace#1452](https://github.com/cline/mcp-marketplace/issues/1452)) claimed the README had "a dedicated Cline configuration block with the exact `cline_mcp_settings.json` paths for macOS/Linux/Windows". It did not — `grep -i cline README.md` returned a single hit in the compatibility list, and the paths only existed in `docs/guides/ide-configuration.md`.

That matters beyond tidiness: Cline's review process tests whether it can set the server up **from the README alone**, so a reviewer checking the claim would have found it false.

## Related Issue

Refs cline/mcp-marketplace#1452

## Type of Change

- [x] Documentation update

## Changes Made

- Added the three `cline_mcp_settings.json` paths (macOS / Linux / Windows) and the Edit Global MCP route to the existing manual-JSON section, pointing at the `mcpServers` block already shown there.

## How to Test

1. `grep -n cline_mcp_settings README.md` returns the three platform paths.
2. `npx markdownlint-cli2 README.md` passes.

## Breaking Changes / Migration Notes

N/A

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...` — unchanged, docs only
- [x] Follows the conventions documented in `CLAUDE.md`

### Testing

- [x] All existing tests pass — no code changed
- [ ] New tests added — N/A, documentation only

### Documentation

- [x] `README.md` updated
- [x] Commit messages follow Conventional Commits
- [ ] Tool counts updated — N/A

### Security

- [x] No secrets, tokens, or credentials in code, tests, fixtures, or logs


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

