### PR TITLE
feat(tooling): generate the LobeHub manifest capability arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       - run: go mod download
       - name: Check generated llms files
         run: make check-llms
+      - name: Check LobeHub manifest
+        run: make check-lhm-manifest
       - name: Check MCP Registry manifest
         run: make check-server-json
       - name: Check Open Plugins manifest

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ image.png
 /format_md_tables
 /gen_action_catalog_manifest
 /gen_docker_tools
+/gen_lhm_manifest
 /gen_llms
 /gen_stats
 /gen_testing_docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ make inspector-stop
 | ActionSpec metadata (catalog routes)                | `go run ./cmd/gen_action_catalog_manifest/` (and `--check` in CI) |
 | Pipe tables in `README.md` or `docs/`               | `go run ./cmd/format_md_tables/` (and `--check`)                  |
 | Tests, after a test phase                           | `go run ./cmd/gen_testing_docs/` (and `--check`)                  |
-| Tool surface (registered tools, resources, prompts) | `go run ./cmd/gen_llms/` (and `--check` via `make check-llms`)    |
+| Tool surface (registered tools, resources, prompts) | `go run ./cmd/gen_llms/` (and `--check` via `make check-llms`), plus `go run ./cmd/gen_lhm_manifest/` (and `--check` via `make check-lhm-manifest`) |
 | `server.json`                                       | `make check-server-json` (uses MCP publisher)                     |
 
 The combined gate is `make audit-docs`. CI runs it on every PR.
@@ -112,7 +112,7 @@ For a full walkthrough use the `create-mcp-tool` skill
    in the sub-package `markdown.go` `init()`. List formatters must add
    `toolutil.HintPreserveLinks` as the first hint in `WriteHints()`.
 6. **Refresh**: `audit_tokens -footprint` + `gen_stats`, `gen_action_catalog_manifest`, `format_md_tables`,
