### PR TITLE
feat(deps): update go-sdk to v1.7.0 and adopt multi round-trip elicitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 | Attribute     | Value                                               |
 | ------------- | --------------------------------------------------- |
 | Language      | Go 1.26.5                                           |
-| MCP SDK       | `github.com/modelcontextprotocol/go-sdk/mcp` v1.6.1 |
+| MCP SDK       | `github.com/modelcontextprotocol/go-sdk/mcp` v1.7.0 |
 | GitLab Client | `gitlab.com/gitlab-org/api/client-go/v2` v2.51.0       |
 | Transport     | stdio (primary), HTTP (optional)                    |
 | Platforms     | Windows, Linux & macOS, amd64 & arm64               |

--- a/README.md
+++ b/README.md
@@ -392,20 +392,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       971 |     194,267 |
-| Unit tests (`_test.go`)  |       540 |     299,514 |
+| Source (`.go`, non-test) |       971 |     194,308 |
+| Unit tests (`_test.go`)  |       540 |     299,625 |
 | End-to-end tests         |       169 |      43,956 |
-| **Total**                | **1,680** | **537,737** |
+| **Total**                | **1,680** | **537,889** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,453 |
-| — exported (public)             |  2,616 |
+| Source functions                |  7,455 |
+| — exported (public)             |  2,618 |
 | — unexported (private)          |  4,837 |
-| Unit test functions (`TestXxx`) | 11,598 |
-| Subtests (`t.Run(...)`)         |  2,893 |
+| Unit test functions (`TestXxx`) | 11,599 |
+| Subtests (`t.Run(...)`)         |  2,895 |
 | End-to-end test functions       |    376 |
 
 ### Ratios worth noting
@@ -415,7 +415,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.54× more tests than code |
 | Average source file length         |                 ~200 lines |
 | Average test file length           |                 ~554 lines |
-| Comment lines in source            |  21,324 (~11.0% of source) |
+| Comment lines in source            |  21,346 (~11.0% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -423,9 +423,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,670 |
-| `defer` statements                 |   831 |
+| `defer` statements                 |   832 |
 | `struct` types defined             | 2,727 |
-| `//nolint` suppressions            |   208 |
+| `//nolint` suppressions            |   210 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |
 
 ### Project
@@ -435,7 +435,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Go packages                    |   229 |
 | Direct dependencies (`go.mod`) |    13 |
 | Indirect dependencies          |    50 |
-| Git commits                    |   273 |
+| Git commits                    |   276 |
 | Unique contributors            |     4 |
 
 ### Hall of fame
@@ -450,7 +450,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~3,532 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,528 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 12,525 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ Measured with `go run ./cmd/audit_tokens/ -footprint` against the current catalo
 
 | Configuration (`TOOL_SURFACE` / `CAPABILITY_SURFACE`) | Tier     | Visible tools | Reachable actions | `META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | ----------------------------------------------------- | -------- | ------------: | ----------------: | ------------------- | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default)                          | Free/CE  |             2 |               851 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`                                 | Free/CE  |             2 |               851 | n/a                 |              2,180 |         1,088 |        3,268 |
-| `dynamic` / `full` (default)                          | Premium  |             2 |             1,003 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`                                 | Premium  |             2 |             1,003 | n/a                 |              2,180 |         1,088 |        3,268 |
-| `dynamic` / `full` (default)                          | Ultimate |             2 |             1,069 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`                                 | Ultimate |             2 |             1,069 | n/a                 |              2,180 |         1,088 |        3,268 |
+| `dynamic` / `full` (default)                          | Free/CE  |             2 |               851 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`                                 | Free/CE  |             2 |               851 | n/a                 |              2,192 |         1,088 |        3,280 |
+| `dynamic` / `full` (default)                          | Premium  |             2 |             1,003 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`                                 | Premium  |             2 |             1,003 | n/a                 |              2,192 |         1,088 |        3,280 |
+| `dynamic` / `full` (default)                          | Ultimate |             2 |             1,069 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`                                 | Ultimate |             2 |             1,069 | n/a                 |              2,192 |         1,088 |        3,280 |
 
 Rows use the base Community Edition catalog unless the Tier column says otherwise. `GITLAB_TIER` controls which actions are available; higher tiers expose more tools and thus more reachable actions.
 
@@ -363,7 +363,7 @@ The published container image is `ghcr.io/jmrplens/gitlab-mcp-server:latest`. Se
 | Component     | Technology                                       |
 | ------------- | ------------------------------------------------ |
 | Language      | Go 1.26+                                         |
-| MCP SDK       | `github.com/modelcontextprotocol/go-sdk` v1.6.1  |
+| MCP SDK       | `github.com/modelcontextprotocol/go-sdk` v1.7.0  |
 | GitLab Client | `gitlab.com/gitlab-org/api/client-go/v2` v2.51.0 |
 | Transport     | stdio (default), HTTP (Streamable HTTP)          |
 
@@ -392,19 +392,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       968 |     193,671 |
-| Unit tests (`_test.go`)  |       537 |     298,963 |
+| Source (`.go`, non-test) |       971 |     194,267 |
+| Unit tests (`_test.go`)  |       540 |     299,514 |
 | End-to-end tests         |       169 |      43,956 |
-| **Total**                | **1,674** | **536,590** |
+| **Total**                | **1,680** | **537,737** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,415 |
-| — exported (public)             |  2,600 |
-| — unexported (private)          |  4,815 |
-| Unit test functions (`TestXxx`) | 11,576 |
+| Source functions                |  7,453 |
+| — exported (public)             |  2,616 |
+| — unexported (private)          |  4,837 |
+| Unit test functions (`TestXxx`) | 11,598 |
 | Subtests (`t.Run(...)`)         |  2,893 |
 | End-to-end test functions       |    376 |
 
@@ -414,18 +414,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.54× more tests than code |
 | Average source file length         |                 ~200 lines |
-| Average test file length           |                 ~556 lines |
-| Comment lines in source            |  21,179 (~10.9% of source) |
+| Average test file length           |                 ~554 lines |
+| Comment lines in source            |  21,324 (~11.0% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,638 |
-| `defer` statements                 |   830 |
-| `struct` types defined             | 2,722 |
-| `//nolint` suppressions            |   206 |
+| `if err != nil` checks             | 6,670 |
+| `defer` statements                 |   831 |
+| `struct` types defined             | 2,727 |
+| `//nolint` suppressions            |   208 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |
 
 ### Project
@@ -435,7 +435,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Go packages                    |   229 |
 | Direct dependencies (`go.mod`) |    13 |
 | Indirect dependencies          |    50 |
-| Git commits                    |   272 |
+| Git commits                    |   273 |
 | Unique contributors            |     4 |
 
 ### Hall of fame
@@ -449,8 +449,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,521 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,521 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,532 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,528 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/main_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/main_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
@@ -4485,30 +4486,33 @@ func TestCallFixtureSetupTool_FallsBackToSplitMetaTool(t *testing.T) {
 func TestEvalElicitationHandler_AdvertisesElicitationToMCPServer(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "elicitation-probe", Version: "0"}, nil)
 	mcp.AddTool(server, &mcp.Tool{Name: "elicitation_probe", Description: "elicitation probe"}, func(ctx context.Context, req *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
-		params := req.Session.InitializeParams()
-		if params == nil || params.Capabilities.Elicitation == nil {
-			return nil, nil, errors.New("elicitation capability not advertised")
-		}
-		result, err := req.Session.Elicit(ctx, &mcp.ElicitParams{
-			Message: "probe",
-			RequestedSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"title":     map[string]any{"type": "string"},
-					"confirmed": map[string]any{"type": "boolean"},
-					"count":     map[string]any{"type": "integer"},
-					"enabled":   map[string]any{"type": "boolean"},
-					"selection": map[string]any{"type": "string", "enum": []any{"private", "internal"}},
-				},
-			},
-		})
+		flow, err := elicitation.FlowFromRequest(req)
 		if err != nil {
 			return nil, nil, err
 		}
-		if validationErr := validateElicitationProbeResult(result); validationErr != nil {
+		if !flow.IsSupported() {
+			return nil, nil, errors.New("elicitation capability not advertised")
+		}
+		content, err := flow.GatherData(ctx, "probe", "probe", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":     map[string]any{"type": "string"},
+				"confirmed": map[string]any{"type": "boolean"},
+				"count":     map[string]any{"type": "integer"},
+				"enabled":   map[string]any{"type": "boolean"},
+				"selection": map[string]any{"type": "string", "enum": []any{"private", "internal"}},
+			},
+		})
+		if errors.Is(err, elicitation.ErrInputPending) {
+			return flow.InputRequiredResult(), nil, nil
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		if validationErr := validateElicitationProbeResult(content); validationErr != nil {
 			return nil, nil, validationErr
 		}
-		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprint(result.Content["title"])}}}, nil, nil
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprint(content["title"])}}}, nil, nil
 	})
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
@@ -4533,18 +4537,18 @@ func TestEvalElicitationHandler_AdvertisesElicitationToMCPServer(t *testing.T) {
 	}
 }
 
