### PR TITLE
test: eliminate all off-goroutine testing.T aborts (FailNow sweep)

### DIFF
--- a/.github/agents/test-expert.agent.md
+++ b/.github/agents/test-expert.agent.md
@@ -460,3 +460,12 @@ Before declaring any test work complete:
 - [ ] `golangci-lint` passes on changed packages
 - [ ] `docs/development/testing/testing.md` refreshed with `go run ./cmd/gen_testing_docs/` at the end of the test phase when tests or coverage changed
 - [ ] `go run ./cmd/gen_testing_docs/ --check` passes
+
+## Assertions off the test goroutine (MANDATORY)
+
+Never call `t.Fatal`/`t.Fatalf`/`t.FailNow` inside an `httptest` handler, a
+`go` statement, an errgroup task, or an MCP tool handler — it kills only that
+goroutine and truncates the response. Follow the six-rule contract in
+`.github/instructions/test-goroutines.instructions.md` (t.Errorf + response +
+return, or record with atomics and assert on the test goroutine). Verify with
+`make check-test-goroutines`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -277,3 +277,7 @@ Key agents: `go-mcp-expert` (primary coding), `test-expert` (testing, coverage, 
 | Git branch names                             | English  |
 
 Conversations with the developer may be in any language, but **every file committed to this repository must be in English**.
+
+- **Tests with HTTP mocks or goroutines**: never `t.Fatal` inside handler
+  literals or `go` statements — follow
+  `.github/instructions/test-goroutines.instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ gitlab-mcp-server/
 │   ├── audit_surface_quality/ # MCP surface metadata + output quality (-view; was audit_tools + audit_output)
 │   ├── audit_tokens/       # Token overhead; -footprint, --compare-schemas (was audit_meta_schema); cl100k_base tokenizer (tokens.go)
 │   ├── audit_metrics/      # MCP tool/resource/prompt metrics
+│   ├── audit_test_goroutines/ # Off-goroutine testing.T abort audit (--check gate)
 │   ├── audit_test_names/   # Test naming convention (+ -apply/-dry-run)
 │   ├── audit_string_dupes/ # Duplicated string literals missing constants
 │   ├── godoc_tool/         # Godoc auditor + fixer (audit/fix; was audit_godocs + add_docs)

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -471,3 +471,10 @@ Schedule cleanup when context is done:
 stop := context.AfterFunc(ctx, func() { conn.Close() })
 defer stop()
 ```
+
+## Test-goroutine assertion contract
+
+`t.Fatal`/`FailNow` must never run off the test goroutine (HTTP mock
+handlers, `go` statements, MCP handlers). See
+`test-goroutines.instructions.md` in this directory for the six-rule
+contract; `make check-test-goroutines` detects violations.

--- a/.github/instructions/test-goroutines.instructions.md
+++ b/.github/instructions/test-goroutines.instructions.md
@@ -1,0 +1,71 @@
+---
+description: "Testing.T usage rules for code that runs off the test goroutine: HTTP mock handlers, go statements, errgroup tasks, and MCP tool handlers"
+applyTo: "**/*_test.go"
+---
+
+# Assertions off the test goroutine
+
+`testing.T.FailNow` — and therefore `t.Fatal`/`t.Fatalf` — must be called from
+the goroutine running the test. Anywhere else (an `http.HandlerFunc` literal,
+a `go` statement, an `errgroup.Group.Go` task, an MCP tool handler registered
+on an in-memory server) it only terminates *that* goroutine: the HTTP response
+is truncated or never written, the client observes a transport error, and the
+test continues against the wreckage. `go vet`'s `testinggoroutine` analyzer
+does not catch handler literals; `cmd/audit_test_goroutines` does
+(`make audit-test-goroutines` / `make check-test-goroutines`).
+
+## The six rules
+
+Every assertion inside a function literal that crosses a goroutine boundary
+MUST follow all of these:
+
+1. **Never `t.Fatal`/`t.Fatalf`/`t.FailNow` inside the literal.** Use
+   `t.Errorf` (or record and assert later — see rule 5).
+2. **Always `return` immediately after the `t.Errorf`, even when it is the
+   last statement.** `t.Fatal` provided that exit for free; a later edit
+   appending code below a bare `t.Errorf` silently reintroduces the bug (this
+   exact mistake produced a nil-dereference panic in PR #270).
+3. **Write a deterministic response before returning.** For HTTP handlers,
+   `http.Error(w, "<what failed>", http.StatusInternalServerError)`; for MCP
+   tool handlers, an error result. Without it the client silently receives a
+   `200` with an empty body — a worse signal than the EOF it replaces.
+4. **Nothing the failed check would have validated may be used afterwards.**
+   If the check guarded a nil (`r.MultipartForm`, a decoded struct), the
+   `return` must come before any use of it.
+5. **Prefer recording over asserting.** Store observed values in locals (or a
+   struct) inside the handler and assert on the test goroutine after the
+   client call returns. This removes the problem instead of mitigating it.
+6. **"Must not be called" guards become a recorded flag** — `var called
+   atomic.Bool` (or `atomic.Int64` for counts) written in the handler and
+   asserted afterwards. The `atomic` is mandatory: an unsynchronised variable
+   written from the handler goroutine is a data race.
+
+## Canonical shapes
+
+```go
+// Guard that must never fire (rule 6):
+var hits atomic.Int64
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    hits.Add(1)
+    http.Error(w, "unexpected call", http.StatusInternalServerError)
+}))
+// ... drive the client ...
+if n := hits.Load(); n != 0 {
+    t.Fatalf("API was reached %d time(s)", n)
+}
+
+// Validation inside a handler that still owes a response (rules 2–4):
+if r.Header.Get("PRIVATE-TOKEN") == "" {
+    t.Errorf("missing PRIVATE-TOKEN header")
+    http.Error(w, "missing token", http.StatusInternalServerError)
+    return
+}
+
+// Recording for later assertion (rule 5):
+var gotBody []byte
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    gotBody, _ = io.ReadAll(r.Body)
+    testutil.RespondJSON(w, http.StatusOK, `{}`)
+}))
+// ... drive the client, then assert on gotBody from the test goroutine.
+```

--- a/.github/instructions/test-goroutines.instructions.md
+++ b/.github/instructions/test-goroutines.instructions.md
@@ -40,10 +40,31 @@ MUST follow all of these:
    asserted afterwards. The `atomic` is mandatory: an unsynchronised variable
    written from the handler goroutine is a data race.
 
+The CI gate (`make check-test-goroutines`) fails only on abort sites
+(`t.Fatal`/`t.Fatalf`/`t.FailNow`, rule 1). Errorf-without-return sites are
+reported as an advisory list, not gated: most are the legitimate
+assert-then-respond shape where the handler keeps writing a deterministic
+response after the `t.Errorf`. Rule 2 applies when the `t.Errorf` replaces an
+abort that used to guard later statements — then the `return` is mandatory.
+
 ## Canonical shapes
+
+Prefer the shared helpers in `internal/testutil` over hand-rolled guards —
+they already follow every rule:
+
+- `testutil.AssertRequestPath(t, r, "/api/v4/...")` /
+  `testutil.AssertRequestMethod(t, r, http.MethodPost)` /
+  `testutil.AssertQueryParam(t, r, "page", "2")` — non-aborting request
+  validation inside a handler that then writes its canned response.
+- `testutil.ForbiddenHandler(t)` — a whole mock server that must never be
+  reached: counts hits atomically, answers 500, and asserts zero hits on the
+  test goroutine via `t.Cleanup`.
 
 ```go
 // Guard that must never fire (rule 6):
+client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+
+// Same shape hand-rolled, when the handler needs extra behavior:
 var hits atomic.Int64
 srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     hits.Add(1)

--- a/.github/skills/golang-testing/SKILL.md
+++ b/.github/skills/golang-testing/SKILL.md
@@ -797,3 +797,12 @@ func TestUserEqual(t *testing.T) {
 ```
 
 **Remember**: Tests are documentation. They show how your code is meant to be used. Write them clearly and keep them up to date.
+
+## Assertions off the test goroutine (MANDATORY)
+
+Never call `t.Fatal`/`t.Fatalf`/`t.FailNow` inside an `httptest` handler, a
+`go` statement, an errgroup task, or an MCP tool handler — it kills only that
+goroutine and truncates the response. Follow the six-rule contract in
+`.github/instructions/test-goroutines.instructions.md` (t.Errorf + response +
+return, or record with atomics and assert on the test goroutine). Verify with
+`make check-test-goroutines`.

--- a/.github/skills/increase-test-coverage/SKILL.md
+++ b/.github/skills/increase-test-coverage/SKILL.md
@@ -405,3 +405,12 @@ After all phases complete:
 - Ensure tests don't share mutable state
 - Use `t.Parallel()` carefully — only when tests are truly independent
 - Check that test helpers don't store state across calls
+
+## Assertions off the test goroutine (MANDATORY)
+
+Never call `t.Fatal`/`t.Fatalf`/`t.FailNow` inside an `httptest` handler, a
+`go` statement, an errgroup task, or an MCP tool handler — it kills only that
+goroutine and truncates the response. Follow the six-rule contract in
+`.github/instructions/test-goroutines.instructions.md` (t.Errorf + response +
+return, or record with atomics and assert on the test goroutine). Verify with
+`make check-test-goroutines`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: make check-openplugin
       - name: Check README repository statistics
         run: make check-stats
+      - name: Check test-goroutine aborts
+        run: make check-test-goroutines
       - name: Check token footprint
         run: make check-footprint
       - name: Check site stats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,7 @@ All tests use `httptest` to mock GitLab API responses. Shared helpers in `intern
 - `testutil.NewTestClient()` — creates a mock GitLab client pointing to httptest server
 - `testutil.RespondJSON()` — responds with JSON body
 - `testutil.RespondJSONWithPagination()` — responds with pagination headers
+- **Never `t.Fatal`/`FailNow` off the test goroutine** (httptest handlers, `go` statements, MCP handlers): follow the six-rule contract in `.github/instructions/test-goroutines.instructions.md` — `t.Errorf` + deterministic response + `return`, or record with atomics and assert afterwards. `make check-test-goroutines` detects violations; `make audit-test-goroutines` writes the work list
 - Test naming: `TestToolName_Scenario_ExpectedResult`
 
 ### Build & test commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ gitlab-mcp-server/
 │   ├── godoc_tool/              # Consolidated Go doc auditor + fixer (was audit_godocs + add_docs)
 │   ├── audit_metrics/           # Audits MCP tool/resource/prompt metrics
 │   ├── audit_surface_quality/   # Consolidated surface audit: metadata violations + output quality (was audit_tools + audit_output)
+│   ├── audit_test_goroutines/   # Audits testing.T aborts made off the test goroutine (A/B categories, --check gate)
 │   ├── audit_test_names/        # Audits test function naming convention compliance
 │   ├── audit_tokens/            # Audits token usage for model-facing surfaces (+ --compare-schemas sizing spike)
 │   ├── eval_mcp_surfaces/       # Evaluates model-facing MCP surface behavior

--- a/Makefile
+++ b/Makefile
@@ -508,11 +508,12 @@ analyze:
 	echo "Go analysis packages: $(GO_ANALYSIS_PKGS)"; \
 	echo "Go analysis build tags: $(GO_ANALYSIS_TAGS)"; \
 	echo ""; \
-	run_check "[1/5] golangci-lint config verify" golangci-lint config verify; \
-	run_check "[2/5] golangci-lint fmt" golangci-lint fmt --diff; \
-	run_check "[3/5] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[4/5] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[5/5] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
+	run_check "[1/6] golangci-lint config verify" golangci-lint config verify; \
+	run_check "[2/6] golangci-lint fmt" golangci-lint fmt --diff; \
+	run_check "[3/6] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[4/6] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[5/6] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
+	run_check "[6/6] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
 	echo "============================================================"; \
 	if [ "$$analysis_status" -ne 0 ]; then \
 		echo "Analysis failed. Review findings above."; \

--- a/Makefile
+++ b/Makefile
@@ -826,6 +826,18 @@ audit-dynamic-aliases:
 audit-e2e-gaps:
 	go run ./cmd/audit_e2e_gaps/
 
+## audit-test-goroutines: report testing.T aborts made off the test goroutine
+## (t.Fatal inside HTTP mock handlers, go statements, MCP tool handlers) and
+## t.Errorf calls without the contract-required return. Writes the JSON work
+## list consumed by the conversion batches.
+audit-test-goroutines:
+	go run ./cmd/audit_test_goroutines/ -json plan/test-goroutines-backlog.json
+
+## check-test-goroutines: fail when any testing.T abort remains off the test
+## goroutine. Wired into CI once the sweep lands (phase 4 of the plan).
+check-test-goroutines:
+	go run ./cmd/audit_test_goroutines/ -check
+
 ## audit-test-names: audit test function naming convention compliance.
 audit-test-names:
 	go run ./cmd/audit_test_names/ cmd internal test

--- a/README.md
+++ b/README.md
@@ -415,19 +415,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       976 |     195,564 |
-| Unit tests (`_test.go`)  |       531 |     302,831 |
+| Source (`.go`, non-test) |       977 |     195,956 |
+| Unit tests (`_test.go`)  |       532 |     302,975 |
 | End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,680** | **543,384** |
+| **Total**                | **1,682** | **543,920** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,496 |
+| Source functions                |  7,507 |
 | — exported (public)             |  2,631 |
-| — unexported (private)          |  4,865 |
-| Unit test functions (`TestXxx`) | 11,677 |
+| — unexported (private)          |  4,876 |
+| Unit test functions (`TestXxx`) | 11,681 |
 | Subtests (`t.Run(...)`)         |  2,931 |
 | End-to-end test functions       |    381 |
 
@@ -437,17 +437,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~200 lines |
-| Average test file length           |                 ~570 lines |
-| Comment lines in source            |  21,704 (~11.1% of source) |
+| Average test file length           |                 ~569 lines |
+| Comment lines in source            |  21,762 (~11.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,755 |
+| `if err != nil` checks             | 6,759 |
 | `defer` statements                 |   865 |
-| `struct` types defined             | 2,729 |
+| `struct` types defined             | 2,732 |
 | `//nolint` suppressions            |   226 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |
 
@@ -455,7 +455,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   231 |
+| Go packages                    |   232 |
 | Direct dependencies (`go.mod`) |    13 |
 | Indirect dependencies          |    50 |
 
@@ -470,7 +470,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,555 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,562 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,562 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       977 |     196,008 |
-| Unit tests (`_test.go`)  |       532 |     302,377 |
+| Unit tests (`_test.go`)  |       532 |     302,371 |
 | End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,682** | **543,374** |
+| **Total**                | **1,682** | **543,368** |
 
 ### Functions
 

--- a/README.md
+++ b/README.md
@@ -415,17 +415,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       977 |     195,992 |
-| Unit tests (`_test.go`)  |       532 |     302,990 |
+| Source (`.go`, non-test) |       977 |     196,008 |
+| Unit tests (`_test.go`)  |       532 |     302,377 |
 | End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,682** | **543,971** |
+| **Total**                | **1,682** | **543,374** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,509 |
-| — exported (public)             |  2,632 |
+| Source functions                |  7,510 |
+| — exported (public)             |  2,633 |
 | — unexported (private)          |  4,877 |
 | Unit test functions (`TestXxx`) | 11,683 |
 | Subtests (`t.Run(...)`)         |  2,931 |
@@ -435,19 +435,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.55× more tests than code |
+| Test lines vs source lines         | 1.54× more tests than code |
 | Average source file length         |                 ~200 lines |
-| Average test file length           |                 ~569 lines |
-| Comment lines in source            |  21,778 (~11.1% of source) |
+| Average test file length           |                 ~568 lines |
+| Comment lines in source            |  21,782 (~11.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,761 |
-| `defer` statements                 |   865 |
-| `struct` types defined             | 2,732 |
+| `if err != nil` checks             | 6,758 |
+| `defer` statements                 |   866 |
+| `struct` types defined             | 2,733 |
 | `//nolint` suppressions            |   226 |
 | `TODO` / `FIXME` / `HACK` comments |     3 |
 
@@ -464,7 +464,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Record              | File                                                     |
 | ------------------- | -------------------------------------------------------- |
 | Longest source file | `internal/tools/projects/projects.go` — 3,846 lines      |
-| Longest test file   | `internal/tools/projects/projects_test.go` — 8,186 lines |
+| Longest test file   | `internal/tools/projects/projects_test.go` — 8,204 lines |
 
 ### Because why not
 

--- a/README.md
+++ b/README.md
@@ -415,19 +415,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       977 |     196,008 |
-| Unit tests (`_test.go`)  |       532 |     302,371 |
+| Source (`.go`, non-test) |       977 |     196,025 |
+| Unit tests (`_test.go`)  |       532 |     302,449 |
 | End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,682** | **543,368** |
+| **Total**                | **1,682** | **543,463** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,510 |
+| Source functions                |  7,511 |
 | — exported (public)             |  2,633 |
-| — unexported (private)          |  4,877 |
-| Unit test functions (`TestXxx`) | 11,683 |
+| — unexported (private)          |  4,878 |
+| Unit test functions (`TestXxx`) | 11,686 |
 | Subtests (`t.Run(...)`)         |  2,931 |
 | End-to-end test functions       |    381 |
 
@@ -438,7 +438,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.54× more tests than code |
 | Average source file length         |                 ~200 lines |
 | Average test file length           |                 ~568 lines |
-| Comment lines in source            |  21,782 (~11.1% of source) |
+| Comment lines in source            |  21,791 (~11.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -470,8 +470,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,563 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,562 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,564 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,565 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -415,19 +415,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       977 |     195,956 |
-| Unit tests (`_test.go`)  |       532 |     302,975 |
+| Source (`.go`, non-test) |       977 |     195,992 |
+| Unit tests (`_test.go`)  |       532 |     302,990 |
 | End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,682** | **543,920** |
+| **Total**                | **1,682** | **543,971** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,507 |
-| — exported (public)             |  2,631 |
-| — unexported (private)          |  4,876 |
-| Unit test functions (`TestXxx`) | 11,681 |
+| Source functions                |  7,509 |
+| — exported (public)             |  2,632 |
+| — unexported (private)          |  4,877 |
+| Unit test functions (`TestXxx`) | 11,683 |
 | Subtests (`t.Run(...)`)         |  2,931 |
 | End-to-end test functions       |    381 |
 
@@ -438,14 +438,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~200 lines |
 | Average test file length           |                 ~569 lines |
-| Comment lines in source            |  21,762 (~11.1% of source) |
+| Comment lines in source            |  21,778 (~11.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,759 |
+| `if err != nil` checks             | 6,761 |
 | `defer` statements                 |   865 |
 | `struct` types defined             | 2,732 |
 | `//nolint` suppressions            |   226 |
@@ -470,7 +470,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,562 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,563 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,562 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/cmd/audit_test_goroutines/main.go
+++ b/cmd/audit_test_goroutines/main.go
@@ -1,0 +1,392 @@
+// Command audit_test_goroutines detects testing.T abort calls made from
+// goroutines other than the one running the test.
+//
+// The testing package documents that FailNow — and therefore t.Fatal and
+// t.Fatalf — must be called from the test goroutine. Inside an HTTP mock
+// handler, a go statement, an errgroup task, or an MCP tool handler, the call
+// instead terminates only that goroutine: the response is truncated or never
+// written, the client observes a transport error, and the test continues
+// against the wreckage. go vet's testinggoroutine analyzer flags bare
+// `go func() { t.Fatal() }()` but cannot see that a function literal passed
+// to http.HandlerFunc or mcp.AddTool crosses a goroutine boundary, which is
+// how these sites accumulate unnoticed.
+//
+// The tool reports every t.Fatal/t.Fatalf/t.FailNow call inside such a
+// literal, classifies each site as category A (the abort is in tail position:
+// nothing else would have run) or category B (the handler still had work to
+// do, so the response is observably truncated), and separately reports
+// t.Error/t.Errorf calls whose enclosing block does not return afterwards —
+// the conversion contract requires an explicit return so a later edit cannot
+// silently reintroduce dead code paths (the defect class behind PR #270's
+// nil-dereference panic).
+//
+// Usage:
+//
+//	go run ./cmd/audit_test_goroutines [-json out.json] [-check] [dirs...]
+//
+// With no directories the module's test files under ./cmd, ./internal, and
+// ./test are scanned. -check exits non-zero when any finding exists, so the
+// tool can gate CI once the sweep lands.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Finding describes one abort or missing-return site inside a non-test
+// goroutine literal.
+type Finding struct {
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Call     string `json:"call"`               // t.Fatal, t.Fatalf, t.FailNow, t.Error, t.Errorf
+	Kind     string `json:"kind"`               // fatal | errorf_no_return
+	Category string `json:"category,omitempty"` // A (tail position) or B (work remained) for fatal sites
+	Boundary string `json:"boundary"`           // what makes the literal run off the test goroutine
+}
+
+// Report is the JSON work list consumed by the conversion batches.
+type Report struct {
+	Fatal          []Finding `json:"fatal"`
+	ErrorfNoReturn []Finding `json:"errorf_no_return"`
+	Summary        Summary   `json:"summary"`
+}
+
+// Summary aggregates the counts the sweep plan tracks.
+type Summary struct {
+	FatalSites     int `json:"fatal_sites"`
+	CategoryA      int `json:"category_a"`
+	CategoryB      int `json:"category_b"`
+	ErrorfNoReturn int `json:"errorf_no_return"`
+	Files          int `json:"files"`
+}
+
+// abortNames are the testing.T methods that call FailNow under the hood.
+var abortNames = map[string]bool{"Fatal": true, "Fatalf": true, "FailNow": true}
+
+// errorNames are the non-aborting assertion methods checked for the
+// missing-return contract.
+var errorNames = map[string]bool{"Error": true, "Errorf": true}
+
+func main() {
+	jsonPath := flag.String("json", "", "write the JSON work list to this path")
+	check := flag.Bool("check", false, "exit non-zero when any finding exists")
+	flag.Parse()
+
+	dirs := flag.Args()
+	if len(dirs) == 0 {
+		dirs = []string{"cmd", "internal", "test"}
+	}
+
+	report, err := scan(dirs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "audit_test_goroutines: %v\n", err)
+		os.Exit(2)
+	}
+
+	printHuman(report)
+
+	if *jsonPath != "" {
+		data, marshalErr := json.MarshalIndent(report, "", "  ")
+		if marshalErr != nil {
+			fmt.Fprintf(os.Stderr, "audit_test_goroutines: marshal: %v\n", marshalErr)
+			os.Exit(2)
+		}
+		if writeErr := os.WriteFile(*jsonPath, append(data, '\n'), 0o600); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "audit_test_goroutines: write %s: %v\n", *jsonPath, writeErr)
+			os.Exit(2)
+		}
+		fmt.Printf("work list written to %s\n", *jsonPath)
+	}
+
+	if *check && (len(report.Fatal) > 0 || len(report.ErrorfNoReturn) > 0) {
+		fmt.Printf("check: FAIL — %d abort site(s) and %d missing-return site(s) off the test goroutine\n",
+			len(report.Fatal), len(report.ErrorfNoReturn))
+		os.Exit(1)
+	}
+	if *check {
+		fmt.Println("check: PASS — no testing.T aborts off the test goroutine")
+	}
+}
+
+// scan walks every _test.go file under dirs and collects findings.
+func scan(dirs []string) (*Report, error) {
+	report := &Report{}
+	files := map[string]bool{}
+	fset := token.NewFileSet()
+
+	for _, dir := range dirs {
+		if walkErr := filepath.WalkDir(dir, collectFindings(fset, report, files)); walkErr != nil {
+			return nil, walkErr
+		}
+	}
+
+	sortFindings(report.Fatal)
+	sortFindings(report.ErrorfNoReturn)
+	report.Summary = Summary{
+		FatalSites:     len(report.Fatal),
+		ErrorfNoReturn: len(report.ErrorfNoReturn),
+		Files:          len(files),
+	}
+	for _, f := range report.Fatal {
+		if f.Category == "A" {
+			report.Summary.CategoryA++
+		} else {
+			report.Summary.CategoryB++
+		}
+	}
+	return report, nil
+}
+
+// collectFindings returns the WalkDir callback that parses each _test.go
+// file and appends its findings to the report.
+func collectFindings(fset *token.FileSet, report *Report, files map[string]bool) fs.WalkDirFunc {
+	return func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == "node_modules" || name == "testdata" || strings.HasPrefix(name, ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		for _, f := range scanFile(fset, path, file) {
+			files[f.File] = true
+			if f.Kind == "fatal" {
+				report.Fatal = append(report.Fatal, f)
+			} else {
+				report.ErrorfNoReturn = append(report.ErrorfNoReturn, f)
+			}
+		}
+		return nil
+	}
+}
+
+// scanFile finds goroutine-boundary literals in one file and audits their
+// bodies.
+func scanFile(fset *token.FileSet, path string, file *ast.File) []Finding {
+	var findings []Finding
+	seen := map[*ast.FuncLit]bool{}
+
+	audit := func(lit *ast.FuncLit, boundary string) {
+		if lit == nil || seen[lit] {
+			return
+		}
+		seen[lit] = true
+		findings = append(findings, auditLiteral(fset, path, lit, boundary)...)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.GoStmt:
+			if lit, ok := node.Call.Fun.(*ast.FuncLit); ok {
+				audit(lit, "go statement")
+			}
+		case *ast.CallExpr:
+			boundary, argIdx := boundaryCall(node)
+			if boundary == "" {
+				return true
+			}
+			if argIdx < len(node.Args) {
+				if lit, ok := node.Args[argIdx].(*ast.FuncLit); ok {
+					audit(lit, boundary)
+				}
+			}
+		case *ast.KeyValueExpr:
+			key, ok := node.Key.(*ast.Ident)
+			if !ok || !strings.HasSuffix(key.Name, "Handler") {
+				return true
+			}
+			if lit, isLit := node.Value.(*ast.FuncLit); isLit {
+				audit(lit, "handler field "+key.Name)
+			}
+		}
+		return true
+	})
+	return findings
+}
+
+// boundaryCall reports whether call hands a function literal to another
+// goroutine, returning a label and the argument index that carries the
+// literal. Conversions like http.HandlerFunc(lit) have the literal at index
+// 0; mux.HandleFunc(pattern, lit) at index 1.
+func boundaryCall(call *ast.CallExpr) (label string, argIndex int) {
+	switch name := calleeName(call.Fun); name {
+	case "HandlerFunc": // the http.HandlerFunc conversion around a literal
+		return "http.HandlerFunc", 0
+	case "HandleFunc": // ServeMux registration: pattern first, literal second
+		return "HandleFunc", 1
+	case "Go": // errgroup.Group.Go and friends
+		return ".Go(...)", 0
+	case "AddTool", "AddResource", "AddResourceTemplate", "AddPrompt":
+		// MCP server registrations: handlers run on the serving session's
+		// goroutine. The handler is the last argument.
+		return "mcp " + name, len(call.Args) - 1
+	case "AddReceivingMiddleware", "AddSendingMiddleware":
+		return "mcp " + name, 0
+	default:
+		return "", 0
+	}
+}
+
+// calleeName extracts the terminal identifier of a call target.
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	case *ast.IndexExpr: // generic instantiation
+		return calleeName(f.X)
+	case *ast.IndexListExpr:
+		return calleeName(f.X)
+	default:
+		return ""
+	}
+}
+
+// auditLiteral reports abort calls and missing-return Errorf calls in the
+// literal's body, including nested literals (they inherit the goroutine).
+func auditLiteral(fset *token.FileSet, path string, lit *ast.FuncLit, boundary string) []Finding {
+	var findings []Finding
+	ast.Inspect(lit.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		recv, ok := sel.X.(*ast.Ident)
+		if !ok || (recv.Name != "t" && recv.Name != "b" && recv.Name != "tb") {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		switch {
+		case abortNames[sel.Sel.Name]:
+			category := "A"
+			if hasWorkAfter(lit, call) {
+				category = "B"
+			}
+			findings = append(findings, Finding{
+				File: path, Line: pos.Line,
+				Call: recv.Name + "." + sel.Sel.Name,
+				Kind: "fatal", Category: category, Boundary: boundary,
+			})
+		case errorNames[sel.Sel.Name]:
+			if !returnsAfter(lit, call) {
+				findings = append(findings, Finding{
+					File: path, Line: pos.Line,
+					Call: recv.Name + "." + sel.Sel.Name,
+					Kind: "errorf_no_return", Boundary: boundary,
+				})
+			}
+		}
+		return true
+	})
+	return findings
+}
+
+// hasWorkAfter reports whether any statement in the literal begins after the
+// call ends — category B: the abort truncates work the handler still owed.
+func hasWorkAfter(lit *ast.FuncLit, call *ast.CallExpr) bool {
+	work := false
+	ast.Inspect(lit.Body, func(n ast.Node) bool {
+		if work || n == nil {
+			return false
+		}
+		if stmt, ok := n.(ast.Stmt); ok && stmt.Pos() > call.End() {
+			work = true
+			return false
+		}
+		return true
+	})
+	return work
+}
+
+// returnsAfter reports whether the statement list that DIRECTLY contains the
+// call has an explicit return after it — the contract's rule 2. Only the
+// innermost block matters: a compliant guard is `t.Errorf; respond; return`
+// inside its own if-body, regardless of what the outer block does next.
+func returnsAfter(lit *ast.FuncLit, call *ast.CallExpr) bool {
+	found := false
+	ast.Inspect(lit.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		block, ok := n.(*ast.BlockStmt)
+		if !ok {
+			return true
+		}
+		for i, stmt := range block.List {
+			expr, isExpr := stmt.(*ast.ExprStmt)
+			if !isExpr || expr.X != ast.Expr(call) {
+				continue
+			}
+			for _, later := range block.List[i+1:] {
+				if _, isReturn := later.(*ast.ReturnStmt); isReturn {
+					found = true
+					break
+				}
+			}
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// sortFindings orders findings by file then line for stable output.
+func sortFindings(findings []Finding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		return findings[i].Line < findings[j].Line
+	})
+}
+
+// printHuman writes the per-file tallies and the summary.
+func printHuman(report *Report) {
+	perFile := map[string][2]int{}
+	for _, f := range report.Fatal {
+		c := perFile[f.File]
+		c[0]++
+		perFile[f.File] = c
+	}
+	for _, f := range report.ErrorfNoReturn {
+		c := perFile[f.File]
+		c[1]++
+		perFile[f.File] = c
+	}
+	files := make([]string, 0, len(perFile))
+	for f := range perFile {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		c := perFile[f]
+		fmt.Printf("%-72s fatal=%-3d errorf_no_return=%d\n", f, c[0], c[1])
+	}
+	fmt.Printf("\nsummary: %d fatal sites (A=%d tail-position, B=%d truncating) + %d errorf-without-return across %d files\n",
+		report.Summary.FatalSites, report.Summary.CategoryA, report.Summary.CategoryB,
+		report.Summary.ErrorfNoReturn, report.Summary.Files)
+}

--- a/cmd/audit_test_goroutines/main.go
+++ b/cmd/audit_test_goroutines/main.go
@@ -79,7 +79,7 @@ var errorNames = map[string]bool{"Error": true, "Errorf": true}
 
 func main() {
 	jsonPath := flag.String("json", "", "write the JSON work list to this path")
-	check := flag.Bool("check", false, "exit non-zero when any finding exists")
+	check := flag.Bool("check", false, "exit non-zero when any abort (Fatal/FailNow) site exists; errorf sites stay advisory")
 	flag.Parse()
 
 	dirs := flag.Args()
@@ -108,13 +108,20 @@ func main() {
 		fmt.Printf("work list written to %s\n", *jsonPath)
 	}
 
-	if *check && (len(report.Fatal) > 0 || len(report.ErrorfNoReturn) > 0) {
-		fmt.Printf("check: FAIL — %d abort site(s) and %d missing-return site(s) off the test goroutine\n",
+	// Pilot amendment (2026-08-17): only abort sites gate. The
+	// errorf-without-return list stays advisory — the sweep found that most
+	// of those sites are the legitimate assert-then-respond shape, where the
+	// handler still writes its canned response and no invalid state is used;
+	// rule 2 of the contract applies to converted Fatal guards, which review
+	// and the testutil helpers cover.
+	if *check && len(report.Fatal) > 0 {
+		fmt.Printf("check: FAIL — %d abort site(s) off the test goroutine (%d advisory errorf sites not gated)\n",
 			len(report.Fatal), len(report.ErrorfNoReturn))
 		os.Exit(1)
 	}
 	if *check {
-		fmt.Println("check: PASS — no testing.T aborts off the test goroutine")
+		fmt.Printf("check: PASS — no testing.T aborts off the test goroutine (%d advisory errorf site(s))\n",
+			len(report.ErrorfNoReturn))
 	}
 }
 
@@ -386,7 +393,7 @@ func printHuman(report *Report) {
 		c := perFile[f]
 		fmt.Printf("%-72s fatal=%-3d errorf_no_return=%d\n", f, c[0], c[1])
 	}
-	fmt.Printf("\nsummary: %d fatal sites (A=%d tail-position, B=%d truncating) + %d errorf-without-return across %d files\n",
+	fmt.Printf("\nsummary: %d fatal sites (A=%d tail-position, B=%d truncating) + %d advisory errorf-without-return across %d files\n",
 		report.Summary.FatalSites, report.Summary.CategoryA, report.Summary.CategoryB,
 		report.Summary.ErrorfNoReturn, report.Summary.Files)
 }

--- a/cmd/audit_test_goroutines/main_test.go
+++ b/cmd/audit_test_goroutines/main_test.go
@@ -1,0 +1,144 @@
+// Package main tests the goroutine-boundary assertion auditor against a
+// fixture file covering every boundary kind and both site categories.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fixtureSource exercises: category A and B t.Fatal sites in an HTTP handler,
+// a compliant t.Errorf (return follows), a violating t.Errorf (no return), a
+// go-statement abort, an errgroup-style .Go abort, a handler struct field,
+// and — as negatives — aborts on the test goroutine plus a helper literal
+// that never leaves it.
+const fixtureSource = `package fixture
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFixture(t *testing.T) {
+	_ = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("category B: handler still writes below") // fatal, B
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	_ = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("category A: tail position") // fatal, A
+	})
+
+	_ = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bad" {
+			t.Errorf("compliant: returns after") // no finding
+			http.Error(w, "bad", http.StatusInternalServerError)
+			return
+		}
+		t.Errorf("violating: nothing returns after this") // errorf_no_return
+	})
+
+	go func() {
+		t.Fatal("go statement abort") // fatal, A
+	}()
+
+	var g interface{ Go(func() error) }
+	g.Go(func() error {
+		t.FailNow() // fatal, B (return follows in source order)
+		return nil
+	})
+
+	_ = struct{ ElicitationHandler func() }{
+		ElicitationHandler: func() {
+			t.Fatal("handler field abort") // fatal, A
+		},
+	}
+
+	// Negatives: test-goroutine aborts must not be flagged.
+	t.Fatal("on the test goroutine")
+}
+
+func helperOnTestGoroutine(t *testing.T) {
+	check := func() {
+		t.Fatal("plain literal, never crosses a goroutine boundary") // not flagged
+	}
+	check()
+}
+`
+
+// TestScan_FixtureClassification verifies the scanner finds exactly the
+// planted sites, classifies A/B correctly, honors the compliant
+// errorf-then-return shape, and ignores test-goroutine aborts.
+func TestScan_FixtureClassification(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "fixture_test.go"), []byte(fixtureSource), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	report, err := scan([]string{dir})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if got, want := report.Summary.FatalSites, 5; got != want {
+		t.Errorf("fatal sites = %d, want %d: %+v", got, want, report.Fatal)
+	}
+	if got, want := report.Summary.CategoryA, 3; got != want {
+		t.Errorf("category A = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.CategoryB, 2; got != want {
+		t.Errorf("category B = %d, want %d", got, want)
+	}
+	if got, want := report.Summary.ErrorfNoReturn, 1; got != want {
+		t.Errorf("errorf_no_return = %d, want %d: %+v", got, want, report.ErrorfNoReturn)
+	}
+
+	boundaries := map[string]bool{}
+	for _, f := range report.Fatal {
+		boundaries[f.Boundary] = true
+	}
+	for _, want := range []string{"http.HandlerFunc", "go statement", ".Go(...)", "handler field ElicitationHandler"} {
+		if !boundaries[want] {
+			t.Errorf("missing boundary kind %q in %v", want, boundaries)
+		}
+	}
+}
+
+// TestScan_CleanFileHasNoFindings verifies a file whose handlers follow the
+// contract produces an empty report.
+func TestScan_CleanFileHasNoFindings(t *testing.T) {
+	clean := `package fixture
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClean(t *testing.T) {
+	_ = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("wrong method")
+			http.Error(w, "wrong method", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	t.Fatal("test goroutine aborts stay legal")
+}
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "clean_test.go"), []byte(clean), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	report, err := scan([]string{dir})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if report.Summary.FatalSites != 0 || report.Summary.ErrorfNoReturn != 0 {
+		t.Fatalf("clean file produced findings: %+v", report.Summary)
+	}
+}

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -420,6 +420,37 @@ go run ./cmd/godoc_tool/ fix ./internal/tools/branches/
 
 Replaces the former `audit_godocs` and `add_docs` binaries. The full rules taxonomy (package comments, exported-symbol conventions, test-function comments, and the common package-comment pitfall) is documented in [godoc.md](godoc.md).
 
+### audit_test_goroutines
+
+Scans `_test.go` files for `testing.T` aborts (`t.Fatal`, `t.Fatalf`, `t.FailNow`) made inside function literals that cross a goroutine boundary (`http.HandlerFunc`, `HandleFunc`, `go` statements, `errgroup.Go`, MCP `AddTool` handlers, middleware, handler struct fields). Classifies each site as category A (tail position) or B (handler still had work to do), and also reports advisory `t.Errorf` sites not followed by `return`. Enforces the contract in `.github/instructions/test-goroutines.instructions.md`.
+
+#### Usage
+
+```bash
+# Human-readable report over the default roots (cmd, internal, test)
+go run ./cmd/audit_test_goroutines/
+
+# JSON work list + CI gate
+go run ./cmd/audit_test_goroutines/ -json plan/test-goroutines-backlog.json
+go run ./cmd/audit_test_goroutines/ --check
+```
+
+#### Flags
+
+| Flag      | Type   | Default | Description                                                                    |
+| --------- | ------ | ------- | ------------------------------------------------------------------------------ |
+| `-json`   | string | _(off)_ | Write the JSON work list to this path                                          |
+| `--check` | bool   | `false` | Exit non-zero when any abort site exists; errorf-without-return stays advisory |
+
+#### Output
+
+Human report to stdout (per-site `file:line [category] boundary`), summary line, and optionally the JSON work list (`fatal`, `errorf_no_return`, `summary`).
+
+#### Make targets
+
+- `make audit-test-goroutines` — writes `plan/test-goroutines-backlog.json`.
+- `make check-test-goroutines` — CI gate; also step [6/6] of `make analyze`.
+
 ### audit_test_names
 
 Scans Go `_test.go` files and classifies `Test*` functions by naming pattern (3-part / 2-part / no-underscore / TestCov / skip), then emits rename suggestions.

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -93,28 +93,30 @@ gotestsum --version
 
 ### Combined Targets
 
-| Target                | Description                                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `make analyze`        | Run `golangci-lint config verify`, `golangci-lint fmt --diff`, `golangci-lint run`, `govulncheck`, and `markdownlint` |
-| `make analyze-fix`    | Apply auto-fixes with `golangci-lint fmt`, `golangci-lint run --fix`, and `markdownlint --fix`                        |
-| `make analyze-report` | Generate a combined Markdown report at `dist/analysis/report.txt`                                                     |
-| `make lint`           | Backward-compatible alias for `make golangci-lint`                                                                    |
+| Target                | Description                                                                                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `make analyze`        | Run `golangci-lint config verify`, `golangci-lint fmt --diff`, `golangci-lint run`, `govulncheck`, `markdownlint`, and the test-goroutine abort gate |
+| `make analyze-fix`    | Apply auto-fixes with `golangci-lint fmt`, `golangci-lint run --fix`, and `markdownlint --fix`                                                       |
+| `make analyze-report` | Generate a combined Markdown report at `dist/analysis/report.txt`                                                                                    |
+| `make lint`           | Backward-compatible alias for `make golangci-lint`                                                                                                   |
 
 ### Project Audit Targets
 
 > Full CLI reference (flags, usage, output formats): [cmd-utilities.md](cmd-utilities.md)
 
-| Target                       | Description                                                                                      |
-| ---------------------------- | ------------------------------------------------------------------------------------------------ |
-| `make audit-surface-quality` | Consolidated MCP surface audit (metadata + output quality)                                       |
-| `make audit-tokens`          | Measure exposed tool token overhead (`--compare-schemas` for meta-tool sizing spike)             |
-| `make audit-metrics`         | Report MCP tool/resource/prompt counts                                                           |
-| `make audit-1to1`            | Consolidated 1:1 SDK↔API parity audit (struct/action/metadata + merged backlog)                  |
-| `make audit-catalog-first`   | Generate ActionSpec surface coverage inventory in `dist/action-spec-coverage.json`               |
-| `make audit-dynamic-aliases` | Audit Dynamic search aliases and canonical action reachability                                   |
-| `make audit-test-names`      | Audit test function naming convention compliance                                                 |
-| `make audit-godocs`          | Generate `dist/analysis/godoc.md` with package, exported symbol, and test documentation findings |
-| `make audit-godocs-check`    | Run the same Godoc audit and fail if findings remain                                             |
+| Target                       | Description                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `make audit-surface-quality` | Consolidated MCP surface audit (metadata + output quality)                                         |
+| `make audit-tokens`          | Measure exposed tool token overhead (`--compare-schemas` for meta-tool sizing spike)               |
+| `make audit-metrics`         | Report MCP tool/resource/prompt counts                                                             |
+| `make audit-1to1`            | Consolidated 1:1 SDK↔API parity audit (struct/action/metadata + merged backlog)                    |
+| `make audit-catalog-first`   | Generate ActionSpec surface coverage inventory in `dist/action-spec-coverage.json`                 |
+| `make audit-dynamic-aliases` | Audit Dynamic search aliases and canonical action reachability                                     |
+| `make audit-test-names`      | Audit test function naming convention compliance                                                   |
+| `make audit-test-goroutines` | Report `testing.T` aborts (`t.Fatal`/`FailNow`) made off the test goroutine, with a JSON work list |
+| `make check-test-goroutines` | Fail when any off-goroutine abort site remains (errorf-without-return stays advisory)              |
+| `make audit-godocs`          | Generate `dist/analysis/godoc.md` with package, exported symbol, and test documentation findings   |
+| `make audit-godocs-check`    | Run the same Godoc audit and fail if findings remain                                               |
 
 ## Tool Details
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,044 |
-| Unit test functions                                   | 11,667 |
+| Total test functions                                  | 12,046 |
+| Unit test functions                                   | 11,669 |
 | E2E test functions                                    |    377 |
 | cmd test functions                                    |    959 |
 | Test files (internal/)                                |    462 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,555 | 87.6% |
+| `TestFunc_Scenario` (2-part)           | 10,557 | 87.6% |
 | `TestFunc` (no underscore)             |    963 |  8.0% |
 | `TestFunc_Scenario_Expected` (3+ part) |    526 |  4.4% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,075 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,077 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,348 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        170 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            959 |         70 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,044** |    **702** |                                                                                                 |
+| **Total**               |     **12,046** |    **702** |                                                                                                 |
 
 ### Core Packages
 
@@ -71,10 +71,10 @@
 | prompts      |       261 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
-| testutil     |        29 |    85.3% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
+| testutil     |        31 |    85.4% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil     |       704 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,075** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,077** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -351,7 +351,7 @@
 | prompts      |   100.0% |
 | resources    |   100.0% |
 | serverpool   |    99.6% |
-| testutil     |    85.3% |
+| testutil     |    85.4% |
 | toolutil     |    98.3% |
 | wizard       |   100.0% |
 
@@ -562,8 +562,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_doc_coverage** (81.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/mcpsurface** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **elicitation** (85.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
-- **testutil** (85.3%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **testutil** (85.4%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,24 +18,24 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,042 |
-| Unit test functions                                   | 11,665 |
+| Total test functions                                  | 12,044 |
+| Unit test functions                                   | 11,667 |
 | E2E test functions                                    |    377 |
-| cmd test functions                                    |    957 |
+| cmd test functions                                    |    959 |
 | Test files (internal/)                                |    462 |
-| Test files (cmd/)                                     |     69 |
+| Test files (cmd/)                                     |     70 |
 | Test files (test/e2e/suite/)                          |    170 |
 | Tool sub-packages tested                              |    175 |
 | Core packages tested                                  |     18 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  91.1% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  91.0% |
 | Overall coverage (`go test ./internal/...`)           |  94.8% |
-| Average package coverage                              |  95.2% |
+| Average package coverage                              |  95.1% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,553 | 87.6% |
+| `TestFunc_Scenario` (2-part)           | 10,555 | 87.6% |
 | `TestFunc` (no underscore)             |    963 |  8.0% |
 | `TestFunc_Scenario_Expected` (3+ part) |    526 |  4.4% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            285 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,348 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        170 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |            957 |         69 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,042** |    **701** |                                                                                                 |
+| cmd packages            |            959 |         70 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,044** |    **702** |                                                                                                 |
 
 ### Core Packages
 
@@ -312,6 +312,7 @@
 | cmd/audit_metrics                              |    52.4% |
 | cmd/audit_string_dupes                         |    90.7% |
 | cmd/audit_surface_quality                      |    71.8% |
+| cmd/audit_test_goroutines                      |    65.6% |
 | cmd/audit_test_names                           |    48.1% |
 | cmd/audit_tokens                               |    59.2% |
 | cmd/eval_mcp_surfaces/internal/evalrun         |    88.9% |
@@ -549,6 +550,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_metrics** (52.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/godoc_tool** (58.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_tokens** (59.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_test_goroutines** (65.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/metadata** (69.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evaluator** (69.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_surface_quality** (71.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,046 |
-| Unit test functions                                   | 11,669 |
+| Total test functions                                  | 12,049 |
+| Unit test functions                                   | 11,672 |
 | E2E test functions                                    |    377 |
 | cmd test functions                                    |    959 |
 | Test files (internal/)                                |    462 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,557 | 87.6% |
+| `TestFunc_Scenario` (2-part)           | 10,560 | 87.6% |
 | `TestFunc` (no underscore)             |    963 |  8.0% |
 | `TestFunc_Scenario_Expected` (3+ part) |    526 |  4.4% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,077 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,080 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,348 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        170 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            959 |         70 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,046** |    **702** |                                                                                                 |
+| **Total**               |     **12,049** |    **702** |                                                                                                 |
 
 ### Core Packages
 
@@ -71,10 +71,10 @@
 | prompts      |       261 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources    |       182 |   100.0% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool   |        47 |    99.6% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
-| testutil     |        31 |    85.4% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
+| testutil     |        34 |    86.5% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil     |       704 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard       |       327 |   100.0% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal** | **2,077** |          |                                                                                                                                                                                                                   |
+| **Subtotal** | **2,080** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -351,7 +351,7 @@
 | prompts      |   100.0% |
 | resources    |   100.0% |
 | serverpool   |    99.6% |
-| testutil     |    85.4% |
+| testutil     |    86.5% |
 | toolutil     |    98.3% |
 | wizard       |   100.0% |
 
@@ -563,7 +563,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/internal/mcpsurface** (81.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **elicitation** (85.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_1to1/internal/merge** (85.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **testutil** (85.4%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
+- **testutil** (86.5%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/gen_docker_tools** (86.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/internal/apidocs** (86.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
 )
 
 // Test endpoint paths and reusable format strings shared across prompt tests.
@@ -1830,9 +1831,7 @@ func TestMRRiskAssessmentPrompt_APIError(t *testing.T) {
 // summarize_pipeline_status prompt returns an error when the project_id
 // argument is empty.
 func TestSummarizePipelineStatusPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      promptSummarizePipelineStatus,
@@ -1847,9 +1846,7 @@ func TestSummarizePipelineStatusPrompt_MissingArgs(t *testing.T) {
 // suggest_mr_reviewers prompt returns an error when the project_id argument
 // is empty.
 func TestSuggestMRReviewersPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "suggest_mr_reviewers",
@@ -1864,9 +1861,7 @@ func TestSuggestMRReviewersPrompt_MissingArgs(t *testing.T) {
 // generate_release_notes prompt returns an error when the project_id
 // argument is empty.
 func TestGenerateReleaseNotesPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "generate_release_notes",
@@ -1881,9 +1876,7 @@ func TestGenerateReleaseNotesPrompt_MissingArgs(t *testing.T) {
 // summarize_open_mrs prompt returns an error when the project_id argument
 // is empty.
 func TestSummarizeOpenMRsPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "summarize_open_mrs",
@@ -1898,9 +1891,7 @@ func TestSummarizeOpenMRsPrompt_MissingArgs(t *testing.T) {
 // project_health_check prompt returns an error when the project_id argument
 // is empty.
 func TestProjectHealthCheckPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "project_health_check",
@@ -1914,9 +1905,7 @@ func TestProjectHealthCheckPrompt_MissingArgs(t *testing.T) {
 // TestCompareBranchesPrompt_MissingArgs verifies that the compare_branches
 // prompt returns an error when the required from argument is empty.
 func TestCompareBranchesPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "compare_branches",
@@ -1930,9 +1919,7 @@ func TestCompareBranchesPrompt_MissingArgs(t *testing.T) {
 // TestDailyStandupPrompt_MissingArgs verifies that the daily_standup prompt
 // returns an error when the project_id argument is empty.
 func TestDailyStandupPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "daily_standup",
@@ -1947,9 +1934,7 @@ func TestDailyStandupPrompt_MissingArgs(t *testing.T) {
 // mr_risk_assessment prompt returns an error when the project_id argument
 // is empty.
 func TestMRRiskAssessmentPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "mr_risk_assessment",
@@ -2076,9 +2061,7 @@ func TestSummarizePipeline_StatusPromptJobStatusBranches(t *testing.T) {
 // TestReviewMRPrompt_MissingArgs verifies that the review_mr prompt returns
 // an error when the project_id argument is empty.
 func TestReviewMRPrompt_MissingArgs(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(msgHandlerNoCallMissingArgs)
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
 		Name:      "review_mr",

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
 )
 
 // Shared format strings and URI prefix constants used across resource tests.
@@ -1803,9 +1804,7 @@ func TestProjectBranchesResource_APIError(t *testing.T) {
 // TestProjectResource_EmptyID verifies that the project resource returns an
 // error when the URI has an empty project identifier (gitlab://project/).
 func TestProjectResource_EmptyID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/"})
 	if err == nil {
@@ -1816,9 +1815,7 @@ func TestProjectResource_EmptyID(t *testing.T) {
 // TestLatestPipelineResource_EmptyProjectID verifies that the latest_pipeline
 // resource returns an error when the project ID segment is empty.
 func TestLatestPipelineResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//pipelines/latest"})
 	if err == nil {
@@ -1829,9 +1826,7 @@ func TestLatestPipelineResource_EmptyProjectID(t *testing.T) {
 // TestGroupResource_EmptyID verifies that the group resource returns an error
 // when the URI has an empty group identifier (gitlab://group/).
 func TestGroupResource_EmptyID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for empty group ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://group/"})
 	if err == nil {
@@ -1842,9 +1837,7 @@ func TestGroupResource_EmptyID(t *testing.T) {
 // TestPipelineResource_InvalidPipelineID verifies that the pipeline resource
 // returns an error when the pipeline ID in the URI is not a valid number.
 func TestPipelineResource_InvalidPipelineID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for invalid pipeline ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/pipeline/abc"})
 	if err == nil {
@@ -1855,9 +1848,7 @@ func TestPipelineResource_InvalidPipelineID(t *testing.T) {
 // TestPipelineJobsResource_InvalidPipelineID verifies that the pipeline_jobs
 // resource returns an error when the pipeline ID in the URI is non-numeric.
 func TestPipelineJobsResource_InvalidPipelineID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for invalid pipeline ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/pipeline/abc/jobs"})
 	if err == nil {
@@ -1868,9 +1859,7 @@ func TestPipelineJobsResource_InvalidPipelineID(t *testing.T) {
 // TestMergeRequestResource_InvalidMRIID verifies that the merge_request
 // resource returns an error when the MR IID in the URI is non-numeric.
 func TestMergeRequestResource_InvalidMRIID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("handler should not be called for invalid MR IID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project/42/mr/abc"})
 	if err == nil {
@@ -1941,9 +1930,7 @@ func TestExtractTwoParts_EmptySecondPart(t *testing.T) {
 
 // TestProjectMembersResource_EmptyProjectID verifies that ProjectMembersResource returns a validation error when project_id is empty.
 func TestProjectMembersResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//members"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in members URI")
@@ -1952,9 +1939,7 @@ func TestProjectMembersResource_EmptyProjectID(t *testing.T) {
 
 // TestProjectLabelsResource_EmptyProjectID verifies that ProjectLabelsResource returns a validation error when project_id is empty.
 func TestProjectLabelsResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//labels"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in labels URI")
@@ -1963,9 +1948,7 @@ func TestProjectLabelsResource_EmptyProjectID(t *testing.T) {
 
 // TestProjectMilestonesResource_EmptyProjectID verifies that ProjectMilestonesResource returns a validation error when project_id is empty.
 func TestProjectMilestonesResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//milestones"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in milestones URI")
@@ -1974,9 +1957,7 @@ func TestProjectMilestonesResource_EmptyProjectID(t *testing.T) {
 
 // TestProjectBranchesResource_EmptyProjectID verifies that ProjectBranchesResource returns a validation error when project_id is empty.
 func TestProjectBranchesResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//branches"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in branches URI")
@@ -1985,9 +1966,7 @@ func TestProjectBranchesResource_EmptyProjectID(t *testing.T) {
 
 // TestGroupMembersResource_EmptyGroupID verifies that GroupMembersResource returns a validation error when group_id is empty.
 func TestGroupMembersResource_EmptyGroupID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty group ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://group//members"})
 	if err == nil {
 		t.Fatal("expected error for empty group ID in members URI")
@@ -1996,9 +1975,7 @@ func TestGroupMembersResource_EmptyGroupID(t *testing.T) {
 
 // TestGroupProjectsResource_EmptyGroupID verifies that GroupProjectsResource returns a validation error when group_id is empty.
 func TestGroupProjectsResource_EmptyGroupID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty group ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://group//projects"})
 	if err == nil {
 		t.Fatal("expected error for empty group ID in projects URI")
@@ -2007,9 +1984,7 @@ func TestGroupProjectsResource_EmptyGroupID(t *testing.T) {
 
 // TestProjectIssuesResource_EmptyProjectID verifies that ProjectIssuesResource returns a validation error when project_id is empty.
 func TestProjectIssuesResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//issues"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in issues URI")
@@ -2018,9 +1993,7 @@ func TestProjectIssuesResource_EmptyProjectID(t *testing.T) {
 
 // TestIssueResource_EmptyProjectID verifies that IssueResource returns a validation error when project_id is empty.
 func TestIssueResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//issue/1"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in issue URI")
@@ -2029,9 +2002,7 @@ func TestIssueResource_EmptyProjectID(t *testing.T) {
 
 // TestProjectReleasesResource_EmptyProjectID verifies that ProjectReleasesResource returns a validation error when project_id is empty.
 func TestProjectReleasesResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//releases"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in releases URI")
@@ -2040,9 +2011,7 @@ func TestProjectReleasesResource_EmptyProjectID(t *testing.T) {
 
 // TestProjectTagsResource_EmptyProjectID verifies that ProjectTagsResource returns a validation error when project_id is empty.
 func TestProjectTagsResource_EmptyProjectID(t *testing.T) {
-	session := newMCPSession(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not call API for empty project ID")
-	}))
+	session := newMCPSession(t, testutil.ForbiddenHandler(t))
 	_, err := session.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: "gitlab://project//tags"})
 	if err == nil {
 		t.Fatal("expected error for empty project ID in tags URI")

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -128,11 +128,11 @@ func AssertQueryParam(t *testing.T, r *http.Request, key, expected string) {
 //
 // The returned client is safe for concurrent use; the httptest.Server that
 // backs it is goroutine-safe by construction.
-func NewTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
-	t.Helper()
+func NewTestClient(tb testing.TB, handler http.Handler) *gitlabclient.Client {
+	tb.Helper()
 
 	srv := httptest.NewServer(handler)
-	t.Cleanup(srv.Close)
+	tb.Cleanup(srv.Close)
 
 	cfg := &config.Config{
 		GitLabURL:      srv.URL,
@@ -141,13 +141,19 @@ func NewTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
 		DisableRetries: true,
 	}
 
-	client, err := gitlabclient.NewClient(cfg)
+	client, err := newGitLabClient(cfg)
 	if err != nil {
-		t.Fatalf("failed to create test gitlab client: %v", err)
+		tb.Fatalf("failed to create test gitlab client: %v", err)
 	}
 
 	return client
 }
+
+// newGitLabClient is the client constructor used by [NewTestClient]. It is a
+// package variable so the construction-failure branch is testable: srv.URL is
+// always a valid base URL, so [gitlabclient.NewClient] cannot be made to fail
+// from outside.
+var newGitLabClient = gitlabclient.NewClient
 
 // RespondJSON writes a JSON response with the given HTTP status and raw body.
 // It sets Content-Type to "application/json". body is written verbatim —
@@ -210,12 +216,23 @@ func RespondJSONWithPagination(w http.ResponseWriter, status int, body string, p
 func ForbiddenHandler(t *testing.T) http.Handler {
 	t.Helper()
 	var hits atomic.Int64
-	t.Cleanup(func() {
-		if n := hits.Load(); n != 0 {
-			t.Errorf("mock API was called %d time(s); the test forbids any request", n)
-		}
-	})
+	t.Cleanup(func() { reportForbiddenHits(t, hits.Load()) })
 	return forbiddenHandlerCore(&hits)
+}
+
+// errorReporter is the subset of [testing.TB] that reportForbiddenHits needs,
+// kept as an interface so the non-zero branch is testable with a recorder
+// instead of failing the calling test.
+type errorReporter interface {
+	Errorf(format string, args ...any)
+}
+
+// reportForbiddenHits fails the test when a [ForbiddenHandler] mock received
+// any request. Zero hits is the expected quiet path.
+func reportForbiddenHits(r errorReporter, n int64) {
+	if n != 0 {
+		r.Errorf("mock API was called %d time(s); the test forbids any request", n)
+	}
 }
 
 // forbiddenHandlerCore is the response half of [ForbiddenHandler], split out

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -39,6 +39,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
@@ -197,4 +198,32 @@ func RespondJSONWithPagination(w http.ResponseWriter, status int, body string, p
 	}
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(body))
+}
+
+// ForbiddenHandler returns an [http.Handler] for mocks that must never be
+// called. Each request is counted atomically and answered with a
+// deterministic 500 so the client under test fails loudly, and a
+// [testing.T.Cleanup] hook asserts on the test goroutine that no request
+// arrived. This is the sanctioned replacement for `t.Fatal("should not be
+// called")` inside handler literals, which the testing package forbids off
+// the test goroutine (see .github/instructions/test-goroutines.instructions.md).
+func ForbiddenHandler(t *testing.T) http.Handler {
+	t.Helper()
+	var hits atomic.Int64
+	t.Cleanup(func() {
+		if n := hits.Load(); n != 0 {
+			t.Errorf("mock API was called %d time(s); the test forbids any request", n)
+		}
+	})
+	return forbiddenHandlerCore(&hits)
+}
+
+// forbiddenHandlerCore is the response half of [ForbiddenHandler], split out
+// so tests can exercise the counting and the deterministic 500 without
+// arming the cleanup assertion.
+func forbiddenHandlerCore(hits *atomic.Int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Error(w, "unexpected call: "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+	})
 }

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -7,6 +7,8 @@ package testutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -14,6 +16,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 )
 
 // TestCancelledCtx verifies that [CancelledCtx] returns a context whose
@@ -284,5 +289,78 @@ func TestForbiddenHandlerCore_CountsAndRespondsWithError(t *testing.T) {
 	}
 	if n := hits.Load(); n != 1 {
 		t.Errorf("hits = %d, want 1", n)
+	}
+}
+
+// errorfRecorder records Errorf calls for asserting on failure-path helpers
+// without failing the running test.
+type errorfRecorder struct {
+	messages []string
+}
+
+// Errorf implements the errorReporter seam by recording the formatted message.
+func (r *errorfRecorder) Errorf(format string, args ...any) {
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+}
+
+// TestReportForbiddenHits_NonZeroFails verifies the failure branch: a non-zero
+// hit count must produce exactly one Errorf naming the count.
+func TestReportForbiddenHits_NonZeroFails(t *testing.T) {
+	rec := &errorfRecorder{}
+	reportForbiddenHits(rec, 3)
+	if len(rec.messages) != 1 {
+		t.Fatalf("Errorf calls = %d, want 1", len(rec.messages))
+	}
+	if !strings.Contains(rec.messages[0], "3 time(s)") {
+		t.Errorf("message = %q, want the hit count named", rec.messages[0])
+	}
+}
+
+// TestReportForbiddenHits_ZeroIsQuiet verifies the expected path: zero hits
+// must not report anything.
+func TestReportForbiddenHits_ZeroIsQuiet(t *testing.T) {
+	rec := &errorfRecorder{}
+	reportForbiddenHits(rec, 0)
+	if len(rec.messages) != 0 {
+		t.Fatalf("Errorf calls = %d, want 0: %v", len(rec.messages), rec.messages)
+	}
+}
+
+// fatalRecorder embeds a real testing.TB and overrides Fatalf so the
+// construction-failure branch of NewTestClient can be observed instead of
+// aborting the running test.
+type fatalRecorder struct {
+	testing.TB
+	fatals []string
+}
+
+// Fatalf implements the override by recording the formatted message and
+// returning, unlike the real implementation which never returns.
+func (r *fatalRecorder) Fatalf(format string, args ...any) {
+	r.fatals = append(r.fatals, fmt.Sprintf(format, args...))
+}
+
+// TestNewTestClient_ConstructionFailureFatals verifies that NewTestClient
+// reports a fatal error when the underlying GitLab client constructor fails.
+// The constructor seam is stubbed because a live httptest URL can never make
+// the real constructor fail.
+func TestNewTestClient_ConstructionFailureFatals(t *testing.T) {
+	orig := newGitLabClient
+	newGitLabClient = func(*config.Config) (*gitlabclient.Client, error) {
+		return nil, errors.New("boom")
+	}
+	t.Cleanup(func() { newGitLabClient = orig })
+
+	rec := &fatalRecorder{TB: t}
+	client := NewTestClient(rec, http.NotFoundHandler())
+
+	if len(rec.fatals) != 1 {
+		t.Fatalf("Fatalf calls = %d, want 1: %v", len(rec.fatals), rec.fatals)
+	}
+	if !strings.Contains(rec.fatals[0], "boom") {
+		t.Errorf("fatal message = %q, want the constructor error named", rec.fatals[0])
+	}
+	if client != nil {
+		t.Errorf("client = %v, want nil after recorded fatal", client)
 	}
 }

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -7,10 +7,12 @@ package testutil
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -245,5 +247,42 @@ func TestRespondJSONWithPagination_PartialHeaders(t *testing.T) {
 		if got := w.Header().Get(header); got != "" {
 			t.Errorf("header %s = %q, want empty (not set)", header, got)
 		}
+	}
+}
+
+// TestForbiddenHandler_NoCallsPasses verifies the zero-request path: arming
+// the handler without driving any request must leave the test green when the
+// cleanup assertion runs.
+func TestForbiddenHandler_NoCallsPasses(t *testing.T) {
+	_ = ForbiddenHandler(t)
+}
+
+// TestForbiddenHandlerCore_CountsAndRespondsWithError verifies the response
+// half: each request increments the counter and receives a deterministic 500
+// naming the unexpected method and path.
+func TestForbiddenHandlerCore_CountsAndRespondsWithError(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(forbiddenHandlerCore(&hits))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/should/not/happen", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "GET /should/not/happen") {
+		t.Errorf("body = %q, want the unexpected method and path named", body)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("hits = %d, want 1", n)
 	}
 }

