### PR TITLE
fix: make HTTP serving independent of machine luck, in tests and in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,15 @@ test-integration:
 # unstated assumption of the developer machine before this — the first run
 # on a clean Linux box provisioned an entire GitLab stack and then died on
 # "gotestsum: command not found" after several minutes.
+# GOTESTSUM resolves to the PATH binary when present, else to the location
+# go install writes to (GOBIN, falling back to GOPATH/bin). Recursive (=) on
+# purpose: the fallback must be re-evaluated after ensure-gotestsum runs,
+# because a prerequisite shell cannot extend the PATH of later recipes.
+GOTESTSUM_INSTALL_DIR = $(or $(shell go env GOBIN),$(shell go env GOPATH)/bin)
+GOTESTSUM = $(or $(shell command -v gotestsum 2>/dev/null),$(GOTESTSUM_INSTALL_DIR)/gotestsum)
+
 ensure-gotestsum:
-	@command -v gotestsum >/dev/null 2>&1 || { \
+	@command -v gotestsum >/dev/null 2>&1 || test -x "$(GOTESTSUM_INSTALL_DIR)/gotestsum" || { \
 		echo "gotestsum not found; installing with go install..."; \
 		go install gotest.tools/gotestsum@latest; \
 	}
@@ -138,7 +145,7 @@ test-e2e: ensure-gotestsum
 	@echo "         Tests create and delete projects, groups, users, and other resources."
 	@read -p "Are you sure you want to continue? [y/N] " confirm && [ "$$confirm" = "y" ] || { echo "Aborted."; exit 1; }
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
-	bash -o pipefail -c 'gotestsum \
+	bash -o pipefail -c '$(GOTESTSUM) \
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-junit.xml \
 	  --jsonfile $(E2E_REPORT_DIR)/e2e-log.json \
@@ -181,7 +188,7 @@ test-e2e-docker: ensure-gotestsum
 	@echo "=== Running E2E tests ==="
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
 	@set +e; \
-	  bash -o pipefail -c 'set -a && . test/e2e/.env.docker && set +a && E2E_MODE=docker gotestsum \
+	  bash -o pipefail -c 'set -a && . test/e2e/.env.docker && set +a && E2E_MODE=docker $(GOTESTSUM) \
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-docker-junit.xml \
 	  --jsonfile $(E2E_REPORT_DIR)/e2e-docker-log.json \
@@ -227,7 +234,7 @@ test-e2e-docker-enterprise: ensure-gotestsum
 	@set +e; \
 	  bash -o pipefail -c 'set -a && . test/e2e/.env.docker && set +a && \
 	  echo "Enterprise E2E suite: build tags e2e,enterprise"; \
-	  E2E_MODE=docker gotestsum \
+	  E2E_MODE=docker $(GOTESTSUM) \
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-docker-enterprise-junit.xml \
 	  --jsonfile $(E2E_REPORT_DIR)/e2e-docker-enterprise-log.json \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run test test-short test-race test-pkg test-integration test-e2e test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run test test-short test-race test-pkg test-integration test-e2e ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -122,7 +122,18 @@ test-integration:
 	go test -v -tags integration -coverprofile=coverage.out $(PKGS)
 
 ## test-e2e: run end-to-end tests against a real GitLab instance (reads GITLAB_URL, GITLAB_TOKEN from .env)
-test-e2e:
+# ensure-gotestsum installs gotestsum on demand, so the e2e targets work on
+# a fresh checkout without a separate install-tools step. The tool was an
+# unstated assumption of the developer machine before this — the first run
+# on a clean Linux box provisioned an entire GitLab stack and then died on
+# "gotestsum: command not found" after several minutes.
+ensure-gotestsum:
+	@command -v gotestsum >/dev/null 2>&1 || { \
+		echo "gotestsum not found; installing with go install..."; \
+		go install gotest.tools/gotestsum@latest; \
+	}
+
+test-e2e: ensure-gotestsum
 	@echo "WARNING: This will run E2E tests against the GitLab instance configured in .env (GITLAB_URL)."
 	@echo "         Tests create and delete projects, groups, users, and other resources."
 	@read -p "Are you sure you want to continue? [y/N] " confirm && [ "$$confirm" = "y" ] || { echo "Aborted."; exit 1; }
@@ -142,7 +153,7 @@ validate-http-stateless-docker:
 	scripts/validate-http-stateless.sh docker
 
 ## test-e2e-docker: start ephemeral GitLab CE (+ Bitbucket fixture), run E2E tests, tear down
-test-e2e-docker:
+test-e2e-docker: ensure-gotestsum
 	@echo "=== Cleaning up previous containers (if any) ==="
 	docker compose -f test/e2e/docker-compose.yml --profile bitbucket down -v 2>/dev/null || true
 	@echo "=== Starting ephemeral GitLab CE and Bitbucket fixture ==="
@@ -186,7 +197,7 @@ test-e2e-docker:
 	  if [ "$$teardown_status" -ne 0 ]; then exit "$$teardown_status"; fi
 
 ## test-e2e-docker-enterprise: start ephemeral GitLab EE with cached license, ENTERPRISE_LICENSE, or GITLAB_ACTIVATION_CODE, run E2E tests, tear down
-test-e2e-docker-enterprise:
+test-e2e-docker-enterprise: ensure-gotestsum
 	@echo "=== Cleaning up previous containers (if any) ==="
 	GITLAB_IMAGE=$${GITLAB_IMAGE:-gitlab/gitlab-ee:latest} docker compose -f test/e2e/docker-compose.yml down -v 2>/dev/null || true
 	@echo "=== Starting ephemeral GitLab EE ==="

--- a/README.md
+++ b/README.md
@@ -416,10 +416,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       989 |     200,161 |
-| Unit tests (`_test.go`)  |       545 |     309,989 |
+| Source (`.go`, non-test) |       989 |     200,178 |
+| Unit tests (`_test.go`)  |       545 |     310,018 |
 | End-to-end tests         |       174 |      45,163 |
-| **Total**                | **1,708** | **555,313** |
+| **Total**                | **1,708** | **555,359** |
 
 ### Functions
 
@@ -439,7 +439,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~202 lines |
 | Average test file length           |                 ~568 lines |
-| Comment lines in source            |  22,765 (~11.4% of source) |
+| Comment lines in source            |  22,774 (~11.4% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -447,9 +447,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,677 |
-| `defer` statements                 |   905 |
+| `defer` statements                 |   906 |
 | `struct` types defined             | 2,725 |
-| `//nolint` suppressions            |   254 |
+| `//nolint` suppressions            |   255 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project

--- a/README.md
+++ b/README.md
@@ -416,10 +416,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       989 |     200,134 |
-| Unit tests (`_test.go`)  |       545 |     309,926 |
+| Source (`.go`, non-test) |       989 |     200,161 |
+| Unit tests (`_test.go`)  |       545 |     309,989 |
 | End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,708** | **555,217** |
+| **Total**                | **1,708** | **555,307** |
 
 ### Functions
 
@@ -428,7 +428,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,475 |
 | — exported (public)             |  2,612 |
 | — unexported (private)          |  4,863 |
-| Unit test functions (`TestXxx`) | 11,652 |
+| Unit test functions (`TestXxx`) | 11,653 |
 | Subtests (`t.Run(...)`)         |  2,915 |
 | End-to-end test functions       |    381 |
 
@@ -439,15 +439,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~202 lines |
 | Average test file length           |                 ~568 lines |
-| Comment lines in source            |  22,752 (~11.4% of source) |
+| Comment lines in source            |  22,765 (~11.4% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,676 |
-| `defer` statements                 |   902 |
+| `if err != nil` checks             | 6,677 |
+| `defer` statements                 |   905 |
 | `struct` types defined             | 2,725 |
 | `//nolint` suppressions            |   254 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -471,7 +471,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,638 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,639 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,565 (impossible to avoid)                                                                         |
 | Longest function name in source      | `baseDestructiveEarlySinglePromptTemplateAndFixtures` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -416,18 +416,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       989 |     200,097 |
-| Unit tests (`_test.go`)  |       545 |     309,856 |
+| Source (`.go`, non-test) |       989 |     200,134 |
+| Unit tests (`_test.go`)  |       545 |     309,926 |
 | End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,708** | **555,110** |
+| **Total**                | **1,708** | **555,217** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,474 |
+| Source functions                |  7,475 |
 | — exported (public)             |  2,612 |
-| — unexported (private)          |  4,862 |
+| — unexported (private)          |  4,863 |
 | Unit test functions (`TestXxx`) | 11,652 |
 | Subtests (`t.Run(...)`)         |  2,915 |
 | End-to-end test functions       |    381 |
@@ -439,14 +439,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~202 lines |
 | Average test file length           |                 ~568 lines |
-| Comment lines in source            |  22,730 (~11.4% of source) |
+| Comment lines in source            |  22,752 (~11.4% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,674 |
+| `if err != nil` checks             | 6,676 |
 | `defer` statements                 |   902 |
 | `struct` types defined             | 2,725 |
 | `//nolint` suppressions            |   254 |

--- a/README.md
+++ b/README.md
@@ -418,8 +418,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |       989 |     200,161 |
 | Unit tests (`_test.go`)  |       545 |     309,989 |
-| End-to-end tests         |       174 |      45,157 |
-| **Total**                | **1,708** | **555,307** |
+| End-to-end tests         |       174 |      45,163 |
+| **Total**                | **1,708** | **555,313** |
 
 ### Functions
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -1069,7 +1070,13 @@ func registerConfiguredToolSurfaceWithCatalog(server *mcp.Server, client *gitlab
 
 // httpShutdownTimeout bounds graceful HTTP shutdown after the process context
 // is cancelled.
-const httpShutdownTimeout = 5 * time.Second
+// 15 seconds rather than 5: under CI load or an instrumented build, five
+// seconds of drain was routinely not enough and shutdown returned a
+// context-deadline error for perfectly healthy in-flight requests. A
+// larger budget never slows a clean shutdown — Shutdown returns as soon as
+// the connections drain — it only stops a loaded one from being reported
+// as a failure.
+const httpShutdownTimeout = 15 * time.Second
 
 // effectiveIdleTimeout maps a user-supplied value to the duration passed to
 // [http.Server.IdleTimeout]. When the caller passes 0 (meaning "disable idle
@@ -1128,6 +1135,13 @@ func newHTTPServer(addr string, handler http.Handler, httpIdleTimeout time.Durat
 // token are rejected. Sessions expire after cfg.SessionTimeout of inactivity.
 // The pool is bounded by cfg.MaxHTTPClients entries with LRU eviction.
 func serveHTTP(ctx context.Context, cfg *config.Config, httpAddr string, httpIdleTimeout time.Duration) error {
+	return serveHTTPOn(ctx, cfg, httpAddr, nil, httpIdleTimeout)
+}
+
+// serveHTTPOn is serveHTTP with an optional pre-bound listener. When
+// listener is non-nil it is served directly and httpAddr is used only for
+// logging and host validation; when nil, the server binds httpAddr itself.
+func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, listener net.Listener, httpIdleTimeout time.Duration) error {
 	slog.Info(
 		"starting MCP server in HTTP mode",
 		"addr", httpAddr,
@@ -1155,16 +1169,29 @@ func serveHTTP(ctx context.Context, cfg *config.Config, httpAddr string, httpIdl
 	pool.StartRevalidation(ctx)
 	pool.StartIdleEviction(ctx)
 
-	// Build server-card JSON once at startup using an ephemeral MCP server
-	// so that /.well-known/mcp/server-card.json is served without authentication.
-	serverCardJSON, serverCardErr := buildServerCard(cfg) //nolint:contextcheck // startup: ephemeral MCP server isolated from request ctx
-	if serverCardErr != nil {
-		slog.Warn("failed to build server-card.json, endpoint will return 503", "error", serverCardErr)
-	}
+	// The server card is built on first request, not at startup. Building
+	// it means standing up an ephemeral MCP server with the full catalog —
+	// tens of seconds under instrumented builds — and doing that inline
+	// held /health hostage: a deployment's readiness probe (and every HTTP
+	// test) was gated on an endpoint almost nobody fetches. sync.OnceValues
+	// keeps the once-per-process semantics; only the first card request
+	// pays.
+	// The card builder runs on the first request's goroutine but builds an
+	// ephemeral in-memory MCP server whose lifetime is its own; tying it to
+	// one request's context would poison the once-cached card for everyone
+	// after a canceled first request.
+	serverCard := sync.OnceValues(func() ([]byte, error) { //nolint:contextcheck // see above
+		cardJSON, err := buildServerCard(cfg)
+		if err != nil {
+			slog.Warn("failed to build server-card.json, endpoint returns 503", "error", err)
+		}
+		return cardJSON, err
+	})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler)
 	mux.HandleFunc("GET /.well-known/mcp/server-card.json", func(w http.ResponseWriter, _ *http.Request) {
+		serverCardJSON, _ := serverCard()
 		if serverCardJSON == nil {
 			http.Error(w, `{"error":"server card unavailable"}`, http.StatusServiceUnavailable)
 			return
@@ -1187,7 +1214,17 @@ func serveHTTP(ctx context.Context, cfg *config.Config, httpAddr string, httpIdl
 
 	serverErr := make(chan error, 1)
 	go func() {
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		// A pre-bound listener wins over the address. This is what lets a
+		// caller — the tests, above all — reserve the port and hand over
+		// the live socket, instead of closing a probe listener and racing
+		// everything else on the machine to re-bind the same address.
+		var err error
+		if listener != nil {
+			err = httpServer.Serve(listener)
+		} else {
+			err = httpServer.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			serverErr <- err
 		}
 		close(serverErr)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1179,14 +1179,29 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	// The card build is bounded by the server's lifecycle context, not by
 	// any single request's: a canceled first request must not poison the
 	// once-cached card for everyone after it, while a server shutdown
-	// should cancel the build rather than wait behind it.
-	serverCard := sync.OnceValues(func() ([]byte, error) {
-		cardJSON, err := buildServerCard(ctx, cfg)
-		if err != nil {
-			slog.Warn("failed to build server-card.json, endpoint returns 503", "error", err)
-		}
-		return cardJSON, err
-	})
+	// should cancel the build rather than wait behind it. One background
+	// goroutine does the building, started by the first request; handlers
+	// only select on its completion channel. Per-request waiter goroutines
+	// would let anyone hammering this public route accumulate goroutines
+	// for the whole duration of the first build.
+	var (
+		serverCardOnce sync.Once
+		serverCardDone = make(chan struct{})
+		serverCardJSON []byte
+	)
+	startServerCardBuild := func() {
+		serverCardOnce.Do(func() {
+			go func() {
+				defer close(serverCardDone)
+				cardJSON, err := buildServerCardFn(ctx, cfg)
+				if err != nil {
+					slog.Warn("failed to build server-card.json, endpoint returns 503", "error", err)
+					return
+				}
+				serverCardJSON = cardJSON
+			}()
+		})
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler)
@@ -1197,15 +1212,11 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 		// hold graceful shutdown hostage for however long the build took.
 		// This way a request caught by shutdown returns 503 immediately,
 		// Shutdown drains, and a build that does finish stays cached for
-		// the next request.
-		done := make(chan struct{})
-		var serverCardJSON []byte
-		go func() {
-			defer close(done)
-			serverCardJSON, _ = serverCard()
-		}()
+		// the next request. serverCardJSON is safe to read after the
+		// channel closes: the write happens before close(serverCardDone).
+		startServerCardBuild()
 		select {
-		case <-done:
+		case <-serverCardDone:
 		case <-r.Context().Done():
 			http.Error(w, `{"error":"server card unavailable"}`, http.StatusServiceUnavailable)
 			return
@@ -1563,6 +1574,12 @@ func newHealthResponse(startedAt, now time.Time) healthResponse {
 // The card includes per-tool OutputSchema, Annotations, and Title so external
 // scanners (Smithery, Glama, MCP Hive) get the full metadata without needing
 // to authenticate against the live MCP endpoint.
+// buildServerCardFn is the card builder serveHTTPOn uses; a variable so a
+// test can substitute a builder it controls and drive the
+// shutdown-during-build path deterministically instead of racing a sleep
+// against the real build.
+var buildServerCardFn = buildServerCard //nolint:gochecknoglobals // test seam
+
 func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 	// Use configured URL or a placeholder — the dummy client only needs a
 	// parseable URL to register tools; it never makes real API calls.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1176,12 +1176,12 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	// test) was gated on an endpoint almost nobody fetches. sync.OnceValues
 	// keeps the once-per-process semantics; only the first card request
 	// pays.
-	// The card builder runs on the first request's goroutine but builds an
-	// ephemeral in-memory MCP server whose lifetime is its own; tying it to
-	// one request's context would poison the once-cached card for everyone
-	// after a canceled first request.
-	serverCard := sync.OnceValues(func() ([]byte, error) { //nolint:contextcheck // see above
-		cardJSON, err := buildServerCard(cfg)
+	// The card build is bounded by the server's lifecycle context, not by
+	// any single request's: a canceled first request must not poison the
+	// once-cached card for everyone after it, while a server shutdown
+	// should cancel the build rather than wait behind it.
+	serverCard := sync.OnceValues(func() ([]byte, error) {
+		cardJSON, err := buildServerCard(ctx, cfg)
 		if err != nil {
 			slog.Warn("failed to build server-card.json, endpoint returns 503", "error", err)
 		}
@@ -1190,8 +1190,29 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", healthHandler)
-	mux.HandleFunc("GET /.well-known/mcp/server-card.json", func(w http.ResponseWriter, _ *http.Request) {
-		serverCardJSON, _ := serverCard()
+	mux.HandleFunc("GET /.well-known/mcp/server-card.json", func(w http.ResponseWriter, r *http.Request) {
+		// The build runs detached and the handler only waits on it: the
+		// catalog registration inside is CPU work no context can
+		// interrupt, so a handler that called the builder inline would
+		// hold graceful shutdown hostage for however long the build took.
+		// This way a request caught by shutdown returns 503 immediately,
+		// Shutdown drains, and a build that does finish stays cached for
+		// the next request.
+		done := make(chan struct{})
+		var serverCardJSON []byte
+		go func() {
+			defer close(done)
+			serverCardJSON, _ = serverCard()
+		}()
+		select {
+		case <-done:
+		case <-r.Context().Done():
+			http.Error(w, `{"error":"server card unavailable"}`, http.StatusServiceUnavailable)
+			return
+		case <-ctx.Done():
+			http.Error(w, `{"error":"server card unavailable"}`, http.StatusServiceUnavailable)
+			return
+		}
 		if serverCardJSON == nil {
 			http.Error(w, `{"error":"server card unavailable"}`, http.StatusServiceUnavailable)
 			return
@@ -1542,7 +1563,7 @@ func newHealthResponse(startedAt, now time.Time) healthResponse {
 // The card includes per-tool OutputSchema, Annotations, and Title so external
 // scanners (Smithery, Glama, MCP Hive) get the full metadata without needing
 // to authenticate against the live MCP endpoint.
-func buildServerCard(cfg *config.Config) ([]byte, error) {
+func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 	// Use configured URL or a placeholder — the dummy client only needs a
 	// parseable URL to register tools; it never makes real API calls.
 	gitlabURL := cfg.GitLabURL
@@ -1555,13 +1576,19 @@ func buildServerCard(cfg *config.Config) ([]byte, error) {
 		return nil, fmt.Errorf("creating dummy client: %w", err)
 	}
 
-	srv, err := createServer(dummyClient, cfg.ServerConfig(), nil)
+	// createServer's internal tool-exclusion pass runs an ephemeral
+	// in-memory session of its own; the caller's context governs the card
+	// session below, not that registration detail.
+	srv, err := createServer(dummyClient, cfg.ServerConfig(), nil) //nolint:contextcheck // see above
 	if err != nil {
 		return nil, fmt.Errorf("creating server-card MCP server: %w", err)
 	}
 
 	st, ct := mcp.NewInMemoryTransports()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// The 30-second ceiling derives from the server's lifecycle context, so
+	// a shutdown that begins while the card is still being built cancels
+	// the build instead of waiting behind it.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	serverSession, err := srv.Connect(ctx, st, nil)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -4047,7 +4047,7 @@ func TestBuildServerCard_ReturnsValidJSON(t *testing.T) {
 		MetaTools:     true,
 	}
 
-	data, err := buildServerCard(cfg)
+	data, err := buildServerCard(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("buildServerCard() returned error: %v", err)
 	}
@@ -4146,7 +4146,7 @@ func TestBuildServerCard_IndividualMode(t *testing.T) {
 		MetaTools:     false,
 	}
 
-	data, err := buildServerCard(cfg)
+	data, err := buildServerCard(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("buildServerCard() returned error: %v", err)
 	}
@@ -4168,6 +4168,69 @@ func TestBuildServerCard_IndividualMode(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly verifies a
+// shutdown that begins while the server card is still being built neither
+// waits behind the build nor reports an error.
+//
+// The card's catalog registration is CPU work no context can interrupt, so
+// the guarantee has to come from the handler: the in-flight card request
+// is released with a 503 the moment shutdown starts, letting Shutdown
+// drain inside its budget while the detached build finishes on its own.
+func TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly(t *testing.T) {
+	srv := newMockGitLabServer(t)
+	cfg := &config.Config{
+		GitLabURL:      srv.URL,
+		MaxHTTPClients: config.DefaultMaxHTTPClients,
+		SessionTimeout: config.DefaultSessionTimeout,
+		// The individual surface on purpose: the slowest possible card
+		// build, so shutdown reliably lands while it is in flight.
+		MetaTools: false,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
+	}()
+	waitForHTTPServerReady(t, addr, errCh)
+
+	// Fire the card request without waiting for it — it is the build we
+	// want in flight when shutdown starts.
+	cardDone := make(chan struct{})
+	go func() {
+		defer close(cardDone)
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet,
+			"http://"+addr+"/.well-known/mcp/server-card.json", nil)
+		if reqErr != nil {
+			t.Errorf("build card request: %v", reqErr)
+			return
+		}
+		resp, doErr := testHTTPClient.Do(req)
+		if doErr == nil {
+			resp.Body.Close()
+		}
+	}()
+	time.Sleep(50 * time.Millisecond) // let the request reach the handler
+	cancel()
+
+	select {
+	case shutdownErr := <-errCh:
+		if shutdownErr != nil {
+			t.Fatalf("serveHTTPOn() = %v during card build, want a clean shutdown", shutdownErr)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("shutdown did not complete while the server card was building")
+	}
+	<-cardDone
+}
+
 // TestBuildServerCard_MinimalCapabilitySurface verifies that server-card
 // generation returns a reduced catalog instead of failing when prompts are not
 // registered.
@@ -4182,7 +4245,7 @@ func TestBuildServerCard_MinimalCapabilitySurface(t *testing.T) {
 		CapabilitySurface: config.CapabilitySurfaceMinimal,
 	}
 
-	data, err := buildServerCard(cfg)
+	data, err := buildServerCard(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("buildServerCard() returned error: %v", err)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -52,7 +52,12 @@ const (
 
 // testHTTPClient avoids http.DefaultClient in tests so that stalled mock
 // servers cannot hang the entire test suite indefinitely.
-var testHTTPClient = &http.Client{Timeout: 10 * time.Second} //nolint:gochecknoglobals // test-only
+// The 30-second timeout matches testHTTPLivenessTimeout's reasoning: a
+// healthy server answers in milliseconds, and the budget only matters on
+// the first request of a process under the race detector, where building
+// the pool entry's full catalog alone can exceed ten seconds. A passing
+// test is never slowed by the larger value.
+var testHTTPClient = &http.Client{Timeout: 30 * time.Second} //nolint:gochecknoglobals // test-only
 
 // closeMCPSession sends an HTTP DELETE to properly terminate an MCP session
 // on the server side, preventing goroutine leaks from StreamableHTTPHandler.
@@ -637,6 +642,11 @@ func TestServeHTTP_GracefulShutdown(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -690,6 +700,11 @@ func TestServeHTTP_PortConflict(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx := t.Context()
@@ -2186,6 +2201,11 @@ func TestServeHTTP_RequestWithToken(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2197,11 +2217,10 @@ func TestServeHTTP_RequestWithToken(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -2245,6 +2264,11 @@ func TestServeHTTP_CrossOriginProtection_RejectsCrossSitePost(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2255,11 +2279,10 @@ func TestServeHTTP_CrossOriginProtection_RejectsCrossSitePost(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -2303,6 +2326,11 @@ func TestServeHTTP_RequestWithTokenAndGitLabURLHeader(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2313,11 +2341,10 @@ func TestServeHTTP_RequestWithTokenAndGitLabURLHeader(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -2365,9 +2392,14 @@ func TestServeHTTP_MissingGitLabURLDefaultsToPublic(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		Tier:           edition.Free,
-		TierExplicit:   true,
-		IgnoreScopes:   true,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:  config.ToolSurfaceDynamic,
+		Tier:         edition.Free,
+		TierExplicit: true,
+		IgnoreScopes: true,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2378,11 +2410,10 @@ func TestServeHTTP_MissingGitLabURLDefaultsToPublic(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -2440,6 +2471,11 @@ func TestServeHTTP_InvalidGitLabURLHeader(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2450,11 +2486,10 @@ func TestServeHTTP_InvalidGitLabURLHeader(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -2529,6 +2564,11 @@ func TestServeHTTP_MissingToken(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2539,11 +2579,10 @@ func TestServeHTTP_MissingToken(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -3043,11 +3082,10 @@ func oauthAddr(t *testing.T, ctx context.Context, cfg *config.Config) (string, <
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 	waitForHTTPServerReady(t, addr, errCh) //nolint:contextcheck // test helper: uses its own probe deadline
 	return addr, errCh
@@ -3148,8 +3186,13 @@ func TestServeHTTP_OAuthMode_MetadataEndpoint(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		AuthMode:       "oauth",
-		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:   config.ToolSurfaceDynamic,
+		AuthMode:      "oauth",
+		OAuthCacheTTL: config.DefaultOAuthCacheTTL,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3204,8 +3247,13 @@ func TestServeHTTP_OAuthMode_RejectsUnauthenticated(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		AuthMode:       "oauth",
-		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:   config.ToolSurfaceDynamic,
+		AuthMode:      "oauth",
+		OAuthCacheTTL: config.DefaultOAuthCacheTTL,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3249,8 +3297,13 @@ func TestServeHTTP_OAuthMode_AcceptsValidBearer(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		AuthMode:       "oauth",
-		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:   config.ToolSurfaceDynamic,
+		AuthMode:      "oauth",
+		OAuthCacheTTL: config.DefaultOAuthCacheTTL,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3312,8 +3365,13 @@ func TestServeHTTP_OAuthMode_PrivateTokenConverted(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		AuthMode:       "oauth",
-		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:   config.ToolSurfaceDynamic,
+		AuthMode:      "oauth",
+		OAuthCacheTTL: config.DefaultOAuthCacheTTL,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3359,8 +3417,13 @@ func TestServeHTTP_OAuthMode_InvalidTokenReturns401(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
-		AuthMode:       "oauth",
-		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface:   config.ToolSurfaceDynamic,
+		AuthMode:      "oauth",
+		OAuthCacheTTL: config.DefaultOAuthCacheTTL,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3405,6 +3468,11 @@ func TestServeHTTP_LegacyMode_NoMetadataEndpoint(t *testing.T) {
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
 		MetaTools:      false,
+		// The dynamic surface, explicitly: these are transport, auth and
+		// routing tests, and none of them needs the pool's first request
+		// to build the full individual catalog — which, under the race
+		// detector, costs longer than any sane client timeout.
+		ToolSurface: config.ToolSurfaceDynamic,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -3560,7 +3628,11 @@ func TestRunHTTP_MissingGitLabURL(t *testing.T) {
 	}()
 
 	err := runHTTP(ctx, &httpConfig{
-		gitlabURL:      "",
+		gitlabURL: "",
+		// An explicit ephemeral port: with addr empty, net/http listens on
+		// ":http" — real port 80 — and the test's outcome then depends on
+		// whether anything on the machine already owns it.
+		addr:           "127.0.0.1:0",
 		maxHTTPClients: config.DefaultMaxHTTPClients, autoUpdateTimeout: config.DefaultAutoUpdateTimeout,
 		sessionTimeout: config.DefaultSessionTimeout,
 	})
@@ -4156,11 +4228,10 @@ func TestServeHTTP_ServerCardEndpoint_ReturnsToolList(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 
 	waitForHTTPServerReady(t, addr, errCh)
@@ -4413,11 +4484,10 @@ func startStatelessServeHTTP(t *testing.T, cfg *config.Config) (string, func()) 
 		t.Fatalf("listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- serveHTTP(ctx, cfg, addr, defaultHTTPIdleTimeout)
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
 	}()
 	waitForHTTPServerReady(t, addr, errCh)
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -4170,22 +4170,37 @@ func TestBuildServerCard_IndividualMode(t *testing.T) {
 
 // TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly verifies a
 // shutdown that begins while the server card is still being built neither
-// waits behind the build nor reports an error.
+// waits behind the build nor reports an error, and that the caught request
+// is answered with 503 rather than left hanging.
 //
 // The card's catalog registration is CPU work no context can interrupt, so
 // the guarantee has to come from the handler: the in-flight card request
 // is released with a 503 the moment shutdown starts, letting Shutdown
 // drain inside its budget while the detached build finishes on its own.
+//
+// The builder is substituted through the buildServerCardFn seam with one
+// the test gates, so cancellation provably lands mid-build instead of
+// racing a sleep against the real build. Deliberately not parallel: the
+// seam is a package global, and the sequential pass runs alone.
 func TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly(t *testing.T) {
 	srv := newMockGitLabServer(t)
 	cfg := &config.Config{
 		GitLabURL:      srv.URL,
 		MaxHTTPClients: config.DefaultMaxHTTPClients,
 		SessionTimeout: config.DefaultSessionTimeout,
-		// The individual surface on purpose: the slowest possible card
-		// build, so shutdown reliably lands while it is in flight.
-		MetaTools: false,
+		MetaTools:      false,
+		ToolSurface:    config.ToolSurfaceDynamic, // the gated fake builds the card; the surface no longer matters
 	}
+
+	buildStarted := make(chan struct{})
+	releaseBuild := make(chan struct{})
+	origBuild := buildServerCardFn
+	buildServerCardFn = func(context.Context, *config.Config) ([]byte, error) {
+		close(buildStarted)
+		<-releaseBuild
+		return []byte(`{}`), nil
+	}
+	t.Cleanup(func() { buildServerCardFn = origBuild })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -4213,11 +4228,22 @@ func TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly(t *testing.T) {
 			return
 		}
 		resp, doErr := testHTTPClient.Do(req)
-		if doErr == nil {
-			resp.Body.Close()
+		if doErr != nil {
+			t.Errorf("card request during shutdown: %v, want a 503 response", doErr)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("card request during shutdown = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
 		}
 	}()
-	time.Sleep(50 * time.Millisecond) // let the request reach the handler
+
+	// Only cancel once the builder is provably in flight.
+	select {
+	case <-buildStarted:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("card build never started")
+	}
 	cancel()
 
 	select {
@@ -4229,6 +4255,9 @@ func TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly(t *testing.T) {
 		t.Fatal("shutdown did not complete while the server card was building")
 	}
 	<-cardDone
+	// Release the gated builder only after the assertions: its goroutine
+	// outlives serveHTTPOn by design, and must not touch the restored seam.
+	close(releaseBuild)
 }
 
 // TestBuildServerCard_MinimalCapabilitySurface verifies that server-card

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -332,7 +332,7 @@
 | cmd/internal/apidocs                           |    87.3% |
 | cmd/internal/docgen                            |    99.6% |
 | cmd/internal/mcpsurface                        |    85.0% |
-| cmd/server                                     |    85.3% |
+| cmd/server                                     |    85.4% |
 
 ### Core Packages
 
@@ -565,7 +565,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_doc_coverage** (81.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **elicitation** (84.9%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/mcpsurface** (85.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/server** (85.3%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
+- **cmd/server** (85.4%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/audit_1to1/internal/merge** (86.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.

--- a/test/e2e/suite/mrdeps_ee_test.go
+++ b/test/e2e/suite/mrdeps_ee_test.go
@@ -28,9 +28,15 @@ func mrDepsCreateMR(ctx context.Context, t *testing.T, proj ProjectFixture, bran
 	branch := uniqueName(branchPrefix)
 	createBranchMeta(ctx, t, sess.meta, proj, branch)
 	commitFileMeta(ctx, t, sess.meta, proj, branch, branch+".txt", "blocking dependency fixture", title)
-	mr := createMRMeta(ctx, t, sess.meta, proj, branch, defaultBranch, title)
-	waitForMRReady(ctx, t, sess.glClient, proj.ID, mr.IID)
-	return mr
+	// Deliberately no waitForMRReady here. A dependency links two MR
+	// records; none of the endpoints under test read DetailedMergeStatus,
+	// so waiting for GitLab to compute it buys nothing — and two
+	// sequential readiness waits, each capped at the 300-second
+	// enterprise budget, cannot fit inside this test's 420 seconds on a
+	// loaded parallel run. That arithmetic is exactly how this test once
+	// burned its whole deadline inside a best-effort helper and then
+	// failed on the next call with a bare "context deadline exceeded".
+	return createMRMeta(ctx, t, sess.meta, proj, branch, defaultBranch, title)
 }
 
 // mrDepsGlobalID resolves the instance-global merge request ID for an IID,


### PR DESCRIPTION
## Description

The `cmd/server` HTTP tests failed under the race detector on every machine they met — three tests reproducibly on a loaded macOS laptop (against clean `main`, measured in an isolated worktree), and the full package terminally on a Debian host where nginx owns port 80. Every failure traced to an environmental assumption, not to the code under test. Two of the fixes are production code.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change

## Changes Made

**Production:**

- **Lazy server card.** `buildServerCard` ran eagerly at startup — an ephemeral MCP server with the full catalog, tens of seconds under instrumentation, all before `/health` existed. A deployment's readiness probe was gated on an endpoint almost nobody fetches. Now built on first request via `sync.OnceValues`; the endpoint already tolerated absence with a 503. Measured on the failing host: startup-to-ready went from >30s (readiness timeout) to milliseconds.
- **Graceful shutdown budget 5s → 15s.** Five seconds of drain was routinely not enough under CI load (`http server shutdown: context deadline exceeded` on healthy in-flight requests — the root cause PR #188 only patched around test-side). `Shutdown` returns the moment connections drain, so the larger budget costs a clean shutdown nothing.

**Tests:**

- **`serveHTTPOn`: serve a pre-bound listener.** Nine test sites reserved a port by binding, closing, and hoping to rebind before anything else on the machine did; with 14 parallel tests under `-race`, the `/health` probe could even reach a *different* test's server. The listener is now handed over live — the race is gone by construction.
- **Transport/auth/routing tests pin the dynamic surface.** Fourteen tests requested the individual surface (~850 tools) they never test; building that catalog on the pool's first request under `-race` exceeded any sane client timeout. The shared test client rises to 30s for the cold first-request path that remains.
- **`TestRunHTTP_MissingGitLabURL` binds an ephemeral port.** With `addr` empty, `net/http` listens on `":http"` — real port 80 — so the test passed or failed depending on whether the machine ran a web server.

## How to Test

1. `go test ./cmd/server/ -race -count=1` — previously never finished on a host with port 80 occupied; now `ok` in ~7m.
2. `go test ./cmd/server/ -race -count=3 -run 'TestServeHTTP_|TestRunHTTP_'` — the previously-flaky subset, stable across repetitions.
3. `go test ./cmd/server/ -count=1` — the non-race suite, unchanged behavior.

## Breaking Changes / Migration Notes

N/A. The server card's content is byte-identical; only *when* it is first computed changes (first request instead of startup). Operators get faster boot and a readiness probe that no longer waits on catalog construction.

## Checklist

- [x] Code compiles: `go build ./...`
- [x] `golangci-lint` clean on changed packages
- [x] All tests pass, including the full package under `-race` on the host that motivated the work
- [x] Commit messages follow Conventional Commits
- [x] No secrets or credentials
- [ ] docs/ updates — not applicable: no user-facing behavior change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Make HTTP serving and its test suites independent of host-specific ports, timing, and tool availability.

Bug Fixes:
- Make HTTP server startup and shutdown resilient to slow catalog generation and loaded environments.
- Remove test flakiness caused by port-binding races, machine-owned port 80, and race-detector timing.
- Avoid unnecessary enterprise E2E readiness waits that can exhaust test deadlines.

Enhancements:
- Defer server-card generation until its first request while preserving its existing response behavior.
- Allow HTTP serving on a caller-provided listener for reliable ephemeral-port testing.
- Use the dynamic tool surface and a longer client timeout for transport, authentication, and routing tests.
- Install gotestsum automatically when running E2E Make targets from a clean checkout.

Build:
- Add on-demand gotestsum provisioning and use it across the E2E Make targets.

Deployment:
- Increase the graceful HTTP shutdown budget from 5 seconds to 15 seconds so healthy in-flight requests can drain under load.

Tests:
- Add deterministic coverage for shutdown during server-card generation and update HTTP tests to avoid environmental port and catalog-generation assumptions.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Optimized server startup by deferring server-card generation to the first request using sync.OnceValues, preventing startup delays.</li>
<li>Introduced serveHTTPOn to allow passing a pre-bound listener, improving test reliability by avoiding port race conditions.</li>
<li>Increased HTTP shutdown timeout from 5s to 15s to prevent deadline errors during heavy CI load.</li>
<li>Updated test HTTP client timeout to 30s and configured tests to use dynamic tool surfaces to accommodate race-detector overhead.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HTTP server startup with support for pre-bound listeners.
  * Extended graceful shutdown time to 15 seconds.
  * Server-card data is generated on first request and reused thereafter.
  * Server-card generation failures now return a service-unavailable response.

* **Documentation**
  * Updated project statistics and reported server package test coverage.

* **Testing**
  * Improved end-to-end test setup and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->