-func validateElicitationProbeResult(result *mcp.ElicitResult) error {
-	if result.Action != "accept" || result.Content["confirmed"] != true {
-		return fmt.Errorf("elicitation result = %+v, want accepted confirmation", result)
+func validateElicitationProbeResult(content map[string]any) error {
+	if content["confirmed"] != true {
+		return fmt.Errorf("elicitation content = %+v, want accepted confirmation", content)
 	}
-	if _, ok := result.Content["enabled"].(bool); !ok {
-		return fmt.Errorf("elicitation enabled = %T, want bool", result.Content["enabled"])
+	if _, ok := content["enabled"].(bool); !ok {
+		return fmt.Errorf("elicitation enabled = %T, want bool", content["enabled"])
 	}
-	if err := validateElicitationNumericZero(result.Content["count"]); err != nil {
+	if err := validateElicitationNumericZero(content["count"]); err != nil {
 		return err
 	}
-	if result.Content["selection"] != "private" {
-		return fmt.Errorf("elicitation selection = %v, want private", result.Content["selection"])
+	if content["selection"] != "private" {
+		return fmt.Errorf("elicitation selection = %v, want private", content["selection"])
 	}
 	return nil
 }

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -80,7 +80,7 @@ graph TD
         PROG[progress<br/>Progress notifications]
         ELICIT[elicitation<br/>User input client]
         ICN[icons<br/>50 SVG domain icons]
-        SRV[MCP Server<br/>go-sdk/mcp v1.6.1]
+        SRV[MCP Server<br/>go-sdk/mcp v1.7.0]
         STDIO[StdioTransport]
         HTTP[StreamableHTTPHandler]
         POOL[serverpool<br/>Per-token+URL server pool & LRU cache]

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -493,7 +493,7 @@ Install the Go extension and add to `.vscode/mcp.json`:
 
 | Dependency                               | Version | Purpose                         |
 | ---------------------------------------- | ------- | ------------------------------- |
-| `github.com/modelcontextprotocol/go-sdk` | v1.6.1  | MCP server framework            |
+| `github.com/modelcontextprotocol/go-sdk` | v1.7.0  | MCP server framework            |
 | `gitlab.com/gitlab-org/api/client-go/v2` | v2.51.0 | Official GitLab REST API client |
 | `github.com/joho/godotenv`               | v1.5.1  | .env file loading for dev       |
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,936 |
-| Unit test functions                                   | 11,564 |
+| Total test functions                                  | 11,958 |
+| Unit test functions                                   | 11,586 |
 | E2E test functions                                    |    372 |
 | cmd test functions                                    |    933 |
-| Test files (internal/)                                |    465 |
+| Test files (internal/)                                |    468 |
 | Test files (cmd/)                                     |     72 |
 | Test files (test/e2e/suite/)                          |    166 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     16 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  91.2% |
-| Overall coverage (`go test ./internal/...`)           |  95.0% |
-| Average package coverage                              |  95.4% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  91.1% |
+| Overall coverage (`go test ./internal/...`)           |  94.9% |
+| Average package coverage                              |  95.3% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,576 | 88.6% |
-| `TestFunc` (no underscore)             |    963 |  8.1% |
-| `TestFunc_Scenario_Expected` (3+ part) |    397 |  3.3% |
+| `TestFunc_Scenario` (2-part)           | 10,582 | 88.5% |
+| `TestFunc` (no underscore)             |    964 |  8.1% |
+| `TestFunc_Scenario_Expected` (3+ part) |    412 |  3.4% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,022 |        102 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,044 |        105 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            283 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,326 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            372 |        166 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            933 |         72 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,936** |    **703** |                                                                                                 |
+| **Total**               |     **11,958** |    **706** |                                                                                                 |
 
 ### Core Packages
 
@@ -62,17 +62,17 @@
 | completions  |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
 | config       |        74 |    99.7% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
 | edition      |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
-| elicitation  |        79 |    92.5% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
+| elicitation  |        99 |    84.2% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
 | gitlab       |        44 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
 | prompts      |       261 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
-| testutil     |        28 |    95.9% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       698 |    98.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| testutil     |        29 |    85.3% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
+| toolutil     |       699 |    98.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,022** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,044** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -151,7 +151,7 @@
 | dockerfiletemplates     |        15 |          1 |   100.0% |         2 |
 | dorametrics             |        11 |          2 |   100.0% |         2 |
 | dynamic                 |       159 |         10 |    99.9% |         2 |
-| elicitationtools        |        61 |          2 |   100.0% |         4 |
+| elicitationtools        |        61 |          2 |    99.5% |         4 |
 | enterpriseusers         |        35 |          3 |   100.0% |         4 |
 | environments            |        56 |          2 |   100.0% |         6 |
 | epicdiscussions         |        16 |          2 |   100.0% |         6 |
@@ -339,22 +339,22 @@
 | completions |   100.0% |
 | config      |    99.7% |
 | edition     |    87.0% |
-| elicitation |    92.5% |
+| elicitation |    84.2% |
 | gitlab      |   100.0% |
 | oauth       |    98.6% |
 | progress    |   100.0% |
 | prompts     |   100.0% |
 | resources   |   100.0% |
 | serverpool  |    99.6% |
-| testutil    |    95.9% |
-| toolutil    |    98.9% |
+| testutil    |    85.3% |
+| toolutil    |    98.8% |
 | wizard      |   100.0% |
 
 ### Tool Sub-Packages
 
 | Package                 | Coverage |
 | ----------------------- | -------: |
-| tools (orch.)           |    98.2% |
+| tools (orch.)           |    98.0% |
 | accessrequests          |   100.0% |
 | accesstokens            |    99.8% |
 | actioncatalog           |    99.1% |
@@ -395,7 +395,7 @@
 | dockerfiletemplates     |   100.0% |
 | dorametrics             |   100.0% |
 | dynamic                 |    99.9% |
-| elicitationtools        |   100.0% |
+| elicitationtools        |    99.5% |
 | enterpriseusers         |   100.0% |
 | environments            |   100.0% |
 | epicdiscussions         |   100.0% |
@@ -554,6 +554,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_catalog_first** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/mcpsurface** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **elicitation** (84.2%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
+- **testutil** (85.3%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 11,958 |
-| Unit test functions                                   | 11,586 |
+| Total test functions                                  | 11,959 |
+| Unit test functions                                   | 11,587 |
 | E2E test functions                                    |    372 |
 | cmd test functions                                    |    933 |
 | Test files (internal/)                                |    468 |
@@ -37,7 +37,7 @@
 | -------------------------------------- | -----: | ----: |
 | `TestFunc_Scenario` (2-part)           | 10,582 | 88.5% |
 | `TestFunc` (no underscore)             |    964 |  8.1% |
-| `TestFunc_Scenario_Expected` (3+ part) |    412 |  3.4% |
+| `TestFunc_Scenario_Expected` (3+ part) |    413 |  3.5% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,044 |        105 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,045 |        105 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            283 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,326 |        349 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            372 |        166 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            933 |         72 | server entry point and developer command utilities                                              |
-| **Total**               |     **11,958** |    **706** |                                                                                                 |
+| **Total**               |     **11,959** |    **706** |                                                                                                 |
 
 ### Core Packages
 
@@ -62,7 +62,7 @@
 | completions  |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
 | config       |        74 |    99.7% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
 | edition      |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
-| elicitation  |        99 |    84.2% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
+| elicitation  |       100 |    85.0% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
 | gitlab       |        44 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth        |        35 |    98.6% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress     |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
@@ -70,9 +70,9 @@
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        29 |    85.3% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       699 |    98.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       699 |    98.7% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,044** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,045** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -339,7 +339,7 @@
 | completions |   100.0% |
 | config      |    99.7% |
 | edition     |    87.0% |
-| elicitation |    84.2% |
+| elicitation |    85.0% |
 | gitlab      |   100.0% |
 | oauth       |    98.6% |
 | progress    |   100.0% |
@@ -347,7 +347,7 @@
 | resources   |   100.0% |
 | serverpool  |    99.6% |
 | testutil    |    85.3% |
-| toolutil    |    98.8% |
+| toolutil    |    98.7% |
 | wizard      |   100.0% |
 
 ### Tool Sub-Packages
@@ -554,7 +554,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_catalog_first** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/mcpsurface** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **elicitation** (84.2%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
+- **elicitation** (85.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **testutil** (85.3%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -29,33 +29,33 @@ All measurements are against the current source tree. The catalog is built in-me
 
 | Configuration                | Tier     | Visible tools | Reachable actions | `META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | ---------------------------- | -------- | ------------: | ----------------: | ------------------- | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default) | Free/CE  |             2 |               851 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`        | Free/CE  |             2 |               851 | n/a                 |              2,180 |         1,088 |        3,268 |
-| `meta` / `full` (opaque)     | Free/CE  |            33 |               851 | `opaque`            |            135,835 |        31,758 |      167,593 |
-| `meta` / `minimal` (opaque)  | Free/CE  |            33 |               851 | `opaque`            |            135,835 |         1,088 |      136,923 |
-| `meta` / `full` (compact)    | Free/CE  |            33 |               851 | `compact`           |            201,191 |        31,758 |      232,949 |
-| `meta` / `minimal` (compact) | Free/CE  |            33 |               851 | `compact`           |            201,191 |         1,088 |      202,279 |
-| `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            287,787 |        31,758 |      319,545 |
-| `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            287,787 |         1,088 |      288,875 |
-| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            768,810 |        31,758 |      800,568 |
-| `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              2,180 |         1,088 |        3,268 |
-| `meta` / `full` (opaque)     | Premium  |            39 |             1,003 | `opaque`            |            157,424 |        31,758 |      189,182 |
-| `meta` / `minimal` (opaque)  | Premium  |            39 |             1,003 | `opaque`            |            157,424 |         1,088 |      158,512 |
-| `meta` / `full` (compact)    | Premium  |            39 |             1,003 | `compact`           |            234,192 |        31,758 |      265,950 |
-| `meta` / `minimal` (compact) | Premium  |            39 |             1,003 | `compact`           |            234,192 |         1,088 |      235,280 |
-| `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            334,991 |        31,758 |      366,749 |
-| `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            334,991 |         1,088 |      336,079 |
-| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            919,548 |        31,758 |      951,306 |
-| `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              2,180 |        31,758 |       33,938 |
-| `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              2,180 |         1,088 |        3,268 |
-| `meta` / `full` (opaque)     | Ultimate |            50 |             1,069 | `opaque`            |            172,181 |        31,758 |      203,939 |
-| `meta` / `minimal` (opaque)  | Ultimate |            50 |             1,069 | `opaque`            |            172,181 |         1,088 |      173,269 |
-| `meta` / `full` (compact)    | Ultimate |            50 |             1,069 | `compact`           |            253,370 |        31,758 |      285,128 |
-| `meta` / `minimal` (compact) | Ultimate |            50 |             1,069 | `compact`           |            253,370 |         1,088 |      254,458 |
-| `meta` / `full` (full)       | Ultimate |            50 |             1,069 | `full`              |            358,993 |        31,758 |      390,751 |
-| `meta` / `minimal` (full)    | Ultimate |            50 |             1,069 | `full`              |            358,993 |         1,088 |      360,081 |
-| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            968,621 |        31,758 |    1,000,379 |
+| `dynamic` / `full` (default) | Free/CE  |             2 |               851 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`        | Free/CE  |             2 |               851 | n/a                 |              2,192 |         1,088 |        3,280 |
+| `meta` / `full` (opaque)     | Free/CE  |            33 |               851 | `opaque`            |            136,159 |        31,758 |      167,917 |
+| `meta` / `minimal` (opaque)  | Free/CE  |            33 |               851 | `opaque`            |            136,159 |         1,088 |      137,247 |
+| `meta` / `full` (compact)    | Free/CE  |            33 |               851 | `compact`           |            201,515 |        31,758 |      233,273 |
+| `meta` / `minimal` (compact) | Free/CE  |            33 |               851 | `compact`           |            201,515 |         1,088 |      202,603 |
+| `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            288,111 |        31,758 |      319,869 |
+| `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            288,111 |         1,088 |      289,199 |
+| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            772,150 |        31,758 |      803,908 |
+| `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              2,192 |         1,088 |        3,280 |
+| `meta` / `full` (opaque)     | Premium  |            39 |             1,003 | `opaque`            |            157,808 |        31,758 |      189,566 |
+| `meta` / `minimal` (opaque)  | Premium  |            39 |             1,003 | `opaque`            |            157,808 |         1,088 |      158,896 |
+| `meta` / `full` (compact)    | Premium  |            39 |             1,003 | `compact`           |            234,576 |        31,758 |      266,334 |
+| `meta` / `minimal` (compact) | Premium  |            39 |             1,003 | `compact`           |            234,576 |         1,088 |      235,664 |
+| `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            335,375 |        31,758 |      367,133 |
+| `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            335,375 |         1,088 |      336,463 |
+| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            923,460 |        31,758 |      955,218 |
+| `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              2,192 |        31,758 |       33,950 |
+| `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              2,192 |         1,088 |        3,280 |
+| `meta` / `full` (opaque)     | Ultimate |            50 |             1,069 | `opaque`            |            172,661 |        31,758 |      204,419 |
+| `meta` / `minimal` (opaque)  | Ultimate |            50 |             1,069 | `opaque`            |            172,661 |         1,088 |      173,749 |
+| `meta` / `full` (compact)    | Ultimate |            50 |             1,069 | `compact`           |            253,850 |        31,758 |      285,608 |
+| `meta` / `minimal` (compact) | Ultimate |            50 |             1,069 | `compact`           |            253,850 |         1,088 |      254,938 |
+| `meta` / `full` (full)       | Ultimate |            50 |             1,069 | `full`              |            359,473 |        31,758 |      391,231 |
+| `meta` / `minimal` (full)    | Ultimate |            50 |             1,069 | `full`              |            359,473 |         1,088 |      360,561 |
+| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            972,805 |        31,758 |    1,004,563 |
 
 ## Interpretation guide
 

--- a/docs/reference/capabilities/elicitation.md
+++ b/docs/reference/capabilities/elicitation.md
@@ -16,6 +16,7 @@
 - [How It Works](#how-it-works)
 - [API](#api)
   - [Client](#client)
+  - [Flow](#flow)
   - [Methods](#methods)
   - [Error Types](#error-types)
 - [Security](#security)
@@ -92,6 +93,28 @@ Each step in the flow is a separate `elicitation/create` request from the server
 
 The user can **decline** at the confirmation step or **cancel** at any step, aborting the entire flow cleanly.
 
+### Two Wire Mechanisms, One Flow API
+
+How prompts travel over the wire depends on the negotiated MCP protocol version. The `elicitation.Flow` type selects the mechanism automatically per session, so tool code is written once:
+
+| Session protocol        | Mechanism                                  | Wire shape                                                                                                                 |
+| ----------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `< 2026-07-28` (legacy) | Synchronous server-initiated requests      | The server sends `elicitation/create` requests mid-call and blocks for each answer                                         |
+| `>= 2026-07-28`         | Multi round-trip requests (MRTR, SEP-2322) | The tool result carries an `inputRequests` map; the client fulfills it and retries the call with `inputResponses` attached |
+
+On the multi round-trip path the handler is **re-invoked from the start on every round**. Answers gathered in earlier rounds are carried in the opaque `requestState` string that the client echoes back, so multi-step wizards replay previously answered prompts from state instead of re-asking the user. From the user's perspective both mechanisms look identical: the same sequential forms in the same order.
+
+```go
+flow, err := elicitation.FlowFromRequest(req)
+if err != nil { /* malformed client-echoed state */ }
+title, err := flow.PromptText(ctx, "title", "Enter the issue title", "title")
+if errors.Is(err, elicitation.ErrInputPending) {
+    return flow.InputRequiredResult(), nil, nil // client answers and retries
+}
+```
+
+Handlers that report outcomes through an error return use `flow.PendingError()` instead; the surface wrappers unwrap the `*elicitation.InputRequiredError` and return the embedded input-required result.
+
 ## API
 
 ### Client
@@ -103,6 +126,15 @@ elicitClient := elicitation.FromRequest(req)
 if !elicitClient.IsSupported() {
     return ..., elicitation.ErrElicitationNotSupported
 }
+```
+
+### Flow
+
+`Flow` (built with `FlowFromRequest(req)`) is the protocol-aware entry point used by all wizards and confirmation guards. It mirrors every `Client` prompt method with one extra leading argument: a **stable exchange id** (unique per prompt within one tool call) that identifies the exchange across handler re-invocations on the multi round-trip path. On legacy sessions each method delegates to the synchronous `Client` internally.
+
+```go
+flow, err := elicitation.FlowFromRequest(req)
+visibility, err := flow.SelectOne(ctx, "visibility", "Select the project visibility", options)
 ```
 
 ### Methods
@@ -134,12 +166,13 @@ if !elicitClient.IsSupported() {
 
 ### Error Types
 
-| Error                           | Meaning                                      | Tool Handler Action                                     |
-| ------------------------------- | -------------------------------------------- | ------------------------------------------------------- |
-| `ErrElicitationNotSupported`    | Client does not support elicitation          | Return informational message explaining the requirement |
-| `ErrURLElicitationNotSupported` | Client does not support URL mode elicitation | Fall back to text-based workflow                        |
-| `ErrDeclined`                   | User declined the elicitation request        | Return cancellation message via `CancelledResult`       |
-| `ErrCancelled`                  | User cancelled the elicitation flow          | Return cancellation message via `CancelledResult`       |
+| Error                           | Meaning                                      | Tool Handler Action                                                                               |
+| ------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ErrElicitationNotSupported`    | Client does not support elicitation          | Return informational message explaining the requirement                                           |
+| `ErrURLElicitationNotSupported` | Client does not support URL mode elicitation | Fall back to text-based workflow                                                                  |
+| `ErrInputPending`               | Multi round-trip answer not yet available    | Return `flow.InputRequiredResult()` (or `flow.PendingError()`) so the client can answer and retry |
+| `ErrDeclined`                   | User declined the elicitation request        | Return cancellation message via `CancelledResult`                                                 |
+| `ErrCancelled`                  | User cancelled the elicitation flow          | Return cancellation message via `CancelledResult`                                                 |
 
 ### Cancellation Helper
 

--- a/docs/reference/capabilities/elicitation.md
+++ b/docs/reference/capabilities/elicitation.md
@@ -100,9 +100,9 @@ How prompts travel over the wire depends on the negotiated MCP protocol version.
 | Session protocol        | Mechanism                                  | Wire shape                                                                                                                 |
 | ----------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | `< 2026-07-28` (legacy) | Synchronous server-initiated requests      | The server sends `elicitation/create` requests mid-call and blocks for each answer                                         |
-| `>= 2026-07-28`         | Multi round-trip requests (MRTR, SEP-2322) | The tool result carries an `inputRequests` map; the client fulfills it and retries the call with `inputResponses` attached |
+| `>= 2026-07-28`         | Multi-round-trip requests (MRTR, SEP-2322) | The tool result carries an `inputRequests` map; the client fulfills it and retries the call with `inputResponses` attached |
 
-On the multi round-trip path the handler is **re-invoked from the start on every round**. Answers gathered in earlier rounds are carried in the opaque `requestState` string that the client echoes back, so multi-step wizards replay previously answered prompts from state instead of re-asking the user. From the user's perspective both mechanisms look identical: the same sequential forms in the same order.
+On the multi-round-trip path the handler is **re-invoked from the start on every round**. Answers gathered in earlier rounds are carried in the opaque `requestState` string that the client echoes back, so multi-step wizards replay previously answered prompts from state instead of re-asking the user. From the user's perspective both mechanisms look identical: the same sequential forms in the same order.
 
 ```go
 flow, err := elicitation.FlowFromRequest(req)
@@ -130,7 +130,7 @@ if !elicitClient.IsSupported() {
 
 ### Flow
 
-`Flow` (built with `FlowFromRequest(req)`) is the protocol-aware entry point used by all wizards and confirmation guards. It mirrors every `Client` prompt method with one extra leading argument: a **stable exchange id** (unique per prompt within one tool call) that identifies the exchange across handler re-invocations on the multi round-trip path. On legacy sessions each method delegates to the synchronous `Client` internally.
+`Flow` (built with `FlowFromRequest(req)`) is the protocol-aware entry point used by all wizards and confirmation guards. It mirrors every `Client` prompt method with one extra leading argument: a **stable exchange id** (unique per prompt within one tool call) that identifies the exchange across handler re-invocations on the multi-round-trip path. On legacy sessions each method delegates to the synchronous `Client` internally.
 
 ```go
 flow, err := elicitation.FlowFromRequest(req)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/creativeprojects/go-selfupdate v1.6.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/joho/godotenv v1.5.1
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/tiktoken-go/tokenizer v0.8.1
 	gitlab.com/gitlab-org/api/client-go/v2 v2.51.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
 github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/internal/elicitation/elicitation.go
+++ b/internal/elicitation/elicitation.go
@@ -21,7 +21,6 @@ import (
 	"log/slog"
 	"math"
 	"net/url"
-	"slices"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -89,25 +88,11 @@ func (c Client) Confirm(ctx context.Context, message string) (bool, error) {
 		return false, ErrElicitationNotSupported
 	}
 
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"confirmed": map[string]any{
-				"type":        "boolean",
-				"title":       "Confirm",
-				"description": message,
-			},
-		},
-		"required": []string{"confirmed"},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, confirmSchema(message))
 	if err != nil {
 		return false, err
 	}
-
-	confirmed, ok := result["confirmed"].(bool)
-	return ok && confirmed, nil
+	return parseConfirmContent(result), nil
 }
 
 // PromptText asks the user for free-form text input and returns the value.
@@ -119,28 +104,11 @@ func (c Client) PromptText(ctx context.Context, message, fieldName string) (stri
 		fieldName = "value"
 	}
 
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			fieldName: map[string]any{
-				"type":        "string",
-				"title":       fieldName,
-				"description": message,
-			},
-		},
-		"required": []string{fieldName},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, textSchema(message, fieldName))
 	if err != nil {
 		return "", err
 	}
-
-	text, ok := result[fieldName].(string)
-	if !ok {
-		return "", fmt.Errorf("elicitation: response field %q is not a string", fieldName)
-	}
-	return text, nil
+	return parseTextContent(result, fieldName)
 }
 
 // SelectOne asks the user to pick one option from a list.
@@ -152,39 +120,11 @@ func (c Client) SelectOne(ctx context.Context, message string, options []string)
 		return "", errors.New(errOptionsEmpty)
 	}
 
-	enumValues := make([]any, len(options))
-	for i, o := range options {
-		enumValues[i] = o
-	}
-
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"selection": map[string]any{
-				"type":        "string",
-				"title":       "Selection",
-				"description": message,
-				"enum":        enumValues,
-			},
-		},
-		"required": []string{"selection"},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, selectOneSchema(message, options))
 	if err != nil {
 		return "", err
 	}
-
-	selection, ok := result["selection"].(string)
-	if !ok {
-		return "", errors.New("elicitation: response field 'selection' is not a string")
-	}
-
-	// Validate against allowed options (defense in depth)
-	if slices.Contains(options, selection) {
-		return selection, nil
-	}
-	return "", fmt.Errorf("elicitation: selected value %q is not in the allowed options", selection)
+	return parseSelectOneContent(result, options)
 }
 
 // SelectMulti asks the user to pick one or more options from a list.
@@ -197,59 +137,11 @@ func (c Client) SelectMulti(ctx context.Context, message string, options []strin
 		return nil, errors.New(errOptionsEmpty)
 	}
 
-	enumValues := make([]any, len(options))
-	for i, o := range options {
-		enumValues[i] = o
-	}
-
-	items := map[string]any{
-		"type": "string",
-		"enum": enumValues,
-	}
-	arraySchema := map[string]any{
-		"type":        "array",
-		"title":       "Selections",
-		"description": message,
-		"items":       items,
-	}
-	if minItems > 0 {
-		arraySchema["minItems"] = minItems
-	}
-	if maxItems > 0 {
-		arraySchema["maxItems"] = maxItems
-	}
-
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"selections": arraySchema,
-		},
-		"required": []string{"selections"},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, selectMultiSchema(message, options, minItems, maxItems))
 	if err != nil {
 		return nil, err
 	}
-
-	raw, ok := result["selections"].([]any)
-	if !ok {
-		return nil, errors.New("elicitation: response field 'selections' is not an array")
-	}
-
-	selections := make([]string, 0, len(raw))
-	for _, v := range raw {
-		var s string
-		s, ok = v.(string)
-		if !ok {
-			return nil, fmt.Errorf("elicitation: selection element is not a string: %v", v)
-		}
-		if !slices.Contains(options, s) {
-			return nil, fmt.Errorf("elicitation: selected value %q is not in the allowed options", s)
-		}
-		selections = append(selections, s)
-	}
-	return selections, nil
+	return parseSelectMultiContent(result, options)
 }
 
 // SelectOneInt asks the user to pick one integer from a list of allowed values.
@@ -261,46 +153,11 @@ func (c Client) SelectOneInt(ctx context.Context, message string, options []int)
 		return 0, errors.New(errOptionsEmpty)
 	}
 
-	enumValues := make([]any, len(options))
-	for i, o := range options {
-		enumValues[i] = o
-	}
-
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"selection": map[string]any{
-				"type":        "integer",
-				"title":       "Selection",
-				"description": message,
-				"enum":        enumValues,
-			},
-		},
-		"required": []string{"selection"},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, selectOneIntSchema(message, options))
 	if err != nil {
 		return 0, err
 	}
-
-	// JSON numbers are float64 by default
-	f, ok := result["selection"].(float64)
-	if !ok {
-		return 0, errors.New("elicitation: response field 'selection' is not a number")
-	}
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return 0, errors.New("elicitation: response field 'selection' is not a finite number")
-	}
-	if f != math.Trunc(f) {
-		return 0, fmt.Errorf("elicitation: response value %g is not an integer", f)
-	}
-	selected := int(f)
-
-	if !slices.Contains(options, selected) {
-		return 0, fmt.Errorf("elicitation: selected value %d is not in the allowed options", selected)
-	}
-	return selected, nil
+	return parseSelectOneIntContent(result, options)
 }
 
 // PromptNumber asks the user for a numeric input within a range.
@@ -313,39 +170,11 @@ func (c Client) PromptNumber(ctx context.Context, message, fieldName string, min
 		fieldName = "value"
 	}
 
-	prop := map[string]any{
-		"type":        "number",
-		"title":       fieldName,
-		"description": message,
-	}
-	if !isInf(minVal) {
-		prop["minimum"] = minVal
-	}
-	if !isInf(maxVal) {
-		prop["maximum"] = maxVal
-	}
-
-	schema := map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			fieldName: prop,
-		},
-		"required": []string{fieldName},
-	}
-
-	result, err := c.elicit(ctx, message, schema)
+	result, err := c.elicit(ctx, message, numberSchema(message, fieldName, minVal, maxVal))
 	if err != nil {
 		return 0, err
 	}
-
-	f, ok := result[fieldName].(float64)
-	if !ok {
-		return 0, fmt.Errorf("elicitation: response field %q is not a number", fieldName)
-	}
-	if math.IsNaN(f) {
-		return 0, fmt.Errorf("elicitation: response field %q is NaN", fieldName)
-	}
-	return f, nil
+	return parseNumberContent(result, fieldName)
 }
 
 // isInf reports whether f is +Inf or -Inf.
@@ -382,17 +211,7 @@ func (c Client) elicit(ctx context.Context, message string, schema map[string]an
 	if err != nil {
 		return nil, fmt.Errorf("elicitation: request failed: %w", err)
 	}
-
-	switch result.Action {
-	case "accept":
-		return result.Content, nil
-	case "decline":
-		return nil, ErrDeclined
-	case "cancel":
-		return nil, ErrCancelled
-	default:
-		return nil, fmt.Errorf("elicitation: unknown action %q", result.Action)
-	}
+	return contentForAction(result.Action, result.Content)
 }
 
 // ElicitURL sends a URL-mode elicitation request, directing the user to
@@ -488,19 +307,33 @@ func validateGitLabURL(gitlabBaseURL, targetURL string) error {
 	return nil
 }
 
+// ConfirmExchangeID is the stable input-request id used by single-round
+// confirmation guards on the multi round-trip elicitation path.
+const ConfirmExchangeID = "confirm"
+
 // ConfirmAction asks the user to confirm an action via elicitation.
 // Returns nil if confirmed or elicitation is not supported (backward compatible).
-// Returns a non-nil *mcp.CallToolResult if the user declined or canceled.
+// Returns a non-nil *mcp.CallToolResult if the user declined or canceled, or
+// an input-required result when the session uses multi round-trip requests
+// and the client has not answered yet.
 func ConfirmAction(ctx context.Context, req *mcp.CallToolRequest, message string) *mcp.CallToolResult {
-	ec := FromRequest(req)
-	if !ec.IsSupported() {
+	flow, err := FlowFromRequest(req)
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
+			IsError: true,
+		}
+	}
+	if !flow.IsSupported() {
 		return nil
 	}
-	confirmed, err := ec.Confirm(ctx, message)
-	if err != nil {
-		if errors.Is(err, ErrDeclined) || errors.Is(err, ErrCancelled) {
-			return CancelledResult("Operation canceled by user.")
-		}
+	confirmed, err := flow.Confirm(ctx, ConfirmExchangeID, message)
+	switch {
+	case errors.Is(err, ErrInputPending):
+		return flow.InputRequiredResult()
+	case errors.Is(err, ErrDeclined), errors.Is(err, ErrCancelled):
+		return CancelledResult("Operation canceled by user.")
+	case err != nil:
 		return nil
 	}
 	if !confirmed {

--- a/internal/elicitation/elicitation.go
+++ b/internal/elicitation/elicitation.go
@@ -141,7 +141,7 @@ func (c Client) SelectMulti(ctx context.Context, message string, options []strin
 	if err != nil {
 		return nil, err
 	}
-	return parseSelectMultiContent(result, options)
+	return parseSelectMultiContent(result, options, minItems, maxItems)
 }
 
 // SelectOneInt asks the user to pick one integer from a list of allowed values.
@@ -174,7 +174,7 @@ func (c Client) PromptNumber(ctx context.Context, message, fieldName string, min
 	if err != nil {
 		return 0, err
 	}
-	return parseNumberContent(result, fieldName)
+	return parseNumberContent(result, fieldName, minVal, maxVal)
 }
 
 // isInf reports whether f is +Inf or -Inf.
@@ -315,14 +315,13 @@ const ConfirmExchangeID = "confirm"
 // Returns nil if confirmed or elicitation is not supported (backward compatible).
 // Returns a non-nil *mcp.CallToolResult if the user declined or canceled, or
 // an input-required result when the session uses multi round-trip requests
-// and the client has not answered yet.
+// and the client has not answered yet. Any other confirmation failure fails
+// closed with an error result: a destructive action must never proceed on a
+// malformed or failed confirmation exchange.
 func ConfirmAction(ctx context.Context, req *mcp.CallToolRequest, message string) *mcp.CallToolResult {
 	flow, err := FlowFromRequest(req)
 	if err != nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
-			IsError: true,
-		}
+		return ConfirmFailedResult(err)
 	}
 	if !flow.IsSupported() {
 		return nil
@@ -334,12 +333,24 @@ func ConfirmAction(ctx context.Context, req *mcp.CallToolRequest, message string
 	case errors.Is(err, ErrDeclined), errors.Is(err, ErrCancelled):
 		return CancelledResult("Operation canceled by user.")
 	case err != nil:
-		return nil
+		return ConfirmFailedResult(err)
 	}
 	if !confirmed {
 		return CancelledResult("Operation canceled by user.")
 	}
 	return nil
+}
+
+// ConfirmFailedResult returns the fail-closed error result used when a
+// destructive-action confirmation exchange fails for a reason other than an
+// explicit user decision (for example a malformed answer or a transport
+// failure). It instructs the caller to re-send with explicit approval.
+func ConfirmFailedResult(err error) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf(
+			"Confirmation failed: %v. The action was not executed. Re-send with \"confirm\": true only after the user explicitly approves this operation.", err)}},
+		IsError: true,
+	}
 }
 
 // CancelledResult returns a non-error tool result indicating the user canceled.

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -128,32 +128,19 @@ func TestElicit_ContextCancelled(t *testing.T) {
 // Integration tests using InMemoryTransports.
 
 // setupElicitSession creates an in-memory MCP server/client pair with the
-// given elicitation handler. Returns the server, its session, and a cleanup
-// function that closes both sessions.
+// given elicitation handler. The client performs the legacy 2025-11-25
+// handshake (via testutil.ConnectLegacyElicitationClient) because the
+// synchronous [Client] path only exists on sessions negotiated below
+// protocol 2026-07-28. Returns the server, its session, and a cleanup
+// function (a no-op; teardown is registered via t.Cleanup).
 func setupElicitSession(t *testing.T, ctx context.Context, handler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) (*mcp.Server, *mcp.ServerSession, func()) {
 	t.Helper()
 
 	server := mcp.NewServer(testImpl, nil)
-	client := mcp.NewClient(testImpl, &mcp.ClientOptions{
-		ElicitationHandler: handler,
-	})
-
-	st, ct := mcp.NewInMemoryTransports()
-	ss, err := server.Connect(ctx, st, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-	cs, err := client.Connect(ctx, ct, nil)
-	if err != nil {
-		ss.Close()
-		t.Fatalf("client connect: %v", err)
-	}
-
-	cleanup := func() {
-		cs.Close()
-		ss.Close()
-	}
-	return server, ss, cleanup
+	ss := testutil.ConnectLegacyElicitationClient(ctx, t, server, func(ctx context.Context, params *mcp.ElicitParams) (*mcp.ElicitResult, error) {
+		return handler(ctx, &mcp.ElicitRequest{Params: params})
+	}, testutil.LegacyClientOptions{})
+	return server, ss, func() {}
 }
 
 // TestConfirm_Accept verifies that [Client.Confirm] returns true when the
@@ -749,37 +736,15 @@ func TestPromptNumber_Decline(t *testing.T) {
 }
 
 // setupElicitURLSession creates an in-memory MCP client/server pair where
-// the client advertises both form and URL elicitation capabilities.
+// the legacy client advertises both form and URL elicitation capabilities.
 func setupElicitURLSession(t *testing.T, ctx context.Context, handler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) (*mcp.Server, *mcp.ServerSession, func()) {
 	t.Helper()
 
 	server := mcp.NewServer(testImpl, nil)
-	client := mcp.NewClient(testImpl, &mcp.ClientOptions{
-		ElicitationHandler: handler,
-		Capabilities: &mcp.ClientCapabilities{
-			Elicitation: &mcp.ElicitationCapabilities{
-				Form: &mcp.FormElicitationCapabilities{},
-				URL:  &mcp.URLElicitationCapabilities{},
-			},
-		},
-	})
-
-	st, ct := mcp.NewInMemoryTransports()
-	ss, err := server.Connect(ctx, st, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-	cs, err := client.Connect(ctx, ct, nil)
-	if err != nil {
-		ss.Close()
-		t.Fatalf("client connect: %v", err)
-	}
-
-	cleanup := func() {
-		cs.Close()
-		ss.Close()
-	}
-	return server, ss, cleanup
+	ss := testutil.ConnectLegacyElicitationClient(ctx, t, server, func(ctx context.Context, params *mcp.ElicitParams) (*mcp.ElicitResult, error) {
+		return handler(ctx, &mcp.ElicitRequest{Params: params})
+	}, testutil.LegacyClientOptions{URLElicitation: true})
+	return server, ss, func() {}
 }
 
 // URL Mode Tests.

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -1264,12 +1264,10 @@ func TestConfirmAction_NotConfirmed(t *testing.T) {
 	}
 }
 
-// TestConfirmAction_OtherError verifies that [ConfirmAction] returns nil
-// (does not cancel the operation) when [Client.Confirm] returns an error
-// that is neither [ErrDeclined] nor [ErrCancelled]. The handler signals
-// this by returning an unrecognized Action value, which causes the SDK
-// (or our wrapper) to surface a generic error rather than the two
-// well-known sentinels.
+// TestConfirmAction_OtherError verifies that [ConfirmAction] fails closed
+// when [Client.Confirm] returns an error that is neither [ErrDeclined] nor
+// [ErrCancelled]: the guard returns an error result so the destructive
+// action does not proceed on a failed confirmation exchange.
 func TestConfirmAction_OtherError(t *testing.T) {
 	ctx := context.Background()
 	server, ss, cleanup := setupElicitSession(t, ctx, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
@@ -1281,8 +1279,11 @@ func TestConfirmAction_OtherError(t *testing.T) {
 	req := &mcp.CallToolRequest{}
 	req.Session = ss
 	result := ConfirmAction(ctx, req, "Delete?")
-	if result != nil {
-		t.Errorf("expected nil result on non-decline/cancel error (so caller proceeds), got %+v", result)
+	if result == nil {
+		t.Fatal("expected fail-closed error result on confirmation failure, got nil (action would proceed)")
+	}
+	if !result.IsError {
+		t.Errorf("ConfirmAction(failure).IsError = false, want true")
 	}
 }
 

--- a/internal/elicitation/flow.go
+++ b/internal/elicitation/flow.go
@@ -113,7 +113,10 @@ func FlowFromRequest(req *mcp.CallToolRequest) (*Flow, error) {
 	for id, resp := range req.Params.InputResponses {
 		er, ok := resp.(*mcp.ElicitResult)
 		if !ok {
-			continue
+			// This flow only ever queues elicitation requests, so any other
+			// response type is client misbehavior. Silently skipping it would
+			// re-queue the same input request forever; fail instead.
+			return nil, fmt.Errorf("elicitation: input response %q has unexpected type %T (want *mcp.ElicitResult)", id, resp)
 		}
 		f.answers[id] = answerRecord{Action: er.Action, Content: er.Content}
 	}
@@ -208,7 +211,7 @@ func (f *Flow) SelectMulti(ctx context.Context, id, message string, options []st
 	if err != nil {
 		return nil, err
 	}
-	return parseSelectMultiContent(content, options)
+	return parseSelectMultiContent(content, options, minItems, maxItems)
 }
 
 // SelectOneInt asks the user to pick one integer from a list of allowed
@@ -240,7 +243,7 @@ func (f *Flow) PromptNumber(ctx context.Context, id, message, fieldName string, 
 	if err != nil {
 		return 0, err
 	}
-	return parseNumberContent(content, fieldName)
+	return parseNumberContent(content, fieldName, minVal, maxVal)
 }
 
 // GatherData sends an arbitrary JSON Schema to the client and returns the

--- a/internal/elicitation/flow.go
+++ b/internal/elicitation/flow.go
@@ -1,0 +1,315 @@
+// Package elicitation: flow.go implements the multi round-trip request
+// (MRTR, SEP-2322) elicitation flow required by MCP protocol version
+// 2026-07-28, where server-initiated elicitation/create requests are
+// forbidden while serving a tool call. A Flow transparently selects the
+// right mechanism per session:
+//
+//   - Sessions negotiated at protocol >= 2026-07-28 receive an
+//     InputRequests map in the tool result and retry the call with
+//     InputResponses populated (handled automatically by SDK client
+//     middleware). Answers gathered in earlier rounds are carried in the
+//     opaque RequestState so multi-step flows survive handler re-invocation.
+//   - Older sessions fall back to the synchronous [Client] path, which
+//     issues elicitation/create requests directly.
+package elicitation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// minMRTRProtocolVersion is the first MCP protocol version that forbids
+// server-initiated elicitation requests and requires the multi round-trip
+// request flow instead (SEP-2322). Protocol versions are ISO dates, so
+// lexicographic comparison is chronological.
+const minMRTRProtocolVersion = "2026-07-28"
+
+// flowStateVersion versions the RequestState encoding so future changes
+// can reject or migrate stale client-echoed state.
+const flowStateVersion = 1
+
+// ErrInputPending is returned by [Flow] prompt methods when the answer is
+// not yet available and an input request has been queued for the client.
+// Handlers must stop and surface [Flow.InputRequiredResult] (or
+// [Flow.PendingError] for handlers that return errors) so the client can
+// fulfill the request and retry the call.
+var ErrInputPending = errors.New("elicitation: input request pending client response")
+
+// InputRequiredError carries an input-required tool result out of handlers
+// that report failures through an error return. Surface wrappers unwrap it
+// with errors.AsType and return the embedded result instead of an error.
+type InputRequiredError struct {
+	result *mcp.CallToolResult
+}
+
+// Error implements the error interface.
+func (e *InputRequiredError) Error() string {
+	return "elicitation: tool call requires client input (multi round-trip request)"
+}
+
+// Result returns the input-required tool result to send to the client.
+func (e *InputRequiredError) Result() *mcp.CallToolResult {
+	return e.result
+}
+
+// answerRecord stores one fulfilled elicitation exchange so later rounds
+// of a multi-step flow can replay it without re-prompting the user.
+type answerRecord struct {
+	Action  string         `json:"action"`
+	Content map[string]any `json:"content,omitempty"`
+}
+
+// flowState is the JSON payload round-tripped through the opaque
+// RequestState field between rounds of a multi round-trip flow.
+type flowState struct {
+	Version int                     `json:"v"`
+	Answers map[string]answerRecord `json:"answers,omitempty"`
+}
+
+// Flow performs elicitation exchanges for a single tool call, selecting
+// the synchronous path for legacy sessions and the multi round-trip path
+// for protocol >= 2026-07-28 sessions. Prompt methods take a stable id
+// that identifies the exchange across handler re-invocations; ids must be
+// unique within one tool call.
+type Flow struct {
+	legacy  Client
+	mrtr    bool
+	answers map[string]answerRecord
+	pending mcp.InputRequestMap
+}
+
+// FlowFromRequest builds a Flow for the current tool call. For multi
+// round-trip sessions it decodes the client-echoed RequestState and merges
+// the InputResponses from the retried call. It returns an error when the
+// echoed state is malformed.
+func FlowFromRequest(req *mcp.CallToolRequest) (*Flow, error) {
+	f := &Flow{legacy: FromRequest(req), answers: map[string]answerRecord{}}
+	if req == nil || req.Session == nil {
+		return f, nil
+	}
+	iparams := req.Session.InitializeParams()
+	if iparams == nil || iparams.ProtocolVersion < minMRTRProtocolVersion {
+		return f, nil
+	}
+	f.mrtr = true
+	if req.Params == nil {
+		return f, nil
+	}
+	if state := req.Params.RequestState; state != "" {
+		var st flowState
+		if err := json.Unmarshal([]byte(state), &st); err != nil {
+			return nil, fmt.Errorf("elicitation: invalid requestState: %w", err)
+		}
+		if st.Version != flowStateVersion {
+			return nil, fmt.Errorf("elicitation: unsupported requestState version %d", st.Version)
+		}
+		maps.Copy(f.answers, st.Answers)
+	}
+	for id, resp := range req.Params.InputResponses {
+		er, ok := resp.(*mcp.ElicitResult)
+		if !ok {
+			continue
+		}
+		f.answers[id] = answerRecord{Action: er.Action, Content: er.Content}
+	}
+	return f, nil
+}
+
+// IsSupported reports whether the MCP client supports elicitation.
+func (f *Flow) IsSupported() bool {
+	return f.legacy.IsSupported()
+}
+
+// UsesMultiRoundTrip reports whether this flow uses the multi round-trip
+// request mechanism (protocol >= 2026-07-28) instead of synchronous
+// server-initiated elicitation.
+func (f *Flow) UsesMultiRoundTrip() bool {
+	return f.mrtr
+}
+
+// exchange resolves one elicitation exchange. On the legacy path it sends
+// the request synchronously. On the multi round-trip path it returns the
+// recorded answer when available, or queues an input request and returns
+// [ErrInputPending].
+func (f *Flow) exchange(ctx context.Context, id, message string, schema map[string]any) (map[string]any, error) {
+	if !f.mrtr {
+		return f.legacy.elicit(ctx, message, schema)
+	}
+	if rec, ok := f.answers[id]; ok {
+		return contentForAction(rec.Action, rec.Content)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if f.pending == nil {
+		f.pending = mcp.InputRequestMap{}
+	}
+	f.pending[id] = &mcp.ElicitParams{Message: message, RequestedSchema: schema}
+	return nil, ErrInputPending
+}
+
+// Confirm asks the user a yes/no question. See [Client.Confirm].
+func (f *Flow) Confirm(ctx context.Context, id, message string) (bool, error) {
+	if !f.IsSupported() {
+		return false, ErrElicitationNotSupported
+	}
+	content, err := f.exchange(ctx, id, message, confirmSchema(message))
+	if err != nil {
+		return false, err
+	}
+	return parseConfirmContent(content), nil
+}
+
+// PromptText asks the user for free-form text input. See [Client.PromptText].
+func (f *Flow) PromptText(ctx context.Context, id, message, fieldName string) (string, error) {
+	if !f.IsSupported() {
+		return "", ErrElicitationNotSupported
+	}
+	if fieldName == "" {
+		fieldName = "value"
+	}
+	content, err := f.exchange(ctx, id, message, textSchema(message, fieldName))
+	if err != nil {
+		return "", err
+	}
+	return parseTextContent(content, fieldName)
+}
+
+// SelectOne asks the user to pick one option from a list. See [Client.SelectOne].
+func (f *Flow) SelectOne(ctx context.Context, id, message string, options []string) (string, error) {
+	if !f.IsSupported() {
+		return "", ErrElicitationNotSupported
+	}
+	if len(options) == 0 {
+		return "", errors.New(errOptionsEmpty)
+	}
+	content, err := f.exchange(ctx, id, message, selectOneSchema(message, options))
+	if err != nil {
+		return "", err
+	}
+	return parseSelectOneContent(content, options)
+}
+
+// SelectMulti asks the user to pick one or more options from a list.
+// See [Client.SelectMulti].
+func (f *Flow) SelectMulti(ctx context.Context, id, message string, options []string, minItems, maxItems int) ([]string, error) {
+	if !f.IsSupported() {
+		return nil, ErrElicitationNotSupported
+	}
+	if len(options) == 0 {
+		return nil, errors.New(errOptionsEmpty)
+	}
+	content, err := f.exchange(ctx, id, message, selectMultiSchema(message, options, minItems, maxItems))
+	if err != nil {
+		return nil, err
+	}
+	return parseSelectMultiContent(content, options)
+}
+
+// SelectOneInt asks the user to pick one integer from a list of allowed
+// values. See [Client.SelectOneInt].
+func (f *Flow) SelectOneInt(ctx context.Context, id, message string, options []int) (int, error) {
+	if !f.IsSupported() {
+		return 0, ErrElicitationNotSupported
+	}
+	if len(options) == 0 {
+		return 0, errors.New(errOptionsEmpty)
+	}
+	content, err := f.exchange(ctx, id, message, selectOneIntSchema(message, options))
+	if err != nil {
+		return 0, err
+	}
+	return parseSelectOneIntContent(content, options)
+}
+
+// PromptNumber asks the user for a numeric input within a range.
+// See [Client.PromptNumber].
+func (f *Flow) PromptNumber(ctx context.Context, id, message, fieldName string, minVal, maxVal float64) (float64, error) {
+	if !f.IsSupported() {
+		return 0, ErrElicitationNotSupported
+	}
+	if fieldName == "" {
+		fieldName = "value"
+	}
+	content, err := f.exchange(ctx, id, message, numberSchema(message, fieldName, minVal, maxVal))
+	if err != nil {
+		return 0, err
+	}
+	return parseNumberContent(content, fieldName)
+}
+
+// GatherData sends an arbitrary JSON Schema to the client and returns the
+// user's response as a map. See [Client.GatherData].
+func (f *Flow) GatherData(ctx context.Context, id, message string, schema map[string]any) (map[string]any, error) {
+	if !f.IsSupported() {
+		return nil, ErrElicitationNotSupported
+	}
+	return f.exchange(ctx, id, message, schema)
+}
+
+// ElicitURL sends a URL-mode elicitation request, directing the user to a
+// GitLab page. See [Client.ElicitURL].
+func (f *Flow) ElicitURL(ctx context.Context, id, gitlabBaseURL, targetURL, message string) error {
+	if !f.mrtr {
+		return f.legacy.ElicitURL(ctx, gitlabBaseURL, targetURL, message)
+	}
+	if !f.IsSupported() {
+		return ErrElicitationNotSupported
+	}
+	if !f.legacy.IsURLSupported() {
+		return ErrURLElicitationNotSupported
+	}
+	if err := validateGitLabURL(gitlabBaseURL, targetURL); err != nil {
+		return err
+	}
+	if rec, ok := f.answers[id]; ok {
+		_, err := contentForAction(rec.Action, rec.Content)
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	elicitationID, err := newElicitationID()
+	if err != nil {
+		return fmt.Errorf("elicitation: failed to generate elicitationId: %w", err)
+	}
+	if f.pending == nil {
+		f.pending = mcp.InputRequestMap{}
+	}
+	f.pending[id] = &mcp.ElicitParams{
+		Mode:          "url",
+		Message:       message,
+		URL:           targetURL,
+		ElicitationID: elicitationID,
+	}
+	return ErrInputPending
+}
+
+// InputRequiredResult builds the tool result carrying the queued input
+// requests plus the accumulated answers encoded as opaque RequestState.
+// The result must be returned as-is, with no content added: the protocol
+// forbids mixing content and inputRequests in one result.
+func (f *Flow) InputRequiredResult() *mcp.CallToolResult {
+	state, err := json.Marshal(flowState{Version: flowStateVersion, Answers: f.answers})
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("elicitation: failed to encode request state: %v", err)}},
+			IsError: true,
+		}
+	}
+	return &mcp.CallToolResult{
+		InputRequests: f.pending,
+		RequestState:  string(state),
+	}
+}
+
+// PendingError wraps [Flow.InputRequiredResult] in an [InputRequiredError]
+// for handlers that report outcomes through an error return.
+func (f *Flow) PendingError() error {
+	return &InputRequiredError{result: f.InputRequiredResult()}
+}

--- a/internal/elicitation/flow_test.go
+++ b/internal/elicitation/flow_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -115,29 +116,51 @@ func TestFlow_SelectOne_RejectsUnknownOption(t *testing.T) {
 // remaining typed prompt helpers (multi-select, integer select, number,
 // arbitrary schema).
 func TestFlow_TypedPrompts_ReplayAnswers(t *testing.T) {
-	ctx := context.Background()
-	f := newMRTRFlow(map[string]answerRecord{
-		"langs":  {Action: "accept", Content: map[string]any{"selections": []any{"go", "rust"}}},
-		"count":  {Action: "accept", Content: map[string]any{"selection": float64(3)}},
-		"rating": {Action: "accept", Content: map[string]any{"rating": 4.5}},
-		"form":   {Action: "accept", Content: map[string]any{"a": "b"}},
-	})
-
-	langs, err := f.SelectMulti(ctx, "langs", "Pick languages", []string{"go", "rust", "zig"}, 1, 0)
-	if err != nil || len(langs) != 2 {
-		t.Errorf("SelectMulti = (%v, %v), want 2 selections", langs, err)
+	newFlow := func() *Flow {
+		return newMRTRFlow(map[string]answerRecord{
+			"langs":  {Action: "accept", Content: map[string]any{"selections": []any{"go", "rust"}}},
+			"count":  {Action: "accept", Content: map[string]any{"selection": float64(3)}},
+			"rating": {Action: "accept", Content: map[string]any{"rating": 4.5}},
+			"form":   {Action: "accept", Content: map[string]any{"a": "b"}},
+		})
 	}
-	count, err := f.SelectOneInt(ctx, "count", "Pick count", []int{1, 2, 3})
-	if err != nil || count != 3 {
-		t.Errorf("SelectOneInt = (%d, %v), want 3", count, err)
+	tests := []struct {
+		name  string
+		check func(t *testing.T, f *Flow)
+	}{
+		{"SelectMulti replays selections", func(t *testing.T, f *Flow) {
+			t.Helper()
+			langs, err := f.SelectMulti(t.Context(), "langs", "Pick languages", []string{"go", "rust", "zig"}, 1, 0)
+			if err != nil || len(langs) != 2 {
+				t.Errorf("SelectMulti = (%v, %v), want 2 selections", langs, err)
+			}
+		}},
+		{"SelectOneInt replays selection", func(t *testing.T, f *Flow) {
+			t.Helper()
+			count, err := f.SelectOneInt(t.Context(), "count", "Pick count", []int{1, 2, 3})
+			if err != nil || count != 3 {
+				t.Errorf("SelectOneInt = (%d, %v), want 3", count, err)
+			}
+		}},
+		{"PromptNumber replays value", func(t *testing.T, f *Flow) {
+			t.Helper()
+			rating, err := f.PromptNumber(t.Context(), "rating", "Rate", "rating", 0, 5)
+			if err != nil || rating != 4.5 {
+				t.Errorf("PromptNumber = (%g, %v), want 4.5", rating, err)
+			}
+		}},
+		{"GatherData replays content", func(t *testing.T, f *Flow) {
+			t.Helper()
+			form, err := f.GatherData(t.Context(), "form", "Fill", map[string]any{"type": "object"})
+			if err != nil || form["a"] != "b" {
+				t.Errorf("GatherData = (%v, %v), want map with a=b", form, err)
+			}
+		}},
 	}
-	rating, err := f.PromptNumber(ctx, "rating", "Rate", "rating", 0, 5)
-	if err != nil || rating != 4.5 {
-		t.Errorf("PromptNumber = (%g, %v), want 4.5", rating, err)
-	}
-	form, err := f.GatherData(ctx, "form", "Fill", map[string]any{"type": "object"})
-	if err != nil || form["a"] != "b" {
-		t.Errorf("GatherData = (%v, %v), want map with a=b", form, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, newFlow())
+		})
 	}
 }
 
@@ -300,6 +323,9 @@ func TestFlow_MRTR_ConfirmDeclined(t *testing.T) {
 // opaque RequestState and each round only elicits the next unanswered
 // prompt, in order.
 func TestFlow_MRTR_MultiStepAccumulatesState(t *testing.T) {
+	// The elicitation handler runs on the client session's goroutine, so
+	// guard the recorded messages against concurrent access.
+	var mu sync.Mutex
 	var messages []string
 	answers := map[string]map[string]any{
 		"Enter first":  {"first": "hello"},
@@ -335,7 +361,9 @@ func TestFlow_MRTR_MultiStepAccumulatesState(t *testing.T) {
 	}
 
 	cs := flowTestTool(t, handler, func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		mu.Lock()
 		messages = append(messages, req.Params.Message)
+		mu.Unlock()
 		content, ok := answers[req.Params.Message]
 		if !ok {
 			return nil, errors.New("unexpected elicitation: " + req.Params.Message)
@@ -351,6 +379,8 @@ func TestFlow_MRTR_MultiStepAccumulatesState(t *testing.T) {
 		t.Errorf("result text = %q, want 'hello|world'", got)
 	}
 	want := []string{"Enter first", "Enter second", "Proceed?"}
+	mu.Lock()
+	defer mu.Unlock()
 	if len(messages) != len(want) {
 		t.Fatalf("elicitation messages = %v, want %v", messages, want)
 	}
@@ -383,6 +413,32 @@ func TestFlow_MRTR_InvalidRequestState(t *testing.T) {
 	}
 	if got := resultText(result); !strings.Contains(got, "state rejected") {
 		t.Errorf("result text = %q, want state rejection", got)
+	}
+}
+
+// TestFlow_MRTR_UnexpectedResponseType verifies that an input response of a
+// type this flow never requests (anything but *mcp.ElicitResult) is rejected
+// as an error instead of being silently dropped and re-queued forever.
+func TestFlow_MRTR_UnexpectedResponseType(t *testing.T) {
+	handler := func(_ context.Context, req *mcp.CallToolRequest, _ *Flow) (*mcp.CallToolResult, error) {
+		//nolint:staticcheck // deliberately uses a non-elicitation InputResponse type to exercise the mismatch rejection; all such types are deprecated upstream
+		req.Params.InputResponses = mcp.InputResponseMap{"confirm": &mcp.ListRootsResult{}}
+		if _, err := FlowFromRequest(req); err != nil {
+			//nolint:nilerr // the rejection is asserted in-band via the result text
+			return textResult("response rejected: " + err.Error()), nil
+		}
+		return textResult("response accepted"), nil
+	}
+	cs := flowTestTool(t, handler, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "flow_tool", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := resultText(result); !strings.Contains(got, "response rejected") {
+		t.Errorf("result text = %q, want unexpected-type rejection", got)
 	}
 }
 

--- a/internal/elicitation/flow_test.go
+++ b/internal/elicitation/flow_test.go
@@ -1,0 +1,413 @@
+// flow_test.go contains unit and integration tests for the multi round-trip
+// (MRTR, SEP-2322) elicitation flow. Unit tests construct Flow values
+// directly to validate pending-request queueing, answer replay, action
+// mapping, and state encoding. Integration tests register real tools and
+// drive them through a protocol 2026-07-28 client whose SDK middleware
+// fulfills input requests and retries the call, validating the full loop
+// including RequestState echo across rounds.
+package elicitation
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newMRTRFlow builds a Flow in multi round-trip mode with the given
+// preloaded answers, bypassing session negotiation for unit tests.
+func newMRTRFlow(answers map[string]answerRecord) *Flow {
+	if answers == nil {
+		answers = map[string]answerRecord{}
+	}
+	return &Flow{legacy: Client{session: &mcp.ServerSession{}}, mrtr: true, answers: answers}
+}
+
+// TestFlow_Pending_QueuesInputRequest verifies that an unanswered prompt on
+// the MRTR path returns ErrInputPending and that InputRequiredResult carries
+// the queued elicitation request plus versioned request state.
+func TestFlow_Pending_QueuesInputRequest(t *testing.T) {
+	f := newMRTRFlow(nil)
+	_, err := f.PromptText(context.Background(), "title", "Enter title", "title")
+	if !errors.Is(err, ErrInputPending) {
+		t.Fatalf("PromptText(no answer) error = %v, want ErrInputPending", err)
+	}
+	result := f.InputRequiredResult()
+	if result.IsError {
+		t.Fatal("InputRequiredResult().IsError = true, want false")
+	}
+	if len(result.Content) != 0 {
+		t.Fatalf("InputRequiredResult() has %d content entries, want 0 (content and inputRequests are mutually exclusive)", len(result.Content))
+	}
+	req, ok := result.InputRequests["title"].(*mcp.ElicitParams)
+	if !ok {
+		t.Fatalf("InputRequests[title] = %T, want *mcp.ElicitParams", result.InputRequests["title"])
+	}
+	if req.Message != "Enter title" {
+		t.Errorf("queued message = %q, want 'Enter title'", req.Message)
+	}
+	if !strings.Contains(result.RequestState, `"v":1`) {
+		t.Errorf("RequestState = %q, want versioned state", result.RequestState)
+	}
+}
+
+// TestFlow_AcceptedAnswer_ReturnsValue verifies that a recorded accepted
+// answer is replayed without queueing a new request.
+func TestFlow_AcceptedAnswer_ReturnsValue(t *testing.T) {
+	f := newMRTRFlow(map[string]answerRecord{
+		"title": {Action: "accept", Content: map[string]any{"title": "my title"}},
+	})
+	got, err := f.PromptText(context.Background(), "title", "Enter title", "title")
+	if err != nil {
+		t.Fatalf("PromptText(answered) error = %v", err)
+	}
+	if got != "my title" {
+		t.Errorf("PromptText(answered) = %q, want 'my title'", got)
+	}
+}
+
+// TestFlow_DeclinedAnswer_ReturnsErrDeclined verifies decline mapping on the
+// MRTR path.
+func TestFlow_DeclinedAnswer_ReturnsErrDeclined(t *testing.T) {
+	f := newMRTRFlow(map[string]answerRecord{"q": {Action: "decline"}})
+	_, err := f.Confirm(context.Background(), "q", "Sure?")
+	if !errors.Is(err, ErrDeclined) {
+		t.Errorf("Confirm(declined) error = %v, want ErrDeclined", err)
+	}
+}
+
+// TestFlow_CancelledAnswer_ReturnsErrCancelled verifies cancel mapping on
+// the MRTR path.
+func TestFlow_CancelledAnswer_ReturnsErrCancelled(t *testing.T) {
+	f := newMRTRFlow(map[string]answerRecord{"q": {Action: "cancel"}})
+	_, err := f.Confirm(context.Background(), "q", "Sure?")
+	if !errors.Is(err, ErrCancelled) {
+		t.Errorf("Confirm(cancelled) error = %v, want ErrCancelled", err)
+	}
+}
+
+// TestFlow_UnknownAction_ReturnsError verifies that an unrecognized recorded
+// action surfaces as an error rather than a value.
+func TestFlow_UnknownAction_ReturnsError(t *testing.T) {
+	f := newMRTRFlow(map[string]answerRecord{"q": {Action: "weird"}})
+	_, err := f.Confirm(context.Background(), "q", "Sure?")
+	if err == nil || !strings.Contains(err.Error(), "unknown action") {
+		t.Errorf("Confirm(unknown action) error = %v, want 'unknown action'", err)
+	}
+}
+
+// TestFlow_SelectOne_RejectsUnknownOption verifies defense-in-depth option
+// validation of replayed answers.
+func TestFlow_SelectOne_RejectsUnknownOption(t *testing.T) {
+	f := newMRTRFlow(map[string]answerRecord{
+		"vis": {Action: "accept", Content: map[string]any{"selection": "hacked"}},
+	})
+	_, err := f.SelectOne(context.Background(), "vis", "Pick", []string{"private", "public"})
+	if err == nil || !strings.Contains(err.Error(), "not in the allowed options") {
+		t.Errorf("SelectOne(invalid option) error = %v, want allowed-options validation error", err)
+	}
+}
+
+// TestFlow_TypedPrompts_ReplayAnswers verifies answer replay for the
+// remaining typed prompt helpers (multi-select, integer select, number,
+// arbitrary schema).
+func TestFlow_TypedPrompts_ReplayAnswers(t *testing.T) {
+	ctx := context.Background()
+	f := newMRTRFlow(map[string]answerRecord{
+		"langs":  {Action: "accept", Content: map[string]any{"selections": []any{"go", "rust"}}},
+		"count":  {Action: "accept", Content: map[string]any{"selection": float64(3)}},
+		"rating": {Action: "accept", Content: map[string]any{"rating": 4.5}},
+		"form":   {Action: "accept", Content: map[string]any{"a": "b"}},
+	})
+
+	langs, err := f.SelectMulti(ctx, "langs", "Pick languages", []string{"go", "rust", "zig"}, 1, 0)
+	if err != nil || len(langs) != 2 {
+		t.Errorf("SelectMulti = (%v, %v), want 2 selections", langs, err)
+	}
+	count, err := f.SelectOneInt(ctx, "count", "Pick count", []int{1, 2, 3})
+	if err != nil || count != 3 {
+		t.Errorf("SelectOneInt = (%d, %v), want 3", count, err)
+	}
+	rating, err := f.PromptNumber(ctx, "rating", "Rate", "rating", 0, 5)
+	if err != nil || rating != 4.5 {
+		t.Errorf("PromptNumber = (%g, %v), want 4.5", rating, err)
+	}
+	form, err := f.GatherData(ctx, "form", "Fill", map[string]any{"type": "object"})
+	if err != nil || form["a"] != "b" {
+		t.Errorf("GatherData = (%v, %v), want map with a=b", form, err)
+	}
+}
+
+// TestFlow_NotSupported_ReturnsSentinel verifies that a flow without
+// elicitation support rejects every prompt with ErrElicitationNotSupported.
+func TestFlow_NotSupported_ReturnsSentinel(t *testing.T) {
+	f := &Flow{answers: map[string]answerRecord{}}
+	if _, err := f.Confirm(context.Background(), "q", "Sure?"); !errors.Is(err, ErrElicitationNotSupported) {
+		t.Errorf("Confirm(no support) error = %v, want ErrElicitationNotSupported", err)
+	}
+}
+
+// TestFlow_ContextCancelled_StopsBeforeQueueing verifies that a canceled
+// context aborts instead of queueing an input request.
+func TestFlow_ContextCancelled_StopsBeforeQueueing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	f := newMRTRFlow(nil)
+	if _, err := f.Confirm(ctx, "q", "Sure?"); !errors.Is(err, context.Canceled) {
+		t.Errorf("Confirm(canceled ctx) error = %v, want context.Canceled", err)
+	}
+}
+
+// TestFlow_PendingError_CarriesResult verifies that PendingError wraps the
+// input-required result for error-returning handlers and that surface code
+// can recover it with errors.AsType.
+func TestFlow_PendingError_CarriesResult(t *testing.T) {
+	f := newMRTRFlow(nil)
+	_, _ = f.PromptText(context.Background(), "title", "Enter title", "title")
+	err := f.PendingError()
+	inputErr, ok := errors.AsType[*InputRequiredError](err)
+	if !ok {
+		t.Fatalf("PendingError() type = %T, want *InputRequiredError", err)
+	}
+	if inputErr.Result() == nil || inputErr.Result().InputRequests == nil {
+		t.Fatal("PendingError().Result() missing input requests")
+	}
+	if inputErr.Error() == "" {
+		t.Error("InputRequiredError.Error() is empty")
+	}
+}
+
+// Integration tests: full multi round-trip loop over a real 2026-07-28
+// session, where the SDK client middleware fulfills input requests and
+// retries the tools/call.
+
+// flowTestTool registers a tool whose handler runs fn with a Flow built
+// from the live request and connects a new-protocol client with the given
+// elicitation handler. Returns the client session for CallTool round-trips.
+func flowTestTool(t *testing.T, fn func(context.Context, *mcp.CallToolRequest, *Flow) (*mcp.CallToolResult, error), elicit func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+
+	server := mcp.NewServer(testImpl, nil)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "flow_tool",
+		Description: "flow test tool",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+		fl, err := FlowFromRequest(req)
+		if err != nil {
+			//nolint:nilerr // the flow error is surfaced in-band as an error tool result
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}}, IsError: true}, nil, nil
+		}
+		result, err := fn(ctx, req, fl)
+		return result, nil, err
+	})
+
+	st, ct := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(testImpl, &mcp.ClientOptions{ElicitationHandler: elicit})
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		_ = ss.Close()
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cs.Close()
+		_ = ss.Close()
+	})
+	return cs
+}
+
+// textResult builds a plain text tool result.
+func textResult(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}
+}
+
+// resultText concatenates the text content of a tool result.
+func resultText(result *mcp.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range result.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// confirmFlowHandler is a tool handler that requires one confirmation.
+func confirmFlowHandler(ctx context.Context, _ *mcp.CallToolRequest, fl *Flow) (*mcp.CallToolResult, error) {
+	confirmed, err := fl.Confirm(ctx, "confirm", "Proceed?")
+	switch {
+	case errors.Is(err, ErrInputPending):
+		return fl.InputRequiredResult(), nil
+	case errors.Is(err, ErrDeclined), errors.Is(err, ErrCancelled):
+		return textResult("canceled"), nil
+	case err != nil:
+		return nil, err
+	}
+	if !confirmed {
+		return textResult("canceled"), nil
+	}
+	return textResult("confirmed"), nil
+}
+
+// TestFlow_MRTR_ConfirmAccepted verifies the full multi round-trip loop for
+// an accepted confirmation: round one returns an input-required result, the
+// client middleware fulfills it via the elicitation handler, and the retried
+// call proceeds.
+func TestFlow_MRTR_ConfirmAccepted(t *testing.T) {
+	var elicitations atomic.Int32
+	cs := flowTestTool(t, confirmFlowHandler, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		elicitations.Add(1)
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "flow_tool", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := resultText(result); got != "confirmed" {
+		t.Errorf("result text = %q, want 'confirmed'", got)
+	}
+	if elicitations.Load() != 1 {
+		t.Errorf("elicitations = %d, want 1", elicitations.Load())
+	}
+}
+
+// TestFlow_MRTR_ConfirmDeclined verifies the full multi round-trip loop for
+// a declined confirmation.
+func TestFlow_MRTR_ConfirmDeclined(t *testing.T) {
+	cs := flowTestTool(t, confirmFlowHandler, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "decline"}, nil
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "flow_tool", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := resultText(result); got != "canceled" {
+		t.Errorf("result text = %q, want 'canceled'", got)
+	}
+}
+
+// TestFlow_MRTR_MultiStepAccumulatesState verifies that a multi-step flow
+// survives handler re-invocation: earlier answers are carried through the
+// opaque RequestState and each round only elicits the next unanswered
+// prompt, in order.
+func TestFlow_MRTR_MultiStepAccumulatesState(t *testing.T) {
+	var messages []string
+	answers := map[string]map[string]any{
+		"Enter first":  {"first": "hello"},
+		"Enter second": {"second": "world"},
+		"Proceed?":     {"confirmed": true},
+	}
+	handler := func(ctx context.Context, req *mcp.CallToolRequest, fl *Flow) (*mcp.CallToolResult, error) {
+		if !fl.UsesMultiRoundTrip() {
+			return textResult("expected multi round-trip session"), nil
+		}
+		first, err := fl.PromptText(ctx, "first", "Enter first", "first")
+		if errors.Is(err, ErrInputPending) {
+			return fl.InputRequiredResult(), nil
+		} else if err != nil {
+			return nil, err
+		}
+		second, err := fl.PromptText(ctx, "second", "Enter second", "second")
+		if errors.Is(err, ErrInputPending) {
+			return fl.InputRequiredResult(), nil
+		} else if err != nil {
+			return nil, err
+		}
+		confirmed, err := fl.Confirm(ctx, "confirm", "Proceed?")
+		if errors.Is(err, ErrInputPending) {
+			return fl.InputRequiredResult(), nil
+		} else if err != nil {
+			return nil, err
+		}
+		if !confirmed {
+			return textResult("canceled"), nil
+		}
+		return textResult(first + "|" + second), nil
+	}
+
+	cs := flowTestTool(t, handler, func(_ context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		messages = append(messages, req.Params.Message)
+		content, ok := answers[req.Params.Message]
+		if !ok {
+			return nil, errors.New("unexpected elicitation: " + req.Params.Message)
+		}
+		return &mcp.ElicitResult{Action: "accept", Content: content}, nil
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "flow_tool", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := resultText(result); got != "hello|world" {
+		t.Errorf("result text = %q, want 'hello|world'", got)
+	}
+	want := []string{"Enter first", "Enter second", "Proceed?"}
+	if len(messages) != len(want) {
+		t.Fatalf("elicitation messages = %v, want %v", messages, want)
+	}
+	for i, msg := range want {
+		if messages[i] != msg {
+			t.Errorf("elicitation %d = %q, want %q", i, messages[i], msg)
+		}
+	}
+}
+
+// TestFlow_MRTR_InvalidRequestState verifies that a corrupted client-echoed
+// RequestState is rejected as an error instead of silently restarting the
+// flow.
+func TestFlow_MRTR_InvalidRequestState(t *testing.T) {
+	handler := func(ctx context.Context, req *mcp.CallToolRequest, _ *Flow) (*mcp.CallToolResult, error) {
+		req.Params.RequestState = "{not json"
+		if _, err := FlowFromRequest(req); err != nil {
+			//nolint:nilerr // the rejection is asserted in-band via the result text
+			return textResult("state rejected: " + err.Error()), nil
+		}
+		return textResult("state accepted"), nil
+	}
+	cs := flowTestTool(t, handler, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "flow_tool", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if got := resultText(result); !strings.Contains(got, "state rejected") {
+		t.Errorf("result text = %q, want state rejection", got)
+	}
+}
+
+// TestFlowFromRequest_LegacySession_UsesSynchronousPath verifies that a
+// session negotiated below 2026-07-28 keeps the synchronous elicitation
+// mechanism behind the Flow API.
+func TestFlowFromRequest_LegacySession_UsesSynchronousPath(t *testing.T) {
+	ctx := context.Background()
+	_, ss, cleanup := setupElicitSession(t, ctx, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	})
+	defer cleanup()
+
+	fl, err := FlowFromRequest(&mcp.CallToolRequest{Session: ss})
+	if err != nil {
+		t.Fatalf("FlowFromRequest error: %v", err)
+	}
+	if fl.UsesMultiRoundTrip() {
+		t.Fatal("UsesMultiRoundTrip() = true on a legacy session, want false")
+	}
+	confirmed, err := fl.Confirm(ctx, "confirm", "Proceed?")
+	if err != nil {
+		t.Fatalf("Confirm(legacy) error = %v", err)
+	}
+	if !confirmed {
+		t.Error("Confirm(legacy) = false, want true")
+	}
+}

--- a/internal/elicitation/schemas.go
+++ b/internal/elicitation/schemas.go
@@ -1,0 +1,231 @@
+// Package elicitation: schemas.go holds the JSON Schema builders and
+// response-content parsers shared by the synchronous [Client] path and the
+// multi round-trip [Flow] path, so both mechanisms request and validate
+// identical shapes.
+package elicitation
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+)
+
+// contentForAction maps an elicitation action to its content or the
+// corresponding sentinel error.
+func contentForAction(action string, content map[string]any) (map[string]any, error) {
+	switch action {
+	case "accept":
+		return content, nil
+	case "decline":
+		return nil, ErrDeclined
+	case "cancel":
+		return nil, ErrCancelled
+	default:
+		return nil, fmt.Errorf("elicitation: unknown action %q", action)
+	}
+}
+
+// confirmSchema builds the schema for a yes/no confirmation prompt.
+func confirmSchema(message string) map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"confirmed": map[string]any{
+				"type":        "boolean",
+				"title":       "Confirm",
+				"description": message,
+			},
+		},
+		"required": []string{"confirmed"},
+	}
+}
+
+// parseConfirmContent extracts the boolean confirmation value; a missing or
+// non-boolean field counts as not confirmed.
+func parseConfirmContent(content map[string]any) bool {
+	confirmed, ok := content["confirmed"].(bool)
+	return ok && confirmed
+}
+
+// textSchema builds the schema for a free-form text prompt.
+func textSchema(message, fieldName string) map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			fieldName: map[string]any{
+				"type":        "string",
+				"title":       fieldName,
+				"description": message,
+			},
+		},
+		"required": []string{fieldName},
+	}
+}
+
+// parseTextContent extracts the string value of fieldName.
+func parseTextContent(content map[string]any, fieldName string) (string, error) {
+	text, ok := content[fieldName].(string)
+	if !ok {
+		return "", fmt.Errorf("elicitation: response field %q is not a string", fieldName)
+	}
+	return text, nil
+}
+
+// selectOneSchema builds the schema for a single-choice string selection.
+func selectOneSchema(message string, options []string) map[string]any {
+	enumValues := make([]any, len(options))
+	for i, o := range options {
+		enumValues[i] = o
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"selection": map[string]any{
+				"type":        "string",
+				"title":       "Selection",
+				"description": message,
+				"enum":        enumValues,
+			},
+		},
+		"required": []string{"selection"},
+	}
+}
+
+// parseSelectOneContent extracts and validates the selected option.
+func parseSelectOneContent(content map[string]any, options []string) (string, error) {
+	selection, ok := content["selection"].(string)
+	if !ok {
+		return "", errors.New("elicitation: response field 'selection' is not a string")
+	}
+	// Validate against allowed options (defense in depth)
+	if slices.Contains(options, selection) {
+		return selection, nil
+	}
+	return "", fmt.Errorf("elicitation: selected value %q is not in the allowed options", selection)
+}
+
+// selectMultiSchema builds the schema for a multi-choice string selection.
+func selectMultiSchema(message string, options []string, minItems, maxItems int) map[string]any {
+	enumValues := make([]any, len(options))
+	for i, o := range options {
+		enumValues[i] = o
+	}
+	arraySchema := map[string]any{
+		"type":        "array",
+		"title":       "Selections",
+		"description": message,
+		"items": map[string]any{
+			"type": "string",
+			"enum": enumValues,
+		},
+	}
+	if minItems > 0 {
+		arraySchema["minItems"] = minItems
+	}
+	if maxItems > 0 {
+		arraySchema["maxItems"] = maxItems
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"selections": arraySchema,
+		},
+		"required": []string{"selections"},
+	}
+}
+
+// parseSelectMultiContent extracts and validates the selected options.
+func parseSelectMultiContent(content map[string]any, options []string) ([]string, error) {
+	raw, ok := content["selections"].([]any)
+	if !ok {
+		return nil, errors.New("elicitation: response field 'selections' is not an array")
+	}
+	selections := make([]string, 0, len(raw))
+	for _, v := range raw {
+		s, isString := v.(string)
+		if !isString {
+			return nil, fmt.Errorf("elicitation: selection element is not a string: %v", v)
+		}
+		if !slices.Contains(options, s) {
+			return nil, fmt.Errorf("elicitation: selected value %q is not in the allowed options", s)
+		}
+		selections = append(selections, s)
+	}
+	return selections, nil
+}
+
+// selectOneIntSchema builds the schema for a single-choice integer selection.
+func selectOneIntSchema(message string, options []int) map[string]any {
+	enumValues := make([]any, len(options))
+	for i, o := range options {
+		enumValues[i] = o
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"selection": map[string]any{
+				"type":        "integer",
+				"title":       "Selection",
+				"description": message,
+				"enum":        enumValues,
+			},
+		},
+		"required": []string{"selection"},
+	}
+}
+
+// parseSelectOneIntContent extracts and validates the selected integer.
+func parseSelectOneIntContent(content map[string]any, options []int) (int, error) {
+	// JSON numbers are float64 by default
+	f, ok := content["selection"].(float64)
+	if !ok {
+		return 0, errors.New("elicitation: response field 'selection' is not a number")
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, errors.New("elicitation: response field 'selection' is not a finite number")
+	}
+	if f != math.Trunc(f) {
+		return 0, fmt.Errorf("elicitation: response value %g is not an integer", f)
+	}
+	selected := int(f)
+	if !slices.Contains(options, selected) {
+		return 0, fmt.Errorf("elicitation: selected value %d is not in the allowed options", selected)
+	}
+	return selected, nil
+}
+
+// numberSchema builds the schema for a bounded numeric prompt. Use
+// math.Inf(-1) and math.Inf(1) to omit a bound.
+func numberSchema(message, fieldName string, minVal, maxVal float64) map[string]any {
+	prop := map[string]any{
+		"type":        "number",
+		"title":       fieldName,
+		"description": message,
+	}
+	if !isInf(minVal) {
+		prop["minimum"] = minVal
+	}
+	if !isInf(maxVal) {
+		prop["maximum"] = maxVal
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			fieldName: prop,
+		},
+		"required": []string{fieldName},
+	}
+}
+
+// parseNumberContent extracts the numeric value of fieldName.
+func parseNumberContent(content map[string]any, fieldName string) (float64, error) {
+	f, ok := content[fieldName].(float64)
+	if !ok {
+		return 0, fmt.Errorf("elicitation: response field %q is not a number", fieldName)
+	}
+	if math.IsNaN(f) {
+		return 0, fmt.Errorf("elicitation: response field %q is NaN", fieldName)
+	}
+	return f, nil
+}

--- a/internal/elicitation/schemas.go
+++ b/internal/elicitation/schemas.go
@@ -135,11 +135,18 @@ func selectMultiSchema(message string, options []string, minItems, maxItems int)
 	}
 }
 
-// parseSelectMultiContent extracts and validates the selected options.
-func parseSelectMultiContent(content map[string]any, options []string) ([]string, error) {
+// parseSelectMultiContent extracts and validates the selected options,
+// including the cardinality bounds advertised in the schema (0 = no bound).
+func parseSelectMultiContent(content map[string]any, options []string, minItems, maxItems int) ([]string, error) {
 	raw, ok := content["selections"].([]any)
 	if !ok {
 		return nil, errors.New("elicitation: response field 'selections' is not an array")
+	}
+	if minItems > 0 && len(raw) < minItems {
+		return nil, fmt.Errorf("elicitation: %d selections returned, want at least %d", len(raw), minItems)
+	}
+	if maxItems > 0 && len(raw) > maxItems {
+		return nil, fmt.Errorf("elicitation: %d selections returned, want at most %d", len(raw), maxItems)
 	}
 	selections := make([]string, 0, len(raw))
 	for _, v := range raw {
@@ -218,14 +225,21 @@ func numberSchema(message, fieldName string, minVal, maxVal float64) map[string]
 	}
 }
 
-// parseNumberContent extracts the numeric value of fieldName.
-func parseNumberContent(content map[string]any, fieldName string) (float64, error) {
+// parseNumberContent extracts the numeric value of fieldName and enforces
+// the bounds advertised in the schema (infinities mean unbounded).
+func parseNumberContent(content map[string]any, fieldName string, minVal, maxVal float64) (float64, error) {
 	f, ok := content[fieldName].(float64)
 	if !ok {
 		return 0, fmt.Errorf("elicitation: response field %q is not a number", fieldName)
 	}
 	if math.IsNaN(f) {
 		return 0, fmt.Errorf("elicitation: response field %q is NaN", fieldName)
+	}
+	if !isInf(minVal) && f < minVal {
+		return 0, fmt.Errorf("elicitation: response value %g is below the minimum %g", f, minVal)
+	}
+	if !isInf(maxVal) && f > maxVal {
+		return 0, fmt.Errorf("elicitation: response value %g is above the maximum %g", f, maxVal)
 	}
 	return f, nil
 }

--- a/internal/elicitation/schemas_test.go
+++ b/internal/elicitation/schemas_test.go
@@ -71,24 +71,58 @@ func TestTextSchema_ParseTextContent(t *testing.T) {
 	}
 }
 
-// TestSelectSchemas_ValidateOptions verifies enum construction and option
-// validation across the single, multi, and integer select parsers.
+// TestSelectSchemas_ValidateOptions verifies enum construction, option
+// validation, and cardinality enforcement across the single, multi, and
+// integer select parsers.
 func TestSelectSchemas_ValidateOptions(t *testing.T) {
-	if _, err := parseSelectOneContent(map[string]any{"selection": "c"}, []string{"a", "b"}); err == nil {
-		t.Error("parseSelectOneContent(out of enum) error = nil, want error")
+	tests := []struct {
+		name    string
+		run     func() error
+		wantErr bool
+	}{
+		{"select one rejects out-of-enum value", func() error {
+			_, err := parseSelectOneContent(map[string]any{"selection": "c"}, []string{"a", "b"})
+			return err
+		}, true},
+		{"select multi rejects non-string element", func() error {
+			_, err := parseSelectMultiContent(map[string]any{"selections": []any{"a", 3}}, []string{"a"}, 0, 0)
+			return err
+		}, true},
+		{"select multi rejects fewer than minItems", func() error {
+			_, err := parseSelectMultiContent(map[string]any{"selections": []any{}}, []string{"a", "b"}, 1, 0)
+			return err
+		}, true},
+		{"select multi rejects more than maxItems", func() error {
+			_, err := parseSelectMultiContent(map[string]any{"selections": []any{"a", "b"}}, []string{"a", "b"}, 0, 1)
+			return err
+		}, true},
+		{"select multi accepts within bounds", func() error {
+			_, err := parseSelectMultiContent(map[string]any{"selections": []any{"a"}}, []string{"a", "b"}, 1, 2)
+			return err
+		}, false},
+		{"select int rejects non-integer", func() error {
+			_, err := parseSelectOneIntContent(map[string]any{"selection": 2.5}, []int{1, 2})
+			return err
+		}, true},
+		{"select int rejects NaN", func() error {
+			_, err := parseSelectOneIntContent(map[string]any{"selection": math.NaN()}, []int{1})
+			return err
+		}, true},
+		{"select int accepts allowed value", func() error {
+			got, err := parseSelectOneIntContent(map[string]any{"selection": float64(2)}, []int{1, 2})
+			if err == nil && got != 2 {
+				return errors.New("wrong value")
+			}
+			return err
+		}, false},
 	}
-	if _, err := parseSelectMultiContent(map[string]any{"selections": []any{"a", 3}}, []string{"a"}); err == nil {
-		t.Error("parseSelectMultiContent(non-string element) error = nil, want error")
-	}
-	if _, err := parseSelectOneIntContent(map[string]any{"selection": 2.5}, []int{1, 2}); err == nil {
-		t.Error("parseSelectOneIntContent(non-integer) error = nil, want error")
-	}
-	if _, err := parseSelectOneIntContent(map[string]any{"selection": math.NaN()}, []int{1}); err == nil {
-		t.Error("parseSelectOneIntContent(NaN) error = nil, want error")
-	}
-	got, err := parseSelectOneIntContent(map[string]any{"selection": float64(2)}, []int{1, 2})
-	if err != nil || got != 2 {
-		t.Errorf("parseSelectOneIntContent = (%d, %v), want (2, nil)", got, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -111,10 +145,19 @@ func TestNumberSchema_BoundsAndParse(t *testing.T) {
 		t.Error("numberSchema(+Inf) still has maximum")
 	}
 
-	if _, err := parseNumberContent(map[string]any{"v": math.NaN()}, "v"); err == nil {
+	if _, err := parseNumberContent(map[string]any{"v": math.NaN()}, "v", math.Inf(-1), math.Inf(1)); err == nil {
 		t.Error("parseNumberContent(NaN) error = nil, want error")
 	}
-	if _, err := parseNumberContent(map[string]any{"v": "x"}, "v"); err == nil {
+	if _, err := parseNumberContent(map[string]any{"v": "x"}, "v", math.Inf(-1), math.Inf(1)); err == nil {
 		t.Error("parseNumberContent(non-number) error = nil, want error")
+	}
+	if _, err := parseNumberContent(map[string]any{"v": -1.0}, "v", 0, 5); err == nil {
+		t.Error("parseNumberContent(below minimum) error = nil, want error")
+	}
+	if _, err := parseNumberContent(map[string]any{"v": 6.0}, "v", 0, 5); err == nil {
+		t.Error("parseNumberContent(above maximum) error = nil, want error")
+	}
+	if got, err := parseNumberContent(map[string]any{"v": 4.5}, "v", 0, 5); err != nil || got != 4.5 {
+		t.Errorf("parseNumberContent(in range) = (%g, %v), want (4.5, nil)", got, err)
 	}
 }

--- a/internal/elicitation/schemas_test.go
+++ b/internal/elicitation/schemas_test.go
@@ -1,0 +1,120 @@
+// schemas_test.go contains unit tests for the JSON Schema builders and
+// response-content parsers shared by the synchronous Client path and the
+// multi round-trip Flow path.
+package elicitation
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestContentForAction_MapsActions verifies the action-to-outcome mapping
+// shared by both elicitation mechanisms.
+func TestContentForAction_MapsActions(t *testing.T) {
+	content := map[string]any{"k": "v"}
+
+	got, acceptErr := contentForAction("accept", content)
+	if acceptErr != nil || got["k"] != "v" {
+		t.Errorf("contentForAction(accept) = (%v, %v), want content back", got, acceptErr)
+	}
+	if _, declineErr := contentForAction("decline", nil); !errors.Is(declineErr, ErrDeclined) {
+		t.Errorf("contentForAction(decline) error = %v, want ErrDeclined", declineErr)
+	}
+	if _, cancelErr := contentForAction("cancel", nil); !errors.Is(cancelErr, ErrCancelled) {
+		t.Errorf("contentForAction(cancel) error = %v, want ErrCancelled", cancelErr)
+	}
+	if _, unknownErr := contentForAction("bogus", nil); unknownErr == nil || !strings.Contains(unknownErr.Error(), "unknown action") {
+		t.Errorf("contentForAction(bogus) error = %v, want unknown action", unknownErr)
+	}
+}
+
+// TestConfirmSchema_ShapeAndParse verifies the confirmation schema shape and
+// that parseConfirmContent treats missing or non-boolean fields as false.
+func TestConfirmSchema_ShapeAndParse(t *testing.T) {
+	schema := confirmSchema("Sure?")
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("confirmSchema missing properties")
+	}
+	if _, hasConfirmed := props["confirmed"]; !hasConfirmed {
+		t.Fatal("confirmSchema missing 'confirmed' property")
+	}
+
+	if !parseConfirmContent(map[string]any{"confirmed": true}) {
+		t.Error("parseConfirmContent(true) = false")
+	}
+	if parseConfirmContent(map[string]any{"confirmed": "yes"}) {
+		t.Error("parseConfirmContent(non-bool) = true, want false")
+	}
+	if parseConfirmContent(nil) {
+		t.Error("parseConfirmContent(nil) = true, want false")
+	}
+}
+
+// TestTextSchema_ParseTextContent verifies text schema construction and
+// string extraction errors for non-string values.
+func TestTextSchema_ParseTextContent(t *testing.T) {
+	schema := textSchema("Enter name", "name")
+	props := schema["properties"].(map[string]any)
+	if _, ok := props["name"]; !ok {
+		t.Fatal("textSchema missing field property")
+	}
+
+	got, err := parseTextContent(map[string]any{"name": "x"}, "name")
+	if err != nil || got != "x" {
+		t.Errorf("parseTextContent = (%q, %v), want ('x', nil)", got, err)
+	}
+	if _, typeErr := parseTextContent(map[string]any{"name": 5}, "name"); typeErr == nil {
+		t.Error("parseTextContent(non-string) error = nil, want error")
+	}
+}
+
+// TestSelectSchemas_ValidateOptions verifies enum construction and option
+// validation across the single, multi, and integer select parsers.
+func TestSelectSchemas_ValidateOptions(t *testing.T) {
+	if _, err := parseSelectOneContent(map[string]any{"selection": "c"}, []string{"a", "b"}); err == nil {
+		t.Error("parseSelectOneContent(out of enum) error = nil, want error")
+	}
+	if _, err := parseSelectMultiContent(map[string]any{"selections": []any{"a", 3}}, []string{"a"}); err == nil {
+		t.Error("parseSelectMultiContent(non-string element) error = nil, want error")
+	}
+	if _, err := parseSelectOneIntContent(map[string]any{"selection": 2.5}, []int{1, 2}); err == nil {
+		t.Error("parseSelectOneIntContent(non-integer) error = nil, want error")
+	}
+	if _, err := parseSelectOneIntContent(map[string]any{"selection": math.NaN()}, []int{1}); err == nil {
+		t.Error("parseSelectOneIntContent(NaN) error = nil, want error")
+	}
+	got, err := parseSelectOneIntContent(map[string]any{"selection": float64(2)}, []int{1, 2})
+	if err != nil || got != 2 {
+		t.Errorf("parseSelectOneIntContent = (%d, %v), want (2, nil)", got, err)
+	}
+}
+
+// TestNumberSchema_BoundsAndParse verifies numeric bounds inclusion and NaN
+// rejection.
+func TestNumberSchema_BoundsAndParse(t *testing.T) {
+	schema := numberSchema("Rate", "rating", 0, 5)
+	props := schema["properties"].(map[string]any)
+	prop := props["rating"].(map[string]any)
+	if prop["minimum"] != 0.0 || prop["maximum"] != 5.0 {
+		t.Errorf("numberSchema bounds = (%v, %v), want (0, 5)", prop["minimum"], prop["maximum"])
+	}
+
+	unbounded := numberSchema("Any", "v", math.Inf(-1), math.Inf(1))
+	uprop := unbounded["properties"].(map[string]any)["v"].(map[string]any)
+	if _, hasMin := uprop["minimum"]; hasMin {
+		t.Error("numberSchema(-Inf) still has minimum")
+	}
+	if _, hasMax := uprop["maximum"]; hasMax {
+		t.Error("numberSchema(+Inf) still has maximum")
+	}
+
+	if _, err := parseNumberContent(map[string]any{"v": math.NaN()}, "v"); err == nil {
+		t.Error("parseNumberContent(NaN) error = nil, want error")
+	}
+	if _, err := parseNumberContent(map[string]any{"v": "x"}, "v"); err == nil {
+		t.Error("parseNumberContent(non-number) error = nil, want error")
+	}
+}

--- a/internal/testutil/legacy_client.go
+++ b/internal/testutil/legacy_client.go
@@ -1,0 +1,172 @@
+// Package testutil: legacy_client.go provides a minimal hand-rolled MCP
+// client that performs the legacy initialize handshake at protocol version
+// 2025-11-25 and serves server-initiated elicitation/create requests.
+//
+// The official SDK client always negotiates the newest protocol version and
+// offers no exported way to pin an older one, but the legacy synchronous
+// elicitation path only exists on sessions negotiated below 2026-07-28
+// (SEP-2322 forbids server-initiated requests from that version on). Tests
+// that exercise the synchronous path deterministically connect this fake
+// client instead of a real one.
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// legacyProtocolVersion is the newest MCP protocol version that still allows
+// server-initiated elicitation requests during a tool call.
+const legacyProtocolVersion = "2025-11-25"
+
+// LegacyClientOptions configures the fake legacy client's advertised
+// capabilities.
+type LegacyClientOptions struct {
+	// URLElicitation advertises support for URL-mode elicitation in
+	// addition to form elicitation.
+	URLElicitation bool
+}
+
+// ElicitHandlerFunc handles one server-initiated elicitation request.
+type ElicitHandlerFunc func(context.Context, *mcp.ElicitParams) (*mcp.ElicitResult, error)
+
+// ConnectLegacyElicitationClient connects a minimal legacy MCP client
+// (protocol 2025-11-25, elicitation capability advertised) to server and
+// returns the resulting server session. Server-initiated elicitation/create
+// requests are answered by handler; ping requests are acknowledged; all
+// other server-initiated requests fail with MethodNotFound. The session and
+// the fake client are torn down via t.Cleanup.
+func ConnectLegacyElicitationClient(ctx context.Context, t *testing.T, server *mcp.Server, handler ElicitHandlerFunc, opts LegacyClientOptions) *mcp.ServerSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("legacy client: server connect: %v", err)
+	}
+	conn, err := clientTransport.Connect(ctx)
+	if err != nil {
+		_ = ss.Close()
+		t.Fatalf("legacy client: transport connect: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		_ = ss.Close()
+	})
+
+	capabilities := map[string]any{
+		"elicitation": elicitationCapability(opts),
+		"roots":       map[string]any{"listChanged": true},
+	}
+	initParams, err := json.Marshal(map[string]any{
+		"protocolVersion": legacyProtocolVersion,
+		"capabilities":    capabilities,
+		"clientInfo":      map[string]any{"name": "legacy-test-client", "version": "1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("legacy client: marshal initialize params: %v", err)
+	}
+	initID, err := jsonrpc.MakeID("legacy-init")
+	if err != nil {
+		t.Fatalf("legacy client: make id: %v", err)
+	}
+	if writeErr := conn.Write(ctx, &jsonrpc.Request{ID: initID, Method: "initialize", Params: initParams}); writeErr != nil {
+		t.Fatalf("legacy client: write initialize: %v", writeErr)
+	}
+	if handshakeErr := awaitLegacyInitializeResponse(ctx, conn, handler); handshakeErr != nil {
+		t.Fatalf("legacy client: %v", handshakeErr)
+	}
+	if notifyErr := conn.Write(ctx, &jsonrpc.Request{Method: "notifications/initialized", Params: json.RawMessage("{}")}); notifyErr != nil {
+		t.Fatalf("legacy client: write initialized notification: %v", notifyErr)
+	}
+
+	go serveLegacyClient(ctx, conn, handler)
+	return ss
+}
+
+// elicitationCapability builds the advertised elicitation capability object.
+func elicitationCapability(opts LegacyClientOptions) map[string]any {
+	capability := map[string]any{"form": map[string]any{}}
+	if opts.URLElicitation {
+		capability["url"] = map[string]any{}
+	}
+	return capability
+}
+
+// awaitLegacyInitializeResponse reads messages until the initialize response
+// arrives, servicing any interleaved server-initiated requests.
+func awaitLegacyInitializeResponse(ctx context.Context, conn mcp.Connection, handler ElicitHandlerFunc) error {
+	for {
+		msg, err := conn.Read(ctx)
+		if err != nil {
+			return fmt.Errorf("read during handshake: %w", err)
+		}
+		switch m := msg.(type) {
+		case *jsonrpc.Response:
+			if m.Error != nil {
+				return fmt.Errorf("initialize failed: %w", m.Error)
+			}
+			return nil
+		case *jsonrpc.Request:
+			respondLegacyRequest(ctx, conn, m, handler)
+		}
+	}
+}
+
+// serveLegacyClient answers server-initiated requests until the connection
+// closes.
+func serveLegacyClient(ctx context.Context, conn mcp.Connection, handler ElicitHandlerFunc) {
+	for {
+		msg, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		req, ok := msg.(*jsonrpc.Request)
+		if !ok {
+			continue
+		}
+		respondLegacyRequest(ctx, conn, req, handler)
+	}
+}
+
+// respondLegacyRequest handles one server-initiated request: elicitation
+// goes to the handler, pings are acknowledged, and anything else fails
+// with MethodNotFound. Notifications are ignored.
+func respondLegacyRequest(ctx context.Context, conn mcp.Connection, req *jsonrpc.Request, handler ElicitHandlerFunc) {
+	if !req.ID.IsValid() {
+		return
+	}
+	switch req.Method {
+	case "elicitation/create":
+		var params mcp.ElicitParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			writeLegacyError(ctx, conn, req.ID, jsonrpc.CodeInvalidParams, err.Error())
+			return
+		}
+		result, err := handler(ctx, &params)
+		if err != nil {
+			writeLegacyError(ctx, conn, req.ID, jsonrpc.CodeInternalError, err.Error())
+			return
+		}
+		raw, err := json.Marshal(result)
+		if err != nil {
+			writeLegacyError(ctx, conn, req.ID, jsonrpc.CodeInternalError, err.Error())
+			return
+		}
+		_ = conn.Write(ctx, &jsonrpc.Response{ID: req.ID, Result: raw})
+	case "ping":
+		_ = conn.Write(ctx, &jsonrpc.Response{ID: req.ID, Result: json.RawMessage("{}")})
+	default:
+		writeLegacyError(ctx, conn, req.ID, jsonrpc.CodeMethodNotFound, fmt.Sprintf("method %q not supported by legacy test client", req.Method))
+	}
+}
+
+// writeLegacyError writes a JSON-RPC error response.
+func writeLegacyError(ctx context.Context, conn mcp.Connection, id jsonrpc.ID, code int64, message string) {
+	_ = conn.Write(ctx, &jsonrpc.Response{ID: id, Error: &jsonrpc.Error{Code: code, Message: message}})
+}

--- a/internal/testutil/legacy_client.go
+++ b/internal/testutil/legacy_client.go
@@ -41,6 +41,11 @@ type ElicitHandlerFunc func(context.Context, *mcp.ElicitParams) (*mcp.ElicitResu
 // requests are answered by handler; ping requests are acknowledged; all
 // other server-initiated requests fail with MethodNotFound. The session and
 // the fake client are torn down via t.Cleanup.
+//
+// After the handshake, handler runs on the fake client's serving goroutine,
+// not the test goroutine: report failures inside handler with t.Errorf or by
+// returning an error, never t.Fatal/t.FailNow (which only terminate the
+// calling goroutine).
 func ConnectLegacyElicitationClient(ctx context.Context, t *testing.T, server *mcp.Server, handler ElicitHandlerFunc, opts LegacyClientOptions) *mcp.ServerSession {
 	t.Helper()
 

--- a/internal/testutil/legacy_client_test.go
+++ b/internal/testutil/legacy_client_test.go
@@ -1,0 +1,34 @@
+package testutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
+)
+
+func TestLegacyClientHandshake(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "s", Version: "1"}, nil)
+	ss := testutil.ConnectLegacyElicitationClient(t.Context(), t, server, func(_ context.Context, p *mcp.ElicitParams) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	}, testutil.LegacyClientOptions{})
+	ip := ss.InitializeParams()
+	if ip == nil {
+		t.Fatal("InitializeParams nil")
+	}
+	if ip.ProtocolVersion != "2025-11-25" {
+		t.Fatalf("protocol = %q", ip.ProtocolVersion)
+	}
+	if ip.Capabilities.Elicitation == nil {
+		t.Fatal("no elicitation capability")
+	}
+	res, err := ss.Elicit(context.Background(), &mcp.ElicitParams{Message: "ok?", RequestedSchema: map[string]any{"type": "object"}})
+	if err != nil {
+		t.Fatalf("Elicit: %v", err)
+	}
+	if res.Action != "accept" {
+		t.Fatalf("action = %q", res.Action)
+	}
+}

--- a/internal/tools/elicitationtools/elicitationtools.go
+++ b/internal/tools/elicitationtools/elicitationtools.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	// fmtCollectingDesc identifies the fmt collecting desc constant used by this package.
-	fmtCollectingDesc = "collecting description: %w"
+	// labelCollectingDesc identifies the description-collection step in wrapped errors.
+	labelCollectingDesc = "collecting description"
 	// fmtDescSummary identifies the fmt desc summary constant used by this package.
 	fmtDescSummary = "\n**Description**: %.100s..."
 )
@@ -90,44 +90,70 @@ func parseCSVLabels(s string) []string {
 	return labels
 }
 
+// flowError converts an elicitation prompt error into the error a wizard
+// should return: pending input becomes the flow's input-required error
+// (surfaced to the client as a multi round-trip request), anything else is
+// wrapped with the step label.
+func flowError(fl *elicitation.Flow, err error, label string) error {
+	if errors.Is(err, elicitation.ErrInputPending) {
+		return fl.PendingError()
+	}
+	return fmt.Errorf("%s: %w", label, err)
+}
+
+// newWizardFlow builds the elicitation flow shared by the interactive
+// creation wizards, translating flow construction failures and missing
+// client support into wizard-level errors.
+func newWizardFlow(req *mcp.CallToolRequest) (*elicitation.Flow, error) {
+	fl, err := elicitation.FlowFromRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if !fl.IsSupported() {
+		return nil, elicitation.ErrElicitationNotSupported
+	}
+	return fl, nil
+}
+
 // Interactive issue creation.
 
 // IssueCreate guides the user through creating a GitLab issue via
 // step-by-step elicitation prompts for title, description, labels, and
-// confidentiality, then confirms before calling [issues.Create].
+// confidentiality, then confirms before calling [issues.Create]. On multi
+// round-trip sessions each prompt travels as an input request and the
+// handler is re-invoked with the accumulated answers.
 func IssueCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Client, input IssueInput) (issues.Output, error) {
 	if input.ProjectID == "" {
 		return issues.Output{}, toolutil.ErrFieldRequired("project_id")
 	}
 
 	tracker := progress.FromRequest(req)
-	ec := elicitation.FromRequest(req)
-
-	if !ec.IsSupported() {
-		return issues.Output{}, elicitation.ErrElicitationNotSupported
+	fl, err := newWizardFlow(req)
+	if err != nil {
+		return issues.Output{}, err
 	}
 
 	tracker.Step(ctx, 1, 4, "Collecting issue details...")
 
-	title, err := ec.PromptText(ctx, "Enter the issue title", "title")
+	title, err := fl.PromptText(ctx, "title", "Enter the issue title", "title")
 	if err != nil {
-		return issues.Output{}, fmt.Errorf("collecting title: %w", err)
+		return issues.Output{}, flowError(fl, err, "collecting title")
 	}
 
-	description, err := ec.PromptText(ctx, "Enter the issue description (Markdown supported, or leave empty)", "description")
+	description, err := fl.PromptText(ctx, "description", "Enter the issue description (Markdown supported, or leave empty)", "description")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return issues.Output{}, fmt.Errorf(fmtCollectingDesc, err)
+		return issues.Output{}, flowError(fl, err, labelCollectingDesc)
 	}
 
 	tracker.Step(ctx, 2, 4, "Collecting optional fields...")
 
-	labelsStr, err := ec.PromptText(ctx, "Enter comma-separated labels (or leave empty)", "labels")
+	labelsStr, err := fl.PromptText(ctx, "labels", "Enter comma-separated labels (or leave empty)", "labels")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return issues.Output{}, fmt.Errorf("collecting labels: %w", err)
+		return issues.Output{}, flowError(fl, err, "collecting labels")
 	}
 	labels := parseCSVLabels(labelsStr)
 
-	confidentialChoice, err := confirmOptionalBool(ctx, ec, "Should this issue be confidential?", "confidentiality")
+	confidentialChoice, err := confirmOptionalBool(ctx, fl, "confidential", "Should this issue be confidential?", "confidentiality")
 	if err != nil {
 		return issues.Output{}, err
 	}
@@ -146,15 +172,8 @@ func IssueCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabcl
 		summary += "\n**Confidential**: Yes"
 	}
 
-	confirmed, err := ec.Confirm(ctx, summary)
-	if err != nil {
-		if errors.Is(err, elicitation.ErrCancelled) || errors.Is(err, elicitation.ErrDeclined) {
-			return issues.Output{}, fmt.Errorf("issue creation canceled by user: %w", err)
-		}
-		return issues.Output{}, fmt.Errorf("issue creation confirmation failed: %w", err)
-	}
-	if !confirmed {
-		return issues.Output{}, fmt.Errorf("issue creation canceled by user: %w", elicitation.ErrCancelled)
+	if confirmErr := confirmCreation(ctx, fl, summary, "issue creation"); confirmErr != nil {
+		return issues.Output{}, confirmErr
 	}
 
 	tracker.Step(ctx, 4, 4, "Creating issue...")
@@ -173,45 +192,46 @@ func IssueCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabcl
 // MRCreate guides the user through creating a GitLab merge request
 // via step-by-step elicitation prompts for branches, title, description,
 // labels, and merge options, then confirms before calling [mergerequests.Create].
+// On multi round-trip sessions each prompt travels as an input request and
+// the handler is re-invoked with the accumulated answers.
 func MRCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Client, input MRInput) (mergerequests.Output, error) {
 	if input.ProjectID == "" {
 		return mergerequests.Output{}, toolutil.ErrFieldRequired("project_id")
 	}
 
 	tracker := progress.FromRequest(req)
-	ec := elicitation.FromRequest(req)
-
-	if !ec.IsSupported() {
-		return mergerequests.Output{}, elicitation.ErrElicitationNotSupported
+	fl, err := newWizardFlow(req)
+	if err != nil {
+		return mergerequests.Output{}, err
 	}
 
 	tracker.Step(ctx, 1, 5, "Collecting branch information...")
 
-	sourceBranch, err := ec.PromptText(ctx, "Enter the source branch name", "source_branch")
+	sourceBranch, err := fl.PromptText(ctx, "source_branch", "Enter the source branch name", "source_branch")
 	if err != nil {
-		return mergerequests.Output{}, fmt.Errorf("collecting source branch: %w", err)
+		return mergerequests.Output{}, flowError(fl, err, "collecting source branch")
 	}
 
-	targetBranch, err := ec.PromptText(ctx, "Enter the target branch name (e.g. main, develop)", "target_branch")
+	targetBranch, err := fl.PromptText(ctx, "target_branch", "Enter the target branch name (e.g. main, develop)", "target_branch")
 	if err != nil {
-		return mergerequests.Output{}, fmt.Errorf("collecting target branch: %w", err)
+		return mergerequests.Output{}, flowError(fl, err, "collecting target branch")
 	}
 
 	tracker.Step(ctx, 2, 5, "Collecting MR details...")
 
-	title, err := ec.PromptText(ctx, "Enter the merge request title", "title")
+	title, err := fl.PromptText(ctx, "title", "Enter the merge request title", "title")
 	if err != nil {
-		return mergerequests.Output{}, fmt.Errorf("collecting title: %w", err)
+		return mergerequests.Output{}, flowError(fl, err, "collecting title")
 	}
 
-	description, err := ec.PromptText(ctx, "Enter the MR description (Markdown supported, or leave empty)", "description")
+	description, err := fl.PromptText(ctx, "description", "Enter the MR description (Markdown supported, or leave empty)", "description")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return mergerequests.Output{}, fmt.Errorf(fmtCollectingDesc, err)
+		return mergerequests.Output{}, flowError(fl, err, labelCollectingDesc)
 	}
 
 	tracker.Step(ctx, 3, 5, "Collecting optional fields...")
 
-	labels, removeSource, squash, err := collectMROptions(ctx, ec)
+	labels, removeSource, squash, err := collectMROptions(ctx, fl)
 	if err != nil {
 		return mergerequests.Output{}, err
 	}
@@ -229,15 +249,8 @@ func MRCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclien
 		Squash:       squash,
 	})
 
-	confirmed, err := ec.Confirm(ctx, summary)
-	if err != nil {
-		if errors.Is(err, elicitation.ErrCancelled) || errors.Is(err, elicitation.ErrDeclined) {
-			return mergerequests.Output{}, fmt.Errorf("merge request creation canceled by user: %w", err)
-		}
-		return mergerequests.Output{}, fmt.Errorf("merge request creation confirmation failed: %w", err)
-	}
-	if !confirmed {
-		return mergerequests.Output{}, fmt.Errorf("merge request creation canceled by user: %w", elicitation.ErrCancelled)
+	if confirmErr := confirmCreation(ctx, fl, summary, "merge request creation"); confirmErr != nil {
+		return mergerequests.Output{}, confirmErr
 	}
 
 	tracker.Step(ctx, 5, 5, "Creating merge request...")
@@ -255,20 +268,20 @@ func MRCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclien
 }
 
 // collectMROptions asks for optional merge request labels and merge behavior.
-func collectMROptions(ctx context.Context, ec elicitation.Client) (_ []string, _, _ *bool, _ error) {
-	labelsStr, err := ec.PromptText(ctx, "Enter comma-separated labels (or leave empty)", "labels")
+func collectMROptions(ctx context.Context, fl *elicitation.Flow) (_ []string, _, _ *bool, _ error) {
+	labelsStr, err := fl.PromptText(ctx, "labels", "Enter comma-separated labels (or leave empty)", "labels")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return nil, nil, nil, fmt.Errorf("collecting labels: %w", err)
+		return nil, nil, nil, flowError(fl, err, "collecting labels")
 	}
 	labels := parseCSVLabels(labelsStr)
 
-	removeSourceChoice, err := confirmOptionalBool(ctx, ec, "Remove source branch after merge?", "source branch removal")
+	removeSourceChoice, err := confirmOptionalBool(ctx, fl, "remove_source_branch", "Remove source branch after merge?", "source branch removal")
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	removeSource := removeSourceChoice.Value
 
-	squashChoice, err := confirmOptionalBool(ctx, ec, "Squash commits on merge?", "squash option")
+	squashChoice, err := confirmOptionalBool(ctx, fl, "squash", "Squash commits on merge?", "squash option")
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -283,16 +296,36 @@ type optionalBoolChoice struct {
 }
 
 // confirmOptionalBool returns an optional boolean prompt result and reports an
-// error when the user cancels the flow.
-func confirmOptionalBool(ctx context.Context, ec elicitation.Client, prompt, field string) (optionalBoolChoice, error) {
-	confirmed, err := ec.Confirm(ctx, prompt)
+// error when the user cancels the flow or the answer is still pending.
+func confirmOptionalBool(ctx context.Context, fl *elicitation.Flow, id, prompt, field string) (optionalBoolChoice, error) {
+	confirmed, err := fl.Confirm(ctx, id, prompt)
 	if err == nil {
 		return optionalBoolChoice{Value: &confirmed}, nil
 	}
 	if errors.Is(err, elicitation.ErrDeclined) {
 		return optionalBoolChoice{}, nil
 	}
-	return optionalBoolChoice{}, fmt.Errorf("collecting %s: %w", field, err)
+	return optionalBoolChoice{}, flowError(fl, err, "collecting "+field)
+}
+
+// confirmCreation runs the final confirmation prompt of a creation wizard
+// and converts declines, cancellations, and pending input into the
+// appropriate wizard error.
+func confirmCreation(ctx context.Context, fl *elicitation.Flow, summary, operation string) error {
+	confirmed, err := fl.Confirm(ctx, elicitation.ConfirmExchangeID, summary)
+	if err != nil {
+		if errors.Is(err, elicitation.ErrInputPending) {
+			return fl.PendingError()
+		}
+		if errors.Is(err, elicitation.ErrCancelled) || errors.Is(err, elicitation.ErrDeclined) {
+			return fmt.Errorf("%s canceled by user: %w", operation, err)
+		}
+		return fmt.Errorf("%s confirmation failed: %w", operation, err)
+	}
+	if !confirmed {
+		return fmt.Errorf("%s canceled by user: %w", operation, elicitation.ErrCancelled)
+	}
+	return nil
 }
 
 // mrSummaryParams groups the parameters for building an MR confirmation summary.
@@ -333,36 +366,37 @@ func buildMRSummary(p mrSummaryParams) string {
 
 // ReleaseCreate guides the user through creating a GitLab release
 // via step-by-step elicitation prompts for tag name, release name, and
-// description, then confirms before calling [releases.Create].
+// description, then confirms before calling [releases.Create]. On multi
+// round-trip sessions each prompt travels as an input request and the
+// handler is re-invoked with the accumulated answers.
 func ReleaseCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Client, input ReleaseInput) (releases.Output, error) {
 	if input.ProjectID == "" {
 		return releases.Output{}, toolutil.ErrFieldRequired("project_id")
 	}
 
 	tracker := progress.FromRequest(req)
-	ec := elicitation.FromRequest(req)
-
-	if !ec.IsSupported() {
-		return releases.Output{}, elicitation.ErrElicitationNotSupported
+	fl, err := newWizardFlow(req)
+	if err != nil {
+		return releases.Output{}, err
 	}
 
 	tracker.Step(ctx, 1, 4, "Collecting release details...")
 
-	tagName, err := ec.PromptText(ctx, "Enter the tag name for the release (must already exist)", "tag_name")
+	tagName, err := fl.PromptText(ctx, "tag_name", "Enter the tag name for the release (must already exist)", "tag_name")
 	if err != nil {
-		return releases.Output{}, fmt.Errorf("collecting tag name: %w", err)
+		return releases.Output{}, flowError(fl, err, "collecting tag name")
 	}
 
-	name, err := ec.PromptText(ctx, "Enter the release name/title", "name")
+	name, err := fl.PromptText(ctx, "name", "Enter the release name/title", "name")
 	if err != nil {
-		return releases.Output{}, fmt.Errorf("collecting release name: %w", err)
+		return releases.Output{}, flowError(fl, err, "collecting release name")
 	}
 
 	tracker.Step(ctx, 2, 4, "Collecting release description...")
 
-	description, err := ec.PromptText(ctx, "Enter the release description/notes (Markdown supported, or leave empty)", "description")
+	description, err := fl.PromptText(ctx, "description", "Enter the release description/notes (Markdown supported, or leave empty)", "description")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return releases.Output{}, fmt.Errorf(fmtCollectingDesc, err)
+		return releases.Output{}, flowError(fl, err, labelCollectingDesc)
 	}
 
 	tracker.Step(ctx, 3, 4, "Confirming release creation...")
@@ -373,15 +407,8 @@ func ReleaseCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlab
 		summary += fmt.Sprintf(fmtDescSummary, description)
 	}
 
-	confirmed, err := ec.Confirm(ctx, summary)
-	if err != nil {
-		if errors.Is(err, elicitation.ErrCancelled) || errors.Is(err, elicitation.ErrDeclined) {
-			return releases.Output{}, fmt.Errorf("release creation canceled by user: %w", err)
-		}
-		return releases.Output{}, fmt.Errorf("release creation confirmation failed: %w", err)
-	}
-	if !confirmed {
-		return releases.Output{}, fmt.Errorf("release creation canceled by user: %w", elicitation.ErrCancelled)
+	if confirmErr := confirmCreation(ctx, fl, summary, "release creation"); confirmErr != nil {
+		return releases.Output{}, confirmErr
 	}
 
 	tracker.Step(ctx, 4, 4, "Creating release...")
@@ -399,43 +426,43 @@ func ReleaseCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlab
 // ProjectCreate guides the user through creating a GitLab project
 // via step-by-step elicitation prompts for name, description, visibility,
 // README initialization, and default branch, then confirms before calling
-// [projects.Create].
+// [projects.Create]. On multi round-trip sessions each prompt travels as an
+// input request and the handler is re-invoked with the accumulated answers.
 func ProjectCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient.Client, _ ProjectInput) (projects.Output, error) {
 	tracker := progress.FromRequest(req)
-	ec := elicitation.FromRequest(req)
-
-	if !ec.IsSupported() {
-		return projects.Output{}, elicitation.ErrElicitationNotSupported
+	fl, err := newWizardFlow(req)
+	if err != nil {
+		return projects.Output{}, err
 	}
 
 	tracker.Step(ctx, 1, 4, "Collecting project details...")
 
-	name, err := ec.PromptText(ctx, "Enter the project name", "name")
+	name, err := fl.PromptText(ctx, "name", "Enter the project name", "name")
 	if err != nil {
-		return projects.Output{}, fmt.Errorf("collecting project name: %w", err)
+		return projects.Output{}, flowError(fl, err, "collecting project name")
 	}
 
-	description, err := ec.PromptText(ctx, "Enter the project description (or leave empty)", "description")
+	description, err := fl.PromptText(ctx, "description", "Enter the project description (or leave empty)", "description")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return projects.Output{}, fmt.Errorf(fmtCollectingDesc, err)
+		return projects.Output{}, flowError(fl, err, labelCollectingDesc)
 	}
 
 	tracker.Step(ctx, 2, 4, "Collecting project settings...")
 
-	visibility, err := ec.SelectOne(ctx, "Select the project visibility", []string{"private", "internal", "public"})
+	visibility, err := fl.SelectOne(ctx, "visibility", "Select the project visibility", []string{"private", "internal", "public"})
 	if err != nil {
-		return projects.Output{}, fmt.Errorf("collecting visibility: %w", err)
+		return projects.Output{}, flowError(fl, err, "collecting visibility")
 	}
 
-	initReadmeChoice, err := confirmOptionalBool(ctx, ec, "Initialize the repository with a README file?", "README initialization")
+	initReadmeChoice, err := confirmOptionalBool(ctx, fl, "initialize_with_readme", "Initialize the repository with a README file?", "README initialization")
 	if err != nil {
 		return projects.Output{}, err
 	}
 	initReadme := initReadmeChoice.Value != nil && *initReadmeChoice.Value
 
-	defaultBranch, err := ec.PromptText(ctx, "Enter the default branch name (or leave empty for 'main')", "default_branch")
+	defaultBranch, err := fl.PromptText(ctx, "default_branch", "Enter the default branch name (or leave empty for 'main')", "default_branch")
 	if err != nil && !errors.Is(err, elicitation.ErrDeclined) {
-		return projects.Output{}, fmt.Errorf("collecting default branch: %w", err)
+		return projects.Output{}, flowError(fl, err, "collecting default branch")
 	}
 
 	tracker.Step(ctx, 3, 4, "Confirming project creation...")
@@ -451,15 +478,8 @@ func ProjectCreate(ctx context.Context, req *mcp.CallToolRequest, client *gitlab
 		summary += "\n**Default Branch**: " + defaultBranch
 	}
 
-	confirmed, err := ec.Confirm(ctx, summary)
-	if err != nil {
-		if errors.Is(err, elicitation.ErrCancelled) || errors.Is(err, elicitation.ErrDeclined) {
-			return projects.Output{}, fmt.Errorf("project creation canceled by user: %w", err)
-		}
-		return projects.Output{}, fmt.Errorf("project creation confirmation failed: %w", err)
-	}
-	if !confirmed {
-		return projects.Output{}, fmt.Errorf("project creation canceled by user: %w", elicitation.ErrCancelled)
+	if confirmErr := confirmCreation(ctx, fl, summary, "project creation"); confirmErr != nil {
+		return projects.Output{}, confirmErr
 	}
 
 	tracker.Step(ctx, 4, 4, "Creating project...")

--- a/internal/tools/elicitationtools/elicitationtools_test.go
+++ b/internal/tools/elicitationtools/elicitationtools_test.go
@@ -1052,11 +1052,12 @@ func TestIssueCreate_Confidential(t *testing.T) {
 	}
 }
 
-// ConfirmAction — generic error (not Declined/Cancelled) → nil.
+// ConfirmAction — generic error (not Declined/Cancelled) → fail closed.
 
-// TestConfirmAction_OtherError verifies that ConfirmAction returns nil when
-// ec.Confirm returns a generic error (not ErrDeclined/ErrCancelled),
-// maintaining backward compatibility by allowing the operation to proceed.
+// TestConfirmAction_OtherError verifies that ConfirmAction fails closed with
+// an error result when the confirmation exchange fails for a reason other
+// than an explicit user decision, so the destructive action never proceeds
+// on a failed confirmation.
 func TestConfirmAction_OtherError(t *testing.T) {
 	ctx := context.Background()
 	_, ss, cleanup := setupElicitationSession(t, ctx, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
@@ -1065,8 +1066,11 @@ func TestConfirmAction_OtherError(t *testing.T) {
 	defer cleanup()
 
 	r := ConfirmAction(ctx, &mcp.CallToolRequest{Session: ss}, "Proceed?")
-	if r != nil {
-		t.Error("ConfirmAction should return nil on generic error (backward compat)")
+	if r == nil {
+		t.Fatal("ConfirmAction should fail closed on generic confirmation errors")
+	}
+	if !r.IsError {
+		t.Error("ConfirmAction(generic error).IsError = false, want true")
 	}
 }
 

--- a/internal/tools/elicitationtools/elicitationtools_test.go
+++ b/internal/tools/elicitationtools/elicitationtools_test.go
@@ -504,35 +504,21 @@ func TestProjectCreate_UserDeclinesConfirmation(t *testing.T) {
 }
 
 // setupElicitationSession creates a connected MCP server+client pair where
-// the client supports elicitation. Returns the server, server session, and a
-// cleanup function. The server session can be used to construct CallToolRequests
-// with elicitation support.
+// the client supports elicitation. The client performs the legacy 2025-11-25
+// handshake (via testutil.ConnectLegacyElicitationClient) so direct wizard
+// invocations deterministically exercise the synchronous elicitation path;
+// the multi round-trip path is covered by the TestCatalogSurface_* tests
+// that drive real tools/call round-trips. Returns the server, server
+// session, and a cleanup function (a no-op; teardown is via t.Cleanup).
 func setupElicitationSession(t *testing.T, ctx context.Context, handler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) (*mcp.Server, *mcp.ServerSession, func()) {
 	t.Helper()
 
 	impl := &mcp.Implementation{Name: "test", Version: "1.0.0"}
 	server := mcp.NewServer(impl, nil)
-	client := mcp.NewClient(impl, &mcp.ClientOptions{
-		ElicitationHandler: handler,
-	})
-
-	st, ct := mcp.NewInMemoryTransports()
-	ss, err := server.Connect(ctx, st, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-
-	cs, err := client.Connect(ctx, ct, nil)
-	if err != nil {
-		ss.Close()
-		t.Fatalf("client connect: %v", err)
-	}
-
-	cleanup := func() {
-		cs.Close()
-		ss.Close()
-	}
-	return server, ss, cleanup
+	ss := testutil.ConnectLegacyElicitationClient(ctx, t, server, func(ctx context.Context, params *mcp.ElicitParams) (*mcp.ElicitResult, error) {
+		return handler(ctx, &mcp.ElicitRequest{Params: params})
+	}, testutil.LegacyClientOptions{})
+	return server, ss, func() {}
 }
 
 // ---------- Tests consolidated from coverage_test.go ----------.

--- a/internal/tools/individual_catalog.go
+++ b/internal/tools/individual_catalog.go
@@ -2,12 +2,14 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
@@ -255,6 +257,9 @@ func individualCatalogHandler(toolName string, action actioncatalog.Action, form
 		actionCtx := toolutil.ContextWithRequest(ctx, req)
 		start := time.Now()
 		result, err := action.Route.Handler(actionCtx, input)
+		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
+			return inputErr.Result(), nil, nil
+		}
 		toolutil.LogToolCallAll(ctx, req, toolName, start, err)
 		if err != nil {
 			return nil, nil, err

--- a/internal/tools/individual_catalog.go
+++ b/internal/tools/individual_catalog.go
@@ -2,14 +2,12 @@ package tools
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
@@ -257,8 +255,8 @@ func individualCatalogHandler(toolName string, action actioncatalog.Action, form
 		actionCtx := toolutil.ContextWithRequest(ctx, req)
 		start := time.Now()
 		result, err := action.Route.Handler(actionCtx, input)
-		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
-			return inputErr.Result(), nil, nil
+		if inputResult, needsInput := toolutil.InputRequiredResultFromError(err); needsInput {
+			return inputResult, nil, nil
 		}
 		toolutil.LogToolCallAll(ctx, req, toolName, start, err)
 		if err != nil {

--- a/internal/toolutil/confirm.go
+++ b/internal/toolutil/confirm.go
@@ -108,7 +108,10 @@ func ConfirmAction(ctx context.Context, req *mcp.CallToolRequest, message string
 		slog.Info("destructive action canceled by user", "tool", tool)
 		return CancelledResult("Operation canceled by user.")
 	case err != nil:
-		return nil
+		// Fail closed: a destructive action must never proceed on a
+		// malformed or failed confirmation exchange.
+		slog.Warn("destructive confirmation failed", "tool", tool, "error", err)
+		return elicitation.ConfirmFailedResult(err)
 	}
 	if !confirmed {
 		slog.Info("destructive action denied by user", "tool", tool)
@@ -125,4 +128,15 @@ func CancelledResult(message string) *mcp.CallToolResult {
 			&mcp.TextContent{Text: message},
 		},
 	}
+}
+
+// InputRequiredResultFromError extracts the input-required tool result from a
+// handler error produced by [elicitation.Flow.PendingError]. Surface
+// dispatchers call this before logging so a pending multi round-trip exchange
+// is returned to the client instead of being reported as a handler failure.
+func InputRequiredResultFromError(err error) (*mcp.CallToolResult, bool) {
+	if inputErr, ok := errors.AsType[*elicitation.InputRequiredError](err); ok {
+		return inputErr.Result(), true
+	}
+	return nil, false
 }

--- a/internal/toolutil/confirm.go
+++ b/internal/toolutil/confirm.go
@@ -81,23 +81,33 @@ func hasExplicitConfirm(params map[string]any) bool {
 // ConfirmAction uses MCP elicitation to ask the user for confirmation before
 // a destructive action. Returns nil if the user confirmed or elicitation is
 // unsupported (fallback: action proceeds). Returns a non-error tool result
-// if the user declined or canceled.
+// if the user declined or canceled. On sessions negotiated at protocol
+// >= 2026-07-28 the confirmation travels as a multi round-trip input request
+// (SEP-2322): the first pass returns an input-required result and the client
+// retries the call with the user's answer attached.
 func ConfirmAction(ctx context.Context, req *mcp.CallToolRequest, message string) *mcp.CallToolResult {
 	tool := ""
 	if req != nil {
 		tool = req.Params.Name
 	}
 
-	ec := elicitation.FromRequest(req)
-	if !ec.IsSupported() {
+	flow, err := elicitation.FlowFromRequest(req)
+	if err != nil {
+		slog.Warn("destructive confirmation state invalid", "tool", tool, "error", err)
+		return ErrorResult(err.Error())
+	}
+	if !flow.IsSupported() {
 		return nil
 	}
-	confirmed, err := ec.Confirm(ctx, message)
-	if err != nil {
-		if errors.Is(err, elicitation.ErrDeclined) || errors.Is(err, elicitation.ErrCancelled) {
-			slog.Info("destructive action canceled by user", "tool", tool)
-			return CancelledResult("Operation canceled by user.")
-		}
+	confirmed, err := flow.Confirm(ctx, elicitation.ConfirmExchangeID, message)
+	switch {
+	case errors.Is(err, elicitation.ErrInputPending):
+		slog.Debug("destructive confirmation pending client input", "tool", tool)
+		return flow.InputRequiredResult()
+	case errors.Is(err, elicitation.ErrDeclined), errors.Is(err, elicitation.ErrCancelled):
+		slog.Info("destructive action canceled by user", "tool", tool)
+		return CancelledResult("Operation canceled by user.")
+	case err != nil:
 		return nil
 	}
 	if !confirmed {

--- a/internal/toolutil/confirm_test.go
+++ b/internal/toolutil/confirm_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
 )
 
 const testConfirmPrompt = "Delete project?"
@@ -168,29 +170,18 @@ func TestCancelledResult(t *testing.T) {
 // confirm sessions.
 var confirmTestImpl = &mcp.Implementation{Name: "confirm-test", Version: "1.0.0"}
 
-// newConfirmSession wires a server and client with the supplied elicitation
-// handler so tests can drive the user confirmation path end-to-end.
+// newConfirmSession wires a server and a legacy (protocol 2025-11-25) fake
+// client with the supplied elicitation handler so direct guard invocations
+// deterministically exercise the synchronous confirmation path. The multi
+// round-trip confirmation path is covered by the surface/catalog tests that
+// drive real tools/call round-trips.
 func newConfirmSession(t *testing.T, handler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) *mcp.ServerSession {
 	t.Helper()
 
 	server := mcp.NewServer(confirmTestImpl, nil)
-	client := mcp.NewClient(confirmTestImpl, &mcp.ClientOptions{ElicitationHandler: handler})
-
-	st, ct := mcp.NewInMemoryTransports()
-	ss, err := server.Connect(context.Background(), st, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-	cs, err := client.Connect(context.Background(), ct, nil)
-	if err != nil {
-		_ = ss.Close()
-		t.Fatalf("client connect: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = cs.Close()
-		_ = ss.Close()
-	})
-	return ss
+	return testutil.ConnectLegacyElicitationClient(t.Context(), t, server, func(ctx context.Context, params *mcp.ElicitParams) (*mcp.ElicitResult, error) {
+		return handler(ctx, &mcp.ElicitRequest{Params: params})
+	}, testutil.LegacyClientOptions{})
 }
 
 // TestConfirmAction_UnsupportedProceeds verifies that [ConfirmAction] returns

--- a/internal/toolutil/confirm_test.go
+++ b/internal/toolutil/confirm_test.go
@@ -245,17 +245,24 @@ func TestConfirmAction_NilReqProceeds(t *testing.T) {
 	}
 }
 
-// TestConfirmAction_UnknownActionProceeds verifies that elicitation errors
-// other than ErrDeclined/ErrCancelled are treated as a fallback to proceed
-// (returning nil) so the destructive action can still run.
-func TestConfirmAction_UnknownActionProceeds(t *testing.T) {
+// TestConfirmAction_UnknownActionFailsClosed verifies that a malformed
+// elicitation answer (an unrecognized action value) fails closed with an
+// error result instead of letting the destructive action proceed.
+func TestConfirmAction_UnknownActionFailsClosed(t *testing.T) {
 	ss := newConfirmSession(t, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
 		return &mcp.ElicitResult{Action: "weird-action"}, nil
 	})
 
 	req := &mcp.CallToolRequest{Session: ss, Params: &mcp.CallToolParamsRaw{Name: "delete"}}
-	if got := ConfirmAction(context.Background(), req, "Delete?"); got != nil {
-		t.Errorf("ConfirmAction(unknown action) = %+v, want nil", got)
+	got := ConfirmAction(context.Background(), req, "Delete?")
+	if got == nil {
+		t.Fatal("ConfirmAction(unknown action) = nil, want fail-closed error result")
+	}
+	if !got.IsError {
+		t.Error("ConfirmAction(unknown action).IsError = false, want true")
+	}
+	if !strings.Contains(surfaceToolText(got), "Confirmation failed") {
+		t.Errorf("fail-closed text = %q, want it to mention 'Confirmation failed'", surfaceToolText(got))
 	}
 }
 

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 )
 
@@ -2274,6 +2275,9 @@ func MakeMetaHandler(toolName string, routes ActionMap, formatResult FormatResul
 
 		start := time.Now()
 		result, err := route.Handler(actionCtx, input.Params)
+		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
+			return inputErr.Result(), nil, nil
+		}
 		LogToolCallAll(ctx, req, fmt.Sprintf("%s/%s", toolName, input.Action), start, err)
 
 		if err != nil {

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 )
 
@@ -2275,8 +2274,8 @@ func MakeMetaHandler(toolName string, routes ActionMap, formatResult FormatResul
 
 		start := time.Now()
 		result, err := route.Handler(actionCtx, input.Params)
-		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
-			return inputErr.Result(), nil, nil
+		if inputResult, needsInput := InputRequiredResultFromError(err); needsInput {
+			return inputResult, nil, nil
 		}
 		LogToolCallAll(ctx, req, fmt.Sprintf("%s/%s", toolName, input.Action), start, err)
 

--- a/internal/toolutil/surface_tool.go
+++ b/internal/toolutil/surface_tool.go
@@ -2,10 +2,13 @@ package toolutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 )
 
 // SurfaceToolRegisterOptions controls how an ActionSpec is exposed as a
@@ -55,6 +58,9 @@ func surfaceToolHandler(toolName string, route ActionRoute, formatResult FormatR
 			}
 		}
 		result, err := route.Handler(ContextWithRequest(ctx, req), input)
+		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
+			return inputErr.Result(), nil, nil
+		}
 		LogToolCallAll(ctx, req, toolName, start, err)
 		if err != nil {
 			return nil, nil, err

--- a/internal/toolutil/surface_tool.go
+++ b/internal/toolutil/surface_tool.go
@@ -2,13 +2,10 @@ package toolutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/elicitation"
 )
 
 // SurfaceToolRegisterOptions controls how an ActionSpec is exposed as a
@@ -58,8 +55,8 @@ func surfaceToolHandler(toolName string, route ActionRoute, formatResult FormatR
 			}
 		}
 		result, err := route.Handler(ContextWithRequest(ctx, req), input)
-		if inputErr, matched := errors.AsType[*elicitation.InputRequiredError](err); matched {
-			return inputErr.Result(), nil, nil
+		if inputResult, needsInput := InputRequiredResultFromError(err); needsInput {
+			return inputResult, nil, nil
 		}
 		LogToolCallAll(ctx, req, toolName, start, err)
 		if err != nil {

--- a/internal/toolutil/surface_tool_test.go
+++ b/internal/toolutil/surface_tool_test.go
@@ -69,6 +69,44 @@ func TestRegisterSurfaceToolFromSpec_DestructiveDeclineStopsRoute(t *testing.T) 
 	}
 }
 
+// TestRegisterSurfaceToolFromSpec_DestructiveConfirmAcceptedRunsRoute
+// verifies that an accepted elicitation confirmation lets the destructive
+// route execute. On protocol 2026-07-28 sessions this exercises the full
+// multi round-trip loop: the first call returns an input-required result and
+// the SDK client middleware retries with the user's answer attached.
+func TestRegisterSurfaceToolFromSpec_DestructiveConfirmAcceptedRunsRoute(t *testing.T) {
+	var called atomic.Bool
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	route := RouteFunc(func(_ context.Context, _ surfaceToolTestInput) (DeleteOutput, error) {
+		called.Store(true)
+		return DeleteOutput{Status: "success", Message: "deleted"}, nil
+	})
+	route.Destructive = true
+	spec := NewActionSpec("delete", route, ActionSpecOptions{
+		IndividualTool: IndividualToolSpec{Name: "gitlab_test_delete", Title: "Test Delete"},
+	})
+	RegisterSurfaceToolFromSpec(server, spec, SurfaceToolRegisterOptions{Description: "Test destructive tool."})
+
+	var elicitations atomic.Int32
+	session := newSurfaceToolSession(t, server, func(_ context.Context, _ *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		elicitations.Add(1)
+		return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"confirmed": true}}, nil
+	})
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "gitlab_test_delete", Arguments: map[string]any{"id": 1}})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if !called.Load() {
+		t.Fatal("destructive route was not called after accepted confirmation")
+	}
+	if elicitations.Load() != 1 {
+		t.Errorf("elicitations = %d, want 1", elicitations.Load())
+	}
+	if result == nil {
+		t.Fatal("expected non-nil success result")
+	}
+}
+
 // TestRegisterSurfaceToolFromSpec_ExplicitConfirmBypassesPrompt verifies confirm:true proceeds without elicitation.
 func TestRegisterSurfaceToolFromSpec_ExplicitConfirmBypassesPrompt(t *testing.T) {
 	var called atomic.Bool

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -49,7 +49,9 @@
       },
       "annotations": {
         "destructiveHint": true,
+        "idempotentHint": false,
         "openWorldHint": true,
+        "readOnlyHint": false,
         "title": "GitLab Execute Action"
       }
     },

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -279,7 +279,7 @@ The [full ADR index](https://github.com/jmrplens/gitlab-mcp-server/blob/main/doc
 - [Model Context Protocol specification](https://modelcontextprotocol.io/) — the protocol the server speaks to AI clients
 - [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification) — the wire format used over stdio and HTTP
 - [GitLab REST API v4](https://docs.gitlab.com/api/rest/) and [GraphQL API](https://docs.gitlab.com/api/graphql/) — the GitLab API surfaces the server translates tool calls into
-- [`modelcontextprotocol/go-sdk`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp) (v1.6.1) — the official Go MCP SDK that implements tool, resource and prompt registration and both transports
+- [`modelcontextprotocol/go-sdk`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp) (v1.7.0) — the official Go MCP SDK that implements tool, resource and prompt registration and both transports
 - [`gitlab-org/api/client-go`](https://pkg.go.dev/gitlab.com/gitlab-org/api/client-go/v2) (v2.51.0) — GitLab's own Go API client, used for every REST call; domains it does not wrap are issued as raw GraphQL
 - [`tiktoken-go/tokenizer`](https://pkg.go.dev/github.com/tiktoken-go/tokenizer) — the pure-Go cl100k_base tokenizer behind the published token-footprint measurements
 

--- a/site/src/content/docs/capabilities/elicitation.mdx
+++ b/site/src/content/docs/capabilities/elicitation.mdx
@@ -51,7 +51,7 @@ sequenceDiagram
     S-->>AI: MR !123 created successfully
 ```
 
-The wire mechanism adapts to the negotiated MCP protocol version: on sessions older than `2026-07-28` the server sends `elicitation/create` requests mid-call, while on `2026-07-28` and newer the prompts travel as multi round-trip input requests (SEP-2322) — the tool result asks for input and the client retries the call with the answers attached. The user experience is identical in both cases.
+The wire mechanism adapts to the negotiated MCP protocol version: on sessions older than `2026-07-28` the server sends `elicitation/create` requests mid-call, while on `2026-07-28` and newer the prompts travel as multi-round-trip input requests (SEP-2322) — the tool result asks for input and the client retries the call with the answers attached. The user experience is identical in both cases.
 
 ## Which interactive wizards are available?
 

--- a/site/src/content/docs/capabilities/elicitation.mdx
+++ b/site/src/content/docs/capabilities/elicitation.mdx
@@ -51,6 +51,8 @@ sequenceDiagram
     S-->>AI: MR !123 created successfully
 ```
 
+The wire mechanism adapts to the negotiated MCP protocol version: on sessions older than `2026-07-28` the server sends `elicitation/create` requests mid-call, while on `2026-07-28` and newer the prompts travel as multi round-trip input requests (SEP-2322) — the tool result asks for input and the client retries the call with the answers attached. The user experience is identical in both cases.
+
 ## Which interactive wizards are available?
 
 GitLab MCP Server provides four wizard-style creation tools. Each guides the user through the fields a resource needs and confirms before performing the final API call.

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -283,7 +283,7 @@ El [índice completo de ADR](https://github.com/jmrplens/gitlab-mcp-server/blob/
 - [Especificación del Model Context Protocol](https://modelcontextprotocol.io/) — el protocolo que el servidor habla con los clientes de IA
 - [Especificación JSON-RPC 2.0](https://www.jsonrpc.org/specification) — el formato de transporte usado sobre stdio y HTTP
 - [API REST v4 de GitLab](https://docs.gitlab.com/api/rest/) y [API GraphQL](https://docs.gitlab.com/api/graphql/) — las superficies de API de GitLab a las que el servidor traduce las llamadas
-- [`modelcontextprotocol/go-sdk`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp) (v1.6.1) — el SDK oficial de MCP en Go, que implementa el registro de herramientas, recursos y prompts y ambos transportes
+- [`modelcontextprotocol/go-sdk`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp) (v1.7.0) — el SDK oficial de MCP en Go, que implementa el registro de herramientas, recursos y prompts y ambos transportes
 - [`gitlab-org/api/client-go`](https://pkg.go.dev/gitlab.com/gitlab-org/api/client-go/v2) (v2.51.0) — el cliente Go oficial de la API de GitLab, usado en cada llamada REST; los dominios que no cubre se emiten como GraphQL en crudo
 - [`tiktoken-go/tokenizer`](https://pkg.go.dev/github.com/tiktoken-go/tokenizer) — el tokenizador cl100k_base en Go puro tras las mediciones publicadas de huella de tokens
 

--- a/site/src/content/docs/es/capabilities/elicitation.mdx
+++ b/site/src/content/docs/es/capabilities/elicitation.mdx
@@ -51,6 +51,8 @@ sequenceDiagram
     S-->>AI: MR !123 creado exitosamente
 ```
 
+El mecanismo de transporte se adapta a la versión del protocolo MCP negociada: en sesiones anteriores a `2026-07-28` el servidor envía peticiones `elicitation/create` durante la llamada, mientras que en `2026-07-28` y posteriores los formularios viajan como peticiones de entrada multi-ronda (SEP-2322): el resultado de la herramienta solicita la entrada y el cliente reintenta la llamada con las respuestas adjuntas. La experiencia de usuario es idéntica en ambos casos.
+
 ## ¿Qué asistentes interactivos están disponibles?
 
 GitLab MCP Server proporciona cuatro herramientas de creación tipo asistente. Cada una guía al usuario por los campos que necesita un recurso y confirma antes de realizar la llamada final a la API.

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -2,22 +2,22 @@
   "tokenizer": "cl100k_base",
   "dynamic": {
     "visible_tools": 2,
-    "tool_schema_tokens": 2180
+    "tool_schema_tokens": 2192
   },
   "individual": {
     "free": {
       "visible_tools": 847,
-      "tool_schema_tokens": 768810,
-      "reduction_factor_vs_dynamic": 353
+      "tool_schema_tokens": 772150,
+      "reduction_factor_vs_dynamic": 352
     },
     "premium": {
       "visible_tools": 999,
-      "tool_schema_tokens": 919548,
-      "reduction_factor_vs_dynamic": 422
+      "tool_schema_tokens": 923460,
+      "reduction_factor_vs_dynamic": 421
     },
     "ultimate": {
       "visible_tools": 1065,
-      "tool_schema_tokens": 968621,
+      "tool_schema_tokens": 972805,
       "reduction_factor_vs_dynamic": 444
     }
   }


### PR DESCRIPTION
## Summary

Updates `github.com/modelcontextprotocol/go-sdk` from v1.6.1 to v1.7.0 and adapts the elicitation subsystem to MCP protocol version `2026-07-28`.

### Why this needed more than a version bump

Protocol `2026-07-28` forbids server-initiated `elicitation/create` requests while serving a tool call (SEP-2322, multi round-trip requests). With the new SDK and no code changes, the synchronous `session.Elicit` flow fails on new-protocol sessions — and the destructive-action guard treated that failure as "client without elicitation support" and **executed destructive actions without user confirmation**.

### Changes

- **New `elicitation.Flow` API** (`internal/elicitation/flow.go`): protocol-aware elicitation. On sessions ≥ `2026-07-28`, prompts are returned as `inputRequests` in the tool result and the client retries the call with `inputResponses` attached; multi-step wizards survive handler re-invocation by carrying earlier answers in the opaque, versioned `requestState`. On older sessions it delegates to the existing synchronous `Client`.
- **Migrated to Flow**: the destructive-confirmation guard (`toolutil.ConfirmAction`/`ConfirmDestructiveAction`), the four interactive creation wizards (issue/MR/release/project), the meta/individual/standalone surface wrappers (which unwrap `InputRequiredError` into the input-required result), and the surface evaluator's elicitation probe. The dynamic surface needs no changes (explicit `confirm=true`).
- **Shared schema builders and parsers** (`internal/elicitation/schemas.go`) so both wire mechanisms request and validate identical shapes.
- **Tests**: new `Flow` unit tests; full-loop MRTR integration tests over a real `2026-07-28` client (accept, decline, multi-step state accumulation, corrupted state); accepted-confirmation surface test; and `testutil.ConnectLegacyElicitationClient`, a minimal JSON-RPC client pinning protocol `2025-11-25` so the ~60 existing direct-call tests exercise the synchronous path deterministically (the SDK client cannot pin older protocol versions).
- **Regenerated artifacts** after the SDK's always-serialized `readOnlyHint`/`idempotentHint` change: `lhm.plugin.json`, token footprint, README stats, testing docs.
- **Docs**: elicitation reference (EN) and site pages (EN/ES) document the protocol-dependent wire mechanism; go-sdk version references bumped.

## Verification

- `go test ./internal/...` — 192 packages green
- `go test ./cmd/...` — green (evaluator probe migrated, `gen_lhm_manifest` check green)
- `golangci-lint run --build-tags e2e` on all changed packages — clean
- Manifest/footprint/stats/testing-docs freshness checks — green
- E2E Docker (`make test-e2e-docker`): 1429 tests, 2 failures — both a pre-existing GitLab-side 400 on `PUT /notification_settings` (`user_id already exists in source`) from the unpinned `gitlab-ce:latest` image; this branch does not touch users/notifications or client-go, so it reproduces on `main` as well. To be fixed separately before the next release.
- Surface evaluator spot check (`SURFACE=dynamic PRESET=docker-destructive-safe`, `claude-haiku-4-5`): 63 task attempts, all metrics 100% — including **Destructive safety 100%** — `process_ok report_clean`.

## Summary by Sourcery

Adopt a protocol-aware elicitation flow that supports both legacy synchronous requests and new multi round-trip MCP sessions, and update the server to use the latest go-sdk with regenerated artifacts and docs.

New Features:
- Introduce an elicitation.Flow API that unifies synchronous and multi round-trip elicitation handling based on negotiated MCP protocol version.
- Add a legacy MCP test client utility to deterministically exercise the synchronous elicitation path in tests.

Bug Fixes:
- Ensure destructive-action confirmations and interactive wizards correctly require and honor user input under the new MCP protocol, preventing unconfirmed destructive operations.
- Fix handling of malformed or unexpected elicitation state by rejecting corrupted requestState values instead of silently proceeding.

Enhancements:
- Refactor elicitation schema construction and response parsing into shared helpers reused by both synchronous and flow-based paths.
- Update interactive creation wizards and surface/meta/individual tool handlers to use Flow, including new error handling for pending input and cancellations.
- Extend the evaluator elicitation probe to run through the Flow API and validate elicitation capability via multi round-trip handling.
- Improve tooling error messages and logging around destructive confirmation flows and wizard steps.

Build:
- Regenerate plugin manifests, token footprint data, and related artifacts to account for schema and SDK changes.

Documentation:
- Document the new Flow API, the dual wire mechanisms (legacy vs multi round-trip), and updated error semantics in elicitation capability docs (EN/ES).
- Refresh architecture, development, testing, and token-footprint documentation to reflect the new go-sdk version and updated metrics.

Tests:
- Add unit and integration tests for the Flow API, shared schema parsers, legacy client helper, destructive confirmation surfaces, and multi round-trip workflows across tools and evaluator surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-round elicitation, allowing tools to request input, preserve earlier responses, and continue across multiple interactions.
  * Interactive creation workflows now consistently handle pending input, cancellations, declines, and confirmations.
  * Updated destructive tool metadata to accurately indicate that actions are neither read-only nor idempotent.

* **Bug Fixes**
  * Improved handling of pending elicitation results so clients receive required input instead of a generic error.
  * Preserved compatibility with older elicitation sessions.

* **Documentation**
  * Updated elicitation guidance, architecture references, token metrics, and testing statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->