--- a/internal/tools/action_specs_test.go
+++ b/internal/tools/action_specs_test.go
@@ -209,7 +209,8 @@ func surfacePolicyTestSpec(t *testing.T) (toolutil.ActionSpec, *bool) {
 		Handler: func(_ context.Context, params map[string]any) (any, error) {
 			handlerCalled = true
 			if params["project_id"] != "123" {
-				t.Fatalf("handler project_id = %v, want 123", params["project_id"])
+				t.Errorf("handler project_id = %v, want 123", params["project_id"])
+				return nil, fmt.Errorf("unexpected project_id %v", params["project_id"])
 			}
 			return map[string]any{"ok": true}, nil
 		},

--- a/internal/tools/applications/applications_test.go
+++ b/internal/tools/applications/applications_test.go
@@ -13,29 +13,19 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
-// fmtUnexpPath identifies the fmt unexp path constant used by this package.
-const fmtUnexpPath = "unexpected path: %s"
-
 // errExpectedNil identifies the err expected nil constant used by this package.
 const errExpectedNil = "expected error, got nil"
 
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 
-// fmtUnexpMethod identifies the fmt unexp method constant used by this package.
-const fmtUnexpMethod = "unexpected method: %s"
-
 // TestList verifies the List handler.
 // The mock GitLab API at /api/v4/applications (GET) responds with HTTP OK.
 // It asserts the returned output matches the expected fields.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/applications" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodGet {
-			t.Fatalf(fmtUnexpMethod, r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/applications")
+		testutil.AssertRequestMethod(t, r, http.MethodGet)
 		testutil.RespondJSON(w, http.StatusOK, `[
 			{"id": 1, "application_id": "app-1", "application_name": "My App", "secret": "sec", "callback_url": "http://localhost", "confidential": true, "scopes": ["api", "read_user"]}
 		]`)
@@ -78,12 +68,8 @@ func TestList_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestCreate(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/applications" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf(fmtUnexpMethod, r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/applications")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.RespondJSON(w, http.StatusCreated, `{
 			"id": 2,
 			"application_id": "app-2",
@@ -137,12 +123,8 @@ func TestCreate_Error(t *testing.T) {
 // It asserts the returned output carries the renewed secret and identity fields.
 func TestRenewSecret(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/applications/2/renew-secret" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf(fmtUnexpMethod, r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/applications/2/renew-secret")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"id": 2,
 			"application_id": "app-2",
@@ -172,9 +154,7 @@ func TestRenewSecret(t *testing.T) {
 // TestRenewSecret_ValidationError verifies RenewSecret rejects non-positive ids
 // before touching the GitLab API.
 func TestRenewSecret_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, id := range []int64{0, -1} {
 		if _, err := RenewSecret(t.Context(), client, RenewSecretInput{ID: id}); err == nil {
 			t.Errorf("ID=%d: expected error, got nil", id)
@@ -203,9 +183,7 @@ func TestRenewSecret_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestDelete_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, id := range []int64{0, -1} {
 		err := Delete(t.Context(), client, DeleteInput{ID: id})
 		if err == nil {
@@ -219,12 +197,8 @@ func TestDelete_ValidationError(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestDelete(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/applications/3" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodDelete {
-			t.Fatalf(fmtUnexpMethod, r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/applications/3")
+		testutil.AssertRequestMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusNoContent)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -323,9 +297,7 @@ func TestFormatRenewSecretMarkdown(t *testing.T) {
 func TestList_WithPagination(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v4/applications" && r.Method == http.MethodGet {
-			if r.URL.Query().Get("page") != "2" {
-				t.Errorf("expected page=2, got %s", r.URL.Query().Get("page"))
-			}
+			testutil.AssertQueryParam(t, r, "page", "2")
 			testutil.RespondJSON(w, http.StatusOK, `[
 				{"id": 5, "application_id": "app-5", "application_name": "Paged", "secret": "s", "callback_url": "http://cb", "confidential": false, "scopes": ["api"]}
 			]`)
@@ -352,19 +324,10 @@ func TestList_WithPagination(t *testing.T) {
 func TestList_WithKeysetAndSort(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v4/applications" && r.Method == http.MethodGet {
-			q := r.URL.Query()
-			if q.Get("pagination") != "keyset" {
-				t.Errorf("expected pagination=keyset, got %s", q.Get("pagination"))
-			}
-			if q.Get("page_token") != "tok-9" {
-				t.Errorf("expected page_token=tok-9, got %s", q.Get("page_token"))
-			}
-			if q.Get("order_by") != "id" {
-				t.Errorf("expected order_by=id, got %s", q.Get("order_by"))
-			}
-			if q.Get("sort") != "desc" {
-				t.Errorf("expected sort=desc, got %s", q.Get("sort"))
-			}
+			testutil.AssertQueryParam(t, r, "pagination", "keyset")
+			testutil.AssertQueryParam(t, r, "page_token", "tok-9")
+			testutil.AssertQueryParam(t, r, "order_by", "id")
+			testutil.AssertQueryParam(t, r, "sort", "desc")
 			testutil.RespondJSON(w, http.StatusOK, `[
 				{"id": 7, "application_id": "app-7", "application_name": "Keyset", "secret": "s", "callback_url": "http://cb", "confidential": false, "scopes": ["api"]}
 			]`)

--- a/internal/tools/appstatistics/appstatistics_test.go
+++ b/internal/tools/appstatistics/appstatistics_test.go
@@ -17,9 +17,7 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/application/statistics" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/application/statistics")
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"forks": 10, "issues": 200, "merge_requests": 50,
 			"notes": 1000, "snippets": 5, "ssh_keys": 30,

--- a/internal/tools/auditevents/auditevents_test.go
+++ b/internal/tools/auditevents/auditevents_test.go
@@ -75,9 +75,7 @@ func TestGetInstance_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetInstance_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetInstance(context.Background(), client, GetInstanceInput{EventID: 0})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -114,9 +112,7 @@ func TestListGroup_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListGroup_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListGroup(context.Background(), client, ListGroupInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -148,9 +144,7 @@ func TestGetGroup_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetGroup_ValidationError_MissingGroup(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetGroup(context.Background(), client, GetGroupInput{EventID: 1})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -187,9 +181,7 @@ func TestListProject_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListProject_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListProject(context.Background(), client, ListProjectInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -221,9 +213,7 @@ func TestGetProject_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetProject_ValidationError_MissingProject(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetProject(context.Background(), client, GetProjectInput{EventID: 1})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -260,9 +250,7 @@ func TestListInstance_WithDateFilter(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestListInstance_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called on cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListInstance(ctx, client, ListInstanceInput{})
@@ -275,9 +263,7 @@ func TestListInstance_ContextCancelled(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetInstance_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetInstance(ctx, client, GetInstanceInput{EventID: 1})
@@ -290,9 +276,7 @@ func TestGetInstance_ContextCancelled(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestListGroup_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListGroup(ctx, client, ListGroupInput{GroupID: "5"})
@@ -305,9 +289,7 @@ func TestListGroup_ContextCancelled(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetGroup_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetGroup(ctx, client, GetGroupInput{GroupID: "5", EventID: 1})
@@ -320,9 +302,7 @@ func TestGetGroup_ContextCancelled(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestListProject_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := ListProject(ctx, client, ListProjectInput{ProjectID: "42"})
@@ -335,9 +315,7 @@ func TestListProject_ContextCancelled(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetProject_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 
 	_, err := GetProject(ctx, client, GetProjectInput{ProjectID: "42", EventID: 1})
@@ -456,9 +434,7 @@ func TestGetProject_APIError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetGroup_ValidationError_MissingEvent(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetGroup(context.Background(), client, GetGroupInput{GroupID: "5", EventID: 0})
 	if err == nil {
@@ -470,9 +446,7 @@ func TestGetGroup_ValidationError_MissingEvent(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetProject_ValidationError_MissingEvent(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetProject(context.Background(), client, GetProjectInput{ProjectID: "42", EventID: 0})
 	if err == nil {
@@ -484,9 +458,7 @@ func TestGetProject_ValidationError_MissingEvent(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetInstance_NegativeEventID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetInstance(context.Background(), client, GetInstanceInput{EventID: -1})
 	if err == nil {

--- a/internal/tools/awardemoji/awardemoji_test.go
+++ b/internal/tools/awardemoji/awardemoji_test.go
@@ -92,9 +92,7 @@ func TestListIssueAwardEmoji_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListIssueAwardEmoji_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ListIssueAwardEmoji(t.Context(), client, IssueListInput{
 		ProjectID: "",
@@ -166,9 +164,7 @@ func TestCreateIssueAwardEmoji_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestCreateIssueAwardEmoji_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := CreateIssueAwardEmoji(t.Context(), client, IssueCreateInput{
 		ProjectID: "",
@@ -305,9 +301,7 @@ func TestListMRAwardEmoji_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestCreateMRAwardEmoji_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := CreateMRAwardEmoji(t.Context(), client, MRCreateInput{
 		ProjectID: "",
@@ -501,9 +495,7 @@ func assertErrContains(t *testing.T, err error, substr string) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListIssueAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueAwardEmoji(t.Context(), client, IssueListInput{ProjectID: "p", IID: 0})
 	assertErrContains(t, err, testFieldIssueIID)
 	_, err = ListIssueAwardEmoji(t.Context(), client, IssueListInput{ProjectID: "p", IID: -1})
@@ -514,9 +506,7 @@ func TestListIssueAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetIssueAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueAwardEmoji(t.Context(), client, IssueGetInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldIssueIID)
 	_, err = GetIssueAwardEmoji(t.Context(), client, IssueGetInput{ProjectID: "p", IID: 1, AwardID: 0})
@@ -527,9 +517,7 @@ func TestGetIssueAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateIssueAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateIssueAwardEmoji(t.Context(), client, IssueCreateInput{ProjectID: "p", IID: 0, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldIssueIID)
 }
@@ -538,9 +526,7 @@ func TestCreateIssueAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteIssueAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteIssueAwardEmoji(t.Context(), client, IssueDeleteInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldIssueIID)
 	err = DeleteIssueAwardEmoji(t.Context(), client, IssueDeleteInput{ProjectID: "p", IID: 1, AwardID: 0})
@@ -551,9 +537,7 @@ func TestDeleteIssueAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueNoteAwardEmoji(t.Context(), client, IssueListOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1})
 	assertErrContains(t, err, testFieldIssueIID)
 	_, err = ListIssueNoteAwardEmoji(t.Context(), client, IssueListOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0})
@@ -564,9 +548,7 @@ func TestListIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueNoteAwardEmoji(t.Context(), client, IssueGetOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldIssueIID)
 	_, err = GetIssueNoteAwardEmoji(t.Context(), client, IssueGetOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})
@@ -579,9 +561,7 @@ func TestGetIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateIssueNoteAwardEmoji(t.Context(), client, IssueCreateOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldIssueIID)
 	_, err = CreateIssueNoteAwardEmoji(t.Context(), client, IssueCreateOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, Name: testEmojiStar})
@@ -592,9 +572,7 @@ func TestCreateIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteIssueNoteAwardEmoji(t.Context(), client, IssueDeleteOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldIssueIID)
 	err = DeleteIssueNoteAwardEmoji(t.Context(), client, IssueDeleteOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})
@@ -607,9 +585,7 @@ func TestDeleteIssueNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListMRAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListMRAwardEmoji(t.Context(), client, MRListInput{ProjectID: "p", IID: 0})
 	assertErrContains(t, err, testFieldMRIID)
 }
@@ -618,9 +594,7 @@ func TestListMRAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetMRAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetMRAwardEmoji(t.Context(), client, MRGetInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldMRIID)
 	_, err = GetMRAwardEmoji(t.Context(), client, MRGetInput{ProjectID: "p", IID: 1, AwardID: 0})
@@ -631,9 +605,7 @@ func TestGetMRAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateMRAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateMRAwardEmoji(t.Context(), client, MRCreateInput{ProjectID: "p", IID: -5, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldMRIID)
 }
@@ -642,9 +614,7 @@ func TestCreateMRAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteMRAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteMRAwardEmoji(t.Context(), client, MRDeleteInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldMRIID)
 	err = DeleteMRAwardEmoji(t.Context(), client, MRDeleteInput{ProjectID: "p", IID: 1, AwardID: -1})
@@ -655,9 +625,7 @@ func TestDeleteMRAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListMRNoteAwardEmoji(t.Context(), client, MRListOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1})
 	assertErrContains(t, err, testFieldMRIID)
 	_, err = ListMRNoteAwardEmoji(t.Context(), client, MRListOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0})
@@ -668,9 +636,7 @@ func TestListMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetMRNoteAwardEmoji(t.Context(), client, MRGetOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldMRIID)
 	_, err = GetMRNoteAwardEmoji(t.Context(), client, MRGetOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})
@@ -683,9 +649,7 @@ func TestGetMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateMRNoteAwardEmoji(t.Context(), client, MRCreateOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldMRIID)
 	_, err = CreateMRNoteAwardEmoji(t.Context(), client, MRCreateOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, Name: testEmojiStar})
@@ -696,9 +660,7 @@ func TestCreateMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteMRNoteAwardEmoji(t.Context(), client, MRDeleteOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldMRIID)
 	err = DeleteMRNoteAwardEmoji(t.Context(), client, MRDeleteOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})
@@ -711,9 +673,7 @@ func TestDeleteMRNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListSnippetAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListSnippetAwardEmoji(t.Context(), client, SnippetListInput{ProjectID: "p", IID: 0})
 	assertErrContains(t, err, testFieldSnippetID)
 }
@@ -722,9 +682,7 @@ func TestListSnippetAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetSnippetAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetSnippetAwardEmoji(t.Context(), client, SnippetGetInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldSnippetID)
 	_, err = GetSnippetAwardEmoji(t.Context(), client, SnippetGetInput{ProjectID: "p", IID: 1, AwardID: 0})
@@ -735,9 +693,7 @@ func TestGetSnippetAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateSnippetAwardEmoji_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateSnippetAwardEmoji(t.Context(), client, SnippetCreateInput{ProjectID: "p", IID: 0, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldSnippetID)
 }
@@ -746,9 +702,7 @@ func TestCreateSnippetAwardEmoji_InvalidIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteSnippetAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteSnippetAwardEmoji(t.Context(), client, SnippetDeleteInput{ProjectID: "p", IID: 0, AwardID: 1})
 	assertErrContains(t, err, testFieldSnippetID)
 	err = DeleteSnippetAwardEmoji(t.Context(), client, SnippetDeleteInput{ProjectID: "p", IID: 1, AwardID: 0})
@@ -759,9 +713,7 @@ func TestDeleteSnippetAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListSnippetNoteAwardEmoji(t.Context(), client, SnippetListOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1})
 	assertErrContains(t, err, testFieldSnippetID)
 	_, err = ListSnippetNoteAwardEmoji(t.Context(), client, SnippetListOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0})
@@ -772,9 +724,7 @@ func TestListSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetSnippetNoteAwardEmoji(t.Context(), client, SnippetGetOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldSnippetID)
 	_, err = GetSnippetNoteAwardEmoji(t.Context(), client, SnippetGetOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})
@@ -787,9 +737,7 @@ func TestGetSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateSnippetNoteAwardEmoji(t.Context(), client, SnippetCreateOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, Name: testEmojiStar})
 	assertErrContains(t, err, testFieldSnippetID)
 	_, err = CreateSnippetNoteAwardEmoji(t.Context(), client, SnippetCreateOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, Name: testEmojiStar})
@@ -800,9 +748,7 @@ func TestCreateSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteSnippetNoteAwardEmoji_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteSnippetNoteAwardEmoji(t.Context(), client, SnippetDeleteOnNoteInput{ProjectID: "p", IID: 0, NoteID: 1, AwardID: 1})
 	assertErrContains(t, err, testFieldSnippetID)
 	err = DeleteSnippetNoteAwardEmoji(t.Context(), client, SnippetDeleteOnNoteInput{ProjectID: "p", IID: 1, NoteID: 0, AwardID: 1})

--- a/internal/tools/awardemoji/awardemoji_test.go
+++ b/internal/tools/awardemoji/awardemoji_test.go
@@ -23,9 +23,6 @@ import (
 // fmtUnexpPath identifies the fmt unexp path constant used by this package.
 const fmtUnexpPath = "unexpected path: %s"
 
-// errNoReachAPI identifies the err no reach API constant used by this package.
-const errNoReachAPI = "should not reach API"
-
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 

--- a/internal/tools/badges/badges_test.go
+++ b/internal/tools/badges/badges_test.go
@@ -410,9 +410,7 @@ func TestPreviewGroup_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetProject_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetProject(t.Context(), client, GetProjectInput{ProjectID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {
@@ -424,9 +422,7 @@ func TestGetProject_BadgeIDRequired(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestEditProject_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := EditProject(t.Context(), client, EditProjectInput{ProjectID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {
@@ -438,9 +434,7 @@ func TestEditProject_BadgeIDRequired(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteProject_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	err := DeleteProject(t.Context(), client, DeleteProjectInput{ProjectID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {
@@ -452,9 +446,7 @@ func TestDeleteProject_BadgeIDRequired(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetGroup_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetGroup(t.Context(), client, GetGroupInput{GroupID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {
@@ -466,9 +458,7 @@ func TestGetGroup_BadgeIDRequired(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestEditGroup_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := EditGroup(t.Context(), client, EditGroupInput{GroupID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {
@@ -480,9 +470,7 @@ func TestEditGroup_BadgeIDRequired(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteGroup_BadgeIDRequired(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	err := DeleteGroup(t.Context(), client, DeleteGroupInput{GroupID: "1", BadgeID: 0})
 	if err == nil || !strings.Contains(err.Error(), testBadgeIDField) {

--- a/internal/tools/badges/badges_test.go
+++ b/internal/tools/badges/badges_test.go
@@ -20,9 +20,6 @@ import (
 // errExpNonNilResult identifies the err exp non nil result constant used by this package.
 const errExpNonNilResult = "expected non-nil result"
 
-// errNoReachAPI identifies the err no reach API constant used by this package.
-const errNoReachAPI = "should not reach API"
-
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 

--- a/internal/tools/broadcastmessages/broadcastmessages_test.go
+++ b/internal/tools/broadcastmessages/broadcastmessages_test.go
@@ -430,7 +430,9 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":2,"message":"Full test","starts_at":"2026-01-01T00:00:00Z","ends_at":"2026-01-02T00:00:00Z","font":"serif","active":true,"target_access_levels":[30],"target_path":"/dashboard","broadcast_type":"notification","dismissable":true,"theme":"blue"}`)

--- a/internal/tools/bulkimports/bulkimports_test.go
+++ b/internal/tools/bulkimports/bulkimports_test.go
@@ -18,15 +18,13 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestStartMigration(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/bulk_imports" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/bulk_imports")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
+			t.Errorf("decode body: %v", err)
+			http.Error(w, "decode body", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"id": 42,

--- a/internal/tools/civariables/civariables_test.go
+++ b/internal/tools/civariables/civariables_test.go
@@ -635,14 +635,20 @@ func TestCIVariableUpdate_AllOptionalFields(t *testing.T) {
 		if r.URL.Path == "/api/v4/projects/1/variables/DB_HOST" && r.Method == http.MethodPut {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode request body: %v", err)
+				t.Errorf("decode request body: %v", err)
+				http.Error(w, "decode request body", http.StatusInternalServerError)
+				return
 			}
 			filter, hasFilter := body["filter"].(map[string]any)
 			if !hasFilter || filter["environment_scope"] != "staging" {
-				t.Fatalf("filter.environment_scope = %#v, want staging", body["filter"])
+				t.Errorf("filter.environment_scope = %#v, want staging", body["filter"])
+				http.Error(w, "filter.environment_scope, want staging", http.StatusInternalServerError)
+				return
 			}
 			if _, hasEnvironmentScope := body["environment_scope"]; hasEnvironmentScope {
-				t.Fatalf("request body contains environment_scope update field: %#v", body)
+				t.Errorf("request body contains environment_scope update field: %#v", body)
+				http.Error(w, "request body contains environment_scope update field", http.StatusInternalServerError)
+				return
 			}
 			testutil.RespondJSON(w, http.StatusOK, `{
 				"key":"DB_HOST","value":"db.prod","variable_type":"file",
@@ -1122,7 +1128,9 @@ func TestCIVariableUpdate_FilterObject(t *testing.T) {
 		if r.URL.Path == "/api/v4/projects/10/variables/DB_URL" && r.Method == http.MethodPut {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode request body: %v", err)
+				t.Errorf("decode request body: %v", err)
+				http.Error(w, "decode request body", http.StatusInternalServerError)
+				return
 			}
 			filter, ok := body["filter"].(map[string]any)
 			if !ok || filter["environment_scope"] != testEnvScope {

--- a/internal/tools/ciyamltemplates/ciyamltemplates_test.go
+++ b/internal/tools/ciyamltemplates/ciyamltemplates_test.go
@@ -18,9 +18,7 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/gitlab_ci_ymls" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/gitlab_ci_ymls")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"Go","name":"Go"},{"key":"Python","name":"Python"}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -55,9 +53,7 @@ func TestList_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/gitlab_ci_ymls/Go" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/gitlab_ci_ymls/Go")
 		testutil.RespondJSON(w, http.StatusOK, `{"name":"Go","content":"stages:\n  - test"}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -88,9 +84,7 @@ func TestGet_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGet_EmptyKey(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not call API with empty key")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{Key: ""})
 	if err == nil {
 		t.Fatal("expected error for empty key")

--- a/internal/tools/clusteragents/clusteragents_test.go
+++ b/internal/tools/clusteragents/clusteragents_test.go
@@ -18,9 +18,6 @@ import (
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 
-// errAPIShouldNotCallZeroAgentID identifies the err API should not call zero agent ID constant used by this package.
-const errAPIShouldNotCallZeroAgentID = "API should not be called when AgentID is 0"
-
 // errExpectedZeroAgentID identifies the err expected zero agent ID constant used by this package.
 const errExpectedZeroAgentID = "expected error for zero AgentID, got nil"
 
@@ -215,9 +212,7 @@ func TestFormatTokensListMarkdown(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetAgent_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetAgent(t.Context(), client, GetAgentInput{ProjectID: "1", AgentID: 0})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -228,9 +223,7 @@ func TestGetAgent_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteAgent_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteAgent(t.Context(), client, DeleteAgentInput{ProjectID: "1", AgentID: 0})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -241,9 +234,7 @@ func TestDeleteAgent_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListAgentTokens_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListAgentTokens(t.Context(), client, ListAgentTokensInput{ProjectID: "1", AgentID: 0})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -254,9 +245,7 @@ func TestListAgentTokens_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetAgentToken_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetAgentToken(t.Context(), client, GetAgentTokenInput{ProjectID: "1", AgentID: 0, TokenID: 1})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -267,9 +256,7 @@ func TestGetAgentToken_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGetAgentToken_ZeroTokenID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TokenID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetAgentToken(t.Context(), client, GetAgentTokenInput{ProjectID: "1", AgentID: 5, TokenID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TokenID, got nil")
@@ -280,9 +267,7 @@ func TestGetAgentToken_ZeroTokenID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCreateAgentToken_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateAgentToken(t.Context(), client, CreateAgentTokenInput{ProjectID: "1", AgentID: 0, Name: "tok"})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -293,9 +278,7 @@ func TestCreateAgentToken_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestRevokeAgentToken_ZeroAgentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPIShouldNotCallZeroAgentID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := RevokeAgentToken(t.Context(), client, RevokeAgentTokenInput{ProjectID: "1", AgentID: 0, TokenID: 1})
 	if err == nil {
 		t.Fatal(errExpectedZeroAgentID)
@@ -306,9 +289,7 @@ func TestRevokeAgentToken_ZeroAgentID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestRevokeAgentToken_ZeroTokenID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TokenID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := RevokeAgentToken(t.Context(), client, RevokeAgentTokenInput{ProjectID: "1", AgentID: 5, TokenID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TokenID, got nil")

--- a/internal/tools/commitdiscussions/commitdiscussions_test.go
+++ b/internal/tools/commitdiscussions/commitdiscussions_test.go
@@ -246,9 +246,7 @@ func TestDeleteNote_APIError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestUpdateNote_NoteIDValidation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := UpdateNote(t.Context(), client, UpdateNoteInput{
 		ProjectID:    testProjectID,
 		CommitSHA:    testCommitSHA,
@@ -268,9 +266,7 @@ func TestUpdateNote_NoteIDValidation(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteNote_NoteIDValidation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteNote(t.Context(), client, DeleteNoteInput{
 		ProjectID:    testProjectID,
 		CommitSHA:    testCommitSHA,

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -1444,7 +1444,9 @@ func TestCommitCreate_WithAllOptions(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathRepoCommits {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":"opt1","short_id":"opt1","title":"t"}`)
@@ -1763,7 +1765,9 @@ func TestSetStatus_WithAllOptions(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/42/statuses/abc" {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{

--- a/internal/tools/compliancepolicy/compliance_policy_test.go
+++ b/internal/tools/compliancepolicy/compliance_policy_test.go
@@ -22,7 +22,7 @@ import (
 func TestGet(t *testing.T) {
 	tests := []struct {
 		name       string
-		handler    http.HandlerFunc
+		handler    http.Handler
 		ctx        func() context.Context
 		wantErr    bool
 		wantNilCSP bool
@@ -115,7 +115,7 @@ func TestUpdate(t *testing.T) {
 	tests := []struct {
 		name       string
 		input      UpdateInput
-		handler    http.HandlerFunc
+		handler    http.Handler
 		ctx        func() context.Context
 		wantErr    bool
 		wantNilCSP bool
@@ -132,11 +132,9 @@ func TestUpdate(t *testing.T) {
 			wantCSP: 456,
 		},
 		{
-			name:  "rejects nil csp_namespace_id",
-			input: UpdateInput{CSPNamespaceID: nil},
-			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				t.Fatal("handler should not be called for nil csp_namespace_id")
-			}),
+			name:    "rejects nil csp_namespace_id",
+			input:   UpdateInput{CSPNamespaceID: nil},
+			handler: testutil.ForbiddenHandler(t),
 			wantErr: true,
 		},
 		{

--- a/internal/tools/customattributes/customattributes_test.go
+++ b/internal/tools/customattributes/customattributes_test.go
@@ -15,9 +15,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
-// fmtUnexpPath identifies the fmt unexp path constant used by this package.
-const fmtUnexpPath = "unexpected path: %s"
-
 // errExpectedNil identifies the err expected nil constant used by this package.
 const errExpectedNil = "expected error, got nil"
 
@@ -44,9 +41,7 @@ const testTypeProject = "project"
 // It asserts the returned output matches the expected fields.
 func TestList_User(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/users/1/custom_attributes" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/users/1/custom_attributes")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"dept","value":"engineering"}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -67,9 +62,7 @@ func TestList_User(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestList_Group(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/groups/2/custom_attributes" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/groups/2/custom_attributes")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"tier","value":"gold"}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -87,9 +80,7 @@ func TestList_Group(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestList_Project(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/3/custom_attributes" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/3/custom_attributes")
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -120,9 +111,7 @@ func TestList_InvalidType(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestGet_User(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/users/1/custom_attributes/dept" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/users/1/custom_attributes/dept")
 		testutil.RespondJSON(w, http.StatusOK, `{"key":"dept","value":"engineering"}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -154,12 +143,8 @@ func TestGet_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestSet_Group(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/groups/2/custom_attributes/tier" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodPut {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/groups/2/custom_attributes/tier")
+		testutil.AssertRequestMethod(t, r, http.MethodPut)
 		testutil.RespondJSON(w, http.StatusOK, `{"key":"tier","value":"platinum"}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -191,12 +176,8 @@ func TestSet_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestDelete_Project(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/3/custom_attributes/old_key" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodDelete {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/3/custom_attributes/old_key")
+		testutil.AssertRequestMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusNoContent)
 	})
 	client := testutil.NewTestClient(t, handler)

--- a/internal/tools/dbmigrations/dbmigrations_test.go
+++ b/internal/tools/dbmigrations/dbmigrations_test.go
@@ -17,12 +17,8 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestMark(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/admin/migrations/20240115100000/mark" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/admin/migrations/20240115100000/mark")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -59,9 +55,7 @@ func TestMark_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestMark_VersionValidation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when version is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/tools/dependencies/dependencies_test.go
+++ b/internal/tools/dependencies/dependencies_test.go
@@ -19,7 +19,7 @@ func TestListDeps(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    ListInput
-		handler  http.HandlerFunc
+		handler  http.Handler
 		wantErr  bool
 		validate func(t *testing.T, out ListOutput)
 	}{
@@ -146,9 +146,7 @@ func TestListDeps(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := tt.handler
 			if handler == nil {
-				handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					t.Fatal("handler should not be called")
-				})
+				handler = testutil.ForbiddenHandler(t)
 			}
 			client := testutil.NewTestClient(t, handler)
 			out, err := ListDeps(context.Background(), client, tt.input)
@@ -210,9 +208,7 @@ func assertRailsDependencyLicense(t *testing.T, d Output) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestListDeps_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := ListDeps(ctx, client, ListInput{ProjectID: "42"})
 	if err == nil {
@@ -227,7 +223,7 @@ func TestCreateExport(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    CreateExportInput
-		handler  http.HandlerFunc
+		handler  http.Handler
 		wantErr  bool
 		validate func(t *testing.T, out ExportOutput)
 	}{
@@ -290,9 +286,7 @@ func TestCreateExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := tt.handler
 			if handler == nil {
-				handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					t.Fatal("handler should not be called")
-				})
+				handler = testutil.ForbiddenHandler(t)
 			}
 			client := testutil.NewTestClient(t, handler)
 			out, err := CreateExport(context.Background(), client, tt.input)
@@ -310,9 +304,7 @@ func TestCreateExport(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestCreateExport_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := CreateExport(ctx, client, CreateExportInput{PipelineID: 100})
 	if err == nil {
@@ -346,7 +338,7 @@ func TestGetExport(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    GetExportInput
-		handler  http.HandlerFunc
+		handler  http.Handler
 		wantErr  bool
 		validate func(t *testing.T, out ExportOutput)
 	}{
@@ -408,9 +400,7 @@ func TestGetExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := tt.handler
 			if handler == nil {
-				handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					t.Fatal("handler should not be called")
-				})
+				handler = testutil.ForbiddenHandler(t)
 			}
 			client := testutil.NewTestClient(t, handler)
 			out, err := GetExport(context.Background(), client, tt.input)
@@ -428,9 +418,7 @@ func TestGetExport(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetExport_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetExport(ctx, client, GetExportInput{ExportID: 1})
 	if err == nil {
@@ -445,7 +433,7 @@ func TestDownloadExport(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    DownloadExportInput
-		handler  http.HandlerFunc
+		handler  http.Handler
 		wantErr  bool
 		validate func(t *testing.T, out DownloadOutput)
 	}{
@@ -503,9 +491,7 @@ func TestDownloadExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler := tt.handler
 			if handler == nil {
-				handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					t.Fatal("handler should not be called")
-				})
+				handler = testutil.ForbiddenHandler(t)
 			}
 			client := testutil.NewTestClient(t, handler)
 			out, err := DownloadExport(context.Background(), client, tt.input)
@@ -523,9 +509,7 @@ func TestDownloadExport(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestDownloadExport_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := DownloadExport(ctx, client, DownloadExportInput{ExportID: 1})
 	if err == nil {

--- a/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
+++ b/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
@@ -140,9 +140,7 @@ func TestList_WithFilters(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestList_InvalidDeploymentID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(t.Context(), client, ListInput{ProjectID: "42", DeploymentID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero deployment_id")

--- a/internal/tools/deployments/deployments_test.go
+++ b/internal/tools/deployments/deployments_test.go
@@ -301,9 +301,7 @@ func TestDeploymentGet_DeployableWithoutProject(t *testing.T) {
 // that real handlers reach only on malformed routes. It asserts both helpers
 // return a non-nil error and never invoke the transport.
 func TestDeploymentRawFetch_NewRequestError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("transport must not be called when NewRequest fails")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := rawGetDeployment(context.Background(), client, "projects/%zz/deployments/1"); err == nil {
 		t.Error("rawGetDeployment: expected NewRequest error, got nil")
 	}
@@ -689,7 +687,9 @@ func TestDeploymentApprove_Success(t *testing.T) {
 				RepresentedAs string `json:"represented_as"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
+				t.Errorf("decode body: %v", err)
+				http.Error(w, "decode body", http.StatusInternalServerError)
+				return
 			}
 			if body.RepresentedAs != "security" {
 				t.Errorf("represented_as = %q, want %q", body.RepresentedAs, "security")

--- a/internal/tools/dockerfiletemplates/dockerfiletemplates_test.go
+++ b/internal/tools/dockerfiletemplates/dockerfiletemplates_test.go
@@ -18,9 +18,7 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/dockerfiles" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/dockerfiles")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"Ruby","name":"Ruby"}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -51,9 +49,7 @@ func TestList_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/dockerfiles/Ruby" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/dockerfiles/Ruby")
 		testutil.RespondJSON(w, http.StatusOK, `{"name":"Ruby","content":"FROM ruby:latest"}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -83,9 +79,7 @@ func TestGet_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestGet_EmptyKey(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not call API with empty key")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{Key: ""})
 	if err == nil {
 		t.Fatal("expected error for empty key")

--- a/internal/tools/dorametrics/dorametrics_test.go
+++ b/internal/tools/dorametrics/dorametrics_test.go
@@ -232,9 +232,7 @@ func assertProjectMetricsCaseResult(t *testing.T, out Output, err error, tt proj
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetProjectMetrics_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetProjectMetrics(ctx, client, ProjectInput{ProjectID: "42", Metric: "deployment_frequency"})
 	if err == nil {
@@ -414,9 +412,7 @@ func metricsCaseHandler(t *testing.T, handler http.HandlerFunc) http.HandlerFunc
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetGroupMetrics_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetGroupMetrics(ctx, client, GroupInput{GroupID: "5", Metric: "deployment_frequency"})
 	if err == nil {

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -5181,10 +5181,9 @@ func TestIntentBoost_SearchCodeSurfacesForCodeQueries(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query[:min(len(query), 60)], func(t *testing.T) {
 			t.Parallel()
-			var out SearchOutput
-			_, out, err = reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: 5})
-			if err != nil {
-				t.Fatalf("search: %v", err)
+			_, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: 5})
+			if searchErr != nil {
+				t.Fatalf("search: %v", searchErr)
 			}
 			if len(out.Results) == 0 {
 				t.Fatal("no results")
@@ -5217,10 +5216,9 @@ func TestIntentBoost_CurrentUserSurfacesForIdentityQueries(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			t.Parallel()
-			var out SearchOutput
-			_, out, err = reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: 5})
-			if err != nil {
-				t.Fatalf("search: %v", err)
+			_, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: query, Limit: 5})
+			if searchErr != nil {
+				t.Fatalf("search: %v", searchErr)
 			}
 			if len(out.Results) == 0 {
 				t.Fatal("no results")
@@ -5257,10 +5255,9 @@ func TestIntentBoost_ControlsNotHijacked(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.query, func(t *testing.T) {
 			t.Parallel()
-			var out SearchOutput
-			_, out, err = reg.Search(context.Background(), nil, SearchInput{Query: tc.query, Limit: 5})
-			if err != nil {
-				t.Fatalf("search: %v", err)
+			_, out, searchErr := reg.Search(context.Background(), nil, SearchInput{Query: tc.query, Limit: 5})
+			if searchErr != nil {
+				t.Fatalf("search: %v", searchErr)
 			}
 			if len(out.Results) == 0 {
 				t.Fatal("no results")

--- a/internal/tools/epics/action_specs_test.go
+++ b/internal/tools/epics/action_specs_test.go
@@ -31,7 +31,9 @@ func TestActionSpecs_CallAllRoutes(t *testing.T) {
 		if r.Method == http.MethodPost {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			query := string(body)
 			switch {
@@ -48,7 +50,9 @@ func TestActionSpecs_CallAllRoutes(t *testing.T) {
 			case strings.Contains(query, "workItemDelete"):
 				testutil.RespondJSON(w, http.StatusOK, deleteDeleteResponseJSON)
 			default:
-				t.Fatalf("unexpected GraphQL query: %s", query)
+				t.Errorf("unexpected GraphQL query: %s", query)
+				http.Error(w, "unexpected GraphQL query", http.StatusInternalServerError)
+				return
 			}
 			return
 		}
@@ -137,9 +141,7 @@ func TestActionSpecs_DeleteError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := epicSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/epics/epics_test.go
+++ b/internal/tools/epics/epics_test.go
@@ -217,9 +217,7 @@ func TestList_RESTFilterOptions(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestList_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(context.Background(), client, ListInput{})
 	if err == nil {
 		t.Fatal("List() expected error for missing full_path, got nil")
@@ -230,9 +228,7 @@ func TestList_MissingFullPath(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestList_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := List(ctx, client, ListInput{FullPath: testFullPath})
 	if err == nil {
@@ -287,9 +283,7 @@ func TestGet_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGet_MissingIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(context.Background(), client, GetInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("Get() expected error for missing iid, got nil")
@@ -303,9 +297,7 @@ func TestGet_MissingIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGet_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(context.Background(), client, GetInput{IID: 1})
 	if err == nil {
 		t.Fatal("Get() expected error for missing full_path, got nil")
@@ -357,9 +349,7 @@ func TestGetLinks_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetLinks_MissingIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetLinks(context.Background(), client, GetLinksInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("GetLinks() expected error for missing iid, got nil")
@@ -370,9 +360,7 @@ func TestGetLinks_MissingIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGetLinks_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetLinks(context.Background(), client, GetLinksInput{IID: 1})
 	if err == nil {
 		t.Fatal("GetLinks() expected error for missing full_path, got nil")
@@ -410,9 +398,7 @@ func TestCreate_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestCreate_MissingTitle(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Create(context.Background(), client, CreateInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("Create() expected error for missing title, got nil")
@@ -423,9 +409,7 @@ func TestCreate_MissingTitle(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestCreate_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Create(context.Background(), client, CreateInput{Title: "Some Title"})
 	if err == nil {
 		t.Fatal("Create() expected error for missing full_path, got nil")
@@ -484,9 +468,7 @@ func TestUpdate_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestUpdate_MissingIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Update(context.Background(), client, UpdateInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("Update() expected error for missing iid, got nil")
@@ -497,9 +479,7 @@ func TestUpdate_MissingIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestUpdate_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Update(context.Background(), client, UpdateInput{IID: 1})
 	if err == nil {
 		t.Fatal("Update() expected error for missing full_path, got nil")
@@ -550,9 +530,7 @@ func TestDelete_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestDelete_MissingIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(context.Background(), client, DeleteInput{FullPath: testFullPath})
 	if err == nil {
 		t.Fatal("Delete() expected error for missing iid, got nil")
@@ -563,9 +541,7 @@ func TestDelete_MissingIID(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestDelete_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(context.Background(), client, DeleteInput{IID: 1})
 	if err == nil {
 		t.Fatal("Delete() expected error for missing full_path, got nil")
@@ -909,7 +885,9 @@ func TestList_WithAllFilters(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars, err := testutil.ParseGraphQLVariables(r)
 		if err != nil {
-			t.Fatalf("ParseGraphQLVariables: %v", err)
+			t.Errorf("ParseGraphQLVariables: %v", err)
+			http.Error(w, "ParseGraphQLVariables", http.StatusInternalServerError)
+			return
 		}
 		for _, key := range []string{"fullPath", "state", "search", "authorUsername", "labelName", "confidential", "sort", "first", "after", "includeAncestors", "includeDescendants"} {
 			if _, ok := vars[key]; !ok {
@@ -949,7 +927,9 @@ func TestList_WorkItems_RequestsEEFields(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read body: %v", err)
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
 		}
 		query := string(body)
 		for _, field := range []string{"weight", "healthStatus", "color", "status"} {
@@ -992,11 +972,15 @@ func TestCreate_WithAllOptions(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars, err := testutil.ParseGraphQLVariables(r)
 		if err != nil {
-			t.Fatalf("ParseGraphQLVariables: %v", err)
+			t.Errorf("ParseGraphQLVariables: %v", err)
+			http.Error(w, "ParseGraphQLVariables", http.StatusInternalServerError)
+			return
 		}
 		input, ok := vars["input"].(map[string]any)
 		if !ok {
-			t.Fatal("GraphQL variables missing 'input' object")
+			t.Error("GraphQL variables missing 'input' object")
+			http.Error(w, "GraphQL variables missing 'input' object", http.StatusInternalServerError)
+			return
 		}
 		for _, key := range []string{"title", "confidential", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "assigneesWidget", "labelsWidget", "weightWidget", "healthStatusWidget"} {
 			if _, exists := input[key]; !exists {
@@ -1032,9 +1016,7 @@ func TestCreate_WithAllOptions(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestCreate_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{FullPath: testFullPath, Title: "X"})
 	if err == nil {
@@ -1057,11 +1039,15 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 		default:
 			vars, err := testutil.ParseGraphQLVariables(r)
 			if err != nil {
-				t.Fatalf("ParseGraphQLVariables: %v", err)
+				t.Errorf("ParseGraphQLVariables: %v", err)
+				http.Error(w, "ParseGraphQLVariables", http.StatusInternalServerError)
+				return
 			}
 			input, ok := vars["input"].(map[string]any)
 			if !ok {
-				t.Fatal("GraphQL variables missing 'input' object")
+				t.Error("GraphQL variables missing 'input' object")
+				http.Error(w, "GraphQL variables missing 'input' object", http.StatusInternalServerError)
+				return
 			}
 			for _, key := range []string{"title", "stateEvent", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "labelsWidget", "assigneesWidget", "weightWidget", "healthStatusWidget", "statusWidget"} {
 				if _, exists := input[key]; !exists {
@@ -1102,9 +1088,7 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestUpdate_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Update(ctx, client, UpdateInput{FullPath: testFullPath, IID: 1, Title: "X"})
 	if err == nil {
@@ -1118,9 +1102,7 @@ func TestUpdate_CancelledContext(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGetLinks_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetLinks(ctx, client, GetLinksInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
@@ -1145,9 +1127,7 @@ func TestGetLinks_APIError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestGet_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{FullPath: testFullPath, IID: 1})
 	if err == nil {
@@ -1159,9 +1139,7 @@ func TestGet_CancelledContext(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that a canceled context aborts the call without contacting GitLab.
 func TestDelete_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{FullPath: testFullPath, IID: 1})
 	if err == nil {

--- a/internal/tools/errortracking/action_specs_test.go
+++ b/internal/tools/errortracking/action_specs_test.go
@@ -152,9 +152,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := errorTrackingSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/errortracking/errortracking_test.go
+++ b/internal/tools/errortracking/errortracking_test.go
@@ -195,9 +195,7 @@ func TestDeleteClientKey_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteClientKey_InvalidKeyID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteClientKey(t.Context(), client, DeleteClientKeyInput{ProjectID: "1", KeyID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero key_id")

--- a/internal/tools/events/events_test.go
+++ b/internal/tools/events/events_test.go
@@ -120,9 +120,7 @@ func TestListProjectEvents_WithFilters(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListProjectEvents_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called for validation error")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ListProjectEvents(context.Background(), client, ListProjectEventsInput{})
 	if err == nil {
@@ -673,9 +671,7 @@ func TestListProjectEvents_APIError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestListProjectEvents_EmptyProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListProjectEvents(t.Context(), client, ListProjectEventsInput{ProjectID: ""})
 	if err == nil {
 		t.Fatal("expected validation error")

--- a/internal/tools/externalstatuschecks/external_status_checks_test.go
+++ b/internal/tools/externalstatuschecks/external_status_checks_test.go
@@ -326,7 +326,9 @@ func TestUpdateProjectExternalStatusCheck_WithAllFields(t *testing.T) {
 	mux.HandleFunc("PUT /api/v4/projects/1/external_status_checks/42", func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, projectStatusCheckJSON)

--- a/internal/tools/featureflags/featureflags_test.go
+++ b/internal/tools/featureflags/featureflags_test.go
@@ -991,7 +991,9 @@ func TestUpdateFeatureFlag_StrategyUserListAndDestroy_RoundTrip(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read body: %v", err)
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
 		}
 		gotBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, `{"name":"flag","description":"","active":true,"version":"new_version_flag","strategies":[{"id":7,"name":"gitlabUserList","user_list":{"id":3,"iid":1,"project_id":9,"name":"beta testers","user_xids":"u1,u2"},"scopes":[]}]}`)
@@ -1034,7 +1036,9 @@ func TestUpdateFeatureFlag_DestroyOnlyStrategyOmitsName(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read body: %v", err)
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
 		}
 		gotBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, `{"name":"flag","description":"","active":true,"version":"new_version_flag","strategies":[]}`)

--- a/internal/tools/features/action_specs_test.go
+++ b/internal/tools/features/action_specs_test.go
@@ -155,9 +155,7 @@ func TestActionSpecs_ErrorsPropagate(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := featureSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/features/features_test.go
+++ b/internal/tools/features/features_test.go
@@ -348,9 +348,7 @@ func TestFormatFeatureMarkdown_NoDefinition(t *testing.T) {
 // the marshal error directly, and the handler wraps it with the operation
 // name so the LLM sees a meaningful diagnostic.
 func TestSet_NewRequestErrorOnUnserializableValue(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when body fails to marshal")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Set(context.Background(), client, SetInput{Name: "flag1", Value: make(chan int)})
 	if err == nil {

--- a/internal/tools/ffuserlists/action_specs_test.go
+++ b/internal/tools/ffuserlists/action_specs_test.go
@@ -135,9 +135,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := userListSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/files/action_specs_test.go
+++ b/internal/tools/files/action_specs_test.go
@@ -111,9 +111,7 @@ func TestActionSpecs_GetNotFound(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := fileSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/freezeperiods/action_specs_test.go
+++ b/internal/tools/freezeperiods/action_specs_test.go
@@ -143,9 +143,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := freezePeriodSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/geo/action_specs_test.go
+++ b/internal/tools/geo/action_specs_test.go
@@ -118,9 +118,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := geoSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/gitignoretemplates/gitignoretemplates_test.go
+++ b/internal/tools/gitignoretemplates/gitignoretemplates_test.go
@@ -18,9 +18,7 @@ import (
 // It asserts the returned output matches the expected fields.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/gitignores" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/gitignores")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"Go","name":"Go"},{"key":"Node","name":"Node"}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -51,9 +49,7 @@ func TestList_Error(t *testing.T) {
 // It asserts the returned output matches the expected fields.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/gitignores/Go" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/gitignores/Go")
 		testutil.RespondJSON(w, http.StatusOK, `{"name":"Go","content":"*.exe\n*.test"}`)
 	})
 	client := testutil.NewTestClient(t, handler)

--- a/internal/tools/groupboards/action_specs_test.go
+++ b/internal/tools/groupboards/action_specs_test.go
@@ -151,9 +151,7 @@ func TestActionSpecs_DeleteOutputs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupBoardSpecsByTool(t, ActionSpecs(client))
 
 	for _, tt := range []struct {

--- a/internal/tools/groupcredentials/action_specs_test.go
+++ b/internal/tools/groupcredentials/action_specs_test.go
@@ -131,9 +131,7 @@ func TestActionSpecs_DeleteOutputs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestActionSpecs_DeleteOutputErrors(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when required identifiers are missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	tests := []struct {
 		name string
 		fn   func() (toolutil.DeleteOutput, error)
@@ -163,9 +161,7 @@ func TestActionSpecs_DeleteOutputErrors(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_ConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupCredentialSpecsByTool(t, ActionSpecs(client))
 
 	tools := []struct {

--- a/internal/tools/groupimportexport/groupimportexport_test.go
+++ b/internal/tools/groupimportexport/groupimportexport_test.go
@@ -275,9 +275,7 @@ func (failingReader) Read([]byte) (int, error) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestImportFile_InvalidArchivePath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("ImportFile should reject invalid file path before API request")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ImportFile(t.Context(), client, ImportFileInput{Name: "test-group", Path: "test-group", File: ""})
 	if err == nil {
 		t.Fatal(errExpectedErr)

--- a/internal/tools/groupiterations/group_iterations_test.go
+++ b/internal/tools/groupiterations/group_iterations_test.go
@@ -89,9 +89,7 @@ func TestList_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestList_ValidationError_MissingGroupID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(context.Background(), client, ListInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")

--- a/internal/tools/grouplabels/grouplabels_test.go
+++ b/internal/tools/grouplabels/grouplabels_test.go
@@ -206,7 +206,9 @@ func TestCreate_ArchivedFlag(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathGroupLabels {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"name":"bug","color":"#d9534f","archived":true}`)
@@ -281,7 +283,9 @@ func TestUpdate_ArchivedFlag(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathLabel1 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"name":"bug-fix","color":"#00ff00","archived":true}`)

--- a/internal/tools/groupmarkdownuploads/action_specs_test.go
+++ b/internal/tools/groupmarkdownuploads/action_specs_test.go
@@ -122,9 +122,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupMarkdownUploadSpecsByTool(t, ActionSpecs(client))
 
 	for _, tt := range []struct {

--- a/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
+++ b/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
@@ -89,9 +89,7 @@ func TestDeleteByID_Error(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDeleteByID_ValidationUploadID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when upload_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, id := range []int64{0, -1} {
 		err := DeleteByID(t.Context(), client, DeleteByIDInput{GroupID: "5", UploadID: id})
 		if err == nil {

--- a/internal/tools/groupmembers/action_specs_test.go
+++ b/internal/tools/groupmembers/action_specs_test.go
@@ -153,9 +153,7 @@ func TestActionSpecs_DeleteOutputs(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupMemberSpecsByTool(t, ActionSpecs(client))
 
 	for _, tt := range []struct {

--- a/internal/tools/groups/hooks_test.go
+++ b/internal/tools/groups/hooks_test.go
@@ -175,7 +175,9 @@ func TestAddHook_Success(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathGroupHooks {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, groupHookJSON)
@@ -248,7 +250,9 @@ func TestEditHook_Success(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathGroupHook10 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, groupHookJSON)

--- a/internal/tools/groupscim/action_specs_test.go
+++ b/internal/tools/groupscim/action_specs_test.go
@@ -116,9 +116,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupSCIMSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/groupsshcerts/action_specs_test.go
+++ b/internal/tools/groupsshcerts/action_specs_test.go
@@ -107,9 +107,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupSSHCertSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/groupvariables/action_specs_test.go
+++ b/internal/tools/groupvariables/action_specs_test.go
@@ -123,9 +123,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := groupVariableSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/groupvariables/groupvariables_test.go
+++ b/internal/tools/groupvariables/groupvariables_test.go
@@ -640,14 +640,20 @@ func TestUpdate_AllOptionalFields(t *testing.T) {
 		if r.URL.Path == "/api/v4/groups/10/variables/DB_HOST" && r.Method == http.MethodPut {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode request body: %v", err)
+				t.Errorf("decode request body: %v", err)
+				http.Error(w, "decode request body", http.StatusInternalServerError)
+				return
 			}
 			filter, hasFilter := body["filter"].(map[string]any)
 			if !hasFilter || filter["environment_scope"] != "staging" {
-				t.Fatalf("filter.environment_scope = %#v, want staging", body["filter"])
+				t.Errorf("filter.environment_scope = %#v, want staging", body["filter"])
+				http.Error(w, "filter.environment_scope, want staging", http.StatusInternalServerError)
+				return
 			}
 			if _, hasEnvironmentScope := body["environment_scope"]; hasEnvironmentScope {
-				t.Fatalf("request body contains environment_scope update field: %#v", body)
+				t.Errorf("request body contains environment_scope update field: %#v", body)
+				http.Error(w, "request body contains environment_scope update field", http.StatusInternalServerError)
+				return
 			}
 			testutil.RespondJSON(w, http.StatusOK, `{
 				"key":"DB_HOST","value":"db.prod","variable_type":"file",
@@ -985,7 +991,9 @@ func TestUpdate_FilterObjectPrecedence(t *testing.T) {
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			filter, ok := body["filter"].(map[string]any)
 			if !ok || filter["environment_scope"] != "production" {
-				t.Fatalf("filter.environment_scope = %#v, want production", body["filter"])
+				t.Errorf("filter.environment_scope = %#v, want production", body["filter"])
+				http.Error(w, "filter.environment_scope, want production", http.StatusInternalServerError)
+				return
 			}
 			testutil.RespondJSON(w, http.StatusOK, varJSON)
 			return

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -355,7 +355,9 @@ func TestImportFromGitHub_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/import/github" {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"name":"imported","full_path":"ns/imported","full_name":"ns / imported","import_source":"github.com/user/repo","import_status":"scheduled"}`)
@@ -511,7 +513,9 @@ func TestImportFromGitHub_WithOptionalStages(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/import/github" {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"name":"my-repo","full_path":"ns/my-repo","full_name":"ns / my-repo","refs_url":"https://gitlab.example.com/ns/my-repo/refs","import_source":"github.com/user/repo","import_status":"scheduled","import_warning":"some collaborators could not be mapped"}`)

--- a/internal/tools/instancevariables/action_specs_test.go
+++ b/internal/tools/instancevariables/action_specs_test.go
@@ -106,9 +106,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := instanceVariableSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/integrations/action_specs_test.go
+++ b/internal/tools/integrations/action_specs_test.go
@@ -84,9 +84,7 @@ func TestActionSpecs_DeleteError(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := integrationSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/integrations/group_datadog_test.go
+++ b/internal/tools/integrations/group_datadog_test.go
@@ -284,9 +284,7 @@ func TestSetGroupDatadog_UseInheritedSettings(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestSetGroupDatadog_EmptyInputRejected(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("transport should not be called when input is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := SetGroupDatadog(t.Context(), client, SetGroupDatadogInput{GroupID: testGroupPath})
 	if err == nil {

--- a/internal/tools/integrations/integrations_test.go
+++ b/internal/tools/integrations/integrations_test.go
@@ -565,7 +565,9 @@ func TestSetJira_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPut {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"title":"Jira","slug":"jira","active":true}`)

--- a/internal/tools/integrations/set_integration_test.go
+++ b/internal/tools/integrations/set_integration_test.go
@@ -97,9 +97,7 @@ func TestSetIntegration_NilConfig(t *testing.T) {
 
 // TestSetIntegration_MissingSlug verifies the slug-required validation guard.
 func TestSetIntegration_MissingSlug(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("transport should not be called when slug is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := SetIntegration(t.Context(), client, SetIntegrationInput{ProjectID: testProjectID}); err == nil {
 		t.Fatal("expected error for missing slug")
 	}
@@ -193,9 +191,7 @@ func TestGetGroupIntegration_Success(t *testing.T) {
 
 // TestGetGroupIntegration_MissingSlug verifies the slug-required guard.
 func TestGetGroupIntegration_MissingSlug(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("transport should not be called when slug is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := GetGroupIntegration(t.Context(), client, GetGroupIntegrationInput{GroupID: testGroupPath}); err == nil {
 		t.Fatal("expected error for missing slug")
 	}
@@ -246,9 +242,7 @@ func TestSetGroupIntegration_Success(t *testing.T) {
 
 // TestSetGroupIntegration_MissingSlug verifies the slug-required guard.
 func TestSetGroupIntegration_MissingSlug(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("transport should not be called when slug is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := SetGroupIntegration(t.Context(), client, SetGroupIntegrationInput{GroupID: testGroupPath}); err == nil {
 		t.Fatal("expected error for missing slug")
 	}
@@ -288,9 +282,7 @@ func TestDeleteGroupIntegration_Success(t *testing.T) {
 
 // TestDeleteGroupIntegration_MissingSlug verifies the slug-required guard.
 func TestDeleteGroupIntegration_MissingSlug(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("transport should not be called when slug is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if err := DeleteGroupIntegration(t.Context(), client, DeleteGroupIntegrationInput{GroupID: testGroupPath}); err == nil {
 		t.Fatal("expected error for missing slug")
 	}

--- a/internal/tools/invites/invites_test.go
+++ b/internal/tools/invites/invites_test.go
@@ -74,9 +74,7 @@ func TestListPendingProjectInvitations_WithQuery(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListPendingProjectInvitations_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ListPendingProjectInvitations(context.Background(), client, ListPendingProjectInvitationsInput{})
 	if err == nil {
@@ -114,9 +112,7 @@ func TestListPendingGroupInvitations_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestListPendingGroupInvitations_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ListPendingGroupInvitations(context.Background(), client, ListPendingGroupInvitationsInput{})
 	if err == nil {
@@ -149,9 +145,7 @@ func TestProjectInvites_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestProjectInvites_ValidationError_NoProject(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ProjectInvites(context.Background(), client, ProjectInvitesInput{Email: "a@b.com", AccessLevel: 30})
 	if err == nil {
@@ -163,9 +157,7 @@ func TestProjectInvites_ValidationError_NoProject(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestProjectInvites_ValidationError_NoEmailOrUser(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := ProjectInvites(context.Background(), client, ProjectInvitesInput{ProjectID: "42", AccessLevel: 30})
 	if err == nil {
@@ -198,9 +190,7 @@ func TestGroupInvites_Success(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGroupInvites_ValidationError_NoGroup(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GroupInvites(context.Background(), client, GroupInvitesInput{Email: "a@b.com", AccessLevel: 30})
 	if err == nil {
@@ -404,9 +394,7 @@ func TestProjectInvites_BadRequest(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts that the returned error is wrapped and contains a useful hint.
 func TestGroupInvites_ValidationErrorNoEmailOrUser(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GroupInvites(context.Background(), client, GroupInvitesInput{GroupID: "10", AccessLevel: 30})
 	if err == nil {
 		t.Fatal("expected error for missing email and user_id, got nil")

--- a/internal/tools/issuediscussions/action_specs_test.go
+++ b/internal/tools/issuediscussions/action_specs_test.go
@@ -89,9 +89,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := issueDiscussionSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/issuediscussions/issuediscussions_test.go
+++ b/internal/tools/issuediscussions/issuediscussions_test.go
@@ -295,9 +295,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestIssueIIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_iid is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = testProjectPath
 
@@ -337,9 +335,7 @@ func TestIssueIIDRequired_Validation(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestNoteIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when note_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = testProjectPath
 
@@ -366,9 +362,7 @@ func TestNoteIDRequired_Validation(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestProjectIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when project_id is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 
 	tests := []struct {
@@ -404,9 +398,7 @@ func TestProjectIDRequired_Validation(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestDiscussionIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when discussion_id is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = testProjectPath
 

--- a/internal/tools/issuelinks/action_specs_test.go
+++ b/internal/tools/issuelinks/action_specs_test.go
@@ -100,9 +100,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := issueLinkSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/issuelinks/issuelinks_test.go
+++ b/internal/tools/issuelinks/issuelinks_test.go
@@ -441,9 +441,7 @@ func assertContains(t *testing.T, err error, substr string) {
 
 // TestIssueIIDNegative_Validation ensures negative issue_iid is rejected by all handlers.
 func TestIssueIIDNegative_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_iid is negative")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -473,9 +471,7 @@ func TestIssueIIDNegative_Validation(t *testing.T) {
 
 // TestIssueLinkIDNegative_Validation ensures negative issue_link_id is rejected.
 func TestIssueLinkIDNegative_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_link_id is negative")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 

--- a/internal/tools/issuenotes/action_specs_test.go
+++ b/internal/tools/issuenotes/action_specs_test.go
@@ -140,9 +140,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := issueNoteSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/issuenotes/issue_notes_test.go
+++ b/internal/tools/issuenotes/issue_notes_test.go
@@ -390,9 +390,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // TestIssueIIDRequired_Validation ensures all handlers that accept issue_iid
 // reject zero/negative values before making any API call.
 func TestIssueIIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_iid is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -423,9 +421,7 @@ func TestIssueIIDRequired_Validation(t *testing.T) {
 // TestNoteIDRequired_Validation ensures GetNote, Update, Delete reject
 // zero/negative note_id before making any API call.
 func TestNoteIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when note_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -823,7 +819,9 @@ func TestCreate_CreatedAtBackdated(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssueNotes {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			if !strings.Contains(string(body), `"created_at":"2026-01-15T10:00:00Z"`) {
 				t.Errorf("body = %s, want created_at 2026-01-15T10:00:00Z", body)
@@ -852,7 +850,9 @@ func TestCreate_CreatedAtUnparseableIgnored(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssueNotes {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			if strings.Contains(string(body), "created_at") {
 				t.Errorf("body = %s, want no created_at", body)

--- a/internal/tools/issues/action_specs_test.go
+++ b/internal/tools/issues/action_specs_test.go
@@ -252,9 +252,7 @@ func TestActionSpecs_GetEmbedsCanonicalResource(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := issueSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/issues/issues_test.go
+++ b/internal/tools/issues/issues_test.go
@@ -159,10 +159,7 @@ func TestCreate_Success(t *testing.T) {
 // when the due_date field has an invalid format. The mock should never be
 // called because validation occurs before the API request.
 func TestCreate_InvalidDueDate(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called for invalid due_date")
-		http.NotFound(w, nil)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Create(context.Background(), client, CreateInput{
 		ProjectID: testProjectID,
@@ -1378,9 +1375,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // TestIssueIIDRequired_Validation ensures all handlers that accept issue_iid
 // reject zero/negative values with ErrRequiredInt64 before making any API call.
 func TestIssueIIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_iid is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -1434,9 +1429,7 @@ func TestIssueIIDRequired_Validation(t *testing.T) {
 
 // TestIssueIDRequired_Validation ensures GetByID rejects zero/negative issue_id.
 func TestIssueIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when issue_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	tests := []struct {
 		name string
 		id   int64
@@ -1493,9 +1486,7 @@ func schemaRequiredFields(schema map[string]any) []string {
 
 // TestToProjectIDRequired_Validation ensures Move rejects zero/negative to_project_id.
 func TestToProjectIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when to_project_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	tests := []struct {
 		name string
 		id   int64
@@ -3283,7 +3274,9 @@ func TestCreate_ConfidentialTrue(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssues {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v, ok := body["confidential"].(bool); !ok || !v {
 				t.Errorf("confidential = %v, want true", body["confidential"])
@@ -3315,7 +3308,9 @@ func TestCreate_ConfidentialFalse(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssues {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v, ok := body["confidential"].(bool); !ok || v {
 				t.Errorf("confidential = %v, want false", body["confidential"])
@@ -3347,7 +3342,9 @@ func TestUpdate_ConfidentialToggle(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathIssue10 {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v, ok := body["confidential"].(bool); !ok || v {
 				t.Errorf("confidential = %v, want false", body["confidential"])
@@ -3407,7 +3404,9 @@ func TestCreate_AssigneeIDSingular(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssues {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode request body: %v", err)
+				t.Errorf("failed to decode request body: %v", err)
+				http.Error(w, "failed to decode request body", http.StatusInternalServerError)
+				return
 			}
 			if _, ok := body["assignee_id"]; !ok {
 				t.Errorf("request body missing assignee_id field: %v", body)
@@ -3441,7 +3440,9 @@ func TestUpdate_AssigneeIDSingular(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathIssue10 {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode request body: %v", err)
+				t.Errorf("failed to decode request body: %v", err)
+				http.Error(w, "failed to decode request body", http.StatusInternalServerError)
+				return
 			}
 			if _, ok := body["assignee_id"]; !ok {
 				t.Errorf("request body missing assignee_id field: %v", body)
@@ -4075,7 +4076,9 @@ func TestCreate_WithIID(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathIssues {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
+				t.Errorf("decode body: %v", err)
+				http.Error(w, "decode body", http.StatusInternalServerError)
+				return
 			}
 			if body["iid"] != float64(900) {
 				t.Errorf("body iid = %v, want 900", body["iid"])
@@ -4099,7 +4102,9 @@ func TestUpdate_WithUpdatedAt(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathIssue10 {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
+				t.Errorf("decode body: %v", err)
+				http.Error(w, "decode body", http.StatusInternalServerError)
+				return
 			}
 			if _, ok := body["updated_at"]; !ok {
 				t.Error("expected updated_at in update body")

--- a/internal/tools/issuestatistics/issuestatistics_test.go
+++ b/internal/tools/issuestatistics/issuestatistics_test.go
@@ -28,9 +28,7 @@ func newStats(all, opened, closed int64) StatisticsOutput {
 // TestGet verifies Get.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/issues_statistics")
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":10,"closed":3,"opened":7}}}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -57,9 +55,7 @@ func TestGet_Error(t *testing.T) {
 // TestGetGroup verifies GetGroup.
 func TestGetGroup(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/groups/5/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/groups/5/issues_statistics")
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":5,"closed":2,"opened":3}}}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -86,9 +82,7 @@ func TestGetGroup_Error(t *testing.T) {
 // TestGetProject verifies GetProject.
 func TestGetProject(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/1/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/1/issues_statistics")
 		testutil.RespondJSON(w, http.StatusOK, `{"statistics":{"counts":{"all":20,"closed":10,"opened":10}}}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -121,9 +115,6 @@ func TestFormatMarkdown(t *testing.T) {
 }
 
 // ---------- Tests consolidated from coverage_test.go ----------.
-
-// fmtUnexpPath identifies the fmt unexp path constant used by this package.
-const fmtUnexpPath = "unexpected path: %s"
 
 // errExpCancelledNil identifies the err exp cancelled nil constant used by this package.
 const errExpCancelledNil = "expected error for canceled context, got nil"
@@ -254,9 +245,7 @@ func TestFromGL_ZeroCounts(t *testing.T) {
 func TestGet_WithAllFilters(t *testing.T) {
 	const resp = `{"statistics":{"counts":{"all":10,"closed":3,"opened":7}}}`
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/issues_statistics")
 		q := r.URL.Query()
 		if q.Get("labels") == "" {
 			t.Error(errExpLabelsParam)
@@ -390,9 +379,7 @@ func TestGet_APIError403(t *testing.T) {
 func TestGetGroup_WithAllFilters(t *testing.T) {
 	const resp = `{"statistics":{"counts":{"all":30,"closed":10,"opened":20}}}`
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/groups/99/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/groups/99/issues_statistics")
 		q := r.URL.Query()
 		if q.Get("labels") == "" {
 			t.Error(errExpLabelsParam)
@@ -514,9 +501,7 @@ func TestGetGroup_APIError404(t *testing.T) {
 func TestGetProject_WithAllFilters(t *testing.T) {
 	const resp = `{"statistics":{"counts":{"all":50,"closed":20,"opened":30}}}`
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/42/issues_statistics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/42/issues_statistics")
 		q := r.URL.Query()
 		if q.Get("labels") == "" {
 			t.Error(errExpLabelsParam)

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -921,9 +921,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // TestJobIDRequired_Validation ensures all handlers that require job_id
 // reject zero and negative values.
 func TestJobIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when job_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -968,9 +966,7 @@ func TestJobIDRequired_Validation(t *testing.T) {
 // TestPipelineIDRequired_ValidationJobs ensures handlers that require pipeline_id
 // reject zero and negative values.
 func TestPipelineIDRequired_ValidationJobs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when pipeline_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 

--- a/internal/tools/jobtokenscope/action_specs_test.go
+++ b/internal/tools/jobtokenscope/action_specs_test.go
@@ -110,9 +110,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_RemoveConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_RemoveConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := jobTokenScopeSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/jobtokenscope/jobtokenscope_test.go
+++ b/internal/tools/jobtokenscope/jobtokenscope_test.go
@@ -181,9 +181,7 @@ func TestRemoveGroupAllowlist_Success(t *testing.T) {
 
 // TestAddProjectAllowlist_ZeroTargetProjectID verifies AddProjectAllowlist when zero target project ID.
 func TestAddProjectAllowlist_ZeroTargetProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TargetProjectID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := AddProjectAllowlist(t.Context(), client, AddProjectAllowlistInput{ProjectID: "42", TargetProjectID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TargetProjectID, got nil")
@@ -192,9 +190,7 @@ func TestAddProjectAllowlist_ZeroTargetProjectID(t *testing.T) {
 
 // TestRemoveProjectAllowlist_ZeroTargetProjectID verifies RemoveProjectAllowlist when zero target project ID.
 func TestRemoveProjectAllowlist_ZeroTargetProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TargetProjectID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := RemoveProjectAllowlist(t.Context(), client, RemoveProjectAllowlistInput{ProjectID: "42", TargetProjectID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TargetProjectID, got nil")
@@ -203,9 +199,7 @@ func TestRemoveProjectAllowlist_ZeroTargetProjectID(t *testing.T) {
 
 // TestAddGroupAllowlist_ZeroTargetGroupID verifies AddGroupAllowlist when zero target group ID.
 func TestAddGroupAllowlist_ZeroTargetGroupID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TargetGroupID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := AddGroupAllowlist(t.Context(), client, AddGroupAllowlistInput{ProjectID: "42", TargetGroupID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TargetGroupID, got nil")
@@ -214,9 +208,7 @@ func TestAddGroupAllowlist_ZeroTargetGroupID(t *testing.T) {
 
 // TestRemoveGroupAllowlist_ZeroTargetGroupID verifies RemoveGroupAllowlist when zero target group ID.
 func TestRemoveGroupAllowlist_ZeroTargetGroupID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when TargetGroupID is 0")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := RemoveGroupAllowlist(t.Context(), client, RemoveGroupAllowlistInput{ProjectID: "42", TargetGroupID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero TargetGroupID, got nil")

--- a/internal/tools/labels/labels_test.go
+++ b/internal/tools/labels/labels_test.go
@@ -258,7 +258,9 @@ func TestLabelCreate_ArchivedFlag(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjectLabels {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":3,"name":"enhancement","color":"#00FF00","archived":true}`)
@@ -331,7 +333,9 @@ func TestLabelUpdate_ArchivedFlag(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathLabelBug {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"name":"critical-bug","color":"#FF0000","archived":true}`)
@@ -367,7 +371,9 @@ func TestLabelUpdate_NameBodyField(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathLabelBug {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"name":"bug","color":"#00FF00","is_project_label":true}`)

--- a/internal/tools/license/action_specs_test.go
+++ b/internal/tools/license/action_specs_test.go
@@ -123,9 +123,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := licenseSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/licensetemplates/licensetemplates_test.go
+++ b/internal/tools/licensetemplates/licensetemplates_test.go
@@ -16,9 +16,7 @@ import (
 // TestList verifies List.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/licenses" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/licenses")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"mit","name":"MIT License","featured":true}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -48,9 +46,7 @@ func TestList_Error(t *testing.T) {
 // TestGet verifies Get.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/templates/licenses/mit" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/templates/licenses/mit")
 		testutil.RespondJSON(w, http.StatusOK, `{"key":"mit","name":"MIT License","content":"MIT License\n\nCopyright...","permissions":["commercial-use"],"conditions":["include-copyright"],"limitations":["no-liability"]}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -68,9 +64,7 @@ func TestGet(t *testing.T) {
 
 // TestGet_EmptyKey verifies that Get returns a validation error when the key is empty.
 func TestGet_EmptyKey(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called with empty key")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{Key: ""})
 	if err == nil {
 		t.Fatal("expected error for empty key")

--- a/internal/tools/memberroles/action_specs_test.go
+++ b/internal/tools/memberroles/action_specs_test.go
@@ -105,9 +105,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := memberRoleSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/memberroles/member_roles_test.go
+++ b/internal/tools/memberroles/member_roles_test.go
@@ -626,7 +626,9 @@ func TestCreateInstance_WithAllPermissions(t *testing.T) {
 		testutil.AssertRequestPath(t, r, "/api/v4/member_roles")
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, `{

--- a/internal/tools/members/action_specs_test.go
+++ b/internal/tools/members/action_specs_test.go
@@ -89,9 +89,7 @@ func TestActionSpecs_MutationErrors(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := memberSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/members/members_test.go
+++ b/internal/tools/members/members_test.go
@@ -546,9 +546,7 @@ func TestMemberDeleteServer_Error(t *testing.T) {
 
 // TestMemberGet_MissingUserID verifies MemberGet when missing user ID.
 func TestMemberGet_MissingUserID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(context.Background(), client, GetInput{ProjectID: testProjectID, UserID: 0})
 	if err == nil {
 		t.Fatal("Get() expected error for missing user_id, got nil")
@@ -560,9 +558,7 @@ func TestMemberGet_MissingUserID(t *testing.T) {
 
 // TestMemberGetInherited_MissingUserID verifies MemberGetInherited when missing user ID.
 func TestMemberGetInherited_MissingUserID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetInherited(context.Background(), client, GetInput{ProjectID: testProjectID, UserID: 0})
 	if err == nil {
 		t.Fatal("GetInherited() expected error for missing user_id, got nil")
@@ -574,9 +570,7 @@ func TestMemberGetInherited_MissingUserID(t *testing.T) {
 
 // TestMemberAdd_MissingUserID verifies MemberAdd when missing user ID.
 func TestMemberAdd_MissingUserID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Add(context.Background(), client, AddInput{ProjectID: testProjectID, UserID: 0, AccessLevel: 30})
 	if err == nil {
 		t.Fatal("Add() expected error for missing user_id, got nil")
@@ -588,9 +582,7 @@ func TestMemberAdd_MissingUserID(t *testing.T) {
 
 // TestMemberEdit_MissingUserID verifies MemberEdit when missing user ID.
 func TestMemberEdit_MissingUserID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Edit(context.Background(), client, EditInput{ProjectID: testProjectID, UserID: 0, AccessLevel: 30})
 	if err == nil {
 		t.Fatal("Edit() expected error for missing user_id, got nil")
@@ -602,9 +594,7 @@ func TestMemberEdit_MissingUserID(t *testing.T) {
 
 // TestMemberDelete_MissingUserID verifies MemberDelete when missing user ID.
 func TestMemberDelete_MissingUserID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(context.Background(), client, DeleteInput{ProjectID: testProjectID, UserID: 0})
 	if err == nil {
 		t.Fatal("Delete() expected error for missing user_id, got nil")

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -2337,11 +2337,11 @@ func TestCreateTodo_APIError(t *testing.T) {
 // TestCreateTodo_AlreadyExists verifies CreateTodo when GitLab returns 304 for an existing todo.
 func TestCreateTodo_AlreadyExists(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Fatalf("method = %s, want POST", r.Method)
-		}
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		if r.URL.Path != pathMR1+"/todo" {
-			t.Fatalf("path = %s, want %s", r.URL.Path, pathMR1+"/todo")
+			t.Errorf("path = %s, want %s", r.URL.Path, pathMR1+"/todo")
+			http.Error(w, "path, want", http.StatusInternalServerError)
+			return
 		}
 		w.WriteHeader(http.StatusNotModified)
 	}))
@@ -3436,7 +3436,9 @@ func TestCreate_AssigneeIDSingular(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathMRs {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			bodyStr := string(body)
 			if !strings.Contains(bodyStr, `"assignee_id":28`) {
@@ -3470,7 +3472,9 @@ func TestUpdate_AssigneeIDSingular(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathMR1 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			bodyStr := string(body)
 			if !strings.Contains(bodyStr, `"assignee_id":28`) {
@@ -3781,7 +3785,9 @@ func TestMerge_AutoDetectsSquashOnMerge(t *testing.T) {
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
@@ -3819,7 +3825,9 @@ func TestMerge_AutoDetectsForceRemoveSourceBranch(t *testing.T) {
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
@@ -3857,7 +3865,9 @@ func TestMerge_EnforcedSquashOverridesExplicitFalse(t *testing.T) {
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)
@@ -3898,7 +3908,9 @@ func TestMerge_ExplicitSquashRespectedWhenNotEnforced(t *testing.T) {
 		case r.Method == http.MethodPut && r.URL.Path == pathMR1+"/merge":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			mergeRequestBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, mrJSONCoverage)

--- a/internal/tools/mergetrains/merge_trains_test.go
+++ b/internal/tools/mergetrains/merge_trains_test.go
@@ -98,7 +98,9 @@ func TestListProjectMergeTrains(t *testing.T) {
 				if tt.handler != nil {
 					tt.handler(t, w, r)
 				} else {
-					t.Fatal("handler should not be called")
+					t.Error("handler should not be called")
+					http.Error(w, "handler should not be called", http.StatusInternalServerError)
+					return
 				}
 			}))
 			out, err := ListProjectMergeTrains(context.Background(), client, tt.input)
@@ -208,7 +210,9 @@ func TestListMergeRequestInMergeTrain(t *testing.T) {
 				if tt.handler != nil {
 					tt.handler(t, w, r)
 				} else {
-					t.Fatal("handler should not be called")
+					t.Error("handler should not be called")
+					http.Error(w, "handler should not be called", http.StatusInternalServerError)
+					return
 				}
 			}))
 			out, err := ListMergeRequestInMergeTrain(context.Background(), client, tt.input)
@@ -287,7 +291,9 @@ func TestGetMergeRequestOnMergeTrain(t *testing.T) {
 				if tt.handler != nil {
 					tt.handler(t, w, r)
 				} else {
-					t.Fatal("handler should not be called")
+					t.Error("handler should not be called")
+					http.Error(w, "handler should not be called", http.StatusInternalServerError)
+					return
 				}
 			}))
 			out, err := GetMergeRequestOnMergeTrain(context.Background(), client, tt.input)
@@ -371,7 +377,9 @@ func TestAddMergeRequestToMergeTrain(t *testing.T) {
 				if tt.handler != nil {
 					tt.handler(t, w, r)
 				} else {
-					t.Fatal("handler should not be called")
+					t.Error("handler should not be called")
+					http.Error(w, "handler should not be called", http.StatusInternalServerError)
+					return
 				}
 			}))
 			out, err := AddMergeRequestToMergeTrain(context.Background(), client, tt.input)
@@ -476,11 +484,15 @@ func TestAddMergeRequestToMergeTrain_WhenPipelineSucceeds(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read body: %v", err)
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
 		}
 		var opts map[string]any
 		if jErr := json.Unmarshal(body, &opts); jErr != nil {
-			t.Fatalf("parse body: %v", jErr)
+			t.Errorf("parse body: %v", jErr)
+			http.Error(w, "parse body", http.StatusInternalServerError)
+			return
 		}
 		if opts["when_pipeline_succeeds"] != true {
 			t.Errorf("when_pipeline_succeeds = %v, want true", opts["when_pipeline_succeeds"])

--- a/internal/tools/metadata/metadata_test.go
+++ b/internal/tools/metadata/metadata_test.go
@@ -15,9 +15,7 @@ import (
 // TestGet verifies Get.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/metadata" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/metadata")
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"version": "16.8.0",
 			"revision": "abc123",

--- a/internal/tools/milestones/milestones_test.go
+++ b/internal/tools/milestones/milestones_test.go
@@ -385,9 +385,7 @@ func TestMilestoneUpdate_WithDates(t *testing.T) {
 		http.NotFound(w, r)
 	})
 	mux.HandleFunc(pathProjectMilestones+"/1", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Fatalf("method = %s, want PUT", r.Method)
-		}
+		testutil.AssertRequestMethod(t, r, http.MethodPut)
 		testutil.RespondJSON(w, http.StatusOK, `{"id":1,"iid":1,"project_id":42,"title":"v1.0"}`)
 	})
 	client := testutil.NewTestClient(t, mux)

--- a/internal/tools/mrapprovals/action_specs_test.go
+++ b/internal/tools/mrapprovals/action_specs_test.go
@@ -104,9 +104,7 @@ func TestActionSpecs_DeleteErrorsPropagate(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := approvalSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/mrchanges/mrchanges_test.go
+++ b/internal/tools/mrchanges/mrchanges_test.go
@@ -272,9 +272,7 @@ func assertContains(t *testing.T, err error, substr string) {
 
 // TestMRIIDRequired_Validation covers MRIIDRequired with table-driven subtests for validation.
 func TestMRIIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when merge_request_iid is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	tests := []struct {
 		name string
@@ -306,9 +304,7 @@ func TestMRIIDRequired_Validation(t *testing.T) {
 
 // TestVersionIDRequired_Validation verifies VersionIDRequired when validation.
 func TestVersionIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when version_id is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	t.Run("GetDiffVersion", func(t *testing.T) {
 		_, err := GetDiffVersion(context.Background(), client, DiffVersionGetInput{ProjectID: "42", MRIID: 1})

--- a/internal/tools/mrcontextcommits/mrcontextcommits_test.go
+++ b/internal/tools/mrcontextcommits/mrcontextcommits_test.go
@@ -222,9 +222,7 @@ func assertContains(t *testing.T, err error, substr string) {
 
 // TestMRIIDRequired_Validation covers MRIIDRequired with table-driven subtests for validation.
 func TestMRIIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called when merge_request_iid is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	tests := []struct {
 		name string
@@ -486,9 +484,7 @@ func newMRContextCommitsSpecsByTool(t *testing.T) map[string]toolutil.ActionSpec
 // TestList_EmptyProjectID verifies that List returns an error when project_id
 // is empty, covering the missed validation branch.
 func TestList_EmptyProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(t.Context(), client, ListInput{ProjectID: "", MergeRequest: 1})
 	if err == nil {
 		t.Fatal("expected error for empty project_id")
@@ -498,9 +494,7 @@ func TestList_EmptyProjectID(t *testing.T) {
 // TestCreate_EmptyProjectID verifies that Create returns an error when
 // project_id is empty.
 func TestCreate_EmptyProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Create(t.Context(), client, CreateInput{ProjectID: "", MergeRequest: 1, Commits: []string{"abc"}})
 	if err == nil {
 		t.Fatal("expected error for empty project_id")
@@ -510,9 +504,7 @@ func TestCreate_EmptyProjectID(t *testing.T) {
 // TestDelete_EmptyProjectID verifies that Delete returns an error when
 // project_id is empty.
 func TestDelete_EmptyProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(t.Context(), client, DeleteInput{ProjectID: "", MergeRequest: 1, Commits: []string{"abc"}})
 	if err == nil {
 		t.Fatal("expected error for empty project_id")

--- a/internal/tools/mrdiscussions/mr_discussions_test.go
+++ b/internal/tools/mrdiscussions/mr_discussions_test.go
@@ -521,7 +521,8 @@ func TestCreate_PositionValidationError(t *testing.T) {
 			testutil.RespondJSON(w, http.StatusOK, `[{"old_path":"other.go","new_path":"other.go","diff":"@@ -1,1 +1,1 @@\n-old\n+new\n"}]`)
 			return
 		}
-		t.Fatalf("unexpected API call: %s %s", r.Method, r.URL.Path)
+		t.Errorf("unexpected API call: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected API call", http.StatusInternalServerError)
 	}))
 
 	_, err := Create(context.Background(), client, CreateInput{

--- a/internal/tools/mrdraftnotes/action_specs_test.go
+++ b/internal/tools/mrdraftnotes/action_specs_test.go
@@ -142,9 +142,7 @@ func TestActionSpecs_PublishOutputsIncludeStatus(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := mrDraftNoteSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/mrnotes/mr_notes_test.go
+++ b/internal/tools/mrnotes/mr_notes_test.go
@@ -724,7 +724,9 @@ func TestCreate_CreatedAtBackdated(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathMR1Notes {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			if !strings.Contains(string(body), `"created_at":"2026-01-15T10:00:00Z"`) {
 				t.Errorf("body = %s, want created_at 2026-01-15T10:00:00Z", body)
@@ -753,7 +755,9 @@ func TestCreate_CreatedAtUnparseableIgnored(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathMR1Notes {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			if strings.Contains(string(body), "created_at") {
 				t.Errorf("body = %s, want no created_at", body)
@@ -782,7 +786,9 @@ func TestCreate_InternalAndDiffHeadSHA(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathMR1Notes {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			s := string(body)
 			if !strings.Contains(s, `"internal":true`) {

--- a/internal/tools/notifications/notifications_test.go
+++ b/internal/tools/notifications/notifications_test.go
@@ -15,9 +15,6 @@ import (
 // fmtUnexpPath identifies the fmt unexp path constant used by this package.
 const fmtUnexpPath = "unexpected path: %s"
 
-// errNoReachAPI identifies the err no reach API constant used by this package.
-const errNoReachAPI = "should not reach API"
-
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 
@@ -68,9 +65,7 @@ func TestGetSettingsForProject_Success(t *testing.T) {
 
 // TestGetSettingsForProject_ValidationError verifies GetSettingsForProject when validation error.
 func TestGetSettingsForProject_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetSettingsForProject(t.Context(), client, GetProjectInput{ProjectID: ""})
 	if err == nil {
@@ -98,9 +93,7 @@ func TestGetSettingsForGroup_Success(t *testing.T) {
 
 // TestGetSettingsForGroup_ValidationError verifies GetSettingsForGroup when validation error.
 func TestGetSettingsForGroup_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GetSettingsForGroup(t.Context(), client, GetGroupInput{GroupID: ""})
 	if err == nil {
@@ -131,9 +124,7 @@ func TestUpdateGlobalSettings_Success(t *testing.T) {
 
 // TestUpdateSettingsForProject_ValidationError verifies UpdateSettingsForProject when validation error.
 func TestUpdateSettingsForProject_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := UpdateSettingsForProject(t.Context(), client, UpdateProjectInput{ProjectID: ""})
 	if err == nil {
@@ -290,9 +281,7 @@ func TestUpdateSettingsForGroup_Success(t *testing.T) {
 
 // TestUpdateSettingsForGroup_ValidationError verifies UpdateSettingsForGroup when validation error.
 func TestUpdateSettingsForGroup_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := UpdateSettingsForGroup(t.Context(), client, UpdateGroupInput{GroupID: ""})
 	if err == nil {
 		t.Fatal("expected validation error")

--- a/internal/tools/orbit/action_specs_test.go
+++ b/internal/tools/orbit/action_specs_test.go
@@ -245,7 +245,9 @@ func TestOrbit_ActionSpecs_CallAllRoutes(t *testing.T) {
 			testutil.AssertRequestMethod(t, r, http.MethodGet)
 			testutil.RespondJSON(w, http.StatusOK, `{"projects":{"indexed":1,"total_known":1},"indexing":{"state":"indexed"}}`)
 		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+			return
 		}
 	}))
 

--- a/internal/tools/orbit/orbit_test.go
+++ b/internal/tools/orbit/orbit_test.go
@@ -87,7 +87,9 @@ func TestSchema_ResponseFormatAlias_ForwardsFormat(t *testing.T) {
 		testutil.AssertRequestPath(t, r, "/api/v4/orbit/schema")
 		testutil.AssertQueryParam(t, r, "format", "llm")
 		if got := r.URL.Query().Get("response_format"); got != "" {
-			t.Fatalf("response_format query parameter = %q, want empty", got)
+			t.Errorf("response_format query parameter = %q, want empty", got)
+			http.Error(w, "response_format query parameter, want empty", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{"schema_version":"1.0"}`)
 	}))
@@ -158,13 +160,19 @@ func TestQuery_Success_ForwardsRawQuery(t *testing.T) {
 		testutil.AssertRequestPath(t, r, "/api/v4/orbit/query")
 		var got map[string]json.RawMessage
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "decode request", http.StatusInternalServerError)
+			return
 		}
 		if string(got["query"]) != `{"node":{"entity":"Project","id":"p","node_ids":[1]},"query_type":"traversal"}` {
-			t.Fatalf("query body = %s, want traversal query with node_ids", got["query"])
+			t.Errorf("query body = %s, want traversal query with node_ids", got["query"])
+			http.Error(w, "query body, want traversal query with node_ids", http.StatusInternalServerError)
+			return
 		}
 		if string(got["response_format"]) != `"raw"` {
-			t.Fatalf("response_format = %s, want raw", got["response_format"])
+			t.Errorf("response_format = %s, want raw", got["response_format"])
+			http.Error(w, "response_format, want raw", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"result": [{"_id": "1", "_type": "Project"}],
@@ -203,10 +211,14 @@ func TestQuery_LLMResponseFormat_UsesRawResponse(t *testing.T) {
 		testutil.AssertRequestPath(t, r, "/api/v4/orbit/query")
 		var got map[string]json.RawMessage
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decode request: %v", err)
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "decode request", http.StatusInternalServerError)
+			return
 		}
 		if string(got["response_format"]) != `"llm"` {
-			t.Fatalf("response_format = %s, want llm", got["response_format"])
+			t.Errorf("response_format = %s, want llm", got["response_format"])
+			http.Error(w, "response_format, want llm", http.StatusInternalServerError)
+			return
 		}
 		w.Header().Set("Content-Type", "text/plain")
 		_, _ = w.Write([]byte("@header\nProject(name: gitlab)\n"))
@@ -939,7 +951,9 @@ func TestSchema_ResponseFormatAliasEmptyString(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.AssertRequestPath(t, r, "/api/v4/orbit/schema")
 		if got := r.URL.Query().Get("format"); got != "" {
-			t.Fatalf("format query parameter = %q, want empty (server default)", got)
+			t.Errorf("format query parameter = %q, want empty (server default)", got)
+			http.Error(w, "format query parameter, want empty (server default)", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{"schema_version":"1.0"}`)
 	}))

--- a/internal/tools/packages/action_specs_test.go
+++ b/internal/tools/packages/action_specs_test.go
@@ -173,9 +173,7 @@ func TestActionSpecs_DeleteError(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := packageSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/packages/markdown_test.go
+++ b/internal/tools/packages/markdown_test.go
@@ -301,9 +301,6 @@ func TestFormatFileListMarkdown_LongSHA(t *testing.T) {
 
 // ---------- Tests consolidated from coverage_test.go ----------.
 
-// errNoReachAPI identifies the err no reach API constant used by this package.
-const errNoReachAPI = "should not reach API"
-
 // errExpectedAPI identifies the err expected API constant used by this package.
 const errExpectedAPI = "expected API error, got nil"
 
@@ -343,9 +340,7 @@ const (
 
 // TestPublish_MissingVersion verifies Publish when missing version.
 func TestPublish_MissingVersion(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:     "42",
 		PackageName:   testPackageName,
@@ -363,9 +358,7 @@ func TestPublish_MissingVersion(t *testing.T) {
 
 // TestPublish_InvalidFileName verifies Publish when invalid file name.
 func TestPublish_InvalidFileName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -384,9 +377,7 @@ func TestPublish_InvalidFileName(t *testing.T) {
 
 // TestPublish_InvalidBase64 verifies Publish when invalid base 64.
 func TestPublish_InvalidBase64(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -405,9 +396,7 @@ func TestPublish_InvalidBase64(t *testing.T) {
 
 // TestDownload_MissingProjectID verifies Download when missing project ID.
 func TestDownload_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		PackageName:    testPackageName,
 		PackageVersion: "1.0.0",
@@ -421,9 +410,7 @@ func TestDownload_MissingProjectID(t *testing.T) {
 
 // TestDownload_MissingPackageName verifies Download when missing package name.
 func TestDownload_MissingPackageName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		ProjectID:      "42",
 		PackageVersion: "1.0.0",
@@ -437,9 +424,7 @@ func TestDownload_MissingPackageName(t *testing.T) {
 
 // TestDownload_MissingVersion verifies Download when missing version.
 func TestDownload_MissingVersion(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		ProjectID:   "42",
 		PackageName: testPackageName,
@@ -453,9 +438,7 @@ func TestDownload_MissingVersion(t *testing.T) {
 
 // TestDownload_MissingFileName verifies Download when missing file name.
 func TestDownload_MissingFileName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -485,9 +468,7 @@ func TestList_APIError(t *testing.T) {
 // TestList_ContextCancelled verifies List when context cancelled.
 func TestList_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(ctx, client, ListInput{ProjectID: "1"})
 	if err == nil || !strings.Contains(err.Error(), testCtxCancelled) {
 		t.Fatalf(fmtExpCtxCancelErr, err)
@@ -569,9 +550,7 @@ func TestFileList_APIError(t *testing.T) {
 // TestFileList_ContextCancelled verifies FileList when context cancelled.
 func TestFileList_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := FileList(ctx, client, FileListInput{ProjectID: "1", PackageID: "10"})
 	if err == nil || !strings.Contains(err.Error(), testCtxCancelled) {
 		t.Fatalf(fmtExpCtxCancelErr, err)
@@ -580,9 +559,7 @@ func TestFileList_ContextCancelled(t *testing.T) {
 
 // TestFileList_MissingProjectID verifies FileList when missing project ID.
 func TestFileList_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := FileList(context.Background(), client, FileListInput{PackageID: "10"})
 	if err == nil || !strings.Contains(err.Error(), "project_id") {
 		t.Fatalf(fmtExpProjectIDErr, err)
@@ -631,9 +608,7 @@ func TestDelete_APIError(t *testing.T) {
 // TestDelete_ContextCancelled verifies Delete when context cancelled.
 func TestDelete_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(ctx, nil, client, DeleteInput{ProjectID: "1", PackageID: "10"})
 	if err == nil || !strings.Contains(err.Error(), testCtxCancelled) {
 		t.Fatalf(fmtExpCtxCancelErr, err)
@@ -658,9 +633,7 @@ func TestFileDelete_APIError(t *testing.T) {
 // TestFileDelete_ContextCancelled verifies FileDelete when context cancelled.
 func TestFileDelete_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := FileDelete(ctx, nil, client, FileDeleteInput{ProjectID: "1", PackageID: "10", PackageFileID: "20"})
 	if err == nil || !strings.Contains(err.Error(), testCtxCancelled) {
 		t.Fatalf(fmtExpCtxCancelErr, err)
@@ -669,9 +642,7 @@ func TestFileDelete_ContextCancelled(t *testing.T) {
 
 // TestFileDelete_MissingProjectID verifies FileDelete when missing project ID.
 func TestFileDelete_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := FileDelete(context.Background(), nil, client, FileDeleteInput{PackageID: "10", PackageFileID: "20"})
 	if err == nil || !strings.Contains(err.Error(), "project_id") {
 		t.Fatalf(fmtExpProjectIDErr, err)
@@ -680,9 +651,7 @@ func TestFileDelete_MissingProjectID(t *testing.T) {
 
 // TestFileDelete_MissingPackageID verifies FileDelete when missing package ID.
 func TestFileDelete_MissingPackageID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := FileDelete(context.Background(), nil, client, FileDeleteInput{ProjectID: "1", PackageFileID: "20"})
 	if err == nil || !strings.Contains(err.Error(), "package_id") {
 		t.Fatalf("expected package_id error, got: %v", err)
@@ -695,9 +664,7 @@ func TestFileDelete_MissingPackageID(t *testing.T) {
 
 // TestPublishDirectory_MissingProjectID verifies PublishDirectory when missing project ID.
 func TestPublishDirectory_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := PublishDirectory(context.Background(), nil, client, PublishDirInput{
 		PackageName:    testPackageName,
 		PackageVersion: "1.0.0",
@@ -710,9 +677,7 @@ func TestPublishDirectory_MissingProjectID(t *testing.T) {
 
 // TestPublishDirectory_InvalidPackageName verifies PublishDirectory when invalid package name.
 func TestPublishDirectory_InvalidPackageName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := PublishDirectory(context.Background(), nil, client, PublishDirInput{
 		ProjectID:      "1",
 		PackageName:    ".invalid",
@@ -726,9 +691,7 @@ func TestPublishDirectory_InvalidPackageName(t *testing.T) {
 
 // TestPublishDirectory_MissingVersion verifies PublishDirectory when missing version.
 func TestPublishDirectory_MissingVersion(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := PublishDirectory(context.Background(), nil, client, PublishDirInput{
 		ProjectID:     "1",
 		PackageName:   testPackageName,
@@ -741,9 +704,7 @@ func TestPublishDirectory_MissingVersion(t *testing.T) {
 
 // TestPublishDirectory_NonexistentDir verifies PublishDirectory when nonexistent dir.
 func TestPublishDirectory_NonexistentDir(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := PublishDirectory(context.Background(), nil, client, PublishDirInput{
 		ProjectID:      "1",
 		PackageName:    testPackageName,
@@ -762,9 +723,7 @@ func TestPublishDirectory_NonexistentDir(t *testing.T) {
 // TestStreamDownload_ContextCancelled verifies StreamDownload when context cancelled.
 func TestStreamDownload_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, _, err := streamDownloadPackageFile(ctx, nil, client, DownloadInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -848,9 +807,7 @@ func TestStreamDownload_APIError(t *testing.T) {
 
 // TestPublish_BothFileAndBase64 verifies Publish when both file and base 64.
 func TestPublish_BothFileAndBase64(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -870,9 +827,7 @@ func TestPublish_BothFileAndBase64(t *testing.T) {
 
 // TestPublish_NeitherFileNorBase64 verifies Publish when neither file nor base 64.
 func TestPublish_NeitherFileNorBase64(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -912,9 +867,7 @@ func TestPublish_APIError(t *testing.T) {
 // TestPublish_ContextCancelled verifies Publish when context cancelled.
 func TestPublish_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(ctx, nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,
@@ -976,9 +929,7 @@ func TestPublish_FilePathSmallFile(t *testing.T) {
 
 // TestPublish_InvalidPackageName verifies Publish when invalid package name.
 func TestPublish_InvalidPackageName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    ".invalid",
@@ -997,9 +948,7 @@ func TestPublish_InvalidPackageName(t *testing.T) {
 
 // TestPublish_MissingProjectID verifies Publish when missing project ID.
 func TestPublish_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		PackageName:    testPackageName,
 		PackageVersion: "1.0.0",
@@ -1061,9 +1010,7 @@ func TestList_WithNameAndTypeFilter(t *testing.T) {
 
 // TestPublishDirectory_EmptyDir verifies PublishDirectory when empty dir.
 func TestPublishDirectory_EmptyDir(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	dir := t.TempDir()
 	_, err := PublishDirectory(context.Background(), nil, client, PublishDirInput{
 		ProjectID:      "1",
@@ -1082,9 +1029,7 @@ func TestPublishDirectory_EmptyDir(t *testing.T) {
 
 // TestPublish_FilePathNonexistent verifies Publish when file path nonexistent.
 func TestPublish_FilePathNonexistent(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
 		PackageName:    testPackageName,

--- a/internal/tools/packages/packages_stream_test.go
+++ b/internal/tools/packages/packages_stream_test.go
@@ -242,9 +242,7 @@ func TestStreamDownload_UnwritablePath(t *testing.T) {
 // TestStreamDownload_OutputPathIsDirectory verifies streamDownloadPackageFile
 // returns the os.Create error when the requested output path is a directory.
 func TestStreamDownload_OutputPathIsDirectory(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected API call: %s %s", r.Method, r.URL.Path)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		ProjectID:      "42",

--- a/internal/tools/packages/packages_test.go
+++ b/internal/tools/packages/packages_test.go
@@ -167,7 +167,9 @@ func TestPackagePublish_WithProgressToken(t *testing.T) {
 			return
 		}
 		if _, err := io.Copy(io.Discard, r.Body); err != nil {
-			t.Fatalf("read upload body: %v", err)
+			t.Errorf("read upload body: %v", err)
+			http.Error(w, "read upload body", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusCreated, publishResponseJSON)
 	}))
@@ -227,9 +229,7 @@ func TestPackagePublish_WithProgressToken(t *testing.T) {
 
 // TestPackagePublishBothParams_Error verifies PackagePublishBothParams when error.
 func TestPackagePublishBothParams_Error(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
@@ -246,9 +246,7 @@ func TestPackagePublishBothParams_Error(t *testing.T) {
 
 // TestPackagePublishNeitherParams_Error verifies PackagePublishNeitherParams when error.
 func TestPackagePublishNeitherParams_Error(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
@@ -263,9 +261,7 @@ func TestPackagePublishNeitherParams_Error(t *testing.T) {
 
 // TestPackagePublish_InvalidPackageName verifies PackagePublish when invalid package name.
 func TestPackagePublish_InvalidPackageName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		ProjectID:      "42",
@@ -281,9 +277,7 @@ func TestPackagePublish_InvalidPackageName(t *testing.T) {
 
 // TestPackagePublish_MissingProjectID verifies PackagePublish when missing project ID.
 func TestPackagePublish_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Publish(context.Background(), nil, client, PublishInput{
 		PackageName:    testPackageName,
@@ -300,9 +294,7 @@ func TestPackagePublish_MissingProjectID(t *testing.T) {
 func TestPackagePublish_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
 
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Publish(ctx, nil, client, PublishInput{
 		ProjectID:      "42",
@@ -364,9 +356,7 @@ func TestPackageDownload_Success(t *testing.T) {
 
 // TestPackageDownload_MissingOutputPath verifies PackageDownload when missing output path.
 func TestPackageDownload_MissingOutputPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Download(context.Background(), nil, client, DownloadInput{
 		ProjectID:      "42",
@@ -383,9 +373,7 @@ func TestPackageDownload_MissingOutputPath(t *testing.T) {
 func TestPackageDownload_ContextCancelled(t *testing.T) {
 	ctx := testutil.CancelledCtx(t)
 
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Download(ctx, nil, client, DownloadInput{
 		ProjectID:      "42",
@@ -660,9 +648,7 @@ func TestPackageList_WithFilters(t *testing.T) {
 
 // TestPackageList_MissingProjectID verifies PackageList when missing project ID.
 func TestPackageList_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := List(context.Background(), client, ListInput{})
 	if err == nil {
@@ -730,9 +716,7 @@ func TestPackageGroupList_Success(t *testing.T) {
 
 // TestPackageGroupList_MissingGroupID verifies GroupList rejects an empty group_id.
 func TestPackageGroupList_MissingGroupID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := GroupList(context.Background(), client, GroupListInput{})
 	if err == nil {
@@ -746,9 +730,7 @@ func TestPackageGroupList_MissingGroupID(t *testing.T) {
 // TestPackageGroupList_ContextCancelled verifies GroupList returns early when
 // the context is already cancelled.
 func TestPackageGroupList_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -820,9 +802,7 @@ func TestPackageFileList_Success(t *testing.T) {
 
 // TestPackageFileList_MissingPackageID verifies PackageFileList when missing package ID.
 func TestPackageFileList_MissingPackageID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := FileList(context.Background(), client, FileListInput{
 		ProjectID: "42",
@@ -853,9 +833,7 @@ func TestPackageDelete_Success(t *testing.T) {
 
 // TestPackageDelete_MissingProjectID verifies PackageDelete when missing project ID.
 func TestPackageDelete_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	err := Delete(context.Background(), nil, client, DeleteInput{
 		PackageID: "10",
@@ -867,9 +845,7 @@ func TestPackageDelete_MissingProjectID(t *testing.T) {
 
 // TestPackageDelete_MissingPackageID verifies PackageDelete when missing package ID.
 func TestPackageDelete_MissingPackageID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	err := Delete(context.Background(), nil, client, DeleteInput{
 		ProjectID: "42",
@@ -901,9 +877,7 @@ func TestPackageFileDelete_Success(t *testing.T) {
 
 // TestPackageFileDelete_MissingFileID verifies PackageFileDelete when missing file ID.
 func TestPackageFileDelete_MissingFileID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	err := FileDelete(context.Background(), nil, client, FileDeleteInput{
 		ProjectID: "42",

--- a/internal/tools/pages/action_specs_test.go
+++ b/internal/tools/pages/action_specs_test.go
@@ -129,9 +129,7 @@ func TestActionSpecs_DeleteOutputs(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := pagesSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/pages/pages_test.go
+++ b/internal/tools/pages/pages_test.go
@@ -52,9 +52,7 @@ func TestGetPages_Success(t *testing.T) {
 
 // TestGetPages_ValidationError verifies GetPages when validation error.
 func TestGetPages_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetPages(context.Background(), client, GetPagesInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -105,9 +103,7 @@ func TestUnpublishPages_Success(t *testing.T) {
 
 // TestUnpublishPages_ValidationError verifies UnpublishPages when validation error.
 func TestUnpublishPages_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := UnpublishPages(context.Background(), client, UnpublishPagesInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -249,9 +245,7 @@ func TestGetDomain_Success(t *testing.T) {
 
 // TestGetDomain_ValidationError verifies GetDomain when validation error.
 func TestGetDomain_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetDomain(context.Background(), client, GetDomainInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected validation error for missing domain")
@@ -358,8 +352,6 @@ const (
 	testDomainA = "a.com"
 	// testMyGroupProject identifies the test my group project constant used by this package.
 	testMyGroupProject = "mygroup/myproject"
-	// errNoHandler identifies the err no handler constant used by this package.
-	errNoHandler = "handler should not be called"
 	// errExpectedAPI identifies the err expected API constant used by this package.
 	errExpectedAPI = "expected API error, got nil"
 	// errEmptyProjID identifies the err empty proj ID constant used by this package.
@@ -378,9 +370,7 @@ const (
 
 // TestUpdatePages_ValidationError verifies UpdatePages when validation error.
 func TestUpdatePages_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := UpdatePages(context.Background(), client, UpdatePagesInput{})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -474,9 +464,7 @@ func TestListAllDomains_APIError(t *testing.T) {
 
 // TestListDomains_ValidationError verifies ListDomains when validation error.
 func TestListDomains_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListDomains(context.Background(), client, ListDomainsInput{})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -500,9 +488,7 @@ func TestListDomains_APIError(t *testing.T) {
 
 // TestGetDomain_ValidationMissingProjectID verifies GetDomain when validation missing project ID.
 func TestGetDomain_ValidationMissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetDomain(context.Background(), client, GetDomainInput{Domain: testDomain})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -526,9 +512,7 @@ func TestGetDomain_APIError(t *testing.T) {
 
 // TestCreateDomain_ValidationMissingProjectID verifies CreateDomain when validation missing project ID.
 func TestCreateDomain_ValidationMissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateDomain(context.Background(), client, CreateDomainInput{Domain: testDomain})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -537,9 +521,7 @@ func TestCreateDomain_ValidationMissingProjectID(t *testing.T) {
 
 // TestCreateDomain_ValidationMissingDomain verifies CreateDomain when validation missing domain.
 func TestCreateDomain_ValidationMissingDomain(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateDomain(context.Background(), client, CreateDomainInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errEmptyDomain)
@@ -586,9 +568,7 @@ func TestCreateDomain_WithCert(t *testing.T) {
 
 // TestUpdateDomain_ValidationMissingProjectID verifies UpdateDomain when validation missing project ID.
 func TestUpdateDomain_ValidationMissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := UpdateDomain(context.Background(), client, UpdateDomainInput{Domain: testDomain})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -597,9 +577,7 @@ func TestUpdateDomain_ValidationMissingProjectID(t *testing.T) {
 
 // TestUpdateDomain_ValidationMissingDomain verifies UpdateDomain when validation missing domain.
 func TestUpdateDomain_ValidationMissingDomain(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := UpdateDomain(context.Background(), client, UpdateDomainInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errEmptyDomain)
@@ -646,9 +624,7 @@ func TestUpdateDomain_WithCert(t *testing.T) {
 
 // TestDeleteDomain_ValidationMissingProjectID verifies DeleteDomain when validation missing project ID.
 func TestDeleteDomain_ValidationMissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteDomain(context.Background(), client, DeleteDomainInput{Domain: testDomain})
 	if err == nil {
 		t.Fatal(errEmptyProjID)
@@ -657,9 +633,7 @@ func TestDeleteDomain_ValidationMissingProjectID(t *testing.T) {
 
 // TestDeleteDomain_ValidationMissingDomain verifies DeleteDomain when validation missing domain.
 func TestDeleteDomain_ValidationMissingDomain(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoHandler)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteDomain(context.Background(), client, DeleteDomainInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal(errEmptyDomain)

--- a/internal/tools/pipelines/pipelines_test.go
+++ b/internal/tools/pipelines/pipelines_test.go
@@ -658,9 +658,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // TestPipelineIDRequired_Validation ensures all handlers that require pipeline_id
 // reject zero and negative values.
 func TestPipelineIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when pipeline_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -978,9 +976,7 @@ func TestDetailToOutput_MinimalFields(t *testing.T) {
 
 // TestGet_CancelledContext verifies Get when cancelled context.
 func TestGet_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Get(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -990,9 +986,7 @@ func TestGet_CancelledContext(t *testing.T) {
 
 // TestCancel_CancelledContext verifies Cancel when cancelled context.
 func TestCancel_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Cancel(ctx, client, ActionInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1002,9 +996,7 @@ func TestCancel_CancelledContext(t *testing.T) {
 
 // TestRetry_CancelledContext verifies Retry when cancelled context.
 func TestRetry_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Retry(ctx, client, ActionInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1014,9 +1006,7 @@ func TestRetry_CancelledContext(t *testing.T) {
 
 // TestDelete_CancelledContext verifies Delete when cancelled context.
 func TestDelete_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	err := Delete(ctx, client, DeleteInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1026,9 +1016,7 @@ func TestDelete_CancelledContext(t *testing.T) {
 
 // TestGetVariables_CancelledContext verifies GetVariables when cancelled context.
 func TestGetVariables_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetVariables(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1038,9 +1026,7 @@ func TestGetVariables_CancelledContext(t *testing.T) {
 
 // TestGetTestReport_CancelledContext verifies GetTestReport when cancelled context.
 func TestGetTestReport_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetTestReport(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1050,9 +1036,7 @@ func TestGetTestReport_CancelledContext(t *testing.T) {
 
 // TestGetTestReportSummary_CancelledContext verifies GetTestReportSummary when cancelled context.
 func TestGetTestReportSummary_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetTestReportSummary(ctx, client, GetInput{ProjectID: "42", PipelineID: 10})
 	if err == nil {
@@ -1062,9 +1046,7 @@ func TestGetTestReportSummary_CancelledContext(t *testing.T) {
 
 // TestGetLatest_CancelledContext verifies GetLatest when cancelled context.
 func TestGetLatest_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := GetLatest(ctx, client, GetLatestInput{ProjectID: "42"})
 	if err == nil {
@@ -1074,9 +1056,7 @@ func TestGetLatest_CancelledContext(t *testing.T) {
 
 // TestCreate_CancelledContext verifies Create when cancelled context.
 func TestCreate_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Create(ctx, client, CreateInput{ProjectID: "42", Ref: "main"})
 	if err == nil {
@@ -1086,9 +1066,7 @@ func TestCreate_CancelledContext(t *testing.T) {
 
 // TestUpdateMetadata_CancelledContext verifies UpdateMetadata when cancelled context.
 func TestUpdateMetadata_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := UpdateMetadata(ctx, client, UpdateMetadataInput{ProjectID: "42", PipelineID: 10, Name: "x"})
 	if err == nil {
@@ -1879,7 +1857,9 @@ func TestGetLatest_FallbackListError(t *testing.T) {
 		// Force a connection-level error by hijacking and closing
 		hj, ok := w.(http.Hijacker)
 		if !ok {
-			t.Fatal("response writer does not support hijacking")
+			t.Error("response writer does not support hijacking")
+			http.Error(w, "response writer does not support hijacking", http.StatusInternalServerError)
+			return
 		}
 		conn, _, _ := hj.Hijack()
 		conn.Close()

--- a/internal/tools/pipelineschedules/action_specs_test.go
+++ b/internal/tools/pipelineschedules/action_specs_test.go
@@ -131,9 +131,7 @@ func TestActionSpecs_MutationErrors(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := pipelineScheduleSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/pipelineschedules/pipelineschedules_test.go
+++ b/internal/tools/pipelineschedules/pipelineschedules_test.go
@@ -825,9 +825,7 @@ func assertContains(t *testing.T, err error, substr string) {
 // TestScheduleIDRequired_Validation ensures all handlers that require schedule_id
 // reject zero and negative values.
 func TestScheduleIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when schedule_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 

--- a/internal/tools/pipelinetriggers/action_specs_test.go
+++ b/internal/tools/pipelinetriggers/action_specs_test.go
@@ -80,9 +80,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := pipelineTriggersSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/projectaliases/action_specs_test.go
+++ b/internal/tools/projectaliases/action_specs_test.go
@@ -94,9 +94,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := projectAliasSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/projectimportexport/projectimportexport_test.go
+++ b/internal/tools/projectimportexport/projectimportexport_test.go
@@ -218,9 +218,7 @@ func TestImportFromFile_FilePath_Success(t *testing.T) {
 // TestImportFromFile_BothParams_Error verifies that providing both file_path
 // and content_base64 returns an error.
 func TestImportFromFile_BothParams_Error(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called")
-	})
+	handler := testutil.ForbiddenHandler(t)
 	client := testutil.NewTestClient(t, handler)
 
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{
@@ -235,9 +233,7 @@ func TestImportFromFile_BothParams_Error(t *testing.T) {
 // TestImportFromFile_NoParams_Error verifies that providing neither file_path
 // nor content_base64 returns an error.
 func TestImportFromFile_NoParams_Error(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called")
-	})
+	handler := testutil.ForbiddenHandler(t)
 	client := testutil.NewTestClient(t, handler)
 
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{})
@@ -249,9 +245,7 @@ func TestImportFromFile_NoParams_Error(t *testing.T) {
 // TestImportFromFile_InvalidBase64_Error verifies that invalid base64 content
 // returns an error before making API calls.
 func TestImportFromFile_InvalidBase64_Error(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called with invalid base64")
-	})
+	handler := testutil.ForbiddenHandler(t)
 	client := testutil.NewTestClient(t, handler)
 
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{
@@ -370,9 +364,7 @@ func TestFormatExportDownloadMarkdown(t *testing.T) {
 
 // TestImportFromFile_FilePath_NonExistent_Error verifies error when file does not exist.
 func TestImportFromFile_FilePath_NonExistent_Error(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("API should not be called")
-	})
+	handler := testutil.ForbiddenHandler(t)
 	client := testutil.NewTestClient(t, handler)
 
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{
@@ -389,9 +381,7 @@ func TestImportFromFile_FilePathOpenError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod-based unreadable file test is Unix-specific")
 	}
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	archivePath := t.TempDir() + "/unreadable.tar.gz"
 	if err := os.WriteFile(archivePath, []byte("fake archive"), 0o600); err != nil {
@@ -629,9 +619,7 @@ func TestActionSpecs_CallRoutes(t *testing.T) {
 // TestImportFromFile_FilePathReadError verifies that ImportFromFile returns
 // an error when the specified file path does not exist (os.ReadFile error).
 func TestImportFromFile_FilePathReadError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{
 		FilePath: "/nonexistent/path/to/file.tar.gz",
 	})
@@ -646,9 +634,7 @@ func TestImportFromFile_FilePathReadError(t *testing.T) {
 // TestImportFromFile_Base64DecodeError verifies that invalid base64 in
 // content_base64 returns an appropriate error.
 func TestImportFromFile_Base64DecodeError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ImportFromFile(t.Context(), client, ImportFromFileInput{
 		ContentBase64: "not-valid-base64!!!",
 	})
@@ -716,9 +702,7 @@ func (errReader) Read([]byte) (int, error) { return 0, errors.New("forced read e
 // TestRawGetImportStatus_RequestError verifies rawGetImportStatus returns the
 // request-construction error when the path contains an invalid percent escape.
 func TestRawGetImportStatus_RequestError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when request construction fails")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := rawGetImportStatus(t.Context(), client, "projects/%zz/import"); err == nil {
 		t.Fatal("expected request-construction error for invalid path escape, got nil")
 	}
@@ -727,9 +711,7 @@ func TestRawGetImportStatus_RequestError(t *testing.T) {
 // TestRawImportFromFile_RequestError verifies rawImportFromFile returns the
 // request-construction error when the archive reader fails during multipart copy.
 func TestRawImportFromFile_RequestError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when request construction fails")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := rawImportFromFile(t.Context(), client, errReader{}, nil); err == nil {
 		t.Fatal("expected request-construction error for failing archive reader, got nil")
 	}
@@ -814,7 +796,9 @@ func TestImportFromFile_OverrideParams(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v4/projects/import" && r.Method == http.MethodPost {
 			if err := r.ParseMultipartForm(1 << 20); err != nil { //nolint:gosec // Test handler parses a small in-memory fixture body.
-				t.Fatalf("parse multipart: %v", err)
+				t.Errorf("parse multipart: %v", err)
+				http.Error(w, "parse multipart", http.StatusInternalServerError)
+				return
 			}
 			for key, want := range wantParams {
 				if got := r.FormValue(key); got != want {

--- a/internal/tools/projectiterations/project_iterations_test.go
+++ b/internal/tools/projectiterations/project_iterations_test.go
@@ -61,9 +61,7 @@ func TestList_Success(t *testing.T) {
 
 // TestList_ValidationError_MissingProjectID verifies List returns error when ProjectID is empty.
 func TestList_ValidationError_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(context.Background(), client, ListInput{})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")

--- a/internal/tools/projectmirrors/action_specs_test.go
+++ b/internal/tools/projectmirrors/action_specs_test.go
@@ -96,9 +96,7 @@ func TestActionSpecs_ErrorPaths(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := projectMirrorSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -489,7 +489,9 @@ func TestProjectDelete_PermanentlyRemoveTwoStep(t *testing.T) {
 		case 2, 3:
 			w.WriteHeader(http.StatusAccepted)
 		default:
-			t.Fatalf("unexpected delete call %d", calls)
+			t.Errorf("unexpected delete call %d", calls)
+			http.Error(w, "unexpected delete call", http.StatusInternalServerError)
+			return
 		}
 	}))
 
@@ -521,9 +523,7 @@ func TestProjectDelete_NotFound(t *testing.T) {
 // TestProjectDelete_EmptyID verifies that Delete returns an error
 // when project_id is empty.
 func TestProjectDelete_EmptyID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not make API call with empty project_id")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Delete(context.Background(), client, DeleteInput{ProjectID: ""})
 	if err == nil {
@@ -593,9 +593,7 @@ func TestProjectRestore_NotFound(t *testing.T) {
 // TestProjectRestore_EmptyID verifies that Restore returns an error
 // when project_id is empty.
 func TestProjectRestore_EmptyID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not make API call with empty project_id")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Restore(context.Background(), client, RestoreInput{ProjectID: ""})
 	if err == nil {
@@ -639,7 +637,9 @@ func TestProjectCreate_ReviewerAssignmentStrategy_SentAndMapped(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":42,"name":"my-repo","path_with_namespace":"jmrplens/my-repo","visibility":"private","reviewer_assignment_strategy":"code_owners"}`)
@@ -673,7 +673,9 @@ func TestProjectCreate_ReviewerAssignmentStrategy_OmittedWhenEmpty(t *testing.T)
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":42,"name":"my-repo"}`)
@@ -703,7 +705,9 @@ func TestProjectUpdate_ReviewerAssignmentStrategy_SentAndMapped(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProject42 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":42,"name":"my-repo","reviewer_assignment_strategy":"dap_powered"}`)
@@ -751,9 +755,7 @@ func TestProjectCreate_ContextCancelled(t *testing.T) {
 // housekeeping, and user-project paths. A failing mock handler ensures each
 // operation observes the cancelled context before touching GitLab.
 func TestProjectHandlers_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("API should not be called with canceled context: %s %s", r.Method, r.URL.Path)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	content := base64.StdEncoding.EncodeToString([]byte("avatar-data"))
 
@@ -1025,9 +1027,7 @@ func TestProjectHandlers_StatusSpecificErrors(t *testing.T) {
 // handler fails on any request, proving validation protects GitLab from malformed
 // calls.
 func TestProjectHandlers_ValidationErrors(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("API should not be called for validation errors: %s %s", r.Method, r.URL.Path)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	tests := []struct {
 		name string
@@ -1172,7 +1172,9 @@ func TestProjectCreate_EnrichedFeatureOpts(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode request body: %v", err)
+				t.Errorf("failed to decode request body: %v", err)
+				http.Error(w, "failed to decode request body", http.StatusInternalServerError)
+				return
 			}
 			assertCreateFeatureBody(t, body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":99,"name":"feature-proj","path_with_namespace":"ns/feature-proj","visibility":"private","default_branch":"main","web_url":"https://gitlab.example.com/ns/feature-proj","description":""}`)
@@ -1462,11 +1464,15 @@ func TestProjectStar_EOFFallsBackToGet(t *testing.T) {
 			callOrder = append(callOrder, "star")
 			hijacker, ok := w.(http.Hijacker)
 			if !ok {
-				t.Fatal("response writer does not support hijacking")
+				t.Error("response writer does not support hijacking")
+				http.Error(w, "response writer does not support hijacking", http.StatusInternalServerError)
+				return
 			}
 			conn, _, err := hijacker.Hijack()
 			if err != nil {
-				t.Fatalf("hijack response: %v", err)
+				t.Errorf("hijack response: %v", err)
+				http.Error(w, "hijack response", http.StatusInternalServerError)
+				return
 			}
 			_ = conn.Close()
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/42":
@@ -1813,9 +1819,7 @@ func TestProjectHookCustomHeadersToOutput_SkipsNilEntries(t *testing.T) {
 // TestDoProjectHookRequest_NewRequestError verifies request construction errors
 // are returned before the GitLab client attempts an HTTP call.
 func TestDoProjectHookRequest_NewRequestError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called when request construction fails")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, resp, err := doProjectHookRequest[projectHookAPI](context.Background(), client, "bad method", pathProject42Hooks, nil)
 	if err == nil {
@@ -2604,9 +2608,7 @@ func TestEditPushRule_EmptyProjectID(t *testing.T) {
 // TestAddPushRule_RequiresRuleSetting verifies AddPushRule rejects calls that
 // GitLab would reject because they contain no actual push rule setting.
 func TestAddPushRule_RequiresRuleSetting(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		t.Fatalf("API should not be called for missing push rule settings: %s %s", r.Method, r.URL.Path)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := AddPushRule(context.Background(), client, AddPushRuleInput{ProjectID: "42"})
 	if err == nil {
@@ -3124,7 +3126,9 @@ func TestFork_WithAllOptions(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Fork {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":100,"name":"my-fork","path_with_namespace":"user/my-fork","visibility":"private","web_url":"https://gitlab.example.com/user/my-fork"}`)
@@ -3190,7 +3194,9 @@ func TestAddHook_WithAllEvents(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Hooks {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"id":1,"url":"https://example.com/hook","project_id":42,"push_events":true,"issues_events":true,"merge_requests_events":true,"tag_push_events":true,"note_events":true,"confidential_note_events":true,"job_events":true,"pipeline_events":true,"wiki_page_events":true,"deployment_events":true,"releases_events":true,"milestone_events":true,"feature_flag_events":true,"emoji_events":true,"resource_access_token_events":true,"resource_deploy_token_events":true,"vulnerability_events":true,"token_present":true,"signing_token_present":true}`)
@@ -3261,7 +3267,9 @@ func TestEditHook_WithAllEvents(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProject42Hook1 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, `{"id":1,"url":"https://example.com/hook-updated","project_id":42,"push_events":true}`)
@@ -4070,7 +4078,9 @@ func TestProjectFork_AllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProject42Fork {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode request body: %v", err)
+				t.Errorf("failed to decode request body: %v", err)
+				http.Error(w, "failed to decode request body", http.StatusInternalServerError)
+				return
 			}
 			assertForkBody(t, body)
 			testutil.RespondJSON(w, http.StatusCreated, projectJSON)
@@ -5568,7 +5578,9 @@ func TestProjectCreate_MergeMethod_FastForward(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v, ok := body["merge_method"].(string); !ok || v != "ff" {
 				t.Errorf("merge_method = %v, want %q", body["merge_method"], "ff")
@@ -5601,7 +5613,9 @@ func TestProjectCreate_MergePoliciesCombined(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v := body["merge_method"]; v != "rebase_merge" {
 				t.Errorf("merge_method = %v, want rebase_merge", v)
@@ -5636,7 +5650,9 @@ func TestProjectCreate_RemoveSourceBranch(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjects {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode body: %v", err)
+				t.Errorf("failed to decode body: %v", err)
+				http.Error(w, "failed to decode body", http.StatusInternalServerError)
+				return
 			}
 			if v, ok := body["remove_source_branch_after_merge"].(bool); !ok || !v {
 				t.Errorf("remove_source_branch_after_merge = %v, want true", body["remove_source_branch_after_merge"])
@@ -6624,7 +6640,9 @@ func TestCreateForUser_AllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProjectForUser5 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			s := string(body)
 			for _, want := range []string{

--- a/internal/tools/projects/target_branch_rules_test.go
+++ b/internal/tools/projects/target_branch_rules_test.go
@@ -83,9 +83,7 @@ func TestListTargetBranchRules_Empty(t *testing.T) {
 
 // TestListTargetBranchRules_MissingProjectID verifies project_id validation.
 func TestListTargetBranchRules_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("handler should not be called when project_id is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListTargetBranchRules(context.Background(), client, ListTargetBranchRulesInput{})
 	if err == nil || !strings.Contains(err.Error(), "project_id is required") {
 		t.Fatalf("err = %v, want project_id is required", err)
@@ -147,9 +145,7 @@ func TestCreateTargetBranchRule_Success(t *testing.T) {
 // TestCreateTargetBranchRule_Validation covers required-field and numeric-ID
 // validation without reaching the API.
 func TestCreateTargetBranchRule_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("handler should not be called on validation failure")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	tests := []struct {
 		name  string
 		input CreateTargetBranchRuleInput
@@ -216,9 +212,7 @@ func TestDeleteTargetBranchRuleOutput_Success(t *testing.T) {
 
 // TestDeleteTargetBranchRule_MissingRuleID verifies rule_id validation.
 func TestDeleteTargetBranchRule_MissingRuleID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("handler should not be called when rule_id is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := DeleteTargetBranchRule(context.Background(), client, DeleteTargetBranchRuleInput{})
 	if err == nil || !strings.Contains(err.Error(), "rule_id is required") {
 		t.Fatalf("err = %v, want rule_id is required", err)

--- a/internal/tools/projectstatistics/projectstatistics_test.go
+++ b/internal/tools/projectstatistics/projectstatistics_test.go
@@ -14,9 +14,7 @@ import (
 // TestGet verifies Get.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/1/statistics" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/1/statistics")
 		testutil.RespondJSON(w, http.StatusOK, `{"fetches":{"total":42,"days":[{"count":5,"date":"2026-01-01"}]}}`)
 	})
 	client := testutil.NewTestClient(t, handler)

--- a/internal/tools/projecttemplates/projecttemplates_test.go
+++ b/internal/tools/projecttemplates/projecttemplates_test.go
@@ -16,9 +16,7 @@ import (
 // TestList verifies List.
 func TestList(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/1/templates/licenses" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/1/templates/licenses")
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"mit","name":"MIT License","popular":true}]`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -48,9 +46,7 @@ func TestList_Error(t *testing.T) {
 // TestGet verifies Get.
 func TestGet(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/projects/1/templates/licenses/mit" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/projects/1/templates/licenses/mit")
 		testutil.RespondJSON(w, http.StatusOK, `{"key":"mit","name":"MIT License","content":"MIT text","permissions":["commercial-use"]}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -65,9 +61,7 @@ func TestGet(t *testing.T) {
 
 // TestGet_EmptyKey verifies that Get returns a validation error when the key is empty.
 func TestGet_EmptyKey(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called with empty key")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{ProjectID: "1", TemplateType: "licenses", Key: ""})
 	if err == nil {
 		t.Fatal("expected error for empty key")

--- a/internal/tools/protectedenvs/action_specs_test.go
+++ b/internal/tools/protectedenvs/action_specs_test.go
@@ -98,9 +98,7 @@ func TestActionSpecs_ProtectRequiresDeployAccessLevels(t *testing.T) {
 
 // TestCatalogSurface_UnprotectConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_UnprotectConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := protectedEnvironmentSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/protectedenvs/protectedenvs_test.go
+++ b/internal/tools/protectedenvs/protectedenvs_test.go
@@ -218,7 +218,9 @@ func TestProtect_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedEnvs {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, envJSON)
@@ -479,7 +481,9 @@ func TestUpdate_WithAllFields(t *testing.T) {
 		if r.Method == http.MethodPut && r.URL.Path == pathProtectedEnv1 {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, envJSON)
@@ -662,7 +666,9 @@ func TestProtect_WithRequiredApprovalCount(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedEnvs {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, envJSON)

--- a/internal/tools/protectedpackages/action_specs_test.go
+++ b/internal/tools/protectedpackages/action_specs_test.go
@@ -76,9 +76,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := protectedPackageSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/releaselinks/action_specs_test.go
+++ b/internal/tools/releaselinks/action_specs_test.go
@@ -124,9 +124,7 @@ func TestActionSpecs_MutationErrors(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := releaseLinkSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/releaselinks/release_links_test.go
+++ b/internal/tools/releaselinks/release_links_test.go
@@ -239,9 +239,7 @@ func TestReleaseLinkUpdate_Success(t *testing.T) {
 // TestReleaseLink_GetRequiresLinkID verifies that Get returns an error
 // when link_id is zero.
 func TestReleaseLink_GetRequiresLinkID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Get(context.Background(), client, GetInput{
 		ProjectID: "42",
@@ -259,9 +257,7 @@ func TestReleaseLink_GetRequiresLinkID(t *testing.T) {
 // TestReleaseLink_UpdateRequiresLinkID verifies that Update returns an error
 // when link_id is zero.
 func TestReleaseLink_UpdateRequiresLinkID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Update(context.Background(), client, UpdateInput{
 		ProjectID: "42",
@@ -279,9 +275,7 @@ func TestReleaseLink_UpdateRequiresLinkID(t *testing.T) {
 // TestReleaseLink_DeleteRequiresLinkID verifies that Delete returns an error
 // when link_id is zero.
 func TestReleaseLink_DeleteRequiresLinkID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Delete(context.Background(), client, DeleteInput{
 		ProjectID: "42",
@@ -1006,9 +1000,7 @@ func TestToOutput_ZeroValue(t *testing.T) {
 
 // TestCreateBatch_EmptyTagName verifies CreateBatch returns error when tag_name is empty.
 func TestCreateBatch_EmptyTagName(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := CreateBatch(context.Background(), client, CreateBatchInput{
 		ProjectID: "42",
 		TagName:   "",

--- a/internal/tools/resourceevents/resourceevents_test.go
+++ b/internal/tools/resourceevents/resourceevents_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	// errNoReachAPI identifies the err no reach API constant used by this package.
-	errNoReachAPI = "should not reach API"
 	// fmtWantOneEvent identifies the fmt want one event constant used by this package.
 	fmtWantOneEvent = "got %d events, want 1"
 	// fmtGotStateWant identifies the fmt got state want constant used by this package.
@@ -80,9 +78,7 @@ func TestGetIssueLabelEvent_Success_DetailedFields(t *testing.T) {
 
 // TestListIssueLabelEvents_ValidationError verifies ListIssueLabelEvents when validation error.
 func TestListIssueLabelEvents_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueLabelEvents(context.Background(), client, ListIssueLabelEventsInput{IssueIID: 1})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -286,18 +282,14 @@ func contains(s, substr string) bool {
 
 // TestListIssueLabelEvents_InvalidIID verifies ListIssueLabelEvents when invalid IID.
 func TestListIssueLabelEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueLabelEvents(context.Background(), client, ListIssueLabelEventsInput{ProjectID: "p", IssueIID: 0})
 	assertErrContains(t, err, "issue_iid")
 }
 
 // TestGetIssueLabelEvent_InvalidIDs verifies GetIssueLabelEvent when invalid IDs.
 func TestGetIssueLabelEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueLabelEvent(context.Background(), client, GetIssueLabelEventInput{ProjectID: "p", IssueIID: 0, LabelEventID: 1})
 	assertErrContains(t, err, "issue_iid")
 	_, err = GetIssueLabelEvent(context.Background(), client, GetIssueLabelEventInput{ProjectID: "p", IssueIID: 1, LabelEventID: 0})
@@ -306,18 +298,14 @@ func TestGetIssueLabelEvent_InvalidIDs(t *testing.T) {
 
 // TestListIssueMilestoneEvents_InvalidIID verifies ListIssueMilestoneEvents when invalid IID.
 func TestListIssueMilestoneEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueMilestoneEvents(context.Background(), client, ListIssueMilestoneEventsInput{ProjectID: "p", IssueIID: 0})
 	assertErrContains(t, err, "issue_iid")
 }
 
 // TestGetIssueMilestoneEvent_InvalidIDs verifies GetIssueMilestoneEvent when invalid IDs.
 func TestGetIssueMilestoneEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueMilestoneEvent(context.Background(), client, GetIssueMilestoneEventInput{ProjectID: "p", IssueIID: 0, MilestoneEventID: 1})
 	assertErrContains(t, err, "issue_iid")
 	_, err = GetIssueMilestoneEvent(context.Background(), client, GetIssueMilestoneEventInput{ProjectID: "p", IssueIID: 1, MilestoneEventID: 0})
@@ -326,18 +314,14 @@ func TestGetIssueMilestoneEvent_InvalidIDs(t *testing.T) {
 
 // TestListIssueStateEvents_InvalidIID verifies ListIssueStateEvents when invalid IID.
 func TestListIssueStateEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueStateEvents(context.Background(), client, ListIssueStateEventsInput{ProjectID: "p", IssueIID: 0})
 	assertErrContains(t, err, "issue_iid")
 }
 
 // TestGetIssueStateEvent_InvalidIDs verifies GetIssueStateEvent when invalid IDs.
 func TestGetIssueStateEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueStateEvent(context.Background(), client, GetIssueStateEventInput{ProjectID: "p", IssueIID: 0, StateEventID: 1})
 	assertErrContains(t, err, "issue_iid")
 	_, err = GetIssueStateEvent(context.Background(), client, GetIssueStateEventInput{ProjectID: "p", IssueIID: 1, StateEventID: 0})
@@ -346,18 +330,14 @@ func TestGetIssueStateEvent_InvalidIDs(t *testing.T) {
 
 // TestListMRLabelEvents_InvalidIID verifies ListMRLabelEvents when invalid IID.
 func TestListMRLabelEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListMRLabelEvents(context.Background(), client, ListMRLabelEventsInput{ProjectID: "p", MRIID: 0})
 	assertErrContains(t, err, "merge_request_iid")
 }
 
 // TestGetMRLabelEvent_InvalidIDs verifies GetMRLabelEvent when invalid IDs.
 func TestGetMRLabelEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetMRLabelEvent(context.Background(), client, GetMRLabelEventInput{ProjectID: "p", MRIID: 0, LabelEventID: 1})
 	assertErrContains(t, err, "merge_request_iid")
 	_, err = GetMRLabelEvent(context.Background(), client, GetMRLabelEventInput{ProjectID: "p", MRIID: 1, LabelEventID: 0})
@@ -366,18 +346,14 @@ func TestGetMRLabelEvent_InvalidIDs(t *testing.T) {
 
 // TestListMRMilestoneEvents_InvalidIID verifies ListMRMilestoneEvents when invalid IID.
 func TestListMRMilestoneEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListMRMilestoneEvents(context.Background(), client, ListMRMilestoneEventsInput{ProjectID: "p", MRIID: 0})
 	assertErrContains(t, err, "merge_request_iid")
 }
 
 // TestGetMRMilestoneEvent_InvalidIDs verifies GetMRMilestoneEvent when invalid IDs.
 func TestGetMRMilestoneEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetMRMilestoneEvent(context.Background(), client, GetMRMilestoneEventInput{ProjectID: "p", MRIID: 0, MilestoneEventID: 1})
 	assertErrContains(t, err, "merge_request_iid")
 	_, err = GetMRMilestoneEvent(context.Background(), client, GetMRMilestoneEventInput{ProjectID: "p", MRIID: 1, MilestoneEventID: 0})
@@ -386,18 +362,14 @@ func TestGetMRMilestoneEvent_InvalidIDs(t *testing.T) {
 
 // TestListMRStateEvents_InvalidIID verifies ListMRStateEvents when invalid IID.
 func TestListMRStateEvents_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListMRStateEvents(context.Background(), client, ListMRStateEventsInput{ProjectID: "p", MRIID: 0})
 	assertErrContains(t, err, "merge_request_iid")
 }
 
 // TestGetMRStateEvent_InvalidIDs verifies GetMRStateEvent when invalid IDs.
 func TestGetMRStateEvent_InvalidIDs(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetMRStateEvent(context.Background(), client, GetMRStateEventInput{ProjectID: "p", MRIID: 0, StateEventID: 1})
 	assertErrContains(t, err, "merge_request_iid")
 	_, err = GetMRStateEvent(context.Background(), client, GetMRStateEventInput{ProjectID: "p", MRIID: 1, StateEventID: 0})
@@ -1048,9 +1020,7 @@ func TestListIssueIterationEvents_Success(t *testing.T) {
 
 // TestListIssueIterationEvents_ValidationError verifies error when ProjectID is empty.
 func TestListIssueIterationEvents_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueIterationEvents(context.Background(), client, ListIssueIterationEventsInput{IssueIID: 1})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -1059,9 +1029,7 @@ func TestListIssueIterationEvents_ValidationError(t *testing.T) {
 
 // TestListIssueIterationEvents_MissingIssueIID verifies error when IssueIID is 0.
 func TestListIssueIterationEvents_MissingIssueIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueIterationEvents(context.Background(), client, ListIssueIterationEventsInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected validation error for missing issue_iid, got nil")
@@ -1070,9 +1038,7 @@ func TestListIssueIterationEvents_MissingIssueIID(t *testing.T) {
 
 // TestGetIssueIterationEvent_MissingProjectID verifies error when ProjectID is empty.
 func TestGetIssueIterationEvent_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueIterationEvent(context.Background(), client, GetIssueIterationEventInput{IssueIID: 1, IterationEventID: 1})
 	if err == nil {
 		t.Fatal("expected validation error for missing project_id, got nil")
@@ -1081,9 +1047,7 @@ func TestGetIssueIterationEvent_MissingProjectID(t *testing.T) {
 
 // TestGetIssueIterationEvent_MissingIssueIID verifies error when IssueIID is 0.
 func TestGetIssueIterationEvent_MissingIssueIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueIterationEvent(context.Background(), client, GetIssueIterationEventInput{ProjectID: "42", IterationEventID: 1})
 	if err == nil {
 		t.Fatal("expected validation error for missing issue_iid, got nil")
@@ -1092,9 +1056,7 @@ func TestGetIssueIterationEvent_MissingIssueIID(t *testing.T) {
 
 // TestListIssueWeightEvents_MissingIssueIID verifies error when IssueIID is 0.
 func TestListIssueWeightEvents_MissingIssueIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueWeightEvents(context.Background(), client, ListIssueWeightEventsInput{ProjectID: "42"})
 	if err == nil {
 		t.Fatal("expected validation error for missing issue_iid, got nil")
@@ -1128,9 +1090,7 @@ func TestGetIssueIterationEvent_Success(t *testing.T) {
 
 // TestGetIssueIterationEvent_ValidationError_MissingEventID verifies error when IterationEventID is 0.
 func TestGetIssueIterationEvent_ValidationError_MissingEventID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := GetIssueIterationEvent(context.Background(), client, GetIssueIterationEventInput{ProjectID: "42", IssueIID: 1, IterationEventID: 0})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -1166,9 +1126,7 @@ func TestListIssueWeightEvents_Success(t *testing.T) {
 
 // TestListIssueWeightEvents_ValidationError verifies error when ProjectID is empty.
 func TestListIssueWeightEvents_ValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListIssueWeightEvents(context.Background(), client, ListIssueWeightEventsInput{IssueIID: 1})
 	if err == nil {
 		t.Fatal("expected validation error, got nil")
@@ -1265,9 +1223,7 @@ func covGID() toolutil.StringOrInt { return toolutil.StringOrInt("acme") }
 // rejects input missing the required group_id and epic_iid fields without
 // reaching the API.
 func TestListGroupEpicLabelEvents_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if _, err := ListGroupEpicLabelEvents(t.Context(), client, ListGroupEpicLabelEventsInput{}); err == nil {
 		t.Fatal(errExpectedValidation)
 	}
@@ -1339,9 +1295,7 @@ func TestListGroupEpicLabelEvents_Success(t *testing.T) {
 // TestGetGroupEpicLabelEvent_Validation verifies GetGroupEpicLabelEvent rejects
 // input missing any required field without reaching the API.
 func TestGetGroupEpicLabelEvent_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	cases := []GetGroupEpicLabelEventInput{
 		{},
 		{GroupID: covGID()},

--- a/internal/tools/runnercontrollers/action_specs_test.go
+++ b/internal/tools/runnercontrollers/action_specs_test.go
@@ -71,9 +71,7 @@ func TestActionSpecs_DeleteAPIError(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := runnerControllerSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/runnercontrollerscopes/action_specs_test.go
+++ b/internal/tools/runnercontrollerscopes/action_specs_test.go
@@ -99,9 +99,7 @@ func TestActionSpecs_RemoveErrors(t *testing.T) {
 
 // TestCatalogSurface_ConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_ConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := runnerControllerScopeSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/runnercontrollertokens/action_specs_test.go
+++ b/internal/tools/runnercontrollertokens/action_specs_test.go
@@ -78,9 +78,7 @@ func TestActionSpecs_RevokeAPIError(t *testing.T) {
 
 // TestCatalogSurface_RevokeConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_RevokeConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := runnerControllerTokenSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/runners/action_specs_test.go
+++ b/internal/tools/runners/action_specs_test.go
@@ -162,9 +162,7 @@ func TestActionSpecs_ErrorOutputs(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := runnerSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/runners/runners_test.go
+++ b/internal/tools/runners/runners_test.go
@@ -1111,7 +1111,9 @@ func TestUpdate_AllOptionalFields(t *testing.T) {
 		if r.URL.Path == "/api/v4/runners/10" && r.Method == http.MethodPut {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
+				t.Errorf("decode body: %v", err)
+				http.Error(w, "decode body", http.StatusInternalServerError)
+				return
 			}
 			if body["active"] != true {
 				t.Errorf("expected active=true in body, got %v", body["active"])
@@ -1423,7 +1425,9 @@ func TestRegister_AllOptionalFields(t *testing.T) {
 		if r.URL.Path == "/api/v4/runners" && r.Method == http.MethodPost {
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
+				t.Errorf("decode body: %v", err)
+				http.Error(w, "decode body", http.StatusInternalServerError)
+				return
 			}
 			if body["active"] != true {
 				t.Errorf("expected active=true in body, got %v", body["active"])
@@ -2037,9 +2041,7 @@ func TestListManagers_Success(t *testing.T) {
 
 // TestListManagers_ZeroRunnerID verifies validation of zero runner ID.
 func TestListManagers_ZeroRunnerID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListManagers(context.Background(), client, ListManagersInput{RunnerID: 0})
 	if err == nil {
 		t.Fatal("expected error for zero runner_id")
@@ -2048,9 +2050,7 @@ func TestListManagers_ZeroRunnerID(t *testing.T) {
 
 // TestListManagers_CancelledContext verifies cancellation before the API request.
 func TestListManagers_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListManagers(testutil.CancelledCtx(t), client, ListManagersInput{RunnerID: 1})
 	if err == nil {
 		t.Fatal("expected error for canceled context")

--- a/internal/tools/safemode_test.go
+++ b/internal/tools/safemode_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -48,14 +49,15 @@ func TestWrapMutatingToolsForSafeMode_ReadOnlyToolPassesThrough(t *testing.T) {
 // mutating tools return a SafeModePreview instead of executing.
 func TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	var mutatingCalls atomic.Int64
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_create_issue",
 		Description: "Create an issue",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 		InputSchema: &map[string]any{"type": "object"},
 	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		t.Fatal("mutating handler should not be called in safe mode")
-		return nil, errors.New("unreachable")
+		mutatingCalls.Add(1)
+		return nil, errors.New("mutating handler must not run in safe mode")
 	})
 
 	wrapped := WrapMutatingToolsForSafeMode(server)
@@ -66,6 +68,9 @@ func TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview(t *testing.T) {
 	args := json.RawMessage(`{"project_id":123,"title":"Bug report"}`)
 	result := callTool(t, server, "gitlab_create_issue", args)
 
+	if n := mutatingCalls.Load(); n != 0 {
+		t.Errorf("mutating handler was called %d time(s) in safe mode", n)
+	}
 	if result.IsError {
 		t.Fatal("safe mode preview should not be an error")
 	}
@@ -101,13 +106,14 @@ func TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview(t *testing.T) {
 // annotations are treated as mutating and get wrapped.
 func TestWrapMutatingToolsForSafeMode_NilAnnotations(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	var handlerCalls atomic.Int64
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_delete_project",
 		Description: "Delete a project",
 		InputSchema: &map[string]any{"type": "object"},
 	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		t.Fatal("handler should not be called")
-		return nil, errors.New("unreachable")
+		handlerCalls.Add(1)
+		return nil, errors.New("wrapped handler must not run in safe mode")
 	})
 
 	wrapped := WrapMutatingToolsForSafeMode(server)
@@ -116,6 +122,9 @@ func TestWrapMutatingToolsForSafeMode_NilAnnotations(t *testing.T) {
 	}
 
 	result := callTool(t, server, "gitlab_delete_project", nil)
+	if n := handlerCalls.Load(); n != 0 {
+		t.Errorf("wrapped handler was called %d time(s) in safe mode", n)
+	}
 	var preview SafeModePreview
 	if err := json.Unmarshal([]byte(extractText(t, result)), &preview); err != nil {
 		t.Fatalf("failed to unmarshal preview: %v", err)
@@ -143,14 +152,15 @@ func TestWrapMutatingToolsForSafeMode_MixedTools(t *testing.T) {
 		}, nil
 	})
 
+	var mutatingCalls atomic.Int64
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_update_issue",
 		Description: "Update an issue",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: false},
 		InputSchema: &map[string]any{"type": "object"},
 	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		t.Fatal("mutating handler should not be called")
-		return nil, errors.New("unreachable")
+		mutatingCalls.Add(1)
+		return nil, errors.New("mutating handler must not run in safe mode")
 	})
 
 	wrapped := WrapMutatingToolsForSafeMode(server)
@@ -167,6 +177,9 @@ func TestWrapMutatingToolsForSafeMode_MixedTools(t *testing.T) {
 	}
 
 	result = callTool(t, server, "gitlab_update_issue", nil)
+	if n := mutatingCalls.Load(); n != 0 {
+		t.Errorf("mutating handler was called %d time(s) in safe mode", n)
+	}
 	var preview SafeModePreview
 	if err := json.Unmarshal([]byte(extractText(t, result)), &preview); err != nil {
 		t.Fatalf("failed to unmarshal preview: %v", err)

--- a/internal/tools/search/search_test.go
+++ b/internal/tools/search/search_test.go
@@ -840,9 +840,7 @@ func TestSearchOpts_InvalidSearchType(t *testing.T) {
 // TestSearchHandlers_InvalidSearchType_ReturnValidationError verifies that every
 // search handler rejects unsupported search_type values before calling GitLab.
 func TestSearchHandlers_InvalidSearchType_ReturnValidationError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("handler should not call GitLab API for invalid search_type: %s %s", r.Method, r.URL.Path)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	tests := []struct {
 		name string

--- a/internal/tools/securefiles/action_specs_test.go
+++ b/internal/tools/securefiles/action_specs_test.go
@@ -84,9 +84,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := secureFilesSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/snippetdiscussions/action_specs_test.go
+++ b/internal/tools/snippetdiscussions/action_specs_test.go
@@ -81,9 +81,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := snippetDiscussionsSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/snippetdiscussions/snippetdiscussions_test.go
+++ b/internal/tools/snippetdiscussions/snippetdiscussions_test.go
@@ -167,9 +167,7 @@ func assertContains(t *testing.T, err error, substr string) {
 
 // TestSnippetIDRequired_Validation ensures all handlers reject zero/negative snippet_id.
 func TestSnippetIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when snippet_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -207,9 +205,7 @@ func TestSnippetIDRequired_Validation(t *testing.T) {
 
 // TestDiscussionIDRequired_Validation ensures discussion-scoped handlers reject an empty discussion_id.
 func TestDiscussionIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when discussion_id is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -242,9 +238,7 @@ func TestDiscussionIDRequired_Validation(t *testing.T) {
 
 // TestContextCancelled_Validation ensures every handler returns early when the context is already cancelled.
 func TestContextCancelled_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when context is cancelled")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	const pid = "my/project"
@@ -373,9 +367,7 @@ func TestUpdateNote_CreatedAt(t *testing.T) {
 
 // TestNoteIDRequired_Validation ensures UpdateNote and DeleteNote reject zero/negative note_id.
 func TestNoteIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when note_id is invalid")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 	const pid = "my/project"
 
@@ -400,9 +392,7 @@ func TestNoteIDRequired_Validation(t *testing.T) {
 
 // TestProjectIDRequired_Validation ensures all handlers reject empty project_id.
 func TestProjectIDRequired_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called when project_id is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/tools/snippetnotes/action_specs_test.go
+++ b/internal/tools/snippetnotes/action_specs_test.go
@@ -79,9 +79,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := snippetNotesSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/snippetnotes/snippet_notes_test.go
+++ b/internal/tools/snippetnotes/snippet_notes_test.go
@@ -786,7 +786,9 @@ func TestCreate_CreatedAt(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathSnippetNotes {
 			raw, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read body: %v", err)
+				t.Errorf("read body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
 			}
 			if !contains(string(raw), "2026-01-15T10:00:00Z") {
 				t.Errorf("request body missing created_at: %s", raw)

--- a/internal/tools/snippets/project_snippets_test.go
+++ b/internal/tools/snippets/project_snippets_test.go
@@ -471,7 +471,9 @@ func TestCreate_WithAllOptions(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, covSnippetJSON)
@@ -503,7 +505,9 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, covSnippetJSON)

--- a/internal/tools/snippets/snippets_test.go
+++ b/internal/tools/snippets/snippets_test.go
@@ -192,10 +192,14 @@ func TestCreate_Success(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		if !strings.Contains(string(body), "package main") {
-			t.Fatalf("request body = %q, want snippet content", string(body))
+			t.Errorf("request body = %q, want snippet content", string(body))
+			http.Error(w, "request body, want snippet content", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusCreated, snippetJSON)
 	})

--- a/internal/tools/systemhooks/action_specs_test.go
+++ b/internal/tools/systemhooks/action_specs_test.go
@@ -120,9 +120,7 @@ func TestActionSpecs_URLVariableOutputs(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := systemHookSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/systemhooks/systemhooks_test.go
+++ b/internal/tools/systemhooks/systemhooks_test.go
@@ -28,9 +28,6 @@ const testHookURL = "https://example.com/hook"
 // errExpectedErrZeroID identifies the err expected err zero ID constant used by this package.
 const errExpectedErrZeroID = "expected error for zero ID, got nil"
 
-// errAPINotCalledZeroID identifies the err API not called zero ID constant used by this package.
-const errAPINotCalledZeroID = "API should not be called when ID is 0"
-
 // hookJSON identifies the hook JSON constant used by this package.
 const hookJSON = `{"id":1,"url":"https://example.com/hook","name":"My Hook","description":"Test hook","created_at":"2026-01-01T00:00:00Z","push_events":true,"tag_push_events":false,"merge_requests_events":true,"repository_update_events":false,"enable_ssl_verification":true,"url_variables":[{"key":"env","value":"prod"}],"token_present":true,"signing_token_present":true}`
 
@@ -122,7 +119,9 @@ func TestAdd_Success(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusCreated, hookJSON)
@@ -143,9 +142,7 @@ func TestAdd_Success(t *testing.T) {
 
 // TestAdd_Validation verifies Add validates required fields before calling the API.
 func TestAdd_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	if _, err := Add(t.Context(), client, AddInput{}); err == nil {
 		t.Fatal("expected error for empty URL, got nil")
@@ -166,7 +163,9 @@ func TestEdit_Success(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, hookJSON)
@@ -197,7 +196,9 @@ func TestEdit_AllOptionalFields(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, `{"id":2,"url":"https://example.com/hook2","name":"Named Hook","description":"Hook desc","created_at":"2026-01-01T00:00:00Z","push_events":false,"tag_push_events":true,"merge_requests_events":true,"repository_update_events":true,"enable_ssl_verification":false}`)
@@ -285,9 +286,7 @@ func TestDelete_Error(t *testing.T) {
 
 // TestGet_ZeroID verifies Get when zero ID.
 func TestGet_ZeroID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{ID: 0})
 	if err == nil {
 		t.Fatal(errExpectedErrZeroID)
@@ -296,9 +295,7 @@ func TestGet_ZeroID(t *testing.T) {
 
 // TestTest_ZeroID verifies Test when zero ID.
 func TestTest_ZeroID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Test(t.Context(), client, TestInput{ID: 0})
 	if err == nil {
 		t.Fatal(errExpectedErrZeroID)
@@ -307,9 +304,7 @@ func TestTest_ZeroID(t *testing.T) {
 
 // TestDelete_ZeroID verifies Delete when zero ID.
 func TestDelete_ZeroID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(t.Context(), client, DeleteInput{ID: 0})
 	if err == nil {
 		t.Fatal(errExpectedErrZeroID)
@@ -318,9 +313,7 @@ func TestDelete_ZeroID(t *testing.T) {
 
 // TestEdit_ZeroID verifies Edit when zero ID.
 func TestEdit_ZeroID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Edit(t.Context(), client, EditInput{ID: 0})
 	if err == nil {
 		t.Fatal(errExpectedErrZeroID)
@@ -339,7 +332,9 @@ func TestSetURLVariable_Success(t *testing.T) {
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("read request body: %v", err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read request body", http.StatusInternalServerError)
+			return
 		}
 		capturedBody = string(body)
 		testutil.RespondJSON(w, http.StatusOK, `{"key":"env","value":"prod"}`)
@@ -389,9 +384,7 @@ func TestDeleteURLVariable_Success(t *testing.T) {
 
 // TestSetURLVariable_Validation verifies SetURLVariable validation branches.
 func TestSetURLVariable_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if err := SetURLVariable(t.Context(), client, SetURLVariableInput{}); err == nil {
 		t.Fatal(errExpectedErrZeroID)
 	}
@@ -409,9 +402,7 @@ func TestSetURLVariable_Validation(t *testing.T) {
 
 // TestDeleteURLVariable_Validation verifies DeleteURLVariable validation branches.
 func TestDeleteURLVariable_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal(errAPINotCalledZeroID)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	if err := DeleteURLVariable(t.Context(), client, DeleteURLVariableInput{}); err == nil {
 		t.Fatal(errExpectedErrZeroID)
 	}

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -797,9 +797,7 @@ func TestTagList_APIError(t *testing.T) {
 
 // TestTagList_EmptyProjectID verifies List validates project_id before calling GitLab.
 func TestTagList_EmptyProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(context.Background(), client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpEmptyProjectID)
@@ -875,7 +873,9 @@ func TestTagProtect_WithAllowedToCreate(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == pathProtectedTags {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, `{"name":"v*","create_access_levels":[{"id":1,"access_level":30,"access_level_description":"Developers + Maintainers","user_id":5}]}`)
@@ -1524,10 +1524,7 @@ func TestActionSpecs_CallAllRoutes(t *testing.T) {
 // the early-return guard at the top of List that checks ctx.Err() prior
 // to performing any GitLab API request.
 func TestList_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("HTTP handler must not be invoked when context is cancelled")
-		_ = w
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	if _, err := List(ctx, client, ListInput{ProjectID: "42"}); err == nil {

--- a/internal/tools/todos/todos_test.go
+++ b/internal/tools/todos/todos_test.go
@@ -37,11 +37,11 @@ const (
 func TestTodoList_Success(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != pathTodos {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
+			t.Errorf(fmtUnexpPath, r.URL.Path)
+			http.Error(w, "assertion failed", http.StatusInternalServerError)
+			return
 		}
-		if r.Method != http.MethodGet {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestMethod(t, r, http.MethodGet)
 		testutil.RespondJSONWithPagination(w, http.StatusOK, `[
 			{
 				"id": 1,
@@ -156,11 +156,11 @@ func TestTodoList_CancelledContext(t *testing.T) {
 func TestTodoMarkDone_Success(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != pathTodoMarkDone {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
+			t.Errorf(fmtUnexpPath, r.URL.Path)
+			http.Error(w, "assertion failed", http.StatusInternalServerError)
+			return
 		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
@@ -219,11 +219,11 @@ func TestTodoMarkDone_CancelledContext(t *testing.T) {
 func TestTodoMarkAllDone_Success(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != pathTodoMarkAll {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
+			t.Errorf(fmtUnexpPath, r.URL.Path)
+			http.Error(w, "assertion failed", http.StatusInternalServerError)
+			return
 		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 

--- a/internal/tools/topics/action_specs_test.go
+++ b/internal/tools/topics/action_specs_test.go
@@ -140,9 +140,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := topicsSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/topics/topics_test.go
+++ b/internal/tools/topics/topics_test.go
@@ -19,9 +19,6 @@ import (
 // errExpNonNilResult identifies the err exp non nil result constant used by this package.
 const errExpNonNilResult = "expected non-nil result"
 
-// errNoReachAPI identifies the err no reach API constant used by this package.
-const errNoReachAPI = "should not reach API"
-
 // fmtUnexpErr identifies the fmt unexp err constant used by this package.
 const fmtUnexpErr = "unexpected error: %v"
 
@@ -231,9 +228,7 @@ func TestDelete_Error(t *testing.T) {
 
 // TestGet_InvalidTopicID verifies Get when invalid topic ID.
 func TestGet_InvalidTopicID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Get(t.Context(), client, GetInput{TopicID: 0})
 	if err == nil {
 		t.Fatal(errExpErrZeroTopicID)
@@ -249,9 +244,7 @@ func TestGet_InvalidTopicID(t *testing.T) {
 
 // TestUpdate_InvalidTopicID verifies Update when invalid topic ID.
 func TestUpdate_InvalidTopicID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Update(t.Context(), client, UpdateInput{TopicID: 0, Title: "x"})
 	if err == nil {
 		t.Fatal(errExpErrZeroTopicID)
@@ -267,9 +260,7 @@ func TestUpdate_InvalidTopicID(t *testing.T) {
 
 // TestDelete_InvalidTopicID verifies Delete when invalid topic ID.
 func TestDelete_InvalidTopicID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal(errNoReachAPI)
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	err := Delete(t.Context(), client, DeleteInput{TopicID: 0})
 	if err == nil {
 		t.Fatal(errExpErrZeroTopicID)
@@ -380,7 +371,9 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPost {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusCreated, topicJSON)
@@ -426,7 +419,9 @@ func TestUpdate_WithAllOptionalFields(t *testing.T) {
 		if r.Method == http.MethodPut {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				t.Fatalf("read request body: %v", err)
+				t.Errorf("read request body: %v", err)
+				http.Error(w, "read request body", http.StatusInternalServerError)
+				return
 			}
 			capturedBody = string(body)
 			testutil.RespondJSON(w, http.StatusOK, topicJSON)

--- a/internal/tools/uploads/action_specs_test.go
+++ b/internal/tools/uploads/action_specs_test.go
@@ -102,9 +102,7 @@ func TestActionSpecs_DeleteOutput(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := uploadSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/uploads/uploads_test.go
+++ b/internal/tools/uploads/uploads_test.go
@@ -142,9 +142,7 @@ func TestProjectUpload_ID_Omitted_VersionTolerance(t *testing.T) {
 // when the content_base64 field contains invalid base64 data. The mock should
 // never be called because validation occurs before the API request.
 func TestProjectUpload_InvalidBase64(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called with invalid base64 input")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID:     "42",
@@ -179,9 +177,7 @@ func TestProjectUpload_APIError(t *testing.T) {
 // TestProjectUpload_CancelledContext verifies that Upload returns an
 // error immediately when called with an already-canceled context.
 func TestProjectUpload_CancelledContext(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called with canceled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	ctx := testutil.CancelledCtx(t)
 
@@ -212,12 +208,16 @@ func TestProjectUpload_SendsFileContent(t *testing.T) {
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 		err := r.ParseMultipartForm(10 << 20) //nolint:gosec // Test handler bounds r.Body with http.MaxBytesReader above.
 		if err != nil {
-			t.Fatalf("failed to parse multipart form: %v", err)
+			t.Errorf("failed to parse multipart form: %v", err)
+			http.Error(w, "failed to parse multipart form", http.StatusInternalServerError)
+			return
 		}
 
 		file, header, err := r.FormFile("file")
 		if err != nil {
-			t.Fatalf("failed to get form file: %v", err)
+			t.Errorf("failed to get form file: %v", err)
+			http.Error(w, "failed to get form file", http.StatusInternalServerError)
+			return
 		}
 		defer file.Close()
 
@@ -227,7 +227,9 @@ func TestProjectUpload_SendsFileContent(t *testing.T) {
 
 		body, err := io.ReadAll(file)
 		if err != nil {
-			t.Fatalf("failed to read file body: %v", err)
+			t.Errorf("failed to read file body: %v", err)
+			http.Error(w, "failed to read file body", http.StatusInternalServerError)
+			return
 		}
 
 		if string(body) != string(originalContent) {
@@ -271,15 +273,21 @@ func TestProjectUpload_WithProgressToken(t *testing.T) {
 		}
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 		if err := r.ParseMultipartForm(10 << 20); err != nil { //nolint:gosec // Test handler bounds r.Body with http.MaxBytesReader above.
-			t.Fatalf("failed to parse multipart form: %v", err)
+			t.Errorf("failed to parse multipart form: %v", err)
+			http.Error(w, "parse multipart form", http.StatusInternalServerError)
+			return
 		}
 		file, _, err := r.FormFile("file")
 		if err != nil {
-			t.Fatalf("failed to get form file: %v", err)
+			t.Errorf("failed to get form file: %v", err)
+			http.Error(w, "failed to get form file", http.StatusInternalServerError)
+			return
 		}
 		defer file.Close()
 		if _, err = io.Copy(io.Discard, file); err != nil {
-			t.Fatalf("failed to read uploaded file: %v", err)
+			t.Errorf("failed to read uploaded file: %v", err)
+			http.Error(w, "failed to read uploaded file", http.StatusInternalServerError)
+			return
 		}
 		testutil.RespondJSON(w, http.StatusCreated, `{
 			"alt": "progress.txt",
@@ -360,11 +368,15 @@ func TestProjectUpload_FilePath_Success(t *testing.T) {
 
 		r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 		if err := r.ParseMultipartForm(10 << 20); err != nil { //nolint:gosec // Test handler bounds r.Body with http.MaxBytesReader above.
-			t.Fatalf("failed to parse multipart form: %v", err)
+			t.Errorf("failed to parse multipart form: %v", err)
+			http.Error(w, "parse multipart form", http.StatusInternalServerError)
+			return
 		}
 		file, _, err := r.FormFile("file")
 		if err != nil {
-			t.Fatalf("failed to get form file: %v", err)
+			t.Errorf("failed to get form file: %v", err)
+			http.Error(w, "failed to get form file", http.StatusInternalServerError)
+			return
 		}
 		defer file.Close()
 
@@ -406,9 +418,7 @@ func TestProjectUpload_FilePath_Success(t *testing.T) {
 
 // TestProjectUpload_BothParams_Error verifies error when both file_path and content_base64 are set.
 func TestProjectUpload_BothParams_Error(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID:     "42",
@@ -426,9 +436,7 @@ func TestProjectUpload_BothParams_Error(t *testing.T) {
 
 // TestProjectUpload_NeitherParams_Error verifies error when neither file_path nor content_base64 is set.
 func TestProjectUpload_NeitherParams_Error(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID: "42",
@@ -444,9 +452,7 @@ func TestProjectUpload_NeitherParams_Error(t *testing.T) {
 
 // TestProjectUpload_FilePath_NotFound verifies error when file_path doesn't exist.
 func TestProjectUpload_FilePath_NotFound(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID: "42",
@@ -460,9 +466,7 @@ func TestProjectUpload_FilePath_NotFound(t *testing.T) {
 
 // TestProjectUpload_FilePath_IsDirectory verifies error when file_path is a directory.
 func TestProjectUpload_FilePath_IsDirectory(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID: "42",
@@ -491,9 +495,7 @@ func TestProjectUpload_FilePath_TooLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ProjectID: "42",
@@ -858,9 +860,7 @@ func TestDeleteBySecret_CancelledContext(t *testing.T) {
 
 // TestUpload_Base64DecodeError validates that invalid base64 returns an error.
 func TestUpload_Base64DecodeError(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Upload(t.Context(), nil, client, UploadInput{
 		ProjectID:     "p",
 		ContentBase64: "not-valid-base64!!!",
@@ -873,9 +873,7 @@ func TestUpload_Base64DecodeError(t *testing.T) {
 
 // TestUpload_ContextCancelled validates context cancellation in Upload.
 func TestUpload_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("API should not be called")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx := testutil.CancelledCtx(t)
 	_, err := Upload(ctx, nil, client, UploadInput{
 		ProjectID:     "p",
@@ -891,9 +889,7 @@ func TestUpload_ContextCancelled(t *testing.T) {
 // validation error when project_id is empty. The mock handler is never
 // invoked because validation occurs before any HTTP call.
 func TestProjectUpload_MissingProjectID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("HTTP handler must not be invoked when project_id is empty")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := Upload(context.Background(), nil, client, UploadInput{
 		ContentBase64: "dGVzdA==",
 		Filename:      "x.txt",

--- a/internal/tools/usagedata/usagedata_test.go
+++ b/internal/tools/usagedata/usagedata_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
-// fmtUnexpPath identifies the fmt unexp path constant used by this package.
-const fmtUnexpPath = "unexpected path: %s"
-
 // errExpectedNil identifies the err expected nil constant used by this package.
 const errExpectedNil = "expected error, got nil"
 
@@ -25,12 +22,8 @@ const fmtUnexpErr = "unexpected error: %v"
 // TestGetServicePing verifies GetServicePing.
 func TestGetServicePing(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/service_ping" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodGet {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/service_ping")
+		testutil.AssertRequestMethod(t, r, http.MethodGet)
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"recorded_at": "2026-01-15T10:00:00Z",
 			"license": {"plan": "premium"},
@@ -86,9 +79,7 @@ func TestGetServicePing_Error(t *testing.T) {
 // TestGetNonSQLMetrics verifies GetNonSQLMetrics.
 func TestGetNonSQLMetrics(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/non_sql_metrics" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/non_sql_metrics")
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"recorded_at": "2026-01-15",
 			"uuid": "abc-123",
@@ -171,9 +162,7 @@ func TestGetNonSQLMetrics_NotFound_HintsAlternatives(t *testing.T) {
 // TestGetQueries verifies GetQueries.
 func TestGetQueries(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/queries" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/queries")
 		testutil.RespondJSON(w, http.StatusOK, `{
 			"recorded_at": "2026-01-15T10:00:00Z",
 			"uuid": "abc-123",
@@ -216,9 +205,7 @@ func TestGetQueries(t *testing.T) {
 func TestGetMetricDefinitions(t *testing.T) {
 	yamlContent := "---\nmetrics:\n  - name: users_count\n    description: Total users\n"
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/metric_definitions" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/metric_definitions")
 		w.Header().Set("Content-Type", "text/yaml")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(yamlContent))
@@ -248,12 +235,8 @@ func TestGetMetricDefinitions_Error(t *testing.T) {
 // TestTrackEvent verifies TrackEvent.
 func TestTrackEvent(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/track_event" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/track_event")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	})
 	client := testutil.NewTestClient(t, handler)
@@ -290,12 +273,8 @@ func TestTrackEvent_Error(t *testing.T) {
 // TestTrackEvents verifies TrackEvents.
 func TestTrackEvents(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v4/usage_data/track_events" {
-			t.Fatalf(fmtUnexpPath, r.URL.Path)
-		}
-		if r.Method != http.MethodPost {
-			t.Fatalf("unexpected method: %s", r.Method)
-		}
+		testutil.AssertRequestPath(t, r, "/api/v4/usage_data/track_events")
+		testutil.AssertRequestMethod(t, r, http.MethodPost)
 		testutil.RespondJSON(w, http.StatusOK, `{}`)
 	})
 	client := testutil.NewTestClient(t, handler)

--- a/internal/tools/users/action_specs_test.go
+++ b/internal/tools/users/action_specs_test.go
@@ -149,9 +149,7 @@ func TestFormatUserNotFound(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := userSpecsByTool(t, ActionSpecs(client, false))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/users/user_misc_test.go
+++ b/internal/tools/users/user_misc_test.go
@@ -107,9 +107,7 @@ func TestUploadCurrentUserAvatar_Success_FilePath(t *testing.T) {
 // TestUploadCurrentUserAvatar_Validation covers the input-validation branches:
 // missing filename, no source, both sources, and invalid base64.
 func TestUploadCurrentUserAvatar_Validation(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called on validation error")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	cases := []struct {
 		name  string
 		input UploadCurrentUserAvatarInput
@@ -159,9 +157,7 @@ func TestUploadCurrentUserAvatar_UnauthorizedError(t *testing.T) {
 // TestUploadCurrentUserAvatar_ContextCancelled verifies the handler returns the
 // context error before performing any work when the context is already cancelled.
 func TestUploadCurrentUserAvatar_ContextCancelled(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called with a cancelled context")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	content := base64.StdEncoding.EncodeToString([]byte("fake"))
@@ -175,9 +171,7 @@ func TestUploadCurrentUserAvatar_ContextCancelled(t *testing.T) {
 // TestUploadCurrentUserAvatar_FilePathNotFound verifies a missing local file path
 // is surfaced as an error before any API call.
 func TestUploadCurrentUserAvatar_FilePathNotFound(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("handler should not be called when local file is missing")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	missing := filepath.Join(t.TempDir(), "does-not-exist.png")
 	if _, err := UploadCurrentUserAvatar(context.Background(), client, UploadCurrentUserAvatarInput{
 		Filename: "avatar.png", FilePath: missing,

--- a/internal/tools/workitems/action_specs_test.go
+++ b/internal/tools/workitems/action_specs_test.go
@@ -85,9 +85,7 @@ func TestActionSpecs_DeleteError(t *testing.T) {
 
 // TestCatalogSurface_DeleteConfirmDeclined covers destructive confirmation when the user declines.
 func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API when confirm is declined")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	byTool := workItemSpecsByTool(t, ActionSpecs(client))
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)

--- a/internal/tools/workitems/workitems_test.go
+++ b/internal/tools/workitems/workitems_test.go
@@ -39,9 +39,7 @@ func TestGet_Success(t *testing.T) {
 
 // TestGet_InvalidIID verifies Get when invalid IID.
 func TestGet_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, iid := range []int64{0, -1, -100} {
 		_, err := Get(t.Context(), client, GetInput{FullPath: testFullPath, IID: iid})
 		if err == nil {
@@ -117,7 +115,9 @@ func TestList_Filters(t *testing.T) {
 			Variables map[string]any `json:"variables"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			t.Fatalf("decode GraphQL request: %v", err)
+			t.Errorf("decode GraphQL request: %v", err)
+			http.Error(w, "decode GraphQL request", http.StatusInternalServerError)
+			return
 		}
 		expected := map[string]any{
 			"fullPath":           testFullPath,
@@ -133,7 +133,9 @@ func TestList_Filters(t *testing.T) {
 		}
 		for key, want := range expected {
 			if got := request.Variables[key]; got != want {
-				t.Fatalf("variable %s = %#v, want %#v", key, got, want)
+				t.Errorf("variable %s = %#v, want %#v", key, got, want)
+				http.Error(w, "variable, want", http.StatusInternalServerError)
+				return
 			}
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{"data":{"namespace":{"workItems":{"nodes":[]}}}}`)
@@ -167,7 +169,9 @@ func TestList_Children(t *testing.T) {
 			Query string `json:"query"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			t.Fatalf("decode GraphQL request: %v", err)
+			t.Errorf("decode GraphQL request: %v", err)
+			http.Error(w, "decode GraphQL request", http.StatusInternalServerError)
+			return
 		}
 		capturedQuery = request.Query
 		testutil.RespondJSON(w, http.StatusOK, `{"data":{"namespace":{"workItems":{"nodes":[{"id":"gid://gitlab/WorkItem/1","iid":"10","workItemType":{"name":"Issue"},"state":"OPEN","title":"Parent","author":{"username":"dev1"},"features":{"hierarchy":{"hasChildren":true,"children":{"nodes":[{"iid":"20","namespace":{"fullPath":"my-group/child-a"}},{"iid":"21","namespace":{"fullPath":"my-group/child-b"}}]}}}}]}}}}`)
@@ -243,9 +247,7 @@ func TestList_Error(t *testing.T) {
 
 // TestList_MissingFullPath verifies List validates full_path before calling GitLab.
 func TestList_MissingFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := List(t.Context(), client, ListInput{})
 	if err == nil {
 		t.Fatal(errExpectedNil)
@@ -384,9 +386,7 @@ func TestDelete_Success(t *testing.T) {
 
 // TestDelete_InvalidIID verifies that Delete rejects invalid IIDs.
 func TestDelete_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, iid := range []int64{0, -1, -100} {
 		err := Delete(t.Context(), client, DeleteInput{FullPath: testFullPath, IID: iid})
 		if err == nil {
@@ -1301,9 +1301,7 @@ func TestUpdate_AllOptions(t *testing.T) {
 // TestUpdate_InvalidIID verifies that Update rejects IID values <= 0
 // with an error mentioning "iid".
 func TestUpdate_InvalidIID(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	for _, iid := range []int64{0, -1, -100} {
 		_, err := Update(t.Context(), client, UpdateInput{FullPath: testFullPath, IID: iid, Title: "x"})
 		if err == nil {
@@ -1881,9 +1879,7 @@ func TestListWorkItemTypes_Success(t *testing.T) {
 // TestListWorkItemTypes_EmptyFullPath verifies ListWorkItemTypes returns a
 // validation error when full_path is empty.
 func TestListWorkItemTypes_EmptyFullPath(t *testing.T) {
-	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		t.Fatal("should not reach API")
-	}))
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
 	_, err := ListWorkItemTypes(t.Context(), client, ListWorkItemTypesInput{})
 	if err == nil {
 		t.Fatal(errExpectedNil)

--- a/internal/wizard/webui.go
+++ b/internal/wizard/webui.go
@@ -42,9 +42,25 @@ var listenFn = func(ctx context.Context, network, address string) (net.Listener,
 	return lc.Listen(ctx, network, address)
 }
 
+// syncWriter serializes writes to an underlying [io.Writer]. RunWebUI shares
+// its progress writer between the calling goroutine and HTTP handler
+// goroutines, so unsynchronized writes to a plain buffer are a data race.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// Write implements [io.Writer] under the mutex.
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
+
 // RunWebUI starts a local HTTP server and opens the setup wizard in the browser.
 // It blocks until the user completes configuration or the context is cancelled.
 func RunWebUI(version string, w io.Writer) error {
+	w = &syncWriter{w: w}
 	listener, err := listenFn(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("starting web server: %w", err)


### PR DESCRIPTION
## Summary

Executes the full test-goroutine FailNow sweep: **541 → 0** `t.Fatal`/`t.Fatalf`/`t.FailNow` sites inside function literals that cross a goroutine boundary (HTTP mock handlers, MCP tool handlers, `go` statements), plus a CI gate so they cannot come back.

`testing.FailNow` must run on the test goroutine; anywhere else it kills only that goroutine — truncating mock responses, misdirecting diagnostics, and enabling a false-pass class where a test expecting *an* error is satisfied by the abort's own transport error. `go vet`'s `testinggoroutine` cannot see handler-literal boundaries, which is how 541 sites accumulated.

## What's in here

- **`cmd/audit_test_goroutines`** (new): AST auditor that finds abort sites across boundary kinds (`http.HandlerFunc`, `HandleFunc`, `go`, `errgroup.Go`, MCP `AddTool` handlers, middleware, handler struct fields), classifies them A (tail) / B (truncating), lists advisory `t.Errorf`-without-`return` sites, and emits a JSON work list. `--check` gates on abort sites only. Wired as `make audit-test-goroutines` / `make check-test-goroutines`, step [6/6] of `make analyze`, and a CI step.
- **Conversion contract**: `.github/instructions/test-goroutines.instructions.md` (six rules + sanctioned shapes), referenced from CLAUDE.md, copilot-instructions, the testing skills and the Test Expert agent.
- **`testutil.ForbiddenHandler(t)`** (new helper): atomic hit counter + deterministic 500 + `t.Cleanup` zero-hit assertion — the sanctioned replacement for `t.Fatal("should not be called")` mocks (362 sites).
- **Guard conversions**: path/method/query mismatch guards → `testutil.AssertRequestPath/Method/QueryParam` (45+ sites); decode/read-body and other guards → `t.Errorf` + `http.Error(500)` + `return` (114 sites); 7 bespoke sites by hand. Two test tables widen `http.HandlerFunc` fields to `http.Handler`; 10 orphaned message constants removed.
- **Two latent data races** surfaced by the full `-race -shuffle=on` validation and fixed at the source:
  - `internal/wizard`: the progress writer was shared between the caller and HTTP handler goroutines — now wrapped in a mutexed `syncWriter`.
  - `internal/tools/dynamic`: three parallel intent-boost subtests assigned the parent closure's `err` — now subtest-local.

## Validation

- `go run ./cmd/audit_test_goroutines --check` → **0 fatal sites** (was 541).
- Full `go test ./internal/... ./cmd/... -race -shuffle=on -count=1` → exit 0.
- Full `golangci-lint run --build-tags e2e ./...` clean; e2e suite compile-only check passes.
- `make analyze` docs/tables/testing-docs checks green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Eliminate off-goroutine testing.T aborts across the test suite and enforce the safe assertion contract in CI.

New Features:
- Add an AST-based auditor and JSON work-list generator for detecting off-goroutine test aborts across common handler and goroutine boundaries.
- Add shared test helpers for forbidden API handlers and safe request assertions.

Bug Fixes:
- Replace off-goroutine fatal assertions throughout the test suite to prevent truncated responses, misleading diagnostics, and false passes.
- Fix a wizard progress-writer data race and parallel dynamic-tool subtest error sharing.

Enhancements:
- Establish and document a six-rule contract for assertions running outside the test goroutine.
- Refactor validation and mock-handler tests to return deterministic HTTP errors or defer assertions to the test goroutine.

Build:
- Add Makefile targets for auditing and checking off-goroutine test aborts, and include the check in the analysis workflow.

CI:
- Add a CI gate that fails when off-goroutine testing.T aborts are introduced.

Documentation:
- Document the test-goroutine assertion contract, auditor command, Makefile targets, and enforcement guidance.

Tests:
- Convert the test suite's off-goroutine fatal assertions to safe alternatives and add coverage for the new auditing and test helpers.

Chores:
- Refresh generated repository and testing statistics.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a mandatory contract for testing goroutines to prevent improper use of t.Fatal/t.FailNow in HTTP handlers, goroutines, and MCP tool handlers.</li>
<li>Added a new audit tool `cmd/audit_test_goroutines` to detect violations of the test-goroutine assertion contract.</li>
<li>Updated CI workflows and Makefile to include `make check-test-goroutines` for automated enforcement.</li>
<li>Refactored numerous test files across the codebase to comply with the new test-goroutine assertion rules.</li>
<li>Added comprehensive documentation in `.github/instructions/test-goroutines.instructions.md` detailing the six-rule contract.</li>
</ul></div>