### PR TITLE
chore(docs): refresh the generated README and testing statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,39 +392,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       966 |     192,994 |
-| Unit tests (`_test.go`)  |       535 |     298,265 |
+| Source (`.go`, non-test) |       968 |     193,671 |
+| Unit tests (`_test.go`)  |       537 |     298,963 |
 | End-to-end tests         |       169 |      43,956 |
-| **Total**                | **1,670** | **535,215** |
+| **Total**                | **1,674** | **536,590** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,394 |
-| — exported (public)             |  2,590 |
-| — unexported (private)          |  4,804 |
-| Unit test functions (`TestXxx`) | 11,552 |
-| Subtests (`t.Run(...)`)         |  2,887 |
+| Source functions                |  7,415 |
+| — exported (public)             |  2,600 |
+| — unexported (private)          |  4,815 |
+| Unit test functions (`TestXxx`) | 11,576 |
+| Subtests (`t.Run(...)`)         |  2,893 |
 | End-to-end test functions       |    376 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.55× more tests than code |
-| Average source file length         |                 ~199 lines |
-| Average test file length           |                 ~557 lines |
-| Comment lines in source            |  21,001 (~10.9% of source) |
+| Test lines vs source lines         | 1.54× more tests than code |
+| Average source file length         |                 ~200 lines |
+| Average test file length           |                 ~556 lines |
+| Comment lines in source            |  21,179 (~10.9% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,614 |
-| `defer` statements                 |   828 |
-| `struct` types defined             | 2,714 |
+| `if err != nil` checks             | 6,638 |
+| `defer` statements                 |   830 |
+| `struct` types defined             | 2,722 |
 | `//nolint` suppressions            |   206 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |
 
@@ -432,10 +432,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   227 |
+| Go packages                    |   229 |
 | Direct dependencies (`go.mod`) |    13 |
 | Indirect dependencies          |    50 |
-| Git commits                    |   260 |
+| Git commits                    |   272 |
 | Unique contributors            |     4 |
 
 ### Hall of fame
@@ -449,8 +449,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,508 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,494 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,521 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,521 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,25 +18,25 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,912 |
-| Unit test functions                                   | 11,540 |
+| Total test functions                                  | 11,936 |
+| Unit test functions                                   | 11,564 |
 | E2E test functions                                    |    372 |
-| cmd test functions                                    |    910 |
+| cmd test functions                                    |    933 |
 | Test files (internal/)                                |    465 |
-| Test files (cmd/)                                     |     70 |
+| Test files (cmd/)                                     |     72 |
 | Test files (test/e2e/suite/)                          |    166 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     16 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  91.2% |
 | Overall coverage (`go test ./internal/...`)           |  95.0% |
-| Average package coverage                              |  95.5% |
+| Average package coverage                              |  95.4% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,553 | 88.6% |
-| `TestFunc` (no underscore)             |    962 |  8.1% |
+| `TestFunc_Scenario` (2-part)           | 10,576 | 88.6% |
+| `TestFunc` (no underscore)             |    963 |  8.1% |
 | `TestFunc_Scenario_Expected` (3+ part) |    397 |  3.3% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,021 |        102 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,022 |        102 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            283 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,326 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            372 |        166 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |            910 |         70 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,912** |    **701** |                                                                                                 |
+| cmd packages            |            933 |         72 | server entry point and developer command utilities                                              |
+| **Total**               |     **11,936** |    **703** |                                                                                                 |
 
 ### Core Packages
 
@@ -66,13 +66,13 @@
 | gitlab       |        44 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
-| prompts      |       260 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
+| prompts      |       261 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        28 |    95.9% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil     |       698 |    98.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,021** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,022** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -311,7 +311,7 @@
 | cmd/audit_string_dupes                         |    90.7% |
 | cmd/audit_surface_quality                      |    71.8% |
 | cmd/audit_test_names                           |    48.1% |
-| cmd/audit_tokens                               |    58.7% |
+| cmd/audit_tokens                               |    59.2% |
 | cmd/eval_mcp_surfaces/internal/evalrun         |    88.9% |
 | cmd/eval_mcp_surfaces/internal/evaluator       |    69.2% |
 | cmd/eval_mcp_surfaces/internal/evaluator/cases |    99.6% |
@@ -319,13 +319,15 @@
 | cmd/format_md_tables                           |    92.7% |
 | cmd/gen_action_catalog_manifest                |    41.0% |
 | cmd/gen_docker_tools                           |    86.6% |
-| cmd/gen_llms                                   |    26.6% |
+| cmd/gen_lhm_manifest                           |    78.5% |
+| cmd/gen_llms                                   |    24.7% |
 | cmd/gen_stats                                  |    51.3% |
 | cmd/gen_testing_docs                           |    27.4% |
 | cmd/godoc_tool                                 |    58.9% |
 | cmd/internal/apidocs                           |    86.7% |
 | cmd/internal/docgen                            |    99.5% |
-| cmd/server                                     |    78.6% |
+| cmd/internal/mcpsurface                        |    81.9% |
+| cmd/server                                     |    78.2% |
 
 ### Core Packages
 
@@ -531,7 +533,7 @@
 
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
-- **cmd/gen_llms** (26.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_llms** (24.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (27.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_edition_tier** (36.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1** (39.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -541,15 +543,17 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_dynamic_aliases** (48.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_stats** (51.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_metrics** (52.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_tokens** (58.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/godoc_tool** (58.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tokens** (59.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/metadata** (69.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evaluator** (69.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_surface_quality** (71.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_discovery_completeness** (77.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/server** (78.6%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
+- **cmd/server** (78.2%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
+- **cmd/gen_lhm_manifest** (78.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_catalog_first** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/internal/mcpsurface** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.


### PR DESCRIPTION
## Summary

The repository statistics section of `README.md` and the counts in `docs/development/testing/testing.md` are generated (`make gen-stats`, `make gen-testing-docs`), but neither has a `check-*` gate wired into CI, so both had drifted from the code — the git commit counter alone was twelve behind.

Regenerated with `make update-all`. **Only these two files moved**, which is the useful part of the result: every other generated artifact (token footprint, site stats, `llms*.txt`, `lhm.plugin.json`, the action catalog manifest, Markdown tables) was already current, because those *are* gated.

Nothing here is hand-edited; the diff is entirely refreshed counts.

## Follow-up worth considering

`check-stats` and a testing-docs equivalent exist as targets but run nowhere in CI. Wiring them into the docs job would stop this drifting again — happy to do it in a separate PR, since it changes CI rather than docs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling

## Checklist

- [x] `make audit-docs` passes (markdownlint, doc links, i18n parity, site lint)
- [x] `make check-stats`, `check-footprint`, `check-site-stats`, `check-llms`, `check-lhm-manifest`, `check-doc-links` pass
- [x] No hand-written changes — output of the committed generators

https://claude.ai/code/session_01Kdq5wyC4TfyMoAj9ZipgHq

## Summary by Sourcery

Refresh generated repository and testing statistics in documentation to match the current codebase.

Documentation:
- Update testing metrics and coverage tables in docs/development/testing/testing.md to reflect the latest test counts and package coverage snapshot.
- Regenerate repository statistics in README.md, including file, function, package, and commit counts, to align with the latest source tree.