### PR TITLE
ci(e2e): size the gate timeouts for the suite's real duration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
   e2e:
     name: E2E (Docker GitLab)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v7
@@ -78,7 +78,7 @@ jobs:
           gotestsum \
             --junitfile test-results/e2e-junit.xml \
             --format standard-verbose \
-            -- -v -tags e2e -timeout 600s -count=1 ./test/e2e/suite/
+            -- -v -tags e2e -timeout 1800s -count=1 ./test/e2e/suite/
         env:
           E2E_MODE: "docker"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   e2e:
     name: E2E Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 
@@ -64,7 +64,7 @@ jobs:
           gotestsum \
             --junitfile test-results/e2e-junit.xml \
             --format standard-verbose \
-            -- -v -tags e2e -timeout 600s -count=1 ./test/e2e/suite/
+            -- -v -tags e2e -timeout 1800s -count=1 ./test/e2e/suite/
         env:
           E2E_MODE: "docker"
 


### PR DESCRIPTION
## Summary

The recreated `v2.6.5` tag failed its E2E Gate **again — but on go test's own `-timeout 600s`, not on any test**: the run panicked at 609s, taking 26 in-flight tests down with it (the telltale `(unknown)` durations, 1439/1453 tests reached).

The suite legitimately outgrew the 10-minute budget: it now publishes a real CI catalog version through a runner pipeline, marks a real database migration, and provisions pending-approval users — on `gitlab-ce` 19.3.0 a full run measures **610–765s** depending on runner speed. The local Makefile target already uses `-timeout 1800s`; the two workflow gates (release + e2e) were still on the old 600s.

- `-timeout 600s` → `-timeout 1800s` in `release.yml` and `e2e.yml` (matching the Makefile).
- Job-level cap 30 → 45 minutes (boot + provisioning takes ~12 minutes before the suite starts).

After merge, the `v2.6.5` tag gets recreated once more.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