-   `gen_testing_docs`, `gen_llms` (run `--check` on each before pushing).
+   `gen_testing_docs`, `gen_llms`, `gen_lhm_manifest` (run `--check` on each before pushing).
 7. **Verify**: `make test-pkg PKG={domain}` and
    `golangci-lint run --build-tags e2e ./internal/tools/{domain}/`.
 8. **Document**: `docs/tools/{domain}.md` and `docs/reference/tools/README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ gitlab-mcp-server/
 │   ├── format_md_tables/        # Formats Markdown pipe tables in README.md and docs/
 │   ├── gen_action_catalog_manifest/ # Generates audited action catalog manifest
 │   ├── gen_docker_tools/        # Generates Docker-related tool metadata
+│   ├── gen_lhm_manifest/        # Generates the capability arrays in lhm.plugin.json (LobeHub)
 │   ├── gen_llms/                # Generates llms.txt and llms-full.txt for LLM discovery
 │   ├── gen_stats/               # Generates README stats section from codebase metrics
 │   └── gen_testing_docs/        # Generates docs/development/testing/testing.md
@@ -245,6 +246,9 @@ When creating a new release and uploading binaries to GitHub Releases:
    - winget version PR to `microsoft/winget-pkgs` via `winget-releaser` (secret `WINGET_TOKEN`)
    - Version stamping of `server.json`, `.plugin/plugin.json`, `mcpb/manifest.json`, and `lhm.plugin.json` (LobeHub Marketplace) committed back to main by `scripts/update-server-json-sha.sh`
 4. **LobeHub Marketplace is a manual publish step.** The stamping script keeps `lhm.plugin.json`'s version current on every release, but the LobeHub CLI (`@lobehub/market-cli`) has no non-interactive publish path (browser OIDC login + GitHub connect are required once), so it cannot run in CI. After a release, run `make publish-lobehub` from a machine with `lhm login` + `lhm github connect` already completed. The listing is `jmrplens-gitlab-mcp-server`.
+5. **The manifest's capability arrays are generated, its version is not.** LobeHub derives the listing's capability badges from the `tools`, `prompts`, and `resources` arrays in `lhm.plugin.json` — its scanner cannot introspect a server shipped as a binary or an image, so a manifest without them advertises zero tools. `make gen-lhm-manifest` rewrites those three arrays from a live `tools/list` + `prompts/list` + `resources/list` round-trip and leaves every other field, `version` included, to the release stamp. `make check-lhm-manifest` gates freshness in CI and runs before `make publish-lobehub`.
+
+   The generator declares the **default** surface: it pins `dynamic` and talks to an in-process stub client instead of reading `TOOL_SURFACE`, `GITLAB_URL` or `GITLAB_TOKEN`. Anything a generator reads from the environment ships in the committed file, so a developer machine with `TOOL_SURFACE=individual` exported would otherwise publish a different manifest than CI checks. New environment-sensitive inputs belong in `cmd/internal/mcpsurface`, pinned there once for every generator, not read at the call site.
 
 ### Post-implementation verification
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-validate-docs audit-edition-tier \
 	audit-discovery audit-discovery-check audit-e2e-gaps \
 	audit-doc-coverage audit-doc-coverage-check \
-	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms check-server-json check-openplugin check-mcpb mcpb publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
+	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest check-server-json check-openplugin check-mcpb mcpb publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
 	docs-local-go \
        docker-build docker-push docker-run \
        fly-check fly-deploy fly-deploy-release fly-status fly-logs fly-ssh fly-restart \
@@ -452,6 +452,7 @@ audit-docs:
 	npx markdownlint-cli2 README.md AGENTS.md CLAUDE.md CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md "docs/**/*.md" "test/e2e/**/*.md" "cmd/eval_mcp_surfaces/**/*.md" "site/src/content/docs/**/*.mdx" "site/src/content/i18n/**/*.md"
 	go run ./cmd/format_md_tables/ --check
 	go run ./cmd/gen_llms/ --check
+	go run ./cmd/gen_lhm_manifest/ --check
 	go run ./cmd/gen_testing_docs/ --check
 	go run ./cmd/audit_metrics/ -site-stats site/src/data/stats.json -check
 	$(MAKE) check-doc-links
@@ -678,6 +679,14 @@ gen-llms:
 check-llms:
 	go run ./cmd/gen_llms/ --check
 
+## gen-lhm-manifest: regenerate the tools/prompts/resources arrays in lhm.plugin.json.
+gen-lhm-manifest:
+	go run ./cmd/gen_lhm_manifest/
+
+## check-lhm-manifest: verify lhm.plugin.json declares the registered MCP surface.
+check-lhm-manifest:
+	go run ./cmd/gen_lhm_manifest/ --check
+
 ## check-server-json: validate server.json with the official MCP Registry publisher.
 check-server-json:
 	go run github.com/modelcontextprotocol/registry/cmd/publisher@$(MCP_PUBLISHER_VERSION) validate server.json
@@ -713,7 +722,7 @@ mcpb:
 ## on each release) and posts it via the @lobehub/market-cli. Requires a one-time
 ## interactive `lhm login` + `lhm github connect` first — LobeHub has no
 ## non-interactive publish path, so this cannot run in CI. See the release process in CLAUDE.md.
-publish-lobehub:
+publish-lobehub: check-lhm-manifest
 	@command -v node >/dev/null || { echo "ERROR: Node.js >= 22 is required"; exit 1; }
 	@NODE_MAJOR=$$(node -v | sed 's/^v\([0-9]*\).*/\1/'); \
 	if [ "$$NODE_MAJOR" -lt 22 ]; then echo "ERROR: Node.js >= 22 is required (found $$(node -v))"; exit 1; fi
@@ -731,7 +740,7 @@ gen-readme: gen-footprint gen-stats
 
 ## update-all: run every generator and doc updater in one pass.
 ## Generates: token footprint, repo stats, site stats, llms.txt, testing docs, action catalog manifest, markdown table formatting.
-update-all: gen-footprint gen-stats gen-site-stats gen-llms gen-testing-docs gen-action-catalog-manifest
+update-all: gen-footprint gen-stats gen-site-stats gen-llms gen-lhm-manifest gen-testing-docs gen-action-catalog-manifest
 	go run ./cmd/format_md_tables/
 	@echo "All generators and formatters complete."
 

--- a/cmd/gen_lhm_manifest/main.go
+++ b/cmd/gen_lhm_manifest/main.go
@@ -27,11 +27,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -124,9 +126,15 @@ func run(checkOnly bool) error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(rootDir, manifestFileName)
+	// The manifest is addressed relative to an os.Root rooted at the project
+	// directory, so the command can only ever read and write that one file.
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return fmt.Errorf("open project root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
 
-	current, err := os.ReadFile(path) //#nosec G304 -- path is the manifest at the resolved project root
+	current, err := root.ReadFile(manifestFileName)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", manifestFileName, err)
 	}
@@ -144,7 +152,7 @@ func run(checkOnly bool) error {
 		return nil
 	}
 
-	if writeErr := os.WriteFile(path, generated, 0o600); writeErr != nil {
+	if writeErr := root.WriteFile(manifestFileName, generated, 0o600); writeErr != nil {
 		return fmt.Errorf("write %s: %w", manifestFileName, writeErr)
 	}
 	fmt.Printf("Generated %s (%s)\n", manifestFileName, counts)
@@ -155,11 +163,9 @@ func run(checkOnly bool) error {
 // capability arrays replaced by the registered surface and every other field
 // left untouched.
 func generate(current []byte) (out []byte, counts string, err error) {
-	decoder := json.NewDecoder(bytes.NewReader(current))
-	decoder.DisallowUnknownFields()
-	var m manifest
-	if err = decoder.Decode(&m); err != nil {
-		return nil, "", fmt.Errorf("parse %s: %w", manifestFileName, err)
+	m, err := decodeManifest(current)
+	if err != nil {
+		return nil, "", err
 	}
 
 	registered, err := readSurface()
@@ -179,6 +185,50 @@ func generate(current []byte) (out []byte, counts string, err error) {
 	}
 	return buf.Bytes(), fmt.Sprintf("%d tools, %d prompts, %d resources",
 		len(m.Tools), len(m.Prompts), len(m.Resources)), nil
+}
+
+// decodeManifest parses the committed manifest and rejects anything the publish
+// endpoint would not accept: an unknown field, a missing required field, or a
+// second JSON value after the manifest object. Without the trailing-value check
+// a decoder that reads only the first value would let the rest be dropped on the
+// next rewrite; without the required-field check --check would certify a
+// manifest that cannot be published.
+func decodeManifest(current []byte) (manifest, error) {
+	decoder := json.NewDecoder(bytes.NewReader(current))
+	decoder.DisallowUnknownFields()
+	var m manifest
+	if err := decoder.Decode(&m); err != nil {
+		return manifest{}, fmt.Errorf("parse %s: %w", manifestFileName, err)
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return manifest{}, fmt.Errorf("parse %s: unexpected content after the manifest object", manifestFileName)
+	}
+	if err := requireManifestFields(m); err != nil {
+		return manifest{}, err
+	}
+	return m, nil
+}
+
+// requireManifestFields reports the manifest fields the LobeHub publish endpoint
+// treats as mandatory and that this command never fills in.
+func requireManifestFields(m manifest) error {
+	var missing []string
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"identifier", m.Identifier},
+		{"name", m.Name},
+		{"version", m.Version},
+	} {
+		if strings.TrimSpace(field.value) == "" {
+			missing = append(missing, field.name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%s is missing required field(s): %s", manifestFileName, strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // readSurface introspects the registered capabilities over real MCP list

--- a/cmd/gen_lhm_manifest/main.go
+++ b/cmd/gen_lhm_manifest/main.go
@@ -1,0 +1,262 @@
+// Command gen_lhm_manifest regenerates the tools, prompts, and resources arrays
+// in lhm.plugin.json, the manifest published to the LobeHub Marketplace.
+//
+// LobeHub derives a listing's capability badges from the manifest's own
+// tools/prompts/resources arrays — its scanner cannot introspect a server that
+// ships as a Go binary or a Docker image, so a manifest without them lists the
+// server as having zero tools and zero prompts no matter what the server
+// actually registers. The arrays are therefore data we owe the marketplace, and
+// this command derives them from a real tools/list, prompts/list, and
+// resources/list round-trip against an in-memory server rather than from a
+// hand-written copy that would drift on the next release.
+//
+// The declared tool surface is the default one, dynamic, pinned explicitly
+// rather than read from TOOL_SURFACE: the manifest describes what a user gets
+// with no configuration, and reading the environment would make the committed
+// file depend on the machine that generated it.
+//
+// Every other field the manifest carries is preserved, version included — the
+// release stamp owns that one.
+//
+// Usage:
+//
+//	go run ./cmd/gen_lhm_manifest/
+//	go run ./cmd/gen_lhm_manifest/ --check
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/mcpsurface"
+)
+
+// manifestFileName is the LobeHub manifest read by `lhm plugin publish`.
+const manifestFileName = "lhm.plugin.json"
+
+// manifest mirrors the schema accepted by the LobeHub publish endpoint
+// (market.lobehub.com/s/publish-mcp/references/manifest). Every documented field
+// is listed so that decoding with DisallowUnknownFields rejects a typo instead
+// of silently dropping it on the next regeneration — the endpoint strips unknown
+// fields without complaint, which is exactly how a misspelled key would ship.
+//
+// homepage and cloudEndpoint are validated but not stored by the endpoint; they
+// stay in the struct so a manifest that carries them round-trips unchanged.
+type manifest struct {
+	Identifier    string             `json:"identifier"`
+	Name          string             `json:"name"`
+	Version       string             `json:"version"`
+	Description   string             `json:"description,omitempty"`
+	Author        string             `json:"author,omitempty"`
+	AuthorURL     string             `json:"authorUrl,omitempty"`
+	Category      string             `json:"category,omitempty"`
+	Homepage      string             `json:"homepage,omitempty"`
+	CloudEndpoint string             `json:"cloudEndpoint,omitempty"`
+	Icon          string             `json:"icon,omitempty"`
+	Tags          []string           `json:"tags,omitempty"`
+	Localizations []json.RawMessage  `json:"localizations,omitempty"`
+	Tools         []manifestTool     `json:"tools,omitempty"`
+	Prompts       []manifestPrompt   `json:"prompts,omitempty"`
+	Resources     []manifestResource `json:"resources,omitempty"`
+}
+
+// manifestTool is one entry of the manifest's tools array, in the standard MCP
+// tool shape. The output schema and the icons are deliberately left out: neither
+// is part of the shape LobeHub documents, and the icon data URIs alone would
+// triple the file for something the listing never renders.
+type manifestTool struct {
+	Name        string               `json:"name"`
+	Title       string               `json:"title,omitempty"`
+	Description string               `json:"description,omitempty"`
+	InputSchema any                  `json:"inputSchema,omitempty"`
+	Annotations *mcp.ToolAnnotations `json:"annotations,omitempty"`
+}
+
+// manifestPrompt is one entry of the manifest's prompts array, in the standard
+// MCP prompt shape.
+type manifestPrompt struct {
+	Name        string                `json:"name"`
+	Title       string                `json:"title,omitempty"`
+	Description string                `json:"description,omitempty"`
+	Arguments   []*mcp.PromptArgument `json:"arguments,omitempty"`
+}
+
+// manifestResource is one entry of the manifest's resources array. Only static
+// resources are listed: a resource template is identified by a URI template
+// rather than a URI, which the marketplace shape has no field for.
+type manifestResource struct {
+	URI         string           `json:"uri"`
+	Name        string           `json:"name"`
+	Title       string           `json:"title,omitempty"`
+	Description string           `json:"description,omitempty"`
+	MIMEType    string           `json:"mimeType,omitempty"`
+	Annotations *mcp.Annotations `json:"annotations,omitempty"`
+}
+
+// surface holds the registered capabilities the manifest declares.
+type surface struct {
+	tools     []manifestTool
+	prompts   []manifestPrompt
+	resources []manifestResource
+}
+
+func main() {
+	checkOnly := flag.Bool("check", false, "verify the committed manifest matches the registered surface without writing it")
+	flag.Parse()
+
+	if err := run(*checkOnly); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to generate %s: %v\n", manifestFileName, err)
+		os.Exit(1)
+	}
+}
+
+// run rewrites the manifest's capability arrays from the live MCP surface, or,
+// in check mode, reports whether the committed file already matches them.
+func run(checkOnly bool) error {
+	rootDir, err := mcpsurface.ProjectRoot()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(rootDir, manifestFileName)
+
+	current, err := os.ReadFile(path) //#nosec G304 -- path is the manifest at the resolved project root
+	if err != nil {
+		return fmt.Errorf("read %s: %w", manifestFileName, err)
+	}
+
+	generated, counts, err := generate(current)
+	if err != nil {
+		return err
+	}
+
+	if checkOnly {
+		if !bytes.Equal(current, generated) {
+			return fmt.Errorf("%s is stale: run `make gen-lhm-manifest` and commit the result", manifestFileName)
+		}
+		fmt.Printf("%s is current (%s)\n", manifestFileName, counts)
+		return nil
+	}
+
+	if writeErr := os.WriteFile(path, generated, 0o600); writeErr != nil {
+		return fmt.Errorf("write %s: %w", manifestFileName, writeErr)
+	}
+	fmt.Printf("Generated %s (%s)\n", manifestFileName, counts)
+	return nil
+}
+
+// generate returns the manifest bytes that current should have, with the
+// capability arrays replaced by the registered surface and every other field
+// left untouched.
+func generate(current []byte) (out []byte, counts string, err error) {
+	decoder := json.NewDecoder(bytes.NewReader(current))
+	decoder.DisallowUnknownFields()
+	var m manifest
+	if err = decoder.Decode(&m); err != nil {
+		return nil, "", fmt.Errorf("parse %s: %w", manifestFileName, err)
+	}
+
+	registered, err := readSurface()
+	if err != nil {
+		return nil, "", err
+	}
+	m.Tools = registered.tools
+	m.Prompts = registered.prompts
+	m.Resources = registered.resources
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err = encoder.Encode(m); err != nil {
+		return nil, "", fmt.Errorf("encode %s: %w", manifestFileName, err)
+	}
+	return buf.Bytes(), fmt.Sprintf("%d tools, %d prompts, %d resources",
+		len(m.Tools), len(m.Prompts), len(m.Resources)), nil
+}
+
+// readSurface introspects the registered capabilities over real MCP list
+// round-trips against an offline stub client.
+func readSurface() (surface, error) {
+	client, closeStub, err := mcpsurface.NewStubClient()
+	if err != nil {
+		return surface{}, fmt.Errorf("create client: %w", err)
+	}
+	defer closeStub()
+
+	toolList, err := mcpsurface.DynamicTools(client)
+	if err != nil {
+		return surface{}, err
+	}
+	promptList, err := mcpsurface.Prompts(client)
+	if err != nil {
+		return surface{}, err
+	}
+	resourceList, _, err := mcpsurface.Resources(client)
+	if err != nil {
+		return surface{}, err
+	}
+	return surface{
+		tools:     manifestTools(toolList),
+		prompts:   manifestPrompts(promptList),
+		resources: manifestResources(resourceList),
+	}, nil
+}
+
+// manifestTools converts the tools/list result into manifest entries. The
+// dynamic surface arrives find-then-execute; the entries are sorted by name so
+// the file does not churn when that presentation order changes.
+func manifestTools(list []*mcp.Tool) []manifestTool {
+	out := make([]manifestTool, 0, len(list))
+	for _, tool := range list {
+		out = append(out, manifestTool{
+			Name:        tool.Name,
+			Title:       tool.Title,
+			Description: tool.Description,
+			InputSchema: tool.InputSchema,
+			Annotations: tool.Annotations,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// manifestPrompts converts the prompts/list result into manifest entries,
+// ordered by name so the output does not depend on registration order.
+func manifestPrompts(list []*mcp.Prompt) []manifestPrompt {
+	out := make([]manifestPrompt, 0, len(list))
+	for _, prompt := range list {
+		out = append(out, manifestPrompt{
+			Name:        prompt.Name,
+			Title:       prompt.Title,
+			Description: prompt.Description,
+			Arguments:   prompt.Arguments,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// manifestResources converts the resources/list result into manifest entries,
+// ordered by name for the same reason as the prompts.
+func manifestResources(list []*mcp.Resource) []manifestResource {
+	out := make([]manifestResource, 0, len(list))
+	for _, resource := range list {
+		out = append(out, manifestResource{
+			URI:         resource.URI,
+			Name:        resource.Name,
+			Title:       resource.Title,
+			Description: resource.Description,
+			MIMEType:    resource.MIMEType,
+			Annotations: resource.Annotations,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/cmd/gen_lhm_manifest/main_test.go
+++ b/cmd/gen_lhm_manifest/main_test.go
@@ -37,8 +37,8 @@ const populatedManifest = `{
   "resources": []
 }`
 
-// decodeManifest runs generate over in and returns the decoded result.
-func decodeManifest(t *testing.T, in string) manifest {
+// generatedManifest runs generate over in and returns the decoded result.
+func generatedManifest(t *testing.T, in string) manifest {
 	t.Helper()
 	out, _, err := generate([]byte(in))
 	if err != nil {
@@ -58,7 +58,7 @@ func decodeManifest(t *testing.T, in string) manifest {
 // because the release stamp writes it, and a generator that reset it would
 // publish the previous release's number.
 func TestGenerate_PreservesManifestMetadata(t *testing.T) {
-	m := decodeManifest(t, populatedManifest)
+	m := generatedManifest(t, populatedManifest)
 
 	if m.Identifier != "jmrplens-gitlab-mcp-server" || m.Version != "9.9.9" || m.Description != "desc" {
 		t.Fatalf("metadata was not preserved: %+v", m)
@@ -77,7 +77,7 @@ func TestGenerate_PreservesManifestMetadata(t *testing.T) {
 // A tool without a description or an input schema, or a resource without a URI,
 // still counts toward the capability badge but shows up blank in the listing.
 func TestGenerate_FillsEveryCapabilityArray(t *testing.T) {
-	m := decodeManifest(t, populatedManifest)
+	m := generatedManifest(t, populatedManifest)
 
 	if len(m.Tools) == 0 || len(m.Prompts) == 0 || len(m.Resources) == 0 {
 		t.Fatalf("got %d tools, %d prompts, %d resources; want all non-zero", len(m.Tools), len(m.Prompts), len(m.Resources))
@@ -123,7 +123,7 @@ func TestGenerate_ReportsCapabilityCounts(t *testing.T) {
 func TestGenerate_DeclaresDefaultDynamicSurface(t *testing.T) {
 	t.Setenv("TOOL_SURFACE", "individual")
 
-	m := decodeManifest(t, minimalManifest)
+	m := generatedManifest(t, minimalManifest)
 
 	if len(m.Tools) != 2 {
 		t.Fatalf("len(tools) = %d, want the 2 dynamic tools", len(m.Tools))
@@ -207,11 +207,39 @@ func TestGenerate_RejectsUnknownField(t *testing.T) {
 	}
 }
 
-// TestGenerate_InvalidJSON verifies a malformed manifest is reported rather than
-// silently overwritten with a freshly generated one.
-func TestGenerate_InvalidJSON(t *testing.T) {
-	if _, _, err := generate([]byte("{not json")); err == nil {
-		t.Fatal("generate() error = nil, want a parse error")
+// TestGenerate_RejectsUnpublishableManifest verifies a manifest the publish
+// endpoint would reject fails here instead of being rewritten and certified by
+// --check.
+//
+// Malformed JSON, a manifest missing a required field, and a second JSON value
+// after the object all have to fail: the decoder reads one value, so trailing
+// content would otherwise be dropped silently on the next rewrite.
+func TestGenerate_RejectsUnpublishableManifest(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		{name: "malformed json", in: "{not json", wantErr: "parse"},
+		{name: "missing identifier", in: `{"name": "y", "version": "1.0.0"}`, wantErr: "identifier"},
+		{name: "missing name and version", in: `{"identifier": "x"}`, wantErr: "name, version"},
+		{name: "blank version", in: `{"identifier": "x", "name": "y", "version": "  "}`, wantErr: "version"},
+		{
+			name:    "trailing json value",
+			in:      `{"identifier": "x", "name": "y", "version": "1.0.0"} {"identifier": "z"}`,
+			wantErr: "unexpected content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := generate([]byte(tt.in))
+			if err == nil {
+				t.Fatalf("generate(%s) error = nil, want an error", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("generate(%s) error = %v, want it to mention %q", tt.name, err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/cmd/gen_lhm_manifest/main_test.go
+++ b/cmd/gen_lhm_manifest/main_test.go
@@ -1,0 +1,263 @@
+// main_test.go covers LobeHub manifest generation: the capability arrays are
+// filled from the registered MCP surface, every other manifest field survives a
+// regeneration, and a malformed or misspelled manifest fails loudly instead of
+// being overwritten.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// minimalManifest is the smallest input generate accepts: the three required
+// fields and nothing else.
+const minimalManifest = `{
+  "identifier": "jmrplens-gitlab-mcp-server",
+  "name": "GitLab MCP Server",
+  "version": "9.9.9"
+}`
+
+// populatedManifest is a manifest carrying every metadata field the generator
+// must leave alone, plus empty capability arrays for it to fill.
+const populatedManifest = `{
+  "identifier": "jmrplens-gitlab-mcp-server",
+  "name": "GitLab MCP Server",
+  "version": "9.9.9",
+  "description": "desc",
+  "author": "Someone",
+  "authorUrl": "https://example.com",
+  "icon": "https://example.com/icon.png",
+  "tags": ["a", "b"],
+  "tools": [],
+  "prompts": [],
+  "resources": []
+}`
+
+// decodeManifest runs generate over in and returns the decoded result.
+func decodeManifest(t *testing.T, in string) manifest {
+	t.Helper()
+	out, _, err := generate([]byte(in))
+	if err != nil {
+		t.Fatalf("generate() error: %v", err)
+	}
+	var m manifest
+	if decodeErr := json.Unmarshal(out, &m); decodeErr != nil {
+		t.Fatalf("unmarshal generated manifest: %v", decodeErr)
+	}
+	return m
+}
+
+// TestGenerate_PreservesManifestMetadata verifies the capability arrays are the
+// only thing this command owns.
+//
+// The icon, the tags, and the version are carried over verbatim — the last one
+// because the release stamp writes it, and a generator that reset it would
+// publish the previous release's number.
+func TestGenerate_PreservesManifestMetadata(t *testing.T) {
+	m := decodeManifest(t, populatedManifest)
+
+	if m.Identifier != "jmrplens-gitlab-mcp-server" || m.Version != "9.9.9" || m.Description != "desc" {
+		t.Fatalf("metadata was not preserved: %+v", m)
+	}
+	if m.Icon != "https://example.com/icon.png" {
+		t.Fatalf("icon = %q, want it preserved", m.Icon)
+	}
+	if len(m.Tags) != 2 {
+		t.Fatalf("tags = %v, want both preserved", m.Tags)
+	}
+}
+
+// TestGenerate_FillsEveryCapabilityArray verifies each generated entry carries
+// the fields the marketplace listing renders.
+//
+// A tool without a description or an input schema, or a resource without a URI,
+// still counts toward the capability badge but shows up blank in the listing.
+func TestGenerate_FillsEveryCapabilityArray(t *testing.T) {
+	m := decodeManifest(t, populatedManifest)
+
+	if len(m.Tools) == 0 || len(m.Prompts) == 0 || len(m.Resources) == 0 {
+		t.Fatalf("got %d tools, %d prompts, %d resources; want all non-zero", len(m.Tools), len(m.Prompts), len(m.Resources))
+	}
+	for _, tool := range m.Tools {
+		if tool.Name == "" || tool.Description == "" || tool.InputSchema == nil {
+			t.Fatalf("tool %q is missing name, description, or inputSchema", tool.Name)
+		}
+	}
+	for _, prompt := range m.Prompts {
+		if prompt.Name == "" || prompt.Description == "" {
+			t.Fatalf("prompt %q is missing name or description", prompt.Name)
+		}
+	}
+	for _, resource := range m.Resources {
+		if resource.URI == "" || resource.Name == "" {
+			t.Fatalf("resource %q is missing uri or name", resource.Name)
+		}
+	}
+}
+
+// TestGenerate_ReportsCapabilityCounts verifies the summary the command prints
+// names all three capability arrays, so a run that silently produced an empty
+// one is visible in the output.
+func TestGenerate_ReportsCapabilityCounts(t *testing.T) {
+	_, counts, err := generate([]byte(minimalManifest))
+	if err != nil {
+		t.Fatalf("generate() error: %v", err)
+	}
+	for _, want := range []string{"tools", "prompts", "resources"} {
+		if !strings.Contains(counts, want) {
+			t.Fatalf("counts summary = %q, want it to mention %q", counts, want)
+		}
+	}
+}
+
+// TestGenerate_DeclaresDefaultDynamicSurface verifies the manifest describes the
+// two-tool dynamic surface a user gets with no configuration.
+//
+// TOOL_SURFACE is set to a different catalog for the duration of the test, and
+// the expected result is unchanged output: reading the environment here would
+// make the committed file depend on the machine that generated it.
+func TestGenerate_DeclaresDefaultDynamicSurface(t *testing.T) {
+	t.Setenv("TOOL_SURFACE", "individual")
+
+	m := decodeManifest(t, minimalManifest)
+
+	if len(m.Tools) != 2 {
+		t.Fatalf("len(tools) = %d, want the 2 dynamic tools", len(m.Tools))
+	}
+	names := []string{m.Tools[0].Name, m.Tools[1].Name}
+	want := []string{"gitlab_execute_action", "gitlab_find_action"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("tools = %v, want %v", names, want)
+		}
+	}
+}
+
+// TestGenerate_OmitsOutputSchemaAndIcons verifies the generated tool entries
+// carry only the documented marketplace shape.
+//
+// The output schemas and the base64 icon data URIs are dropped: neither is part
+// of the shape LobeHub documents, and the icons alone would triple the file for
+// something the listing never renders.
+func TestGenerate_OmitsOutputSchemaAndIcons(t *testing.T) {
+	out, _, err := generate([]byte(minimalManifest))
+	if err != nil {
+		t.Fatalf("generate() error: %v", err)
+	}
+
+	var raw struct {
+		Tools     []map[string]json.RawMessage `json:"tools"`
+		Prompts   []map[string]json.RawMessage `json:"prompts"`
+		Resources []map[string]json.RawMessage `json:"resources"`
+	}
+	if decodeErr := json.Unmarshal(out, &raw); decodeErr != nil {
+		t.Fatalf("unmarshal generated manifest: %v", decodeErr)
+	}
+	groups := map[string][]map[string]json.RawMessage{
+		"tool": raw.Tools, "prompt": raw.Prompts, "resource": raw.Resources,
+	}
+	for kind, entries := range groups {
+		for _, entry := range entries {
+			for _, unwanted := range []string{"outputSchema", "icons", "_meta"} {
+				if _, found := entry[unwanted]; found {
+					t.Fatalf("%s entry carries %q, want it dropped", kind, unwanted)
+				}
+			}
+		}
+	}
+}
+
+// TestGenerate_Idempotent verifies that re-running generate over its own output
+// changes nothing. The --check gate compares bytes, so any instability here
+// would fail CI on a machine that merely ran the generator twice.
+func TestGenerate_Idempotent(t *testing.T) {
+	first, _, err := generate([]byte(minimalManifest))
+	if err != nil {
+		t.Fatalf("first generate() error: %v", err)
+	}
+	second, _, err := generate(first)
+	if err != nil {
+		t.Fatalf("second generate() error: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("generate() is not idempotent: a second run produced different bytes")
+	}
+}
+
+// TestGenerate_RejectsUnknownField verifies a misspelled key fails loudly.
+//
+// LobeHub's publish endpoint strips unknown fields silently, so a typo would
+// otherwise be dropped here and never noticed in the listing either. Note the
+// limit of the guard: encoding/json matches field names case-insensitively, so
+// "authorURL" still binds to authorUrl. It catches a wrong name, not wrong
+// casing.
+func TestGenerate_RejectsUnknownField(t *testing.T) {
+	in := []byte(`{"identifier": "x", "name": "y", "version": "1.0.0", "autorUrl": "https://example.com"}`)
+
+	_, _, err := generate(in)
+	if err == nil {
+		t.Fatal("generate() error = nil, want an error for an unknown field")
+	}
+	if !strings.Contains(err.Error(), "autorUrl") {
+		t.Fatalf("generate() error = %v, want it to name the offending field", err)
+	}
+}
+
+// TestGenerate_InvalidJSON verifies a malformed manifest is reported rather than
+// silently overwritten with a freshly generated one.
+func TestGenerate_InvalidJSON(t *testing.T) {
+	if _, _, err := generate([]byte("{not json")); err == nil {
+		t.Fatal("generate() error = nil, want a parse error")
+	}
+}
+
+// TestManifestPrompts_SortedByName verifies prompts come out in name order, so
+// the file does not churn when registration order changes.
+func TestManifestPrompts_SortedByName(t *testing.T) {
+	got := manifestPrompts([]*mcp.Prompt{
+		{Name: "review_mr"},
+		{Name: "audit_project_full"},
+		{Name: "my_open_mrs"},
+	})
+
+	want := []string{"audit_project_full", "my_open_mrs", "review_mr"}
+	for i := range want {
+		if got[i].Name != want[i] {
+			t.Fatalf("position %d = %q, want %q", i, got[i].Name, want[i])
+		}
+	}
+}
+
+// TestManifestResources_SortedByName verifies resources are ordered by name and
+// keep the URI and annotations the listing displays.
+func TestManifestResources_SortedByName(t *testing.T) {
+	got := manifestResources([]*mcp.Resource{
+		{Name: "groups", URI: "gitlab://groups"},
+		{Name: "current_user", URI: "gitlab://user/current", Annotations: &mcp.Annotations{Priority: 0.6}},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("len(manifestResources()) = %d, want 2", len(got))
+	}
+	if got[0].Name != "current_user" || got[1].Name != "groups" {
+		t.Fatalf("resources = %q/%q, want current_user before groups", got[0].Name, got[1].Name)
+	}
+	if got[0].URI != "gitlab://user/current" || got[0].Annotations == nil {
+		t.Fatalf("resource fields were dropped: %+v", got[0])
+	}
+}
+
+// TestRun_CheckModeAcceptsCommittedManifest verifies the committed
+// lhm.plugin.json matches the registered surface.
+//
+// This is the same gate CI runs; failing here means the manifest needs
+// regenerating before the marketplace listing goes stale.
+func TestRun_CheckModeAcceptsCommittedManifest(t *testing.T) {
+	if err := run(true); err != nil {
+		t.Fatalf("run(true) error: %v", err)
+	}
+}

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -26,14 +25,11 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/mcpsurface"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/resources"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
-	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -74,10 +70,8 @@ const (
 	// site rather than living only in the repository.
 	siteBaseURL = "https://jmrplens.github.io/gitlab-mcp-server/"
 
-	dynamicFindToolName          = "gitlab_find_action"
-	dynamicExecuteActionToolName = "gitlab_execute_action"
-	llmsSummaryItemFormat        = "- %s: %s\n"
-	llmsBoldTitleFormat          = "**%s**\n\n"
+	llmsSummaryItemFormat = "- %s: %s\n"
+	llmsBoldTitleFormat   = "**%s**\n\n"
 )
 
 // llmsCatalog holds the full introspection result of one MCP server build,
@@ -116,25 +110,22 @@ func main() {
 // run introspects the live MCP catalog and regenerates llms.txt and
 // llms-full.txt in the project root.
 func run(checkOnly bool) error {
-	rootDir, err := findProjectRoot()
+	rootDir, err := mcpsurface.ProjectRoot()
 	if err != nil {
 		return err
 	}
 
-	client, closeStub, err := auditshared.NewStubGitLabClient("gen-llms-token") //#nosec G101 -- not a real credential, test-only dummy token
+	client, closeStub, err := mcpsurface.NewStubClient()
 	if err != nil {
 		return fmt.Errorf("create client: %w", err)
 	}
 	defer closeStub()
-	gitLabComClient, err := gitlabclient.NewClient(&config.Config{ //#nosec G101 -- not a real credential, test-only dummy token
-		GitLabURL:   config.DefaultGitLabURL,
-		GitLabToken: "gen-llms-token",
-	})
+	gitLabComClient, err := mcpsurface.NewGitLabComClient()
 	if err != nil {
-		return fmt.Errorf("create gitlab.com client: %w", err)
+		return err
 	}
 	version := readVersion(rootDir)
-	res, resTpl, err := listResources(client)
+	res, resTpl, err := mcpsurface.Resources(client)
 	if err != nil {
 		return err
 	}
@@ -158,7 +149,7 @@ func run(checkOnly bool) error {
 	if err != nil {
 		return err
 	}
-	dynamicTools, err := listDynamicTools(gitLabComClient)
+	dynamicTools, err := mcpsurface.DynamicTools(gitLabComClient)
 	if err != nil {
 		return err
 	}
@@ -166,7 +157,7 @@ func run(checkOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("build meta action catalog: %w", err)
 	}
-	promptList, err := listPrompts(client)
+	promptList, err := mcpsurface.Prompts(client)
 	if err != nil {
 		return err
 	}
@@ -215,41 +206,10 @@ func readVersion(rootDir string) string {
 	return strings.TrimSpace(string(data))
 }
 
-// newSession creates an in-memory MCP server+client session with high page size.
-func newSession(setupServer func(*mcp.Server) error) (session *mcp.ClientSession, cleanup func(), err error) {
-	opts := &mcp.ServerOptions{PageSize: 2000}
-	server := mcp.NewServer(&mcp.Implementation{Name: "gen-llms", Version: "0.0.1"}, opts)
-	if setupErr := setupServer(server); setupErr != nil {
-		return nil, nil, setupErr
-	}
-	toolutil.LockdownInputSchemas(server)
-
-	st, ct := mcp.NewInMemoryTransports()
-	ctx := context.Background()
-
-	serverSession, err := server.Connect(ctx, st, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("server connect: %w", err)
-	}
-
-	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "gen-llms-client", Version: "0.0.1"}, nil)
-	session, err = mcpClient.Connect(ctx, ct, nil)
-	if err != nil {
-		_ = serverSession.Close()
-		_ = serverSession.Wait()
-		return nil, nil, fmt.Errorf("client connect: %w", err)
-	}
-
-	return session, func() {
-		_ = session.Close()
-		_ = serverSession.Wait()
-	}, nil
-}
-
 // listTools returns either the enterprise individual catalog or the base
 // meta-tool catalog, depending on meta.
 func listTools(client *gitlabclient.Client, meta bool) ([]*mcp.Tool, error) {
-	session, cleanup, err := newSession(func(server *mcp.Server) error {
+	session, cleanup, err := mcpsurface.Session(func(server *mcp.Server) error {
 		if meta {
 			return tools.RegisterAllMeta(server, client, edition.Free)
 		}
@@ -270,7 +230,7 @@ func listTools(client *gitlabclient.Client, meta bool) ([]*mcp.Tool, error) {
 
 // listToolsEnterprise returns the Enterprise/Premium meta-tool catalog.
 func listToolsEnterprise(client *gitlabclient.Client) ([]*mcp.Tool, error) {
-	session, cleanup, err := newSession(func(server *mcp.Server) error {
+	session, cleanup, err := mcpsurface.Session(func(server *mcp.Server) error {
 		return tools.RegisterAllMeta(server, client, edition.Ultimate)
 	})
 	if err != nil {
@@ -283,128 +243,6 @@ func listToolsEnterprise(client *gitlabclient.Client) ([]*mcp.Tool, error) {
 		return nil, fmt.Errorf("list enterprise tools: %w", err)
 	}
 	return result.Tools, nil
-}
-
-// listDynamicTools returns the visible two-tool dynamic catalog from a real MCP
-// tools/list session.
-func listDynamicTools(client *gitlabclient.Client) ([]*mcp.Tool, error) {
-	catalog, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		return nil, fmt.Errorf("build dynamic action catalog: %w", err)
-	}
-	catalog, err = dynamictools.AddStandaloneCatalog(catalog, client, dynamictools.StandaloneOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("add dynamic standalone catalog: %w", err)
-	}
-	session, cleanup, err := newSession(func(server *mcp.Server) error {
-		dynamictools.RegisterCatalogFindExecuteTools(server, catalog)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	defer cleanup()
-
-	result, err := session.ListTools(context.Background(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list dynamic tools: %w", err)
-	}
-	sortDynamicTools(result.Tools)
-	if contractErr := validateDynamicToolContract(result.Tools); contractErr != nil {
-		return nil, contractErr
-	}
-	return result.Tools, nil
-}
-
-func sortDynamicTools(dynamicTools []*mcp.Tool) {
-	order := map[string]int{
-		dynamicFindToolName:          0,
-		dynamicExecuteActionToolName: 1,
-	}
-	sort.SliceStable(dynamicTools, func(i, j int) bool {
-		left, leftOK := order[dynamicTools[i].Name]
-		right, rightOK := order[dynamicTools[j].Name]
-		if leftOK && rightOK {
-			return left < right
-		}
-		if leftOK != rightOK {
-			return leftOK
-		}
-		return dynamicTools[i].Name < dynamicTools[j].Name
-	})
-}
-
-func validateDynamicToolContract(dynamicTools []*mcp.Tool) error {
-	expected := []string{dynamicFindToolName, dynamicExecuteActionToolName}
-	if len(dynamicTools) != len(expected) {
-		return fmt.Errorf("expected %d dynamic tools, got %d", len(expected), len(dynamicTools))
-	}
-	for i, name := range expected {
-		if dynamicTools[i].Name != name {
-			return fmt.Errorf("unexpected dynamic tool %q at position %d", dynamicTools[i].Name, i)
-		}
-	}
-	return nil
-}
-
-// listResources returns the static resources and resource templates advertised
-// by the MCP server, including the surface-aware tool manifest template.
-func listResources(client *gitlabclient.Client) ([]*mcp.Resource, []*mcp.ResourceTemplate, error) {
-	dynamicCatalog, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{IncludeMCP: true})
-	if err != nil {
-		return nil, nil, fmt.Errorf("build dynamic action catalog: %w", err)
-	}
-	dynamicCatalog, err = dynamictools.AddStandaloneCatalog(dynamicCatalog, client, dynamictools.StandaloneOptions{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("add dynamic standalone catalog: %w", err)
-	}
-	dynamicTools, err := listDynamicTools(client)
-	if err != nil {
-		return nil, nil, err
-	}
-	session, cleanup, err := newSession(func(server *mcp.Server) error {
-		resources.Register(server, client)
-		resources.RegisterToolSurfaceResources(server, resources.ToolSurfaceResourceOptions{
-			Surface: config.ToolSurfaceDynamic,
-			Tools:   dynamicTools,
-			Catalog: dynamicCatalog,
-		})
-		resources.RegisterWorkflowGuides(server)
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	defer cleanup()
-
-	ctx := context.Background()
-	res, err := session.ListResources(ctx, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list resources: %w", err)
-	}
-	tpl, err := session.ListResourceTemplates(ctx, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list resource templates: %w", err)
-	}
-	return res.Resources, tpl.ResourceTemplates, nil
-}
-
-// listPrompts returns all registered MCP prompt definitions for llms output.
-func listPrompts(client *gitlabclient.Client) ([]*mcp.Prompt, error) {
-	session, cleanup, err := newSession(func(server *mcp.Server) error {
-		prompts.Register(server, client)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	defer cleanup()
-
-	result, err := session.ListPrompts(context.Background(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("list prompts: %w", err)
-	}
-	return result.Prompts, nil
 }
 
 // writeLLMSTxt generates the concise llms.txt overview.
@@ -1257,7 +1095,7 @@ func writeGeneratedFile(name, content string, checkOnly bool) error {
 	if !isGeneratedLLMSFile(name) {
 		return fmt.Errorf("unexpected generated file %q", name)
 	}
-	dir, err := findProjectRoot()
+	dir, err := mcpsurface.ProjectRoot()
 	if err != nil {
 		return err
 	}
@@ -1291,23 +1129,5 @@ func isGeneratedLLMSFile(name string) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-// findProjectRoot walks up from cwd looking for go.mod.
-func findProjectRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	for {
-		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", errors.New("could not find project root (no go.mod found)")
-		}
-		dir = parent
 	}
 }

--- a/cmd/gen_llms/main_test.go
+++ b/cmd/gen_llms/main_test.go
@@ -8,94 +8,15 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
-	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
-
-// newGenLLMSClient creates a [gitlabclient.Client] backed by a mock
-// /api/v4/version endpoint for gen_llms tests.
-func newGenLLMSClient(t *testing.T) *gitlabclient.Client {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	t.Cleanup(srv.Close)
-
-	client, err := gitlabclient.NewClient(&config.Config{GitLabURL: srv.URL, GitLabToken: "gen-llms-token"})
-	if err != nil {
-		t.Fatalf("NewClient() error: %v", err)
-	}
-	return client
-}
-
-// TestListDynamicTools_ExposesFindAndExecute verifies dynamic llms generation
-// exposes only the find and execute tools in deterministic order.
-//
-// The test builds a mock GitLab-backed client, lists dynamic tools, and checks
-// the execute input schema for action, params, and confirm fields. This protects
-// the low-token dynamic contract consumed by generated LLM discovery files.
-func TestListDynamicTools_ExposesFindAndExecute(t *testing.T) {
-	tools, err := listDynamicTools(newGenLLMSClient(t))
-	if err != nil {
-		t.Fatalf("listDynamicTools() error: %v", err)
-	}
-	if len(tools) != 2 {
-		t.Fatalf("len(listDynamicTools()) = %d, want 2", len(tools))
-	}
-	names := []string{tools[0].Name, tools[1].Name}
-	if names[0] != dynamicFindToolName || names[1] != dynamicExecuteActionToolName {
-		t.Fatalf("dynamic tools = %v, want find before execute", names)
-	}
-
-	executeSchema, ok := tools[1].InputSchema.(map[string]any)
-	if !ok {
-		t.Fatalf("execute InputSchema has type %T, want map[string]any", tools[1].InputSchema)
-	}
-	executeProperties, ok := executeSchema["properties"].(map[string]any)
-	if !ok {
-		t.Fatalf("execute InputSchema properties has type %T, want map[string]any", executeSchema["properties"])
-	}
-	for _, property := range []string{"action", "params", "confirm"} {
-		if _, exists := executeProperties[property]; !exists {
-			t.Fatalf("execute InputSchema missing %q property: %v", property, executeProperties)
-		}
-	}
-	required, ok := executeSchema["required"].([]any)
-	if !ok {
-		t.Fatalf("execute InputSchema required has type %T, want []any", executeSchema["required"])
-	}
-	if !slices.Contains(required, any("action")) || !slices.Contains(required, any("params")) {
-		t.Fatalf("execute InputSchema required = %v, want action and params", required)
-	}
-}
-
-// TestValidateDynamicToolContract_RejectsDrift verifies the generated dynamic
-// tool contract fails when the expected find/execute pair changes.
-//
-// The happy-path assertion accepts the canonical two-tool list, while the drift
-// assertion removes find and expects validation to fail. This keeps accidental
-// dynamic surface changes visible during llms generation.
-func TestValidateDynamicToolContract_RejectsDrift(t *testing.T) {
-	if err := validateDynamicToolContract([]*mcp.Tool{{Name: dynamicFindToolName}, {Name: dynamicExecuteActionToolName}}); err != nil {
-		t.Fatalf("validateDynamicToolContract() error = %v", err)
-	}
-	if err := validateDynamicToolContract([]*mcp.Tool{{Name: dynamicExecuteActionToolName}}); err == nil {
-		t.Fatal("validateDynamicToolContract() error = nil, want error")
-	}
-}
 
 // TestReadVersion_UsesProjectRoot verifies readVersion reads VERSION from the
 // supplied project root and trims trailing whitespace.
@@ -111,34 +32,6 @@ func TestReadVersion_UsesProjectRoot(t *testing.T) {
 
 	if got := readVersion(dir); got != "2.1.0" {
 		t.Fatalf("readVersion() = %q, want 2.1.0", got)
-	}
-}
-
-// TestListResources_IncludesToolManifestTemplate verifies llms generation sees
-// the unified tool manifest template alongside regular resources.
-func TestListResources_IncludesToolManifestTemplate(t *testing.T) {
-	resources, templates, err := listResources(newGenLLMSClient(t))
-	if err != nil {
-		t.Fatalf("listResources() error: %v", err)
-	}
-	if len(resources) == 0 {
-		t.Fatal("listResources() returned no static resources")
-	}
-	wantTemplates := map[string]bool{
-		"gitlab://tools/{id}": false,
-	}
-	for _, template := range templates {
-		if template.URITemplate == "gitlab://schema/meta/{tool}/{action}" || template.URITemplate == "gitlab://schema/dynamic/{action}" {
-			t.Fatalf("listResources() exposed legacy schema template %s: %v", template.URITemplate, templates)
-		}
-		if _, ok := wantTemplates[template.URITemplate]; ok {
-			wantTemplates[template.URITemplate] = true
-		}
-	}
-	for uri, found := range wantTemplates {
-		if !found {
-			t.Fatalf("listResources() templates missing %s: %v", uri, templates)
-		}
 	}
 }
 

--- a/cmd/internal/mcpsurface/surface.go
+++ b/cmd/internal/mcpsurface/surface.go
@@ -1,0 +1,265 @@
+// Package mcpsurface introspects the registered MCP surface for the generator
+// commands.
+//
+// Several commands under cmd/ need the same thing: the tools, prompts and
+// resources the server actually registers, read over a real MCP round-trip
+// rather than described by hand, and against a surface that does not depend on
+// the ambient environment. The server chooses its catalog from TOOL_SURFACE and
+// its client from GITLAB_URL/GITLAB_TOKEN, so a generator that read either would
+// emit different files on a developer machine than in CI. Every constructor here
+// pins the surface explicitly and talks to an in-process stub instead, which is
+// what makes the committed artifacts reproducible.
+package mcpsurface
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/resources"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
+	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// The dynamic surface is the default a user gets with no configuration, and it
+// is a fixed two-tool contract. Generators name the pair so a rename shows up as
+// a failed generation rather than as silently different output.
+const (
+	DynamicFindToolName          = "gitlab_find_action"
+	DynamicExecuteActionToolName = "gitlab_execute_action"
+)
+
+// listPageSize is high enough that the whole surface arrives in a single list
+// response, so callers never have to paginate.
+const listPageSize = 2000
+
+// StubToken is the dummy credential the generators authenticate their stub
+// client with. It is never sent to a real GitLab instance: NewStubClient points
+// the client at an in-process HTTP server. A generator must not fall back to
+// GITLAB_TOKEN, or a machine that exports one would produce different output
+// from a machine that does not.
+const StubToken = "gen-surface-token" //#nosec G101 -- not a real credential, in-process stub only
+
+// NewStubClient returns a GitLab client backed by an in-process stub that
+// answers every request with a fixed version payload, plus the cleanup func that
+// shuts the stub down. Catalog construction needs a client but performs no real
+// request, so this keeps generation offline and identical on every machine.
+func NewStubClient() (*gitlabclient.Client, func(), error) {
+	return auditshared.NewStubGitLabClient(StubToken)
+}
+
+// NewGitLabComClient returns a client pinned to the public GitLab.com URL. The
+// catalog registers the GitLab.com-only tools (Orbit) against it, so generated
+// documentation can describe the full capability set rather than whatever the
+// ambient GITLAB_URL points at.
+func NewGitLabComClient() (*gitlabclient.Client, error) {
+	client, err := gitlabclient.NewClient(&config.Config{
+		GitLabURL:   config.DefaultGitLabURL,
+		GitLabToken: StubToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create gitlab.com client: %w", err)
+	}
+	return client, nil
+}
+
+// Session creates an in-memory MCP server+client pair, applies setup to the
+// server, and returns the connected client session together with a cleanup
+// function the caller must invoke.
+func Session(setup func(*mcp.Server) error) (session *mcp.ClientSession, cleanup func(), err error) {
+	opts := &mcp.ServerOptions{PageSize: listPageSize}
+	server := mcp.NewServer(&mcp.Implementation{Name: "mcpsurface", Version: "0.0.1"}, opts)
+	if setupErr := setup(server); setupErr != nil {
+		return nil, nil, setupErr
+	}
+	toolutil.LockdownInputSchemas(server)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server connect: %w", err)
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "mcpsurface-client", Version: "0.0.1"}, nil)
+	session, err = mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		_ = serverSession.Close()
+		_ = serverSession.Wait()
+		return nil, nil, fmt.Errorf("client connect: %w", err)
+	}
+
+	return session, func() {
+		_ = session.Close()
+		_ = serverSession.Wait()
+	}, nil
+}
+
+// DynamicCatalog builds the canonical action catalog behind the dynamic
+// find/execute surface, including the standalone actions that are not part of
+// any domain meta-tool. enterprise selects the Premium/Ultimate catalog.
+func DynamicCatalog(client *gitlabclient.Client, enterprise bool) (*actioncatalog.Catalog, error) {
+	catalog, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Enterprise: enterprise, IncludeMCP: true})
+	if err != nil {
+		return nil, fmt.Errorf("build dynamic action catalog: %w", err)
+	}
+	catalog, err = dynamictools.AddStandaloneCatalog(catalog, client, dynamictools.StandaloneOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("add dynamic standalone catalog: %w", err)
+	}
+	return catalog, nil
+}
+
+// DynamicTools returns the visible two-tool dynamic catalog from a real MCP
+// tools/list session, in find-then-execute order.
+func DynamicTools(client *gitlabclient.Client) ([]*mcp.Tool, error) {
+	catalog, err := DynamicCatalog(client, true)
+	if err != nil {
+		return nil, err
+	}
+	session, cleanup, err := Session(func(server *mcp.Server) error {
+		dynamictools.RegisterCatalogFindExecuteTools(server, catalog)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	result, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list dynamic tools: %w", err)
+	}
+	SortDynamicTools(result.Tools)
+	if contractErr := ValidateDynamicToolContract(result.Tools); contractErr != nil {
+		return nil, contractErr
+	}
+	return result.Tools, nil
+}
+
+// SortDynamicTools orders the dynamic surface find-then-execute, which is the
+// order a model should use them in, and sorts anything unexpected by name so the
+// output stays deterministic.
+func SortDynamicTools(dynamicTools []*mcp.Tool) {
+	order := map[string]int{
+		DynamicFindToolName:          0,
+		DynamicExecuteActionToolName: 1,
+	}
+	sort.SliceStable(dynamicTools, func(i, j int) bool {
+		left, leftOK := order[dynamicTools[i].Name]
+		right, rightOK := order[dynamicTools[j].Name]
+		if leftOK && rightOK {
+			return left < right
+		}
+		if leftOK != rightOK {
+			return leftOK
+		}
+		return dynamicTools[i].Name < dynamicTools[j].Name
+	})
+}
+
+// ValidateDynamicToolContract fails when the dynamic surface is no longer
+// exactly find plus execute, so a rename or an extra tool aborts generation
+// instead of quietly rewriting every generated artifact.
+func ValidateDynamicToolContract(dynamicTools []*mcp.Tool) error {
+	expected := []string{DynamicFindToolName, DynamicExecuteActionToolName}
+	if len(dynamicTools) != len(expected) {
+		return fmt.Errorf("expected %d dynamic tools, got %d", len(expected), len(dynamicTools))
+	}
+	for i, name := range expected {
+		if dynamicTools[i].Name != name {
+			return fmt.Errorf("unexpected dynamic tool %q at position %d", dynamicTools[i].Name, i)
+		}
+	}
+	return nil
+}
+
+// Resources returns the static resources and resource templates advertised by
+// the MCP server, including the surface-aware tool manifest template. The
+// manifest is rendered for the dynamic surface because that is what a user gets
+// by default.
+func Resources(client *gitlabclient.Client) ([]*mcp.Resource, []*mcp.ResourceTemplate, error) {
+	dynamicCatalog, err := DynamicCatalog(client, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	dynamicTools, err := DynamicTools(client)
+	if err != nil {
+		return nil, nil, err
+	}
+	session, cleanup, err := Session(func(server *mcp.Server) error {
+		resources.Register(server, client)
+		resources.RegisterToolSurfaceResources(server, resources.ToolSurfaceResourceOptions{
+			Surface: config.ToolSurfaceDynamic,
+			Tools:   dynamicTools,
+			Catalog: dynamicCatalog,
+		})
+		resources.RegisterWorkflowGuides(server)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cleanup()
+
+	ctx := context.Background()
+	res, err := session.ListResources(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list resources: %w", err)
+	}
+	tpl, err := session.ListResourceTemplates(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list resource templates: %w", err)
+	}
+	return res.Resources, tpl.ResourceTemplates, nil
+}
+
+// Prompts returns every registered MCP prompt definition over a real
+// prompts/list round-trip.
+func Prompts(client *gitlabclient.Client) ([]*mcp.Prompt, error) {
+	session, cleanup, err := Session(func(server *mcp.Server) error {
+		prompts.Register(server, client)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	result, err := session.ListPrompts(context.Background(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list prompts: %w", err)
+	}
+	return result.Prompts, nil
+}
+
+// ProjectRoot walks up from the working directory to the directory holding
+// go.mod, so a generator works from anywhere in the repository.
+func ProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not find project root (no go.mod found)")
+		}
+		dir = parent
+	}
+}

--- a/cmd/internal/mcpsurface/surface.go
+++ b/cmd/internal/mcpsurface/surface.go
@@ -81,7 +81,7 @@ func Session(setup func(*mcp.Server) error) (session *mcp.ClientSession, cleanup
 	opts := &mcp.ServerOptions{PageSize: listPageSize}
 	server := mcp.NewServer(&mcp.Implementation{Name: "mcpsurface", Version: "0.0.1"}, opts)
 	if setupErr := setup(server); setupErr != nil {
-		return nil, nil, setupErr
+		return nil, nil, fmt.Errorf("set up MCP server: %w", setupErr)
 	}
 	toolutil.LockdownInputSchemas(server)
 

--- a/cmd/internal/mcpsurface/surface_test.go
+++ b/cmd/internal/mcpsurface/surface_test.go
@@ -1,0 +1,209 @@
+// surface_test.go covers the shared MCP introspection helpers the generator
+// commands build on: the pinned dynamic two-tool contract, resource and prompt
+// discovery over a real in-memory round-trip, and project-root resolution.
+package mcpsurface
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+)
+
+// newStubClientForTest builds the offline GitLab client the surface helpers run
+// against and registers its shutdown with the test.
+func newStubClientForTest(t *testing.T) *gitlabclient.Client {
+	t.Helper()
+	client, cleanup, err := NewStubClient()
+	if err != nil {
+		t.Fatalf("NewStubClient() error: %v", err)
+	}
+	t.Cleanup(cleanup)
+	return client
+}
+
+// TestDynamicTools_ExposesFindAndExecute verifies the shared helper exposes only
+// the find and execute tools in deterministic order.
+//
+// The test lists the dynamic surface against the offline stub client and checks
+// the execute input schema for action, params, and confirm fields. This protects
+// the low-token dynamic contract every generated artifact describes.
+func TestDynamicTools_ExposesFindAndExecute(t *testing.T) {
+	dynamicTools, err := DynamicTools(newStubClientForTest(t))
+	if err != nil {
+		t.Fatalf("DynamicTools() error: %v", err)
+	}
+	if len(dynamicTools) != 2 {
+		t.Fatalf("len(DynamicTools()) = %d, want 2", len(dynamicTools))
+	}
+	names := []string{dynamicTools[0].Name, dynamicTools[1].Name}
+	if names[0] != DynamicFindToolName || names[1] != DynamicExecuteActionToolName {
+		t.Fatalf("dynamic tools = %v, want find before execute", names)
+	}
+
+	executeSchema, ok := dynamicTools[1].InputSchema.(map[string]any)
+	if !ok {
+		t.Fatalf("execute InputSchema has type %T, want map[string]any", dynamicTools[1].InputSchema)
+	}
+	executeProperties, ok := executeSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("execute InputSchema properties has type %T, want map[string]any", executeSchema["properties"])
+	}
+	for _, property := range []string{"action", "params", "confirm"} {
+		if _, exists := executeProperties[property]; !exists {
+			t.Fatalf("execute InputSchema missing %q property: %v", property, executeProperties)
+		}
+	}
+	required, ok := executeSchema["required"].([]any)
+	if !ok {
+		t.Fatalf("execute InputSchema required has type %T, want []any", executeSchema["required"])
+	}
+	if !slices.Contains(required, any("action")) || !slices.Contains(required, any("params")) {
+		t.Fatalf("execute InputSchema required = %v, want action and params", required)
+	}
+}
+
+// TestSortDynamicTools_PutsFindBeforeExecute verifies the ordering helper is
+// independent of registration order and sorts unknown names last.
+//
+// The input arrives reversed with an extra tool appended, and the expected
+// result keeps find, then execute, then anything else by name. This keeps the
+// generated files stable when the SDK changes list ordering.
+func TestSortDynamicTools_PutsFindBeforeExecute(t *testing.T) {
+	dynamicTools := []*mcp.Tool{
+		{Name: "zzz_unexpected"},
+		{Name: DynamicExecuteActionToolName},
+		{Name: "aaa_unexpected"},
+		{Name: DynamicFindToolName},
+	}
+	SortDynamicTools(dynamicTools)
+
+	want := []string{DynamicFindToolName, DynamicExecuteActionToolName, "aaa_unexpected", "zzz_unexpected"}
+	for i, name := range want {
+		if dynamicTools[i].Name != name {
+			t.Fatalf("position %d = %q, want %q", i, dynamicTools[i].Name, name)
+		}
+	}
+}
+
+// TestValidateDynamicToolContract_RejectsDrift verifies the dynamic tool
+// contract fails when the expected find/execute pair changes.
+//
+// The happy-path assertion accepts the canonical two-tool list, while the drift
+// assertions drop find and rename execute. This keeps accidental dynamic surface
+// changes visible during generation instead of silently rewriting every
+// generated artifact.
+func TestValidateDynamicToolContract_RejectsDrift(t *testing.T) {
+	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicFindToolName}, {Name: DynamicExecuteActionToolName}}); err != nil {
+		t.Fatalf("ValidateDynamicToolContract() error = %v", err)
+	}
+	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicExecuteActionToolName}}); err == nil {
+		t.Fatal("ValidateDynamicToolContract() error = nil, want error for a missing tool")
+	}
+	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicFindToolName}, {Name: "gitlab_renamed"}}); err == nil {
+		t.Fatal("ValidateDynamicToolContract() error = nil, want error for a renamed tool")
+	}
+}
+
+// TestResources_IncludesToolManifestTemplate verifies resource discovery sees
+// the unified tool manifest template alongside the regular resources.
+func TestResources_IncludesToolManifestTemplate(t *testing.T) {
+	res, templates, err := Resources(newStubClientForTest(t))
+	if err != nil {
+		t.Fatalf("Resources() error: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("Resources() returned no static resources")
+	}
+	wantTemplates := map[string]bool{
+		"gitlab://tools/{id}": false,
+	}
+	for _, template := range templates {
+		if template.URITemplate == "gitlab://schema/meta/{tool}/{action}" || template.URITemplate == "gitlab://schema/dynamic/{action}" {
+			t.Fatalf("Resources() exposed legacy schema template %s: %v", template.URITemplate, templates)
+		}
+		if _, ok := wantTemplates[template.URITemplate]; ok {
+			wantTemplates[template.URITemplate] = true
+		}
+	}
+	for uri, found := range wantTemplates {
+		if !found {
+			t.Fatalf("Resources() templates missing %s: %v", uri, templates)
+		}
+	}
+}
+
+// TestPrompts_ReturnsDescribedPrompts verifies prompt discovery returns the
+// registered set with the metadata generated artifacts render.
+//
+// Every prompt must carry a name and a description, because a blank one would
+// ship to the marketplace listing and to llms.txt as an empty entry.
+func TestPrompts_ReturnsDescribedPrompts(t *testing.T) {
+	list, err := Prompts(newStubClientForTest(t))
+	if err != nil {
+		t.Fatalf("Prompts() error: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("Prompts() returned no prompts, want the registered set")
+	}
+	for _, prompt := range list {
+		if prompt.Name == "" || prompt.Description == "" {
+			t.Fatalf("prompt %q is missing name or description", prompt.Name)
+		}
+	}
+}
+
+// TestSession_SetupError verifies a failing setup aborts before any connection
+// is made, rather than returning a session the caller would have to clean up.
+func TestSession_SetupError(t *testing.T) {
+	want := errors.New("setup failed")
+	session, cleanup, err := Session(func(*mcp.Server) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("Session() error = %v, want %v", err, want)
+	}
+	if session != nil || cleanup != nil {
+		t.Fatal("Session() returned a session or cleanup after a failed setup")
+	}
+}
+
+// TestNewGitLabComClient_UsesPublicHost verifies the GitLab.com client is pinned
+// to the public host rather than to whatever GITLAB_URL points at, which is what
+// keeps generated output identical between a developer machine and CI.
+func TestNewGitLabComClient_UsesPublicHost(t *testing.T) {
+	t.Setenv("GITLAB_URL", "https://gitlab.example.com")
+
+	client, err := NewGitLabComClient()
+	if err != nil {
+		t.Fatalf("NewGitLabComClient() error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("NewGitLabComClient() returned no client")
+	}
+}
+
+// TestProjectRoot_FindsGoMod verifies the walk up from the package directory
+// lands on the directory holding go.mod.
+func TestProjectRoot_FindsGoMod(t *testing.T) {
+	root, err := ProjectRoot()
+	if err != nil {
+		t.Fatalf("ProjectRoot() error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "go.mod")); statErr != nil {
+		t.Fatalf("ProjectRoot() = %q, which holds no go.mod: %v", root, statErr)
+	}
+}
+
+// TestProjectRoot_NotFound verifies the walk reports an error instead of
+// returning the filesystem root when no go.mod exists above the caller.
+func TestProjectRoot_NotFound(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if _, err := ProjectRoot(); err == nil {
+		t.Fatal("ProjectRoot() error = nil, want an error in a tree without go.mod")
+	}
+}

--- a/cmd/internal/mcpsurface/surface_test.go
+++ b/cmd/internal/mcpsurface/surface_test.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 )
 
@@ -92,21 +94,52 @@ func TestSortDynamicTools_PutsFindBeforeExecute(t *testing.T) {
 }
 
 // TestValidateDynamicToolContract_RejectsDrift verifies the dynamic tool
-// contract fails when the expected find/execute pair changes.
+// contract accepts the canonical pair and fails on every way it can drift.
 //
-// The happy-path assertion accepts the canonical two-tool list, while the drift
-// assertions drop find and rename execute. This keeps accidental dynamic surface
-// changes visible during generation instead of silently rewriting every
-// generated artifact.
+// A rename, a dropped tool, an extra tool, or a swapped order all have to abort
+// generation: the alternative is silently rewriting every generated artifact
+// around a surface nobody meant to change.
 func TestValidateDynamicToolContract_RejectsDrift(t *testing.T) {
-	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicFindToolName}, {Name: DynamicExecuteActionToolName}}); err != nil {
-		t.Fatalf("ValidateDynamicToolContract() error = %v", err)
+	tests := []struct {
+		name    string
+		tools   []*mcp.Tool
+		wantErr bool
+	}{
+		{
+			name:  "canonical pair",
+			tools: []*mcp.Tool{{Name: DynamicFindToolName}, {Name: DynamicExecuteActionToolName}},
+		},
+		{
+			name:    "missing tool",
+			tools:   []*mcp.Tool{{Name: DynamicExecuteActionToolName}},
+			wantErr: true,
+		},
+		{
+			name:    "renamed tool",
+			tools:   []*mcp.Tool{{Name: DynamicFindToolName}, {Name: "gitlab_renamed"}},
+			wantErr: true,
+		},
+		{
+			name:    "extra tool",
+			tools:   []*mcp.Tool{{Name: DynamicFindToolName}, {Name: DynamicExecuteActionToolName}, {Name: "gitlab_extra"}},
+			wantErr: true,
+		},
+		{
+			name:    "swapped order",
+			tools:   []*mcp.Tool{{Name: DynamicExecuteActionToolName}, {Name: DynamicFindToolName}},
+			wantErr: true,
+		},
 	}
-	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicExecuteActionToolName}}); err == nil {
-		t.Fatal("ValidateDynamicToolContract() error = nil, want error for a missing tool")
-	}
-	if err := ValidateDynamicToolContract([]*mcp.Tool{{Name: DynamicFindToolName}, {Name: "gitlab_renamed"}}); err == nil {
-		t.Fatal("ValidateDynamicToolContract() error = nil, want error for a renamed tool")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDynamicToolContract(tt.tools)
+			if tt.wantErr && err == nil {
+				t.Fatalf("ValidateDynamicToolContract(%s) error = nil, want an error", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("ValidateDynamicToolContract(%s) error = %v", tt.name, err)
+			}
+		})
 	}
 }
 
@@ -181,8 +214,12 @@ func TestNewGitLabComClient_UsesPublicHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGitLabComClient() error: %v", err)
 	}
-	if client == nil {
-		t.Fatal("NewGitLabComClient() returned no client")
+	if !client.IsGitLabDotCom() {
+		t.Error("NewGitLabComClient() is not configured for GitLab.com")
+	}
+	got := client.GL().BaseURL().String()
+	if !strings.HasPrefix(got, config.DefaultGitLabURL) {
+		t.Errorf("base URL = %q, want it under %q", got, config.DefaultGitLabURL)
 	}
 }
 

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -23,6 +23,7 @@ Every utility can be run directly with `go run ./cmd/<name>/ [flags]`, or throug
 | `audit_test_names`             | Source quality audits     | Classifies `Test*` functions by naming pattern; emits rename hints                                                                | `make audit-test-names`                   |
 | `audit_string_dupes`           | Source quality audits     | Finds duplicated string literals missing `const`/`var` declarations                                                               | —                                         |
 | `gen_action_catalog_manifest`  | Generators                | Generates the ActionSpec group-builder manifest                                                                                   | `make gen-action-catalog-manifest`        |
+| `gen_lhm_manifest`             | Generators                | Generates the tools/prompts/resources arrays in `lhm.plugin.json` (LobeHub Marketplace)                                           | `make gen-lhm-manifest`                   |
 | `gen_llms`                     | Generators                | Generates `llms.txt` and `llms-full.txt`                                                                                          | `make gen-llms`                           |
 | `gen_stats`                    | Generators                | Regenerates the managed repository statistics section in `README.md`                                                              | `make gen-stats`                          |
 | `gen_testing_docs`             | Generators                | Regenerates the test-metrics block in `docs/development/testing/testing.md`                                                       | `make gen-testing-docs`                   |
@@ -517,6 +518,37 @@ Rewrites the manifest Go file in place, or (with `-check`) verifies it is curren
 - `make gen-action-catalog-manifest`
 - `make check-action-catalog-manifest` — CI gate.
 
+### gen_lhm_manifest
+
+Regenerates the `tools`, `prompts`, and `resources` arrays in `lhm.plugin.json`, the manifest published to the LobeHub Marketplace. LobeHub derives the listing's capability badges from those arrays — its scanner cannot introspect a server distributed as a Go binary or a Docker image — so a manifest without them advertises zero tools no matter what the server registers.
+
+The declared tool surface is the default one, `dynamic`, pinned explicitly rather than read from `TOOL_SURFACE`; the round-trip runs against an in-process stub client rather than `GITLAB_URL`/`GITLAB_TOKEN`. Both keep the committed file independent of the machine that generated it. Output schemas and tool icons are dropped: neither is part of the shape LobeHub documents, and the base64 icon data URIs alone would triple the file. Every other field is preserved, `version` included — the release stamp owns that one.
+
+#### Usage
+
+```bash
+# Rewrite the capability arrays
+go run ./cmd/gen_lhm_manifest/
+
+# CI gate
+go run ./cmd/gen_lhm_manifest/ --check
+```
+
+#### Flags
+
+| Flag      | Type   | Default | Description                                                                   |
+| --------- | ------ | ------- | ----------------------------------------------------------------------------- |
+| `--check` | `bool` | `false` | Verify the committed manifest matches the registered surface, without writing |
+
+#### Output
+
+Rewrites `lhm.plugin.json` at the project root.
+
+#### Make targets
+
+- `make gen-lhm-manifest`
+- `make check-lhm-manifest` — CI gate; also runs before `make publish-lobehub`.
+
 ### gen_llms
 
 Generates `llms.txt` (the concise llmstxt.org index) and `llms-full.txt` (detailed per-tool schemas) by introspecting all surfaces, resources, and prompts via in-memory MCP.
@@ -709,6 +741,7 @@ The following utilities expose a verification mode (`--check` or `-check`, or an
 | ---------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
 | `check-action-catalog-manifest`          | `gen_action_catalog_manifest`  | Generated ActionSpec manifest is current                                             | Non-zero if the manifest is stale                         |
 | `check-llms`                             | `gen_llms`                     | `llms.txt` and `llms-full.txt` are current and structurally valid                    | Non-zero if either file is stale or malformed             |
+| `check-lhm-manifest`                     | `gen_lhm_manifest`             | `lhm.plugin.json` declares the registered tools, prompts, and resources              | Non-zero if the manifest is stale                         |
 | `check-footprint`                        | `audit_tokens -footprint`      | README token-footprint section and `docs/development/token-footprint.md` are current | Non-zero if either is stale                               |
 | `check-stats`                            | `gen_stats`                    | README repository-statistics section is current                                      | Non-zero if the section is stale                          |
 | `audit-discovery-check`                  | `audit_discovery_completeness` | No META-001 finding meets the configured severity threshold                          | Non-zero if any finding meets `-severity` (default error) |

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -39,6 +39,7 @@ gitlab-mcp-server/
 │   ├── format_md_tables/        # Normalizes Markdown pipe tables
 │   ├── gen_action_catalog_manifest/ # Generates ActionSpec manifest
 │   ├── gen_docker_tools/        # Generates Docker MCP Registry tools.json
+│   ├── gen_lhm_manifest/        # Generates the LobeHub manifest capability arrays
 │   ├── gen_llms/                # Generates llms.txt and llms-full.txt
 │   ├── gen_stats/               # Regenerates README stats section
 │   ├── gen_testing_docs/        # Regenerates testing.md managed sections

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -275,10 +275,10 @@ packages and 55 linters that working set does not fit comfortably in memory on a
 many-threaded machine — it thrashes rather than going faster. Measured on a cold
 cache on the same 16-thread machine:
 
-| Concurrency         | Peak RSS | Cold run    |
-| ------------------- | -------- | ----------- |
-| 16 (former default) | 4.4 GB   | >18m, unfinished |
-| 4 (`run.concurrency`) | 3.6 GB | **3m01s**   |
+| Concurrency           | Peak RSS | Cold run         |
+| --------------------- | -------- | ---------------- |
+| 16 (former default)   | 4.4 GB   | >18m, unfinished |
+| 4 (`run.concurrency`) | 3.6 GB   | **3m01s**        |
 
 `run.concurrency: 4` is therefore set in `.golangci.yml`. CI runners have 4 vCPUs
 and were already getting this implicitly, which is why CI completed in ~4 minutes

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -37,7 +37,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Free/CE  |            33 |               851 | `compact`           |            201,191 |         1,088 |      202,279 |
 | `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            287,787 |        31,758 |      319,545 |
 | `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            287,787 |         1,088 |      288,875 |
-| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            768,808 |        31,758 |      800,566 |
+| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            768,810 |        31,758 |      800,568 |
 | `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              2,180 |        31,758 |       33,938 |
 | `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              2,180 |         1,088 |        3,268 |
 | `meta` / `full` (opaque)     | Premium  |            39 |             1,003 | `opaque`            |            157,424 |        31,758 |      189,182 |
@@ -46,7 +46,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Premium  |            39 |             1,003 | `compact`           |            234,192 |         1,088 |      235,280 |
 | `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            334,991 |        31,758 |      366,749 |
 | `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            334,991 |         1,088 |      336,079 |
-| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            919,546 |        31,758 |      951,304 |
+| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            919,548 |        31,758 |      951,306 |
 | `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              2,180 |        31,758 |       33,938 |
 | `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              2,180 |         1,088 |        3,268 |
 | `meta` / `full` (opaque)     | Ultimate |            50 |             1,069 | `opaque`            |            172,181 |        31,758 |      203,939 |
@@ -55,7 +55,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Ultimate |            50 |             1,069 | `compact`           |            253,370 |         1,088 |      254,458 |
 | `meta` / `full` (full)       | Ultimate |            50 |             1,069 | `full`              |            358,993 |        31,758 |      390,751 |
 | `meta` / `minimal` (full)    | Ultimate |            50 |             1,069 | `full`              |            358,993 |         1,088 |      360,081 |
-| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            968,619 |        31,758 |    1,000,377 |
+| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            968,621 |        31,758 |    1,000,379 |
 
 ## Interpretation guide
 

--- a/internal/prompts/prompt_cross_project.go
+++ b/internal/prompts/prompt_cross_project.go
@@ -171,7 +171,7 @@ func registerMyIssuesPrompt(server *mcp.Server, client *gitlabclient.Client) {
 		Icons:       toolutil.IconIssue,
 		Arguments: []*mcp.PromptArgument{
 			usernameArg(),
-			stateArg("opened"),
+			issueStateArg("opened"),
 		},
 	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		return handleMyIssues(ctx, client, req)

--- a/internal/prompts/prompt_helpers.go
+++ b/internal/prompts/prompt_helpers.go
@@ -25,8 +25,14 @@ const (
 	descGroupID      = "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')"
 	descUsername     = "GitLab username to query"
 	descDays         = "Number of days to look back (default: %d)"
-	descState        = "State filter: opened, closed, merged, all (default: %s)"
+	descState        = "State filter: %s (default: %s)"
 	descTargetBranch = "Target branch name to filter MRs (e.g. 'develop_5.4.0')"
+
+	// GitLab accepts a different state vocabulary per resource: an issue is
+	// never "merged", so offering that value to a model only earns a 400 from
+	// the API.
+	statesIssue        = "opened, closed, all"
+	statesMergeRequest = "opened, closed, merged, all"
 
 	maxListItems = 100
 )
@@ -61,12 +67,24 @@ func daysArg(defaultDays int) *mcp.PromptArgument {
 	}
 }
 
-// stateArg returns an optional prompt argument for state filtering.
-func stateArg(defaultState string) *mcp.PromptArgument {
+// issueStateArg returns an optional state filter for a prompt that lists
+// issues.
+func issueStateArg(defaultState string) *mcp.PromptArgument {
+	return stateArg(statesIssue, defaultState)
+}
+
+// mrStateArg returns an optional state filter for a prompt that lists merge
+// requests.
+func mrStateArg(defaultState string) *mcp.PromptArgument {
+	return stateArg(statesMergeRequest, defaultState)
+}
+
+// stateArg returns an optional prompt argument offering states for filtering.
+func stateArg(states, defaultState string) *mcp.PromptArgument {
 	return &mcp.PromptArgument{
 		Name:        argState,
 		Title:       toolutil.TitleFromName(argState),
-		Description: fmt.Sprintf(descState, defaultState),
+		Description: fmt.Sprintf(descState, states, defaultState),
 		Required:    false,
 	}
 }

--- a/internal/prompts/prompt_helpers_test.go
+++ b/internal/prompts/prompt_helpers_test.go
@@ -1228,3 +1228,39 @@ func TestProjectPathFromWebURL(t *testing.T) {
 		}
 	})
 }
+
+// TestIssueStateArg_OmitsMergedState verifies the issue state filter offers only
+// the states GitLab accepts for an issue.
+//
+// "merged" is a merge-request state; advertising it to a model on an issue
+// prompt only earns a 400 from the API, so the description must not list it.
+func TestIssueStateArg_OmitsMergedState(t *testing.T) {
+	got := issueStateArg("opened")
+
+	if got.Name != argState || got.Required {
+		t.Fatalf("issueStateArg() = %+v, want an optional %q argument", got, argState)
+	}
+	if strings.Contains(got.Description, "merged") {
+		t.Fatalf("issueStateArg() description = %q, want no merged state", got.Description)
+	}
+	for _, state := range []string{"opened", "closed", "all"} {
+		if !strings.Contains(got.Description, state) {
+			t.Fatalf("issueStateArg() description = %q, want it to offer %q", got.Description, state)
+		}
+	}
+	if !strings.Contains(got.Description, "default: opened") {
+		t.Fatalf("issueStateArg() description = %q, want the default named", got.Description)
+	}
+}
+
+// TestMRStateArg_OffersMergedState verifies the merge-request state filter keeps
+// the merged state, which is valid there.
+func TestMRStateArg_OffersMergedState(t *testing.T) {
+	got := mrStateArg("opened")
+
+	for _, state := range []string{"opened", "closed", "merged", "all"} {
+		if !strings.Contains(got.Description, state) {
+			t.Fatalf("mrStateArg() description = %q, want it to offer %q", got.Description, state)
+		}
+	}
+}

--- a/internal/prompts/prompt_helpers_test.go
+++ b/internal/prompts/prompt_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 )
 
@@ -1229,38 +1230,48 @@ func TestProjectPathFromWebURL(t *testing.T) {
 	})
 }
 
-// TestIssueStateArg_OmitsMergedState verifies the issue state filter offers only
-// the states GitLab accepts for an issue.
+// TestStateArg_PerResourceVocabulary verifies each state filter offers exactly
+// the states GitLab accepts for that resource.
 //
-// "merged" is a merge-request state; advertising it to a model on an issue
-// prompt only earns a 400 from the API, so the description must not list it.
-func TestIssueStateArg_OmitsMergedState(t *testing.T) {
-	got := issueStateArg("opened")
-
-	if got.Name != argState || got.Required {
-		t.Fatalf("issueStateArg() = %+v, want an optional %q argument", got, argState)
+// "merged" is a merge-request state: advertising it on an issue prompt only
+// earns a 400 from the issues API, and the description is what a model reads.
+func TestStateArg_PerResourceVocabulary(t *testing.T) {
+	tests := []struct {
+		name     string
+		arg      *mcp.PromptArgument
+		want     []string
+		unwanted []string
+	}{
+		{
+			name:     "issue states",
+			arg:      issueStateArg("opened"),
+			want:     []string{"opened", "closed", "all"},
+			unwanted: []string{"merged"},
+		},
+		{
+			name: "merge request states",
+			arg:  mrStateArg("opened"),
+			want: []string{"opened", "closed", "merged", "all"},
+		},
 	}
-	if strings.Contains(got.Description, "merged") {
-		t.Fatalf("issueStateArg() description = %q, want no merged state", got.Description)
-	}
-	for _, state := range []string{"opened", "closed", "all"} {
-		if !strings.Contains(got.Description, state) {
-			t.Fatalf("issueStateArg() description = %q, want it to offer %q", got.Description, state)
-		}
-	}
-	if !strings.Contains(got.Description, "default: opened") {
-		t.Fatalf("issueStateArg() description = %q, want the default named", got.Description)
-	}
-}
-
-// TestMRStateArg_OffersMergedState verifies the merge-request state filter keeps
-// the merged state, which is valid there.
-func TestMRStateArg_OffersMergedState(t *testing.T) {
-	got := mrStateArg("opened")
-
-	for _, state := range []string{"opened", "closed", "merged", "all"} {
-		if !strings.Contains(got.Description, state) {
-			t.Fatalf("mrStateArg() description = %q, want it to offer %q", got.Description, state)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.arg.Name != argState || tt.arg.Required {
+				t.Fatalf("%s = %+v, want an optional %q argument", tt.name, tt.arg, argState)
+			}
+			for _, state := range tt.want {
+				if !strings.Contains(tt.arg.Description, state) {
+					t.Errorf("%s description = %q, want it to offer %q", tt.name, tt.arg.Description, state)
+				}
+			}
+			for _, state := range tt.unwanted {
+				if strings.Contains(tt.arg.Description, state) {
+					t.Errorf("%s description = %q, want no %q state", tt.name, tt.arg.Description, state)
+				}
+			}
+			if !strings.Contains(tt.arg.Description, "default: opened") {
+				t.Errorf("%s description = %q, want the default named", tt.name, tt.arg.Description)
+			}
+		})
 	}
 }

--- a/internal/prompts/prompt_project_reports.go
+++ b/internal/prompts/prompt_project_reports.go
@@ -41,7 +41,7 @@ func registerBranchMRSummaryPrompt(server *mcp.Server, client *gitlabclient.Clie
 		Arguments: []*mcp.PromptArgument{
 			projectIDArg(),
 			targetBranchArg(true),
-			stateArg("opened"),
+			mrStateArg("opened"),
 		},
 	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		return handleBranchMRSummary(ctx, client, req)

--- a/internal/prompts/prompt_team.go
+++ b/internal/prompts/prompt_team.go
@@ -294,7 +294,7 @@ func registerGroupMRDashboardPrompt(server *mcp.Server, client *gitlabclient.Cli
 		Icons:       toolutil.IconMR,
 		Arguments: []*mcp.PromptArgument{
 			groupIDArg(),
-			stateArg("opened"),
+			mrStateArg("opened"),
 			targetBranchArg(false),
 		},
 	}, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {

--- a/internal/toolutil/text.go
+++ b/internal/toolutil/text.go
@@ -211,10 +211,19 @@ func IsBinaryFile(filename string) bool {
 	}
 }
 
+// titleAcronyms are the name segments that render fully capitalized in a title.
+// A segment also matches in its plural form, which keeps the "s" lowercase:
+// "mrs" becomes "MRs", not "MRS".
+var titleAcronyms = map[string]bool{
+	"mr": true, "ci": true, "ssh": true, "api": true, "url": true, "id": true,
+	"iid": true, "gpg": true, "ssl": true, "ip": true, "yaml": true, "ui": true,
+}
+
 // TitleFromName generates a human-readable UI title from a snake_case MCP tool
 // name by stripping the "gitlab_" prefix and converting to Title Case.
 //
 //	TitleFromName("gitlab_list_projects") // returns "List Projects"
+//	TitleFromName("my_open_mrs")          // returns "My Open MRs"
 func TitleFromName(name string) string {
 	s := strings.TrimPrefix(name, "gitlab_")
 	parts := strings.Split(s, "_")
@@ -222,13 +231,21 @@ func TitleFromName(name string) string {
 		if p == "" {
 			continue
 		}
-		// Capitalize well-known acronyms
-		switch strings.ToLower(p) {
-		case "mr", "ci", "ssh", "api", "url", "id", "iid", "gpg", "ssl", "ip", "yaml", "ui":
-			parts[i] = strings.ToUpper(p)
-		default:
-			parts[i] = strings.ToUpper(p[:1]) + p[1:]
-		}
+		parts[i] = titleSegment(p)
 	}
 	return strings.Join(parts, " ")
+}
+
+// titleSegment capitalizes one underscore-separated name segment: a well-known
+// acronym in full, a plural acronym with a lowercase "s", anything else as a
+// leading capital.
+func titleSegment(segment string) string {
+	lower := strings.ToLower(segment)
+	if titleAcronyms[lower] {
+		return strings.ToUpper(segment)
+	}
+	if stem, ok := strings.CutSuffix(lower, "s"); ok && titleAcronyms[stem] {
+		return strings.ToUpper(segment[:len(segment)-1]) + "s"
+	}
+	return strings.ToUpper(segment[:1]) + segment[1:]
 }

--- a/internal/toolutil/text_test.go
+++ b/internal/toolutil/text_test.go
@@ -272,6 +272,10 @@ func TestTitleFromName(t *testing.T) {
 		{name: "no prefix", in: "list_projects", want: "List Projects"},
 		{name: "long name", in: "gitlab_create_merge_request", want: "Create Merge Request"},
 		{name: "meta tool", in: "gitlab_project", want: "Project"},
+		{name: "plural acronym MR", in: "my_open_mrs", want: "My Open MRs"},
+		{name: "plural acronym ID", in: "gitlab_list_user_ids", want: "List User IDs"},
+		{name: "plural non-acronym", in: "gitlab_list_projects", want: "List Projects"},
+		{name: "acronym-like word", in: "gitlab_list_users", want: "List Users"},
 		{name: "empty", in: "", want: ""},
 	}
 	for _, tt := range tests {

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -5,6 +5,7 @@
   "description": "Model Context Protocol server exposing 1000+ GitLab REST + GraphQL operations as AI tools — merge requests, pipelines, issues, releases, milestones, and more. One static Go binary; stdio or HTTP transport, with dynamic/meta/individual tool surfaces.",
   "author": "José M. Requena Plens",
   "authorUrl": "https://github.com/jmrplens",
+  "icon": "https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/mcpb/icon.png",
   "tags": [
     "gitlab",
     "mcp",
@@ -16,6 +17,75 @@
     "git",
     "go",
     "graphql"
+  ],
+  "tools": [
+    {
+      "name": "gitlab_execute_action",
+      "title": "GitLab Execute Action",
+      "description": "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.",
+            "type": "string"
+          },
+          "confirm": {
+            "description": "Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.",
+            "type": "boolean"
+          },
+          "params": {
+            "additionalProperties": true,
+            "description": "Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.",
+            "properties": {},
+            "type": "object"
+          }
+        },
+        "required": [
+          "action",
+          "params"
+        ],
+        "type": "object"
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true,
+        "title": "GitLab Execute Action"
+      }
+    },
+    {
+      "name": "gitlab_find_action",
+      "title": "GitLab Find Action",
+      "description": "Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "explain": {
+            "description": "When true, include deterministic scoring reasons for each returned action. Defaults to false to keep responses compact.",
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "Maximum number of matches to return. Defaults to 20 and is capped at 50.",
+            "type": "integer"
+          },
+          "query": {
+            "description": "Search terms combining a GitLab domain or resource with a verb, filter, or object name, such as project create, merge request approve, pipeline retry, issue delete, or ci variable.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "GitLab Find Action"
+      }
+    }
   ],
   "prompts": [
     {
@@ -730,75 +800,6 @@
           "assistant"
         ],
         "priority": 0.4
-      }
-    }
-  ],
-  "tools": [
-    {
-      "name": "gitlab_execute_action",
-      "title": "GitLab Execute Action",
-      "description": "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.",
-      "inputSchema": {
-        "additionalProperties": false,
-        "properties": {
-          "action": {
-            "description": "Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.",
-            "type": "string"
-          },
-          "confirm": {
-            "description": "Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.",
-            "type": "boolean"
-          },
-          "params": {
-            "additionalProperties": true,
-            "description": "Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.",
-            "properties": {},
-            "type": "object"
-          }
-        },
-        "required": [
-          "action",
-          "params"
-        ],
-        "type": "object"
-      },
-      "annotations": {
-        "destructiveHint": true,
-        "openWorldHint": true,
-        "title": "GitLab Execute Action"
-      }
-    },
-    {
-      "name": "gitlab_find_action",
-      "title": "GitLab Find Action",
-      "description": "Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.",
-      "inputSchema": {
-        "additionalProperties": false,
-        "properties": {
-          "explain": {
-            "description": "When true, include deterministic scoring reasons for each returned action. Defaults to false to keep responses compact.",
-            "type": "boolean"
-          },
-          "limit": {
-            "description": "Maximum number of matches to return. Defaults to 20 and is capped at 50.",
-            "type": "integer"
-          },
-          "query": {
-            "description": "Search terms combining a GitLab domain or resource with a verb, filter, or object name, such as project create, merge request approve, pipeline retry, issue delete, or ci variable.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "query"
-        ],
-        "type": "object"
-      },
-      "annotations": {
-        "destructiveHint": false,
-        "idempotentHint": true,
-        "openWorldHint": true,
-        "readOnlyHint": true,
-        "title": "GitLab Find Action"
       }
     }
   ]

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -16,5 +16,790 @@
     "git",
     "go",
     "graphql"
+  ],
+  "prompts": [
+    {
+      "name": "audit_commit_hygiene",
+      "title": "Audit Commit Hygiene",
+      "description": "Audit commit message quality between two refs. Scores Conventional Commit usage, merge commits, breaking-change markers, body/detail quality, and linked work references for release and contribution readiness.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "from",
+          "title": "From",
+          "description": "Starting ref: tag name, branch name, or commit SHA",
+          "required": true
+        },
+        {
+          "name": "to",
+          "title": "To",
+          "description": "Ending ref: tag name, branch name, or commit SHA (defaults to HEAD if omitted)"
+        }
+      ]
+    },
+    {
+      "name": "audit_project_full",
+      "title": "Audit Project Full",
+      "description": "Run a comprehensive audit of a GitLab project covering settings, branch protection, access management, labels, milestones, and templates in a single report. Use this for a complete project health assessment with actionable recommendations.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "audit_project_workflow",
+      "title": "Audit Project Workflow",
+      "description": "Audit workflow configuration for a GitLab project: labels (names, colors, descriptions), milestones (open/closed, due dates), and issue/MR templates. Identifies gaps like labels without descriptions, milestones without due dates, or missing templates.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "branch_mr_summary",
+      "title": "Branch MR Summary",
+      "description": "List all MRs targeting a specific branch in a project. Shows readiness summary with conflict/draft/approval counts. Ideal for release branch reviews.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "target_branch",
+          "title": "Target Branch",
+          "description": "Target branch name to filter MRs (e.g. 'develop_5.4.0')",
+          "required": true
+        },
+        {
+          "name": "state",
+          "title": "State",
+          "description": "State filter: opened, closed, merged, all (default: opened)"
+        }
+      ]
+    },
+    {
+      "name": "compare_branches",
+      "title": "Compare Branches",
+      "description": "Compare commit and file differences between two Git refs. Use for release branch preparation, feature branch divergence analysis, or deciding whether a merge/backport needs deeper review.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "from",
+          "title": "From",
+          "description": "Source branch name, tag, or commit SHA to compare from",
+          "required": true
+        },
+        {
+          "name": "to",
+          "title": "To",
+          "description": "Target branch name, tag, or commit SHA to compare to",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "daily_standup",
+      "title": "Daily Standup",
+      "description": "Generate a daily standup summary based on the user's GitLab activity in the last 24 hours: contribution events, authored MRs, assigned MRs, MRs under review, assigned issues, and created issues. Produces a comprehensive report with done/planned/blockers sections.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to generate the standup for (defaults to the authenticated user if omitted)"
+        }
+      ]
+    },
+    {
+      "name": "generate_release_notes",
+      "title": "Generate Release Notes",
+      "description": "Generate comprehensive release notes from commits, merge requests, and file changes between two Git refs (tags, branches, or SHAs). Produces a structured document with commits, merged MRs with labels, contributors, and statistics for organizing into user-friendly release notes.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "from",
+          "title": "From",
+          "description": "Starting ref: tag name (e.g. 'v1.0.0'), branch name, or commit SHA",
+          "required": true
+        },
+        {
+          "name": "to",
+          "title": "To",
+          "description": "Ending ref: tag name, branch name, or commit SHA (defaults to HEAD if omitted)"
+        }
+      ]
+    },
+    {
+      "name": "group_milestone_progress",
+      "title": "Group Milestone Progress",
+      "description": "Track milestone progress across all projects in a group. Shows issue/MR completion per milestone with progress bars.",
+      "arguments": [
+        {
+          "name": "group_id",
+          "title": "Group ID",
+          "description": "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "group_mr_dashboard",
+      "title": "Group MR Dashboard",
+      "description": "List merge requests across a GitLab group with optional state and target branch filters. Shows MRs grouped by project with blocker and readiness summary statistics.",
+      "arguments": [
+        {
+          "name": "group_id",
+          "title": "Group ID",
+          "description": "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')",
+          "required": true
+        },
+        {
+          "name": "state",
+          "title": "State",
+          "description": "State filter: opened, closed, merged, all (default: opened)"
+        },
+        {
+          "name": "target_branch",
+          "title": "Target Branch",
+          "description": "Target branch name to filter MRs (e.g. 'develop_5.4.0')"
+        }
+      ]
+    },
+    {
+      "name": "label_distribution",
+      "title": "Label Distribution",
+      "description": "Analyze label usage distribution in a project. Shows open/closed issue counts and open MR counts per label. Zero additional API calls beyond label list.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "merge_velocity",
+      "title": "Merge Velocity",
+      "description": "Analyze MR throughput metrics for a project. Shows merge rate, average time-to-merge, and daily merged count chart. Ideal for tracking team delivery pace.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 30)"
+        }
+      ]
+    },
+    {
+      "name": "milestone_progress",
+      "title": "Milestone Progress",
+      "description": "Track milestone progress for a project. Shows issue/MR completion, progress bar, and due date risk. Omit milestone argument to see all active milestones.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "milestone",
+          "title": "Milestone",
+          "description": "Specific milestone title (omit for all active)"
+        }
+      ]
+    },
+    {
+      "name": "mr_description_quality",
+      "title": "MR Description Quality",
+      "description": "Score a merge request description for reviewer readiness. Checks context, linked work, test evidence, rollout/risk notes, checklists, and whether changed files suggest missing screenshots or migration notes.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "merge_request_iid",
+          "title": "Merge Request IID",
+          "description": "Merge request IID (project-scoped numeric ID, visible as !N in GitLab)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "mr_discussion_health",
+      "title": "MR Discussion Health",
+      "description": "Analyze unresolved discussion threads across open MRs in a project. Use this for review follow-up and merge-readiness cleanup, not approval-rule status.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "mr_risk_assessment",
+      "title": "MR Risk Assessment",
+      "description": "Assess the risk level (LOW/MEDIUM/HIGH/CRITICAL) of a merge request based on size (lines added/removed), number of changed files, new/deleted files, sensitive file patterns (env, auth, migration, CI, security), and conflict status.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "merge_request_iid",
+          "title": "Merge Request IID",
+          "description": "Merge request IID (project-scoped numeric ID, visible as !N in GitLab)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "my_activity_summary",
+      "title": "My Activity Summary",
+      "description": "Generate a personal activity summary for a configurable time period. Includes contribution events breakdown, MRs created/merged/reviewed, issues created/closed, and a daily activity chart. Aggregates across all projects.",
+      "arguments": [
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to query"
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 7)"
+        }
+      ]
+    },
+    {
+      "name": "my_issues",
+      "title": "My Issues",
+      "description": "Show all issues assigned to you across all projects. Includes overdue detection and project grouping. Use this to see your full issue backlog without specifying a project.",
+      "arguments": [
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to query"
+        },
+        {
+          "name": "state",
+          "title": "State",
+          "description": "State filter: opened, closed, merged, all (default: opened)"
+        }
+      ]
+    },
+    {
+      "name": "my_open_mrs",
+      "title": "My Open Mrs",
+      "description": "Show all open merge requests across all projects where you are author or assignee. Results are grouped by project for easy scanning. Use this to get a personal MR dashboard without specifying a project.",
+      "arguments": [
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to query"
+        }
+      ]
+    },
+    {
+      "name": "my_pending_reviews",
+      "title": "My Pending Reviews",
+      "description": "Show all open merge requests where you are assigned as reviewer across all projects. Helps track which MRs are waiting for your review. Results grouped by project.",
+      "arguments": [
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to query"
+        }
+      ]
+    },
+    {
+      "name": "project_activity_report",
+      "title": "Project Activity Report",
+      "description": "Generate a project activity report including recent events, merged MRs, and open issues. Shows daily activity chart and contributor breakdown.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 7)"
+        }
+      ]
+    },
+    {
+      "name": "project_contributors",
+      "title": "Project Contributors",
+      "description": "Rank project contributors by commits, additions, and deletions. Uses the repository contributors API for accurate stats.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "project_health_check",
+      "title": "Project Health Check",
+      "description": "Comprehensive project health assessment combining latest pipeline status, open merge requests, and branch hygiene (merged/stale branch counts). Provides actionable recommendations for project maintenance.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "release_cadence",
+      "title": "Release Cadence",
+      "description": "Analyze release frequency for a project. Shows time between releases, average cadence, and release history chart.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 90)"
+        }
+      ]
+    },
+    {
+      "name": "release_readiness",
+      "title": "Release Readiness",
+      "description": "Check readiness of a release branch by analyzing open MRs targeting it, draft/conflict counts, and unresolved discussion threads.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "branch",
+          "title": "Branch",
+          "description": "Target release branch (default: main)"
+        }
+      ]
+    },
+    {
+      "name": "review_mr",
+      "title": "Review MR",
+      "description": "Generate a structured code review for a merge request. Files are categorized by risk (high-risk, business logic, tests, documentation) with per-file metrics, branch context, and a review plan. Full diffs are included without truncation.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "merge_request_iid",
+          "title": "Merge Request IID",
+          "description": "Merge request IID (project-scoped numeric ID, visible as !N in GitLab)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "reviewer_workload",
+      "title": "Reviewer Workload",
+      "description": "Analyze review distribution across group members. Shows how many open MRs each member is reviewing and identifies imbalances. Useful for managers to ensure fair review distribution.",
+      "arguments": [
+        {
+          "name": "group_id",
+          "title": "Group ID",
+          "description": "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "stale_items_report",
+      "title": "Stale Items Report",
+      "description": "Find MRs and issues in a project that haven't been updated for a configurable number of days. Helps identify forgotten or blocked items.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "stale_days",
+          "title": "Stale Days",
+          "description": "Days without update to consider stale (default: 14)"
+        }
+      ]
+    },
+    {
+      "name": "suggest_mr_reviewers",
+      "title": "Suggest MR Reviewers",
+      "description": "Suggest suitable merge request reviewers based on the files changed and the list of active project members. Excludes the MR author and asks the model to consider ownership, approval-rule fit, and workload balance.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "merge_request_iid",
+          "title": "Merge Request IID",
+          "description": "Merge request IID (project-scoped numeric ID, visible as !N in GitLab)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "summarize_mr_changes",
+      "title": "Summarize MR Changes",
+      "description": "Summarize the changed files and key modifications in a merge request. Lists each file with its change type (new/modified/deleted/renamed). Use this to quickly understand the scope of a merge request.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "merge_request_iid",
+          "title": "Merge Request IID",
+          "description": "Merge request IID (project-scoped numeric ID, visible as !N in GitLab)",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "summarize_open_mrs",
+      "title": "Summarize Open Mrs",
+      "description": "Summarize all open merge requests in a project including title, author, branches, age in days, and merge status. Highlights stale MRs (>7 days) and blockers. For one target branch, use branch_mr_summary.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "summarize_pipeline_status",
+      "title": "Summarize Pipeline Status",
+      "description": "Summarize the latest CI/CD pipeline status for a project. Groups jobs by outcome (failed/passed/other) and includes failure reasons for debugging.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "team_member_workload",
+      "title": "Team Member Workload",
+      "description": "Generate a comprehensive workload summary for a specific team member over a configurable time period. Includes contribution events, authored and assigned merge requests, MRs under review, authored and assigned issues. Use this for team management and capacity planning.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username of the team member to analyze",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back for activity (default: 7)"
+        }
+      ]
+    },
+    {
+      "name": "team_overview",
+      "title": "Team Overview",
+      "description": "Generate a team dashboard showing all group members with their open MR counts and recently merged MRs. Includes a workload distribution pie chart. Requires a GitLab group ID.",
+      "arguments": [
+        {
+          "name": "group_id",
+          "title": "Group ID",
+          "description": "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 7)"
+        }
+      ]
+    },
+    {
+      "name": "unassigned_items",
+      "title": "Unassigned Items",
+      "description": "Find open MRs and issues in a project that have no assignee. Helps identify ownership gaps and items needing attention.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "user_activity_report",
+      "title": "User Activity Report",
+      "description": "Generate a detailed activity report for a specific user: contribution events, merged MRs, reviewed MRs, daily activity chart. Designed for managers to review team member productivity.",
+      "arguments": [
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to report on",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 7)"
+        }
+      ]
+    },
+    {
+      "name": "user_stats",
+      "title": "User Stats",
+      "description": "Generate comprehensive user statistics from GitLab: contribution events breakdown, merge request stats (authored/assigned/reviewed by state), issue stats (authored/assigned by state), daily activity trends, and a Mermaid activity chart. Use this for performance reviews, productivity tracking, or personal dashboards.",
+      "arguments": [
+        {
+          "name": "project_id",
+          "title": "Project ID",
+          "description": "Project ID (numeric) or URL-encoded path (e.g. 'group/project')",
+          "required": true
+        },
+        {
+          "name": "username",
+          "title": "Username",
+          "description": "GitLab username to generate stats for (defaults to the authenticated user if omitted)"
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back for activity (default: 30)"
+        }
+      ]
+    },
+    {
+      "name": "weekly_team_recap",
+      "title": "Weekly Team Recap",
+      "description": "Generate a comprehensive weekly recap for a team. Combines merged MRs, open MRs, issues activity, and events into a single summary with Mermaid charts.",
+      "arguments": [
+        {
+          "name": "group_id",
+          "title": "Group ID",
+          "description": "GitLab group ID (numeric) or URL-encoded path (e.g. 'my-group' or 'parent/child')",
+          "required": true
+        },
+        {
+          "name": "days",
+          "title": "Days",
+          "description": "Number of days to look back (default: 7)"
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "uri": "gitlab://guides/code-review",
+      "name": "code_review",
+      "description": "Code review checklist and best practices for GitLab merge request reviews.",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "gitlab://guides/conventional-commits",
+      "name": "conventional_commits",
+      "description": "Conventional commit message format and examples for consistent Git history.",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "gitlab://user/current",
+      "name": "current_user",
+      "title": "Current User Profile",
+      "description": "Get the currently authenticated GitLab user profile. Returns username, display name, email, state (active/blocked), admin status, and web URL.",
+      "mimeType": "application/json",
+      "annotations": {
+        "audience": [
+          "assistant"
+        ],
+        "priority": 0.6
+      }
+    },
+    {
+      "uri": "gitlab://guides/git-workflow",
+      "name": "git_workflow",
+      "description": "Best practices for Git branching strategies with GitLab (feature branches, trunk-based, GitLab Flow).",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "gitlab://groups",
+      "name": "groups",
+      "title": "All Groups",
+      "description": "List all GitLab groups accessible to the authenticated user. Returns each group's ID, name, full path, description, visibility level, and web URL.",
+      "mimeType": "application/json",
+      "annotations": {
+        "audience": [
+          "assistant"
+        ],
+        "priority": 0.4
+      }
+    },
+    {
+      "uri": "gitlab://guides/merge-request-hygiene",
+      "name": "merge_request_hygiene",
+      "description": "Guidelines for creating and reviewing high-quality merge requests.",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "gitlab://guides/pipeline-troubleshooting",
+      "name": "pipeline_troubleshooting",
+      "description": "Common GitLab CI/CD pipeline issues and how to diagnose and fix them.",
+      "mimeType": "text/markdown"
+    },
+    {
+      "uri": "gitlab://tools",
+      "name": "tool_manifest",
+      "title": "Tool Manifest",
+      "description": "Surface-aware manifest of the tools and executable actions available in this server instance. Use gitlab://tools/{id} to fetch one entry's accepted call shape and input schema.",
+      "mimeType": "application/json",
+      "annotations": {
+        "audience": [
+          "assistant"
+        ],
+        "priority": 0.4
+      }
+    }
+  ],
+  "tools": [
+    {
+      "name": "gitlab_execute_action",
+      "title": "GitLab Execute Action",
+      "description": "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "description": "Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.",
+            "type": "string"
+          },
+          "confirm": {
+            "description": "Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.",
+            "type": "boolean"
+          },
+          "params": {
+            "additionalProperties": true,
+            "description": "Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.",
+            "properties": {},
+            "type": "object"
+          }
+        },
+        "required": [
+          "action",
+          "params"
+        ],
+        "type": "object"
+      },
+      "annotations": {
+        "destructiveHint": true,
+        "openWorldHint": true,
+        "title": "GitLab Execute Action"
+      }
+    },
+    {
+      "name": "gitlab_find_action",
+      "title": "GitLab Find Action",
+      "description": "Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "explain": {
+            "description": "When true, include deterministic scoring reasons for each returned action. Defaults to false to keep responses compact.",
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "Maximum number of matches to return. Defaults to 20 and is capped at 50.",
+            "type": "integer"
+          },
+          "query": {
+            "description": "Search terms combining a GitLab domain or resource with a verb, filter, or object name, such as project create, merge request approve, pipeline retry, issue delete, or ci variable.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "annotations": {
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true,
+        "readOnlyHint": true,
+        "title": "GitLab Find Action"
+      }
+    }
   ]
 }

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -395,7 +395,7 @@
         {
           "name": "state",
           "title": "State",
-          "description": "State filter: opened, closed, merged, all (default: opened)"
+          "description": "State filter: opened, closed, all (default: opened)"
         }
       ]
     },

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -401,7 +401,7 @@
     },
     {
       "name": "my_open_mrs",
-      "title": "My Open Mrs",
+      "title": "My Open MRs",
       "description": "Show all open merge requests across all projects where you are author or assignee. Results are grouped by project for easy scanning. Use this to get a personal MR dashboard without specifying a project.",
       "arguments": [
         {
@@ -593,7 +593,7 @@
     },
     {
       "name": "summarize_open_mrs",
-      "title": "Summarize Open Mrs",
+      "title": "Summarize Open MRs",
       "description": "Summarize all open merge requests in a project including title, author, branches, age in days, and merge status. Highlights stale MRs (>7 days) and blockers. For one target branch, use branch_mr_summary.",
       "arguments": [
         {

--- a/llms-full-resources-prompts.txt
+++ b/llms-full-resources-prompts.txt
@@ -431,7 +431,7 @@ Show all issues assigned to you across all projects. Includes overdue detection 
 **Arguments:**
 
 - `username`: GitLab username to query
-- `state`: State filter: opened, closed, merged, all (default: opened)
+- `state`: State filter: opened, closed, all (default: opened)
 
 ### my_open_mrs
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -29154,7 +29154,7 @@ Show all issues assigned to you across all projects. Includes overdue detection 
 **Arguments:**
 
 - `username`: GitLab username to query
-- `state`: State filter: opened, closed, merged, all (default: opened)
+- `state`: State filter: opened, closed, all (default: opened)
 
 ### my_open_mrs
 

--- a/llms-medium.txt
+++ b/llms-medium.txt
@@ -1936,7 +1936,7 @@ Show all issues assigned to you across all projects. Includes overdue detection 
 **Arguments:**
 
 - `username`: GitLab username to query
-- `state`: State filter: opened, closed, merged, all (default: opened)
+- `state`: State filter: opened, closed, all (default: opened)
 
 ### my_open_mrs
 

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -7,17 +7,17 @@
   "individual": {
     "free": {
       "visible_tools": 847,
-      "tool_schema_tokens": 768808,
+      "tool_schema_tokens": 768810,
       "reduction_factor_vs_dynamic": 353
     },
     "premium": {
       "visible_tools": 999,
-      "tool_schema_tokens": 919546,
+      "tool_schema_tokens": 919548,
       "reduction_factor_vs_dynamic": 422
     },
     "ultimate": {
       "visible_tools": 1065,
-      "tool_schema_tokens": 968619,
+      "tool_schema_tokens": 968621,
       "reduction_factor_vs_dynamic": 444
     }
   }


### PR DESCRIPTION
## Description

The LobeHub Marketplace listing for this server showed **0 tools and 0 prompts**. LobeHub's automatic scanner cannot introspect a server distributed as a Go binary or a Docker image (the official `github-mcp-server` is listed the same way), and the capability badges are derived solely from the arrays declared in `lhm.plugin.json`: *"a non-empty `tools` array sets the 'tools' capability, and likewise for `resources` and `prompts` … there is no separate capabilities field."*

`lhm.plugin.json` carried only metadata, so the listing had nothing to advertise. This PR fills in the three catalogs — and then makes them generated, so they cannot go stale the next time a prompt is added or a description is reworded.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional change)
- [x] Documentation update
- [x] CI / build / tooling

## Changes Made

**Manifest (first commit)**

- Declares `tools` in `lhm.plugin.json` with the **default (dynamic) tool surface** — the two tools a user gets with no configuration: `gitlab_find_action` and `gitlab_execute_action`.
- Declares the 37 `prompts` and 8 `resources`, each with `name` / `title` / `description` (plus `arguments` for prompts and `uri` / `mimeType` / `annotations` for resources).
- `outputSchema` and `icons` are dropped: neither is part of the documented manifest shape, and the base64 icon data URIs would have roughly tripled the file for no marketplace benefit.
- Adds `icon` pointing at `mcpb/icon.png` on `raw.githubusercontent.com` (512×512, HTTP 200). `icon` is part of the LobeHub schema and accepts an emoji or an image URL.
- `version` is untouched (2.5.2, matching `VERSION`), so the `publish-lobehub` version gate stays green.

**Shared introspection package**

- `cmd/internal/mcpsurface` now owns the in-memory MCP round-trip that `gen_llms` had to itself: session wiring, the project-root walk, dynamic/prompt/resource listing, and the two-tool dynamic contract check. Extracting it rather than copying it keeps the new generator from duplicating ~120 lines of `gen_llms` (and keeps SonarCloud's 3% new-code duplication budget intact).
- The package also pins the inputs that would otherwise leak the developer's environment into generated files: the stub client and the GitLab.com URL are fixed there instead of read from `GITLAB_URL` / `GITLAB_TOKEN`, and the tool surface is pinned to `dynamic` instead of read from `TOOL_SURFACE`.
- `llms.txt` and its five companions come out **byte-identical** after the refactor (`make check-llms` passes unchanged).

**Generator**

- `cmd/gen_lhm_manifest` rewrites only the `tools`, `prompts`, and `resources` arrays from a real `tools/list` + `prompts/list` + `resources/list` round-trip. Every other field survives untouched, `version` included — the release stamp owns that one.
- The manifest is decoded into a struct covering the whole documented LobeHub schema with `DisallowUnknownFields`, so a misspelled key fails loudly here instead of being silently stripped by the publish endpoint. Re-encoding uses `json.Encoder` with `SetEscapeHTML(false)` and two-space indent; `--check` compares bytes.
- Entries are sorted by name, so the file does not churn when registration order changes.
- Wiring: `make gen-lhm-manifest` / `make check-lhm-manifest`, the check in the CI test job beside `check-llms`, in `make audit-docs`, in `update-all`, and as a prerequisite of `make publish-lobehub`. `.gitignore` covers the stray `/gen_lhm_manifest` binary.
- Docs: release-process step in `CLAUDE.md` (including why the surface is pinned rather than read from the environment), the generator table + section in `docs/development/cmd-utilities.md`, the `cmd/` trees, and the `AGENTS.md` "what to regenerate" table.

**Source fixes the generator surfaced (review follow-ups)**

Two defects that the review found in the manifest turned out to live in the server, so they are fixed there and the manifest diff was produced by re-running the generator:

- `fix(prompts)`: `descState` was one shared string listing `opened, closed, merged, all` for both the MR prompts and `my_issues`. An issue is never merged, so a model taking the description at its word got a 400 from the issues API. Split into `statesIssue` / `statesMergeRequest` behind `issueStateArg` / `mrStateArg`.
- `fix(toolutil)`: `TitleFromName` matched an acronym only when the segment *was* the acronym, so `my_open_mrs` rendered "My Open Mrs" while `review_mr` rendered "Review MR". Plural segments now keep the acronym capitalized and the "s" lowercase. Across the entire registered surface this changes exactly four titles (two prompts, `gitlab_issue_mrs_closing`, `gitlab_issue_mrs_related`) and nothing else; the +2 tokens in the individual-surface footprint are those two tool titles.
- `fix(tooling)`: the manifest decoder now requires EOF after the manifest object and reports missing `identifier`/`name`/`version`, so `--check` cannot certify a file `lhm plugin publish` would reject; the manifest is addressed through an `os.Root` at the project directory.

**Generated vs hand-written manifest**

Regenerating over the hand-written commit produced **semantically identical arrays** — every tool, prompt, and resource entry matches field for field. The only difference is top-level key order: the generator emits `tools`, `prompts`, `resources` (struct order) where the hand-written file had `prompts`, `resources`, `tools`, plus the newly added `icon`.

## How to Test

1. `go run ./cmd/gen_lhm_manifest/ --check` → `lhm.plugin.json is current (2 tools, 37 prompts, 8 resources)`.
2. `TOOL_SURFACE=individual GITLAB_URL=https://gitlab.example.com go run ./cmd/gen_lhm_manifest/ && git diff --exit-code lhm.plugin.json` → no diff; the environment cannot change the output.
3. `make check-llms` → unchanged, proving the `gen_llms` refactor is byte-neutral.
4. `go test ./cmd/gen_lhm_manifest/ ./cmd/internal/mcpsurface/ ./cmd/gen_llms/ -count=1` (and with `-race`).

