### PR TITLE
feat(deps): client-go v2.58.2 — directory-structured generic package file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,9 +416,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       977 |     196,164 |
-| Unit tests (`_test.go`)  |       532 |     302,678 |
+| Unit tests (`_test.go`)  |       532 |     302,741 |
 | End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,683** | **543,999** |
+| **Total**                | **1,683** | **544,062** |
 
 ### Functions
 
@@ -427,8 +427,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,352 |
 | — exported (public)             |  2,586 |
 | — unexported (private)          |  4,766 |
-| Unit test functions (`TestXxx`) | 11,465 |
-| Subtests (`t.Run(...)`)         |  2,849 |
+| Unit test functions (`TestXxx`) | 11,466 |
+| Subtests (`t.Run(...)`)         |  2,850 |
 | End-to-end test functions       |    381 |
 
 ### Ratios worth noting
@@ -437,7 +437,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.54× more tests than code |
 | Average source file length         |                 ~200 lines |
-| Average test file length           |                 ~568 lines |
+| Average test file length           |                 ~569 lines |
 | Comment lines in source            |  21,421 (~10.9% of source) |
 | Test functions per source function |                       1.6× |
 
@@ -445,7 +445,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,594 |
+| `if err != nil` checks             | 6,595 |
 | `defer` statements                 |   864 |
 | `struct` types defined             | 2,699 |
 | `//nolint` suppressions            |   249 |

--- a/README.md
+++ b/README.md
@@ -415,10 +415,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       977 |     196,155 |
-| Unit tests (`_test.go`)  |       532 |     302,604 |
+| Source (`.go`, non-test) |       977 |     196,164 |
+| Unit tests (`_test.go`)  |       532 |     302,678 |
 | End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,683** | **543,916** |
+| **Total**                | **1,683** | **543,999** |
 
 ### Functions
 
@@ -427,8 +427,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,352 |
 | — exported (public)             |  2,586 |
 | — unexported (private)          |  4,766 |
-| Unit test functions (`TestXxx`) | 11,464 |
-| Subtests (`t.Run(...)`)         |  2,848 |
+| Unit test functions (`TestXxx`) | 11,465 |
+| Subtests (`t.Run(...)`)         |  2,849 |
 | End-to-end test functions       |    381 |
 
 ### Ratios worth noting
@@ -445,7 +445,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,593 |
+| `if err != nil` checks             | 6,594 |
 | `defer` statements                 |   864 |
 | `struct` types defined             | 2,699 |
 | `//nolint` suppressions            |   249 |
@@ -471,7 +471,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~3,566 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,400 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 12,401 (impossible to avoid)                                                                         |
 | Longest function name in source      | `baseDestructiveEarlySinglePromptTemplateAndFixtures` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -415,10 +415,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       977 |     196,164 |
-| Unit tests (`_test.go`)  |       532 |     302,741 |
+| Source (`.go`, non-test) |       977 |     196,165 |
+| Unit tests (`_test.go`)  |       532 |     302,727 |
 | End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,683** | **544,062** |
+| **Total**                | **1,683** | **544,049** |
 
 ### Functions
 
@@ -445,7 +445,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,595 |
+| `if err != nil` checks             | 6,594 |
 | `defer` statements                 |   864 |
 | `struct` types defined             | 2,699 |
 | `//nolint` suppressions            |   249 |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,051 |
-| Unit test functions                                   | 11,674 |
+| Total test functions                                  | 12,052 |
+| Unit test functions                                   | 11,675 |
 | E2E test functions                                    |    377 |
 | cmd test functions                                    |    960 |
 | Test files (internal/)                                |    462 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,561 | 87.6% |
+| `TestFunc_Scenario` (2-part)           | 10,562 | 87.6% |
 | `TestFunc` (no underscore)             |    964 |  8.0% |
 | `TestFunc_Scenario_Expected` (3+ part) |    526 |  4.4% |
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,080 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          8,349 |        345 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (175) |          8,350 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        171 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            960 |         70 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,051** |    **703** |                                                                                                 |
+| **Total**               |     **12,052** |    **703** |                                                                                                 |
 
 ### Core Packages
 
