### PR TITLE
fix(oauth): cross-origin trusted-origins, dual-header auth bug, PRM CORS + fields

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# base_branches defaults to an empty list, which means only pull requests
+# targeting the default branch are reviewed automatically. This project uses
+# stacked pull requests, where every layer above the bottom one targets the
+# branch below it, so leaving the default in place is the difference between
+# "reviewed" and "merged unseen" for most of a stack.
+language: en-US
+
+reviews:
+  auto_review:
+    enabled: true
+    # Any base branch, so a stacked pull request is reviewed on its own diff
+    # rather than skipped for not targeting main.
+    base_branches:
+      - ".*"
+    # Bot commits (version stamping, generated manifests, dependency bumps)
+    # carry no reviewable intent.
+    ignore_usernames:
+      - "github-actions[bot]"
+      - "dependabot[bot]"

--- a/README.md
+++ b/README.md
@@ -423,20 +423,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       991 |     201,194 |
-| Unit tests (`_test.go`)  |       549 |     311,106 |
+| Source (`.go`, non-test) |       991 |     201,215 |
+| Unit tests (`_test.go`)  |       549 |     311,132 |
 | End-to-end tests         |       174 |      45,163 |
-| **Total**                | **1,714** | **557,463** |
+| **Total**                | **1,714** | **557,510** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,503 |
-| — exported (public)             |  2,617 |
+| Source functions                |  7,504 |
+| — exported (public)             |  2,618 |
 | — unexported (private)          |  4,886 |
 | Unit test functions (`TestXxx`) | 11,668 |
-| Subtests (`t.Run(...)`)         |  2,941 |
+| Subtests (`t.Run(...)`)         |  2,943 |
 | End-to-end test functions       |    381 |
 
 ### Ratios worth noting
@@ -446,7 +446,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~203 lines |
 | Average test file length           |                 ~566 lines |
