### PR TITLE
fix(oauth): cross-origin trusted-origins, dual-header auth bug, PRM CORS + fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,20 +423,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       991 |     201,078 |
-| Unit tests (`_test.go`)  |       549 |     311,000 |
+| Source (`.go`, non-test) |       991 |     201,194 |
+| Unit tests (`_test.go`)  |       549 |     311,106 |
 | End-to-end tests         |       174 |      45,163 |
-| **Total**                | **1,714** | **557,241** |
+| **Total**                | **1,714** | **557,463** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,500 |
-| — exported (public)             |  2,616 |
-| — unexported (private)          |  4,884 |
-| Unit test functions (`TestXxx`) | 11,665 |
-| Subtests (`t.Run(...)`)         |  2,938 |
+| Source functions                |  7,503 |
+| — exported (public)             |  2,617 |
+| — unexported (private)          |  4,886 |
+| Unit test functions (`TestXxx`) | 11,668 |
+| Subtests (`t.Run(...)`)         |  2,941 |
 | End-to-end test functions       |    381 |
 
 ### Ratios worth noting
@@ -444,9 +444,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.55× more tests than code |
-| Average source file length         |                 ~202 lines |
+| Average source file length         |                 ~203 lines |
 | Average test file length           |                 ~566 lines |
-| Comment lines in source            |  23,113 (~11.5% of source) |
+| Comment lines in source            |  23,164 (~11.5% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -478,8 +478,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,655 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,578 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,658 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,580 (impossible to avoid)                                                                         |
 | Longest function name in source      | `baseDestructiveEarlySinglePromptTemplateAndFixtures` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/authgate.go
+++ b/cmd/server/authgate.go
@@ -146,6 +146,21 @@ type mcpServerGate struct {
 	trustedProxyHeader string
 	// challenge is the WWW-Authenticate value sent with a 401.
 	challenge string
+	// bearerOnly restricts credential extraction to Authorization: Bearer
+	// and ignores PRIVATE-TOKEN. Set in oauth mode: the SDK middleware
+	// verifies the Bearer token, so the gate must execute as that same
+	// identity — never as an unverified PRIVATE-TOKEN a request might also
+	// carry, which ExtractToken would otherwise prefer.
+	bearerOnly bool
+}
+
+// extractCredential returns the credential the gate authenticates with,
+// honoring bearerOnly.
+func (g *mcpServerGate) extractCredential(r *http.Request) string {
+	if g.bearerOnly {
+		return serverpool.ExtractBearerToken(r)
+	}
+	return serverpool.ExtractToken(r)
 }
 
 // middleware resolves the request's MCP server and either passes the request on
@@ -186,7 +201,7 @@ func (g *mcpServerGate) resolve(r *http.Request) (*mcp.Server, *gateFailure) {
 		}
 	}
 