@@ -87,7 +87,7 @@
 | users             |   210 |   100.0% |    38 |
 | dynamic           |   159 |    99.7% |     2 |
 | jobs              |   147 |    99.6% |    17 |
-| packages          |   123 |    99.3% |     9 |
+| packages          |   124 |    98.9% |     9 |
 | search            |   118 |   100.0% |    10 |
 | commits           |   114 |    99.8% |    13 |
 | resourceevents    |   114 |   100.0% |    17 |
@@ -231,7 +231,7 @@
 | namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
-| packages                |       123 |          5 |    99.3% |         9 |
+| packages                |       124 |          5 |    98.9% |         9 |
 | pages                   |        54 |          2 |   100.0% |         9 |
 | pipelines               |       111 |          3 |   100.0% |        12 |
 | pipelineschedules       |        94 |          2 |    99.7% |        11 |
@@ -288,7 +288,7 @@
 | waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        89 |          2 |    97.3% |         6 |
-| **Total**               | **8,349** |    **345** |          | **1,169** |
+| **Total**               | **8,350** |    **345** |          | **1,169** |
 
 </details>
 
@@ -478,7 +478,7 @@
 | namespaces              |    99.2% |
 | notifications           |   100.0% |
 | orbit                   |   100.0% |
-| packages                |    99.3% |
+| packages                |    98.9% |
 | pages                   |   100.0% |
 | pipelines               |   100.0% |
 | pipelineschedules       |    99.7% |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -87,7 +87,7 @@
 | users             |   210 |   100.0% |    38 |
 | dynamic           |   159 |    99.7% |     2 |
 | jobs              |   147 |    99.6% |    17 |
-| packages          |   125 |    99.3% |     9 |
+| packages          |   125 |    99.5% |     9 |
 | search            |   118 |   100.0% |    10 |
 | commits           |   114 |    99.8% |    13 |
 | resourceevents    |   114 |   100.0% |    17 |
@@ -231,7 +231,7 @@
 | namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
-| packages                |       125 |          5 |    99.3% |         9 |
+| packages                |       125 |          5 |    99.5% |         9 |
 | pages                   |        54 |          2 |   100.0% |         9 |
 | pipelines               |       111 |          3 |   100.0% |        12 |
 | pipelineschedules       |        94 |          2 |    99.7% |        11 |
@@ -478,7 +478,7 @@
 | namespaces              |    99.2% |
 | notifications           |   100.0% |
 | orbit                   |   100.0% |
-| packages                |    99.3% |
+| packages                |    99.5% |
 | pages                   |   100.0% |
 | pipelines               |   100.0% |
 | pipelineschedules       |    99.7% |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,052 |
-| Unit test functions                                   | 11,675 |
+| Total test functions                                  | 12,053 |
+| Unit test functions                                   | 11,676 |
 | E2E test functions                                    |    377 |
 | cmd test functions                                    |    960 |
 | Test files (internal/)                                |    462 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,562 | 87.6% |
+| `TestFunc_Scenario` (2-part)           | 10,563 | 87.6% |
 | `TestFunc` (no underscore)             |    964 |  8.0% |
 | `TestFunc_Scenario_Expected` (3+ part) |    526 |  4.4% |
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,080 |        103 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            285 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          8,350 |        345 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (175) |          8,351 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        171 | build-tagged real GitLab integration suite                                                      |
 | cmd packages            |            960 |         70 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,052** |    **703** |                                                                                                 |
+| **Total**               |     **12,053** |    **703** |                                                                                                 |
 
 ### Core Packages
 
@@ -87,7 +87,7 @@
 | users             |   210 |   100.0% |    38 |
 | dynamic           |   159 |    99.7% |     2 |
 | jobs              |   147 |    99.6% |    17 |
-| packages          |   124 |    98.9% |     9 |
+| packages          |   125 |    99.3% |     9 |
 | search            |   118 |   100.0% |    10 |
 | commits           |   114 |    99.8% |    13 |
 | resourceevents    |   114 |   100.0% |    17 |
@@ -231,7 +231,7 @@
 | namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
-| packages                |       124 |          5 |    98.9% |         9 |
+| packages                |       125 |          5 |    99.3% |         9 |
 | pages                   |        54 |          2 |   100.0% |         9 |
 | pipelines               |       111 |          3 |   100.0% |        12 |
 | pipelineschedules       |        94 |          2 |    99.7% |        11 |
