### PR TITLE
ci(release): retry cosign signing on transient OIDC failures

### DIFF
--- a/.github/scripts/cosign-sign-retry.sh
+++ b/.github/scripts/cosign-sign-retry.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Sign a container image with cosign, retrying transient OIDC failures.
+#
+# Keyless signing resolves its identity token from the ambient GitHub OIDC
+# endpoint. That endpoint intermittently answers with a plain-text error body
+# where cosign expects JSON, which surfaces as:
+#
+#   fetching ambient OIDC credentials: invalid character 'u' looking for
+#   beginning of value
+#
+# The image itself is already pushed by then, so failing the step leaves a
+# published but unsigned image and fails the release. The condition clears on
+# its own, so retry before giving up.
+#
+# Usage: cosign-sign-retry.sh <image-ref-with-digest>
+
+set -euo pipefail
+
+IMAGE_REF="${1:?Usage: $0 <image-ref-with-digest>}"
+ATTEMPTS="${COSIGN_SIGN_ATTEMPTS:-3}"
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if cosign sign --yes "$IMAGE_REF"; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -eq "$ATTEMPTS" ]]; then
+    echo "cosign sign failed for ${IMAGE_REF} after ${ATTEMPTS} attempts" >&2
+    exit 1
+  fi
+
+  delay=$((attempt * 10))
+  echo "cosign sign failed for ${IMAGE_REF} (attempt ${attempt}/${ATTEMPTS}); retrying in ${delay}s" >&2
+  sleep "$delay"
+done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,16 +311,24 @@ jobs:
             ${{ steps.dockerhub-login.outputs.skip == 'false' && format('docker.io/{0}:{1}', env.DOCKERHUB_IMAGE, steps.version.outputs.version) || '' }}
             ${{ steps.dockerhub-login.outputs.skip == 'false' && format('docker.io/{0}:latest', env.DOCKERHUB_IMAGE) || '' }}
 
+      # Keyless signing reads an OIDC token from the ambient GitHub endpoint,
+      # which intermittently answers with a plain-text error body instead of
+      # JSON. cosign then fails with "fetching ambient OIDC credentials:
+      # invalid character 'u' looking for beginning of value" and takes the
+      # whole release down even though the image pushed fine (v2.5.3 failed
+      # this way and signed cleanly on a rerun with no code change). Retry
+      # before giving up so a blip on that endpoint stops leaving published
+      # images unsigned.
       - name: Sign Docker image (ghcr.io)
-        run: |
-          cosign sign --yes \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.docker-push.outputs.digest }}
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.docker-push.outputs.digest }}
+        run: bash .github/scripts/cosign-sign-retry.sh "$IMAGE_REF"
 
       - name: Sign Docker image (Docker Hub)
         if: steps.dockerhub-login.outputs.skip == 'false'
-        run: |
-          cosign sign --yes \
-            docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
+        env:
+          IMAGE_REF: docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
+        run: bash .github/scripts/cosign-sign-retry.sh "$IMAGE_REF"
 
   fly-deploy:
     name: Fly.io Deploy


### PR DESCRIPTION
## Problem

The v2.5.3 Docker job pushed its images and then failed to sign them:

```
fetching ambient OIDC credentials: invalid character 'u' looking for beginning of value
```

That is a JSON decode error: GitHub's ambient OIDC endpoint answered with a plain-text body where cosign expects a token document.

## Diagnosis

It was transient. Rerunning the job with no code change signed both images cleanly, and the signature artifact now matches the digest published as `2.5.3`/`latest`.

Two things it was *not*:

- **Not a permissions problem.** `id-token: write` is set at workflow level and the `docker` job does not override it.
- **Not a regression.** Neither the job nor the `sigstore/cosign-installer@v4.1.2` pin changed since v2.5.2, which signed successfully.

## Why it still needs fixing

The push happens before the signature, so a blip on that endpoint publishes an image and *then* fails the release. That is exactly how v2.5.3 shipped unsigned until the rerun. Left alone it will recur, and the failure mode is silent from a consumer's point of view: the tag exists and works, it simply has no signature.

## Change

Both signing steps now call a small retry wrapper with backoff (3 attempts, 10s then 20s). The image reference moves into an env var instead of being interpolated straight into the script body, which is the pattern the repository's security guidance asks for.

Verified by driving the script with a stub `cosign`: it exits 1 after exhausting attempts, and exits 0 when a retry succeeds. `shellcheck` and `bash -n` are clean, and the workflow still parses with the two steps wired to the wrapper.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

