### PR TITLE
test(e2e): self-provisioned Bitbucket Server fixture and db_migration_mark happy path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,9 @@ QWEN_API_KEY=your-qwen-api-key
 # import_gists (a repository owned by the token's user is resolved
 # automatically); the BITBUCKET_* set drives the Bitbucket Cloud import; the
 # BITBUCKET_SERVER_* set targets a self-hosted Bitbucket Server if you have
-# one reachable.
+# one reachable. In Docker mode (make test-e2e-docker) the BITBUCKET_SERVER_*
+# values are auto-provisioned by the ephemeral Bitbucket fixture and written
+# to test/e2e/.env.docker — only fill them here for self-hosted runs.
 GH_TOKEN=
 BITBUCKET_USERNAME=
 BITBUCKET_API_TOKEN=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,11 +143,12 @@ go test -v -tags e2e -timeout 300s ./test/e2e/suite/
 make test-e2e
 
 # Docker mode (ephemeral GitLab CE with CI runner and fixture service)
-docker compose -f test/e2e/docker-compose.yml up -d
-./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh
+export E2E_BITBUCKET_ADMIN_PASSWORD=$(openssl rand -hex 16)
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
+./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh && ./test/e2e/scripts/setup-bitbucket.sh
 set -a && source test/e2e/.env.docker && set +a
 go test -v -tags e2e -timeout 600s ./test/e2e/suite/
-docker compose -f test/e2e/docker-compose.yml down -v
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v
 
 # Or via Makefile
 make test-e2e-docker

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ image.png
 /godoc_tool
 /gitlab-mcp-server
 /server
+test/e2e/.bitbucket-admin-pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,11 +616,12 @@ go test -tags e2e -c -o /dev/null ./test/e2e/suite/  # Linux
 **Docker mode** — ephemeral GitLab CE container with CI runner and fixture service (enables pipeline/job tests and deterministic webhook/custom-emoji/mirror endpoints):
 
 ```bash
-docker compose -f test/e2e/docker-compose.yml up -d
-./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh
+export E2E_BITBUCKET_ADMIN_PASSWORD=$(openssl rand -hex 16)
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
+./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh && ./test/e2e/scripts/setup-bitbucket.sh
 set -a && source test/e2e/.env.docker && set +a
 go test -v -tags e2e -timeout 600s ./test/e2e/suite/
-docker compose -f test/e2e/docker-compose.yml down -v
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v
 ```
 
 The suite runs three sequential workflows:

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,12 @@ validate-http-stateless:
 validate-http-stateless-docker:
 	scripts/validate-http-stateless.sh docker
 
-## test-e2e-docker: start ephemeral GitLab CE, run E2E tests, tear down
+## test-e2e-docker: start ephemeral GitLab CE (+ Bitbucket fixture), run E2E tests, tear down
 test-e2e-docker:
 	@echo "=== Cleaning up previous containers (if any) ==="
-	docker compose -f test/e2e/docker-compose.yml down -v 2>/dev/null || true
-	@echo "=== Starting ephemeral GitLab CE ==="
-	docker compose -f test/e2e/docker-compose.yml up -d
+	docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v 2>/dev/null || true
+	@echo "=== Starting ephemeral GitLab CE and Bitbucket fixture ==="
+	docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
 	@echo "=== Waiting for GitLab readiness ==="
 	./test/e2e/scripts/wait-for-gitlab.sh http://localhost:8929 600
 	@echo "=== Setting up test user and token ==="
@@ -164,6 +164,8 @@ test-e2e-docker:
 	done
 	@echo "=== Registering GitLab Runner ==="
 	./test/e2e/scripts/register-runner.sh http://localhost:8929
+	@echo "=== Provisioning Bitbucket import fixture ==="
+	./test/e2e/scripts/setup-bitbucket.sh http://localhost:7990
 	@echo "=== Running E2E tests ==="
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
 	@set +e; \
@@ -176,7 +178,7 @@ test-e2e-docker:
 	@echo "=== Tearing down ==="
 	@status=$$(cat $(E2E_REPORT_DIR)/e2e-docker-status); \
 	  teardown_status=0; \
-	  docker compose -f test/e2e/docker-compose.yml down -v || teardown_status=$$?; \
+	  docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v || teardown_status=$$?; \
 	  echo "=== E2E reports saved to $(E2E_REPORT_DIR)/ ==="; \
 	  rm -f $(E2E_REPORT_DIR)/e2e-docker-status; \
 	  if [ "$$status" -ne 0 ]; then exit "$$status"; fi; \

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ test-e2e-docker:
 	@echo "=== Cleaning up previous containers (if any) ==="
 	docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v 2>/dev/null || true
 	@echo "=== Starting ephemeral GitLab CE and Bitbucket fixture ==="