@@ -288,7 +288,7 @@
 | waitpoll                |        13 |          1 |   100.0% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        89 |          2 |    97.3% |         6 |
-| **Total**               | **8,350** |    **345** |          | **1,169** |
+| **Total**               | **8,351** |    **345** |          | **1,169** |
 
 </details>
 
@@ -478,7 +478,7 @@
 | namespaces              |    99.2% |
 | notifications           |   100.0% |
 | orbit                   |   100.0% |
-| packages                |    98.9% |
+| packages                |    99.3% |
 | pages                   |   100.0% |
 | pipelines               |   100.0% |
 | pipelineschedules       |    99.7% |

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -35,27 +35,27 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (opaque)  | Free/CE  |            33 |               851 | `opaque`            |            136,215 |         1,088 |      137,303 |
 | `meta` / `full` (compact)    | Free/CE  |            33 |               851 | `compact`           |            201,755 |        31,758 |      233,513 |
 | `meta` / `minimal` (compact) | Free/CE  |            33 |               851 | `compact`           |            201,755 |         1,088 |      202,843 |
-| `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            289,249 |        31,758 |      321,007 |
-| `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            289,249 |         1,088 |      290,337 |
-| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            776,286 |        31,758 |      808,044 |
+| `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            289,287 |        31,758 |      321,045 |
+| `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            289,287 |         1,088 |      290,375 |
+| `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            776,324 |        31,758 |      808,082 |
 | `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              2,204 |        31,758 |       33,962 |
 | `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              2,204 |         1,088 |        3,292 |
 | `meta` / `full` (opaque)     | Premium  |            39 |             1,003 | `opaque`            |            157,864 |        31,758 |      189,622 |
 | `meta` / `minimal` (opaque)  | Premium  |            39 |             1,003 | `opaque`            |            157,864 |         1,088 |      158,952 |
 | `meta` / `full` (compact)    | Premium  |            39 |             1,003 | `compact`           |            234,816 |        31,758 |      266,574 |
 | `meta` / `minimal` (compact) | Premium  |            39 |             1,003 | `compact`           |            234,816 |         1,088 |      235,904 |
-| `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            336,513 |        31,758 |      368,271 |
-| `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            336,513 |         1,088 |      337,601 |
-| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            927,596 |        31,758 |      959,354 |
+| `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            336,551 |        31,758 |      368,309 |
+| `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            336,551 |         1,088 |      337,639 |
+| `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            927,634 |        31,758 |      959,392 |
 | `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              2,204 |        31,758 |       33,962 |
 | `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              2,204 |         1,088 |        3,292 |
 | `meta` / `full` (opaque)     | Ultimate |            50 |             1,069 | `opaque`            |            172,717 |        31,758 |      204,475 |
 | `meta` / `minimal` (opaque)  | Ultimate |            50 |             1,069 | `opaque`            |            172,717 |         1,088 |      173,805 |
 | `meta` / `full` (compact)    | Ultimate |            50 |             1,069 | `compact`           |            254,090 |        31,758 |      285,848 |
 | `meta` / `minimal` (compact) | Ultimate |            50 |             1,069 | `compact`           |            254,090 |         1,088 |      255,178 |
-| `meta` / `full` (full)       | Ultimate |            50 |             1,069 | `full`              |            360,611 |        31,758 |      392,369 |
-| `meta` / `minimal` (full)    | Ultimate |            50 |             1,069 | `full`              |            360,611 |         1,088 |      361,699 |
-| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            976,941 |        31,758 |    1,008,699 |
+| `meta` / `full` (full)       | Ultimate |            50 |             1,069 | `full`              |            360,649 |        31,758 |      392,407 |
+| `meta` / `minimal` (full)    | Ultimate |            50 |             1,069 | `full`              |            360,649 |         1,088 |      361,737 |
+| `individual` / `full`        | Ultimate |         1,065 |             1,065 | n/a                 |            976,979 |        31,758 |    1,008,737 |
 
 ## Interpretation guide
 

