### PR TITLE
fix(release): sync the winget-pkgs fork before submitting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,11 +238,14 @@ jobs:
       # validation service hiccups.
       #
       # The fork MUST be synced first: komac creates its branch on the fork,
-      # and a stale fork fails with "Ref cannot be created" — which
-      # continue-on-error then hides. That exact combination silently
-      # skipped the 2.7.2 and 2.7.3 submissions (fork 24 days behind).
+      # and a stale fork fails with "Ref cannot be created" — which the
+      # releaser's continue-on-error then hides. That exact combination
+      # silently skipped the 2.7.2 and 2.7.3 submissions (fork 24 days
+      # behind). This step is deliberately blocking: if the sync fails
+      # (409 divergence, 422), the releaser would fail against the stale
+      # fork anyway and hide it — a red winget job is the visibility that
+      # was missing, and nothing downstream depends on this job.
       - name: Sync winget-pkgs fork with upstream
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: gh api -X POST repos/jmrplens/winget-pkgs/merge-upstream -f branch=master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,16 @@ jobs:
       # manifest (jmrplens.gitlab-mcp-server) has been merged upstream —
       # continue-on-error keeps releases green until then and if Microsoft's
       # validation service hiccups.
+      #
+      # The fork MUST be synced first: komac creates its branch on the fork,
+      # and a stale fork fails with "Ref cannot be created" — which
+      # continue-on-error then hides. That exact combination silently
+      # skipped the 2.7.2 and 2.7.3 submissions (fork 24 days behind).
+      - name: Sync winget-pkgs fork with upstream
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: gh api -X POST repos/jmrplens/winget-pkgs/merge-upstream -f branch=master
       - uses: vedantmgoyal9/winget-releaser@v2
         continue-on-error: true
         with:


### PR DESCRIPTION
komac creates its release branch on the `jmrplens/winget-pkgs` fork; a stale fork fails with "Ref cannot be created", and the step's `continue-on-error` — kept for Microsoft's validation hiccups — hides that failure behind a green job. That exact combination **silently skipped the 2.7.2 and 2.7.3 winget submissions** (the fork was 24 days behind; 2.7.3 was submitted manually as [microsoft/winget-pkgs#424614](https://github.com/microsoft/winget-pkgs/pull/424614), now the only open PR for the package).

The fix: a `merge-upstream` fast-forward of the fork via the same `WINGET_TOKEN`, immediately before the releaser step — removing the common failure cause while keeping `continue-on-error` for the reasons it was added.

- [x] Workflow-only change; verified the API call works (it is how the fork was just synced manually)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Synchronize the winget-pkgs fork before submitting release manifests to avoid hidden failures caused by stale fork state.

Bug Fixes:
- Prevent skipped winget package submissions by synchronizing the winget-pkgs fork with upstream before release submission.

Enhancements:
- Make fork synchronization a blocking release prerequisite while preserving tolerance for external winget validation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the Windows package release workflow by synchronizing the package repository with upstream changes before submission.
  - Release submissions remain non-blocking if synchronization or publishing encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->