### PR TITLE
fix(e2e): seed db_migration_mark with a post_migrate version the web process can resolve

### DIFF
--- a/test/e2e/scripts/setup-gitlab.sh
+++ b/test/e2e/scripts/setup-gitlab.sh
@@ -629,12 +629,17 @@ fi
 # guaranteed to still have a migration file the mark service can resolve.
 if command -v docker >/dev/null 2>&1; then
     echo "  [7/8] Seeding a pending schema migration for db_migration_mark coverage..."
-    # The version must be one the Rails migration context can resolve to a
-    # file — the newest schema_migrations row is not guaranteed to (structure
-    # loads insert historical versions whose files were squashed away), so
-    # Rails itself is asked for the newest migration it knows.
+    # The version must be one the WEB process can resolve to a migration
+    # file. Omnibus configures the migration paths as ["db/migrate",
+    # "/opt/.../db/post_migrate"] — the first entry is relative, and Puma
+    # runs with cwd=/ (verified on gitlab-ce 19.3), so the API's migration
+    # context resolves only the absolutely-pathed post_migrate directory.
+    # A db/migrate version therefore 404s on POST /admin/migrations/:v/mark
+    # even though gitlab-rails runner (cwd = the Rails root) sees it. Seed
+    # the newest post_migrate migration: both processes resolve it, and it
+    # is recent enough to never be a squashed structure-load row.
     mig_version=$(docker compose -f "${COMPOSE_FILE}" exec -T gitlab gitlab-rails runner \
-        "puts ActiveRecord::Base.connection_pool.migration_context.migrations.last.version" 2>/dev/null | tr -d '[:space:]' || true)
+        "puts ActiveRecord::Base.connection_pool.migration_context.migrations.select { |m| m.filename.include?('/post_migrate/') }.last.version" 2>/dev/null | tr -d '[:space:]' || true)
     if [ -n "${mig_version}" ] && docker compose -f "${COMPOSE_FILE}" exec -T gitlab gitlab-psql -c \
         "DELETE FROM schema_migrations WHERE version='${mig_version}'" >/dev/null 2>&1; then
         echo "E2E_DB_MIGRATION_VERSION=${mig_version}" >> "${ENV_FILE}"


### PR DESCRIPTION
## Summary

Unblocks the v2.6.5 release: the tag-triggered **E2E Gate failed on the freshly pulled `gitlab-ce:latest` (19.3.0)** — `db_migration_mark` 404'd for the version the setup seeds, while the identical `MarkMigrationService` call succeeded through `gitlab-rails runner` on the same instance.

**Root cause** (verified live): Omnibus configures the Rails migration paths as `["db/migrate", "/opt/.../db/post_migrate"]` — the first entry is **relative**, and Puma runs with `cwd=/` (checked via `/proc/<pid>/cwd`), so the web process's migration context resolves only the absolutely-pathed `post_migrate` directory. `gitlab-rails runner` (cwd = Rails root) resolves both. The seeding picked `migrations.last`, which on 19.3.0 is a `db/migrate` file — visible to the seeding query, invisible to the API. On the older local image the last migration happened to be a post_migrate file, which is why every previous run passed.

**Fix**: seed the newest **post_migrate** migration — both processes resolve it, and it is recent enough to never be a squashed structure-load row.

## Validation

- Live proof on 19.3.0: `DELETE` row → `POST /admin/migrations/:v/mark` → **201** → row restored.
- Full `make test-e2e-docker` on the fresh image: **1453 tests, 0 failures** — `Marked migration 20260813000002 as executed`. (Two graceful subtest skips in group export download/import: the archive took >3m to materialize on 19.3.0; the schedule path passed and the skip is the documented fallback.)

After merge, the `v2.6.5` tag will be recreated to rerun the release.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending migration test setup by selecting the newest post-migration script, ensuring migrations are correctly detected when preparing the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->