--- a/docs/reference/tools/packages.md
+++ b/docs/reference/tools/packages.md
@@ -38,7 +38,7 @@ Tools marked **Delete** require user confirmation before execution.
 
 ### `gitlab_package_publish`
 
-Publish (upload) a file to the GitLab Generic Package Registry. Provide either file_path (absolute local path) or content_base64 (base64-encoded content), not both. Returns the package file ID, size, SHA256, and download URL.
+Publish (upload) a file to the GitLab Generic Package Registry. Provide either file_path (absolute local path) or content_base64 (base64-encoded content), not both. The `file_name` may include `/` to describe a directory structure inside the package; segments between separators must not be empty, `.`, or `..`. Returns the package file ID, size, SHA256, and download URL.
 
 | Annotation | **Create** |
 | ---------- | ---------- |

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/shirou/gopsutil/v4 v4.26.7
 	github.com/tiktoken-go/tokenizer v0.8.1
-	gitlab.com/gitlab-org/api/client-go/v2 v2.58.1
+	gitlab.com/gitlab-org/api/client-go/v2 v2.58.2
 	golang.org/x/crypto v0.55.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 gitlab.com/gitlab-org/api/client-go v1.46.0 h1:YxBWFZIFYKcGESCb9fpkwzouo+apyB9pr/XTWzNoL24=
 gitlab.com/gitlab-org/api/client-go v1.46.0/go.mod h1:FtgyU6g2HS5+fMhw6nLK96GBEEBx5MzntOiJWfIaiN8=
-gitlab.com/gitlab-org/api/client-go/v2 v2.58.1 h1:XMuEYGaruQ3Yu7RFGE4b1fmi//QkAPUisq9LV9jahbA=
-gitlab.com/gitlab-org/api/client-go/v2 v2.58.1/go.mod h1:tuYYHZSRj9eKea28W3uySf9bSqfkE2RknDpBdzxdnhk=
+gitlab.com/gitlab-org/api/client-go/v2 v2.58.2 h1:/4x891eadlccWl4dcf/NIN4g50fTudASfMSqfI7uWUQ=
+gitlab.com/gitlab-org/api/client-go/v2 v2.58.2/go.mod h1:tuYYHZSRj9eKea28W3uySf9bSqfkE2RknDpBdzxdnhk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=

--- a/internal/tools/packages/packages.go
+++ b/internal/tools/packages/packages.go
@@ -27,7 +27,7 @@ type PublishInput struct {
 	ProjectID      toolutil.StringOrInt `json:"project_id" jsonschema:"Project ID or URL-encoded path,required"`
 	PackageName    string               `json:"package_name" jsonschema:"Package name (alphanumeric, dots, dashes, underscores),required"`
 	PackageVersion string               `json:"package_version" jsonschema:"Package version (e.g. 1.0.0),required"`
-	FileName       string               `json:"file_name" jsonschema:"Name of the file within the package,required"`
+	FileName       string               `json:"file_name" jsonschema:"Name of the file within the package; may include / to describe a directory structure (segments must not be empty or . or ..),required"`
 	FilePath       string               `json:"file_path,omitempty" jsonschema:"Absolute path to a local file. Alternative to content_base64. Only one of file_path or content_base64 should be provided."`
 	ContentBase64  string               `json:"content_base64,omitempty" jsonschema:"Base64-encoded file content. Only one should be provided."`
 	Status         string               `json:"status,omitempty" jsonschema:"Package status: default or hidden"`
@@ -119,6 +119,10 @@ func Publish(ctx context.Context, req *mcp.CallToolRequest, client *gitlabclient
 		},
 	)
 	if err != nil {
+		if errors.Is(err, gl.ErrInvalidFileName) {
+			return PublishOutput{}, toolutil.WrapErrWithHint("packagePublish", err,
+				"file_name segments between / separators must not be empty, \".\", or \"..\"")
+		}
 		return PublishOutput{}, toolutil.WrapErrWithStatusHint("packagePublish", err, http.StatusBadRequest,
 			"package_name and package_version must match pattern [A-Za-z0-9.\\-_]+ with version following SemVer; verify file_name does not already exist in this package or use status=hidden to override")
 	}
