### PR TITLE
test: address the review findings the file relocation surfaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       975 |     195,231 |
-| Unit tests (`_test.go`)  |       527 |     301,571 |
+| Unit tests (`_test.go`)  |       527 |     301,547 |
 | End-to-end tests         |       171 |      44,440 |
-| **Total**                | **1,673** | **541,242** |
+| **Total**                | **1,673** | **541,218** |
 
 ### Functions
 
@@ -427,7 +427,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,483 |
 | — exported (public)             |  2,629 |
 | — unexported (private)          |  4,854 |
-| Unit test functions (`TestXxx`) | 11,654 |
+| Unit test functions (`TestXxx`) | 11,649 |
 | Subtests (`t.Run(...)`)         |  2,918 |
 | End-to-end test functions       |    379 |
 
@@ -445,7 +445,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,726 |
+| `if err != nil` checks             | 6,723 |
 | `defer` statements                 |   855 |
 | `struct` types defined             | 2,728 |
 | `//nolint` suppressions            |   212 |

--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       975 |     195,231 |
-| Unit tests (`_test.go`)  |       527 |     301,576 |
+| Unit tests (`_test.go`)  |       527 |     301,584 |
 | End-to-end tests         |       171 |      44,440 |
-| **Total**                | **1,673** | **541,247** |
+| **Total**                | **1,673** | **541,255** |
 
 ### Functions
 
@@ -428,7 +428,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,629 |
 | — unexported (private)          |  4,854 |
 | Unit test functions (`TestXxx`) | 11,649 |
-| Subtests (`t.Run(...)`)         |  2,921 |
+| Subtests (`t.Run(...)`)         |  2,922 |
 | End-to-end test functions       |    379 |
 
 ### Ratios worth noting

--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       975 |     195,231 |
-| Unit tests (`_test.go`)  |       527 |     301,547 |
+| Unit tests (`_test.go`)  |       527 |     301,576 |
 | End-to-end tests         |       171 |      44,440 |
-| **Total**                | **1,673** | **541,218** |
+| **Total**                | **1,673** | **541,247** |
 
 ### Functions
 
@@ -428,7 +428,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,629 |
 | — unexported (private)          |  4,854 |
 | Unit test functions (`TestXxx`) | 11,649 |
-| Subtests (`t.Run(...)`)         |  2,918 |
+| Subtests (`t.Run(...)`)         |  2,921 |
 | End-to-end test functions       |    379 |
 
 ### Ratios worth noting
@@ -446,7 +446,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,723 |
-| `defer` statements                 |   855 |
+| `defer` statements                 |   854 |
 | `struct` types defined             | 2,728 |
 | `//nolint` suppressions            |   212 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |

--- a/cmd/audit_tokens/main_test.go
+++ b/cmd/audit_tokens/main_test.go
@@ -394,10 +394,10 @@ func assertBefore(t *testing.T, s, before, after string) {
 	}
 }
 
-// TestRenderReadmeFootprint_DynamicOnlyWithTiers verifies the README footprint
+// TestRenderReadmeFootprint_DynamicOnlyRows_KeepsOneRowPerTier verifies the README footprint
 // table keeps only the dynamic surface (default configuration) across all
 // tiers and links to the detailed reference, without the meta/individual rows.
-func TestRenderReadmeFootprint_DynamicOnlyWithTiers(t *testing.T) {
+func TestRenderReadmeFootprint_DynamicOnlyRows_KeepsOneRowPerTier(t *testing.T) {
 	rows := []tokenFootprintRow{
 		{Tier: "Free/CE", Configuration: "`dynamic` / `full` (default)", VisibleTools: 2, ToolSchemaTokens: 2180, SharedTokens: 31758},
 		{Tier: "Free/CE", Configuration: "`dynamic` / `minimal`", VisibleTools: 2, ToolSchemaTokens: 2180, SharedTokens: 1088},
@@ -422,11 +422,11 @@ func TestRenderReadmeFootprint_DynamicOnlyWithTiers(t *testing.T) {
 	}
 }
 
-// TestFootprintStaleTargets verifies the drift detector backing
-// -footprint -check: it reports no stale targets when the README section and
-// detailed doc match the rendered content, and names exactly the target(s)
-// that diverge otherwise.
-func TestFootprintStaleTargets(t *testing.T) {
+// TestFootprintStaleTargets_DriftPerTarget_NamesOnlyTheDivergingFile verifies
+// the drift detector backing -footprint -check: it reports no stale targets
+// when the README section and detailed doc match the rendered content, and
+// names exactly the target that diverges otherwise.
+func TestFootprintStaleTargets_DriftPerTarget_NamesOnlyTheDivergingFile(t *testing.T) {
 	rows := completeFootprintRows()
 	// A README whose managed section already holds the rendered content.
 	readme := footprintStartMarker + "\n\n" + renderReadmeFootprint(rows) + "\n" + footprintEndMarker + "\n"
@@ -437,41 +437,43 @@ func TestFootprintStaleTargets(t *testing.T) {
 	}
 	site := string(siteJSON)
 
-	t.Run("current content reports no stale targets", func(t *testing.T) {
-		stale, err := footprintStaleTargets(readme, detailed, site, rows)
-		if err != nil {
-			t.Fatalf("footprintStaleTargets(current) error: %v", err)
-		}
-		if len(stale) != 0 {
-			t.Fatalf("expected no stale targets, got %v", stale)
-		}
-	})
+	tests := []struct {
+		name      string
+		readme    string
+		detailed  string
+		site      string
+		wantErr   bool
+		wantStale string // substring the single stale target must contain; "" means none
+	}{
+		{name: "current content reports no stale targets", readme: readme, detailed: detailed, site: site},
+		{name: "detailed-doc drift reports only the detailed doc", readme: readme, detailed: detailed + "\nextra drift\n", site: site, wantStale: detailedFootprintPath},
+		{name: "site JSON drift reports only the site data file", readme: readme, detailed: detailed, site: `{"tokenizer":"stale"}`, wantStale: siteFootprintPath},
+		{name: "missing README markers returns an error", readme: "no markers here", detailed: detailed, site: site, wantErr: true},
+	}
 
-	t.Run("detailed-doc drift reports only the detailed doc", func(t *testing.T) {
-		stale, err := footprintStaleTargets(readme, detailed+"\nextra drift\n", site, rows)
-		if err != nil {
-			t.Fatalf("footprintStaleTargets(stale detailed) error: %v", err)
-		}
-		if len(stale) != 1 || !strings.Contains(stale[0], detailedFootprintPath) {
-			t.Fatalf("expected only %q stale, got %v", detailedFootprintPath, stale)
-		}
-	})
-
-	t.Run("site JSON drift reports only the site data file", func(t *testing.T) {
-		stale, err := footprintStaleTargets(readme, detailed, `{"tokenizer":"stale"}`, rows)
-		if err != nil {
-			t.Fatalf("footprintStaleTargets(stale site) error: %v", err)
-		}
-		if len(stale) != 1 || !strings.Contains(stale[0], siteFootprintPath) {
-			t.Fatalf("expected only %q stale, got %v", siteFootprintPath, stale)
-		}
-	})
-
-	t.Run("missing README markers returns an error", func(t *testing.T) {
-		if _, err := footprintStaleTargets("no markers here", detailed, site, rows); err == nil {
-			t.Fatal("expected error when README lacks the footprint markers")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stale, err := footprintStaleTargets(tt.readme, tt.detailed, tt.site, rows)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("footprintStaleTargets() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("footprintStaleTargets() error: %v", err)
+			}
+			if tt.wantStale == "" {
+				if len(stale) != 0 {
+					t.Fatalf("stale = %v, want none", stale)
+				}
+				return
+			}
+			if len(stale) != 1 || !strings.Contains(stale[0], tt.wantStale) {
+				t.Fatalf("stale = %v, want only %q", stale, tt.wantStale)
+			}
+		})
+	}
 }
 
 // completeFootprintRows returns a fixture covering every row the site-facing
@@ -488,12 +490,12 @@ func completeFootprintRows() []tokenFootprintRow {
 	}
 }
 
-// TestRenderSiteFootprintJSON verifies the site-facing headline extract: the
+// TestRenderSiteFootprintJSON_CompleteMatrix_DerivesReductionFactor verifies the site-facing headline extract: the
 // dynamic surface is taken from the Ultimate tier, every tier gets an
 // individual-surface entry, and the reduction factor is derived rather than
 // restated. This is the number the docs site publishes as its headline claim,
 // so a wrong ratio would propagate straight into AI answers.
-func TestRenderSiteFootprintJSON(t *testing.T) {
+func TestRenderSiteFootprintJSON_CompleteMatrix_DerivesReductionFactor(t *testing.T) {
 	raw, renderErr := renderSiteFootprintJSON(completeFootprintRows())
 	if renderErr != nil {
 		t.Fatalf("renderSiteFootprintJSON() error: %v", renderErr)
@@ -522,9 +524,9 @@ func TestRenderSiteFootprintJSON(t *testing.T) {
 	}
 }
 
-// TestRenderSiteFootprintJSON_RejectsIncompleteMatrix verifies generation fails
+// TestRenderSiteFootprintJSON_IncompleteMatrix_ReturnsError verifies generation fails
 // loudly rather than publishing a partial headline claim.
-func TestRenderSiteFootprintJSON_RejectsIncompleteMatrix(t *testing.T) {
+func TestRenderSiteFootprintJSON_IncompleteMatrix_ReturnsError(t *testing.T) {
 	tests := []struct {
 		name string
 		rows []tokenFootprintRow
@@ -553,10 +555,10 @@ func TestRenderSiteFootprintJSON_RejectsIncompleteMatrix(t *testing.T) {
 	}
 }
 
-// TestMeasureTokenFootprintRows_AllTiersAllModes verifies the full measurement
+// TestMeasureTokenFootprintRows_AllTiersAllModes_CoversEveryCombination verifies the full measurement
 // matrix: 3 tiers \u00d7 9 configurations, tier ordering, meta schema-mode token
 // scaling, and tier-based individual tool scaling.
-func TestMeasureTokenFootprintRows_AllTiersAllModes(t *testing.T) {
+func TestMeasureTokenFootprintRows_AllTiersAllModes_CoversEveryCombination(t *testing.T) {
 	client := newAuditTokensClient(t)
 
 	rows, err := measureTokenFootprintRows(client)
@@ -595,12 +597,12 @@ func TestMeasureTokenFootprintRows_AllTiersAllModes(t *testing.T) {
 	}
 }
 
-// TestMeasureToolSchemaTokens_UsesRealTokenizer verifies the schema token
+// TestMeasureToolSchemaTokens_RealTokenizer_ReturnsNonZeroCounts verifies the schema token
 // estimator runs the cl100k_base tokenizer, not the bytes/4 fallback. It counts
 // the same serialized tools both ways and asserts they differ, so a tokenizer
 // init/encode regression (silently dropping to bytes/4) fails here. The
 // tokenizer itself is unit-tested in tokens_test.go.
-func TestMeasureToolSchemaTokens_UsesRealTokenizer(t *testing.T) {
+func TestMeasureToolSchemaTokens_RealTokenizer_ReturnsNonZeroCounts(t *testing.T) {
 	toolList := []*mcp.Tool{{Name: "a"}, {Name: "bb"}, {Name: "ccc"}}
 
 	got, err := measureToolSchemaTokens(toolList)
@@ -624,18 +626,18 @@ func TestMeasureToolSchemaTokens_UsesRealTokenizer(t *testing.T) {
 	}
 }
 
-// TestRunMetaSchemaSizing_Completes verifies the meta-schema sizing can build
+// TestRunMetaSchemaSizing_DefaultOptions_CompletesWithoutError verifies the meta-schema sizing can build
 // the full base-plus-enterprise meta-tool registry and measure schema sizes.
 // Migrated from the former cmd/audit_meta_schema/main_test.go.
-func TestRunMetaSchemaSizing_Completes(t *testing.T) {
+func TestRunMetaSchemaSizing_DefaultOptions_CompletesWithoutError(t *testing.T) {
 	if err := runMetaSchemaSizing(); err != nil {
 		t.Fatalf("runMetaSchemaSizing() error: %v", err)
 	}
 }
 
-// TestHumanBytes_AllMagnitudes verifies the humanBytes byte formatter emits
+// TestHumanBytes_AllMagnitudes_FormatsWithUnitSuffix verifies the humanBytes byte formatter emits
 // expected B/KB/MB suffixes for the three supported magnitude ranges.
-func TestHumanBytes_AllMagnitudes(t *testing.T) {
+func TestHumanBytes_AllMagnitudes_FormatsWithUnitSuffix(t *testing.T) {
 	tests := []struct {
 		name string
 		n    int

--- a/cmd/eval_mcp_surfaces/internal/evaluator/live_fixture_helpers_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/live_fixture_helpers_test.go
@@ -257,16 +257,18 @@ func TestFixtureSetupToolEnvelope_KeepsMetaDispatcher(t *testing.T) {
 // TestCallFixtureSetupTool_FallsBackToSplitMetaTool verifies CallFixtureSetupTool falls back to split meta tool.
 func TestCallFixtureSetupTool_FallsBackToSplitMetaTool(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "fixture-test", Version: "0"}, nil)
-	called := false
+	// The handler runs on the server goroutine, so it records what it saw and
+	// the assertions run on the test goroutine after the call returns. Asserting
+	// inside would call FailNow off-test and abandon the request mid-flight.
+	var (
+		gotAction any
+		gotParams map[string]any
+		called    bool
+	)
 	mcp.AddTool(server, &mcp.Tool{Name: "gitlab_branch", Description: "branch meta-tool"}, func(_ context.Context, _ *mcp.CallToolRequest, input map[string]any) (*mcp.CallToolResult, any, error) {
 		called = true
-		if input["action"] != "create" {
-			t.Fatalf("action = %v, want create", input["action"])
-		}
-		params, _ := input["params"].(map[string]any)
-		if params["project_id"] != "my-org/tools/gitlab-mcp-server" {
-			t.Fatalf("params = %+v", params)
-		}
+		gotAction = input["action"]
+		gotParams, _ = input["params"].(map[string]any)
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
 	})
 
@@ -287,5 +289,11 @@ func TestCallFixtureSetupTool_FallsBackToSplitMetaTool(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("split meta-tool was not called")
+	}
+	if gotAction != "create" {
+		t.Errorf("action = %v, want create", gotAction)
+	}
+	if gotParams["project_id"] != "my-org/tools/gitlab-mcp-server" {
+		t.Errorf("params = %+v, want project_id my-org/tools/gitlab-mcp-server", gotParams)
 	}
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/providers_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/providers_test.go
@@ -1031,14 +1031,16 @@ func TestQwenEndpoint_UsesConfiguredBaseURL(t *testing.T) {
 func TestOpenAIProvider_CallOnceConvertsToolCall(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
-			t.Fatalf("Authorization = %q, want bearer", got)
+			t.Errorf("Authorization = %q, want bearer", got)
 		}
 		var request openAIRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			t.Fatalf("decode request: %v", err)
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "decode request", http.StatusBadRequest)
+			return
 		}
 		if request.Model != "gpt-test" || len(request.Tools) != 1 || request.ToolChoice != "required" {
-			t.Fatalf("request = %+v", request)
+			t.Errorf("request = %+v", request)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
@@ -1052,7 +1054,7 @@ func TestOpenAIProvider_CallOnceConvertsToolCall(t *testing.T) {
 			}}}}},
 			"usage": map[string]any{"prompt_tokens": 11, "completion_tokens": 7},
 		}); err != nil {
-			t.Fatalf("encode response: %v", err)
+			t.Errorf("encode response: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -1081,13 +1083,15 @@ func TestOpenAIProvider_QwenDisablesThinking(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request openAIRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			t.Fatalf("decode request: %v", err)
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "decode request", http.StatusBadRequest)
+			return
 		}
 		if request.EnableThinking == nil || *request.EnableThinking {
-			t.Fatalf("enable_thinking = %v, want false", request.EnableThinking)
+			t.Errorf("enable_thinking = %v, want false", request.EnableThinking)
 		}
 		if request.ToolChoice != "required" || request.MaxTokens == 0 {
-			t.Fatalf("request = %+v", request)
+			t.Errorf("request = %+v", request)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
@@ -1100,7 +1104,7 @@ func TestOpenAIProvider_QwenDisablesThinking(t *testing.T) {
 				},
 			}}}}},
 		}); err != nil {
-			t.Fatalf("encode response: %v", err)
+			t.Errorf("encode response: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -1132,7 +1136,7 @@ func TestOpenAIProvider_EmptyToolArgumentsAreRetryable(t *testing.T) {
 				},
 			}}}}},
 		}); err != nil {
-			t.Fatalf("encode response: %v", err)
+			t.Errorf("encode response: %v", err)
 		}
 	}))
 	defer server.Close()