-	docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
+	@openssl rand -hex 16 > test/e2e/.bitbucket-admin-pass
+	E2E_BITBUCKET_ADMIN_PASSWORD=$$(cat test/e2e/.bitbucket-admin-pass) docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
 	@echo "=== Waiting for GitLab readiness ==="
 	./test/e2e/scripts/wait-for-gitlab.sh http://localhost:8929 600
 	@echo "=== Setting up test user and token ==="
@@ -165,7 +166,7 @@ test-e2e-docker:
 	@echo "=== Registering GitLab Runner ==="
 	./test/e2e/scripts/register-runner.sh http://localhost:8929
 	@echo "=== Provisioning Bitbucket import fixture ==="
-	./test/e2e/scripts/setup-bitbucket.sh http://localhost:7990
+	E2E_BITBUCKET_ADMIN_PASSWORD=$$(cat test/e2e/.bitbucket-admin-pass) ./test/e2e/scripts/setup-bitbucket.sh http://localhost:7990
 	@echo "=== Running E2E tests ==="
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
 	@set +e; \

--- a/README.md
+++ b/README.md
@@ -417,8 +417,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       977 |     196,025 |
 | Unit tests (`_test.go`)  |       532 |     302,449 |
-| End-to-end tests         |       173 |      44,989 |
-| **Total**                | **1,682** | **543,463** |
+| End-to-end tests         |       173 |      44,993 |
+| **Total**                | **1,682** | **543,467** |
 
 ### Functions
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -631,11 +631,13 @@ All E2E Docker infrastructure is version-controlled under `test/e2e/`:
 - `test/e2e/scripts/wait-for-gitlab.sh` — Polls GitLab readiness endpoint
 
 ```bash
-# Start GitLab container and provision test environment
-docker compose -f test/e2e/docker-compose.yml up -d
+# Start GitLab + Bitbucket fixture and provision test environment
+export E2E_BITBUCKET_ADMIN_PASSWORD=$(openssl rand -hex 16)
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
 ./test/e2e/scripts/wait-for-gitlab.sh
-./test/e2e/scripts/setup-gitlab.sh    # Creates .env.docker
-./test/e2e/scripts/register-runner.sh # Registers CI runner
+./test/e2e/scripts/setup-gitlab.sh     # Creates .env.docker
+./test/e2e/scripts/register-runner.sh  # Registers CI runner
+./test/e2e/scripts/setup-bitbucket.sh  # Provisions the import fixture
 
 # Run tests
 set -a && source test/e2e/.env.docker && set +a
@@ -803,12 +805,13 @@ go test ./internal/... -race -count=1
 go test -v -tags e2e -timeout 300s ./test/e2e/suite/
 make test-e2e
 
-# Docker mode (ephemeral GitLab CE container)
-docker compose -f test/e2e/docker-compose.yml up -d
-./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh
+# Docker mode (ephemeral GitLab CE container + Bitbucket import fixture)
+export E2E_BITBUCKET_ADMIN_PASSWORD=$(openssl rand -hex 16)
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
+./test/e2e/scripts/wait-for-gitlab.sh && ./test/e2e/scripts/setup-gitlab.sh && ./test/e2e/scripts/register-runner.sh && ./test/e2e/scripts/setup-bitbucket.sh
 set -a && source test/e2e/.env.docker && set +a
 go test -v -tags e2e -timeout 600s ./test/e2e/suite/
-docker compose -f test/e2e/docker-compose.yml down -v
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v
 
 # Individual and meta-tool domains
 go test -v -tags e2e -timeout 300s -run '^TestIndividual_' ./test/e2e/suite/

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,24 +30,29 @@ Uses an ephemeral GitLab CE container plus a Bitbucket Data Center import fixtur
 
 All Docker infrastructure is version-controlled in this directory:
 
-- `docker-compose.yml` — GitLab CE + Runner + fixture service definition
+- `docker-compose.yml` — GitLab CE + Runner + Bitbucket + fixture service definition
 - `scripts/setup-gitlab.sh` — Creates test user, PAT, generates `test/e2e/.env.docker`
+- `scripts/setup-bitbucket.sh` — Provisions the Bitbucket import fixture, appends `BITBUCKET_SERVER_*`
 - `scripts/register-runner.sh` — Registers CI runner
 - `scripts/wait-for-gitlab.sh` — Polls readiness endpoint
 
-All commands run from the **project root**:
+All commands run from the **project root**. The Bitbucket fixture needs an
+ephemeral admin password shared between compose and the provisioning script
+(`make test-e2e-docker` generates one per run automatically):
 
 ```bash
-docker compose -f test/e2e/docker-compose.yml up -d
+export E2E_BITBUCKET_ADMIN_PASSWORD=$(openssl rand -hex 16)
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
 ./test/e2e/scripts/wait-for-gitlab.sh
 ./test/e2e/scripts/setup-gitlab.sh
 ./test/e2e/scripts/register-runner.sh