@@ -171,7 +175,7 @@ type DownloadInput struct {
 	ProjectID      toolutil.StringOrInt `json:"project_id" jsonschema:"Project ID or URL-encoded path,required"`
 	PackageName    string               `json:"package_name" jsonschema:"Package name,required"`
 	PackageVersion string               `json:"package_version" jsonschema:"Package version,required"`
-	FileName       string               `json:"file_name" jsonschema:"File name to download,required"`
+	FileName       string               `json:"file_name" jsonschema:"File name to download; may include / to describe a directory structure (segments must not be empty or . or ..),required"`
 	OutputPath     string               `json:"output_path" jsonschema:"Absolute path where the file will be saved on the local filesystem,required"`
 }
 

--- a/internal/tools/packages/packages_stream.go
+++ b/internal/tools/packages/packages_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/progress"
@@ -40,6 +42,9 @@ func streamDownloadPackageFile(
 		projectID, input.PackageName, input.PackageVersion, input.FileName,
 	)
 	if err != nil {
+		if errors.Is(err, gl.ErrInvalidFileName) {
+			return 0, "", fmt.Errorf("format package URL: %w (file_name segments between / separators must not be empty, \".\", or \"..\")", err)
+		}
 		return 0, "", fmt.Errorf("format package URL: %w", err)
 	}
 

--- a/internal/tools/packages/packages_stream.go
+++ b/internal/tools/packages/packages_stream.go
@@ -42,10 +42,11 @@ func streamDownloadPackageFile(
 		projectID, input.PackageName, input.PackageVersion, input.FileName,
 	)
 	if err != nil {
+		hint := ""
 		if errors.Is(err, gl.ErrInvalidFileName) {
-			return 0, "", fmt.Errorf("format package URL: %w (file_name segments between / separators must not be empty, \".\", or \"..\")", err)
+			hint = " (file_name segments between / separators must not be empty, \".\", or \"..\")"
 		}
-		return 0, "", fmt.Errorf("format package URL: %w", err)
+		return 0, "", fmt.Errorf("format package URL: %w%s", err, hint)
 	}
 
 	httpReq, err := client.GL().NewRequest(http.MethodGet, apiPath, nil, nil)

--- a/internal/tools/packages/packages_test.go
+++ b/internal/tools/packages/packages_test.go
@@ -938,19 +938,19 @@ func TestPtrString(t *testing.T) {
 // Ensure fmt is referenced to avoid unused import error.
 var _ = fmt.Sprintf
 
-// assertFileNameShapeResult checks one TestPublish_FileNameShapes outcome:
-// success for valid names, or an ErrInvalidFileName carrying the
-// segment-rule hint for rejected ones.
-func assertFileNameShapeResult(t *testing.T, fileName, wantErr string, err error) {
+// assertFileNameShapeResult checks one file-name-contract outcome for op
+// (Publish/Download): success for valid names, or an ErrInvalidFileName
+// carrying the segment-rule hint for rejected ones.
+func assertFileNameShapeResult(t *testing.T, op, fileName, wantErr string, err error) {
 	t.Helper()
 	if wantErr == "" {
 		if err != nil {
-			t.Fatalf("Publish() error = %v, want success for directory-structured file_name", err)
+			t.Fatalf("%s() error = %v, want success for directory-structured file_name", op, err)
 		}
 		return
 	}
 	if err == nil {
-		t.Fatalf("Publish() = nil error, want ErrInvalidFileName for %q", fileName)
+		t.Fatalf("%s() = nil error, want ErrInvalidFileName for %q", op, fileName)
 	}
 	if !errors.Is(err, gl.ErrInvalidFileName) {
 		t.Fatalf("error = %v, want errors.Is ErrInvalidFileName", err)
@@ -1006,7 +1006,7 @@ func TestPublish_FileNameShapes(t *testing.T) {
 				FileName:       tt.fileName,
 				ContentBase64:  "aGVsbG8=",
 			})
-			assertFileNameShapeResult(t, tt.fileName, tt.wantErr, err)
+			assertFileNameShapeResult(t, "Publish", tt.fileName, tt.wantErr, err)
 		})
 	}
 }
