### PR TITLE
feat: read the Person entity from its canonical source

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -126,91 +126,117 @@ const featureList = [
 const softwareRequirements =
 	"A GitLab instance (GitLab.com or self-hosted, Community or Enterprise Edition) with REST v4/GraphQL API access and a personal access token.";
 
+// --- Canonical identity --------------------------------------------------
+// The `#person` entity is no longer restated here; it is fetched from its
+// single source of truth on jmrp.io and spliced into the graph verbatim. Every
+// property this site used to hand-copy (jobTitle, description, image, sameAs,
+// alternateName) had to be kept in sync by hand across five project sites, and
+// it drifted: two ended up publishing values that contradicted the canonical
+// node, one an avatar URL that had started returning 404.
+//
+// Fetched from raw.githubusercontent.com rather than https://jmrp.io on
+// purpose: this build runs on a CI runner, and jmrp.io sits behind Cloudflare,
+// CrowdSec and a MikroTik bouncer, where a blocked runner IP would silently
+// degrade this site to a stale snapshot. GitHub serves the same bytes and is
+// already a hard dependency of the build — the checkout comes from it.
+const CANONICAL_IDENTITY_URL =
+	"https://raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld";
+
+// Committed fallback, only reached if the fetch fails — which, given the URL is
+// on the same host as the checkout, effectively means GitHub is down and there
+// is no build anyway. The warning is deliberately loud so a stale identity
+// never ships unnoticed. Refresh with `pnpm run identity:sync`.
+const identitySnapshot = JSON.parse(
+	readFileSync(
+		new URL("./identity/person.snapshot.json", import.meta.url),
+		"utf8",
+	),
+);
+
+// `@context` is stripped: the document is standalone, but here it becomes one
+// node of a graph that already declares the context once.
+const { "@context": _identityContext, ...canonicalPerson } = await fetch(
+	CANONICAL_IDENTITY_URL,
+	{ signal: AbortSignal.timeout(10_000) },
+)
+	.then((response) =>
+		response.ok
+			? response.json()
+			: Promise.reject(new Error(`HTTP ${response.status}`)),
+	)
+	.catch((error) => {
+		console.warn(
+			`\n⚠ [identity] Could not fetch the canonical Person entity (${error.message}).\n` +
+				`  Falling back to the committed snapshot — this build may ship a stale identity.\n`,
+		);
+		return identitySnapshot;
+	});
+
+/**
+ * Topics specific to this project, kept alongside the canonical expertise list
+ * rather than replacing it. `knowsAbout` is multi-valued, so the two sets merge
+ * instead of conflicting — which is why these may stay local while the
+ * single-valued properties above may not. The full original set is listed, not
+ * just the entries the canonical lacks, so this site keeps asserting its own
+ * topics even if the canonical list changes.
+ */
+const projectTopics = [
+	{
+		"@type": "Thing",
+		name: "Model Context Protocol",
+		"@id": "http://www.wikidata.org/entity/Q133436854",
+	},
+	{
+		"@type": "Thing",
+		name: "GitLab",
+		"@id": "http://www.wikidata.org/entity/Q16639197",
+	},
+	{
+		"@type": "Thing",
+		name: "Go",
+		"@id": "http://www.wikidata.org/entity/Q37227",
+	},
+	{
+		"@type": "Thing",
+		name: "DevOps",
+		"@id": "http://www.wikidata.org/entity/Q3025536",
+	},
+	{
+		"@type": "Thing",
+		name: "CI/CD",
+		"@id": "http://www.wikidata.org/entity/Q28136854",
+	},
+];
+
+/** Reads a `knowsAbout` entry's label, which may be a string or a Thing. */
+const topicName = (topic) =>
+	typeof topic === "string" ? topic : (topic.name ?? "");
+
+/**
+ * Canonical topics first, then this project's own, de-duplicated by label
+ * (case-insensitively). Canonical entries win a collision because they carry a
+ * verified Wikidata `@id`.
+ */
+const personNode = (() => {
+	const canonical = canonicalPerson.knowsAbout ?? [];
+	const seen = new Set(canonical.map((t) => topicName(t).toLowerCase()));
+	return {
+		...canonicalPerson,
+		knowsAbout: [
+			...canonical,
+			...projectTopics.filter((t) => !seen.has(topicName(t).toLowerCase())),
+		],
+	};
+})();
+
 const jsonLd = JSON.stringify({
 	"@context": "https://schema.org",
 	"@graph": [
-		// This node shares its @id with the Person referenced at
-		// https://jmrp.io/#person. Two nodes under one @id that disagree weaken
-		// the entity rather than reinforcing it, so name, jobTitle, description,
-		// url, identifier and sameAs are kept byte-identical to the portfolio's.
-		//
-		// NOTE: as of 2026-07-26 the portfolio does NOT publish a full Person at
-		// that @id — https://jmrp.io/ only references it via `about`, and
-		// https://jmrp.io/cv/ defines it with just alumniOf / hasOccupation /
-		// hasCredential. So this site is currently the only publisher of the
-		// identity attributes, not a restatement of them. Do not delete fields
-		// here on the assumption the portfolio still supplies them; publish the
-		// full node there first, then re-verify.
-		// `image` is the one deliberate divergence: the portfolio points at a
-		// content-hashed Astro asset whose URL changes on every rebuild there, so
-		// this node uses the stable GitHub avatar (already a sameAs origin)
-		// instead of a URL that would silently rot.
-		{
-			"@type": "Person",
-			"@id": authorId,
-			name: "José Manuel Requena Plens",
-			alternateName: "jmrplens",
-			jobTitle: "R&D · Firmware & Software Engineer",
-			description:
-				"Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
-			url: `${authorUrl}/`,
-			image: {
-				"@type": "ImageObject",
-				url: "https://github.com/jmrplens.png",
-				width: 460,
-				height: 460,
-			},
-			identifier: {
-				"@type": "PropertyValue",
-				propertyID: "ORCID",
-				value: "0000-0003-1250-6212",
-				url: "https://orcid.org/0000-0003-1250-6212",
-			},
-			// Wikidata-linked rather than bare strings, so an engine resolves each
-			// topic to a known entity instead of guessing from a label. This is a
-			// project-relevant subset of the portfolio's topic set; where a topic
-			// appears in both, it carries the same Q-id there and here, so the two
-			// descriptions of one person never disagree about what a term means.
-			knowsAbout: [
-				{
-					"@type": "Thing",
-					name: "Model Context Protocol",
-					"@id": "http://www.wikidata.org/entity/Q133436854",
-				},
-				{
-					"@type": "Thing",
-					name: "GitLab",
-					"@id": "http://www.wikidata.org/entity/Q16639197",
-				},
-				{
-					"@type": "Thing",
-					name: "Go",
-					"@id": "http://www.wikidata.org/entity/Q37227",
-				},
-				{
-					"@type": "Thing",
-					name: "DevOps",
-					"@id": "http://www.wikidata.org/entity/Q3025536",
-				},
-				{
-					"@type": "Thing",
-					name: "CI/CD",
-					"@id": "http://www.wikidata.org/entity/Q28136854",
-				},
-			],
-			sameAs: [
-				"https://github.com/jmrplens",
-				"https://www.linkedin.com/in/jmrplens",
-				"https://mstdn.jmrp.io/@jmrplens",
-				"https://bsky.app/profile/jmrp.io",
-				"https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
-				"https://orcid.org/0000-0003-1250-6212",
-				"https://www.researchgate.net/profile/Jose-Requena-Plens-2",
-				"https://www.mathworks.com/matlabcentral/profile/authors/5890853",
-				"https://matrix.to/#/@jmrplens:matrix.jmrp.io",
-				"https://keyoxide.org/0A993B268654DBBA52B7E8D3FCF653391E2C91FC",
-			],
-		},
+		// The canonical Person entity, fetched at build time — see the
+		// "Canonical identity" block above. Spliced verbatim so this document
+		// and jmrp.io describe the same node with the same values, instead of
+		// two hand-maintained copies that drift.
+		personNode,
 		{
 			"@type": "WebSite",
 			"@id": websiteId,
@@ -277,6 +303,10 @@ const jsonLd = JSON.stringify({
 			releaseNotes: releasesUrl,
 			maintainer: { "@id": authorId },
 			author: { "@id": authorId },
+			// Same three agents jmrp.io/projects/ emits for this @id, so the merged
+			// node states one consistent set instead of a partial one per document.
+			creator: { "@id": authorId },
+			maintainer: { "@id": authorId },
 			// Deliberately no aggregateRating: GitHub stars are not user reviews,
 			// and Google's structured-data policy treats synthesised ratings as a
 			// manual-action risk.
@@ -311,6 +341,10 @@ const jsonLd = JSON.stringify({
 			license: "https://opensource.org/licenses/MIT",
 			isPartOf: { "@id": softwareId },
 			author: { "@id": authorId },
+			// Same three agents jmrp.io/projects/ emits for this @id, so the merged
+			// node states one consistent set instead of a partial one per document.
+			creator: { "@id": authorId },
+			maintainer: { "@id": authorId },
 		},
 	],
 });

--- a/site/identity/person.snapshot.json
+++ b/site/identity/person.snapshot.json
@@ -1,0 +1,179 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "https://jmrp.io/#person",
+  "name": "José Manuel Requena Plens",
+  "alternateName": [
+    "jmrplens",
+    "José M. Requena-Plens",
+    "Jose M. Requena-Plens",
+    "José M. Requena Plens",
+    "Jose M. Requena Plens",
+    "José Manuel Requena-Plens",
+    "Jose Manuel Requena-Plens",
+    "Jose Manuel Requena Plens"
+  ],
+  "jobTitle": "R&D · Firmware & Software Engineer",
+  "description": "Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
+  "url": "https://jmrp.io/",
+  "image": {
+    "@type": "ImageObject",
+    "url": "https://github.com/jmrplens.png",
+    "width": "460",
+    "height": "460"
+  },
+  "knowsAbout": [
+    {
+      "@type": "Thing",
+      "name": "Embedded Systems",
+      "@id": "http://www.wikidata.org/entity/Q193040"
+    },
+    {
+      "@type": "Thing",
+      "name": "Firmware",
+      "@id": "http://www.wikidata.org/entity/Q104851"
+    },
+    {
+      "@type": "Thing",
+      "name": "STM32",
+      "@id": "http://www.wikidata.org/entity/Q7394773"
+    },
+    {
+      "@type": "Thing",
+      "name": "FreeRTOS",
+      "@id": "http://www.wikidata.org/entity/Q1186761"
+    },
+    {
+      "@type": "Thing",
+      "name": "Modbus",
+      "@id": "http://www.wikidata.org/entity/Q1135322"
+    },
+    {
+      "@type": "Thing",
+      "name": "Cryptography",
+      "@id": "http://www.wikidata.org/entity/Q8789"
+    },
+    {
+      "@type": "Thing",
+      "name": "Network Security",
+      "@id": "http://www.wikidata.org/entity/Q989632"
+    },
+    {
+      "@type": "Thing",
+      "name": "Nginx",
+      "@id": "http://www.wikidata.org/entity/Q306144"
+    },
+    {
+      "@type": "Thing",
+      "name": "MikroTik RouterOS",
+      "@id": "http://www.wikidata.org/entity/Q12036888"
+    },
+    {
+      "@type": "Thing",
+      "name": "WireGuard",
+      "@id": "http://www.wikidata.org/entity/Q28975568"
+    },
+    {
+      "@type": "Thing",
+      "name": "IPv6",
+      "@id": "http://www.wikidata.org/entity/Q2551624"
+    },
+    {
+      "@type": "Thing",
+      "name": "Acoustics",
+      "@id": "http://www.wikidata.org/entity/Q82811"
+    },
+    {
+      "@type": "Thing",
+      "name": "Signal Processing",
+      "@id": "http://www.wikidata.org/entity/Q208163"
+    },
+    {
+      "@type": "Thing",
+      "name": "Go",
+      "@id": "http://www.wikidata.org/entity/Q37227"
+    },
+    {
+      "@type": "Thing",
+      "name": "Model Context Protocol",
+      "@id": "http://www.wikidata.org/entity/Q133436854"
+    },
+    {
+      "@type": "Thing",
+      "name": "CI/CD",
+      "@id": "http://www.wikidata.org/entity/Q28136854"
+    },
+    {
+      "@type": "Thing",
+      "name": "DevSecOps",
+      "@id": "http://www.wikidata.org/entity/Q108525696"
+    },
+    {
+      "@type": "Thing",
+      "name": "Software Testing",
+      "@id": "http://www.wikidata.org/entity/Q188522"
+    },
+    {
+      "@type": "Thing",
+      "name": "ESP32",
+      "@id": "http://www.wikidata.org/entity/Q27921668"
+    }
+  ],
+  "owns": [
+    {
+      "@id": "https://github.com/jmrplens/gitlab-mcp-server#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/phonometry#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/cs-routeros-bouncer#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/Cloudflare-DNS-Updater#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/libgen-mcp#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/TFG-TFM_EPS#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/A-Lab#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/mastodon_official_profiles#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/SetFigPaper#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/LoVE-BASS#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/FDTDexamples#software"
+    }
+  ],
+  "identifier": {
+    "@type": "PropertyValue",
+    "propertyID": "ORCID",
+    "value": "0000-0003-1250-6212",
+    "url": "https://orcid.org/0000-0003-1250-6212"
+  },
+  "sameAs": [
+    "https://github.com/jmrplens",
+    "https://www.linkedin.com/in/jmrplens",
+    "https://mstdn.jmrp.io/@jmrplens",
+    "https://bsky.app/profile/jmrp.io",
+    "https://matrix.to/#/@jmrplens:matrix.jmrp.io",
+    "https://keyoxide.org/0A993B268654DBBA52B7E8D3FCF653391E2C91FC",
+    "https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
+    "https://orcid.org/0000-0003-1250-6212",
+    "https://www.researchgate.net/profile/Jose-Requena-Plens-2",
+    "https://www.mathworks.com/matlabcentral/profile/authors/5890853",
+    "https://codeberg.org/jmrplens",
+    "https://gitlab.com/jmrp",
+    "https://pypi.org/user/jmrplens/",
+    "https://hub.docker.com/u/jmrplens"
+  ]
+}

--- a/site/package.json
+++ b/site/package.json
@@ -12,6 +12,7 @@
     "postbuild": "node scripts/normalize-html.mjs && node scripts/add-sitemap-lastmod.mjs",
     "preview": "astro preview",
     "check": "astro check",
+    "identity:sync": "node scripts/sync-identity.mjs",
     "eslint": "eslint .",
     "html-validate": "html-validate 'dist/**/*.html'",
     "htmlhint": "htmlhint 'dist/**/*.html'",

--- a/site/scripts/sync-identity.mjs
+++ b/site/scripts/sync-identity.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Refreshes the committed snapshot of the canonical `#person` entity.
+ *
+ * The build fetches the live document (see `astro.config.mjs`); this snapshot
+ * is only the offline fallback. Refresh it deliberately — via this script, in
+ * its own commit — so the identity this site would ship without a network is
+ * visible in review rather than silently frozen at whatever it was on the day
+ * the file was first added.
+ *
+ * Usage:
+ *   node scripts/sync-identity.mjs           # write the snapshot
+ *   node scripts/sync-identity.mjs --check   # fail if it is stale
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+
+const SOURCE =
+	"https://raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld";
+const TARGET = new URL("../identity/person.snapshot.json", import.meta.url);
+
+const response = await fetch(SOURCE, { signal: AbortSignal.timeout(15_000) });
+if (!response.ok) {
+	console.error(`✗ Could not fetch ${SOURCE} — HTTP ${response.status}`);
+	process.exit(1);
+}
+const latest = `${JSON.stringify(await response.json(), null, 2)}\n`;
+
+if (process.argv.includes("--check")) {
+	const committed = readFileSync(TARGET, "utf8");
+	if (committed !== latest) {
+		console.error(
+			"✗ identity/person.snapshot.json is stale.\n" +
+				"  Refresh it with: pnpm run identity:sync",
+		);
+		process.exit(1);
+	}
+	console.log("✓ Identity snapshot matches the canonical document.");
+} else {
+	writeFileSync(TARGET, latest);
+	console.log("✓ Refreshed identity/person.snapshot.json");
+}

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -12,6 +12,16 @@ const rel = pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
 const isES = rel === "/es" || rel.startsWith("/es/");
 
 const label = isES ? "Mantenido por" : "Maintained by";
+
+// The maintainer's project index. Gives a reader — and a crawler — a path from
+// this project to the whole portfolio, where every #software node in the
+// identity graph is listed together. Not `rel="me"`: it is a page, not an
+// identity profile.
+const projectsUrl = isES
+	? "https://jmrp.io/es/projects/"
+	: "https://jmrp.io/projects/";
+const projectsText = isES ? "Todos los proyectos" : "All projects";
+
 // Curated subset of the Person `sameAs` set in the site-wide @graph — the
 // human-relevant profiles; machine-oriented entries (Matrix, Keyoxide) stay
 // JSON-LD-only.
@@ -40,6 +50,9 @@ const links = [
 				</a>
 			))
 		}
+	<a href={projectsUrl} rel="noopener noreferrer" target="_blank">
+			{projectsText}
+		</a>
 	</span>
 </div>
 


### PR DESCRIPTION
Part of a rollout across the six sites that publish the `https://jmrp.io/#person` entity. jmrp.io now serves it as a standalone document; this site consumes it instead of restating it.

## Problem

This site restated the entity by **copying its values**. Across the five project sites doing the same, that convention failed twice:

- `cs-routeros-bouncer` published *"Open-source developer; author and maintainer of cs-routeros-bouncer"* as the `description` of the shared entity — a project description on a person node.
- `Cloudflare-DNS-Updater` advertised an avatar URL that **returned 404** — a fingerprinted Astro asset the portfolio had long since rebuilt.

Both are fixed upstream. Values that must not diverge should not be copied at all.

## Change

The node is fetched at build time from the canonical document and spliced verbatim, so this document and jmrp.io describe the same entity with the same values **by construction**.

```
raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld
```

Fetched from GitHub rather than `https://jmrp.io` **on purpose**: this build runs on a CI runner, and jmrp.io sits behind Cloudflare, CrowdSec and a MikroTik bouncer — the one place a blocked runner IP would silently degrade this site to a stale snapshot. GitHub serves the same bytes and is already a hard dependency of the build (the checkout comes from it). If GitHub is down there is no build anyway, which makes the committed snapshot a belt-and-braces fallback rather than a real dependency.

## What it gains

Beyond removing the drift risk, this site now asserts things it never did:

| | Before | After |
| --- | --- | --- |
| `alternateName` | `"jmrplens"` | **8 observed variants**, including `José M. Requena-Plens` — the citation form in every published paper |
| `sameAs` | 6–10 | **14**, including two forge accounts with signed OpenPGP proofs |
| `owns` | absent | **11 projects** |

## Deliberate choices

- **`knowsAbout` stays local and is merged, not replaced.** It is multi-valued, so the project's own topics reinforce the canonical list instead of conflicting with it. The full local set is kept — not just the entries the canonical lacks — so this site keeps asserting its own topics even if that list changes.
- **`creator` + `maintainer` added alongside `author`** on the software nodes, matching the three agents `jmrp.io/projects/` emits for those `@id`s. They merge, so a partial set per document was untidy rather than wrong.
- **Visible footer link to the project index**, localized where the site is bilingual. Deliberately **not** `rel="me"`: it is a page, not an identity profile.
- **`pnpm run identity:sync`** refreshes the snapshot deliberately, in its own commit, so the identity this site would ship without a network is visible in review rather than frozen at whatever it was the day the file was added.

## Verification

Built and re-parsed out of the built HTML:

```
props identical to canonical : YES
extra props                  : none
alternateName 8 · owns 11 · sameAs 14
knowsAbout: canonical 19 + this project's own, no duplicates
```

The full JSON-LD node inventory was compared before and after — not just the `Person` — after an earlier attempt in this rollout silently deleted two sibling nodes while still producing a green build.

https://claude.ai/code/session_01Ecf6hESxYdc7f1UV1vHrQU

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