## Breaking Changes / Migration Notes

N/A

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...`
- [x] `golangci-lint fmt --diff` clean; `golangci-lint run --build-tags e2e` clean on the changed packages
- [x] `go vet ./cmd/...` clean
- [x] Follows the conventions documented in `CLAUDE.md`

### Testing

- [x] Full suite green: `go test -count=1 -coverpkg=./cmd/...,./internal/... ./cmd/... ./internal/...` → total coverage 91.4% (gate: 90%)
- [x] `-race` green on the changed packages
- [x] New tests for the generator (surface fill, metadata preservation, pinned dynamic surface, dropped `outputSchema`/`icons`, idempotence, unknown-field and malformed-JSON rejection, sorting, committed-manifest check) and for the shared package (dynamic contract, resources, prompts, session setup error, project root)
- [x] Test names pass `make audit-test-names`

### Documentation

- [x] Doc comments on every new exported symbol; `godoc_tool audit --include-tests` reports no new findings
- [x] `docs/` updated (`cmd-utilities.md`, `development.md`), plus `CLAUDE.md` and `AGENTS.md`
- [x] Markdown tables normalized (`format_md_tables --check`) and `markdownlint-cli2` clean
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [x] No secrets, tokens, or credentials in the manifest. The generator authenticates a stub HTTP server with a fixed dummy token and never reads `GITLAB_TOKEN`.

## Notes

- The `chore(docs)` commit normalizes an unpadded Markdown table in `docs/development/static-analysis.md` that `format_md_tables` rewrites on the next run; it predates this branch.
- `README.md` repository statistics and `docs/development/testing/testing.md` are stale on `main` (the commit counter alone is 11 behind) and are not gated by CI, so they are deliberately left untouched here rather than dragging an unrelated regeneration diff into this PR.

https://claude.ai/code/session_01Kdq5wyC4TfyMoAj9ZipgHq