@@ -1052,24 +1052,10 @@ func TestDownload_FileNameShapes(t *testing.T) {
 				FileName:       tt.fileName,
 				OutputPath:     filepath.Join(t.TempDir(), "out", "tool.bin"),
 			})
-			if tt.wantErr == "" {
-				if err != nil {
-					t.Fatalf("Download() error = %v, want success for directory-structured file_name", err)
-				}
-				if out.Size != int64(len("binary-content")) {
-					t.Errorf("Size = %d, want %d", out.Size, len("binary-content"))
-				}
-				return
+			if tt.wantErr == "" && err == nil && out.Size != int64(len("binary-content")) {
+				t.Errorf("Size = %d, want %d", out.Size, len("binary-content"))
 			}
-			if err == nil {
-				t.Fatalf("Download() = nil error, want ErrInvalidFileName for %q", tt.fileName)
-			}
-			if !errors.Is(err, gl.ErrInvalidFileName) {
-				t.Fatalf("error = %v, want errors.Is ErrInvalidFileName", err)
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("error = %q, want segment-rule hint containing %q", err.Error(), tt.wantErr)
-			}
+			assertFileNameShapeResult(t, "Download", tt.fileName, tt.wantErr, err)
 		})
 	}
 }

--- a/internal/tools/packages/packages_test.go
+++ b/internal/tools/packages/packages_test.go
@@ -1010,3 +1010,66 @@ func TestPublish_FileNameShapes(t *testing.T) {
 		})
 	}
 }
+
+// TestDownload_FileNameShapes verifies the v2.58.2 file-name contract on the
+// download path, as table-driven subtests:
+//
+//   - DirectoryStructure: a directory-structured file_name reaches the API
+//     with real "/" separators and the file streams to disk.
+//   - InvalidDotSegment: FormatPackageURL rejects the name client-side with
+//     ErrInvalidFileName (no request leaves) and the wrapped error carries
+//     the segment-rule hint.
+func TestDownload_FileNameShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		wantErr  string // empty = expect success
+	}{
+		{name: "DirectoryStructure", fileName: "dist/linux-amd64/tool.bin"},
+		{name: "InvalidDotSegment", fileName: "dist/../escape.bin", wantErr: "must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handler http.Handler
+			if tt.wantErr == "" {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if got := r.URL.EscapedPath(); got != "/api/v4/projects/42/packages/generic/pkg/1.0.0/dist/linux-amd64/tool.bin" {
+						t.Errorf("escaped path = %q, want directory separators preserved (no %%2F)", got)
+					}
+					w.Header().Set("Content-Type", "application/octet-stream")
+					_, _ = w.Write([]byte("binary-content"))
+				})
+			} else {
+				handler = testutil.ForbiddenHandler(t)
+			}
+			client := testutil.NewTestClient(t, handler)
+
+			out, err := Download(context.Background(), nil, client, DownloadInput{
+				ProjectID:      "42",
+				PackageName:    "pkg",
+				PackageVersion: "1.0.0",
+				FileName:       tt.fileName,
+				OutputPath:     filepath.Join(t.TempDir(), "out", "tool.bin"),
+			})
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Download() error = %v, want success for directory-structured file_name", err)
+				}
+				if out.Size != int64(len("binary-content")) {
+					t.Errorf("Size = %d, want %d", out.Size, len("binary-content"))
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Download() = nil error, want ErrInvalidFileName for %q", tt.fileName)
+			}
+			if !errors.Is(err, gl.ErrInvalidFileName) {
+				t.Fatalf("error = %v, want errors.Is ErrInvalidFileName", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want segment-rule hint containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tools/packages/packages_test.go
+++ b/internal/tools/packages/packages_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -936,3 +937,76 @@ func TestPtrString(t *testing.T) {
 
 // Ensure fmt is referenced to avoid unused import error.
 var _ = fmt.Sprintf
+
+// assertFileNameShapeResult checks one TestPublish_FileNameShapes outcome:
+// success for valid names, or an ErrInvalidFileName carrying the
+// segment-rule hint for rejected ones.
+func assertFileNameShapeResult(t *testing.T, fileName, wantErr string, err error) {
+	t.Helper()
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("Publish() error = %v, want success for directory-structured file_name", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("Publish() = nil error, want ErrInvalidFileName for %q", fileName)
+	}
+	if !errors.Is(err, gl.ErrInvalidFileName) {
+		t.Fatalf("error = %v, want errors.Is ErrInvalidFileName", err)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("error = %q, want segment-rule hint containing %q", err.Error(), wantErr)
+	}
+}
+
+// TestPublish_FileNameShapes verifies the v2.58.2 file-name contract through
+// the publish handler, as table-driven subtests:
+//
+//   - DirectoryStructure: a file_name with "/" separators reaches the API
+//     with the separators preserved and each segment escaped individually.
+//   - InvalidDotSegment: a "." segment is rejected client-side by client-go's
+//     ErrInvalidFileName before any request, and the wrapped error carries
+//     the segment-rule hint.
+func TestPublish_FileNameShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		wantErr  string // empty = expect success
+	}{
+		{name: "DirectoryStructure", fileName: "dist/linux-amd64/tool.bin"},
+		{name: "InvalidDotSegment", fileName: "dist/./tool.bin", wantErr: "must not be empty"},
+		{name: "InvalidParentSegment", fileName: "../escape.bin", wantErr: "must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handler http.Handler
+			if tt.wantErr == "" {
+				handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// EscapedPath distinguishes real "/" separators from the
+					// %2F-escaped flat name pre-2.58.2 client-go sent (Go
+					// preserves %2F escapes, and canonicalizes needless ones
+					// like %2E away).
+					if got := r.URL.EscapedPath(); got != "/api/v4/projects/42/packages/generic/pkg/1.0.0/dist/linux-amd64/tool.bin" {
+						t.Errorf("escaped path = %q, want directory separators preserved (no %%2F)", got)
+					}
+					testutil.RespondJSON(w, http.StatusCreated, `{"message":"201 Created"}`)
+				})
+			} else {
+				// The SDK must reject the name before any request is issued.
+				handler = testutil.ForbiddenHandler(t)
+			}
+			client := testutil.NewTestClient(t, handler)
+
+			_, err := Publish(context.Background(), nil, client, PublishInput{
+				ProjectID:      "42",
+				PackageName:    "pkg",
+				PackageVersion: "1.0.0",
+				FileName:       tt.fileName,
+				ContentBase64:  "aGVsbG8=",
+			})
+			assertFileNameShapeResult(t, tt.fileName, tt.wantErr, err)
+		})
+	}
+}

