### PR TITLE
feat(dockerhub): own the Docker Hub descriptions from CI

### DIFF
--- a/.github/dockerhub-description.md
+++ b/.github/dockerhub-description.md
@@ -1,0 +1,59 @@
+# GitLab MCP Server
+
+**Connect your AI assistant to GitLab so it can review merge requests, triage pipelines, manage issues, and draft releases — in plain language.** One static binary (or this container), [1000+ GitLab tools](https://github.com/jmrplens/gitlab-mcp-server#tool-surfaces) over the full REST + GraphQL API, working with Claude, Cursor, VS Code, and any MCP client.
+
+You talk to your AI assistant; it does the GitLab work. No project IDs, API endpoints, or JSON to remember.
+
+> "Review merge request !15 — is it safe to merge?" · "Why did the last pipeline fail?" · "List open issues assigned to me" · "Generate release notes from v1.0 to v2.0"
+
+## Run with Docker
+
+Stdio transport (for desktop MCP clients such as Claude Desktop, Cursor, or VS Code):
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "GITLAB_URL", "-e", "GITLAB_TOKEN", "jmrplens/gitlab-mcp-server:latest", "--http=false"],
+      "env": {
+        "GITLAB_URL": "https://gitlab.com",
+        "GITLAB_TOKEN": "glpat-xxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+HTTP transport (remote/shared use — the container's default mode, listening on `:8080`):
+
+```bash
+docker run --rm -p 8080:8080 jmrplens/gitlab-mcp-server:latest
+```
+
+Images are multi-arch (`linux/amd64`, `linux/arm64`), published for every release with provenance and SBOM attestations, and signed with Cosign. The same image is also available as `ghcr.io/jmrplens/gitlab-mcp-server`.
+
+## Why this server
+
+- 🗣️ **Plain-language GitLab.** The AI translates "is MR !15 safe to merge?" into the right API calls. You don't touch endpoints, IDs, or JSON.
+- 🧰 **The whole platform — 1000+ tools.** Broad GitLab REST v4 + GraphQL coverage: projects, branches, tags, releases, merge requests, issues, pipelines, jobs, groups, users, wikis, environments, deployments, packages, container registry, runners, feature flags, CI/CD variables, security, admin, tokens, and more.
+- 🪶 **Low-token by default.** The default **dynamic** surface exposes just 2 tools (`find` + `execute`) while reaching the full catalog — so it fits any client's context window.
+- ✅ **Proven with real models.** An automated evaluator runs Anthropic, Google, OpenAI, and Qwen against live GitLab instances: **99.5% aggregate success** across thousands of operations.
+- 🔒 **Safe by design.** Read-only mode, safe mode (dry-run preview of every mutation), TLS options for self-hosted GitLab, and continuous SonarCloud quality/security gates.
+- 🖥️ **Runs anywhere.** One static binary or container; Windows, Linux & macOS; amd64 & arm64; stdio (desktop) and HTTP (remote).
+
+## Try it without installing anything
+
+A public instance runs at **`https://mcp.jmrp.io/gitlab`** — nothing to install, no account beyond your own GitLab token (`PRIVATE-TOKEN` header, sent per request and never stored). It is stateless streamable HTTP: `POST` is the transport, a `GET` answers `405` by design. For private self-managed instances, run the container locally so your credentials never leave your machine.
+
+## Documentation
+
+- [Repository and full README](https://github.com/jmrplens/gitlab-mcp-server)
+- [Getting Started guide](https://jmrp.io/docs/gitlab-mcp-server)
+- [Releases and signed binaries](https://github.com/jmrplens/gitlab-mcp-server/releases)
+
+---
+
+Maintained by [José M. Requena Plens](https://jmrp.io/) ·
+[Project page](https://jmrp.io/projects/) ·
+Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab) (POST-only; a GET returns 405 by design)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,3 +329,22 @@ jobs:
         env:
           IMAGE_REF: docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
         run: bash .github/scripts/cosign-sign-retry.sh "$IMAGE_REF"
+
+      # The Docker Hub repository descriptions are owned by this repo so they
+      # cannot drift (they had been empty since the repository was published,
+      # across thousands of pulls): the short description and the curated
+      # description file are re-pushed on every release, right after the
+      # image publish. The full README (~33KB) exceeds Docker Hub's 25,000
+      # character limit, so .github/dockerhub-description.md carries the
+      # Docker-relevant sections verbatim. DOCKERHUB_TOKEN must be a Docker
+      # Hub PAT with read/write/delete scope — the descriptions API rejects
+      # narrower ones.
+      - name: Update Docker Hub description
+        if: steps.dockerhub-login.outputs.skip == 'false'
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          short-description: "MCP server exposing 1,000+ GitLab operations as AI-accessible tools. By jmrp.io"
+          readme-filepath: ./.github/dockerhub-description.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,11 @@ jobs:
       # narrower ones.
       - name: Update Docker Hub description
         if: steps.dockerhub-login.outputs.skip == 'false'
-        uses: peter-evans/dockerhub-description@v5
+        # Pinned to a commit SHA (unlike the org-owned actions above) because
+        # this is an individually-maintained action that receives
+        # DOCKERHUB_TOKEN — a mutable tag would let a compromised release
+        # exfiltrate it.
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -478,3 +478,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 <!-- END STATS -->
 
 </details>
+
+---
+
+Maintained by [José M. Requena Plens](https://jmrp.io/) ·
+[Project page](https://jmrp.io/projects/) ·
+Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab) (POST-only; a GET returns 405 by design)

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
     "source": "github",
     "id": "1208139072"
   },
-  "websiteUrl": "https://jmrplens.github.io/gitlab-mcp-server/",
+  "websiteUrl": "https://mcp.jmrp.io/",
   "icons": [
     {
       "src": "https://raw.githubusercontent.com/jmrplens/gitlab-mcp-server/main/site/src/assets/logo-light.svg",


### PR DESCRIPTION
## Summary

From GEO audit #4 (finding M13): the `jmrplens/gitlab-mcp-server` Docker Hub repository had an **empty short and full description since publication — 4,000+ pulls with zero attribution**. Both are now owned by this repo and re-pushed on every release so they cannot drift.

- **CI step**: the release workflow's Docker job gains `peter-evans/dockerhub-description@v5`, using the same skip-guard and `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets as the existing Docker Hub image publish. ⚠️ The descriptions API requires the PAT to have **read/write/delete** scope — if the first release run fails on this step, regenerate the existing `DOCKERHUB_TOKEN` with that scope (no new secret needed).
- **`.github/dockerhub-description.md`**: the full README (~33KB) exceeds Docker Hub's 25,000-character cap, so a curated file carries the Docker-relevant sections verbatim — intro, container usage for both transports (stdio JSON and the default HTTP mode), the "Why this server" bullets, the hosted endpoint, docs links, and the authorship footer.
- **README** gains the authorship footer (maintainer · project page · hosted instance).
- **`server.json`** `websiteUrl` → `https://mcp.jmrp.io/` for the next registry publish (docs remain in their own field); the GitHub repo homepage now points at `https://jmrp.io/docs/gitlab-mcp-server` (301 to the docs, verified with `curl -sI`).

## Verification — done, not promised

An initial manual upload was performed with the maintainer's local Docker credentials, so the attribution is **already live**:

```json
{
 "description": "MCP server exposing 1,000+ GitLab operations as AI-accessible tools. By jmrp.io",
 "full_len": 3521,
 "has_jmrp": true
}
```

Gates: markdownlint, `check-stats`, `check-llms`, `check-doc-links`, `check-server-json` all green; workflow YAML validated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Own the Docker Hub repository metadata from the project by publishing maintained descriptions and attribution on every release.

New Features:
- Add a curated Docker Hub description covering container usage, project capabilities, hosted access, and documentation.

Bug Fixes:
- Restore and continuously maintain Docker Hub repository attribution and descriptions.

Enhancements:
- Add release-time synchronization of Docker Hub short and full descriptions.
- Add maintainer, project, and hosted-instance attribution to the README.
- Point the MCP registry website and repository homepage to the project documentation and hosted service.

Documentation:
- Publish Docker-focused documentation for Docker Hub while preserving the full README separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Docker Hub documentation covering capabilities, supported clients, transports, configuration, architecture support, hosted access, and project resources.
  * Updated the README with maintainer attribution, project details, and hosted instance information.
  * Updated the server website link to the current project site.

* **Chores**
  * Docker image releases now keep the Docker Hub repository description synchronized automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->