--- a/cmd/eval_mcp_surfaces/internal/evaluator/report_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/report_test.go
@@ -245,24 +245,27 @@ func TestRouteDomainName_UsesDynamicActionDomain(t *testing.T) {
 // TestFailureDiagnosticCategory_SeparatesPhase4Buckets covers FailureDiagnosticCategory with table-driven subtests for separates phase 4 buckets.
 func TestFailureDiagnosticCategory_SeparatesPhase4Buckets(t *testing.T) {
 	tests := []struct {
+		name  string
 		notes []string
 		want  string
 	}{
-		{[]string{"json: cannot unmarshal string into Go struct field id of type int64"}, "mcp_implementation_bug"},
-		{[]string{"GitLab 503 service unavailable"}, "transient_gitlab_5xx"},
-		{[]string{"feature requires Premium license"}, "gitlab_ce_limitation"},
-		{[]string{"fixture state is missing project identity"}, "fixture_setup_failure"},
-		{[]string{"expected action issue.create, got project.create"}, "model_route_selection_miss"},
-		{[]string{"unknown params for gitlab/issue.create: iid"}, "model_parameter_shape_miss"},
-		{[]string{"missing required project_id"}, "model_parameter_shape_miss"},
-		{[]string{"destructive task requires params.confirm=true"}, "destructive_safety"},
-		{[]string{"context deadline exceeded"}, "timeout_resource_exhaustion"},
+		{"unmarshal type error", []string{"json: cannot unmarshal string into Go struct field id of type int64"}, "mcp_implementation_bug"},
+		{"gitlab 5xx", []string{"GitLab 503 service unavailable"}, "transient_gitlab_5xx"},
+		{"premium license", []string{"feature requires Premium license"}, "gitlab_ce_limitation"},
+		{"missing fixture identity", []string{"fixture state is missing project identity"}, "fixture_setup_failure"},
+		{"wrong action", []string{"expected action issue.create, got project.create"}, "model_route_selection_miss"},
+		{"unknown param", []string{"unknown params for gitlab/issue.create: iid"}, "model_parameter_shape_miss"},
+		{"missing required param", []string{"missing required project_id"}, "model_parameter_shape_miss"},
+		{"unconfirmed destructive", []string{"destructive task requires params.confirm=true"}, "destructive_safety"},
+		{"deadline exceeded", []string{"context deadline exceeded"}, "timeout_resource_exhaustion"},
 	}
 
 	for _, tt := range tests {
-		if got := failureDiagnosticCategory(tt.notes); got != tt.want {
-			t.Fatalf("failureDiagnosticCategory(%q) = %q, want %q", strings.Join(tt.notes, "; "), got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := failureDiagnosticCategory(tt.notes); got != tt.want {
+				t.Errorf("failureDiagnosticCategory(%q) = %q, want %q", strings.Join(tt.notes, "; "), got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/runner_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/runner_test.go
@@ -983,7 +983,8 @@ func newResourceLookupSessionForTest(t *testing.T) *mcp.ClientSession {
 	return session
 }
 
-// toolUseResponse converts the GitLab API response to the tool output format.
+// toolUseResponse builds a scripted modelResponse carrying a single tool_use
+// content block, so a test can drive the runner without a real model call.
 func toolUseResponse(id, name string, input map[string]any) modelResponse {
 	return modelResponse{Content: []modelContentBlock{{Type: "tool_use", ID: id, Name: name, Input: input}}}
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/support_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/support_test.go
@@ -43,15 +43,6 @@ func TestLiveUniqueSuffix_ReturnsDistinctNonEmptyValues(t *testing.T) {
 	}
 }
 
-// TestWaitForContext_CanceledContextReturnsError verifies WaitForContext when canceled context returns error.
-func TestWaitForContext_CanceledContextReturnsError(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-	if err := waitForContext(ctx, time.Hour); !errors.Is(err, context.Canceled) {
-		t.Fatalf("waitForContext() error = %v, want context.Canceled", err)
-	}
-}
-
 // roundTripFunc adapts a function to http.RoundTripper so a test can serve
 // canned responses without a server. It lives here rather than beside any one
 // test because both the runner and the provider tests use it.

--- a/cmd/eval_mcp_surfaces/internal/evaluator/task_prompts_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/task_prompts_test.go
@@ -225,9 +225,8 @@ func TestDynamicTaskPrompt_MultiStepUsesFindFirst(t *testing.T) {
 // leaking expected action IDs.
 func TestDynamicTaskPrompt_ProviderConfusionCasesUseFindFirst(t *testing.T) {
 	tests := []struct {
-		name   string
-		task   evalTask
-		absent []string
+		name string
+		task evalTask
 	}{
 		{
 			name: "failed pipeline investigation workflow",
@@ -371,44 +370,44 @@ func TestDynamicTaskPrompt_MultiStepOmitsExactActionPlan(t *testing.T) {
 // examples are no longer injected into Dynamic prompts.
 func TestDynamicTaskPrompt_OmitsRoleSensitiveExactCallContent(t *testing.T) {
 	tests := []struct {
-		name string
-		task evalTask
-		want []string
+		name   string
+		task   evalTask
+		absent []string
 	}{
 		{
 			name: "allowlist source and target projects",
 			task: evalTask{ID: "MT-066", Prompt: "Remove project ID `51` from the CI job token allowlist of project `1`.", Steps: []evalStep{
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "job.token_scope_remove_project", RequiredParams: []string{"project_id", "target_project_id"}, OptionalParams: []string{"confirm"}, Destructive: true},
 			}},
-			want: []string{`"action":"job.token_scope_remove_project"`, `"confirm":true`, `"params":{"project_id":1,"target_project_id":51}`},
+			absent: []string{`"action":"job.token_scope_remove_project"`, `"confirm":true`, `"params":{"project_id":1,"target_project_id":51}`},
 		},
 		{
 			name: "issue link source and target",
 			task: evalTask{ID: "MT-LINK", Prompt: "Link source issue IID `5` in project `my-org/source` to target issue IID `9` in target project ID `77`.", Steps: []evalStep{
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "issue.link_create", RequiredParams: []string{"project_id", "issue_iid", "target_project_id", "target_issue_iid"}},
 			}},
-			want: []string{`"action":"issue.link_create"`, `"issue_iid":5`, `"project_id":"my-org/source"`, `"target_issue_iid":9`, `"target_project_id":77`},
+			absent: []string{`"action":"issue.link_create"`, `"issue_iid":5`, `"project_id":"my-org/source"`, `"target_issue_iid":9`, `"target_project_id":77`},
 		},
 		{
 			name: "merge request branches",
 			task: evalTask{ID: "MT-MR", Prompt: "Create a merge request in project `my-org/tools/gitlab-mcp-server` from `feature/eval` into `main` titled `Evaluation MR`.", Steps: []evalStep{
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "merge_request.create", RequiredParams: []string{"project_id", "source_branch", "target_branch", "title"}},
 			}},
-			want: []string{`"action":"merge_request.create"`, `"project_id":"my-org/tools/gitlab-mcp-server"`, `"source_branch":"feature/eval"`, `"target_branch":"main"`, `"title":"Evaluation MR"`},
+			absent: []string{`"action":"merge_request.create"`, `"project_id":"my-org/tools/gitlab-mcp-server"`, `"source_branch":"feature/eval"`, `"target_branch":"main"`, `"title":"Evaluation MR"`},
 		},
 		{
 			name: "group epic child issue",
 			task: evalTask{ID: "MT-140", Prompt: "Assign issue IID `99` from child project path `my-org/tools/gitlab-mcp-server` to epic IID `12` in group full path `my-org`.", Steps: []evalStep{
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "group.epic_issue_assign", RequiredParams: []string{"full_path", "epic_iid", "child_project_path", "child_iid"}},
 			}},
-			want: []string{`"action":"group.epic_issue_assign"`, `"child_iid":99`, `"child_project_path":"my-org/tools/gitlab-mcp-server"`, `"epic_iid":12`, `"full_path":"my-org"`},
+			absent: []string{`"action":"group.epic_issue_assign"`, `"child_iid":99`, `"child_project_path":"my-org/tools/gitlab-mcp-server"`, `"epic_iid":12`, `"full_path":"my-org"`},
 		},
 		{
 			name: "project deploy token delete",
 			task: evalTask{ID: "MT-112", Prompt: "Delete project deploy token ID `66` from project `my-org/tools/gitlab-mcp-server`.", Steps: []evalStep{
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "access.deploy_token_delete_project", RequiredParams: []string{"project_id", "deploy_token_id"}, OptionalParams: []string{"confirm"}, Destructive: true},
 			}},
-			want: []string{`"action":"access.deploy_token_delete_project"`, `"confirm":true`, `"deploy_token_id":66`, `"project_id":"my-org/tools/gitlab-mcp-server"`},
+			absent: []string{`"action":"access.deploy_token_delete_project"`, `"confirm":true`, `"deploy_token_id":66`, `"project_id":"my-org/tools/gitlab-mcp-server"`},
 		},
 		{
 			name: "group ci variable environment scope",
@@ -416,7 +415,7 @@ func TestDynamicTaskPrompt_OmitsRoleSensitiveExactCallContent(t *testing.T) {
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "ci_variable.group_create", RequiredParams: []string{"group_id", "key", "value"}, OptionalParams: []string{"environment_scope", "masked"}},
 				{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "ci_variable.group_get", RequiredParams: []string{"group_id", "key"}, OptionalParams: []string{"environment_scope"}},
 			}},
-			want: []string{`"action":"ci_variable.group_create"`, `"environment_scope":"review/eval"`, `"group_id":"my-org"`, `"key":"GROUP_EVAL_CRUD_TOKEN"`, `"value":"group-crud-value-1"`},
+			absent: []string{`"action":"ci_variable.group_create"`, `"environment_scope":"review/eval"`, `"group_id":"my-org"`, `"key":"GROUP_EVAL_CRUD_TOKEN"`, `"value":"group-crud-value-1"`},
 		},
 	}
 
@@ -428,7 +427,7 @@ func TestDynamicTaskPrompt_OmitsRoleSensitiveExactCallContent(t *testing.T) {
 				"Use the returned result ID, input_schema, required_params, and example",
 				"Do not use action IDs from memory",
 			})
-			for _, unwanted := range tt.want {
+			for _, unwanted := range tt.absent {
 				if strings.Contains(prompt, unwanted) {
 					t.Fatalf("taskPromptForSurface() = %q, want no exact-call content %q", prompt, unwanted)
 				}
@@ -510,8 +509,7 @@ func TestTaskPrompt_SingleOperationPrefersOneClearToolCall(t *testing.T) {
 		ExpectedAction: "project.list",
 	}
 	prompt := taskPrompt(task)
-	assertTaskPromptContains(
-		t, prompt,
+	requireContainsAll(t, "taskPrompt()", prompt, []string{
 		"exactly one tool call",
 		"A schema lookup before the task call is a failure",
 		"Do not look up schemas for ordinary parameter names already supplied by the task prompt",
@@ -542,16 +540,7 @@ func TestTaskPrompt_SingleOperationPrefersOneClearToolCall(t *testing.T) {
 		"latest pipelines plural means pipeline.list",
 		"do not send empty arrays or objects",
 		"call the selected action with params:{}",
-	)
-}
-
-func assertTaskPromptContains(t *testing.T, prompt string, snippets ...string) {
-	t.Helper()
-	for _, snippet := range snippets {
-		if !strings.Contains(prompt, snippet) {
-			t.Fatalf("taskPrompt() = %q, want %q", prompt, snippet)
-		}
-	}
+	})
 }
 
 // TestTaskPrompt_MultiStepAvoidsImplicitPagination verifies TaskPrompt when multi step avoids implicit pagination.

--- a/cmd/eval_mcp_surfaces/internal/evaluator/terminal_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/terminal_test.go
@@ -92,22 +92,32 @@ func TestConfigureTerminalOutput_WritesLogWithoutEcho(t *testing.T) {
 // all enable terminal output. This keeps validation commands from creating
 // unnecessary artifacts.
 func TestShouldConfigureTerminalOutput_SkipsCheckDocsWithoutExplicitOutput(t *testing.T) {
-	for _, opts := range []options{
-		{CheckDocs: true},
-		{CheckEfficiency: stringList{"dist/evaluation/efficiency.md"}},
-		{CompareTraces: stringList{"dist/evaluation/report.traces"}},
+	for _, tt := range []struct {
+		name string
+		opts options
+	}{
+		{"check docs", options{CheckDocs: true}},
+		{"check efficiency", options{CheckEfficiency: stringList{"dist/evaluation/efficiency.md"}}},
+		{"compare traces", options{CompareTraces: stringList{"dist/evaluation/report.traces"}}},
 	} {
-		if shouldConfigureTerminalOutput(opts) {
-			t.Fatalf("shouldConfigureTerminalOutput(%+v) = true, want false", opts)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if shouldConfigureTerminalOutput(tt.opts) {
+				t.Errorf("shouldConfigureTerminalOutput(%+v) = true, want false", tt.opts)
+			}
+		})
 	}
-	for _, opts := range []options{
-		{},
-		{CheckDocs: true, TerminalLog: "check.log"},
-		{CheckDocs: true, PrintOutput: true},
+	for _, tt := range []struct {
+		name string
+		opts options
+	}{
+		{"default options", options{}},
+		{"check docs with explicit log path", options{CheckDocs: true, TerminalLog: "check.log"}},
+		{"check docs with print output", options{CheckDocs: true, PrintOutput: true}},
 	} {
-		if !shouldConfigureTerminalOutput(opts) {
-			t.Fatalf("shouldConfigureTerminalOutput(%+v) = false, want true", opts)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if !shouldConfigureTerminalOutput(tt.opts) {
+				t.Errorf("shouldConfigureTerminalOutput(%+v) = false, want true", tt.opts)
+			}
+		})
 	}
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/terminal_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/terminal_test.go
@@ -9,20 +9,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/eval_mcp_surfaces/internal/termio"
 )
 
-// TestShouldConfigureTerminalOutput_RespectsQuietCheckModes verifies terminal log
-// setup is skipped for pure check commands unless explicitly requested.
-func TestShouldConfigureTerminalOutput_RespectsQuietCheckModes(t *testing.T) {
-	if !shouldConfigureTerminalOutput(options{}) {
-		t.Fatal("shouldConfigureTerminalOutput(default) = false, want true")
-	}
-	if shouldConfigureTerminalOutput(options{CheckDocs: true}) {
-		t.Fatal("shouldConfigureTerminalOutput(check docs) = true, want false")
-	}
-	if !shouldConfigureTerminalOutput(options{CheckDocs: true, PrintOutput: true}) {
-		t.Fatal("shouldConfigureTerminalOutput(explicit print) = false, want true")
-	}
-}
-
 // TestTerminalPrintHelpers_WriteToConfiguredLog verifies package-level terminal
 // helpers write into the configured command output sink.
 func TestTerminalPrintHelpers_WriteToConfiguredLog(t *testing.T) {
@@ -75,6 +61,12 @@ func TestConfigureTerminalOutput_DefaultAndOverride(t *testing.T) {
 // TestConfigureTerminalOutput_WritesLogWithoutEcho verifies progress output is
 // captured in the terminal log by default.
 func TestConfigureTerminalOutput_WritesLogWithoutEcho(t *testing.T) {
+	// configureTerminalOutput swaps the process-wide termio sink. Without this
+	// restore the global keeps pointing at the log file closed below, and the
+	// next test in the package to call terminalPrintf writes to a closed file —
+	// a failure that only appears under some orderings.
+	t.Cleanup(termio.SetOutputForTest(termio.NewOutput(&strings.Builder{}, false)))
+
 	logPath := filepath.Join(t.TempDir(), "terminal.log")
 	_, closeLog, err := configureTerminalOutput(options{TerminalLog: logPath})
 	if err != nil {
@@ -96,8 +88,9 @@ func TestConfigureTerminalOutput_WritesLogWithoutEcho(t *testing.T) {
 // report-checking modes avoid terminal log setup unless output is requested.
 //
 // The test covers check-docs, efficiency checks, and trace comparisons as quiet
-// modes, then asserts that an explicit log path or print flag re-enables terminal
-// output. This keeps validation commands from creating unnecessary artifacts.
+// modes, then asserts that default options, an explicit log path, or a print flag
+// all enable terminal output. This keeps validation commands from creating
+// unnecessary artifacts.
 func TestShouldConfigureTerminalOutput_SkipsCheckDocsWithoutExplicitOutput(t *testing.T) {
 	for _, opts := range []options{
 		{CheckDocs: true},
@@ -108,7 +101,11 @@ func TestShouldConfigureTerminalOutput_SkipsCheckDocsWithoutExplicitOutput(t *te
 			t.Fatalf("shouldConfigureTerminalOutput(%+v) = true, want false", opts)
 		}
 	}
-	for _, opts := range []options{{CheckDocs: true, TerminalLog: "check.log"}, {CheckDocs: true, PrintOutput: true}} {
+	for _, opts := range []options{
+		{},
+		{CheckDocs: true, TerminalLog: "check.log"},
+		{CheckDocs: true, PrintOutput: true},
+	} {
 		if !shouldConfigureTerminalOutput(opts) {
 			t.Fatalf("shouldConfigureTerminalOutput(%+v) = false, want true", opts)
 		}

--- a/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
@@ -71,8 +71,13 @@ func TestModelProviderCallError_WrapsProviderTrace(t *testing.T) {
 	}
 }
 
-// TestDynamicCallBudgetForTask_ClassifiesExactAndAmbiguousTasks verifies DynamicCallBudgetForTask classifies exact and ambiguous tasks.
-func TestDynamicCallBudgetForTask_ClassifiesExactAndAmbiguousTasks(t *testing.T) {
+// TestDynamicCallBudgetForTask_ExactAndAmbiguousTasks_ShareOneDiscoveryBudget
+// pins the fact that callBudgetForTask does not classify tasks at all: it
+// hardcodes AllowedDiscoveryCalls to 0 and never sets SuppressDiscovery, so an
+// exact task and an ambiguous one get the same discovery budget. Only the
+// step-derived fields vary, and those are asserted here so a change to either
+// behavior is caught.
+func TestDynamicCallBudgetForTask_ExactAndAmbiguousTasks_ShareOneDiscoveryBudget(t *testing.T) {
 	exactTask := evalTask{ID: "MT-066", Prompt: "Remove project ID `51` from the CI job token allowlist of project `1`.", Steps: []evalStep{
 		{ExpectedTool: dynamicExecuteActionTool, ExpectedAction: "job.token_scope_remove_project", RequiredParams: []string{"project_id", "target_project_id"}, OptionalParams: []string{"confirm"}, Destructive: true},
 	}}
@@ -87,6 +92,19 @@ func TestDynamicCallBudgetForTask_ClassifiesExactAndAmbiguousTasks(t *testing.T)
 	ambiguousBudget := callBudgetForTask(ambiguousTask, config.ToolSurfaceDynamic)
 	if ambiguousBudget.AllowedDiscoveryCalls != 0 || ambiguousBudget.SuppressDiscovery {
 		t.Fatalf("ambiguous budget = %+v, want default discovery budget", ambiguousBudget)
+	}
+	if ambiguousBudget.ExpectedSteps != exactBudget.ExpectedSteps {
+		t.Fatalf("ExpectedSteps: ambiguous = %d, exact = %d; both tasks have one step",
+			ambiguousBudget.ExpectedSteps, exactBudget.ExpectedSteps)
+	}
+	// MaxCalls is the only field a caller can act on, and it must leave room for
+	// the repair attempts the surface allows on top of the expected steps.
+	if exactBudget.MaxCalls < exactBudget.ExpectedSteps+exactBudget.AllowedRepairCalls {
+		t.Fatalf("exact budget = %+v, want MaxCalls >= ExpectedSteps+AllowedRepairCalls", exactBudget)
+	}
+	if ambiguousBudget.MaxCalls != exactBudget.MaxCalls {
+		t.Fatalf("MaxCalls: ambiguous = %d, exact = %d; the budget is not task-dependent",
+			ambiguousBudget.MaxCalls, exactBudget.MaxCalls)
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
@@ -101,10 +101,18 @@ func TestDynamicCallBudgetForTask_ExactAndAmbiguousTasks_ShareOneDiscoveryBudget
 	// the repair attempts the surface allows on top of the expected steps. Both
 	// budgets are checked: a task-dependent repair allowance would otherwise
 	// undersize the ambiguous one without failing the equality check below.
-	for name, budget := range map[string]taskCallBudget{"exact": exactBudget, "ambiguous": ambiguousBudget} {
-		if budget.MaxCalls < budget.ExpectedSteps+budget.AllowedRepairCalls {
-			t.Errorf("%s budget = %+v, want MaxCalls >= ExpectedSteps+AllowedRepairCalls", name, budget)
-		}
+	for _, tt := range []struct {
+		name   string
+		budget taskCallBudget
+	}{
+		{"exact", exactBudget},
+		{"ambiguous", ambiguousBudget},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.budget.MaxCalls < tt.budget.ExpectedSteps+tt.budget.AllowedRepairCalls {
+				t.Errorf("budget = %+v, want MaxCalls >= ExpectedSteps+AllowedRepairCalls", tt.budget)
+			}
+		})
 	}
 	if ambiguousBudget.MaxCalls != exactBudget.MaxCalls {
 		t.Fatalf("MaxCalls: ambiguous = %d, exact = %d; the budget is not task-dependent",

--- a/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
@@ -98,9 +98,13 @@ func TestDynamicCallBudgetForTask_ExactAndAmbiguousTasks_ShareOneDiscoveryBudget
 			ambiguousBudget.ExpectedSteps, exactBudget.ExpectedSteps)
 	}
 	// MaxCalls is the only field a caller can act on, and it must leave room for
-	// the repair attempts the surface allows on top of the expected steps.
-	if exactBudget.MaxCalls < exactBudget.ExpectedSteps+exactBudget.AllowedRepairCalls {
-		t.Fatalf("exact budget = %+v, want MaxCalls >= ExpectedSteps+AllowedRepairCalls", exactBudget)
+	// the repair attempts the surface allows on top of the expected steps. Both
+	// budgets are checked: a task-dependent repair allowance would otherwise
+	// undersize the ambiguous one without failing the equality check below.
+	for name, budget := range map[string]taskCallBudget{"exact": exactBudget, "ambiguous": ambiguousBudget} {
+		if budget.MaxCalls < budget.ExpectedSteps+budget.AllowedRepairCalls {
+			t.Errorf("%s budget = %+v, want MaxCalls >= ExpectedSteps+AllowedRepairCalls", name, budget)
+		}
 	}
 	if ambiguousBudget.MaxCalls != exactBudget.MaxCalls {
 		t.Fatalf("MaxCalls: ambiguous = %d, exact = %d; the budget is not task-dependent",

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,017 |
-| Unit test functions                                   | 11,642 |
+| Total test functions                                  | 12,012 |
+| Unit test functions                                   | 11,637 |
 | E2E test functions                                    |    375 |
-| cmd test functions                                    |    957 |
+| cmd test functions                                    |    955 |
 | Test files (internal/)                                |    459 |
 | Test files (cmd/)                                     |     68 |
 | Test files (test/e2e/suite/)                          |    168 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,603 | 88.2% |
-| `TestFunc` (no underscore)             |    967 |  8.0% |
-| `TestFunc_Scenario_Expected` (3+ part) |    447 |  3.7% |
+| `TestFunc_Scenario` (2-part)           | 10,538 | 87.7% |
+| `TestFunc` (no underscore)             |    963 |  8.0% |
+| `TestFunc_Scenario_Expected` (3+ part) |    511 |  4.3% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,055 |        101 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,054 |        101 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          8,345 |        345 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (175) |          8,343 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            375 |        168 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |            957 |         68 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,017** |    **695** |                                                                                                 |
+| cmd packages            |            955 |         68 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,012** |    **695** |                                                                                                 |
 
 ### Core Packages
 
@@ -71,9 +71,9 @@
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | testutil     |        29 |    85.3% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
-| toolutil     |       702 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
+| toolutil     |       701 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,055** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,054** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -84,7 +84,7 @@
 | mergerequests     |   241 |    99.5% |    30 |
 | issues            |   223 |   100.0% |    21 |
 | users             |   210 |   100.0% |    38 |
-| dynamic           |   161 |    99.7% |     2 |
+| dynamic           |   159 |    99.7% |     2 |
 | jobs              |   147 |    99.5% |    17 |
 | packages          |   123 |    99.2% |     9 |
 | search            |   118 |   100.0% |    10 |
@@ -151,7 +151,7 @@
 | deploytokens            |        68 |          2 |   100.0% |         9 |
 | dockerfiletemplates     |        15 |          1 |   100.0% |         2 |
 | dorametrics             |        11 |          2 |   100.0% |         2 |
-| dynamic                 |       161 |          8 |    99.7% |         2 |
+| dynamic                 |       159 |          8 |    99.7% |         2 |
 | elicitationtools        |        61 |          2 |    99.5% |         4 |
 | enterpriseusers         |        35 |          3 |   100.0% |         4 |
 | environments            |        56 |          2 |   100.0% |         6 |
@@ -287,7 +287,7 @@
 | waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        89 |          2 |    97.2% |         6 |
-| **Total**               | **8,345** |    **345** |          | **1,169** |
+| **Total**               | **8,343** |    **345** |          | **1,169** |
 
 </details>
 

--- a/internal/prompts/prompt_analytics_test.go
+++ b/internal/prompts/prompt_analytics_test.go
@@ -334,15 +334,15 @@ func TestWeeklyTeamRecap_MissingGroupID(t *testing.T) {
 	}
 }
 
-// TestMergeVelocity_APIError verifies that merge_velocity returns an error
+// TestMergeVelocity_APIError_ReturnsError verifies that merge_velocity returns an error
 // when the MR list API fails.
-func TestMergeVelocity_APIError(t *testing.T) {
+func TestMergeVelocity_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "merge_velocity", map[string]string{"project_id": "42"})
 }
 
-// TestWriteDailyMergeChart_NoMergedDates verifies that the daily merge chart
+// TestWriteDailyMergeChart_NoMergedDates_WritesNothing verifies that the daily merge chart
 // is omitted when no MR carries a merged_at timestamp.
-func TestWriteDailyMergeChart_NoMergedDates(t *testing.T) {
+func TestWriteDailyMergeChart_NoMergedDates_WritesNothing(t *testing.T) {
 	var b strings.Builder
 	writeDailyMergeChart(&b, []*gl.BasicMergeRequest{{IID: 1}})
 	if b.Len() != 0 {
@@ -350,15 +350,15 @@ func TestWriteDailyMergeChart_NoMergedDates(t *testing.T) {
 	}
 }
 
-// TestReleaseReadiness_APIError verifies that release_readiness returns an
+// TestReleaseReadiness_APIError_ReturnsError verifies that release_readiness returns an
 // error when the MR list API fails.
-func TestReleaseReadiness_APIError(t *testing.T) {
+func TestReleaseReadiness_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "release_readiness", map[string]string{"project_id": "42"})
 }
 
-// TestReleaseReadiness_DiscussionsAPIError verifies that unresolved-thread
+// TestReleaseReadiness_DiscussionsAPIError_StillRendersReport verifies that unresolved-thread
 // counting skips MRs whose discussion API fails (continue branch).
-func TestReleaseReadiness_DiscussionsAPIError(t *testing.T) {
+func TestReleaseReadiness_DiscussionsAPIError_StillRendersReport(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":42,"title":"MR1","source_branch":"a","target_branch":"main"}]`)
@@ -373,15 +373,15 @@ func TestReleaseReadiness_DiscussionsAPIError(t *testing.T) {
 	}
 }
 
-// TestReleaseCadence_APIError verifies that release_cadence returns an error
+// TestReleaseCadence_APIError_ReturnsError verifies that release_cadence returns an error
 // when the releases API fails.
-func TestReleaseCadence_APIError(t *testing.T) {
+func TestReleaseCadence_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "release_cadence", map[string]string{"project_id": "42"})
 }
 
-// TestFilterRecentReleases_CreatedAtFallback verifies that a release without
+// TestFilterRecentReleases_CreatedAtFallback_FallsBackToCreatedAt verifies that a release without
 // released_at falls back to created_at for the recency filter.
-func TestFilterRecentReleases_CreatedAtFallback(t *testing.T) {
+func TestFilterRecentReleases_CreatedAtFallback_FallsBackToCreatedAt(t *testing.T) {
 	created := time.Now().Add(-24 * time.Hour)
 	since := time.Now().Add(-30 * 24 * time.Hour)
 
@@ -391,11 +391,11 @@ func TestFilterRecentReleases_CreatedAtFallback(t *testing.T) {
 	}
 }
 
-// TestWriteReleaseHistoryTable_TagNameFallback verifies that a release
+// TestWriteReleaseHistoryTable_TagNameFallback_FallsBackToTagName verifies that a release
 // without a name is rendered using its tag name. The slice is built
 // dynamically so gosec does not bounds-propagate a literal length into the
 // production loop (G602 false positive).
-func TestWriteReleaseHistoryTable_TagNameFallback(t *testing.T) {
+func TestWriteReleaseHistoryTable_TagNameFallback_FallsBackToTagName(t *testing.T) {
 	now := time.Now()
 	var releases []*gl.Release
 	releases = append(releases, &gl.Release{TagName: "v1.0.0", ReleasedAt: &now})
@@ -407,18 +407,18 @@ func TestWriteReleaseHistoryTable_TagNameFallback(t *testing.T) {
 	}
 }
 
-// TestWeeklyTeamRecap_MergedAPIError verifies that weekly_team_recap degrades
+// TestWeeklyTeamRecap_MergedAPIError_StillRendersRecap verifies that weekly_team_recap degrades
 // to a zero-count recap (warn-and-continue) when the group MR API fails.
-func TestWeeklyTeamRecap_MergedAPIError(t *testing.T) {
+func TestWeeklyTeamRecap_MergedAPIError_StillRendersRecap(t *testing.T) {
 	text := getPromptText(t, notFoundHandler(), "weekly_team_recap", map[string]string{"group_id": "g1"})
 	if !strings.Contains(text, "| MRs merged | 0 |") {
 		t.Error("expected zero merged MRs when API fails")
 	}
 }
 
-// TestWeeklyTeamRecap_OpenMRConflicts verifies the open-MR conflict counting
+// TestWeeklyTeamRecap_OpenMRConflicts_ReportsConflictCount verifies the open-MR conflict counting
 // branch of weekly_team_recap.
-func TestWeeklyTeamRecap_OpenMRConflicts(t *testing.T) {
+func TestWeeklyTeamRecap_OpenMRConflicts_ReportsConflictCount(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v4/groups/g1/merge_requests", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("state") == "merged" {

--- a/internal/prompts/prompt_audit_test.go
+++ b/internal/prompts/prompt_audit_test.go
@@ -669,9 +669,9 @@ func TestMaskURL(t *testing.T) {
 	}
 }
 
-// TestAuditBranchProtection_ProjectAPIError verifies the project-fetch error
+// TestAuditBranchProtection_ProjectAPIError_ReturnsError verifies the project-fetch error
 // branch of the branch protection audit.
-func TestAuditBranchProtection_ProjectAPIError(t *testing.T) {
+func TestAuditBranchProtection_ProjectAPIError_ReturnsError(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	_, err := handleAuditBranchProtection(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
 	if err == nil {
@@ -679,9 +679,9 @@ func TestAuditBranchProtection_ProjectAPIError(t *testing.T) {
 	}
 }
 
-// TestAuditBranchProtection_BranchesAPIError verifies the protected-branches
+// TestAuditBranchProtection_BranchesAPIError_ReturnsError verifies the protected-branches
 // error branch of the branch protection audit (project fetch succeeds).
-func TestAuditBranchProtection_BranchesAPIError(t *testing.T) {
+func TestAuditBranchProtection_BranchesAPIError_ReturnsError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `{"path_with_namespace":"group/p","default_branch":"main"}`)
@@ -697,9 +697,9 @@ func TestAuditBranchProtection_BranchesAPIError(t *testing.T) {
 	}
 }
 
-// TestWriteSharedGroups_WithExpiry verifies the expiry-date branch of the
+// TestWriteSharedGroups_WithExpiry_RendersExpiryDate verifies the expiry-date branch of the
 // shared-groups table.
-func TestWriteSharedGroups_WithExpiry(t *testing.T) {
+func TestWriteSharedGroups_WithExpiry_RendersExpiryDate(t *testing.T) {
 	expires := gl.ISOTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	var b strings.Builder
 	writeSharedGroups(&b, []gl.ProjectSharedWithGroup{
@@ -710,9 +710,9 @@ func TestWriteSharedGroups_WithExpiry(t *testing.T) {
 	}
 }
 
-// TestAuditProjectAccess_MembersAPIError verifies the members-fetch error
+// TestAuditProjectAccess_MembersAPIError_ReturnsError verifies the members-fetch error
 // branch of the project access audit.
-func TestAuditProjectAccess_MembersAPIError(t *testing.T) {
+func TestAuditProjectAccess_MembersAPIError_ReturnsError(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	_, err := handleAuditProjectAccess(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
 	if err == nil {
@@ -720,9 +720,9 @@ func TestAuditProjectAccess_MembersAPIError(t *testing.T) {
 	}
 }
 
-// TestAuditProjectAccess_ProjectAPIError verifies the project-fetch error
+// TestAuditProjectAccess_ProjectAPIError_ReturnsError verifies the project-fetch error
 // branch of the project access audit (members fetch succeeds).
-func TestAuditProjectAccess_ProjectAPIError(t *testing.T) {
+func TestAuditProjectAccess_ProjectAPIError_ReturnsError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeMembersAll, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `[]`)
@@ -738,9 +738,9 @@ func TestAuditProjectAccess_ProjectAPIError(t *testing.T) {
 	}
 }
 
-// TestAuditProjectAccess_InactiveAccounts verifies the inactive-accounts
+// TestAuditProjectAccess_InactiveAccounts_RendersInactiveSection verifies the inactive-accounts
 // section branch when a member is neither active nor blocked.
-func TestAuditProjectAccess_InactiveAccounts(t *testing.T) {
+func TestAuditProjectAccess_InactiveAccounts_RendersInactiveSection(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeMembersAll, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `[{"id":1,"username":"u1","name":"U One","access_level":30,"state":"awaiting"}]`)
@@ -760,9 +760,9 @@ func TestAuditProjectAccess_InactiveAccounts(t *testing.T) {
 	}
 }
 
-// TestAuditProjectWorkflow_ProjectAPIError verifies the project-fetch error
+// TestAuditProjectWorkflow_ProjectAPIError_ReturnsError verifies the project-fetch error
 // branch of the workflow audit.
-func TestAuditProjectWorkflow_ProjectAPIError(t *testing.T) {
+func TestAuditProjectWorkflow_ProjectAPIError_ReturnsError(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	_, err := handleAuditProjectWorkflow(t.Context(), client, testPromptRequest(map[string]string{"project_id": "42"}))
 	if err == nil {
@@ -770,10 +770,10 @@ func TestAuditProjectWorkflow_ProjectAPIError(t *testing.T) {
 	}
 }
 
-// TestAuditProjectWorkflow_SubResourceAPIErrors verifies that the workflow
+// TestAuditProjectWorkflow_SubResourceAPIErrors_StillRendersReport verifies that the workflow
 // audit degrades gracefully (warn-and-continue) when the labels and template
 // APIs fail while the project fetch succeeds.
-func TestAuditProjectWorkflow_SubResourceAPIErrors(t *testing.T) {
+func TestAuditProjectWorkflow_SubResourceAPIErrors_StillRendersReport(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeProject, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `{"path_with_namespace":"group/p"}`)

--- a/internal/prompts/prompt_cross_project_test.go
+++ b/internal/prompts/prompt_cross_project_test.go
@@ -373,15 +373,15 @@ func getPromptExpectError(t *testing.T, handler http.Handler, name string, args 
 	}
 }
 
-// TestMyOpenMRs_UserAPIError verifies that my_open_mrs returns an error when
+// TestMyOpenMRs_UserAPIError_ReturnsError verifies that my_open_mrs returns an error when
 // the current-user lookup fails.
-func TestMyOpenMRs_UserAPIError(t *testing.T) {
+func TestMyOpenMRs_UserAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "my_open_mrs", nil)
 }
 
-// TestMyOpenMRs_MRListAPIErrors verifies that my_open_mrs degrades to an
+// TestMyOpenMRs_MRListAPIErrors_StillRendersSummary verifies that my_open_mrs degrades to an
 // empty dashboard (warn-and-continue) when both MR list calls fail.
-func TestMyOpenMRs_MRListAPIErrors(t *testing.T) {
+func TestMyOpenMRs_MRListAPIErrors_StillRendersSummary(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, basicUserJSON)
@@ -396,15 +396,15 @@ func TestMyOpenMRs_MRListAPIErrors(t *testing.T) {
 	}
 }
 
-// TestMyPendingReviews_UserAPIError verifies that my_pending_reviews returns
+// TestMyPendingReviews_UserAPIError_ReturnsError verifies that my_pending_reviews returns
 // an error when the current-user lookup fails.
-func TestMyPendingReviews_UserAPIError(t *testing.T) {
+func TestMyPendingReviews_UserAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "my_pending_reviews", nil)
 }
 
-// TestMyPendingReviews_ListAPIError verifies that my_pending_reviews returns
+// TestMyPendingReviews_ListAPIError_ReturnsError verifies that my_pending_reviews returns
 // an error when the reviewer MR list fails.
-func TestMyPendingReviews_ListAPIError(t *testing.T) {
+func TestMyPendingReviews_ListAPIError_ReturnsError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, basicUserJSON)
@@ -415,15 +415,15 @@ func TestMyPendingReviews_ListAPIError(t *testing.T) {
 	getPromptExpectError(t, mux, "my_pending_reviews", nil)
 }
 
-// TestMyIssues_UserAPIError verifies that my_issues returns an error when the
+// TestMyIssues_UserAPIError_ReturnsError verifies that my_issues returns an error when the
 // current-user lookup fails.
-func TestMyIssues_UserAPIError(t *testing.T) {
+func TestMyIssues_UserAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "my_issues", nil)
 }
 
-// TestMyIssues_ListAPIError verifies that my_issues returns an error when the
+// TestMyIssues_ListAPIError_ReturnsError verifies that my_issues returns an error when the
 // issue list fails.
-func TestMyIssues_ListAPIError(t *testing.T) {
+func TestMyIssues_ListAPIError_ReturnsError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, basicUserJSON)
@@ -434,16 +434,16 @@ func TestMyIssues_ListAPIError(t *testing.T) {
 	getPromptExpectError(t, mux, "my_issues", nil)
 }
 
-// TestMyActivitySummary_UserAPIError verifies that my_activity_summary
+// TestMyActivitySummary_UserAPIError_ReturnsError verifies that my_activity_summary
 // returns an error when the current-user lookup fails.
-func TestMyActivitySummary_UserAPIError(t *testing.T) {
+func TestMyActivitySummary_UserAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "my_activity_summary", nil)
 }
 
-// TestMyActivitySummary_MRListAPIErrors verifies that my_activity_summary
+// TestMyActivitySummary_MRListAPIErrors_StillRendersSummary verifies that my_activity_summary
 // renders N/A rows (warn-and-continue) when the merged and reviewed MR list
 // calls fail.
-func TestMyActivitySummary_MRListAPIErrors(t *testing.T) {
+func TestMyActivitySummary_MRListAPIErrors_StillRendersSummary(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(routeGetUser, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, basicUserJSON)

--- a/internal/prompts/prompt_git_workflow_test.go
+++ b/internal/prompts/prompt_git_workflow_test.go
@@ -140,16 +140,16 @@ func testCommit(title, message string, parents []string) *gl.Commit {
 	return &gl.Commit{Title: title, Message: message, ParentIDs: parents}
 }
 
-// TestAuditCommitHygiene_CompareAPIError verifies that audit_commit_hygiene
+// TestAuditCommitHygiene_CompareAPIError_ReturnsError verifies that audit_commit_hygiene
 // returns an error when the repository compare API fails.
-func TestAuditCommitHygiene_CompareAPIError(t *testing.T) {
+func TestAuditCommitHygiene_CompareAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "audit_commit_hygiene",
 		map[string]string{"project_id": "42", "from": "v1.0.0"})
 }
 
-// TestAuditCommitHygiene_SameRef verifies the early-exit branch when both
+// TestAuditCommitHygiene_SameRef_ReportsNoCommits verifies the early-exit branch when both
 // refs point at the same commit and no commits are returned.
-func TestAuditCommitHygiene_SameRef(t *testing.T) {
+func TestAuditCommitHygiene_SameRef_ReportsNoCommits(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathRepoCompare, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `{"compare_same_ref":true,"commits":[],"diffs":[]}`)
@@ -162,23 +162,23 @@ func TestAuditCommitHygiene_SameRef(t *testing.T) {
 	}
 }
 
-// TestMRDescriptionQuality_InvalidIID verifies that a non-numeric MR IID is
+// TestMRDescriptionQuality_InvalidIID_ReturnsError verifies that a non-numeric MR IID is
 // rejected before any API call.
-func TestMRDescriptionQuality_InvalidIID(t *testing.T) {
-	getPromptExpectError(t, notFoundHandler(), "mr_description_quality",
+func TestMRDescriptionQuality_InvalidIID_ReturnsError(t *testing.T) {
+	getPromptExpectErrorWithoutAPICall(t, "mr_description_quality",
 		map[string]string{"project_id": "42", "merge_request_iid": "abc"})
 }
 
-// TestMRDescriptionQuality_MRAPIError verifies the MR-fetch error branch of
+// TestMRDescriptionQuality_MRAPIError_ReturnsError verifies the MR-fetch error branch of
 // mr_description_quality.
-func TestMRDescriptionQuality_MRAPIError(t *testing.T) {
+func TestMRDescriptionQuality_MRAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "mr_description_quality",
 		map[string]string{"project_id": "42", "merge_request_iid": "5"})
 }
 
-// TestMRDescriptionQuality_DiffsAPIError verifies the diff-fetch error branch
+// TestMRDescriptionQuality_DiffsAPIError_ReturnsError verifies the diff-fetch error branch
 // of mr_description_quality (MR fetch succeeds).
-func TestMRDescriptionQuality_DiffsAPIError(t *testing.T) {
+func TestMRDescriptionQuality_DiffsAPIError_ReturnsError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+pathMR5, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `{"iid":5,"title":"T","source_branch":"a","target_branch":"main","description":""}`)
@@ -190,9 +190,9 @@ func TestMRDescriptionQuality_DiffsAPIError(t *testing.T) {
 		map[string]string{"project_id": "42", "merge_request_iid": "5"})
 }
 
-// TestCommitBody_EmptyMessage verifies that a whitespace-only commit message
+// TestCommitBody_EmptyMessage_ReturnsEmptyBody verifies that a whitespace-only commit message
 // yields an empty body.
-func TestCommitBody_EmptyMessage(t *testing.T) {
+func TestCommitBody_EmptyMessage_ReturnsEmptyBody(t *testing.T) {
 	if got := commitBody(&gl.Commit{Message: "   "}); got != "" {
 		t.Errorf("commitBody() = %q, want empty", got)
 	}

--- a/internal/prompts/prompt_milestone_label_test.go
+++ b/internal/prompts/prompt_milestone_label_test.go
@@ -490,9 +490,9 @@ func TestProjectContributors_APIError(t *testing.T) {
 	}
 }
 
-// TestProjectContributors_PieChartCap verifies that the contributor pie chart
+// TestProjectContributors_PieChartCap_CapsPieChartSlices verifies that the contributor pie chart
 // is capped at eight entries while the table still lists everyone.
-func TestProjectContributors_PieChartCap(t *testing.T) {
+func TestProjectContributors_PieChartCap_CapsPieChartSlices(t *testing.T) {
 	var sb strings.Builder
 	sb.WriteString("[")
 	for i := 1; i <= 9; i++ {

--- a/internal/prompts/prompt_project_reports_test.go
+++ b/internal/prompts/prompt_project_reports_test.go
@@ -428,17 +428,17 @@ func TestStaleItemsReport_MissingProjectID(t *testing.T) {
 	}
 }
 
-// TestBranchMRSummary_APIError verifies that branch_mr_summary returns an
+// TestBranchMRSummary_APIError_ReturnsError verifies that branch_mr_summary returns an
 // error when the MR list API fails.
-func TestBranchMRSummary_APIError(t *testing.T) {
+func TestBranchMRSummary_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "branch_mr_summary",
 		map[string]string{"project_id": "42", "target_branch": "main"})
 }
 
-// TestProjectActivityReport_EventsAPIErrorWithMergedMRs verifies that
+// TestProjectActivityReport_EventsAPIErrorWithMergedMRs_RendersMergedMRsWithZeroEvents verifies that
 // project_activity_report tolerates a failing events API (warn-and-continue)
 // and still renders the recently-merged MRs section when merged MRs exist.
-func TestProjectActivityReport_EventsAPIErrorWithMergedMRs(t *testing.T) {
+func TestProjectActivityReport_EventsAPIErrorWithMergedMRs_RendersMergedMRsWithZeroEvents(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("state") == "merged" {
@@ -464,16 +464,16 @@ func TestProjectActivityReport_EventsAPIErrorWithMergedMRs(t *testing.T) {
 	}
 }
 
-// TestMRDiscussionHealth_APIError verifies that mr_discussion_health returns
+// TestMRDiscussionHealth_APIError_ReturnsError verifies that mr_discussion_health returns
 // an error when the MR list API fails.
-func TestMRDiscussionHealth_APIError(t *testing.T) {
+func TestMRDiscussionHealth_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "mr_discussion_health", map[string]string{"project_id": "42"})
 }
 
-// TestMRDiscussionHealth_DiscussionsAPIError verifies that a failing
+// TestMRDiscussionHealth_DiscussionsAPIError_StillRendersReport verifies that a failing
 // discussion API for a single MR yields a zero-thread row instead of failing
 // the whole prompt (warn-and-continue branch).
-func TestMRDiscussionHealth_DiscussionsAPIError(t *testing.T) {
+func TestMRDiscussionHealth_DiscussionsAPIError_StillRendersReport(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathMRs, func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":42,"title":"MR1","source_branch":"a","target_branch":"main","author":{"username":"alice"}}]`)

--- a/internal/prompts/prompt_team_test.go
+++ b/internal/prompts/prompt_team_test.go
@@ -480,9 +480,9 @@ func TestReviewerWorkload_MembersAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "reviewer_workload", map[string]string{"group_id": "g1"})
 }
 
-// TestRecordReviewerWorkloadMR_UnknownReviewer_IsIgnored verifies that a reviewer who
+// TestRecordReviewerWorkloadMR_UnknownReviewer_CreatesStatsEntry verifies that a reviewer who
 // is not a group member gets a stats entry created on the fly.
-func TestRecordReviewerWorkloadMR_UnknownReviewer_IsIgnored(t *testing.T) {
+func TestRecordReviewerWorkloadMR_UnknownReviewer_CreatesStatsEntry(t *testing.T) {
 	stats := map[string]*reviewerWorkloadStats{}
 	created := time.Now().Add(-24 * time.Hour)
 

--- a/internal/prompts/prompt_team_test.go
+++ b/internal/prompts/prompt_team_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -311,6 +312,27 @@ func notFoundHandler() http.Handler {
 	})
 }
 
+// getPromptExpectErrorWithoutAPICall asserts that a prompt fails argument
+// validation before it reaches GitLab.
+//
+// getPromptExpectError with notFoundHandler cannot express this: a handler that
+// answers 404 makes the prompt fail either way, so the test passes whether the
+// argument was rejected up front or the first API call simply failed. Counting
+// requests and requiring zero is what pins the validation to the right side of
+// the client call.
+func getPromptExpectErrorWithoutAPICall(t *testing.T, name string, args map[string]string) {
+	t.Helper()
+	var requests atomic.Int64
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		respondNotFound(w)
+	})
+	getPromptExpectError(t, handler, name, args)
+	if got := requests.Load(); got != 0 {
+		t.Errorf("%s made %d GitLab request(s); argument validation must reject before the client call", name, got)
+	}
+}
+
 // getPromptText issues a GetPrompt call that is expected to succeed and
 // returns the text of the first message.
 func getPromptText(t *testing.T, handler http.Handler, name string, args map[string]string) string {
@@ -325,17 +347,17 @@ func getPromptText(t *testing.T, handler http.Handler, name string, args map[str
 
 // prompts.go error branches.
 
-// TestUserActivityReport_UserLookupAPIError verifies that the
+// TestUserActivityReport_UserLookupAPIError_ReturnsError verifies that the
 // user_activity_report prompt returns an error when the /users lookup fails
 // (covers both the handler branch and resolveUser's lookup-error branch).
-func TestUserActivityReport_UserLookupAPIError(t *testing.T) {
+func TestUserActivityReport_UserLookupAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "user_activity_report", map[string]string{"username": "alice"})
 }
 
-// TestUserActivityReport_NoEventsWithMRs verifies the user_activity_report
+// TestUserActivityReport_NoEventsWithMRs_RendersMRSectionOnly verifies the user_activity_report
 // branches for an empty event list combined with non-empty merged and
 // under-review MR lists (the grouped per-project MR tables).
-func TestUserActivityReport_NoEventsWithMRs(t *testing.T) {
+func TestUserActivityReport_NoEventsWithMRs_RendersMRSectionOnly(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v4/users", func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, aliceLookupJSON)
@@ -359,9 +381,9 @@ func TestUserActivityReport_NoEventsWithMRs(t *testing.T) {
 	}
 }
 
-// TestUserActivityReport_MultiDayChart verifies the daily activity chart
+// TestUserActivityReport_MultiDayChart_RendersDailyChart verifies the daily activity chart
 // separator branches when contribution events span more than one day.
-func TestUserActivityReport_MultiDayChart(t *testing.T) {
+func TestUserActivityReport_MultiDayChart_RendersDailyChart(t *testing.T) {
 	d1 := time.Now().Add(-48 * time.Hour)
 	d2 := time.Now().Add(-24 * time.Hour)
 	mux := http.NewServeMux()
@@ -389,16 +411,16 @@ func TestUserActivityReport_MultiDayChart(t *testing.T) {
 	}
 }
 
-// TestTeamOverview_MembersAPIError verifies that team_overview returns an
+// TestTeamOverview_MembersAPIError_ReturnsError verifies that team_overview returns an
 // error when the group members API fails.
-func TestTeamOverview_MembersAPIError(t *testing.T) {
+func TestTeamOverview_MembersAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "team_overview", map[string]string{"group_id": "g1"})
 }
 
-// TestBuildTeamOverviewStats_MergedMRAuthors verifies the merged-MR
+// TestBuildTeamOverviewStats_MergedMRAuthors_CountsMergedMRAuthors verifies the merged-MR
 // attribution branches: authors that are active members are counted while
 // unknown or nil authors are ignored.
-func TestBuildTeamOverviewStats_MergedMRAuthors(t *testing.T) {
+func TestBuildTeamOverviewStats_MergedMRAuthors_CountsMergedMRAuthors(t *testing.T) {
 	members := []*gl.GroupMember{{Username: "alice", Name: "Alice", State: "active"}}
 	mergedMRs := []*gl.BasicMergeRequest{
 		{Author: &gl.BasicUser{Username: "alice"}},
@@ -416,9 +438,9 @@ func TestBuildTeamOverviewStats_MergedMRAuthors(t *testing.T) {
 	}
 }
 
-// TestWriteTeamOverviewChart_EmptyStats verifies the chart is omitted when
+// TestWriteTeamOverviewChart_EmptyStats_WritesNothing verifies the chart is omitted when
 // there are no member stats to plot.
-func TestWriteTeamOverviewChart_EmptyStats(t *testing.T) {
+func TestWriteTeamOverviewChart_EmptyStats_WritesNothing(t *testing.T) {
 	var b strings.Builder
 	writeTeamOverviewChart(&b, map[string]*teamOverviewMemberStats{})
 	if b.Len() != 0 {
@@ -426,21 +448,21 @@ func TestWriteTeamOverviewChart_EmptyStats(t *testing.T) {
 	}
 }
 
-// TestGroupMRDashboard_MissingGroupID verifies that group_mr_dashboard
+// TestGroupMRDashboard_MissingGroupID_ReturnsError verifies that group_mr_dashboard
 // rejects requests without a group_id.
-func TestGroupMRDashboard_MissingGroupID(t *testing.T) {
-	getPromptExpectError(t, notFoundHandler(), "group_mr_dashboard", nil)
+func TestGroupMRDashboard_MissingGroupID_ReturnsError(t *testing.T) {
+	getPromptExpectErrorWithoutAPICall(t, "group_mr_dashboard", nil)
 }
 
-// TestGroupMRDashboard_APIError verifies that group_mr_dashboard returns an
+// TestGroupMRDashboard_APIError_ReturnsError verifies that group_mr_dashboard returns an
 // error when the group MR list API fails.
-func TestGroupMRDashboard_APIError(t *testing.T) {
+func TestGroupMRDashboard_APIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "group_mr_dashboard", map[string]string{"group_id": "g1"})
 }
 
-// TestGroupMRDashboard_ConflictCount verifies the conflict-counting branch
+// TestGroupMRDashboard_ConflictCount_ReportsConflictCount verifies the conflict-counting branch
 // when an MR in the dashboard has merge conflicts.
-func TestGroupMRDashboard_ConflictCount(t *testing.T) {
+func TestGroupMRDashboard_ConflictCount_ReportsConflictCount(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v4/groups/g1/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
 		respondJSON(w, http.StatusOK, `[{"iid":1,"project_id":10,"title":"MR1","source_branch":"a","target_branch":"main","has_conflicts":true,"references":{"full":"group/proj!1"},"created_at":"2026-01-01T00:00:00Z"}]`)
@@ -452,15 +474,15 @@ func TestGroupMRDashboard_ConflictCount(t *testing.T) {
 	}
 }
 
-// TestReviewerWorkload_MembersAPIError verifies that reviewer_workload
+// TestReviewerWorkload_MembersAPIError_ReturnsError verifies that reviewer_workload
 // returns an error when the group members API fails.
-func TestReviewerWorkload_MembersAPIError(t *testing.T) {
+func TestReviewerWorkload_MembersAPIError_ReturnsError(t *testing.T) {
 	getPromptExpectError(t, notFoundHandler(), "reviewer_workload", map[string]string{"group_id": "g1"})
 }
 
-// TestRecordReviewerWorkloadMR_UnknownReviewer verifies that a reviewer who
+// TestRecordReviewerWorkloadMR_UnknownReviewer_IsIgnored verifies that a reviewer who
 // is not a group member gets a stats entry created on the fly.
-func TestRecordReviewerWorkloadMR_UnknownReviewer(t *testing.T) {
+func TestRecordReviewerWorkloadMR_UnknownReviewer_IsIgnored(t *testing.T) {
 	stats := map[string]*reviewerWorkloadStats{}
 	created := time.Now().Add(-24 * time.Hour)
 
@@ -478,9 +500,9 @@ func TestRecordReviewerWorkloadMR_UnknownReviewer(t *testing.T) {
 	}
 }
 
-// TestWriteReviewerWorkloadChart_NoActiveReviewers verifies the chart is
+// TestWriteReviewerWorkloadChart_NoActiveReviewers_WritesNothing verifies the chart is
 // omitted when nobody is reviewing anything.
-func TestWriteReviewerWorkloadChart_NoActiveReviewers(t *testing.T) {
+func TestWriteReviewerWorkloadChart_NoActiveReviewers_WritesNothing(t *testing.T) {
 	var b strings.Builder
 	writeReviewerWorkloadChart(&b, map[string]*reviewerWorkloadStats{"a": {name: "A"}}, 0)
 	if b.Len() != 0 {

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -2139,7 +2139,10 @@ func TestWriteMRSection_FetchError_WritesNothing(t *testing.T) {
 // TestTeamMemberWorkload_MissingProjectID_ReturnsError verifies that the
 // team_member_workload prompt rejects requests without a project_id.
 func TestTeamMemberWorkload_MissingProjectID_ReturnsError(t *testing.T) {
-	getPromptExpectErrorWithoutAPICall(t, "team_member_workload", nil)
+	// username is supplied so only project_id is missing: passing nil would
+	// omit both required arguments and the case would pass even if the
+	// project_id check were broken.
+	getPromptExpectErrorWithoutAPICall(t, "team_member_workload", map[string]string{"username": "alice"})
 }
 
 // prompt_team.go error branches.

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -2089,10 +2089,10 @@ func TestReviewMRPrompt_MissingArgs(t *testing.T) {
 	}
 }
 
-// TestFetchContributionEvents_APIError verifies that fetchContributionEvents
+// TestFetchContributionEvents_APIError_ReturnsNoEvents verifies that fetchContributionEvents
 // logs and returns an empty slice (instead of failing the prompt) when the
 // events API fails, for both the current-user and other-user endpoints.
-func TestFetchContributionEvents_APIError(t *testing.T) {
+func TestFetchContributionEvents_APIError_ReturnsNoEvents(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	since := time.Now().Add(-7 * 24 * time.Hour)
 
@@ -2104,9 +2104,9 @@ func TestFetchContributionEvents_APIError(t *testing.T) {
 	}
 }
 
-// TestWriteOpenMRsSection_APIError verifies that the open-MRs section of the
+// TestWriteOpenMRsSection_APIError_WritesNothing verifies that the open-MRs section of the
 // project health check is silently skipped when the MR list API fails.
-func TestWriteOpenMRsSection_APIError(t *testing.T) {
+func TestWriteOpenMRsSection_APIError_WritesNothing(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	var b strings.Builder
 	writeOpenMRsSection(t.Context(), &b, client, "42")
@@ -2115,9 +2115,9 @@ func TestWriteOpenMRsSection_APIError(t *testing.T) {
 	}
 }
 
-// TestWriteBranchesSection_APIError verifies that the branches section of the
+// TestWriteBranchesSection_APIError_WritesNothing verifies that the branches section of the
 // project health check is silently skipped when the branch list API fails.
-func TestWriteBranchesSection_APIError(t *testing.T) {
+func TestWriteBranchesSection_APIError_WritesNothing(t *testing.T) {
 	client := newTestClient(t, notFoundHandler())
 	var b strings.Builder
 	writeBranchesSection(t.Context(), &b, client, "42")
@@ -2126,9 +2126,9 @@ func TestWriteBranchesSection_APIError(t *testing.T) {
 	}
 }
 
-// TestWriteMRSection_FetchError verifies that writeMRSection skips the whole
+// TestWriteMRSection_FetchError_WritesNothing verifies that writeMRSection skips the whole
 // section (warn-and-continue) when the MR fetch that produced the slice failed.
-func TestWriteMRSection_FetchError(t *testing.T) {
+func TestWriteMRSection_FetchError_WritesNothing(t *testing.T) {
 	var b strings.Builder
 	writeMRSection(&b, "Open MRs by", "alice", nil, errors.New("boom"))
 	if b.Len() != 0 {
@@ -2136,10 +2136,10 @@ func TestWriteMRSection_FetchError(t *testing.T) {
 	}
 }
 
-// TestTeamMemberWorkload_MissingProjectID verifies that the
+// TestTeamMemberWorkload_MissingProjectID_ReturnsError verifies that the
 // team_member_workload prompt rejects requests without a project_id.
-func TestTeamMemberWorkload_MissingProjectID(t *testing.T) {
-	getPromptExpectError(t, notFoundHandler(), "team_member_workload", nil)
+func TestTeamMemberWorkload_MissingProjectID_ReturnsError(t *testing.T) {
+	getPromptExpectErrorWithoutAPICall(t, "team_member_workload", nil)
 }
 
 // prompt_team.go error branches.

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -5910,102 +5910,34 @@ func TestCompactParameterGuidance_AlphabeticalTieBreaker(t *testing.T) {
 	}
 }
 
-// TestDebugScores_SearchProjectsVsMRList is a diagnostic test that prints the
-// per-term scoring breakdown for the "project list search" query across the
-// search.projects and merge-request list candidates, used to inspect why one
-// action outranks the other when tuning the discovery scorer.
-func TestDebugScores_SearchProjectsVsMRList(t *testing.T) {
+// TestRegistrySearch_ProjectListSearchQuery_RanksSearchProjectsFirst pins the
+// ranking outcome three print-only diagnostics used to investigate.
+//
+// Those diagnostics dumped score components for "project list search" and
+// always passed, so a regression in scoring, ranking, or Search error handling
+// went unreported. The end-to-end outcome is the part worth pinning: component
+// scores move whenever the scorer is tuned, but search.projects must stay the
+// top hit for this query, and it must not depend on the result window — the
+// limit-sensitivity that prompted the investigation in the first place.
+func TestRegistrySearch_ProjectListSearchQuery_RanksSearchProjectsFirst(t *testing.T) {
 	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("BuildActionCatalog() error = %v", err)
+	}
+	catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
+	if err != nil {
+		t.Fatalf("AddStandaloneCatalog() error = %v", err)
 	}
 	reg := NewRegistryFromCatalog(catalog)
 
-	query := "project list search gitlab-mcp-server"
-	terms := normalizeSearchTerms(query)
-
-	fmt.Printf("Query: %q → terms: %v\n", query, terms)
-
-	for _, entry := range reg.entries {
-		doc := documentForEntry(entry)
-		key := doc.Domain + "." + doc.Action
-		if key == "search.projects" || key == "merge_request.list" {
-			score := scoreEntry(entry, terms)
-			intentScore := scoreSearchProjectsIntentValue(entry, terms)
-			fmt.Printf("  %s → total=%d  searchProjectsIntent=%d\n", key, score, intentScore)
+	const query = "project list search gitlab-mcp-server"
+	for _, limit := range []int{8, 20} {
+		if _, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: limit}); searchErr != nil {
+			t.Errorf("Search(limit=%d) error = %v", limit, searchErr)
+		} else if len(out.Results) == 0 {
+			t.Errorf("Search(limit=%d) returned no results", limit)
+		} else if out.Results[0].ID != "search.projects" {
+			t.Errorf("Search(limit=%d) top result = %q, want search.projects", limit, out.Results[0].ID)
 		}
-	}
-}
-
-// TestDebugScores_ActionSpecificityForSearchProjects is a diagnostic test that
-// reports the action-specificity component of the discovery score for the
-// search.projects entry against the "project list search" query, used to tune
-// how strongly exact action matches are boosted.
-func TestDebugScores_ActionSpecificityForSearchProjects(t *testing.T) {
-	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	reg := NewRegistryFromCatalog(catalog)
-
-	query := "project list search gitlab-mcp-server"
-	terms := normalizeSearchTerms(query)
-
-	for _, entry := range reg.entries {
-		doc := documentForEntry(entry)
-		key := doc.Domain + "." + doc.Action
-		if key == "search.projects" {
-			base := 0
-			base += scoreVerbIntentValue(entry, terms)
-			base += scoreRequiredParamSignalValue(entry, terms)
-			base += scoreCompoundTagSignalValue(entry, terms)
-			base += scoreServiceAccountIntentValue(entry, terms)
-			base += scoreScopeIntentValue(entry, terms)
-			base += scoreCompareRefsIntentValue(entry, terms)
-			base += scoreReleaseListIntentValue(entry, terms)
-			base += scoreDiscoverProjectIntentValue(entry, terms)
-			base += scoreProjectGetIntentValue(entry, terms)
-			boost := scoreSearchProjectsIntentValue(entry, terms)
-			spec := scoreActionSpecificityValue(entry, terms)
-			fmt.Printf("search.projects:\n  base=%d\n  searchProjectsBoost=%d\n  specificityPenalty=%d\n  total_before_floor=%d\n",
-				base, boost, spec, base+boost+spec)
-		}
-	}
-}
-
-// TestDebugScores_SearchWithDefaultLimit is a diagnostic test that runs the
-// discovery search for the "project list search" query at the default limit and
-// reports whether search.projects appears in the returned window, used to inspect
-// limit-sensitivity of the ranking.
-func TestDebugScores_SearchWithDefaultLimit(t *testing.T) {
-	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	reg := NewRegistryFromCatalog(catalog)
-	catalog2, err := AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
-	if err == nil {
-		reg = NewRegistryFromCatalog(catalog2)
-	}
-
-	query := "project list search gitlab-mcp-server"
-
-	// default limit (20) - should fail to find search.projects
-	ctx := context.Background()
-	_, out20, _ := reg.Search(ctx, nil, SearchInput{Query: query, Limit: 20})
-	// limit 8 (as in unit test) - should find search.projects
-	_, out8, _ := reg.Search(ctx, nil, SearchInput{Query: query, Limit: 8})
-
-	fmt.Printf("Limit 8 top result: ")
-	if len(out8.Results) > 0 {
-		fmt.Printf("%s\n", out8.Results[0].ID)
-	} else {
-		fmt.Println("no results")
-	}
-	fmt.Printf("Limit 20 top result: ")
-	if len(out20.Results) > 0 {
-		fmt.Printf("%s\n", out20.Results[0].ID)
-	} else {
-		fmt.Println("no results")
 	}
 }

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -5932,12 +5932,17 @@ func TestRegistrySearch_ProjectListSearchQuery_RanksSearchProjectsFirst(t *testi
 
 	const query = "project list search gitlab-mcp-server"
 	for _, limit := range []int{8, 20} {
-		if _, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: limit}); searchErr != nil {
-			t.Errorf("Search(limit=%d) error = %v", limit, searchErr)
-		} else if len(out.Results) == 0 {
-			t.Errorf("Search(limit=%d) returned no results", limit)
-		} else if out.Results[0].ID != "search.projects" {
-			t.Errorf("Search(limit=%d) top result = %q, want search.projects", limit, out.Results[0].ID)
-		}
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			_, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: limit})
+			if searchErr != nil {
+				t.Fatalf("Search() error = %v", searchErr)
+			}
+			if len(out.Results) == 0 {
+				t.Fatal("Search() returned no results")
+			}
+			if out.Results[0].ID != "search.projects" {
+				t.Errorf("Search() top result = %q, want search.projects", out.Results[0].ID)
+			}
+		})
 	}
 }

--- a/internal/tools/events/action_specs_test.go
+++ b/internal/tools/events/action_specs_test.go
@@ -16,12 +16,14 @@ func TestUserActionSpecs_Descriptions(t *testing.T) {
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
 	for _, spec := range UserActionSpecs(client) {
-		desc := spec.IndividualTool.Description
-		if desc == "" {
-			t.Fatalf("%s: empty description", spec.IndividualTool.Name)
-		}
-		if !contains(desc, "Returns:") || !contains(desc, "See also:") {
-			t.Errorf("%s: description missing Returns/See also: %q", spec.IndividualTool.Name, desc)
-		}
+		t.Run(spec.IndividualTool.Name, func(t *testing.T) {
+			desc := spec.IndividualTool.Description
+			if desc == "" {
+				t.Fatal("empty description")
+			}
+			if !contains(desc, "Returns:") || !contains(desc, "See also:") {
+				t.Errorf("description missing Returns/See also: %q", desc)
+			}
+		})
 	}
 }

--- a/internal/tools/groupmembers/markdown_test.go
+++ b/internal/tools/groupmembers/markdown_test.go
@@ -23,7 +23,7 @@ func TestFormatBillableMembersMarkdown(t *testing.T) {
 		}},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	for _, want := range []string{"Billable Group Members", "dev", "group_member", "https://gl/dev"} {
+	for _, want := range []string{"Billable Group Members", "[dev](https://gl/dev)", "group_member"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("markdown missing %q:\n%s", want, md)
 		}
@@ -45,7 +45,12 @@ func TestFormatBillableMembershipsMarkdown(t *testing.T) {
 		}},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	for _, want := range []string{"Billable Member Memberships", "Org / Team", "Developer", "30"} {
+	for _, want := range []string{
+		"Billable Member Memberships",
+		"[Org / Team](https://gl/groups/team/-/group_members)",
+		"Developer",
+		"30",
+	} {
 		if !strings.Contains(md, want) {
 			t.Errorf("markdown missing %q:\n%s", want, md)
 		}

--- a/internal/tools/groups/avatar_test.go
+++ b/internal/tools/groups/avatar_test.go
@@ -26,16 +26,23 @@ func TestUploadAvatar_ContentBase64_Multipart(t *testing.T) {
 	mux.HandleFunc("PUT /api/v4/groups/99", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseMultipartForm(1 << 20); err != nil { //nolint:gosec // Test handler parses a small in-memory fixture body.
 			t.Errorf("ParseMultipartForm: %v", err)
+			http.Error(w, "parse multipart form", http.StatusBadRequest)
+			return
 		}
 		for field, files := range r.MultipartForm.File {
+			if len(files) == 0 {
+				t.Errorf("multipart field %q has no files", field)
+				continue
+			}
 			gotField = field
 			f, err := files[0].Open()
 			if err != nil {
 				t.Errorf("open multipart file: %v", err)
+				continue
 			}
-			defer f.Close()
 			buf := make([]byte, 64)
 			n, _ := f.Read(buf)
+			_ = f.Close()
 			gotContent = string(buf[:n])
 			gotFilename = files[0].Filename
 		}

--- a/internal/tools/groups/avatar_test.go
+++ b/internal/tools/groups/avatar_test.go
@@ -25,13 +25,13 @@ func TestUploadAvatar_ContentBase64_Multipart(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/v4/groups/99", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseMultipartForm(1 << 20); err != nil { //nolint:gosec // Test handler parses a small in-memory fixture body.
-			t.Fatalf("ParseMultipartForm: %v", err)
+			t.Errorf("ParseMultipartForm: %v", err)
 		}
 		for field, files := range r.MultipartForm.File {
 			gotField = field
 			f, err := files[0].Open()
 			if err != nil {
-				t.Fatalf("open multipart file: %v", err)
+				t.Errorf("open multipart file: %v", err)
 			}
 			defer f.Close()
 			buf := make([]byte, 64)
@@ -166,8 +166,9 @@ func TestUploadAvatar_ErrorStatuses(t *testing.T) {
 	}
 }
 
-// TestContextCancellation covers the ctx.Err() guard in both new handlers.
-func TestContextCancellation(t *testing.T) {
+// TestUploadAvatar_CanceledContext_ReturnsContextError covers the ctx.Err()
+// guard in both avatar handlers.
+func TestUploadAvatar_CanceledContext_ReturnsContextError(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/tools/groups/groups_test.go
+++ b/internal/tools/groups/groups_test.go
@@ -3669,7 +3669,7 @@ func TestTransferLocationsList_MissingGroupID(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Markdown
+// Create and update request bodies
 // ---------------------------------------------------------------------------.
 
 // TestCreate_NewOptions verifies that the v2.41.0 group create options are sent to the API.
@@ -3679,9 +3679,8 @@ func TestCreate_NewOptions(t *testing.T) {
 	var body string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v4/groups", func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(buf)
-		body = string(buf)
+		raw, _ := io.ReadAll(r.Body)
+		body = string(raw)
 		testutil.RespondJSON(w, http.StatusCreated,
 			`{"id":1,"name":"G","path":"g","full_path":"g","visibility":"private","web_url":"https://x/groups/g"}`)
 	})
@@ -3725,9 +3724,8 @@ func TestUpdate_NewOptions(t *testing.T) {
 	var body string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v4/groups/5", func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(buf)
-		body = string(buf)
+		raw, _ := io.ReadAll(r.Body)
+		body = string(raw)
 		testutil.RespondJSON(w, http.StatusOK,
 			`{"id":5,"name":"G","path":"g","full_path":"g","visibility":"private","web_url":"https://x/groups/g"}`)
 	})

--- a/internal/tools/groups/markdown_test.go
+++ b/internal/tools/groups/markdown_test.go
@@ -20,8 +20,8 @@ func TestFormatProvisionedUsersListMarkdown_Rows(t *testing.T) {
 	md := FormatProvisionedUsersListMarkdown(ProvisionedUsersListOutput{
 		Users: []ProvisionedUserOutput{{ID: 7, Username: "scim-user", Name: "SCIM User", State: "active", Email: "s@e.com", WebURL: "https://g/scim-user"}},
 	})
-	if !strings.Contains(md, "scim-user") || !strings.Contains(md, "https://g/scim-user") {
-		t.Fatalf("markdown = %q, want user row with link", md)
+	if !strings.Contains(md, "[scim-user](https://g/scim-user)") {
+		t.Fatalf("markdown = %q, want a clickable user link", md)
 	}
 }
 

--- a/internal/tools/mergerequests/action_specs_test.go
+++ b/internal/tools/mergerequests/action_specs_test.go
@@ -63,23 +63,25 @@ func TestActionSpecs_Metadata_NoGenericPlaceholders(t *testing.T) {
 	byTool := mergeRequestSpecsByTool(t, ActionSpecs(client))
 
 	for _, tool := range mrMetaActions {
-		spec, ok := byTool[tool]
-		if !ok {
-			t.Fatalf("missing action spec for %s", tool)
-		}
-		if u := strings.ToLower(strings.TrimSpace(spec.Usage)); u == "" || strings.HasPrefix(u, "use to execute") {
-			t.Errorf("%s: generic or empty Usage = %q", tool, spec.Usage)
-		}
-		if !hasNaturalLanguageAlias(spec, tool) {
-			t.Errorf("%s: aliases lack a natural-language entry: %v", tool, spec.Aliases)
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: RelatedActions is empty", tool)
-		}
-		desc := spec.IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: individual description lacks Returns/See also: %q", tool, desc)
-		}
+		t.Run(tool, func(t *testing.T) {
+			spec, ok := byTool[tool]
+			if !ok {
+				t.Fatal("missing action spec")
+			}
+			if u := strings.ToLower(strings.TrimSpace(spec.Usage)); u == "" || strings.HasPrefix(u, "use to execute") {
+				t.Errorf("generic or empty Usage = %q", spec.Usage)
+			}
+			if !hasNaturalLanguageAlias(spec, tool) {
+				t.Errorf("aliases lack a natural-language entry: %v", spec.Aliases)
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Error("RelatedActions is empty")
+			}
+			desc := spec.IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("individual description lacks Returns/See also: %q", desc)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -4771,7 +4771,7 @@ func TestMarkdownHelpers_EdgeBranches(t *testing.T) {
 	}
 }
 
-// captureQuery is a tiny helper returning a handler that records the query
+// captureQueryHandler is a tiny helper returning a handler that records the query
 // values of the first matching request and replies with an empty paginated
 // list. The captured url.Values are written through the provided pointer.
 func captureQueryHandler(t *testing.T, method, path string, captured *url.Values) http.HandlerFunc {

--- a/internal/tools/users/user_crud_test.go
+++ b/internal/tools/users/user_crud_test.go
@@ -325,16 +325,23 @@ func TestDeleteUser_CancelledContext(t *testing.T) {
 
 // decodeJSONBody reads an HTTP request's JSON body into a generic map so tests
 // can assert which option fields the SDK serialized.
+//
+// It is called from httptest handlers, which run on the server goroutine, so it
+// reports failures with t.Errorf and returns an empty map. testing requires
+// FailNow to run on the test goroutine; from a handler it would abort the
+// request mid-response and the client would report a misleading transport error
+// instead of the decoding failure.
 func decodeJSONBody(t *testing.T, r *http.Request) map[string]any {
 	t.Helper()
+	m := map[string]any{}
 	raw, readErr := io.ReadAll(r.Body)
 	if readErr != nil {
-		t.Fatalf("read body: %v", readErr)
+		t.Errorf("read body: %v", readErr)
+		return m
 	}
-	m := map[string]any{}
 	if len(raw) > 0 {
 		if jsonErr := json.Unmarshal(raw, &m); jsonErr != nil {
-			t.Fatalf("unmarshal body %q: %v", raw, jsonErr)
+			t.Errorf("unmarshal body %q: %v", raw, jsonErr)
 		}
 	}
 	return m

--- a/internal/toolutil/errors_test.go
+++ b/internal/toolutil/errors_test.go
@@ -837,9 +837,8 @@ func fieldSet(names ...string) map[string]struct{} {
 // helper does after the first clone (it reuses the same backing map).
 // Tests using this helper should treat the supplied params as
 // in-out: the same map will be mutated in place.
-func aliasClone(initial map[string]any) (clone func() map[string]any, _ *map[string]any) {
-	clone = func() map[string]any { return initial }
-	return clone, nil
+func aliasClone(initial map[string]any) func() map[string]any {
+	return func() map[string]any { return initial }
 }
 
 // TestExplainIIDParamAliasDirect verifies the explanation helper
@@ -924,7 +923,7 @@ func TestRemoveContextOnlyDiscussionIDDirect(t *testing.T) {
 
 	t.Run("removes when note_id is canonical and present", func(t *testing.T) {
 		params := map[string]any{"discussion_id": "abc", "note_id": 7}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		removeContextOnlyDiscussionID(params, acceptsNoteID, clone)
 		if _, ok := params["discussion_id"]; ok {
 			t.Errorf("discussion_id not removed: %+v", params)
@@ -936,7 +935,7 @@ func TestRemoveContextOnlyDiscussionIDDirect(t *testing.T) {
 
 	t.Run("keeps when schema accepts discussion_id", func(t *testing.T) {
 		params := map[string]any{"discussion_id": "abc", "note_id": 7}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		removeContextOnlyDiscussionID(params, acceptsAll, clone)
 		if _, ok := params["discussion_id"]; !ok {
 			t.Error("discussion_id removed even though schema accepts it")
@@ -945,7 +944,7 @@ func TestRemoveContextOnlyDiscussionIDDirect(t *testing.T) {
 
 	t.Run("keeps when note_id is absent", func(t *testing.T) {
 		params := map[string]any{"discussion_id": "abc"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		removeContextOnlyDiscussionID(params, acceptsNoteID, clone)
 		if _, ok := params["discussion_id"]; !ok {
 			t.Error("discussion_id removed even though note_id is absent")
@@ -961,7 +960,7 @@ func TestNormalizeActiveAliasDirect(t *testing.T) {
 
 	t.Run("active false becomes paused true", func(t *testing.T) {
 		params := map[string]any{"active": false}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeActiveAlias(params, acceptsPaused, clone)
 		if v, ok := params["paused"]; !ok || v != true {
 			t.Errorf("paused = %v/%v, want true", v, ok)
@@ -973,7 +972,7 @@ func TestNormalizeActiveAliasDirect(t *testing.T) {
 
 	t.Run("active true becomes paused false", func(t *testing.T) {
 		params := map[string]any{"active": true}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeActiveAlias(params, acceptsPaused, clone)
 		if v, ok := params["paused"]; !ok || v != false {
 			t.Errorf("paused = %v/%v, want false", v, ok)
@@ -982,7 +981,7 @@ func TestNormalizeActiveAliasDirect(t *testing.T) {
 
 	t.Run("no-op when paused not accepted", func(t *testing.T) {
 		params := map[string]any{"active": false}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeActiveAlias(params, acceptsFalse, clone)
 		if _, ok := params["paused"]; ok {
 			t.Error("paused added when schema does not accept it")
@@ -991,7 +990,7 @@ func TestNormalizeActiveAliasDirect(t *testing.T) {
 
 	t.Run("preserves existing paused value", func(t *testing.T) {
 		params := map[string]any{"active": false, "paused": true}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeActiveAlias(params, acceptsPaused, clone)
 		if params["paused"] != true {
 			t.Errorf("paused = %v, want true (preserved)", params["paused"])
@@ -1000,7 +999,7 @@ func TestNormalizeActiveAliasDirect(t *testing.T) {
 
 	t.Run("non-bool active is ignored", func(t *testing.T) {
 		params := map[string]any{"active": "yes"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeActiveAlias(params, acceptsPaused, clone)
 		if _, ok := params["paused"]; ok {
 			t.Error("paused added for non-bool active")
@@ -1015,7 +1014,7 @@ func TestNormalizeFilePathAliasDirect(t *testing.T) {
 
 	t.Run("splits file_path into path+filename", func(t *testing.T) {
 		params := map[string]any{"file_path": "packages/npm/pkg.tgz"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeFilePathAlias(params, acceptsBoth, clone)
 		if params["path"] != "packages/npm" {
 			t.Errorf("path = %q, want packages/npm", params["path"])
@@ -1030,7 +1029,7 @@ func TestNormalizeFilePathAliasDirect(t *testing.T) {
 
 	t.Run("preserves existing path", func(t *testing.T) {
 		params := map[string]any{"file_path": "packages/npm/pkg.tgz", "path": "custom"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeFilePathAlias(params, acceptsBoth, clone)
 		if params["path"] != "custom" {
 			t.Errorf("path = %q, want custom (preserved)", params["path"])
@@ -1039,7 +1038,7 @@ func TestNormalizeFilePathAliasDirect(t *testing.T) {
 
 	t.Run("non-string file_path is ignored", func(t *testing.T) {
 		params := map[string]any{"file_path": 42}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeFilePathAlias(params, acceptsBoth, clone)
 		if _, ok := params["path"]; ok {
 			t.Error("path added for non-string file_path")
@@ -1048,7 +1047,7 @@ func TestNormalizeFilePathAliasDirect(t *testing.T) {
 
 	t.Run("empty file_path is ignored", func(t *testing.T) {
 		params := map[string]any{"file_path": ""}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeFilePathAlias(params, acceptsBoth, clone)
 		if _, ok := params["path"]; ok {
 			t.Error("path added for empty file_path")
@@ -1064,7 +1063,7 @@ func TestNormalizeIIDAliasDirect(t *testing.T) {
 
 	t.Run("iid is renamed to merge_request_iid", func(t *testing.T) {
 		params := map[string]any{"iid": "5"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeIIDAlias(params, fieldSet("merge_request_iid"), acceptsMRIID, clone)
 		if params["merge_request_iid"] != "5" {
 			t.Errorf("merge_request_iid = %v, want 5", params["merge_request_iid"])
@@ -1076,7 +1075,7 @@ func TestNormalizeIIDAliasDirect(t *testing.T) {
 
 	t.Run("no rename when iid is accepted", func(t *testing.T) {
 		params := map[string]any{"iid": "5"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeIIDAlias(params, fieldSet("iid"), acceptsNoIID, clone)
 		if _, ok := params["merge_request_iid"]; ok {
 			t.Error("iid was renamed even though it is accepted")
@@ -1085,7 +1084,7 @@ func TestNormalizeIIDAliasDirect(t *testing.T) {
 
 	t.Run("ambiguous canonical field → no rename", func(t *testing.T) {
 		params := map[string]any{"iid": "5"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeIIDAlias(params, fieldSet("merge_request_iid", "issue_iid"), acceptsNoIID, clone)
 		if _, ok := params["merge_request_iid"]; ok {
 			t.Error("iid was renamed when canonical was ambiguous")
@@ -1094,7 +1093,7 @@ func TestNormalizeIIDAliasDirect(t *testing.T) {
 
 	t.Run("missing canonical field → no rename", func(t *testing.T) {
 		params := map[string]any{"iid": "5"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeIIDAlias(params, fieldSet("title"), acceptsNoIID, clone)
 		if _, ok := params["merge_request_iid"]; ok {
 			t.Error("iid was renamed when no canonical field exists")
@@ -1111,7 +1110,7 @@ func TestNormalizeEnvironmentNameAliasDirect(t *testing.T) {
 
 	t.Run("environment is renamed to name", func(t *testing.T) {
 		params := map[string]any{"environment": "production"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeEnvironmentNameAlias(params, acceptsName, clone)
 		if params["name"] != "production" {
 			t.Errorf("name = %q, want production", params["name"])
@@ -1123,7 +1122,7 @@ func TestNormalizeEnvironmentNameAliasDirect(t *testing.T) {
 
 	t.Run("preserves existing name and drops environment", func(t *testing.T) {
 		params := map[string]any{"environment": "production", "name": "stage"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeEnvironmentNameAlias(params, acceptsName, clone)
 		if params["name"] != "stage" {
 			t.Errorf("name = %q, want stage (preserved)", params["name"])
@@ -1135,7 +1134,7 @@ func TestNormalizeEnvironmentNameAliasDirect(t *testing.T) {
 
 	t.Run("no-op when environment_scope is accepted", func(t *testing.T) {
 		params := map[string]any{"environment": "production"}
-		clone, _ := aliasClone(params)
+		clone := aliasClone(params)
 		normalizeEnvironmentNameAlias(params, acceptsScope, clone)
 		if _, ok := params["name"]; ok {
 			t.Error("name was added despite environment_scope being accepted")
@@ -1330,8 +1329,10 @@ func TestGitLabRoleAccessLevelStringAliases(t *testing.T) {
 // TestHasUnknownParamNamesDirect verifies the unknown-parameter
 // detector handles empty params, missing properties, and unknown keys.
 func TestHasUnknownParamNamesDirect(t *testing.T) {
-	// empty params → false
-	if hasUnknownParamNames(map[string]any{"x": 1}, map[string]any{}) {
+	// empty params → false, with a schema that does declare properties so this
+	// case exercises the empty-params branch rather than the no-properties one.
+	emptyParamsSchema := map[string]any{"properties": map[string]any{"known": map[string]any{}}}
+	if hasUnknownParamNames(emptyParamsSchema, map[string]any{}) {
 		t.Error("hasUnknownParamNames(empty) = true, want false")
 	}
 	// schema has no properties → false

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -4394,9 +4394,12 @@ func TestValidGitLabRoleAccessLevelFloat64Direct(t *testing.T) {
 
 // TestNumericRoleAccessLevel verifies the type-switch dispatch accepts
 // int, int64, and float64 numeric types and rejects everything else.
-// Note: this helper does not validate the canonical access-level
-// whitelist — it only narrows the type. Validation happens in the
-// subsequent validGitLabRoleAccessLevel{Int64,Float64} call sites.
+//
+// The three numeric arms are not equivalent: int64 and float64 delegate to
+// validGitLabRoleAccessLevel{Int64,Float64}, so the canonical access-level
+// whitelist is enforced here for those two, while a plain int is narrowed and
+// returned unchecked. The out-of-range assertions below cover only the
+// validating arms for that reason.
 func TestNumericRoleAccessLevel(t *testing.T) {
 	if got, ok := numericRoleAccessLevel(int(30)); !ok || got != 30 {
 		t.Errorf("numericRoleAccessLevel(int 30) = %d/%v, want 30/true", got, ok)
@@ -4550,16 +4553,6 @@ func TestIsStringSliceTypeAndIsStringTypeDirect(t *testing.T) {
 			t.Errorf("%s: isStringSliceType = %v, want %v", tc.name, got, tc.isSlice)
 		}
 	}
-}
-
-// TestCoerceStructuredValueDirect verifies the structured-value
-// coercion helper handles map-with-access_level shorthand, plain
-// role strings, scalar values that cannot be interpreted, and
-// non-slice targets.
-func TestCoerceStructuredValueDirect(t *testing.T) {
-	sliceType := reflect.TypeFor[[]accessLevelEntryInput]()
-	elemType := sliceType.Elem()
-	_ = elemType // documented for direct use elsewhere
 }
 
 // TestCoerceStructuredValue_MapWithAccessLevelKey verifies the helper


### PR DESCRIPTION
## Description

PR #269 relocated 23 orphan test files into the files matching the modules they test. Reviewing that diff surfaced **30 findings in the relocated code**; three were fixed inside #269, and the move deliberately changed nothing else, so the remaining **27 are fixed here**.

I verified every one against the code before touching it. All 27 were valid.

## Related Issue

Follow-up recorded in [#269](https://github.com/jmrplens/gitlab-mcp-server/pull/269#issuecomment-5200596353).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional change)

## Changes Made

### Correctness and stability

| Fix | Why it mattered |
| --- | --- |
| `t.Fatal` moved off server goroutines — OpenAI provider handlers, group avatar handler, `decodeJSONBody`, MCP fixture handler | `runtime.Goexit` abandons the request mid-response, so the client reports a transport error instead of the real assertion. `TestOpenAIProvider_EmptyToolArgumentsAreRetryable` was the sharp case: a truncated response makes `callOnce` return a *retryable transport error*, which is exactly what the test asserts — it could pass for the wrong reason |
| `TestConfigureTerminalOutput_WritesLogWithoutEcho` now restores the termio sink | It replaced the process-wide output and never restored it, leaving the global pointing at a **closed file** for every later test. Same leak class as the registry maps fixed in #269, and only visible under some orderings |
| `callBudgetForTask` test rewritten | The function classifies nothing — `AllowedDiscoveryCalls` is hardcoded `0` and `SuppressDiscovery` is never set. The test claimed to verify exact-vs-ambiguous classification while asserting identical values on both branches, so a one-budget-fits-all implementation passed |
| `hasUnknownParamNames` "empty params" case | It passed a schema with no `properties`, hitting the same branch as the case below it — the branch was uncovered |
| Three prompt validation tests count requests | They proved "rejected before any API call" with a 404 handler, which fails either way |
| Markdown tests assert `[text](url)` | Asserting label and URL separately lets a regression from a clickable link to plain text pass — and clickable links are a documented project convention |
| Two tests that asserted nothing deleted; three print-only scoring diagnostics replaced | They passed unconditionally. The diagnostics now assert the invariant they were chasing: `search.projects` stays the top hit for `"project list search"` at both result windows |
| `r.Body.Read(buf)` → `io.ReadAll` (2 sites) | A single `Read` can return fewer bytes than the buffer, so the body assertions could fail intermittently |

### Maintainability

Three-part names for the 53 relocated prompt tests and the `audit_tokens` tests, derived from what each test actually asserts rather than a blanket suffix; named subtests for four tables; `absent` for a field that listed forbidden content under the name `want`; one assertion helper instead of two; `roundTripFunc` and doc comments corrected — including `numericRoleAccessLevel`, whose comment claimed no validation happens there when `int64` and `float64` **do** enforce the access-level whitelist and only a plain `int` passes through unchecked.

## How to Test

1. `go test -count=1 -shuffle=on` over every touched package — run three times, clean. Shuffle is the point: it is what exposes the global-state leaks.
2. `make golangci-lint` — clean.
3. All ten `check-*` gates pass.
4. `go build ./...`, `go vet ./cmd/... ./internal/...` — clean.

## Breaking Changes / Migration Notes

N/A — tests only, plus one comment in `cmd/gen_stats`. No production code path changes.

## Known follow-up, deliberately not in this PR

The `t.Fatal`-on-a-handler-goroutine pattern is **not confined to these files**. A repo-wide scan finds **531 call sites across 136 files**, all pre-existing. Fixing them here would bury these 27 targeted changes in a mechanical sweep an order of magnitude larger. Worth its own PR; the scan is easy to reproduce if you want it.

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...`
- [x] `make golangci-lint` passes; `make analyze-fix` applied the formatters
- [x] Follows the conventions in `CLAUDE.md` / `.github/instructions/`

### Testing

- [x] Every touched package passes under `-shuffle=on`, three consecutive runs
- [x] Two tests removed for asserting nothing; three replaced with a real assertion — coverage of behaviour goes up, not down
- [x] No production code changed, so no new tests are required

### Documentation

- [x] `docs/development/testing/testing.md`, README statistics and token footprint regenerated
- [x] Commit message follows Conventional Commits

### Security

- [x] No secrets, tokens or credentials touched

## Summary by Sourcery

Improve correctness and resilience of test suite after relocating orphan tests, while tightening naming and documentation around prompt, tooling, and evaluation behaviour.

Bug Fixes:
- Prevent misleading test passes by replacing print-only diagnostics and no-op tests with assertions that pin expected ranking, validation, and error-handling behaviour.
- Fix tests that relied on t.Fatal inside server goroutines or handlers so failures are reported correctly without corrupting HTTP flows or global state.
- Eliminate flaky or incomplete body reads in HTTP handler tests by reading request bodies in full before assertions.
- Ensure prompt and report tests explicitly verify that argument validation fails before any GitLab API call in cases that should be rejected up front.
- Correct the hasUnknownParamNames empty-params test to exercise the intended branch against schemas that actually declare properties.

Enhancements:
- Rename many prompt, audit, analytics, and footprint tests to three-part, behaviour-describing names and restructure several into table-driven subtests for clearer coverage.
- Strengthen OpenAI provider, MCP fixture, and dynamic task prompt tests to assert on concrete request/response shapes, budgets, and tool-call content, including role-sensitive cases.
- Refine markdown formatting tests to assert on clickable links rather than bare text, matching documented link conventions.
- Clarify and expand test-only helpers and comments (e.g., callBudgetForTask, numericRoleAccessLevel, toolUseResponse) to document invariants and actual validation behaviour.
- Consolidate repeated terminal-output and footprint drift test logic into shared helpers and tables, improving maintainability of cmd/eval_mcp_surfaces tests.

Documentation:
- Regenerate testing metrics and README statistics to reflect the updated test counts and code statistics after test relocations and cleanups.

Tests:
- Remove a few redundant or assertion-free tests while adding or tightening assertions across many prompt, tool, and evaluator tests to better cover error paths and edge cases.
- Rework several tests to avoid global-state leaks (e.g., restoring terminal sinks) and to run robustly under -shuffle and concurrent handler execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for search ranking, prompt validation, error handling, cancellation, request validation, and Markdown output.
  * Added checks confirming member names and usernames render as clickable links.
  * Clarified test names and scenarios for easier diagnosis of failures.
  * Removed redundant and obsolete tests while retaining equivalent coverage.

* **Documentation**
  * Updated testing statistics and audit-footprint metrics to reflect the current test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->