--- a/internal/tools/testdata/tools_individual.json
+++ b/internal/tools/testdata/tools_individual.json
@@ -137995,7 +137995,7 @@
       "additionalProperties": false,
       "properties": {
         "file_name": {
-          "description": "File name to download",
+          "description": "File name to download; may include / to describe a directory structure (segments must not be empty or . or ..)",
           "type": "string"
         },
         "output_path": {
@@ -138682,7 +138682,7 @@
           "type": "string"
         },
         "file_name": {
-          "description": "Name of the file within the package",
+          "description": "Name of the file within the package; may include / to describe a directory structure (segments must not be empty or . or ..)",
           "type": "string"
         },
         "file_path": {

--- a/llms-full-individual-tools.txt
+++ b/llms-full-individual-tools.txt
@@ -10278,7 +10278,7 @@ Download a single file from the Generic Package Registry to a local path. Return
 
 **Parameters:**
 
-- `file_name` (string) (required): File name to download
+- `file_name` (string) (required): File name to download; may include / to describe a directory structure (segments must not be empty or . or ..)
 - `output_path` (string) (required): Absolute path where the file will be saved on the local filesystem
 - `package_name` (string) (required): Package name
 - `package_version` (string) (required): Package version
@@ -10344,7 +10344,7 @@ Publish a single file to the Generic Package Registry. Returns: the published fi
 **Parameters:**
 
 - `content_base64` (string): Base64-encoded file content. Only one should be provided.
-- `file_name` (string) (required): Name of the file within the package
+- `file_name` (string) (required): Name of the file within the package; may include / to describe a directory structure (segments must not be empty or . or ..)
 - `file_path` (string): Absolute path to a local file. Alternative to content_base64. Only one of file_path or content_base64 should be provided.
 - `package_name` (string) (required): Package name (alphanumeric, dots, dashes, underscores)
 - `package_version` (string) (required): Package version (e.g. 1.0.0)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23378,7 +23378,7 @@ Download a single file from the Generic Package Registry to a local path. Return
 
 **Parameters:**
 
-- `file_name` (string) (required): File name to download
+- `file_name` (string) (required): File name to download; may include / to describe a directory structure (segments must not be empty or . or ..)
 - `output_path` (string) (required): Absolute path where the file will be saved on the local filesystem
 - `package_name` (string) (required): Package name
 - `package_version` (string) (required): Package version
@@ -23444,7 +23444,7 @@ Publish a single file to the Generic Package Registry. Returns: the published fi
 **Parameters:**
 
 - `content_base64` (string): Base64-encoded file content. Only one should be provided.
-- `file_name` (string) (required): Name of the file within the package
+- `file_name` (string) (required): Name of the file within the package; may include / to describe a directory structure (segments must not be empty or . or ..)
 - `file_path` (string): Absolute path to a local file. Alternative to content_base64. Only one of file_path or content_base64 should be provided.
 - `package_name` (string) (required): Package name (alphanumeric, dots, dashes, underscores)
 - `package_version` (string) (required): Package version (e.g. 1.0.0)

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -7,17 +7,17 @@
   "individual": {
     "free": {
       "visible_tools": 847,
-      "tool_schema_tokens": 776286,
+      "tool_schema_tokens": 776324,
       "reduction_factor_vs_dynamic": 352
     },
     "premium": {
       "visible_tools": 999,
-      "tool_schema_tokens": 927596,
+      "tool_schema_tokens": 927634,
       "reduction_factor_vs_dynamic": 421
     },
     "ultimate": {
       "visible_tools": 1065,
-      "tool_schema_tokens": 976941,
+      "tool_schema_tokens": 976979,
       "reduction_factor_vs_dynamic": 443
     }
   }


### PR DESCRIPTION
## Summary

client-go [v2.58.2](https://gitlab.com/gitlab-org/api/client-go/-/releases/v2.58.2) (released today) carries one behavioral change, in the **generic package registry**: file names may describe a directory structure. The SDK now keeps `/` as real path separators (escaping each segment individually instead of flat-escaping the whole name) and rejects empty, `.`, or `..` segments client-side with the new `ErrInvalidFileName` — before any request is issued.

Mirrored across the MCP surface per the 1:1 policy:

- **Schemas**: `gitlab_package_publish` / `gitlab_package_download` `file_name` descriptions document the directory-structure contract and segment rules.
- **Errors (ADR-0007)**: the publish handler and download streamer detect `ErrInvalidFileName` with `errors.Is` and return the specific segment-rule hint instead of the generic 400 guidance.
- **Tests**: table-driven `TestPublish_FileNameShapes` pins both sides — a directory-structured name reaches the API with real `/` separators (asserted via `EscapedPath()`, which distinguishes the new form from the `%2F` flat-escaped path the pre-2.58.2 client sent), and invalid segments are rejected before any request leaves the client (`testutil.ForbiddenHandler` proves the mock is never hit).
- **Docs**: `docs/reference/tools/packages.md` notes the contract.

## Validation

- `make audit-1to1`: still **zero findings across all dimensions** (the release's new exported helpers are package-level functions, outside the service-interface surface).
- Full unit suite and full `golangci-lint` green; golden snapshots, llms, and footprint regenerated for the schema-description change; doc-coverage and all check-* gates pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Adopt client-go v2.58.2 to support directory-structured generic package file names with validation, documentation, and end-to-end handler coverage.

New Features:
- Support directory-structured generic package file names for publishing and downloading through the updated GitLab client.

Bug Fixes:
- Reject invalid file-name segments before issuing requests and provide specific validation guidance for publish and download errors.

Enhancements:
- Document the directory-structured file-name contract across tool schemas and package documentation.

Build:
- Upgrade the GitLab client-go dependency to v2.58.2.

Documentation:
- Update package tool documentation with file-name segment rules.

Tests:
- Add coverage for preserved directory separators and client-side rejection of empty, dot, and parent-directory segments.

Chores:
- Regenerate project metrics and tool metadata affected by the schema and test updates.