+./test/e2e/scripts/setup-bitbucket.sh
 
 set -a && source test/e2e/.env.docker && set +a
 go test -v -tags e2e -timeout 600s ./test/e2e/suite/
 
 # Cleanup
-docker compose -f test/e2e/docker-compose.yml down -v
+docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v
 ```
 
 Or use the Makefile target:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -26,7 +26,7 @@ go test -v -tags e2e -timeout 300s ./test/e2e/suite/
 
 ### Docker Mode
 
-Uses an ephemeral GitLab CE container. Requires Docker and ~4 GB RAM.
+Uses an ephemeral GitLab CE container plus a Bitbucket Data Center import fixture. Requires Docker and ~5.5 GB RAM.
 
 All Docker infrastructure is version-controlled in this directory:
 
@@ -112,6 +112,33 @@ coverage that used to skip can run:
   macOS. Without a docker CLI the registry tag tests skip.
 - **GitLab Pages** is enabled in the omnibus config; the Pages write test
   publishes a real deployment through a `pages` CI job before asserting.
+- **Pending schema migration seed**: deletes the newest `schema_migrations`
+  row via `gitlab-psql` and records its version as
+  `E2E_DB_MIGRATION_VERSION`, so the mutating `db_migration_mark` path runs
+  for real — the test's mark call re-inserts the row, leaving the instance
+  as it started. The newest version is used because GitLab squashes old
+  migrations and only recent versions still have a resolvable migration
+  file.
+
+### What setup-bitbucket.sh provisions
+
+The CE docker target also starts a real Bitbucket Data Center container
+(`e2e-bitbucket`, compose profile `bitbucket`) so `import_bitbucket_server`
+runs instead of skipping:
+
+- **Unattended setup** is driven by a `bitbucket.properties` file written
+  before the stock entrypoint runs, using Atlassian's public 3-hour
+  [timebomb Data Center test license](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/)
+  — long enough for an ephemeral run, torn down with the stack. Search is
+  disabled and the embedded eval database is used, keeping the container at
+  one ~1 GB JVM.
+- **Fixture content**: project `E2E`, repository `fixture` with an initial
+  commit seeded through the browse edit REST API, and an admin HTTP access
+  token for the importer.
+- The `BITBUCKET_SERVER_*` variables are appended to `.env.docker` with the
+  compose-network URL (`http://e2e-bitbucket:7990`) because GitLab — not the
+  test process — dereferences it. Provisioning is best-effort: on any
+  failure it warns and the suite falls back to the documented skip.
 
 ### Optional operator credentials
 