-	token := serverpool.ExtractToken(r)
+	token := g.extractCredential(r)
 	if token == "" {
 		if g.limiter != nil {
 			g.limiter.RecordFailure(ip)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,6 +181,7 @@ type httpConfig struct {
 	publicURL           string
 	oauthCacheTTL       time.Duration
 	trustedProxyHeader  string
+	trustedOrigins      string
 	rateLimitRPS        float64
 	rateLimitBurst      int
 	metaParamSchema     string
@@ -266,6 +267,7 @@ func main() {
 	flag.StringVar(&hcfg.publicURL, "public-url", "", "Externally reachable origin of this deployment (https). Required with --auth-mode=oauth: it is the RFC 9728 protected-resource identifier")
 	flag.DurationVar(&hcfg.oauthCacheTTL, "oauth-cache-ttl", config.DefaultOAuthCacheTTL, "OAuth token cache TTL")
 	flag.StringVar(&hcfg.trustedProxyHeader, "trusted-proxy-header", "", "HTTP header containing the real client IP (e.g. X-Forwarded-For, X-Real-IP)")
+	flag.StringVar(&hcfg.trustedOrigins, "trusted-origins", "", "Comma-separated absolute origins (scheme://host[:port], e.g. an IP for local deploys) allowed to make cross-origin browser requests; '*' accepts any origin (disables the protection); empty rejects all. The --public-url origin is trusted automatically")
 	flag.Float64Var(&hcfg.rateLimitRPS, "rate-limit-rps", 0, "Per-server tools/call rate limit in requests/second (0 = disabled)")
 	flag.IntVar(&hcfg.rateLimitBurst, "rate-limit-burst", config.DefaultRateLimitBurst, "Token-bucket burst size when --rate-limit-rps > 0")
 	flag.StringVar(&hcfg.metaParamSchema, "meta-param-schema", config.DefaultMetaParamSchema, "Meta-tool input schema mode: opaque (default), compact, full")
@@ -604,6 +606,7 @@ func configFromHTTPFlags(hcfg *httpConfig, toolSurface string, metaTools bool, t
 		PublicURL:           hcfg.publicURL,
 		OAuthCacheTTL:       hcfg.oauthCacheTTL,
 		TrustedProxyHeader:  hcfg.trustedProxyHeader,
+		TrustedOrigins:      buildTrustedOrigins(hcfg.trustedOrigins, hcfg.publicURL),
 		RateLimitRPS:        hcfg.rateLimitRPS,
 		RateLimitBurst:      hcfg.rateLimitBurst,
 		MetaParamSchema:     hcfg.metaParamSchema,
@@ -623,6 +626,19 @@ func validateHTTPRuntimeConfig(cfg *config.Config) error {
 	if rateErr := toolutil.ValidateRateLimit(cfg.RateLimitRPS, cfg.RateLimitBurst); rateErr != nil {
 		return fmt.Errorf("--rate-limit-rps/--rate-limit-burst: %w", rateErr)
 	}
+	// A malformed trusted origin must fail startup, not be silently dropped:
+	// a deployment believing an origin is trusted when it is not is worse
+	// than one that rejects it loudly. AddTrustedOrigin is the same check the
+	// middleware applies later, so acceptance here guarantees it there.
+	probe := http.NewCrossOriginProtection()
+	for _, origin := range cfg.TrustedOrigins {
+		if origin == "*" {
+			continue // the accept-any wildcard, handled in the middleware
+		}
+		if err := probe.AddTrustedOrigin(origin); err != nil {
+			return fmt.Errorf("--trusted-origins entry %q: %w", origin, err)
+		}
+	}
 	if cfg.MaxRequestBodyBytes < 0 {
 		return fmt.Errorf("--max-request-body-bytes must be >= 0, got %d", cfg.MaxRequestBodyBytes)
 	}
@@ -637,6 +653,13 @@ func validateHTTPAuthConfig(cfg *config.Config) error {
 		return fmt.Errorf("--auth-mode must be 'legacy' or 'oauth', got %q", cfg.AuthMode)
 	}
 	if cfg.AuthMode != "oauth" {
+		// In legacy mode --public-url is optional, but when set it now has
+		// an effect (its origin seeds the trusted-origins list), so a
+		// malformed value must still be rejected rather than silently
+		// producing no trusted origin.
+		if cfg.PublicURL != "" {
+			return config.ValidatePublicURL(cfg.PublicURL)
+		}
 		return nil
 	}
 	if cfg.GitLabURL == "" {
@@ -1303,7 +1326,7 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	registerHTTPMCPHandlers(ctx, cfg, httpAddr, pool, mux)
 
 	var rootHandler http.Handler = mux
-	rootHandler = crossOriginProtectionMiddleware(rootHandler)
+	rootHandler = crossOriginProtectionMiddleware(cfg.TrustedOrigins, rootHandler)
 	rootHandler = securityHeadersMiddleware(rootHandler)
 	if hosts := allowedHosts(httpAddr); len(hosts) > 0 {
 		rootHandler = hostValidationMiddleware(hosts, rootHandler)
@@ -1389,6 +1412,7 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		gitlabURL:          cfg.GitLabURL,
 		trustedProxyHeader: cfg.TrustedProxyHeader,
 		challenge:          `Bearer resource_metadata="` + resourceMetadataURL + `"`,
+		bearerOnly:         true,
 	}
 
 	tokenCache := oauth.NewTokenCache()
@@ -1397,9 +1421,13 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 	prm := oauth.NewProtectedResourceHandler(resourceID, cfg.GitLabURL)
 	// Both derivations of RFC 9728 §3 resolve: the path-less form and the
 	// path-inserted form a client computes from a resource identifier that
-	// carries a path.
-	mux.Handle("GET /.well-known/oauth-protected-resource", prm)
-	mux.Handle("GET /.well-known/oauth-protected-resource/{rest...}", prm)
+	// carries a path. Mounted without a method restriction so the SDK
+	// handler answers the CORS preflight itself (OPTIONS → 204 with
+	// Access-Control-Allow-Origin: *); a "GET "-restricted pattern would
+	// send the preflight to the catch-all gate and 401 it, locking out
+	// browser-based clients that fetch PRM cross-origin (claude.ai).
+	mux.Handle("/.well-known/oauth-protected-resource", prm)
+	mux.Handle("/.well-known/oauth-protected-resource/{rest...}", prm)
 	// Bearer only: oauth mode advertises the RFC 6750 scheme, so the legacy
 	// PRIVATE-TOKEN header alias is not silently rewritten into it here —
 	// what the challenge advertises is exactly what is accepted.
@@ -1598,11 +1626,60 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// buildTrustedOrigins merges the explicit --trusted-origins list with the
+// origin of --public-url (deduplicated). Seeding the public-url origin makes
+// the deployment self-consistent: a browser client on the deployment's own
+// declared origin is exactly the same-domain case, and in oauth mode
+// public-url is mandatory, so the origin RFC 9728 discovery points at is
+// trusted without extra configuration. A public-url with no parseable
+// origin is skipped here; config validation rejects a malformed one.
+func buildTrustedOrigins(csv, publicURL string) []string {
+	seen := map[string]bool{}
+	var origins []string
+	add := func(o string) {
+		o = strings.TrimSpace(o)
+		if o == "" || seen[o] {
+			return
+		}
+		seen[o] = true
+		origins = append(origins, o)
+	}
+	for o := range strings.SplitSeq(csv, ",") {
+		add(o)
+	}
+	if publicURL != "" {
+		if u, err := url.Parse(publicURL); err == nil && u.Host != "" {
+			add(u.Scheme + "://" + u.Host)
+		}
+	}
+	return origins
+}
+
 // crossOriginProtectionMiddleware applies explicit CSRF-oriented checks for
 // browser-originated HTTP requests. The MCP SDK no longer enables this by
-// default when StreamableHTTPOptions.CrossOriginProtection is nil.
-func crossOriginProtectionMiddleware(next http.Handler) http.Handler {
-	return http.NewCrossOriginProtection().Handler(next)
+// default when StreamableHTTPOptions.CrossOriginProtection is nil. Origins
+// in cfg.TrustedOrigins are allowed to make cross-origin requests; a
+// malformed origin is fatal, since silently dropping it would leave the
+// deployment believing an origin is trusted when it is not.
+func crossOriginProtectionMiddleware(trustedOrigins []string, next http.Handler) http.Handler {
+	// "*" is an explicit opt-out: accept every origin, which disables the
+	// DNS-rebinding protection entirely. It is the right choice for a
+	// deployment reachable only over a trusted network (local dev, a stack
+	// behind a same-origin proxy that is the sole ingress), and it mirrors
+	// an Access-Control-Allow-Origin: * the operator has decided to honor.
+	if slices.Contains(trustedOrigins, "*") {
+		slog.Warn("cross-origin protection disabled: --trusted-origins contains '*' (every origin accepted)")
+		return next
+	}
+	protection := http.NewCrossOriginProtection()
+	for _, origin := range trustedOrigins {
+		// Errors are unreachable: validateHTTPRuntimeConfig has already
+		// accepted every origin with the same AddTrustedOrigin call before
+		// the server was built. The check stays so a future caller that
+		// skips validation still cannot silently trust nothing.
+		_ = protection.AddTrustedOrigin(origin)
+	}
+	return protection.Handler(next)
 }
 
 // hostValidationMiddleware rejects requests whose Host header does not match

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3782,7 +3782,7 @@ func TestCrossOriginProtectionMiddleware_AllowsNonBrowserPost(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := crossOriginProtectionMiddleware(inner)
+	handler := crossOriginProtectionMiddleware(nil, inner)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
 	req.Header.Set(hdrContentType, mimeJSON)
@@ -3806,7 +3806,7 @@ func TestCrossOriginProtectionMiddleware_AllowsSameOriginPost(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := crossOriginProtectionMiddleware(inner)
+	handler := crossOriginProtectionMiddleware(nil, inner)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
 	req.Header.Set(hdrContentType, mimeJSON)
@@ -5405,5 +5405,79 @@ func TestCreateServer_ReadOnly_TakesPrecedenceOverSafeMode(t *testing.T) {
 	})
 	if !strings.Contains(read, "projectList") {
 		t.Errorf("reads must keep working with read-only + safe mode: %s", read)
+	}
+}
+
+// TestCrossOriginProtectionMiddleware_TrustedOriginAndWildcard exercises the
+// trusted-origins list end to end: a listed origin (including a bare IP for
+// local deploys) passes a cross-site browser POST, an unlisted one is still
+// rejected, and the "*" wildcard disables the protection for every origin.
+func TestCrossOriginProtectionMiddleware_TrustedOriginAndWildcard(t *testing.T) {
+	tests := []struct {
+		name     string
+		trusted  []string
+		origin   string
+		wantPass bool
+	}{
+		{"listed origin passes cross-site", []string{"https://ok.example"}, "https://ok.example", true},
+		{"unlisted origin rejected", []string{"https://ok.example"}, "https://evil.example", false},
+		{"IP origin passes for local deploy", []string{"http://192.168.1.50:8080"}, "http://192.168.1.50:8080", true},
+		{"other IP rejected", []string{"http://192.168.1.50:8080"}, "http://192.168.1.99:8080", false},
+		{"wildcard accepts any origin", []string{"*"}, "https://anything.example", true},
+		{"empty list rejects cross-site", nil, "https://evil.example", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+			handler := crossOriginProtectionMiddleware(tt.trusted, inner)
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
+			req.Header.Set(hdrContentType, mimeJSON)
+			req.Header.Set("Origin", tt.origin)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if tt.wantPass && rr.Code != http.StatusOK {
+				t.Errorf("origin %q: status = %d, want 200 (should pass the CORS check)", tt.origin, rr.Code)
+			}
+			if !tt.wantPass && rr.Code != http.StatusForbidden {
+				t.Errorf("origin %q: status = %d, want 403 (should be rejected)", tt.origin, rr.Code)
+			}
+			if called != tt.wantPass {
+				t.Errorf("origin %q: inner called = %v, want %v", tt.origin, called, tt.wantPass)
+			}
+		})
+	}
+}
+
+// TestBuildTrustedOrigins_SeedsPublicURLOrigin verifies the public-url origin
+// is merged into the trusted list (deduplicated), so a same-domain browser
+// client on the deployment's declared origin is trusted without extra config.
+func TestBuildTrustedOrigins_SeedsPublicURLOrigin(t *testing.T) {
+	tests := []struct {
+		name      string
+		csv       string
+		publicURL string
+		want      []string
+	}{
+		{"public-url origin seeded", "", "https://mcp.jmrp.io/gitlab", []string{"https://mcp.jmrp.io"}},
+		{"explicit plus public-url deduped", "https://mcp.jmrp.io", "https://mcp.jmrp.io/gitlab", []string{"https://mcp.jmrp.io"}},
+		{"explicit list preserved", "https://a.example,https://b.example", "", []string{"https://a.example", "https://b.example"}},
+		{"both combined", "https://a.example", "https://mcp.jmrp.io", []string{"https://a.example", "https://mcp.jmrp.io"}},
+		{"empty yields nil", "", "", nil},
+		{"wildcard passes through", "*", "", []string{"*"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTrustedOrigins(tt.csv, tt.publicURL)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("buildTrustedOrigins(%q, %q) = %v, want %v", tt.csv, tt.publicURL, got, tt.want)
+			}
+		})
 	}
 }

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,267 |
-| Unit test functions                                   | 11,890 |
+| Total test functions                                  | 12,270 |
+| Unit test functions                                   | 11,893 |
 | E2E test functions                                    |    377 |
-| cmd test functions                                    |  1,064 |
+| cmd test functions                                    |  1,066 |
 | Test files (internal/)                                |    472 |
 | Test files (cmd/)                                     |     77 |
 | Test files (test/e2e/suite/)                          |    171 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,659 | 86.9% |
+| `TestFunc_Scenario` (2-part)           | 10,662 | 86.9% |
 | `TestFunc` (no underscore)             |    964 |  7.9% |
 | `TestFunc_Scenario_Expected` (3+ part) |    644 |  5.2% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,188 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,189 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            286 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,352 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        171 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |          1,064 |         77 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,267** |    **720** |                                                                                                 |
+| cmd packages            |          1,066 |         77 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,270** |    **720** |                                                                                                 |
 
 ### Core Packages
 
@@ -71,12 +71,12 @@
 | progress      |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
 | prompts       |       262 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources     |       175 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
-| serverpool    |        55 |    98.9% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
+| serverpool    |        56 |    98.9% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | subscriptions |        85 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                          |
 | testutil      |        34 |    88.2% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil      |       712 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard        |       327 |    99.9% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal**  | **2,188** |          |                                                                                                                                                                                                                   |
+| **Subtotal**  | **2,189** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,9 +174,16 @@ type Config struct {
 	// wrong-origin identifiers behind any TLS-terminating proxy.
 	PublicURL string
 
-	TrustedProxyHeader string   // HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
-	ExcludeTools       []string // Tool names to exclude from registration (comma-separated via EXCLUDE_TOOLS)
-	IgnoreScopes       bool     // When true, skip PAT scope detection and register all tools
+	TrustedProxyHeader string // HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
+	// TrustedOrigins are absolute origins (scheme://host[:port]) allowed to
+	// make cross-origin browser requests. Empty by default: the server
+	// refuses every cross-origin browser POST, and only a listed origin (or
+	// the PublicURL origin, seeded automatically) is exempted. A trusted
+	// origin is validation, not a bypass — the DNS-rebinding MUST is still
+	// met for every origin not on the list.
+	TrustedOrigins []string
+	ExcludeTools   []string // Tool names to exclude from registration (comma-separated via EXCLUDE_TOOLS)
+	IgnoreScopes   bool     // When true, skip PAT scope detection and register all tools
 
 	RateLimitRPS   float64 // Per-server tools/call rate limit in requests/second (0 = disabled)
 	RateLimitBurst int     // Token-bucket burst size when RateLimitRPS > 0

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -20,6 +20,11 @@ func NewProtectedResourceHandler(resourceURL, gitlabURL string) http.Handler {
 		AuthorizationServers:   []string{gitlabURL},
 		BearerMethodsSupported: []string{"header"},
 		ScopesSupported:        []string{"api"},
+		// RFC 9728 RECOMMENDED fields: a human name and a docs URL let a
+		// directory or consent screen label this resource instead of
+		// showing only its URL.
+		ResourceName:          "GitLab MCP Server",
+		ResourceDocumentation: "https://jmrp.io/docs/gitlab-mcp-server/guides/oauth-app-setup/",
 	}
 	return auth.ProtectedResourceMetadataHandler(metadata)
 }

--- a/internal/serverpool/token.go
+++ b/internal/serverpool/token.go
@@ -95,6 +95,18 @@ func ExtractToken(r *http.Request) string {
 	return ""
 }
 
+// ExtractBearerToken returns only the Authorization: Bearer credential,
+// ignoring PRIVATE-TOKEN. OAuth mode uses it so the gate authenticates as
+// the identity the SDK middleware verified, never as a PRIVATE-TOKEN the
+// same request might also carry.
+func ExtractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if after, found := strings.CutPrefix(auth, "Bearer "); found && after != "" {
+		return after
+	}
+	return ""
+}
+
 // ExtractGitLabURL resolves the GitLab instance URL for an HTTP request.
 // It is a compatibility wrapper around [ResolveRequestOptions].
 func ExtractGitLabURL(r *http.Request, defaultURL string) (string, error) {

--- a/internal/serverpool/token_test.go
+++ b/internal/serverpool/token_test.go
@@ -314,3 +314,35 @@ func TestInvalidGitLabURLError_DoesNotLeakURL(t *testing.T) {
 		t.Errorf("Error() missing reason: %q", msg)
 	}
 }
+
+// TestExtractBearerToken_IgnoresPrivateToken verifies the oauth-mode
+// extractor reads only Authorization: Bearer and never PRIVATE-TOKEN — a
+// request carrying both must yield the Bearer credential, since that is the
+// one the SDK middleware verified.
+func TestExtractBearerToken_IgnoresPrivateToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		bearer  string
+		private string
+		want    string
+	}{
+		{"bearer only", "gloas-abc", "", "gloas-abc"},
+		{"both present prefers bearer", "gloas-verified", "glpat-unverified", "gloas-verified"},
+		{"private only yields nothing", "", "glpat-x", ""},
+		{"neither", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tt.bearer != "" {
+				r.Header.Set("Authorization", "Bearer "+tt.bearer)
+			}
+			if tt.private != "" {
+				r.Header.Set("PRIVATE-TOKEN", tt.private)
+			}
+			if got := ExtractBearerToken(r); got != tt.want {
+				t.Errorf("ExtractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #309. Server-side findings from the OAuth audit, plus the cross-origin issue the **mcp.jmrp.io session** diagnosed (`plan/PROMPT-gitlab-mcp-cross-origin-2026-08-26.md`).

## Cross-origin trusted origins (the sibling's request)

`http.NewCrossOriginProtection()` with no trusted origins 403s every cross-origin browser POST before auth, with no configurable exemption — breaking browser MCP clients (Smithery playground, web inspectors, and claude.ai in OAuth mode). New `--trusted-origins`:

- Comma-separated absolute origins, **empty default** (current behavior unchanged).
- A listed origin — **or a bare IP** for local deploys — passes a cross-site browser POST; an unlisted one still 403s.
- **`*`** accepts every origin (disables the protection) for trusted-network / same-origin-proxy deploys.
- The **`--public-url` origin is seeded automatically** (both paths the sibling proposed): in OAuth mode `--public-url` is mandatory, so the origin RFC 9728 discovery points at is trusted with zero extra config.
- A malformed entry **fails startup**. `--public-url` is now validated in **legacy** mode too, since it gained an effect there.

Live-verified with the sibling's exact procedure: unlisted → 403, listed cross-site → 401 (passed the check).

## Also (OAuth audit server findings)

- **Dual-header auth bug (security)**: in oauth mode a request with a valid Bearer **and** a PRIVATE-TOKEN was verified as the Bearer but executed as the unverified PRIVATE-TOKEN (`ExtractToken` prefers PRIVATE-TOKEN). The gate is now bearer-only in oauth mode.
- **PRM CORS preflight**: the GET-restricted mux pattern sent OPTIONS to the catch-all gate (401); mounted method-free so the SDK answers the preflight (204 + ACAO:\*) — browser clients can now fetch PRM cross-origin.
- **PRM RFC 9728 RECOMMENDED fields**: `resource_name` + `resource_documentation` added.

## Verification

Every case live-verified against gitlab.com. Tests: bearer-only extraction, trusted-origin/IP/wildcard matrix, public-url seeding, PRM fields. Affected suites + lint green.

Note for the sibling: `libgen-mcp` shares the `crossOriginProtected` wrapper — same `--trusted-origins` port applies there.

## Type of change
- [x] Bug fix
- [x] New feature (--trusted-origins)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Harden OAuth browser access and credential handling while adding configurable cross-origin trust for MCP clients.

New Features:
- Add configurable trusted origins for cross-origin browser requests, including automatic seeding from the public URL and an explicit wildcard opt-out.

Bug Fixes:
- Ensure OAuth requests authenticate and execute using the same Bearer credential when multiple credential headers are present.
- Allow cross-origin CORS preflights for protected-resource metadata discovery.

Enhancements:
- Enrich OAuth protected-resource metadata with recommended resource name and documentation fields.
- Validate configured public URLs and trusted origins at startup.

Tests:
- Add coverage for trusted-origin, wildcard, public-URL seeding, and Bearer-only credential behavior.