### PR TITLE
docs: swap Smithery badge for MCP Toplist, drop stale mentions

### DIFF
--- a/.github/dockerhub-description.md
+++ b/.github/dockerhub-description.md
@@ -56,4 +56,4 @@ A public instance runs at **`https://mcp.jmrp.io/gitlab`** — nothing to instal
 
 Maintained by [José M. Requena Plens](https://jmrp.io/) ·
 [Project page](https://jmrp.io/projects/) ·
-Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab) (POST-only; a GET returns 405 by design)
+Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 [![Glama MCP Score](https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/gitlab-mcp-server)
 [![MCP Badge](https://lobehub.com/badge/mcp/jmrplens-gitlab-mcp-server)](https://lobehub.com/mcp/jmrplens-gitlab-mcp-server)
-[![smithery badge](https://smithery.ai/badge/jmrp/gitlab-mcp-server)](https://smithery.ai/servers/jmrp/gitlab-mcp-server)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.jmrplens%2Fgitlab-mcp-server.svg)](https://mcptoplist.com/server/io.github.jmrplens%2Fgitlab-mcp-server)
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-000000?logo=cursor&logoColor=white)](https://cursor.directory/plugins/gitlab-mcp-server)
 [![Hosted endpoint](https://img.shields.io/badge/Hosted-mcp.jmrp.io%2Fgitlab-6366f1?style=flat&logo=icloud&logoColor=white)](https://mcp.jmrp.io/)
 
@@ -186,7 +186,7 @@ A public instance runs at **`https://mcp.jmrp.io/gitlab`** — nothing to instal
 
 `PRIVATE-TOKEN` is required and travels per request — it is never stored on the server. `GITLAB-URL` is optional and defaults to `https://gitlab.com`; set it to reach another instance (it must be reachable from the public internet).
 
-It is the fastest way to try the server, and the right way to keep using it is still **locally** (any option above) or through [Smithery](https://smithery.ai/servers/jmrp/gitlab-mcp-server) — for one concrete reason, not as a disclaimer: **your token and every request pass through someone else's machine.** Running it locally means your credentials and your GitLab traffic never leave your computer, which also makes it the only sensible option for a private self-managed instance.
+It is the fastest way to try the server, and the right way to keep using it is still **locally** (any option above) — for one concrete reason, not as a disclaimer: **your token and every request pass through someone else's machine.** Running it locally means your credentials and your GitLab traffic never leave your computer, which also makes it the only sensible option for a private self-managed instance.
 
 The endpoint is **stateless streamable HTTP** on the default `dynamic` surface: `POST` is the transport, `GET` on it answers `405` by design, and `https://mcp.jmrp.io/gitlab/health` answers `ok`. It is one of the servers listed at **[mcp.jmrp.io](https://mcp.jmrp.io/)**, a directory of the MCP servers I maintain, each reachable at its own endpoint; [`https://mcp.jmrp.io/servers.json`](https://mcp.jmrp.io/servers.json) is the same list for automated clients.
 
@@ -483,4 +483,4 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 Maintained by [José M. Requena Plens](https://jmrp.io/) ·
 [Project page](https://jmrp.io/projects/) ·
-Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab) (POST-only; a GET returns 405 by design)
+Hosted instance: [mcp.jmrp.io/gitlab](https://mcp.jmrp.io/gitlab)

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -173,7 +173,7 @@ Hay una instancia pública en **`https://mcp.jmrp.io/gitlab`** — nada que inst
 
 La cabecera `PRIVATE-TOKEN` es obligatoria y viaja en cada petición — nunca se guarda en el servidor. `GITLAB-URL` es opcional y por defecto vale `https://gitlab.com`; ponla para llegar a otra instancia, que debe ser accesible desde Internet.
 
-Es la forma más rápida de probar el servidor, y la forma correcta de usarlo a diario sigue siendo **en local** (cualquier opción de arriba) o a través de [Smithery](https://smithery.ai/servers/jmrp/gitlab-mcp-server), por un motivo concreto: tu token y todas tus peticiones pasan por la máquina de otra persona. Ejecutarlo en local mantiene ambos en tu ordenador — la única opción sensata para una instancia autogestionada privada.
+Es la forma más rápida de probar el servidor, y la forma correcta de usarlo a diario sigue siendo **en local** (cualquier opción de arriba), por un motivo concreto: tu token y todas tus peticiones pasan por la máquina de otra persona. Ejecutarlo en local mantiene ambos en tu ordenador — la única opción sensata para una instancia autogestionada privada.
 
 El endpoint es **streamable HTTP sin estado** sobre la superficie `dynamic` por defecto: `POST` es el transporte, `GET` responde `405` por diseño y `https://mcp.jmrp.io/gitlab/health` responde `ok`. Es uno de los servidores listados en [mcp.jmrp.io](https://mcp.jmrp.io/), un directorio de los servidores MCP que mantiene el autor, cada uno accesible en su propio endpoint; [`https://mcp.jmrp.io/servers.json`](https://mcp.jmrp.io/servers.json) es esa misma lista para clientes automáticos.
 

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -486,7 +486,7 @@ La auto-actualización está **deshabilitada por defecto** cuando se usa el `doc
 
 ## Endpoint público alojado
 
-Hay una instancia lista para usar de este servidor en **`https://mcp.jmrp.io/gitlab`** — nada que instalar, sin más cuenta que tu propio token de GitLab. Es la forma más rápida de probar el servidor; ejecutarlo en local (stdio, Docker) o a través de Smithery sigue siendo la forma correcta de usarlo a diario, porque en un endpoint alojado tu token y todas tus peticiones pasan por la máquina de otra persona.
+Hay una instancia lista para usar de este servidor en **`https://mcp.jmrp.io/gitlab`** — nada que instalar, sin más cuenta que tu propio token de GitLab. Es la forma más rápida de probar el servidor; ejecutarlo en local (stdio, Docker) sigue siendo la forma correcta de usarlo a diario, porque en un endpoint alojado tu token y todas tus peticiones pasan por la máquina de otra persona.
 
 ```json
 {

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -172,7 +172,7 @@ A public instance runs at **`https://mcp.jmrp.io/gitlab`** — nothing to instal
 
 `PRIVATE-TOKEN` is required and travels per request — it is never stored on the server. `GITLAB-URL` is optional and defaults to `https://gitlab.com`; set it to reach another instance, which must be reachable from the public internet.
 
-It is the fastest way to try the server, and the right way to keep using it is still **locally** (any option above) or through [Smithery](https://smithery.ai/servers/jmrp/gitlab-mcp-server), for one concrete reason: your token and every request pass through someone else's machine. Running it locally keeps both on your own computer — the only sensible option for a private self-managed instance.
+It is the fastest way to try the server, and the right way to keep using it is still **locally** (any option above), for one concrete reason: your token and every request pass through someone else's machine. Running it locally keeps both on your own computer — the only sensible option for a private self-managed instance.
 
 The endpoint is **stateless streamable HTTP** on the default `dynamic` surface: `POST` is the transport, `GET` on it answers `405` by design, and `https://mcp.jmrp.io/gitlab/health` answers `ok`. It is one of the servers listed at [mcp.jmrp.io](https://mcp.jmrp.io/), a directory of the MCP servers maintained by this author, each reachable at its own endpoint; [`https://mcp.jmrp.io/servers.json`](https://mcp.jmrp.io/servers.json) is the same list for automated clients.
 

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -486,7 +486,7 @@ Auto-update is **disabled by default** when using the reference `docker-compose.
 
 ## Public hosted endpoint
 
-A ready-to-use instance of this server runs at **`https://mcp.jmrp.io/gitlab`** — nothing to install, no account beyond your own GitLab token. It is the fastest way to try the server; running it locally (stdio, Docker) or through Smithery remains the right way to keep using it, because on a hosted endpoint your token and every request traverse someone else's machine.
+A ready-to-use instance of this server runs at **`https://mcp.jmrp.io/gitlab`** — nothing to install, no account beyond your own GitLab token. It is the fastest way to try the server; running it locally (stdio, Docker) remains the right way to keep using it, because on a hosted endpoint your token and every request traverse someone else's machine.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Replace the Smithery badge with the MCP Toplist badge in `README.md` (Smithery is being deprecated and its badge will stop resolving).
- Drop the "or through Smithery" recommendation from `README.md` and the Starlight `getting-started`/`operations/http-server` pages (EN+ES).
- Trim the redundant `(POST-only; a GET returns 405 by design)` note from the maintainer footer in `README.md` and `.github/dockerhub-description.md` — already covered in the hosted-endpoint section above it.

## Test plan
- [x] `npx markdownlint-cli2 README.md` passes
- [x] Verified `.github/dockerhub-description.md` is the file the release workflow's `peter-evans/dockerhub-description` step uploads to Docker Hub

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Refresh project documentation by replacing obsolete Smithery references and simplifying hosted-endpoint descriptions.

Enhancements:
- Replace the deprecated Smithery references with an MCP Toplist badge and remove Smithery recommendations from the README and English and Spanish documentation.
- Remove redundant hosted-endpoint method details from the maintainer footers.

Documentation:
- Update the README and localized Starlight documentation to reflect current discovery and usage guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project badge in the README.
  * Refined hosted endpoint guidance in English and Spanish documentation.
  * Removed references to the former hosted-service installation option.
  * Local installation and deployment methods remain documented as recommended alternatives.
  * Simplified hosted endpoint descriptions by removing the POST-only/GET behavior note from relevant footers and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->