@@ -123,8 +150,8 @@ when unset:
 | --- | --- |
 | `GH_TOKEN` | `import_github` / `import_cancel_github` / `import_gists` (a repository owned by the token's user is resolved via the GitHub API) |
 | `BITBUCKET_USERNAME`, `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, `BITBUCKET_REPO_PATH` | Bitbucket Cloud imports (Atlassian API token created **with Bitbucket scopes**, paired with the account email) |
-| `BITBUCKET_SERVER_URL`, `BITBUCKET_SERVER_USERNAME`, `BITBUCKET_SERVER_TOKEN`, `BITBUCKET_SERVER_PROJECT_KEY`, `BITBUCKET_SERVER_REPO_SLUG` | `import_bitbucket_server` against a self-hosted Bitbucket Server |
-| `E2E_DB_MIGRATION_VERSION` | The mutating `db_migration_mark` path (only meaningful when debugging a genuinely stuck migration; the error path always runs) |
+| `BITBUCKET_SERVER_URL`, `BITBUCKET_SERVER_USERNAME`, `BITBUCKET_SERVER_TOKEN`, `BITBUCKET_SERVER_PROJECT_KEY`, `BITBUCKET_SERVER_REPO_SLUG` | `import_bitbucket_server` against a self-hosted Bitbucket Server (auto-provisioned by the Docker fixture; set manually only for self-hosted mode) |
+| `E2E_DB_MIGRATION_VERSION` | The mutating `db_migration_mark` path (auto-seeded by setup-gitlab.sh in Docker mode; set manually only when debugging a genuinely stuck migration on a self-hosted instance — the error path always runs) |
 
 Imported projects are registered for permanent deletion in the per-test
 resource ledger.

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -115,14 +115,18 @@ services:
     container_name: e2e-bitbucket
     profiles: ["bitbucket"]
     ports:
-      - "7990:7990"
+      - "127.0.0.1:7990:7990"
     environment:
       SEARCH_ENABLED: "false"
       JVM_MAXIMUM_MEMORY: "1024m"
-      BITBUCKET_ADMIN_PASSWORD: ${E2E_BITBUCKET_ADMIN_PASSWORD:-E2e_BB_admin1}
+      BITBUCKET_ADMIN_PASSWORD: ${E2E_BITBUCKET_ADMIN_PASSWORD:-}
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
+        if [ -z "$${BITBUCKET_ADMIN_PASSWORD}" ]; then
+          echo "E2E_BITBUCKET_ADMIN_PASSWORD is required (the Makefile generates an ephemeral one per run)" >&2
+          exit 1
+        fi
         mkdir -p /var/atlassian/application-data/bitbucket/shared
         cat > /var/atlassian/application-data/bitbucket/shared/bitbucket.properties <<PROPS
         setup.displayName=E2E Bitbucket

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -97,6 +97,51 @@ services:
       retries: 30
       start_period: 30s
 
+  # e2e-bitbucket provides a real self-hosted Bitbucket Data Center for the
+  # import_bitbucket_server e2e coverage (profile "bitbucket", enabled by the
+  # CE docker target). Unattended setup is driven by bitbucket.properties
+  # written before the stock entrypoint runs; the license is Atlassian's
+  # public 3-hour timebomb Data Center test license
+  # (https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/),
+  # which comfortably outlives an ephemeral e2e run. Search is disabled (the
+  # importer only needs git + REST) and the embedded eval database is used,
+  # so the container stays at one JVM. setup-bitbucket.sh provisions the
+  # project/repo/token after boot and appends BITBUCKET_SERVER_* to
+  # .env.docker; GitLab reaches it as http://e2e-bitbucket:7990 over the
+  # compose network.
+  e2e-bitbucket:
+    image: atlassian/bitbucket:9.6
+    hostname: bitbucket-e2e
+    container_name: e2e-bitbucket
+    profiles: ["bitbucket"]
+    ports:
+      - "7990:7990"
+    environment:
+      SEARCH_ENABLED: "false"
+      JVM_MAXIMUM_MEMORY: "1024m"
+      BITBUCKET_ADMIN_PASSWORD: ${E2E_BITBUCKET_ADMIN_PASSWORD:-E2e_BB_admin1}
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        mkdir -p /var/atlassian/application-data/bitbucket/shared
+        cat > /var/atlassian/application-data/bitbucket/shared/bitbucket.properties <<PROPS
+        setup.displayName=E2E Bitbucket
+        setup.baseUrl=http://e2e-bitbucket:7990
+        setup.license=AAABrQ0ODAoPeNp9kVFvmzAQx9/9KSztLZIJZIu0RkJqA6yNViAK0G3d+uDApXgjNrKPbPn2dYG0a6fuwS8+393v//O7vAMa8yN1PerOFrPZYn5GL+OczlzvI0m6/RZ0uisMaON7LgmURF5iwvfgVy3XWpj6nGPDjRFcOqXaE4Pc1M61KEEayI8t9I+DNI6jTbC6uP73wd/FdafLmhsIOYL/yMDcOXM98p95Yyn60wp97PvW769OpFHMRfMWagb6AHoV+svLs5x9LW4+sM+3t1ds6XpfRkw7jwcgEbSPugOSdVtTatGiUHK4mUwmSZqzT+mGrTdpWAT5Kk1YkUW24AcaLFBFt0eKNdARlUayVBVo2mr1E0qk32vE9sdiOr1XzgvEaTN0MBg67hwaKioV0koY1GLbIdjJwlBUtOwMqr39KYfY1JZZclm+9jLEsmbEAZ4CBJvoIo9Ctvz2CP2GrRHe6irkL6l+S5JFiW8Pm7suSfU9l8LwXkwIB2hUaxPmYPAUm/Q2bP315w5MGXL95DmEZ839jFEE3SlNedvS6rTCkOjAm25YvOON3fMAVTj4nTAtAhRH4o+fI5MQ7xSh2mtA1bPJrq0WAgIVAIGperR8m2N0fl/GfUUJfQnd+T1aX02kk
+        setup.sysadmin.username=admin
+        setup.sysadmin.password=$${BITBUCKET_ADMIN_PASSWORD}
+        setup.sysadmin.displayName=E2E Admin
+        setup.sysadmin.emailAddress=admin@example.com
+        PROPS
+        chown -R 2003:2003 /var/atlassian/application-data/bitbucket
+        exec /usr/bin/tini -- /entrypoint.py --log=INFO
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:7990/status | grep -q RUNNING"]
+      interval: 15s
+      timeout: 5s
+      retries: 40
+      start_period: 90s
+
   e2e-fixture:
     image: nginx:alpine
     command:

--- a/test/e2e/scripts/setup-bitbucket.sh
+++ b/test/e2e/scripts/setup-bitbucket.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# setup-bitbucket.sh — provision the ephemeral Bitbucket Data Center fixture
+# for the import_bitbucket_server e2e coverage.
+#
+# Waits for the e2e-bitbucket compose service (unattended setup driven by
+# docker-compose.yml) to reach RUNNING, then provisions over REST:
+#   1. Project E2E
+#   2. Repository "fixture" with an initial commit (browse edit API — no git
+#      client involvement needed)
+#   3. An admin HTTP access token for GitLab's importer
+# and appends the BITBUCKET_SERVER_* variables to test/e2e/.env.docker.
+# The URL written is the compose-network address (http://e2e-bitbucket:7990)
+# because GitLab — not the test process — dereferences it.
+#
+# Best-effort by design: any failure prints a WARNING and exits 0 so the
+# suite falls back to the documented skip instead of failing the whole run.
+set -uo pipefail
+
+BITBUCKET_URL="${1:-http://localhost:7990}"
+INTERNAL_URL="${E2E_BITBUCKET_INTERNAL_URL:-http://e2e-bitbucket:7990}"
+ADMIN_USER="admin"
+ADMIN_PASSWORD="${E2E_BITBUCKET_ADMIN_PASSWORD:-E2e_BB_admin1}"
+PROJECT_KEY="E2E"
+REPO_SLUG="fixture"
+WAIT_SECONDS="${2:-420}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ENV_FILE="${REPO_ROOT}/test/e2e/.env.docker"
+
+warn_skip() {
+    echo "      WARNING: $1; import_bitbucket_server e2e coverage will skip"
+    exit 0
+}
+
+echo "  Waiting for Bitbucket at ${BITBUCKET_URL} (up to ${WAIT_SECONDS}s)..."
+deadline=$((SECONDS + WAIT_SECONDS))
+while true; do
+    state=$(curl -sf --connect-timeout 5 --max-time 10 "${BITBUCKET_URL}/status" 2>/dev/null || true)
+    case "${state}" in
+        *RUNNING*) break ;;
+    esac
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+        warn_skip "Bitbucket did not reach RUNNING within ${WAIT_SECONDS}s (last state: ${state:-unreachable})"
+    fi
+    sleep 10
+done
+echo "  Bitbucket is RUNNING"
+
+bb_api() {
+    curl -sS -u "${ADMIN_USER}:${ADMIN_PASSWORD}" --connect-timeout 5 --max-time 60 "$@"
+}
+
+# Project and repository creation are idempotent for this script's purpose:
+# a 409 from a previous provisioning attempt is as good as a 201.
+echo "  Creating project ${PROJECT_KEY} and repository ${REPO_SLUG}..."
+status=$(bb_api -o /dev/null -w '%{http_code}' -X POST "${BITBUCKET_URL}/rest/api/1.0/projects" \
+    -H 'Content-Type: application/json' \
+    -d "{\"key\":\"${PROJECT_KEY}\",\"name\":\"E2E Import Fixtures\"}")
+case "${status}" in
+    201|409) ;;
+    *) warn_skip "project creation failed (HTTP ${status})" ;;
+esac
+
+status=$(bb_api -o /dev/null -w '%{http_code}' -X POST "${BITBUCKET_URL}/rest/api/1.0/projects/${PROJECT_KEY}/repos" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"${REPO_SLUG}\",\"scmId\":\"git\",\"defaultBranch\":\"main\"}")
+case "${status}" in
+    201|409) ;;
+    *) warn_skip "repository creation failed (HTTP ${status})" ;;
+esac
+
+# Seed the initial commit through the browse edit API so the imported project
+# has real content. A 409 means the file already exists from a previous run.
+status=$(bb_api -o /dev/null -w '%{http_code}' -X PUT \
+    "${BITBUCKET_URL}/rest/api/1.0/projects/${PROJECT_KEY}/repos/${REPO_SLUG}/browse/README.md" \
+    -F content="# e2e import fixture" -F message="Initial commit" -F branch=main)
+case "${status}" in
+    200|201|409) ;;
+    *) warn_skip "initial commit failed (HTTP ${status})" ;;
+esac
+
+echo "  Minting HTTP access token for the importer..."
+token_json=$(bb_api -X PUT "${BITBUCKET_URL}/rest/access-tokens/1.0/users/${ADMIN_USER}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"e2e-import-$(date +%s)\",\"permissions\":[\"REPO_ADMIN\",\"PROJECT_ADMIN\"]}" 2>/dev/null)
+token=$(printf '%s' "${token_json}" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("token", ""))
+except Exception:
+    pass')
+[ -n "${token}" ] || warn_skip "access token creation failed"
+
+{
+    echo "BITBUCKET_SERVER_URL=${INTERNAL_URL}"
+    echo "BITBUCKET_SERVER_USERNAME=${ADMIN_USER}"
+    echo "BITBUCKET_SERVER_TOKEN=${token}"
+    echo "BITBUCKET_SERVER_PROJECT_KEY=${PROJECT_KEY}"
+    echo "BITBUCKET_SERVER_REPO_SLUG=${REPO_SLUG}"
+} >> "${ENV_FILE}"
+echo "  Bitbucket fixture ready: ${INTERNAL_URL} ${PROJECT_KEY}/${REPO_SLUG} (vars appended to .env.docker)"

--- a/test/e2e/scripts/setup-bitbucket.sh
+++ b/test/e2e/scripts/setup-bitbucket.sh
@@ -19,7 +19,7 @@ set -uo pipefail
 BITBUCKET_URL="${1:-http://localhost:7990}"
 INTERNAL_URL="${E2E_BITBUCKET_INTERNAL_URL:-http://e2e-bitbucket:7990}"
 ADMIN_USER="admin"
-ADMIN_PASSWORD="${E2E_BITBUCKET_ADMIN_PASSWORD:-E2e_BB_admin1}"
+ADMIN_PASSWORD="${E2E_BITBUCKET_ADMIN_PASSWORD:-}"
 PROJECT_KEY="E2E"
 REPO_SLUG="fixture"
 WAIT_SECONDS="${2:-420}"
@@ -32,6 +32,8 @@ warn_skip() {
     echo "      WARNING: $1; import_bitbucket_server e2e coverage will skip"
     exit 0
 }
+
+[ -n "${ADMIN_PASSWORD}" ] || warn_skip "E2E_BITBUCKET_ADMIN_PASSWORD is not set (the Makefile generates an ephemeral one per run)"
 
 echo "  Waiting for Bitbucket at ${BITBUCKET_URL} (up to ${WAIT_SECONDS}s)..."
 deadline=$((SECONDS + WAIT_SECONDS))

--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -551,7 +551,7 @@ for _ in 1 2 3; do
 done
 
 # 4. Write .env.docker
-echo "  [4/6] Writing ${ENV_FILE_DISPLAY}..."
+echo "  [4/7] Writing ${ENV_FILE_DISPLAY}..."
 cat > "${ENV_FILE}" <<EOF
 GITLAB_URL=${GITLAB_URL}
 GITLAB_TOKEN=${PAT}
@@ -569,7 +569,7 @@ EOF
 # disable default-branch protection for new projects (GitLab applies that
 # protection asynchronously after project creation, so tests that unprotect
 # and immediately push were racing the protection job).
-echo "  [5/6] Applying instance settings (importer sources, no default branch protection)..."
+echo "  [5/7] Applying instance settings (importer sources, no default branch protection)..."
 curl -sSf -o /dev/null -X PUT "${GITLAB_URL}/api/v4/application/settings" \
     -H "PRIVATE-TOKEN: ${PAT}" \
     --data "import_sources[]=github&import_sources[]=bitbucket&import_sources[]=bitbucket_server&default_branch_protection=0" \
@@ -583,7 +583,7 @@ curl -sSf -o /dev/null -X PUT "${GITLAB_URL}/api/v4/application/settings" \
 REGISTRY_HOST="${REGISTRY_HOST:-localhost:5050}"
 REGISTRY_PROJECT_NAME="e2e-registry-seed"
 if command -v docker >/dev/null 2>&1; then
-    echo "  [6/6] Seeding container registry image (${REGISTRY_HOST})..."
+    echo "  [6/7] Seeding container registry image (${REGISTRY_HOST})..."
     seed_project_json=$(curl -sS -X POST "${GITLAB_URL}/api/v4/projects" \
         -H "PRIVATE-TOKEN: ${PAT}" \
         --data "name=${REGISTRY_PROJECT_NAME}&visibility=private" \
@@ -616,7 +616,35 @@ if command -v docker >/dev/null 2>&1; then
         echo "      WARNING: registry image seeding failed; registry tag e2e coverage will skip"
     fi
 else
-    echo "  [6/6] docker CLI not found; skipping registry image seeding"
+    echo "  [6/7] docker CLI not found; skipping registry image seeding"
+fi
+
+# 7. Seed a pending schema migration so the db_migration_mark happy path can
+# run: a healthy instance has no stuck migration to mark, so the newest
+# executed row is deleted from schema_migrations (making Rails consider that
+# migration pending) and its version is exported. The e2e test marks it via
+# POST /admin/migrations/:version/mark, which re-inserts the row — the
+# instance ends the run in the same state it started. The newest version is
+# used because GitLab squashes old migrations: only recent versions are
+# guaranteed to still have a migration file the mark service can resolve.
+if command -v docker >/dev/null 2>&1; then
+    echo "  [7/7] Seeding a pending schema migration for db_migration_mark coverage..."
+    compose_file="${REPO_ROOT}/test/e2e/docker-compose.yml"
+    # The version must be one the Rails migration context can resolve to a
+    # file — the newest schema_migrations row is not guaranteed to (structure
+    # loads insert historical versions whose files were squashed away), so
+    # Rails itself is asked for the newest migration it knows.
+    mig_version=$(docker compose -f "${compose_file}" exec -T gitlab gitlab-rails runner \
+        "puts ActiveRecord::Base.connection_pool.migration_context.migrations.last.version" 2>/dev/null | tr -d '[:space:]' || true)
+    if [ -n "${mig_version}" ] && docker compose -f "${compose_file}" exec -T gitlab gitlab-psql -c \
+        "DELETE FROM schema_migrations WHERE version='${mig_version}'" >/dev/null 2>&1; then
+        echo "E2E_DB_MIGRATION_VERSION=${mig_version}" >> "${ENV_FILE}"
+        echo "      Removed schema_migrations row ${mig_version}; the mark test restores it"
+    else
+        echo "      WARNING: could not seed a pending migration; db_migration_mark happy path will skip"
+    fi
+else
+    echo "  [7/7] docker CLI not found; skipping db_migration_mark seeding"
 fi
 
 echo ""

--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -629,14 +629,13 @@ fi
 # guaranteed to still have a migration file the mark service can resolve.
 if command -v docker >/dev/null 2>&1; then
     echo "  [7/7] Seeding a pending schema migration for db_migration_mark coverage..."
-    compose_file="${REPO_ROOT}/test/e2e/docker-compose.yml"
     # The version must be one the Rails migration context can resolve to a
     # file — the newest schema_migrations row is not guaranteed to (structure
     # loads insert historical versions whose files were squashed away), so
     # Rails itself is asked for the newest migration it knows.
-    mig_version=$(docker compose -f "${compose_file}" exec -T gitlab gitlab-rails runner \
+    mig_version=$(docker compose -f "${COMPOSE_FILE}" exec -T gitlab gitlab-rails runner \
         "puts ActiveRecord::Base.connection_pool.migration_context.migrations.last.version" 2>/dev/null | tr -d '[:space:]' || true)
-    if [ -n "${mig_version}" ] && docker compose -f "${compose_file}" exec -T gitlab gitlab-psql -c \
+    if [ -n "${mig_version}" ] && docker compose -f "${COMPOSE_FILE}" exec -T gitlab gitlab-psql -c \
         "DELETE FROM schema_migrations WHERE version='${mig_version}'" >/dev/null 2>&1; then
         echo "E2E_DB_MIGRATION_VERSION=${mig_version}" >> "${ENV_FILE}"
         echo "      Removed schema_migrations row ${mig_version}; the mark test restores it"

--- a/test/e2e/suite/adminextras_ce_test.go
+++ b/test/e2e/suite/adminextras_ce_test.go
@@ -1026,9 +1026,11 @@ func adminExtrasImportGists(ctx context.Context, t *testing.T, ghToken string) {
 // for Bitbucket Cloud. Missing credentials skip the corresponding subtest,
 // so the isolated CI run stays deterministic while a developer with a filled
 // .env exercises the full family. Imported projects are registered for
-// permanent deletion in the per-test ledger. import_bitbucket_server keeps a
-// documented skip: it needs a reachable self-hosted Bitbucket Server
-// (BITBUCKET_SERVER_URL/USERNAME/TOKEN/PROJECT_KEY/REPO_SLUG to override).
+// permanent deletion in the per-test ledger. import_bitbucket_server reads
+// BITBUCKET_SERVER_URL/USERNAME/TOKEN/PROJECT_KEY/REPO_SLUG — in Docker mode
+// setup-bitbucket.sh provisions the ephemeral e2e-bitbucket fixture and
+// writes them to .env.docker, so the subtest runs for real; elsewhere it
+// skips unless the operator points it at a reachable Bitbucket Server.
 //
 // Build tag: e2e && !enterprise. Mode: any (credential-gated). Surface: meta.
 func TestMeta_AdminExternalImporters(t *testing.T) {
@@ -1121,7 +1123,7 @@ func TestMeta_AdminExternalImporters(t *testing.T) {
 				"personal_access_token":     token,
 				"bitbucket_server_project":  projectKey,
 				"bitbucket_server_repo":     repoSlug,
-				"target_namespace":          sess.username,
+				"new_namespace":             sess.username,
 				"new_name":                  uniqueName("e2e-bbs-import"),
 			},
 		})
@@ -1138,8 +1140,10 @@ func TestMeta_AdminExternalImporters(t *testing.T) {
 // the route, the destructive-action confirmation, and the error mapping end
 // to end. The mutating happy path requires a migration that is actually
 // stuck — something a healthy, freshly migrated instance cannot have — so
-// it only runs when the operator provides E2E_DB_MIGRATION_VERSION (and, as
-// a safety interlock for real instances, only in Docker mode).
+// it only runs when E2E_DB_MIGRATION_VERSION is set (and, as a safety
+// interlock for real instances, only in Docker mode). setup-gitlab.sh seeds
+// it automatically in Docker mode by deleting the newest Rails-resolvable
+// schema_migrations row; the mark call here re-inserts it.
 //
 // Build tag: e2e && !enterprise. Mode: any (error path) / Docker with
 // E2E_DB_MIGRATION_VERSION (mutating path). Surface: meta.


### PR DESCRIPTION
## Summary

Converts the last two operator-gated e2e skips into real Docker-mode coverage, following the same pattern as the existing `e2e-ldap` and fixture services: the stack provisions everything itself.

### Bitbucket Server import — real, ephemeral, license included

- The CE docker target boots a real **Bitbucket Data Center** container (`e2e-bitbucket`, compose profile `bitbucket`, `atlassian/bitbucket:9.6`). Unattended setup is driven by a `bitbucket.properties` written before the stock entrypoint runs, using Atlassian's public [3-hour timebomb DC test license](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/) — it comfortably outlives an ephemeral run and dies with the stack. Search stays disabled and the embedded eval database is used, keeping the container at one ~1 GB JVM (`SEARCH_ENABLED=false`, `JVM_MAXIMUM_MEMORY=1024m`).
- New `setup-bitbucket.sh` provisions over REST: project `E2E`, repository `fixture` with an initial commit (browse edit API — no git client involved), and an admin HTTP access token for the importer. The `BITBUCKET_SERVER_*` variables land in `.env.docker` with the compose-network URL (`http://e2e-bitbucket:7990`), because GitLab — not the test process — dereferences it. Best-effort by design: any failure warns and the suite falls back to the documented skip.
- Bug fix the new coverage immediately caught: the subtest sent `target_namespace`, a field the action schema never declared (`new_namespace` is the real one) — it had never reached GitLab before.

### db_migration_mark happy path

`setup-gitlab.sh` gains a seeding step: it asks Rails for the newest migration version it can resolve to a file (`ActiveRecord::Base.connection_pool.migration_context`) and deletes that row from `schema_migrations`, exporting `E2E_DB_MIGRATION_VERSION`. The newest *table* row is deliberately not used — structure loads insert historical versions whose files were squashed away, and the mark endpoint 404s on those (verified live). The test's mark call re-inserts the row, so the instance ends the run exactly as it started.

## Validation

Two full `make test-e2e-docker` runs from scratch: **1452 tests, 3 skipped (pre-existing, unrelated), 0 failures**, with both new paths passing for real — `Started Bitbucket Server import as project N` and `Marked migration 20260513120002 as executed` with the `schema_migrations` row confirmed restored afterwards. Boot cost is amortized: Bitbucket starts in parallel with GitLab and is RUNNING (~2.5 min) long before the suite needs it. RAM for the docker stack goes from ~4 GB to ~5.5 GB (documented).

## Summary by Sourcery

Expand Docker-mode E2E coverage with an ephemeral Bitbucket Server fixture and an automatically seeded migration-mark scenario.

New Features:
- Add a self-provisioned Bitbucket Data Center fixture to Docker-mode E2E tests so Bitbucket Server imports run against a real ephemeral service.
- Enable Docker-mode E2E coverage of the db_migration_mark happy path by automatically seeding and restoring a resolvable migration record.

Bug Fixes:
- Correct the Bitbucket Server import test payload to use the action schema's supported namespace field.

Enhancements:
- Make the Bitbucket fixture provisioning best-effort and configure its connection details automatically for GitLab-based imports.

Build:
- Update the Docker E2E Makefile workflow to start, provision, and tear down the Bitbucket fixture alongside GitLab.

Documentation:
- Document the Bitbucket-backed Docker E2E setup, migration seeding behavior, resource requirements, and related environment variables.

Tests:
- Replace the operator-gated Bitbucket Server import and migration-mark happy-path skips with real Docker-mode coverage.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added an ephemeral Bitbucket Data Center container to the E2E test suite to enable testing of the `import_bitbucket_server` functionality.</li>
<li>Implemented `setup-bitbucket.sh` to automatically provision the Bitbucket fixture (project, repository, and access token) and configure the necessary environment variables.</li>
<li>Updated `Makefile` to include the new Bitbucket fixture in the `test-e2e-docker` target.</li>
<li>Updated documentation in `README.md` and `test/e2e/README.md` to reflect the new Bitbucket import testing capabilities.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added Docker-based Bitbucket Data Center coverage for end-to-end import tests.
  * Added automatic Bitbucket project, repository, credentials, and migration fixture provisioning.
  * Improved test setup resilience with readiness checks and graceful fallback when provisioning is unavailable.

* **Documentation**
  * Updated E2E setup instructions, credential guidance, resource requirements, and migration testing details.
  * Clarified Bitbucket Server importer configuration for Docker-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->