-| Comment lines in source            |  23,164 (~11.5% of source) |
+| Comment lines in source            |  23,169 (~11.5% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -454,7 +454,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,685 |
-| `defer` statements                 |   914 |
+| `defer` statements                 |   913 |
 | `struct` types defined             | 2,723 |
 | `//nolint` suppressions            |   258 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -479,7 +479,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~3,658 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,580 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 12,585 (impossible to avoid)                                                                         |
 | Longest function name in source      | `baseDestructiveEarlySinglePromptTemplateAndFixtures` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -423,20 +423,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       991 |     201,099 |
-| Unit tests (`_test.go`)  |       549 |     311,026 |
+| Source (`.go`, non-test) |       991 |     201,194 |
+| Unit tests (`_test.go`)  |       549 |     311,106 |
 | End-to-end tests         |       174 |      45,163 |
-| **Total**                | **1,714** | **557,288** |
+| **Total**                | **1,714** | **557,463** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,501 |
+| Source functions                |  7,503 |
 | — exported (public)             |  2,617 |
-| — unexported (private)          |  4,884 |
-| Unit test functions (`TestXxx`) | 11,665 |
-| Subtests (`t.Run(...)`)         |  2,940 |
+| — unexported (private)          |  4,886 |
+| Unit test functions (`TestXxx`) | 11,668 |
+| Subtests (`t.Run(...)`)         |  2,941 |
 | End-to-end test functions       |    381 |
 
 ### Ratios worth noting
@@ -444,9 +444,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.55× more tests than code |
-| Average source file length         |                 ~202 lines |
+| Average source file length         |                 ~203 lines |
 | Average test file length           |                 ~566 lines |
-| Comment lines in source            |  23,118 (~11.5% of source) |
+| Comment lines in source            |  23,164 (~11.5% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -454,7 +454,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,685 |
-| `defer` statements                 |   913 |
+| `defer` statements                 |   914 |
 | `struct` types defined             | 2,723 |
 | `//nolint` suppressions            |   258 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -478,8 +478,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,656 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,583 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,658 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,580 (impossible to avoid)                                                                         |
 | Longest function name in source      | `baseDestructiveEarlySinglePromptTemplateAndFixtures` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       991 |     201,215 |
+| Source (`.go`, non-test) |       991 |     201,217 |
 | Unit tests (`_test.go`)  |       549 |     311,132 |
 | End-to-end tests         |       174 |      45,163 |
-| **Total**                | **1,714** | **557,510** |
+| **Total**                | **1,714** | **557,512** |
 
 ### Functions
 

--- a/cmd/server/authgate.go
+++ b/cmd/server/authgate.go
@@ -146,6 +146,21 @@ type mcpServerGate struct {
 	trustedProxyHeader string
 	// challenge is the WWW-Authenticate value sent with a 401.
 	challenge string
+	// bearerOnly restricts credential extraction to Authorization: Bearer
+	// and ignores PRIVATE-TOKEN. Set in oauth mode: the SDK middleware
+	// verifies the Bearer token, so the gate must execute as that same
+	// identity — never as an unverified PRIVATE-TOKEN a request might also
+	// carry, which ExtractToken would otherwise prefer.
+	bearerOnly bool
+}
+
+// extractCredential returns the credential the gate authenticates with,
+// honoring bearerOnly.
+func (g *mcpServerGate) extractCredential(r *http.Request) string {
+	if g.bearerOnly {
+		return serverpool.ExtractBearerToken(r)
+	}
+	return serverpool.ExtractToken(r)
 }
 
 // middleware resolves the request's MCP server and either passes the request on
@@ -186,7 +201,7 @@ func (g *mcpServerGate) resolve(r *http.Request) (*mcp.Server, *gateFailure) {
 		}
 	}
 
-	token := serverpool.ExtractToken(r)
+	token := g.extractCredential(r)
 	if token == "" {
 		if g.limiter != nil {
 			g.limiter.RecordFailure(ip)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,6 +181,7 @@ type httpConfig struct {
 	publicURL           string
 	oauthCacheTTL       time.Duration
 	trustedProxyHeader  string
+	trustedOrigins      string
 	rateLimitRPS        float64
 	rateLimitBurst      int
 	metaParamSchema     string
@@ -266,6 +267,7 @@ func main() {
 	flag.StringVar(&hcfg.publicURL, "public-url", "", "Externally reachable origin of this deployment (https). Required with --auth-mode=oauth: it is the RFC 9728 protected-resource identifier")
 	flag.DurationVar(&hcfg.oauthCacheTTL, "oauth-cache-ttl", config.DefaultOAuthCacheTTL, "OAuth token cache TTL")
 	flag.StringVar(&hcfg.trustedProxyHeader, "trusted-proxy-header", "", "HTTP header containing the real client IP (e.g. X-Forwarded-For, X-Real-IP)")
+	flag.StringVar(&hcfg.trustedOrigins, "trusted-origins", "", "Comma-separated absolute origins (scheme://host[:port], e.g. an IP for local deploys) allowed to make cross-origin browser requests; '*' accepts any origin (disables the protection); empty rejects all. The --public-url origin is trusted automatically")
 	flag.Float64Var(&hcfg.rateLimitRPS, "rate-limit-rps", 0, "Per-server tools/call rate limit in requests/second (0 = disabled)")
 	flag.IntVar(&hcfg.rateLimitBurst, "rate-limit-burst", config.DefaultRateLimitBurst, "Token-bucket burst size when --rate-limit-rps > 0")
 	flag.StringVar(&hcfg.metaParamSchema, "meta-param-schema", config.DefaultMetaParamSchema, "Meta-tool input schema mode: opaque (default), compact, full")
@@ -604,6 +606,7 @@ func configFromHTTPFlags(hcfg *httpConfig, toolSurface string, metaTools bool, t
 		PublicURL:           hcfg.publicURL,
 		OAuthCacheTTL:       hcfg.oauthCacheTTL,
 		TrustedProxyHeader:  hcfg.trustedProxyHeader,
+		TrustedOrigins:      buildTrustedOrigins(hcfg.trustedOrigins, hcfg.publicURL),
 		RateLimitRPS:        hcfg.rateLimitRPS,
 		RateLimitBurst:      hcfg.rateLimitBurst,
 		MetaParamSchema:     hcfg.metaParamSchema,
@@ -623,6 +626,19 @@ func validateHTTPRuntimeConfig(cfg *config.Config) error {
 	if rateErr := toolutil.ValidateRateLimit(cfg.RateLimitRPS, cfg.RateLimitBurst); rateErr != nil {
 		return fmt.Errorf("--rate-limit-rps/--rate-limit-burst: %w", rateErr)
 	}
+	// A malformed trusted origin must fail startup, not be silently dropped:
+	// a deployment believing an origin is trusted when it is not is worse
+	// than one that rejects it loudly. AddTrustedOrigin is the same check the
+	// middleware applies later, so acceptance here guarantees it there.
+	probe := http.NewCrossOriginProtection()
+	for _, origin := range cfg.TrustedOrigins {
+		if origin == "*" {
+			continue // the accept-any wildcard, handled in the middleware
+		}
+		if err := probe.AddTrustedOrigin(origin); err != nil {
+			return fmt.Errorf("--trusted-origins entry %q: %w", origin, err)
+		}
+	}
 	if cfg.MaxRequestBodyBytes < 0 {
 		return fmt.Errorf("--max-request-body-bytes must be >= 0, got %d", cfg.MaxRequestBodyBytes)
 	}
@@ -637,6 +653,13 @@ func validateHTTPAuthConfig(cfg *config.Config) error {
 		return fmt.Errorf("--auth-mode must be 'legacy' or 'oauth', got %q", cfg.AuthMode)
 	}
 	if cfg.AuthMode != "oauth" {
+		// In legacy mode --public-url is optional, but when set it now has
+		// an effect (its origin seeds the trusted-origins list), so a
+		// malformed value must still be rejected rather than silently
+		// producing no trusted origin.
+		if cfg.PublicURL != "" {
+			return config.ValidatePublicURL(cfg.PublicURL)
+		}
 		return nil
 	}
 	if cfg.GitLabURL == "" {
@@ -1306,7 +1329,7 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	registerHTTPMCPHandlers(ctx, cfg, httpAddr, pool, mux)
 
 	var rootHandler http.Handler = mux
-	rootHandler = crossOriginProtectionMiddleware(rootHandler)
+	rootHandler = crossOriginProtectionMiddleware(cfg.TrustedOrigins, rootHandler)
 	rootHandler = securityHeadersMiddleware(rootHandler)
 	if hosts := allowedHosts(httpAddr); len(hosts) > 0 {
 		rootHandler = hostValidationMiddleware(hosts, rootHandler)
@@ -1392,6 +1415,7 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		gitlabURL:          cfg.GitLabURL,
 		trustedProxyHeader: cfg.TrustedProxyHeader,
 		challenge:          `Bearer resource_metadata="` + resourceMetadataURL + `"`,
+		bearerOnly:         true,
 	}
 
 	tokenCache := oauth.NewTokenCache()
@@ -1400,9 +1424,13 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 	prm := oauth.NewProtectedResourceHandler(resourceID, cfg.GitLabURL)
 	// Both derivations of RFC 9728 §3 resolve: the path-less form and the
 	// path-inserted form a client computes from a resource identifier that
-	// carries a path.
-	mux.Handle("GET /.well-known/oauth-protected-resource", prm)
-	mux.Handle("GET /.well-known/oauth-protected-resource/{rest...}", prm)
+	// carries a path. Mounted without a method restriction so the SDK
+	// handler answers the CORS preflight itself (OPTIONS → 204 with
+	// Access-Control-Allow-Origin: *); a "GET "-restricted pattern would
+	// send the preflight to the catch-all gate and 401 it, locking out
+	// browser-based clients that fetch PRM cross-origin (claude.ai).
+	mux.Handle("/.well-known/oauth-protected-resource", prm)
+	mux.Handle("/.well-known/oauth-protected-resource/{rest...}", prm)
 	// Bearer only: oauth mode advertises the RFC 6750 scheme, so the legacy
 	// PRIVATE-TOKEN header alias is not silently rewritten into it here —
 	// what the challenge advertises is exactly what is accepted.
@@ -1601,11 +1629,60 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// buildTrustedOrigins merges the explicit --trusted-origins list with the
+// origin of --public-url (deduplicated). Seeding the public-url origin makes
+// the deployment self-consistent: a browser client on the deployment's own
+// declared origin is exactly the same-domain case, and in oauth mode
+// public-url is mandatory, so the origin RFC 9728 discovery points at is
+// trusted without extra configuration. A public-url with no parseable
+// origin is skipped here; config validation rejects a malformed one.
+func buildTrustedOrigins(csv, publicURL string) []string {
+	seen := map[string]bool{}
+	var origins []string
+	add := func(o string) {
+		o = strings.TrimSpace(o)
+		if o == "" || seen[o] {
+			return
+		}
+		seen[o] = true
+		origins = append(origins, o)
+	}
+	for o := range strings.SplitSeq(csv, ",") {
+		add(o)
+	}
+	if publicURL != "" {
+		if u, err := url.Parse(publicURL); err == nil && u.Host != "" {
+			add(u.Scheme + "://" + u.Host)
+		}
+	}
+	return origins
+}
+
 // crossOriginProtectionMiddleware applies explicit CSRF-oriented checks for
 // browser-originated HTTP requests. The MCP SDK no longer enables this by
-// default when StreamableHTTPOptions.CrossOriginProtection is nil.
-func crossOriginProtectionMiddleware(next http.Handler) http.Handler {
-	return http.NewCrossOriginProtection().Handler(next)
+// default when StreamableHTTPOptions.CrossOriginProtection is nil. Origins
+// in cfg.TrustedOrigins are allowed to make cross-origin requests; a
+// malformed origin is fatal, since silently dropping it would leave the
+// deployment believing an origin is trusted when it is not.
+func crossOriginProtectionMiddleware(trustedOrigins []string, next http.Handler) http.Handler {
+	// "*" is an explicit opt-out: accept every origin, which disables the
+	// DNS-rebinding protection entirely. It is the right choice for a
+	// deployment reachable only over a trusted network (local dev, a stack
+	// behind a same-origin proxy that is the sole ingress), and it mirrors
+	// an Access-Control-Allow-Origin: * the operator has decided to honor.
+	if slices.Contains(trustedOrigins, "*") {
+		slog.Warn("cross-origin protection disabled: --trusted-origins contains '*' (every origin accepted)")
+		return next
+	}
+	protection := http.NewCrossOriginProtection()
+	for _, origin := range trustedOrigins {
+		// Errors are unreachable: validateHTTPRuntimeConfig has already
+		// accepted every origin with the same AddTrustedOrigin call before
+		// the server was built. The check stays so a future caller that
+		// skips validation still cannot silently trust nothing.
+		_ = protection.AddTrustedOrigin(origin)
+	}
+	return protection.Handler(next)
 }
 
 // hostValidationMiddleware rejects requests whose Host header does not match

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -406,7 +406,9 @@ FLAGS
   -auto-update-timeout dur  Timeout for startup/background update checks (default %s)
   -auth-mode string         Authentication mode: legacy|oauth (default "legacy")
   -oauth-cache-ttl duration OAuth token cache TTL (default %s, min %s, max %s)
+  -public-url string        Externally reachable https origin; required with -auth-mode=oauth (RFC 9728 resource identifier)
   -trusted-proxy-header str HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
+  -trusted-origins string   Origins allowed to make cross-origin browser requests ('*' accepts any; empty rejects all)
   -rate-limit-rps float     Per-server tools/call rate limit (0 = disabled)
   -rate-limit-burst int     Token-bucket burst size when --rate-limit-rps > 0 (default %d)
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3782,7 +3782,7 @@ func TestCrossOriginProtectionMiddleware_AllowsNonBrowserPost(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := crossOriginProtectionMiddleware(inner)
+	handler := crossOriginProtectionMiddleware(nil, inner)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
 	req.Header.Set(hdrContentType, mimeJSON)
@@ -3806,7 +3806,7 @@ func TestCrossOriginProtectionMiddleware_AllowsSameOriginPost(t *testing.T) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	handler := crossOriginProtectionMiddleware(inner)
+	handler := crossOriginProtectionMiddleware(nil, inner)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
 	req.Header.Set(hdrContentType, mimeJSON)
@@ -5435,6 +5435,80 @@ func TestValidateHTTPAuthConfig_OAuthRequiresHTTPSGitLabURL(t *testing.T) {
 			err := validateHTTPAuthConfig(cfg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateHTTPAuthConfig(gitlab-url=%q) error = %v, wantErr %v", tt.gitlabURL, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestCrossOriginProtectionMiddleware_TrustedOriginAndWildcard exercises the
+// trusted-origins list end to end: a listed origin (including a bare IP for
+// local deploys) passes a cross-site browser POST, an unlisted one is still
+// rejected, and the "*" wildcard disables the protection for every origin.
+func TestCrossOriginProtectionMiddleware_TrustedOriginAndWildcard(t *testing.T) {
+	tests := []struct {
+		name     string
+		trusted  []string
+		origin   string
+		wantPass bool
+	}{
+		{"listed origin passes cross-site", []string{"https://ok.example"}, "https://ok.example", true},
+		{"unlisted origin rejected", []string{"https://ok.example"}, "https://evil.example", false},
+		{"IP origin passes for local deploy", []string{"http://192.168.1.50:8080"}, "http://192.168.1.50:8080", true},
+		{"other IP rejected", []string{"http://192.168.1.50:8080"}, "http://192.168.1.99:8080", false},
+		{"wildcard accepts any origin", []string{"*"}, "https://anything.example", true},
+		{"empty list rejects cross-site", nil, "https://evil.example", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+			handler := crossOriginProtectionMiddleware(tt.trusted, inner)
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "http://mcp.example/mcp", strings.NewReader(`{}`))
+			req.Header.Set(hdrContentType, mimeJSON)
+			req.Header.Set("Origin", tt.origin)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if tt.wantPass && rr.Code != http.StatusOK {
+				t.Errorf("origin %q: status = %d, want 200 (should pass the CORS check)", tt.origin, rr.Code)
+			}
+			if !tt.wantPass && rr.Code != http.StatusForbidden {
+				t.Errorf("origin %q: status = %d, want 403 (should be rejected)", tt.origin, rr.Code)
+			}
+			if called != tt.wantPass {
+				t.Errorf("origin %q: inner called = %v, want %v", tt.origin, called, tt.wantPass)
+			}
+		})
+	}
+}
+
+// TestBuildTrustedOrigins_SeedsPublicURLOrigin verifies the public-url origin
+// is merged into the trusted list (deduplicated), so a same-domain browser
+// client on the deployment's declared origin is trusted without extra config.
+func TestBuildTrustedOrigins_SeedsPublicURLOrigin(t *testing.T) {
+	tests := []struct {
+		name      string
+		csv       string
+		publicURL string
+		want      []string
+	}{
+		{"public-url origin seeded", "", "https://mcp.jmrp.io/gitlab", []string{"https://mcp.jmrp.io"}},
+		{"explicit plus public-url deduped", "https://mcp.jmrp.io", "https://mcp.jmrp.io/gitlab", []string{"https://mcp.jmrp.io"}},
+		{"explicit list preserved", "https://a.example,https://b.example", "", []string{"https://a.example", "https://b.example"}},
+		{"both combined", "https://a.example", "https://mcp.jmrp.io", []string{"https://a.example", "https://mcp.jmrp.io"}},
+		{"empty yields nil", "", "", nil},
+		{"wildcard passes through", "*", "", []string{"*"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTrustedOrigins(tt.csv, tt.publicURL)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("buildTrustedOrigins(%q, %q) = %v, want %v", tt.csv, tt.publicURL, got, tt.want)
 			}
 		})
 	}

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -21,7 +21,7 @@
 | Total test functions                                  | 12,270 |
 | Unit test functions                                   | 11,893 |
 | E2E test functions                                    |    377 |
-| cmd test functions                                    |  1,066 |
+| cmd test functions                                    |  1,067 |
 | Test files (internal/)                                |    472 |
 | Test files (cmd/)                                     |     77 |
 | Test files (test/e2e/suite/)                          |    171 |
@@ -45,11 +45,11 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,189 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,188 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            286 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,352 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        171 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |          1,066 |         77 | server entry point and developer command utilities                                              |
+| cmd packages            |          1,067 |         77 | server entry point and developer command utilities                                              |
 | **Total**               |     **12,270** |    **720** |                                                                                                 |
 
 ### Core Packages
@@ -63,20 +63,20 @@
 | clientcompat  |        18 |   100.0% | Package clientcompat applies per-client response compatibility profiles to MCP results.                                                                                                                           |
 | cmdutil       |         5 |    92.3% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                         |
 | completions   |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
-| config        |        81 |    98.8% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
+| config        |        81 |    97.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
 | elicitation   |       100 |    86.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
-| gitlab        |        46 |    98.8% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
+| gitlab        |        45 |    98.8% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth         |        37 |    97.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress      |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
 | prompts       |       262 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources     |       175 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
 | serverpool    |        56 |    98.9% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | subscriptions |        85 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                          |
-| testutil      |        34 |    88.2% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
+| testutil      |        34 |    88.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil      |       712 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard        |       327 |    99.9% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal**  | **2,189** |          |                                                                                                                                                                                                                   |
+| **Subtotal**  | **2,188** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -347,7 +347,7 @@
 | clientcompat  |   100.0% |
 | cmdutil       |    92.3% |
 | completions   |   100.0% |
-| config        |    98.8% |
+| config        |    97.0% |
 | edition       |    87.0% |
 | elicitation   |    86.3% |
 | gitlab        |    98.8% |
@@ -357,7 +357,7 @@
 | resources     |    99.5% |
 | serverpool    |    98.9% |
 | subscriptions |   100.0% |
-| testutil      |    88.2% |
+| testutil      |    88.7% |
 | toolutil      |    98.3% |
 | wizard        |    99.9% |
 
@@ -573,8 +573,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **testutil** (88.2%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/gen_docker_tools** (88.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **testutil** (88.7%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 
 <!-- END TESTING STATS -->

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,267 |
-| Unit test functions                                   | 11,890 |
+| Total test functions                                  | 12,270 |
+| Unit test functions                                   | 11,893 |
 | E2E test functions                                    |    377 |
-| cmd test functions                                    |  1,065 |
+| cmd test functions                                    |  1,066 |
 | Test files (internal/)                                |    472 |
 | Test files (cmd/)                                     |     77 |
 | Test files (test/e2e/suite/)                          |    171 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,659 | 86.9% |
+| `TestFunc_Scenario` (2-part)           | 10,662 | 86.9% |
 | `TestFunc` (no underscore)             |    964 |  7.9% |
 | `TestFunc_Scenario_Expected` (3+ part) |    644 |  5.2% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,187 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,189 |        112 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            286 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,352 |        345 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            377 |        171 | build-tagged real GitLab integration suite                                                      |
-| cmd packages            |          1,065 |         77 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,267** |    **720** |                                                                                                 |
+| cmd packages            |          1,066 |         77 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,270** |    **720** |                                                                                                 |
 
 ### Core Packages
 
@@ -63,20 +63,20 @@
 | clientcompat  |        18 |   100.0% | Package clientcompat applies per-client response compatibility profiles to MCP results.                                                                                                                           |
 | cmdutil       |         5 |    92.3% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                         |
 | completions   |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                          |
-| config        |        81 |    97.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
+| config        |        81 |    98.8% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                  |
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                     |
 | elicitation   |       100 |    86.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                      |
-| gitlab        |        45 |    98.8% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
+| gitlab        |        46 |    98.8% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                           |
 | oauth         |        37 |    97.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                           |
 | progress      |        17 |   100.0% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                     |
 | prompts       |       262 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                        |
 | resources     |       175 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                               |
-| serverpool    |        55 |    98.9% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
+| serverpool    |        56 |    98.9% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                   |
 | subscriptions |        85 |   100.0% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                          |
-| testutil      |        34 |    88.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
+| testutil      |        34 |    88.2% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                     |
 | toolutil      |       712 |    98.3% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                     |
 | wizard        |       327 |    99.9% | Package wizard implements the setup wizard that configures GitLab MCP Server credentials, binary installation, and IDE client configuration when the binary runs interactively instead of as an MCP stdio server. |
-| **Subtotal**  | **2,187** |          |                                                                                                                                                                                                                   |
+| **Subtotal**  | **2,189** |          |                                                                                                                                                                                                                   |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -347,7 +347,7 @@
 | clientcompat  |   100.0% |
 | cmdutil       |    92.3% |
 | completions   |   100.0% |
-| config        |    97.0% |
+| config        |    98.8% |
 | edition       |    87.0% |
 | elicitation   |    86.3% |
 | gitlab        |    98.8% |
@@ -357,7 +357,7 @@
 | resources     |    99.5% |
 | serverpool    |    98.9% |
 | subscriptions |   100.0% |
-| testutil      |    88.7% |
+| testutil      |    88.2% |
 | toolutil      |    98.3% |
 | wizard        |    99.9% |
 
@@ -573,8 +573,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **testutil** (88.2%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/gen_docker_tools** (88.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **testutil** (88.7%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 
 <!-- END TESTING STATS -->

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,9 +174,16 @@ type Config struct {
 	// wrong-origin identifiers behind any TLS-terminating proxy.
 	PublicURL string
 
-	TrustedProxyHeader string   // HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
-	ExcludeTools       []string // Tool names to exclude from registration (comma-separated via EXCLUDE_TOOLS)
-	IgnoreScopes       bool     // When true, skip PAT scope detection and register all tools
+	TrustedProxyHeader string // HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
+	// TrustedOrigins are absolute origins (scheme://host[:port]) allowed to
+	// make cross-origin browser requests. Empty by default: the server
+	// refuses every cross-origin browser POST, and only a listed origin (or
+	// the PublicURL origin, seeded automatically) is exempted. A trusted
+	// origin is validation, not a bypass — the DNS-rebinding MUST is still
+	// met for every origin not on the list.
+	TrustedOrigins []string
+	ExcludeTools   []string // Tool names to exclude from registration (comma-separated via EXCLUDE_TOOLS)
+	IgnoreScopes   bool     // When true, skip PAT scope detection and register all tools
 
 	RateLimitRPS   float64 // Per-server tools/call rate limit in requests/second (0 = disabled)
 	RateLimitBurst int     // Token-bucket burst size when RateLimitRPS > 0

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -1082,10 +1082,10 @@ func TestPoolClientConstructors_UseTheirAuthScheme(t *testing.T) {
 // authentication scheme and nothing else.
 func assertAuthScheme(t *testing.T, path, bearer, private, token string, wantBearer, wantPrivate bool) {
 	t.Helper()
-	if got := bearer == "Bearer "+token; got != wantBearer {
+	if (bearer == "Bearer "+token) != wantBearer {
 		t.Errorf("%s: Authorization = %q, want bearer=%v", path, bearer, wantBearer)
 	}
-	if got := private == token; got != wantPrivate {
+	if (private == token) != wantPrivate {
 		t.Errorf("%s: PRIVATE-TOKEN = %q, want private=%v", path, private, wantPrivate)
 	}
 }

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -20,6 +20,11 @@ func NewProtectedResourceHandler(resourceURL, gitlabURL string) http.Handler {
 		AuthorizationServers:   []string{gitlabURL},
 		BearerMethodsSupported: []string{"header"},
 		ScopesSupported:        []string{"api"},
+		// RFC 9728 RECOMMENDED fields: a human name and a docs URL let a
+		// directory or consent screen label this resource instead of
+		// showing only its URL.
+		ResourceName:          "GitLab MCP Server",
+		ResourceDocumentation: "https://jmrp.io/docs/gitlab-mcp-server/guides/oauth-app-setup/",
 	}
 	return auth.ProtectedResourceMetadataHandler(metadata)
 }

--- a/internal/serverpool/token.go
+++ b/internal/serverpool/token.go
@@ -95,6 +95,18 @@ func ExtractToken(r *http.Request) string {
 	return ""
 }
 
+// ExtractBearerToken returns only the Authorization: Bearer credential,
+// ignoring PRIVATE-TOKEN. OAuth mode uses it so the gate authenticates as
+// the identity the SDK middleware verified, never as a PRIVATE-TOKEN the
+// same request might also carry.
+func ExtractBearerToken(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if after, found := strings.CutPrefix(auth, "Bearer "); found && after != "" {
+		return after
+	}
+	return ""
+}
+
 // ExtractGitLabURL resolves the GitLab instance URL for an HTTP request.
 // It is a compatibility wrapper around [ResolveRequestOptions].
 func ExtractGitLabURL(r *http.Request, defaultURL string) (string, error) {

--- a/internal/serverpool/token_test.go
+++ b/internal/serverpool/token_test.go
@@ -314,3 +314,35 @@ func TestInvalidGitLabURLError_DoesNotLeakURL(t *testing.T) {
 		t.Errorf("Error() missing reason: %q", msg)
 	}
 }
+
+// TestExtractBearerToken_IgnoresPrivateToken verifies the oauth-mode
+// extractor reads only Authorization: Bearer and never PRIVATE-TOKEN — a
+// request carrying both must yield the Bearer credential, since that is the
+// one the SDK middleware verified.
+func TestExtractBearerToken_IgnoresPrivateToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		bearer  string
+		private string
+		want    string
+	}{
+		{"bearer only", "gloas-abc", "", "gloas-abc"},
+		{"both present prefers bearer", "gloas-verified", "glpat-unverified", "gloas-verified"},
+		{"private only yields nothing", "", "glpat-x", ""},
+		{"neither", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tt.bearer != "" {
+				r.Header.Set("Authorization", "Bearer "+tt.bearer)
+			}
+			if tt.private != "" {
+				r.Header.Set("PRIVATE-TOKEN", tt.private)
+			}
+			if got := ExtractBearerToken(r); got != tt.want {
+				t.Errorf("ExtractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/serverpool/token_test.go
+++ b/internal/serverpool/token_test.go
@@ -333,7 +333,7 @@ func TestExtractBearerToken_IgnoresPrivateToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
 			if tt.bearer != "" {
 				r.Header.Set("Authorization", "Bearer "+tt.bearer)
 			}


### PR DESCRIPTION
Replaces #310, which GitHub auto-closed when its base branch (`fix/oauth-bearer-pool`) was deleted on merging #309. Same content, rebased onto main.

Server-side findings from the OAuth audit, plus the cross-origin issue the **mcp.jmrp.io session** diagnosed (`plan/PROMPT-gitlab-mcp-cross-origin-2026-08-26.md`) — **confirmed live against the production deployment**: `Sec-Fetch-Site: cross-site` and `same-site` both 403 there today, exactly as reported.

## Cross-origin trusted origins

`http.NewCrossOriginProtection()` with no trusted origins 403s every cross-origin browser POST before auth, with no configurable exemption — breaking browser MCP clients (Smithery playground, web inspectors, claude.ai in OAuth mode). New `--trusted-origins`:

- Comma-separated absolute origins, **empty default** (current behavior unchanged).
- A listed origin — **or a bare IP** for local deploys — passes a cross-site browser POST; an unlisted one still 403s.
- **`*`** accepts every origin (disables the protection) for trusted-network / same-origin-proxy deploys.
- The **`--public-url` origin is seeded automatically**: in OAuth mode `--public-url` is mandatory, so the origin RFC 9728 discovery points at is trusted with zero extra config.
- A malformed entry **fails startup**. `--public-url` is now validated in **legacy** mode too, since it gained an effect there.

Verified with the sibling's exact procedure, and again inside Docker: unlisted → 403, listed cross-site → 200.

## Also (OAuth audit server findings)

- **Dual-header auth bug (security)**: in oauth mode a request with a valid Bearer **and** a PRIVATE-TOKEN was verified as the Bearer but executed as the unverified PRIVATE-TOKEN. The gate is now bearer-only in oauth mode.
- **PRM CORS preflight**: the GET-restricted mux pattern sent OPTIONS to the catch-all gate (401); mounted method-free so the SDK answers the preflight (204 + ACAO:\*).
- **PRM RFC 9728 RECOMMENDED fields**: `resource_name` + `resource_documentation`.
- Sonar S8193 ×2 from #309's helper fixed here.

## Verification

Full matrix live-verified in Docker (HTTP stateless) against gitlab.com with a real OAuth token and a PAT. Tests: bearer-only extraction, trusted-origin/IP/wildcard matrix, public-url seeding, PRM fields.

Note for the sibling: `libgen-mcp` shares the `crossOriginProtected` wrapper — same `--trusted-origins` port applies there.

## Type of change
- [x] Bug fix
- [x] New feature (--trusted-origins)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Harden OAuth browser interoperability and credential handling while adding configurable cross-origin trust controls.

New Features:
- Add configurable trusted origins for cross-origin browser requests, including automatic public URL seeding and an explicit wildcard opt-out.

Bug Fixes:
- Ensure OAuth requests use only the verified Bearer credential when both Bearer and PRIVATE-TOKEN headers are present.
- Allow OAuth protected-resource metadata preflights to complete successfully for browser clients.
- Add recommended RFC 9728 protected-resource metadata fields.

Enhancements:
- Validate configured public URLs and trusted origins at startup and expand coverage for origin, authentication, and metadata behavior.

CI:
- Configure CodeRabbit to review pull requests targeting any branch while ignoring automated bot commits.

Tests:
- Add coverage for trusted-origin and wildcard behavior, public URL origin seeding, and Bearer-only credential extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable trusted origins for browser requests, including wildcard support.
  * Added Bearer-token-only authentication for OAuth-protected connections.
  * Improved protected-resource metadata with a resource name and documentation link.
  * Added startup validation for configured public URLs and trusted origins.

* **Bug Fixes**
  * OAuth authentication now ignores private-token credentials when Bearer authentication is required.
  * Cross-origin preflight requests are handled correctly for protected metadata endpoints.

* **Documentation**
  * Updated generated code and testing statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->