### PR TITLE
test(http): cover the HTTP transport end to end, and fix what it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,15 @@ jobs:
       - name: Verify E2E tests compile
         run: go test -tags e2e -c -o /dev/null ./test/e2e/suite/
 
+      # The HTTP transport module needs no GitLab and no credentials, so it
+      # runs here rather than only on demand. It is the gate for the handler
+      # chain in package main — cross-origin, preflight, auth modes, rate
+      # limiting, and every flag that restricts something — which unit tests
+      # cannot reach and which has shipped broken more than once. The nginx
+      # cases skip when Docker is unavailable.
+      - name: HTTP transport end-to-end
+        run: go test -tags httpe2e -count=1 -timeout 900s ./test/e2e/http/
+
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ image.png
 /gitlab-mcp-server
 /server
 test/e2e/.bitbucket-admin-pass
+
+# Playwright MCP session artifacts (snapshots, console logs)
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ gitlab-mcp-server/
 │   ├── oauth-app-setup.md       # Creating GitLab OAuth applications for MCP clients
 │   └── ide-configuration.md     # Per-IDE MCP JSON configuration (stdio, HTTP legacy, OAuth)
 ├── test/e2e/                    # End-to-end integration tests
+│   ├── http/                    # HTTP transport module (`httpe2e`): cross-origin, preflight, auth modes, rate limiting, nginx layer. Needs no GitLab
 │   ├── docker-compose.yml       # Ephemeral GitLab CE + Runner + fixture service for Docker mode
 │   ├── .env.docker              # Docker mode environment variables
 │   ├── README.md                # E2E documentation
@@ -214,6 +215,7 @@ make golangci-lint                       # Consolidated Go formatting and lintin
 # End-to-end tests (requires .env with GITLAB_URL, GITLAB_TOKEN)
 go test -v -tags e2e -timeout 300s ./test/e2e/suite/   # Run all e2e tests
 make test-e2e                                          # Same via Makefile
+make test-e2e-http                                     # HTTP transport module: no GitLab, no credentials
 make test-e2e-docker                                   # Ephemeral GitLab CE + runner + fixture service (Docker, ~4 GB RAM)
 go test -tags e2e -c -o NUL ./test/e2e/suite/           # Compile-only check (Windows)
 go test -tags e2e -c -o /dev/null ./test/e2e/suite/     # Compile-only check (Linux)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run brand brand-check brand-rasters test test-short test-race test-pkg test-integration test-e2e ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run brand brand-check brand-rasters test test-short test-race test-pkg test-integration test-e2e test-e2e-http ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -139,6 +139,14 @@ ensure-gotestsum:
 		echo "gotestsum not found; installing with go install..."; \
 		go install gotest.tools/gotestsum@latest; \
 	}
+
+## test-e2e-http: run the HTTP transport end-to-end module (no GitLab needed; nginx layer skips without Docker).
+test-e2e-http: ensure-gotestsum
+	$(call MKDIR_P,$(E2E_REPORT_DIR))
+	bash -o pipefail -c '$(GOTESTSUM) \
+	  --format testdox \
+	  --junitfile $(E2E_REPORT_DIR)/e2e-http-junit.xml \
+	  -- -tags httpe2e -count=1 -timeout 900s ./test/e2e/http/'
 
 test-e2e: ensure-gotestsum
 	@echo "WARNING: This will run E2E tests against the GitLab instance configured in .env (GITLAB_URL)."

--- a/README.md
+++ b/README.md
@@ -246,12 +246,12 @@ Measured with `go run ./cmd/audit_tokens/ -footprint` against the current catalo
 
 | Configuration (`TOOL_SURFACE` / `CAPABILITY_SURFACE`) | Tier     | Visible tools | Reachable actions | `META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | ----------------------------------------------------- | -------- | ------------: | ----------------: | ------------------- | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default)                          | Free/CE  |             2 |               851 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`                                 | Free/CE  |             2 |               851 | n/a                 |              1,504 |           170 |        1,674 |
-| `dynamic` / `full` (default)                          | Premium  |             2 |             1,003 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`                                 | Premium  |             2 |             1,003 | n/a                 |              1,504 |           170 |        1,674 |
-| `dynamic` / `full` (default)                          | Ultimate |             2 |             1,069 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`                                 | Ultimate |             2 |             1,069 | n/a                 |              1,504 |           170 |        1,674 |
+| `dynamic` / `full` (default)                          | Free/CE  |             2 |               851 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`                                 | Free/CE  |             2 |               851 | n/a                 |              1,499 |           170 |        1,669 |
+| `dynamic` / `full` (default)                          | Premium  |             2 |             1,003 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`                                 | Premium  |             2 |             1,003 | n/a                 |              1,499 |           170 |        1,669 |
+| `dynamic` / `full` (default)                          | Ultimate |             2 |             1,069 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`                                 | Ultimate |             2 |             1,069 | n/a                 |              1,499 |           170 |        1,669 |
 
 Rows use the base Community Edition catalog unless the Tier column says otherwise. `GITLAB_TIER` controls which actions are available; higher tiers expose more tools and thus more reachable actions.
 
@@ -434,21 +434,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       992 |     202,019 |
-| Unit tests (`_test.go`)  |       550 |     312,374 |
-| End-to-end tests         |       174 |      45,048 |
-| **Total**                | **1,716** | **559,441** |
+| Source (`.go`, non-test) |       992 |     202,089 |
+| Unit tests (`_test.go`)  |       550 |     312,480 |
+| End-to-end tests         |       182 |      47,489 |
+| **Total**                | **1,724** | **562,058** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,691 |
+| Source functions                |  7,692 |
 | — exported (public)             |  2,675 |
-| — unexported (private)          |  5,016 |
-| Unit test functions (`TestXxx`) | 11,926 |
-| Subtests (`t.Run(...)`)         |  2,953 |
-| End-to-end test functions       |    381 |
+| — unexported (private)          |  5,017 |
+| Unit test functions (`TestXxx`) | 11,928 |
+| Subtests (`t.Run(...)`)         |  2,971 |
+| End-to-end test functions       |    439 |
 
 ### Ratios worth noting
 
@@ -456,27 +456,27 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~203 lines |
-| Average test file length           |                 ~567 lines |
-| Comment lines in source            |  23,496 (~11.6% of source) |
+| Average test file length           |                 ~568 lines |
+| Comment lines in source            |  23,538 (~11.6% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,683 |
-| `defer` statements                 |   923 |
+| `if err != nil` checks             | 6,693 |
+| `defer` statements                 |   933 |
 | `struct` types defined             | 2,743 |
-| `//nolint` suppressions            |   257 |
+| `//nolint` suppressions            |   258 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   236 |
-| Direct dependencies (`go.mod`) |    16 |
-| Indirect dependencies          |    48 |
+| Go packages                    |   237 |
+| Direct dependencies (`go.mod`) |    17 |
+| Indirect dependencies          |    47 |
 
 ### Hall of fame
 
@@ -489,7 +489,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,673 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,674 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,628 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -434,10 +434,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       992 |     202,089 |
-| Unit tests (`_test.go`)  |       550 |     312,480 |
-| End-to-end tests         |       182 |      47,489 |
-| **Total**                | **1,724** | **562,058** |
+| Source (`.go`, non-test) |       992 |     202,100 |
+| Unit tests (`_test.go`)  |       550 |     312,515 |
+| End-to-end tests         |       182 |      47,508 |
+| **Total**                | **1,724** | **562,123** |
 
 ### Functions
 
@@ -446,7 +446,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,692 |
 | — exported (public)             |  2,675 |
 | — unexported (private)          |  5,017 |
-| Unit test functions (`TestXxx`) | 11,928 |
+| Unit test functions (`TestXxx`) | 11,929 |
 | Subtests (`t.Run(...)`)         |  2,971 |
 | End-to-end test functions       |    439 |
 
@@ -457,7 +457,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.55× more tests than code |
 | Average source file length         |                 ~203 lines |
 | Average test file length           |                 ~568 lines |
-| Comment lines in source            |  23,538 (~11.6% of source) |
+| Comment lines in source            |  23,545 (~11.7% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~3,674 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,628 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 12,629 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -383,8 +383,8 @@ FLAGS
   -http-addr string         HTTP listen address (default ":8080")
   -gitlab-url string        Fixed GitLab URL; omit to require per-request GITLAB-URL header
   -skip-tls-verify          Skip TLS certificate verification (default false)
-	-meta-tools               Legacy boolean tool selector; prefer -tool-surface
-	-tool-surface string      Tool surface: dynamic|meta|individual (default dynamic)
+  -meta-tools               Legacy boolean tool selector; prefer -tool-surface
+  -tool-surface string      Tool surface: dynamic|meta|individual (default dynamic)
   -capability-surface str   Capability surface: full|minimal (default full)
   -meta-param-schema str    Meta-tool input schema mode: opaque|compact|full (default opaque)
   -tier string              Force licensing tier: free|ce|premium|ultimate; omit to detect per server entry
@@ -408,6 +408,7 @@ FLAGS
   -oauth-cache-ttl duration OAuth token cache TTL (default %s, min %s, max %s)
   -public-url string        Externally reachable https origin; required with -auth-mode=oauth (RFC 9728 resource identifier)
   -trusted-proxy-header str HTTP header with real client IP (e.g. X-Forwarded-For, X-Real-IP)
+  -revalidate-interval dur  How often pooled tokens are re-validated against GitLab (default %s, 0 to disable)
   -trusted-origins string   Origins allowed to make cross-origin browser requests ('*' accepts any; empty rejects all)
   -rate-limit-rps float     Per-server tools/call rate limit (0 = disabled)
   -rate-limit-burst int     Token-bucket burst size when --rate-limit-rps > 0 (default %d)
@@ -416,8 +417,8 @@ ENVIRONMENT VARIABLES (stdio mode)
   GITLAB_URL                GitLab instance URL (default: %s; set for self-managed instances)
   GITLAB_TOKEN              Personal Access Token (glpat-...)
   GITLAB_SKIP_TLS_VERIFY    Skip TLS verification: true/false (default false)
-	TOOL_SURFACE              Canonical tool surface: dynamic|meta|individual (default dynamic)
-	META_TOOLS                Deprecated legacy selector: true|false|dynamic; ignored when TOOL_SURFACE is set
+  TOOL_SURFACE              Canonical tool surface: dynamic|meta|individual (default dynamic)
+  META_TOOLS                Deprecated legacy selector: true|false|dynamic; ignored when TOOL_SURFACE is set
   CAPABILITY_SURFACE        Resource/prompt surface: full|minimal (default full)
   META_PARAM_SCHEMA         Meta-tool input schema: opaque|compact|full (default opaque)
   GITLAB_TIER               Force licensing tier: free|ce|premium|ultimate; omit to detect from license
@@ -435,6 +436,20 @@ ENVIRONMENT VARIABLES (stdio mode)
   RATE_LIMIT_BURST          Token-bucket burst size when RATE_LIMIT_RPS > 0 (default 40)
   YOLO_MODE                 Skip destructive action confirmation prompts (default false)
   LOG_LEVEL                 Logging: debug/info/warn/error (default info)
+
+ENVIRONMENT VARIABLES (HTTP mode)
+  Every flag above also reads its value from the environment when the flag is
+  not passed. Precedence: an explicitly passed flag, then the environment,
+  then the built-in default. The variables below have no stdio equivalent:
+
+  AUTH_MODE                 Authentication mode: legacy|oauth (default legacy)
+  PUBLIC_URL                Externally reachable https origin; required with AUTH_MODE=oauth
+  TRUSTED_ORIGINS           Origins allowed to make cross-origin browser requests
+  OAUTH_CACHE_TTL           OAuth token cache TTL (default 15m, min 1m, max 2h)
+  MAX_HTTP_CLIENTS          Maximum concurrent client sessions (default 100)
+  SESSION_TIMEOUT           Idle session timeout (default 30m)
+  POOL_IDLE_TIMEOUT         Reclaim an unused pooled server after this long (default 1h, 0 disables)
+  SESSION_REVALIDATE_INTERVAL  Token re-validation interval (default 15m, 0 disables)
 
 JSON CONFIGURATION EXAMPLES
 
@@ -478,6 +493,7 @@ JSON CONFIGURATION EXAMPLES
 		config.DefaultAutoUpdateRepo, config.DefaultAutoUpdateInterval,
 		config.DefaultAutoUpdateTimeout,
 		config.DefaultOAuthCacheTTL, config.MinOAuthCacheTTL, config.MaxOAuthCacheTTL,
+		config.DefaultRevalidateInterval,
 		config.DefaultRateLimitBurst,
 		config.DefaultGitLabURL,
 		config.DefaultAutoUpdateRepo)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -4921,8 +4921,12 @@ func TestServeHTTP_ToolsList_ExecuteActionCarriesXMCPHeader(t *testing.T) {
 		if tool.Name != "gitlab_execute_action" {
 			continue
 		}
-		if got := tool.InputSchema.Properties["action"].XMCPHeader; got != "Mcp-Param-Action" {
-			t.Fatalf("gitlab_execute_action action x-mcp-header = %q, want Mcp-Param-Action", got)
+		// The suffix, not the full header name: the SDK prepends
+		// "Mcp-Param-" to this value, so the wire header a client sends is
+		// Mcp-Param-Action. Asserting the full name here is what let
+		// "Mcp-Param-Mcp-Param-Action" ship.
+		if got := tool.InputSchema.Properties["action"].XMCPHeader; got != "Action" {
+			t.Fatalf("gitlab_execute_action action x-mcp-header = %q, want Action", got)
 		}
 		return
 	}

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -125,6 +125,27 @@ Vary: Origin
 
 The actual response then carries `Access-Control-Allow-Origin` and `Access-Control-Expose-Headers: Mcp-Session-Id, Mcp-Protocol-Version` — without the latter a browser cannot read either header, since neither is CORS-safelisted.
 
+### Do not let a reverse proxy answer CORS as well
+
+A proxy in front that advertises CORS on the server's behalf — the shape most deployments started with, because the server could not answer a preflight — now collides with the server's own answer:
+
+```http
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: https://claude.ai
+Access-Control-Allow-Origin: *
+```
+
+`curl` reports `200` and the headers look generous. A browser refuses the response outright, because [Fetch](https://fetch.spec.whatwg.org/) treats more than one `Access-Control-Allow-Origin` as a failure rather than merging them. Chromium says so plainly:
+
+```text
+The 'Access-Control-Allow-Origin' header contains multiple values
+'https://claude.ai, *', but only one is allowed.
+```
+
+So a deployment that keeps its proxy-level CORS after upgrading is **worse off than before**: previously the proxy's lone `*` at least worked for requests without credentials. Remove the `add_header Access-Control-*` block and the `OPTIONS` short-circuit from the MCP location, and let `--trusted-origins` decide. Both changes belong in the same deploy — between them the endpoint is broken for browsers in a way no `curl` check reveals.
+
+`test/e2e/http` pins this: `TestProxy_ServerAndProxyCORSCollide` runs a real nginx with that block and reports the collision.
+
 Two properties are deliberate:
 
 - **The origin is echoed, never `*`.** These requests carry an `Authorization` header, and a browser rejects the wildcard on a credentialed request. `--trusted-origins='*'` echoes whatever origin asked rather than emitting a literal asterisk.

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -29,8 +29,8 @@ All measurements are against the current source tree. The catalog is built in-me
 
 | Configuration                | Tier     | Visible tools | Reachable actions | `META_PARAM_SCHEMA` | Tool schema tokens | Shared tokens | Total tokens |
 | ---------------------------- | -------- | ------------: | ----------------: | ------------------- | -----------------: | ------------: | -----------: |
-| `dynamic` / `full` (default) | Free/CE  |             2 |               851 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`        | Free/CE  |             2 |               851 | n/a                 |              1,504 |           170 |        1,674 |
+| `dynamic` / `full` (default) | Free/CE  |             2 |               851 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`        | Free/CE  |             2 |               851 | n/a                 |              1,499 |           170 |        1,669 |
 | `meta` / `full` (opaque)     | Free/CE  |            33 |               851 | `opaque`            |            124,725 |         8,720 |      133,445 |
 | `meta` / `minimal` (opaque)  | Free/CE  |            33 |               851 | `opaque`            |            124,725 |           170 |      124,895 |
 | `meta` / `full` (compact)    | Free/CE  |            33 |               851 | `compact`           |            190,272 |         8,720 |      198,992 |
@@ -38,8 +38,8 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `full` (full)       | Free/CE  |            33 |               851 | `full`              |            277,907 |         8,720 |      286,627 |
 | `meta` / `minimal` (full)    | Free/CE  |            33 |               851 | `full`              |            277,907 |           170 |      278,077 |
 | `individual` / `full`        | Free/CE  |           847 |               847 | n/a                 |            494,297 |         8,720 |      503,017 |
-| `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              1,504 |           170 |        1,674 |
+| `dynamic` / `full` (default) | Premium  |             2 |             1,003 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`        | Premium  |             2 |             1,003 | n/a                 |              1,499 |           170 |        1,669 |
 | `meta` / `full` (opaque)     | Premium  |            39 |             1,003 | `opaque`            |            143,970 |         8,720 |      152,690 |
 | `meta` / `minimal` (opaque)  | Premium  |            39 |             1,003 | `opaque`            |            143,970 |           170 |      144,140 |
 | `meta` / `full` (compact)    | Premium  |            39 |             1,003 | `compact`           |            220,929 |         8,720 |      229,649 |
@@ -47,8 +47,8 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `full` (full)       | Premium  |            39 |             1,003 | `full`              |            322,767 |         8,720 |      331,487 |
 | `meta` / `minimal` (full)    | Premium  |            39 |             1,003 | `full`              |            322,767 |           170 |      322,937 |
 | `individual` / `full`        | Premium  |           999 |               999 | n/a                 |            592,705 |         8,720 |      601,425 |
-| `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              1,504 |         8,720 |       10,224 |
-| `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              1,504 |           170 |        1,674 |
+| `dynamic` / `full` (default) | Ultimate |             2 |             1,069 | n/a                 |              1,499 |         8,720 |       10,219 |
+| `dynamic` / `minimal`        | Ultimate |             2 |             1,069 | n/a                 |              1,499 |           170 |        1,669 |
 | `meta` / `full` (opaque)     | Ultimate |            50 |             1,069 | `opaque`            |            155,869 |         8,720 |      164,589 |
 | `meta` / `minimal` (opaque)  | Ultimate |            50 |             1,069 | `opaque`            |            155,869 |           170 |      156,039 |
 | `meta` / `full` (compact)    | Ultimate |            50 |             1,069 | `compact`           |            237,249 |         8,720 |      245,969 |

--- a/docs/guides/http-server-mode.md
+++ b/docs/guides/http-server-mode.md
@@ -164,7 +164,8 @@ cancels its in-flight GitLab API calls. The SDK applies this to protocol
 
 On the dynamic tool surface, the `action` property of `gitlab_execute_action`
 carries the [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)
-`x-mcp-header` annotation with the value `Mcp-Param-Action`. MCP-aware gateways
+`x-mcp-header` annotation with the value `Action`, which the SDK prefixes to
+form the wire header `Mcp-Param-Action`. MCP-aware gateways
 can therefore route, rate-limit, and observe calls by canonical action ID from
 the request header, without parsing the JSON-RPC body.
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/crypto v0.55.0
 	golang.org/x/image v0.45.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.49.0
 )
@@ -66,7 +67,6 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.46.0 // indirect
 	golang.org/x/exp v0.0.0-20260812173653-3d80eb74bc5b // indirect
 	golang.org/x/mod v0.40.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
@@ -70,8 +71,16 @@ const DefaultRevalidateInterval = 15 * time.Minute
 const DefaultIdleTimeout = 1 * time.Hour
 
 // idleSweepDivisor sets the sweep cadence as a fraction of the idle timeout,
-// so an entry outlives its timeout by at most a quarter of it. The sweep never
-// runs more often than idleSweepMinInterval.
+// bounded below by idleSweepMinInterval so a small timeout cannot turn the
+// sweep into a hot loop.
+//
+// The floor is the part worth stating plainly: an entry outlives its timeout by
+// at most a quarter of it only while that quarter is longer than the floor,
+// which means from a four-minute timeout upwards. Below that the floor
+// dominates, and an entry configured to expire after a second can still be
+// held for up to a minute. That is a deliberate trade — the sweep costs a lock
+// and a walk of every entry — but it is not what "a quarter of the timeout"
+// suggests on its own.
 const (
 	idleSweepDivisor     = 4
 	idleSweepMinInterval = 1 * time.Minute
@@ -117,6 +126,10 @@ type ServerPool struct {
 	idleTimeout        time.Duration
 	metrics            Metrics
 	createdAt          time.Time
+	// building collapses concurrent first-requests for one key into a single
+	// build, so a client opening several connections at once costs one set of
+	// upstream lookups rather than one per connection.
+	building singleflight.Group
 	// baseContext supplies the lifetime that bounds the GitLab lookups which
 	// build an entry — the credential probe, tier and scope discovery,
 	// identity resolution.
@@ -249,18 +262,38 @@ func (p *ServerPool) GetOrCreate(token, gitlabURL string) (*mcp.Server, error) {
 	}
 	p.mu.RUnlock()
 
-	// Slow path: build the new client and server WITHOUT holding p.mu. Client
-	// creation, tier/scope detection (entryConfig), and the factory all perform
-	// GitLab network I/O; doing that under the write lock would serialize every
-	// caller behind a single slow round-trip and can stall the whole pool when an
-	// instance is slow or unreachable. The freshly built entry is committed below
-	// under the lock with a double-check, so concurrent builders for the same key
-	// converge on one stored entry.
-	entry, err := p.buildEntry(token, gitlabURL)
+	// Slow path: build WITHOUT holding p.mu. Client creation, tier and scope
+	// detection and the factory all perform GitLab network I/O, and doing that
+	// under the write lock would serialize every caller behind one slow
+	// round-trip, stalling the whole pool whenever an instance is slow.
+	//
+	// Callers racing for the *same* key are collapsed into one build instead of
+	// each doing their own. A client that opens several connections at once —
+	// which is the normal startup burst — used to cost one credential probe,
+	// one tier lookup, one scope lookup and one identity lookup per connection,
+	// all for a single credential, with every result but one thrown away. The
+	// waiters block exactly as long as they would have blocked building it
+	// themselves, so nothing is slower and the upstream cost is one.
+	// Counted here rather than inside the build, so that Hits plus Misses is
+	// still the number of calls: a caller that joins someone else's in-flight
+	// build found no entry, which is a miss however the work was shared.
+	p.metrics.Misses.Add(1)
+
+	built, err, _ := p.building.Do(key, func() (any, error) {
+		entry, buildErr := p.buildEntry(token, gitlabURL)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+		return p.insertEntry(key, token, entry), nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return p.insertEntry(key, token, entry), nil
+	server, ok := built.(*mcp.Server)
+	if !ok || server == nil {
+		return nil, errors.New("creating MCP server for pool: builder returned no server")
+	}
+	return server, nil
 }
 
 // buildEntry creates the GitLab client, resolves the per-entry configuration,
@@ -374,8 +407,6 @@ func (p *ServerPool) insertEntry(key, token string, entry *poolEntry) *mcp.Serve
 		return server
 	}
 
-	p.metrics.Misses.Add(1)
-
 	if p.lru.Len() >= p.maxSize {
 		p.evictLRU()
 	}
@@ -405,6 +436,11 @@ func (p *ServerPool) insertEntry(key, token string, entry *poolEntry) *mcp.Serve
 // Every hit refreshes lastUsed, which is what idle eviction reads; the LRU
 // position alone cannot serve that purpose because it only orders entries
 // relative to each other and carries no wall-clock age.
+//
+// It counts nothing. Its only caller is the double check in [ServerPool.insertEntry],
+// which is reached from the slow path where the miss has already been charged;
+// counting a hit here too would make one call show up as both, and Hits plus
+// Misses would stop being the number of calls.
 func (p *ServerPool) existingServerLocked(key string) (*mcp.Server, bool) {
 	entry, ok := p.entries[key]
 	if !ok {
@@ -412,7 +448,6 @@ func (p *ServerPool) existingServerLocked(key string) (*mcp.Server, bool) {
 	}
 	p.lru.MoveToFront(entry.element)
 	entry.lastUsed = time.Now()
-	p.metrics.Hits.Add(1)
 	return entry.server, true
 }
 

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -305,6 +305,17 @@ func (p *ServerPool) buildEntry(token, gitlabURL string) (*poolEntry, error) {
 		return nil, errors.New("creating MCP server for pool: server factory is nil")
 	}
 
+	// Bail before doing any work if the pool's lifetime has already ended.
+	// The lookups below each bound themselves with a timeout derived from
+	// this context, so a cancelled one makes them fail fast — but the
+	// credential probe reports "not rejected" when it cannot reach GitLab,
+	// which on a cancelled context would wave a build through and register a
+	// full tool catalog after shutdown had begun. Checking here stops that
+	// at the door.
+	if err := p.lifetime().Err(); err != nil {
+		return nil, fmt.Errorf("pool shutting down, not building entry: %w", err)
+	}
+
 	// In oauth mode every credential arrives as Authorization: Bearer, and
 	// the pool must forward it the same way: an OAuth access token is only
 	// valid as Bearer (GitLab rejects gloas- tokens in PRIVATE-TOKEN, which

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -1608,3 +1608,38 @@ func TestGetOrCreate_ConcurrentDistinctKeysDoNotSerialize(t *testing.T) {
 		t.Errorf("%d of %d distinct-key builds were in flight together; distinct credentials are being serialized", inFlight, callers)
 	}
 }
+
+// TestGetOrCreate_AfterLifetimeCancel_DoesNotBuild verifies that once the
+// pool's base context is done, GetOrCreate refuses to build a new entry rather
+// than running the credential probe, tier and scope lookups and the factory
+// after shutdown has begun.
+//
+// The credential probe reports "not rejected" when it cannot reach GitLab,
+// which on a cancelled context would wave the build through; the factory has
+// no context of its own, so its tool-registration work would still run and
+// could delay a graceful shutdown. The guard stops it at the door.
+func TestGetOrCreate_AfterLifetimeCancel_DoesNotBuild(t *testing.T) {
+	var builds atomic.Int32
+	baseCtx, cancel := context.WithCancel(context.Background())
+	cfg := testConfig(stubGitLabBase)
+	pool := New(cfg, func(*gitlabclient.Client, *config.ServerConfig) (*mcp.Server, error) {
+		builds.Add(1)
+		return mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.0"}, nil), nil
+	}, WithBaseContext(func() context.Context { return baseCtx }))
+
+	cancel()
+
+	srv, err := pool.GetOrCreate("glpat-after-shutdown", stubGitLabBase)
+	if err == nil {
+		t.Error("GetOrCreate built an entry after the lifetime was cancelled")
+	}
+	if srv != nil {
+		t.Error("a server was returned despite the cancelled lifetime")
+	}
+	if builds.Load() != 0 {
+		t.Errorf("the factory ran %d times after shutdown; it should not run at all", builds.Load())
+	}
+	if pool.Size() != 0 {
+		t.Errorf("pool.Size() = %d, want 0 — nothing should have been inserted", pool.Size())
+	}
+}

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -696,8 +697,13 @@ func TestInsertEntry_ExistingEntry(t *testing.T) {
 	if size := pool.Size(); size != 2 {
 		t.Fatalf("pool.Size() = %d, want 2 (rebuilt entry discarded)", size)
 	}
-	if hits := pool.Stats().Hits; hits != 1 {
-		t.Fatalf("Hits = %d, want 1", hits)
+	// insertEntry counts nothing. It is only reached from the slow path in
+	// GetOrCreate, where the miss has already been charged, so counting a hit
+	// here as well would make one call show up as both and Hits plus Misses
+	// would stop being the number of calls. This test drives insertEntry
+	// directly, so no counter should have moved at all.
+	if stats := pool.Stats(); stats.Hits != 0 || stats.Misses != 0 {
+		t.Fatalf("Hits = %d, Misses = %d; insertEntry must not touch the counters", stats.Hits, stats.Misses)
 	}
 }
 
@@ -1515,5 +1521,90 @@ func TestNew_WithoutBaseContext_StillBuildsEntries(t *testing.T) {
 	}, WithBaseContext(func() context.Context { return nil }))
 	if _, err := pool3.GetOrCreate("glpat-nil-return", srv.URL); err != nil {
 		t.Fatalf("GetOrCreate with a base-context function returning nil: %v", err)
+	}
+}
+
+// TestGetOrCreate_ConcurrentCallersShareOneBuild verifies that callers racing
+// for the same credential collapse into a single build.
+//
+// A client that opens several connections at once — the normal startup burst —
+// used to cost one credential probe, one tier lookup, one scope lookup and one
+// identity lookup per connection, all for a single credential, with every
+// result but one discarded. The waiters block exactly as long as they would
+// have blocked building it themselves, so nothing is slower.
+func TestGetOrCreate_ConcurrentCallersShareOneBuild(t *testing.T) {
+	var builds atomic.Int32
+	cfg := testConfig(stubGitLabBase)
+	pool := New(cfg, func(*gitlabclient.Client, *config.ServerConfig) (*mcp.Server, error) {
+		builds.Add(1)
+		// Long enough that every caller is inside the race window.
+		time.Sleep(50 * time.Millisecond)
+		return mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.0"}, nil), nil
+	})
+
+	const callers = 20
+	var wg sync.WaitGroup
+	servers := make([]*mcp.Server, callers)
+	for i := range callers {
+		wg.Go(func() {
+			srv, _ := pool.GetOrCreate("glpat-same", stubGitLabBase)
+			servers[i] = srv
+		})
+	}
+	wg.Wait()
+
+	if got := builds.Load(); got != 1 {
+		t.Errorf("factory ran %d times for %d concurrent callers sharing one credential, want 1", got, callers)
+	}
+	for i, srv := range servers {
+		if srv == nil {
+			t.Errorf("caller %d got no server", i)
+			continue
+		}
+		if srv != servers[0] {
+			t.Errorf("caller %d got a different server; every caller must share the one entry", i)
+		}
+	}
+	// Every caller found no entry when it asked, so every caller is a miss:
+	// Hits plus Misses must still be the number of calls.
+	if stats := pool.Stats(); stats.Hits+stats.Misses != callers {
+		t.Errorf("Hits(%d) + Misses(%d) = %d, want %d", stats.Hits, stats.Misses, stats.Hits+stats.Misses, callers)
+	}
+}
+
+// TestGetOrCreate_ConcurrentDistinctKeysDoNotSerialize verifies the other half
+// of the trade: collapsing same-key builds must not put different credentials
+// behind one another, which is what building under the pool lock would do.
+func TestGetOrCreate_ConcurrentDistinctKeysDoNotSerialize(t *testing.T) {
+	release := make(chan struct{})
+	var started atomic.Int32
+
+	cfg := testConfig(stubGitLabBase)
+	pool := New(cfg, func(*gitlabclient.Client, *config.ServerConfig) (*mcp.Server, error) {
+		started.Add(1)
+		<-release
+		return mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.0"}, nil), nil
+	})
+
+	const callers = 5
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Go(func() {
+			_, _ = pool.GetOrCreate(fmt.Sprintf("glpat-distinct-%d", i), stubGitLabBase)
+		})
+	}
+
+	// All five builds must be in flight at once. If they were serialized, only
+	// the first would have started.
+	deadline := time.Now().Add(5 * time.Second)
+	for started.Load() < callers && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	inFlight := started.Load()
+	close(release)
+	wg.Wait()
+
+	if inFlight != callers {
+		t.Errorf("%d of %d distinct-key builds were in flight together; distinct credentials are being serialized", inFlight, callers)
 	}
 }

--- a/internal/serverpool/token.go
+++ b/internal/serverpool/token.go
@@ -87,12 +87,25 @@ func ExtractToken(r *http.Request) string {
 		return token
 	}
 
-	auth := r.Header.Get("Authorization")
-	if after, found := strings.CutPrefix(auth, "Bearer "); found && after != "" {
-		return after
-	}
+	return bearerCredential(r)
+}
 
-	return ""
+// bearerCredential returns the token from an Authorization: Bearer header.
+//
+// The scheme is matched case-insensitively because RFC 9110 section 11.1 says
+// it is case-insensitive, and because the SDK's own bearer middleware lowercases
+// it before comparing. Matching only "Bearer " meant a client sending "bearer"
+// was verified upstream by the SDK — at the cost of a real API call — and then
+// refused here as though it had sent no credential at all.
+func bearerCredential(r *http.Request) string {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	scheme, token, found := strings.Cut(auth, " ")
+	if !found || !strings.EqualFold(scheme, "bearer") {
+		return ""
+	}
+	// RFC 9110 allows more than one space between the scheme and the
+	// credential, and some clients emit one.
+	return strings.TrimSpace(token)
 }
 
 // ExtractBearerToken returns only the Authorization: Bearer credential,
@@ -100,11 +113,7 @@ func ExtractToken(r *http.Request) string {
 // the identity the SDK middleware verified, never as a PRIVATE-TOKEN the
 // same request might also carry.
 func ExtractBearerToken(r *http.Request) string {
-	auth := r.Header.Get("Authorization")
-	if after, found := strings.CutPrefix(auth, "Bearer "); found && after != "" {
-		return after
-	}
-	return ""
+	return bearerCredential(r)
 }
 
 // ExtractGitLabURL resolves the GitLab instance URL for an HTTP request.

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -34,11 +34,21 @@ const (
 	// executeActionActionParam is the top-level input property carrying the
 	// canonical action ID for gitlab_execute_action.
 	executeActionActionParam = "action"
-	// executeActionHeaderName is the HTTP header that MCP-aware gateways
-	// receive the action ID in, declared through the SEP-2243 x-mcp-header
-	// annotation so they can route and observe calls without inspecting the
-	// JSON-RPC body.
-	executeActionHeaderName = "Mcp-Param-Action"
+	// executeActionHeaderSuffix is the value of the SEP-2243 x-mcp-header
+	// annotation on the action property, so MCP-aware gateways can route and
+	// observe calls by canonical action ID without inspecting the JSON-RPC
+	// body.
+	//
+	// It is the suffix, not the full header name: the SDK prepends
+	// "Mcp-Param-" to whatever this annotation says, on both the sending and
+	// the validating side. Declaring the full name here produced
+	// "Mcp-Param-Mcp-Param-Action" on the wire, so a client sending the
+	// documented header was answered "header mismatch" — the annotation was
+	// unusable for the one purpose it exists for.
+	executeActionHeaderSuffix = "Action"
+	// executeActionHeaderName is the resulting wire header, for documentation
+	// and for tests that assert what a client must actually send.
+	executeActionHeaderName = "Mcp-Param-" + executeActionHeaderSuffix
 	// xMCPHeaderKeyword is the JSON Schema keyword defined by SEP-2243.
 	xMCPHeaderKeyword = "x-mcp-header"
 
@@ -301,7 +311,7 @@ func annotateActionHeader(schema *jsonschema.Schema) *jsonschema.Schema {
 	if action.Extra == nil {
 		action.Extra = make(map[string]any, 1)
 	}
-	action.Extra[xMCPHeaderKeyword] = executeActionHeaderName
+	action.Extra[xMCPHeaderKeyword] = executeActionHeaderSuffix
 	return schema
 }
 

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -2556,8 +2556,19 @@ func TestExecuteActionSchema_XMCPHeader_AnnotatesActionParam(t *testing.T) {
 	if !ok {
 		t.Fatalf("gitlab_execute_action schema has no action property: %v", properties)
 	}
-	if got := action["x-mcp-header"]; got != executeActionHeaderName {
-		t.Fatalf("action x-mcp-header = %v, want %q", got, executeActionHeaderName)
+	// The annotation carries the suffix, not the full header: the SDK
+	// prepends "Mcp-Param-" on both the sending and validating side, so
+	// declaring the full name here put "Mcp-Param-Mcp-Param-Action" on the
+	// wire and made the documented header a mismatch.
+	if got := action["x-mcp-header"]; got != executeActionHeaderSuffix {
+		t.Fatalf("action x-mcp-header = %v, want %q", got, executeActionHeaderSuffix)
+	}
+	// And the wire header a client must send is the prefixed form. Naming it
+	// here is what makes the relationship legible: the schema value and the
+	// header are not the same string, and conflating them is the bug this
+	// pair of assertions exists to prevent.
+	if executeActionHeaderName != "Mcp-Param-"+executeActionHeaderSuffix {
+		t.Errorf("wire header = %q, want the annotation prefixed with Mcp-Param-", executeActionHeaderName)
 	}
 	if params, paramsOK := properties["params"].(map[string]any); !paramsOK {
 		t.Fatalf("gitlab_execute_action schema has no params property: %v", properties)

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -30,7 +30,7 @@
           "action": {
             "description": "Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.",
             "type": "string",
-            "x-mcp-header": "Mcp-Param-Action"
+            "x-mcp-header": "Action"
           },
           "confirm": {
             "description": "Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.",

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -247,7 +247,7 @@ Las cancelaciones del cliente siempre se propagan a los contextos de los manejad
 
 ### Anotación de enrutado para gateways
 
-En la superficie dinámica de herramientas, la propiedad `action` de `gitlab_execute_action` lleva la anotación `x-mcp-header` de [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243) con el valor `Mcp-Param-Action`, de modo que los gateways compatibles con MCP pueden enrutar, limitar y observar las llamadas por ID canónico de acción sin analizar el cuerpo JSON-RPC.
+En la superficie dinámica de herramientas, la propiedad `action` de `gitlab_execute_action` lleva la anotación `x-mcp-header` de [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243) con el valor `Action` —el SDK le antepone el prefijo para formar la cabecera real `Mcp-Param-Action`—, de modo que los gateways compatibles con MCP pueden enrutar, limitar y observar las llamadas por ID canónico de acción sin analizar el cuerpo JSON-RPC.
 
 ## Gestión de sesiones
 

--- a/site/src/content/docs/es/operations/security.mdx
+++ b/site/src/content/docs/es/operations/security.mdx
@@ -222,6 +222,8 @@ gitlab-mcp-server --http --trusted-origins=https://mcp.example.com
 
 Una lista blanca **es** validación: todo origen que no esté en ella se sigue rechazando. Una IP a secas sirve para despliegues locales, `*` acepta cualquier origen (desactivando la protección — solo razonable en una red de confianza o tras un proxy del mismo origen), y el origen de `--public-url` es de confianza automáticamente. Una entrada malformada impide arrancar.
 
+Si un proxy inverso delante ya anuncia CORS en nombre del servidor —la forma con la que arrancaron casi todos los despliegues—, ese bloque tiene que salir en el mismo cambio. Dos cabeceras `Access-Control-Allow-Origin` son un fallo de CORS, no una fusión: `curl` responde `200` y el navegador rechaza la respuesta diciendo que la cabecera «contiene múltiples valores… y solo se permite uno». Dejar las dos deja el endpoint peor que antes, porque el `*` solitario del proxy al menos servía para peticiones sin credenciales.
+
 Permitir el origen es solo la mitad de lo que necesita un navegador. Antes de enviar un `POST` cross-origin con `Authorization`, envía un preflight `OPTIONS` sin credenciales — que el modo OAuth rechazaba con `401`, así que la petición real nunca llegaba a salir. Un preflight desde un origen de confianza se responde ahora con `204` y las cabeceras CORS, y la respuesta expone `Mcp-Session-Id` y `Mcp-Protocol-Version` para que un navegador pueda leerlas. El origen se devuelve tal cual en lugar de responder `*`, porque un navegador rechaza el comodín en una petición con credenciales.
 
 ## Verificación de la integridad del release

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -247,7 +247,7 @@ Client aborts are always propagated into handler contexts, so an abandoned POST 
 
 ### Gateway routing annotation
 
-On the dynamic tool surface, the `action` property of `gitlab_execute_action` carries the [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243) `x-mcp-header` annotation with the value `Mcp-Param-Action`, so MCP-aware gateways can route, rate-limit, and observe calls by canonical action ID without parsing the JSON-RPC body.
+On the dynamic tool surface, the `action` property of `gitlab_execute_action` carries the [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243) `x-mcp-header` annotation with the value `Action` — the SDK prefixes it to form the wire header `Mcp-Param-Action` — so MCP-aware gateways can route, rate-limit, and observe calls by canonical action ID without parsing the JSON-RPC body.
 
 ## Session management
 

--- a/site/src/content/docs/operations/security.mdx
+++ b/site/src/content/docs/operations/security.mdx
@@ -222,6 +222,8 @@ gitlab-mcp-server --http --trusted-origins=https://mcp.example.com
 
 An allowlist **is** validation: every origin not on it is still refused. A bare IP works for local deployments, `*` accepts any origin (disabling the protection — only sensible on a trusted network or behind a same-origin proxy), and the `--public-url` origin is trusted automatically. A malformed entry fails startup.
 
+If a reverse proxy in front already advertises CORS on the server's behalf — the shape most deployments started with — that block has to come out in the same change. Two `Access-Control-Allow-Origin` headers is a CORS failure, not a merge: `curl` reports `200` and a browser refuses the response, saying the header "contains multiple values ... but only one is allowed". Keeping both leaves the endpoint worse off than before, because the proxy's lone `*` at least worked for requests without credentials.
+
 Allowing the origin is only half of what a browser needs. Before it sends a cross-origin `POST` carrying `Authorization`, it sends a preflight `OPTIONS` with no credentials — which OAuth mode used to refuse with `401`, so the real request never happened. A preflight from a trusted origin is now answered `204` with the CORS headers, and the response exposes `Mcp-Session-Id` and `Mcp-Protocol-Version` so a browser can actually read them. The origin is echoed rather than answered with `*`, because a browser rejects the wildcard on a credentialed request.
 
 ## Verifying release integrity

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -6,23 +6,23 @@
   },
   "dynamic": {
     "visible_tools": 2,
-    "tool_schema_tokens": 1504
+    "tool_schema_tokens": 1499
   },
   "individual": {
     "free": {
       "visible_tools": 847,
       "tool_schema_tokens": 494297,
-      "reduction_factor_vs_dynamic": 329
+      "reduction_factor_vs_dynamic": 330
     },
     "premium": {
       "visible_tools": 999,
       "tool_schema_tokens": 592705,
-      "reduction_factor_vs_dynamic": 394
+      "reduction_factor_vs_dynamic": 395
     },
     "ultimate": {
       "visible_tools": 1065,
       "tool_schema_tokens": 621718,
-      "reduction_factor_vs_dynamic": 413
+      "reduction_factor_vs_dynamic": 415
     }
   }
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -2,6 +2,26 @@
 
 E2E tests validate the full MCP server against a real GitLab instance using in-memory transport (`mcp.NewInMemoryTransports()`). Build tag: `e2e`.
 
+There are two modules, answering different questions:
+
+| Module           | Build tag  | Needs GitLab | What it covers                                                                     |
+| ---------------- | ---------- | ------------ | ---------------------------------------------------------------------------------- |
+| `test/e2e/suite` | `e2e`      | yes          | Tool behaviour against a real instance, over in-memory MCP transport                |
+| `test/e2e/http`  | `httpe2e`  | no           | The HTTP transport itself: cross-origin, preflight, auth modes, rate limiting, proxy |
+| `test/e2e/orbit` | `orbitlive`| gitlab.com   | The experimental Knowledge Graph API                                                |
+
+## HTTP transport module
+
+```bash
+make test-e2e-http
+```
+
+No GitLab and no credentials: the module builds the binary, starts it with the flags each case needs, and stands up a fake instance for the few behaviours that only appear once GitLab answers — the failure budget is charged when a credential is *rejected*, and deliberately not when the instance is merely unreachable.
+
+It exists because the in-memory suite cannot reach any of this. The handler chain is assembled in `package main`, so a unit test could not import it and a test that reassembled it would be testing its own copy. Every case in the module corresponds to something that shipped broken: a preflight answered `401`, which made `--trusted-origins` useless in a browser; a throttled GitLab reported as an invalid token; an invalid token relayed upstream on every retry; and an `x-mcp-header` annotation carrying a prefix the transport also adds.
+
+The `TestProxy_*` cases run a real nginx in Docker in front of the server, and **skip** when Docker is unavailable rather than modelling one. That layer is not optional detail: a proxy answering `OPTIONS` itself hides a server that cannot, and a proxy adding its own CORS headers collides with the server's to produce a response `curl` reports as `200` and a browser refuses outright.
+
 ## Quick Start
 
 ### Self-Hosted Mode

--- a/test/e2e/http/clientcompat_test.go
+++ b/test/e2e/http/clientcompat_test.go
@@ -1,0 +1,297 @@
+//go:build httpe2e
+
+// clientcompat_test.go covers the ways real MCP clients differ from each other
+// over HTTP.
+//
+// The clients that reach this server are not one implementation. They disagree
+// about which protocol version to announce, which Accept types to send, whether
+// to carry a session, which credential header to use, and — the one that
+// surprises people — whether to send an Origin at all. An Electron-based client
+// sends one, and a server that treats "has an Origin" as "is a web page" locks
+// out a desktop app.
+package httpe2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestClient_ProtocolVersions verifies that the versions clients actually
+// announce are all served.
+//
+// A client that predates the standard headers must not be required to send
+// them, and a client that announces nothing at all must still be answered:
+// the transport defaults to the initialization-era version rather than
+// refusing, and refusing here would break every client that has not caught up.
+func TestClient_ProtocolVersions(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, version := range []string{"", "2025-06-18", "2025-11-25", "2026-07-28"} {
+		name := version
+		if name == "" {
+			name = "no version header"
+		}
+		t.Run(name, func(t *testing.T) {
+			headers := map[string]string{"PRIVATE-TOKEN": "glpat-whatever"}
+			if version != "" {
+				headers["MCP-Protocol-Version"] = version
+			}
+			got := srv.do(t, request{
+				method: http.MethodPost, path: "/mcp",
+				body:    toolsListBody,
+				headers: headers,
+			})
+			// The credential is invalid, so 401 is the expected answer. What
+			// matters is that the version was not itself grounds for refusal.
+			if got.status == http.StatusBadRequest {
+				t.Errorf("protocol version %q was refused outright: %s", version, got.body)
+			}
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("protocol version %q produced %d: %s", version, got.status, got.body)
+			}
+		})
+	}
+}
+
+// TestClient_UnknownProtocolVersionIsNotFatal verifies that a version this
+// build has never heard of does not take the server down or produce a 5xx.
+// Clients ship ahead of servers.
+func TestClient_UnknownProtocolVersionIsNotFatal(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, version := range []string{"2099-01-01", "not-a-date", "0"} {
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp", body: toolsListBody,
+			headers: map[string]string{
+				"PRIVATE-TOKEN":        "glpat-whatever",
+				"MCP-Protocol-Version": version,
+			},
+		})
+		if got.status >= http.StatusInternalServerError {
+			t.Errorf("version %q produced %d, want a client error at worst: %s", version, got.status, got.body)
+		}
+	}
+}
+
+// TestClient_AcceptHeaderVariants verifies the Accept types clients send.
+//
+// The streamable transport can answer as SSE or as JSON, and clients differ:
+// some send both types, some only one, and some send nothing. None of those is
+// a reason to fail.
+func TestClient_AcceptHeaderVariants(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, accept := range []string{
+		"application/json, text/event-stream",
+		"application/json",
+		"text/event-stream",
+		"*/*",
+		"",
+	} {
+		name := accept
+		if name == "" {
+			name = "no Accept header"
+		}
+		t.Run(name, func(t *testing.T) {
+			got := srv.do(t, request{
+				method: http.MethodPost, path: "/mcp", body: toolsListBody,
+				headers: map[string]string{
+					"PRIVATE-TOKEN":        "glpat-whatever",
+					"Accept":               accept,
+					"MCP-Protocol-Version": protocolVersion,
+				},
+			})
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("Accept %q produced %d: %s", accept, got.status, got.body)
+			}
+		})
+	}
+}
+
+// TestClient_DesktopOriginBehaviour records how a client that sends an Origin
+// without browser fetch metadata is treated, and how an operator lets one in.
+//
+// Electron-based clients can send an Origin like app:// or vscode-file://. The
+// stdlib compares Origin against Host when Sec-Fetch-Site is absent, so such a
+// request is refused by default — conservatively and, for a DNS-rebinding
+// control, correctly, since nothing distinguishes it from a page. What matters
+// is that the escape hatch works: an operator who runs such a client names its
+// origin in --trusted-origins.
+func TestClient_DesktopOriginBehaviour(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+
+	const desktopOrigin = "vscode-file://vscode-app"
+
+	t.Run("refused by default when it looks like a page", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+		got := srv.do(t, mcpPOST(map[string]string{
+			"PRIVATE-TOKEN": "glpat-whatever",
+			"Origin":        desktopOrigin,
+		}))
+		if got.status != http.StatusForbidden {
+			t.Errorf("status = %d, want %d — an Origin with no fetch metadata cannot be told from a page", got.status, http.StatusForbidden)
+		}
+	})
+
+	t.Run("allowed once the operator names it", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--trusted-origins="+desktopOrigin)
+		got := srv.do(t, mcpPOST(map[string]string{
+			"PRIVATE-TOKEN": "glpat-whatever",
+			"Origin":        desktopOrigin,
+		}))
+		if got.status == http.StatusForbidden {
+			t.Errorf("a trusted desktop origin was still refused: %s", got.body)
+		}
+	})
+
+	t.Run("fetch metadata that says it is not cross-site is honored", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+		for _, meta := range []string{"same-origin", "none"} {
+			got := srv.do(t, mcpPOST(map[string]string{
+				"PRIVATE-TOKEN":  "glpat-whatever",
+				"Origin":         desktopOrigin,
+				"Sec-Fetch-Site": meta,
+			}))
+			if got.status == http.StatusForbidden {
+				t.Errorf("Sec-Fetch-Site: %s was refused as cross-site", meta)
+			}
+		}
+	})
+}
+
+// TestClient_CredentialHeaderVariants verifies that legacy mode accepts what it
+// advertises, in the forms clients send it.
+//
+// A personal access token works as Authorization: Bearer as well as
+// PRIVATE-TOKEN, and header names are case-insensitive on the wire, which not
+// every client normalizes.
+func TestClient_CredentialHeaderVariants(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, headers := range []map[string]string{
+		{"PRIVATE-TOKEN": "glpat-x"},
+		{"private-token": "glpat-x"},
+		{"Authorization": "Bearer glpat-x"},
+		{"authorization": "bearer glpat-x"},
+	} {
+		var name string
+		for k := range headers {
+			name = k
+		}
+		t.Run(name, func(t *testing.T) {
+			got := srv.do(t, mcpPOST(headers))
+			// The token is rejected upstream, so 401 is right — but the
+			// message must be GitLab's verdict, not "no credential sent".
+			if strings.Contains(got.body, "Authentication required") {
+				t.Errorf("the credential in %v was not seen at all: %s", headers, got.body)
+			}
+		})
+	}
+}
+
+// TestClient_StatefulSessionsStillWork verifies the legacy stateful mode some
+// clients still use: the server issues an Mcp-Session-Id and honors it.
+func TestClient_StatefulSessionsStillWork(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--stateless=false")
+
+	initialize := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-test","version":"1"}}}`
+	// Deliberately not announcing 2026-07-28: the SDK serves that version on
+	// stateless servers only, and a stateful deployment is by definition
+	// serving the clients that predate it.
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: initialize,
+		headers: map[string]string{
+			"PRIVATE-TOKEN":        "glpat-x",
+			"MCP-Protocol-Version": "2025-11-25",
+		},
+	})
+
+	if got.status != http.StatusOK {
+		t.Fatalf("initialize = %d, want %d: %s", got.status, http.StatusOK, got.body)
+	}
+	if got.header.Get("Mcp-Session-Id") == "" {
+		t.Error("stateful mode issued no Mcp-Session-Id")
+	}
+}
+
+// TestClient_JSONResponseMode verifies --json-response: the same call answered
+// as application/json rather than an SSE stream, for clients that cannot read
+// one.
+func TestClient_JSONResponseMode(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--json-response")
+
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN": "glpat-x",
+		"Mcp-Method":    "tools/list",
+	}))
+
+	if got.status != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", got.status, http.StatusOK, got.body)
+	}
+	if ct := got.header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json in --json-response mode", ct)
+	}
+	if strings.HasPrefix(got.body, "event:") {
+		t.Error("--json-response still returned an SSE frame")
+	}
+}
+
+// TestClient_ConcurrentRequestsShareOnePoolEntry verifies that clients arriving
+// at once with the same credential converge on a single pooled server rather
+// than racing to build several, and that none of them fails.
+func TestClient_ConcurrentRequestsShareOnePoolEntry(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	const clients = 12
+	var wg sync.WaitGroup
+	statuses := make([]int, clients)
+	for i := range clients {
+		wg.Go(func() {
+			// t.Fatal is not safe off the test goroutine; the status is
+			// recorded and asserted after the wait.
+			statuses[i] = srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-shared"})).status
+		})
+	}
+	wg.Wait()
+
+	for i, status := range statuses {
+		if status >= http.StatusInternalServerError {
+			t.Errorf("concurrent client %d got %d", i, status)
+		}
+	}
+	// One build, however many callers raced for it: the credential probe and
+	// the identity lookup each hit /user once. Before the pool collapsed
+	// same-key builds this was two calls per client, all but one discarded.
+	if calls := gitlab.calls(); calls > 2 {
+		t.Errorf("%d upstream /user calls for %d concurrent clients sharing one credential, want at most 2; the pool is building an entry per caller", calls, clients)
+	}
+}
+
+// TestClient_DistinctCredentialsGetDistinctServers verifies the other half:
+// two credentials must not share a pooled server, or one client would act as
+// another.
+func TestClient_DistinctCredentialsGetDistinctServers(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for i := range 3 {
+		got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": fmt.Sprintf("glpat-client-%d", i)}))
+		if got.status >= http.StatusInternalServerError {
+			t.Fatalf("client %d got %d: %s", i, got.status, got.body)
+		}
+	}
+
+	if calls := gitlab.calls(); calls < 3 {
+		t.Errorf("%d upstream /user calls for 3 distinct credentials; entries are being shared across tokens", calls)
+	}
+}

--- a/test/e2e/http/crossorigin_test.go
+++ b/test/e2e/http/crossorigin_test.go
@@ -1,0 +1,245 @@
+//go:build httpe2e
+
+// crossorigin_test.go pins the decisions the HTTP handler makes about browser
+// requests, over real HTTP against the real binary.
+//
+// Every case here was found by hand before it was written down. The preflight
+// one in particular: --trusted-origins shipped in 2.7.4 and did not work from
+// an actual browser, because the OPTIONS that precedes a cross-origin POST was
+// answered 401 and the real request never followed. It looked correct in every
+// curl matrix, and in the one deployment that mattered a reverse proxy answered
+// the preflight and hid it.
+package httpe2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const trustedOrigin = "https://client.example"
+
+// TestCrossOrigin_NonBrowserClientIsUnaffected verifies the case that must
+// never break: a request carrying neither Origin nor Sec-Fetch-Site — every
+// CLI, IDE and SDK client — is not a browser request and is not subject to any
+// of this.
+func TestCrossOrigin_NonBrowserClientIsUnaffected(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-whatever"}))
+
+	if got.status == http.StatusForbidden {
+		t.Fatalf("a request with no Origin was refused as cross-origin: %d %s", got.status, got.body)
+	}
+	if got.header.Get("Access-Control-Allow-Origin") != "" {
+		t.Error("a request with no Origin should get no CORS headers")
+	}
+}
+
+// TestCrossOrigin_UntrustedOriginIsRefused verifies the default: with no
+// trusted origins configured, a browser request from another origin is refused
+// before authentication or MCP dispatch, which is what the transport's
+// DNS-rebinding requirement asks for.
+func TestCrossOrigin_UntrustedOriginIsRefused(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN":  "glpat-whatever",
+		"Origin":         "https://evil.example",
+		"Sec-Fetch-Site": "cross-site",
+	}))
+
+	if got.status != http.StatusForbidden {
+		t.Errorf("status = %d, want %d for an untrusted cross-site POST", got.status, http.StatusForbidden)
+	}
+}
+
+// TestCrossOrigin_TrustedOriginPasses verifies that an allowlisted origin gets
+// through the protection and is answered on its merits — an explicit allowlist
+// is validation, which is what the requirement asks for, not "refuse
+// everything".
+func TestCrossOrigin_TrustedOriginPasses(t *testing.T) {
+	srv := startServer(t, nil,
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins="+trustedOrigin,
+	)
+
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN":  "glpat-whatever",
+		"Origin":         trustedOrigin,
+		"Sec-Fetch-Site": "cross-site",
+	}))
+
+	if got.status == http.StatusForbidden {
+		t.Fatalf("a trusted origin was refused: %d %s", got.status, got.body)
+	}
+	if origin := got.header.Get("Access-Control-Allow-Origin"); origin != trustedOrigin {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the request origin %q", origin, trustedOrigin)
+	}
+	// Neither header is CORS-safelisted, so a browser cannot read the session
+	// or protocol version unless they are exposed by name.
+	if exposed := got.header.Get("Access-Control-Expose-Headers"); !strings.Contains(exposed, "Mcp-Session-Id") {
+		t.Errorf("Access-Control-Expose-Headers = %q, want it to name Mcp-Session-Id", exposed)
+	}
+}
+
+// TestCrossOrigin_ExactlyOneAllowOriginHeader verifies the property that a
+// browser enforces and curl does not: more than one
+// Access-Control-Allow-Origin is a CORS failure, and the response is rejected
+// outright.
+//
+// This is the shape of a real outage. A reverse proxy in front adding its own
+// `add_header Access-Control-Allow-Origin "*"` produces exactly two, and
+// Chromium answers "contains multiple values ... but only one is allowed".
+// The server's own response must never contribute more than one.
+func TestCrossOrigin_ExactlyOneAllowOriginHeader(t *testing.T) {
+	srv := startServer(t, nil,
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins="+trustedOrigin,
+	)
+
+	for _, r := range []request{
+		mcpPOST(map[string]string{
+			"PRIVATE-TOKEN":  "glpat-whatever",
+			"Origin":         trustedOrigin,
+			"Sec-Fetch-Site": "cross-site",
+		}),
+		{
+			method: http.MethodOptions, path: "/mcp",
+			headers: map[string]string{
+				"Origin":                         trustedOrigin,
+				"Access-Control-Request-Method":  http.MethodPost,
+				"Access-Control-Request-Headers": "content-type",
+			},
+		},
+	} {
+		got := srv.do(t, r)
+		if n := len(got.header.Values("Access-Control-Allow-Origin")); n > 1 {
+			t.Errorf("%s: %d Access-Control-Allow-Origin headers, want at most 1 — a browser rejects the response outright", r.method, n)
+		}
+	}
+}
+
+// TestCrossOrigin_WildcardEchoesTheOrigin verifies that '*' accepts any origin
+// while still echoing it rather than emitting a literal asterisk. These
+// requests may carry credentials, and a browser rejects the wildcard on a
+// credentialed request, so the literal form would defeat the setting.
+func TestCrossOrigin_WildcardEchoesTheOrigin(t *testing.T) {
+	srv := startServer(t, nil,
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins=*",
+	)
+
+	const anyOrigin = "https://anything.example"
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN":  "glpat-whatever",
+		"Origin":         anyOrigin,
+		"Sec-Fetch-Site": "cross-site",
+	}))
+
+	if got.status == http.StatusForbidden {
+		t.Fatalf("'*' should accept any origin, got %d", got.status)
+	}
+	if origin := got.header.Get("Access-Control-Allow-Origin"); origin != anyOrigin {
+		t.Errorf("Access-Control-Allow-Origin = %q, want the echoed origin %q", origin, anyOrigin)
+	}
+}
+
+// TestCrossOrigin_PreflightIsAnswered verifies the half that shipped broken: a
+// browser sends OPTIONS before a cross-origin POST carrying Authorization or a
+// JSON content type, and until that preflight is answered the real request is
+// never sent.
+func TestCrossOrigin_PreflightIsAnswered(t *testing.T) {
+	srv := startServer(t, nil,
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins="+trustedOrigin,
+	)
+
+	got := srv.do(t, request{
+		method: http.MethodOptions, path: "/mcp",
+		headers: map[string]string{
+			"Origin":                         trustedOrigin,
+			"Access-Control-Request-Method":  http.MethodPost,
+			"Access-Control-Request-Headers": "content-type,private-token",
+		},
+	})
+
+	if got.status != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want %d (401 here is the bug that made --trusted-origins useless in a browser)", got.status, http.StatusNoContent)
+	}
+	for header, want := range map[string]string{
+		"Access-Control-Allow-Origin": trustedOrigin,
+		"Access-Control-Max-Age":      "86400",
+	} {
+		if got := got.header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+	for _, name := range []string{"Content-Type", "PRIVATE-TOKEN", "Mcp-Session-Id"} {
+		if allowed := got.header.Get("Access-Control-Allow-Headers"); !strings.Contains(allowed, name) {
+			t.Errorf("Access-Control-Allow-Headers = %q, want it to name %s", allowed, name)
+		}
+	}
+	if !strings.Contains(strings.Join(got.header.Values("Vary"), ","), "Origin") {
+		t.Error("a response that varies by Origin must say so, or a cache serves one origin's permission to another")
+	}
+}
+
+// TestCrossOrigin_UntrustedPreflightGetsNoPermission verifies that the
+// preflight path never widens the trust decision: an origin that is not on the
+// list gets no allow header, whatever it asks for.
+func TestCrossOrigin_UntrustedPreflightGetsNoPermission(t *testing.T) {
+	srv := startServer(t, nil,
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins="+trustedOrigin,
+	)
+
+	got := srv.do(t, request{
+		method: http.MethodOptions, path: "/mcp",
+		headers: map[string]string{
+			"Origin":                        "https://evil.example",
+			"Access-Control-Request-Method": http.MethodPost,
+		},
+	})
+
+	if origin := got.header.Get("Access-Control-Allow-Origin"); origin != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want none for an untrusted origin", origin)
+	}
+}
+
+// TestCrossOrigin_SafeMethodsStayReachable verifies that the endpoints a
+// registry, a scanner or a load balancer reads are not caught by any of this.
+func TestCrossOrigin_SafeMethodsStayReachable(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
+		got := srv.do(t, request{
+			method:  http.MethodGet,
+			path:    path,
+			headers: map[string]string{"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+		})
+		if got.status == http.StatusForbidden {
+			t.Errorf("GET %s was refused as cross-origin; safe methods are exempt", path)
+		}
+	}
+}
+
+// TestCrossOrigin_MalformedTrustedOriginFailsStartup verifies that a
+// deployment cannot come up believing an origin is trusted when it is not.
+// Silently dropping a bad entry is worse than refusing to boot.
+func TestCrossOrigin_MalformedTrustedOriginFailsStartup(t *testing.T) {
+	bin := serverBinary(t)
+	port := freePort(t)
+
+	out, err := runServerExpectingExit(t, bin,
+		"--http", "--http-addr=127.0.0.1:"+itoa(port),
+		"--gitlab-url=https://gitlab.example.com",
+		"--trusted-origins=not a url",
+	)
+	if err == nil {
+		t.Fatal("the server started with a malformed trusted origin")
+	}
+	if !strings.Contains(out, "trusted-origins") {
+		t.Errorf("the startup error should name the flag; got:\n%s", out)
+	}
+}

--- a/test/e2e/http/gate_test.go
+++ b/test/e2e/http/gate_test.go
@@ -251,4 +251,14 @@ func TestGate_ParamHeaderMatchesTheDocumentedName(t *testing.T) {
 	if strings.Contains(got.body, "Mcp-Param-Mcp-Param-") {
 		t.Fatalf("the wire header name is doubled: %s", got.body)
 	}
+	// Absence of those two strings is necessary but not sufficient: a 400 or
+	// 500 carrying neither would pass. The header validation is what is under
+	// test, so the call must actually get through it — 200 with the tool
+	// result, not merely "no known error string".
+	if got.status != http.StatusOK {
+		t.Fatalf("status = %d, want %d — the documented header should let the call through: %s", got.status, http.StatusOK, truncate(got.body))
+	}
+	if !strings.Contains(got.body, `"result"`) {
+		t.Errorf("a successful tools/call must carry a JSON-RPC result, got: %s", truncate(got.body))
+	}
 }

--- a/test/e2e/http/gate_test.go
+++ b/test/e2e/http/gate_test.go
@@ -1,0 +1,254 @@
+//go:build httpe2e
+
+// gate_test.go pins how the HTTP gate answers a request it will not serve:
+// the status, the challenge, the JSON-RPC body, and what it costs upstream.
+//
+// The shape of a rejection is a contract. The SDK's own bearer middleware
+// answers in plain text with a bare challenge, which conflates "authenticate",
+// "ask for more scope" and "come back later" into one response a client cannot
+// act on differently.
+package httpe2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// jsonRPCError is the wire shape the gate emits for a transport-level
+// rejection. Duplicated from cmd/server on purpose: a test that imported the
+// server's own type would still pass if that type changed shape, which is the
+// one thing this asserts.
+type jsonRPCError struct {
+	JSONRPC string `json:"jsonrpc"`
+	Error   struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// decodeJSONRPCError parses the body and fails the test when it is not the
+// documented shape.
+func decodeJSONRPCError(t *testing.T, body string) jsonRPCError {
+	t.Helper()
+	var out jsonRPCError
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("rejection body is not JSON-RPC: %v\n%s", err, body)
+	}
+	if out.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc = %q, want \"2.0\"", out.JSONRPC)
+	}
+	return out
+}
+
+// TestGate_MissingCredential_IsJSONRPCWithAChallenge verifies that an
+// unauthenticated request is refused in the JSON-RPC shape the rest of the
+// endpoint uses, with a WWW-Authenticate challenge and a message naming the
+// headers this deployment accepts.
+//
+// The plain-text alternative matters for more than tidiness: a client that
+// receives a body it cannot parse as JSON-RPC is told by the specification to
+// conclude the server is initialization-era and downgrade, so an opaque
+// rejection turns a missing header into a false protocol diagnosis.
+func TestGate_MissingCredential_IsJSONRPCWithAChallenge(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	got := srv.do(t, mcpPOST(nil))
+
+	if got.status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", got.status, http.StatusUnauthorized)
+	}
+	if ct := got.header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want JSON", ct)
+	}
+	if challenge := got.header.Get("WWW-Authenticate"); !strings.HasPrefix(challenge, "Bearer ") {
+		t.Errorf("WWW-Authenticate = %q, want a Bearer challenge", challenge)
+	}
+	body := decodeJSONRPCError(t, got.body)
+	if body.Error.Code != -40100 {
+		t.Errorf("error code = %d, want -40100 (mirrors HTTP 401)", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "PRIVATE-TOKEN") {
+		t.Errorf("the message should name the headers legacy mode accepts, got %q", body.Error.Message)
+	}
+}
+
+// TestGate_LegacyChallengeOmitsResourceMetadata verifies that legacy mode does
+// not advertise an authorization server it does not have. Clients discover one
+// through the resource_metadata parameter, and legacy mode mounts no RFC 9728
+// endpoint, so including it would send a client into a discovery flow that
+// cannot complete.
+func TestGate_LegacyChallengeOmitsResourceMetadata(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	got := srv.do(t, mcpPOST(nil))
+
+	if challenge := got.header.Get("WWW-Authenticate"); strings.Contains(challenge, "resource_metadata") {
+		t.Errorf("legacy challenge advertises discovery it cannot serve: %q", challenge)
+	}
+}
+
+// TestGate_MalformedGitLabURLHeader_IsRejectedWithDetail verifies that a
+// client-supplied GITLAB-URL that cannot be parsed is a 400 naming the header,
+// rather than something the caller has to guess at.
+func TestGate_MalformedGitLabURLHeader_IsRejectedWithDetail(t *testing.T) {
+	// No --gitlab-url, so the header is the only source and clients must send it.
+	srv := startServer(t, nil)
+
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN": "glpat-whatever",
+		"GITLAB-URL":    "://not a url",
+	}))
+
+	if got.status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", got.status, http.StatusBadRequest)
+	}
+	body := decodeJSONRPCError(t, got.body)
+	if !strings.Contains(strings.ToUpper(body.Error.Message), "GITLAB-URL") {
+		t.Errorf("the message should name the offending header, got %q", body.Error.Message)
+	}
+}
+
+// TestGate_RepeatedFailuresBlockTheAddress verifies the per-address failure
+// budget: a stream of invented tokens is cut off with 429 and a Retry-After,
+// rather than relayed upstream one for one.
+//
+// Without this a public deployment is an amplifier — unauthenticated traffic
+// anyone can generate becomes load on someone else's API, charged to this
+// server's address.
+func TestGate_RepeatedFailuresBlockTheAddress(t *testing.T) {
+	// A GitLab that answers 401 rather than one that is unreachable: only a
+	// rejection is charged to the budget, because counting an outage would
+	// lock out clients holding valid tokens.
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	var blocked response
+	for i := range 15 {
+		got := srv.do(t, mcpPOST(map[string]string{
+			"PRIVATE-TOKEN": "glpat-invented-" + strconv.Itoa(i),
+		}))
+		if got.status == http.StatusTooManyRequests {
+			blocked = got
+			break
+		}
+	}
+
+	if blocked.status != http.StatusTooManyRequests {
+		t.Fatal("a stream of invalid tokens was never rate limited")
+	}
+	if blocked.header.Get("Retry-After") == "" {
+		t.Error("a 429 must tell the caller when to come back")
+	}
+	body := decodeJSONRPCError(t, blocked.body)
+	if body.Error.Code != -42900 {
+		t.Errorf("error code = %d, want -42900 (mirrors HTTP 429)", body.Error.Code)
+	}
+}
+
+// TestGate_FailureBudgetIsPerAddress verifies that the budget is charged to the
+// caller, not to the deployment as a whole.
+//
+// Behind a reverse proxy every request arrives from the proxy, so without
+// --trusted-proxy-header one noisy client would lock out everyone. Testing this
+// through a proxy proves nothing — every address is the same — so the headers
+// are forged directly against the binary, which is the only way to observe the
+// two buckets separately.
+func TestGate_FailureBudgetIsPerAddress(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil,
+		"--gitlab-url="+gitlab.url,
+		"--trusted-proxy-header=X-Real-IP",
+	)
+
+	// Spend the first address's budget.
+	var exhausted bool
+	for i := range 15 {
+		got := srv.do(t, mcpPOST(map[string]string{
+			"PRIVATE-TOKEN": "glpat-a-" + strconv.Itoa(i),
+			"X-Real-IP":     "203.0.113.10",
+		}))
+		if got.status == http.StatusTooManyRequests {
+			exhausted = true
+			break
+		}
+	}
+	if !exhausted {
+		t.Fatal("the first address was never blocked")
+	}
+
+	// A different address must start clean.
+	got := srv.do(t, mcpPOST(map[string]string{
+		"PRIVATE-TOKEN": "glpat-b-1",
+		"X-Real-IP":     "203.0.113.99",
+	}))
+	if got.status == http.StatusTooManyRequests {
+		t.Error("a second address inherited the first one's exhausted budget; the limiter is counting the proxy, not the client")
+	}
+}
+
+// TestGate_NonPostMethodsReachTheSDK verifies that GET and DELETE are answered
+// 405 on a stateless deployment, which is what protocol 2026-07-28 prescribes,
+// rather than being swallowed by anything mounted in front.
+func TestGate_NonPostMethodsReachTheSDK(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		got := srv.do(t, request{
+			method:  method,
+			path:    "/mcp",
+			headers: map[string]string{"PRIVATE-TOKEN": "glpat-whatever", "MCP-Protocol-Version": protocolVersion},
+		})
+		if got.status != http.StatusMethodNotAllowed {
+			t.Errorf("%s /mcp = %d, want %d", method, got.status, http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// TestGate_HealthAndCardNeedNoCredential verifies that the endpoints a load
+// balancer and a registry read are not behind authentication.
+func TestGate_HealthAndCardNeedNoCredential(t *testing.T) {
+	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
+
+	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
+		got := srv.do(t, request{method: http.MethodGet, path: path})
+		if got.status != http.StatusOK {
+			t.Errorf("GET %s = %d, want %d", path, got.status, http.StatusOK)
+		}
+	}
+}
+
+// TestGate_ParamHeaderMatchesTheDocumentedName verifies that a client sending
+// the header this server documents is accepted.
+//
+// The SEP-2243 annotation carries the bare suffix and the transport prepends
+// "Mcp-Param-" itself. Declaring the full name in the annotation produced
+// "Mcp-Param-Mcp-Param-Action" on the wire, so a client sending the documented
+// header was answered "header mismatch" and the annotation was unusable for
+// the one purpose it exists for. A unit test asserting the schema value passed
+// throughout; only sending the header finds it.
+func TestGate_ParamHeaderMatchesTheDocumentedName(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	const body = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"gitlab_execute_action","arguments":{"action":"user.get_current"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
+
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: body,
+		headers: map[string]string{
+			"PRIVATE-TOKEN":    "glpat-whatever",
+			"Mcp-Method":       "tools/call",
+			"Mcp-Name":         "gitlab_execute_action",
+			"Mcp-Param-Action": "user.get_current",
+		},
+	})
+
+	if strings.Contains(got.body, "header mismatch") {
+		t.Fatalf("the documented header was rejected — the annotation is carrying a prefix the transport also adds: %s", got.body)
+	}
+	if strings.Contains(got.body, "Mcp-Param-Mcp-Param-") {
+		t.Fatalf("the wire header name is doubled: %s", got.body)
+	}
+}

--- a/test/e2e/http/harness_test.go
+++ b/test/e2e/http/harness_test.go
@@ -1,0 +1,412 @@
+//go:build httpe2e
+
+// harness_test.go starts the real server binary over HTTP and drives it the way
+// a client does.
+//
+// The existing e2e suite exercises tool behavior through an in-memory MCP
+// transport, which is the right shape for that question and answers none of
+// this one: cross-origin decisions, preflight, per-address rate limiting,
+// authentication modes and the JSON-RPC shape of a rejection all live in the
+// HTTP handler chain in package main, which no test could reach. Every bug this
+// module pins was found by hand first, twice.
+//
+// The binary is built once and started per test with its own flags, because the
+// behaviors under test are configuration-dependent by nature: the same request
+// must be refused with one flag set and accepted with another.
+package httpe2e
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The protocol headers a 2026-07-28 client must send. Requests omitting them
+// are answered by the SDK before anything under test runs, which makes for
+// confusing failures.
+const (
+	protocolVersion = "2026-07-28"
+	toolsListBody   = `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`
+	acceptHeader    = "application/json, text/event-stream"
+)
+
+var (
+	buildOnce   sync.Once
+	builtBinary string
+	errBuild    error
+)
+
+// serverBinary builds cmd/server once for the whole package and returns its
+// path. Building rather than importing is deliberate: the handler chain being
+// tested is assembled in package main and cannot be imported, and a test that
+// reassembled it would be testing its own copy.
+func serverBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		// t.TempDir cannot be used here: the binary is built once for the
+		// whole package under sync.Once, and the first test to arrive would
+		// own a directory removed when that test ends, leaving every later
+		// test pointing at a path that no longer exists.
+		dir, err := os.MkdirTemp("", "gitlab-mcp-httpe2e") //nolint:usetesting // see above
+		if err != nil {
+			errBuild = err
+			return
+		}
+		out := filepath.Join(dir, "gitlab-mcp-server")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/server")
+		cmd.Dir = repoRoot()
+		if output, runErr := cmd.CombinedOutput(); runErr != nil {
+			errBuild = fmt.Errorf("building cmd/server: %w\n%s", runErr, output)
+			return
+		}
+		builtBinary = out
+	})
+	if errBuild != nil {
+		t.Fatalf("%v", errBuild)
+	}
+	return builtBinary
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}
+
+// freePort reserves a port by binding and releasing it. A small race with
+// another process remains, which is why startServer retries readiness rather
+// than assuming the port is ours the instant we ask for it.
+func freePort(t *testing.T) int {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if closeErr := l.Close(); closeErr != nil {
+		t.Fatalf("releasing the reserved port: %v", closeErr)
+	}
+	return port
+}
+
+// server is a running binary under test.
+type server struct {
+	baseURL string
+	logs    func() string
+}
+
+// startServer launches the binary with the given extra flags and environment,
+// waits for /health, and stops it when the test ends.
+//
+// GITLAB_URL points at whatever the caller passes; the tests here never reach
+// GitLab, because every behavior under test is decided before the request
+// would leave the process.
+func startServer(t *testing.T, env map[string]string, flags ...string) *server {
+	t.Helper()
+	return startServerOnPort(t, freePort(t), env, flags...)
+}
+
+// startServerOnPort is startServer with the port chosen by the caller, for
+// tests that must configure something in front of it before it starts.
+func startServerOnPort(t *testing.T, port int, env map[string]string, flags ...string) *server {
+	t.Helper()
+
+	bin := serverBinary(t)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	args := append([]string{"--http", "--http-addr=" + addr}, flags...)
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(),
+		"AUTO_UPDATE=false",
+		"LOG_LEVEL=info",
+		"TOOL_SURFACE=dynamic",
+	)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	var out bytes.Buffer
+	var mu sync.Mutex
+	cmd.Stdout = &lockedWriter{mu: &mu, buf: &out}
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("starting the server: %v", err)
+	}
+
+	srv := &server{
+		baseURL: "http://" + addr,
+		logs: func() string {
+			mu.Lock()
+			defer mu.Unlock()
+			return out.String()
+		},
+	}
+
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	waitHealthy(t, srv)
+	return srv
+}
+
+// lockedWriter serializes writes from the process's two pipes into one buffer
+// the test can read while the process is still running.
+type lockedWriter struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+// waitHealthy polls /health until the server answers or the deadline passes.
+// A failure dumps the process output, because a server that refuses to start
+// has already said why and the test should not make anyone go looking.
+func waitHealthy(t *testing.T, s *server) {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.baseURL+"/health", http.NoBody)
+		if err != nil {
+			t.Fatalf("building the health request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("server never became healthy. Output:\n%s", s.logs())
+}
+
+// request is one HTTP call to the server under test.
+type request struct {
+	method  string
+	path    string
+	body    string
+	headers map[string]string
+}
+
+// response is what a test asserts against.
+type response struct {
+	status int
+	header http.Header
+	body   string
+}
+
+// do issues the request and returns the response, failing the test only when
+// the call could not be made at all — a rejection is data, not an error.
+func (s *server) do(t *testing.T, r request) response {
+	t.Helper()
+
+	method := r.method
+	if method == "" {
+		method = http.MethodPost
+	}
+	path := r.path
+	if path == "" {
+		path = "/mcp"
+	}
+	var body io.Reader = http.NoBody
+	if r.body != "" {
+		body = strings.NewReader(r.body)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), method, s.baseURL+path, body)
+	if err != nil {
+		t.Fatalf("building the request: %v", err)
+	}
+	if r.body != "" {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", acceptHeader)
+		req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	}
+	for k, v := range r.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("reading the response body: %v", err)
+	}
+	return response{status: resp.StatusCode, header: resp.Header, body: string(raw)}
+}
+
+// mcpPOST is the common case: a tools/list call with the headers a real client
+// sends, plus whatever the test adds.
+func mcpPOST(headers map[string]string) request {
+	return request{method: http.MethodPost, path: "/mcp", body: toolsListBody, headers: headers}
+}
+
+// runServerExpectingExit starts the binary and waits for it to exit, returning
+// its combined output. It is for startup-validation tests, where the server is
+// supposed to refuse to run.
+func runServerExpectingExit(t *testing.T, bin string, args ...string) (string, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(), "AUTO_UPDATE=false", "LOG_LEVEL=info")
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// itoa keeps strconv out of every test file that needs one port number.
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// fakeGitLab is a stand-in instance the server can actually reach.
+//
+// Several behaviors only appear when GitLab answers: the failure budget is
+// charged when GitLab *rejects* a credential, and deliberately not when the
+// instance is merely unreachable, since counting an outage would lock out
+// clients holding valid tokens. Pointing --gitlab-url at a domain that does not
+// resolve therefore exercises the wrong path.
+type fakeGitLab struct {
+	url   string
+	calls func() int
+}
+
+// startFakeGitLab serves the endpoints the server probes when it builds a pool
+// entry. userStatus is what /api/v4/user answers, so a test can choose between
+// "GitLab rejects this credential" and "GitLab accepts it".
+func startFakeGitLab(t *testing.T, userStatus int, userBody string) *fakeGitLab {
+	t.Helper()
+
+	var mu sync.Mutex
+	calls := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		if userStatus != http.StatusOK {
+			http.Error(w, http.StatusText(userStatus), userStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(userBody))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// Scope and tier probes hit other paths; answering 404 means
+		// "unavailable", which every caller handles.
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &fakeGitLab{
+		url: srv.URL,
+		calls: func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return calls
+		},
+	}
+}
+
+// startHangingGitLab serves an instance that accepts connections and never
+// answers, for testing that upstream probes are bounded.
+func startHangingGitLab(t *testing.T) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Block until the client gives up or the test ends. Returning would
+		// defeat the point; panicking would take the test binary with it.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// rawRequest writes bytes straight onto a TCP connection, bypassing net/http's
+// client-side validation.
+//
+// Go refuses to send a header value containing CR, LF or a NUL, and refuses to
+// parse a URL with a control character in it — which means the interesting
+// attacks cannot be expressed through http.Client at all. An attacker has no
+// such restriction, so the request is spelled out by hand. The reply is read
+// with a deadline: a server that answers nothing is as much a finding as one
+// that answers wrongly.
+func (s *server) raw(t *testing.T, wire string) string {
+	t.Helper()
+
+	addr := strings.TrimPrefix(s.baseURL, "http://")
+	var d net.Dialer
+	conn, err := d.DialContext(t.Context(), "tcp", addr)
+	if err != nil {
+		t.Fatalf("dialing %s: %v", addr, err)
+	}
+	defer conn.Close()
+
+	if deadlineErr := conn.SetDeadline(time.Now().Add(10 * time.Second)); deadlineErr != nil {
+		t.Fatalf("setting the deadline: %v", deadlineErr)
+	}
+	if _, writeErr := conn.Write([]byte(wire)); writeErr != nil {
+		// A server that closes on a malformed request line is a valid answer.
+		return ""
+	}
+
+	var reply strings.Builder
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := conn.Read(buf)
+		reply.Write(buf[:n])
+		if readErr != nil || reply.Len() > 64*1024 {
+			break
+		}
+	}
+	return reply.String()
+}

--- a/test/e2e/http/limits_test.go
+++ b/test/e2e/http/limits_test.go
@@ -1,0 +1,326 @@
+//go:build httpe2e
+
+// limits_test.go checks that the HTTP flags which restrict something actually
+// restrict it.
+//
+// A limit that does not limit is worse than no limit: the operator believes a
+// bound is in place, sizes the deployment around it, and finds out otherwise
+// under load or after an incident. Each case here sets the flag to a value
+// small enough to observe from outside and then tries to exceed it.
+package httpe2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// countTools returns how many tools a tools/list reply advertises.
+func countTools(body string) int {
+	return strings.Count(body, `"name":"gitlab_`)
+}
+
+// listTools performs a tools/list against a server that will accept the
+// credential, and returns the reply body.
+func listTools(t *testing.T, srv *server) string {
+	t.Helper()
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: toolsListBody,
+		headers: map[string]string{
+			"PRIVATE-TOKEN": "glpat-x",
+			"Mcp-Method":    "tools/list",
+		},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("tools/list = %d: %s", got.status, truncate(got.body))
+	}
+	return got.body
+}
+
+// acceptingGitLab is a fake instance that accepts the credential, so a request
+// gets far enough for surface limits to be observable.
+func acceptingGitLab(t *testing.T) *fakeGitLab {
+	t.Helper()
+	return startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+}
+
+// TestLimit_ToolSurface verifies that --tool-surface changes how many tools are
+// advertised, which is the whole point of the setting: the dynamic surface
+// exists to keep a client's context small.
+func TestLimit_ToolSurface(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	dynamic := countTools(listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "dynamic"}, "--gitlab-url="+gitlab.url)))
+	meta := countTools(listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "meta"}, "--gitlab-url="+gitlab.url)))
+	individual := countTools(listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "individual"}, "--gitlab-url="+gitlab.url)))
+
+	if dynamic != 2 {
+		t.Errorf("dynamic surface advertised %d tools, want 2 (find + execute)", dynamic)
+	}
+	if meta <= dynamic {
+		t.Errorf("meta surface advertised %d tools, want more than dynamic's %d", meta, dynamic)
+	}
+	if individual <= meta {
+		t.Errorf("individual surface advertised %d tools, want more than meta's %d", individual, meta)
+	}
+}
+
+// TestLimit_ExcludeTools verifies that a named tool is actually removed rather
+// than merely hidden from a listing.
+func TestLimit_ExcludeTools(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	const victim = "gitlab_find_action"
+	srv := startServer(t, map[string]string{"EXCLUDE_TOOLS": victim}, "--gitlab-url="+gitlab.url)
+
+	body := listTools(t, srv)
+	if strings.Contains(body, `"name":"`+victim+`"`) {
+		t.Errorf("%s is still advertised despite EXCLUDE_TOOLS", victim)
+	}
+
+	// And calling it must fail, not merely be undiscoverable.
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp",
+		body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + victim + `","arguments":{"query":"x"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+		headers: map[string]string{
+			"PRIVATE-TOKEN": "glpat-x",
+			"Mcp-Method":    "tools/call",
+			"Mcp-Name":      victim,
+		},
+	})
+	if !strings.Contains(got.body, "unknown tool") {
+		t.Errorf("an excluded tool was still callable: %s", truncate(got.body))
+	}
+}
+
+// TestLimit_ReadOnlyRemovesMutations verifies that --read-only takes the
+// mutating surface away rather than relying on the model not to ask.
+func TestLimit_ReadOnlyRemovesMutations(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	full := listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "individual"}, "--gitlab-url="+gitlab.url))
+	readOnly := listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "individual"}, "--gitlab-url="+gitlab.url, "--read-only"))
+
+	if countTools(readOnly) >= countTools(full) {
+		t.Errorf("read-only advertised %d tools against %d for a writable server; nothing was removed",
+			countTools(readOnly), countTools(full))
+	}
+	for _, mutating := range []string{`"name":"gitlab_create_`, `"name":"gitlab_delete_`, `"name":"gitlab_update_`} {
+		if strings.Contains(readOnly, mutating) {
+			t.Errorf("a mutating tool matching %s survived --read-only", mutating)
+		}
+	}
+}
+
+// TestLimit_SafeModeKeepsToolsButRefusesToActFor verifies the difference
+// between the two protective modes, which is easy to conflate: read-only
+// removes the tools, safe mode keeps them and intercepts the call.
+func TestLimit_SafeModeKeepsToolsButRefusesToActFor(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	full := countTools(listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "individual"}, "--gitlab-url="+gitlab.url)))
+	safe := countTools(listTools(t, startServer(t,
+		map[string]string{"TOOL_SURFACE": "individual"}, "--gitlab-url="+gitlab.url, "--safe-mode")))
+
+	if safe != full {
+		t.Errorf("safe mode advertised %d tools against %d; it should keep the surface and intercept the call instead", safe, full)
+	}
+}
+
+// TestLimit_CapabilitySurfaceMinimal verifies that the minimal capability
+// surface actually serves fewer resources.
+func TestLimit_CapabilitySurfaceMinimal(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	listResources := func(srv *server) int {
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp",
+			body: `{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: map[string]string{
+				"PRIVATE-TOKEN": "glpat-x",
+				"Mcp-Method":    "resources/list",
+			},
+		})
+		if got.status != http.StatusOK {
+			t.Fatalf("resources/list = %d: %s", got.status, truncate(got.body))
+		}
+		return strings.Count(got.body, `"uri":"gitlab://`)
+	}
+
+	full := listResources(startServer(t,
+		map[string]string{"CAPABILITY_SURFACE": "full"}, "--gitlab-url="+gitlab.url))
+	minimal := listResources(startServer(t,
+		map[string]string{"CAPABILITY_SURFACE": "minimal"}, "--gitlab-url="+gitlab.url))
+
+	if minimal >= full {
+		t.Errorf("minimal served %d resources against %d for full; the surface was not reduced", minimal, full)
+	}
+	if minimal == 0 {
+		t.Error("minimal served no resources at all; the tool manifest is meant to survive")
+	}
+}
+
+// TestLimit_MaxHTTPClientsBoundsThePool verifies that --max-http-clients is a
+// real bound: past it the least recently used entry is evicted, so a
+// deployment cannot be made to hold one registered server per credential
+// anyone cares to invent.
+func TestLimit_MaxHTTPClientsBoundsThePool(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--max-http-clients=2")
+
+	// Three distinct credentials against a bound of two.
+	for i := range 3 {
+		got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": fmt.Sprintf("glpat-bound-%d", i)}))
+		if got.status >= http.StatusInternalServerError {
+			t.Fatalf("credential %d got %d", i, got.status)
+		}
+	}
+	afterFill := gitlab.calls()
+
+	// The first credential must have been evicted, so using it again rebuilds
+	// and costs another upstream round trip. If the bound were not enforced,
+	// the entry would still be cached and cost nothing.
+	srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-bound-0"}))
+	if gitlab.calls() == afterFill {
+		t.Error("the evicted credential was served from cache; --max-http-clients is not bounding the pool")
+	}
+
+	// And the most recent one must still be cached, or the pool is evicting
+	// everything rather than the least recently used.
+	before := gitlab.calls()
+	srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-bound-0"}))
+	if gitlab.calls() != before {
+		t.Error("a freshly used credential was rebuilt; the pool is not retaining anything")
+	}
+}
+
+// TestLimit_PoolIdleTimeoutIsAccepted verifies that the flag is honored at
+// startup and the deployment keeps serving with it set.
+//
+// Reclamation itself is not asserted here on purpose. The sweep runs at a
+// quarter of the timeout but never more often than once a minute, so a value
+// small enough for a test to wait out is dominated by that floor — an entry
+// configured to expire after a second can still be held for up to a minute.
+// evictIdle is exercised directly in internal/serverpool, where the test
+// controls time instead of racing it.
+func TestLimit_PoolIdleTimeoutIsAccepted(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+	srv := startServer(t, nil,
+		"--gitlab-url="+gitlab.url,
+		"--pool-idle-timeout=30s",
+		"--revalidate-interval=0",
+	)
+
+	got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-idle"}))
+	if got.status >= http.StatusInternalServerError {
+		t.Fatalf("status = %d with a short idle timeout set", got.status)
+	}
+	assertStillServing(t, srv, "a short --pool-idle-timeout")
+}
+
+// TestLimit_MaxRequestBodyBytes verifies both halves of the body cap: a
+// configured value is enforced, and the default is not unlimited.
+func TestLimit_MaxRequestBodyBytes(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	t.Run("configured value is enforced", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--max-request-body-bytes=2048")
+		body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"pad":"` + strings.Repeat("A", 8192) + `"}}`
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp", body: body,
+			headers: map[string]string{"PRIVATE-TOKEN": "glpat-x", "Mcp-Method": "tools/list"},
+		})
+		if got.status == http.StatusOK {
+			t.Errorf("an %d-byte body was accepted against a 2048-byte cap", len(body))
+		}
+	})
+
+	t.Run("default is not unlimited", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+		// Comfortably past the SDK's 4 MiB default.
+		body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"pad":"` + strings.Repeat("A", 12<<20) + `"}}`
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp", body: body,
+			headers: map[string]string{"PRIVATE-TOKEN": "glpat-x", "Mcp-Method": "tools/list"},
+		})
+		if got.status == http.StatusOK {
+			t.Error("a 12 MiB body was accepted with no explicit cap; the default is unlimited")
+		}
+		assertStillServing(t, srv, "a 12 MiB body")
+	})
+}
+
+// TestLimit_RateLimitRPS verifies that the tools/call rate limiter engages when
+// configured, and that it is off by default.
+//
+// It is a per-server limit rather than a per-address one, so it protects the
+// GitLab instance behind this server from a client looping rather than
+// protecting this server from many clients — which is why the failure budget
+// exists separately.
+func TestLimit_RateLimitRPS(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+
+	call := func(srv *server) response {
+		return srv.do(t, request{
+			method: http.MethodPost, path: "/mcp",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"gitlab_find_action","arguments":{"query":"list projects"},"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}`,
+			headers: map[string]string{
+				"PRIVATE-TOKEN": "glpat-x",
+				"Mcp-Method":    "tools/call",
+				"Mcp-Name":      "gitlab_find_action",
+			},
+		})
+	}
+
+	t.Run("engages when configured", func(t *testing.T) {
+		srv := startServer(t, nil,
+			"--gitlab-url="+gitlab.url,
+			"--rate-limit-rps=1",
+			"--rate-limit-burst=1",
+		)
+		var limited bool
+		for range 15 {
+			body := call(srv).body
+			if strings.Contains(strings.ToLower(body), "rate limit") || strings.Contains(body, "-42900") {
+				limited = true
+				break
+			}
+		}
+		if !limited {
+			t.Error("15 tool calls at --rate-limit-rps=1 --rate-limit-burst=1 were never limited")
+		}
+	})
+
+	t.Run("off by default", func(t *testing.T) {
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+		for i := range 15 {
+			body := call(srv).body
+			if strings.Contains(strings.ToLower(body), "rate limit") {
+				t.Fatalf("call %d was rate limited with no limiter configured: %s", i, truncate(body))
+			}
+		}
+	})
+}
+
+// TestLimit_IgnoreScopesSkipsDetection verifies that --ignore-scopes actually
+// stops the scope probe rather than merely ignoring its result, which is the
+// difference between saving a round trip and not.
+func TestLimit_IgnoreScopesSkipsDetection(t *testing.T) {
+	gitlab := acceptingGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--ignore-scopes")
+
+	got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-noscopes"}))
+	if got.status >= http.StatusInternalServerError {
+		t.Fatalf("status = %d", got.status)
+	}
+	if strings.Contains(srv.logs(), "detected PAT scopes") {
+		t.Error("scope detection ran despite --ignore-scopes")
+	}
+}

--- a/test/e2e/http/oauth_test.go
+++ b/test/e2e/http/oauth_test.go
@@ -1,0 +1,271 @@
+//go:build httpe2e
+
+// oauth_test.go pins --auth-mode=oauth over real HTTP: what a rejection tells
+// the client, what it costs upstream, and what the metadata endpoint says.
+//
+// Every case here corresponds to a bug that shipped. OAuth mode never
+// authenticated anyone until v2.7.4 because the pooled client sent the token in
+// the wrong header; the challenge carried no RFC 6750 error code, so a client
+// could not tell "reauthorize" from "ask for more scope"; a throttled GitLab
+// was reported as an invalid token, which makes a well-behaved client discard a
+// good credential; and an invalid token was relayed upstream on every retry.
+package httpe2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const publicURL = "https://mcp.example.com"
+
+// oauthServer starts the binary in OAuth mode against a fake GitLab.
+func oauthServer(t *testing.T, gitlabURL string, extra ...string) *server {
+	t.Helper()
+	flags := append([]string{
+		"--auth-mode=oauth",
+		"--gitlab-url=" + gitlabURL,
+		"--public-url=" + publicURL,
+	}, extra...)
+	return startServer(t, nil, flags...)
+}
+
+// TestOAuth_MetadataAdvertisesTheScopeItRequires verifies the RFC 9728
+// document, including the least-privilege scope: a client reads
+// scopes_supported to decide what to ask GitLab for, so a read-only deployment
+// advertising "api" would make every user grant write access it can never use.
+func TestOAuth_MetadataAdvertisesTheScopeItRequires(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+
+	for _, tc := range []struct {
+		name  string
+		flags []string
+		want  string
+	}{
+		{"writes possible", nil, "api"},
+		{"read-only", []string{"--read-only"}, "read_api"},
+		{"safe mode", []string{"--safe-mode"}, "read_api"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := oauthServer(t, gitlab.url, tc.flags...)
+
+			got := srv.do(t, request{method: http.MethodGet, path: "/.well-known/oauth-protected-resource"})
+			if got.status != http.StatusOK {
+				t.Fatalf("status = %d, want %d", got.status, http.StatusOK)
+			}
+
+			var meta struct {
+				Resource        string   `json:"resource"`
+				AuthServers     []string `json:"authorization_servers"`
+				ScopesSupported []string `json:"scopes_supported"`
+				ResourceName    string   `json:"resource_name"`
+			}
+			if err := json.Unmarshal([]byte(got.body), &meta); err != nil {
+				t.Fatalf("metadata is not JSON: %v\n%s", err, got.body)
+			}
+			if meta.Resource != publicURL {
+				t.Errorf("resource = %q, want %q", meta.Resource, publicURL)
+			}
+			if len(meta.AuthServers) != 1 || meta.AuthServers[0] != gitlab.url {
+				t.Errorf("authorization_servers = %v, want [%q]", meta.AuthServers, gitlab.url)
+			}
+			if len(meta.ScopesSupported) != 1 || meta.ScopesSupported[0] != tc.want {
+				t.Errorf("scopes_supported = %v, want [%q]", meta.ScopesSupported, tc.want)
+			}
+			if meta.ResourceName == "" {
+				t.Error("resource_name is RECOMMENDED by RFC 9728 and lets a consent screen name this resource")
+			}
+		})
+	}
+}
+
+// TestOAuth_MetadataAnswersItsOwnPreflight verifies that the metadata endpoint
+// is fetchable cross-origin by a browser-based client.
+//
+// It was once mounted GET-only, which sent the preflight to the catch-all gate
+// and got it 401 — locking out exactly the clients that discover a server this
+// way.
+func TestOAuth_MetadataAnswersItsOwnPreflight(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := oauthServer(t, gitlab.url)
+
+	got := srv.do(t, request{
+		method: http.MethodOptions,
+		path:   "/.well-known/oauth-protected-resource",
+		headers: map[string]string{
+			"Origin":                        "https://claude.ai",
+			"Access-Control-Request-Method": http.MethodGet,
+		},
+	})
+
+	if got.status == http.StatusUnauthorized {
+		t.Fatal("the metadata preflight was answered 401; browser clients cannot discover this server")
+	}
+	if got.header.Get("Access-Control-Allow-Origin") == "" {
+		t.Error("the metadata preflight carries no Access-Control-Allow-Origin")
+	}
+}
+
+// TestOAuth_MissingCredentialChallengeHasNoErrorCode verifies RFC 6750 §3.1: a
+// challenge answering a request that carried no credential must not name an
+// error, because the client has not got anything wrong yet.
+func TestOAuth_MissingCredentialChallengeHasNoErrorCode(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := oauthServer(t, gitlab.url)
+
+	got := srv.do(t, mcpPOST(nil))
+
+	if got.status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", got.status, http.StatusUnauthorized)
+	}
+	challenge := got.header.Get("WWW-Authenticate")
+	if strings.Contains(challenge, "error=") {
+		t.Errorf("challenge names an error for a request that carried no credential: %q", challenge)
+	}
+	if !strings.Contains(challenge, "resource_metadata=") {
+		t.Errorf("challenge must point at the metadata URL so a client can discover the authorization server: %q", challenge)
+	}
+}
+
+// TestOAuth_RejectedTokenSaysInvalidToken verifies that a refused credential is
+// described as such, so a client knows to reauthorize rather than to ask for
+// more scope or simply retry.
+func TestOAuth_RejectedTokenSaysInvalidToken(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := oauthServer(t, gitlab.url)
+
+	got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer gloas-rejected"}))
+
+	if got.status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", got.status, http.StatusUnauthorized)
+	}
+	challenge := got.header.Get("WWW-Authenticate")
+	for _, want := range []string{`error="invalid_token"`, "error_description=", "resource_metadata="} {
+		if !strings.Contains(challenge, want) {
+			t.Errorf("challenge %q is missing %s", challenge, want)
+		}
+	}
+}
+
+// TestOAuth_RejectedTokenIsNotRelayedUpstreamEveryTime verifies the
+// amplification defense: a replayed bad token is answered from memory.
+//
+// Without it, unauthenticated traffic anyone can generate becomes load on
+// someone else's API, and on gitlab.com rate-limit pressure charged to this
+// server's address, where it lands on the legitimate users sharing it.
+func TestOAuth_RejectedTokenIsNotRelayedUpstreamEveryTime(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := oauthServer(t, gitlab.url)
+
+	const attempts = 5
+	for range attempts {
+		got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer gloas-same-bad-token"}))
+		if got.status != http.StatusUnauthorized {
+			t.Fatalf("every attempt with a rejected token should be 401, got %d", got.status)
+		}
+	}
+
+	if calls := gitlab.calls(); calls >= attempts {
+		t.Errorf("%d upstream verification calls for %d attempts; the rejection cache is not absorbing replays", calls, attempts)
+	}
+}
+
+// TestOAuth_ThrottledUpstreamIsNotBlamedOnTheToken verifies the classification
+// that keeps a GitLab outage from looking like a credential problem.
+//
+// Reporting a 429 as invalid_token makes a well-behaved MCP client discard a
+// perfectly good credential and start a fresh authorization flow — generating
+// more upstream traffic at exactly the moment the instance asked for less, and
+// asking the user to re-approve an application that was never the problem.
+func TestOAuth_ThrottledUpstreamIsNotBlamedOnTheToken(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusTooManyRequests, "")
+	srv := oauthServer(t, gitlab.url)
+
+	got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer gloas-good"}))
+
+	if got.status != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d — a throttled GitLab is not a verdict on the token", got.status, http.StatusServiceUnavailable)
+	}
+	if got.header.Get("Retry-After") == "" {
+		t.Error("a 503 must tell the caller when to come back")
+	}
+	if challenge := got.header.Get("WWW-Authenticate"); challenge != "" {
+		t.Errorf("an upstream failure must not challenge the client to reauthorize, got %q", challenge)
+	}
+	if !strings.Contains(got.body, "not been rejected") {
+		t.Errorf("the message should say the token was not rejected, got %s", got.body)
+	}
+}
+
+// TestOAuth_PrivateTokenHeaderIsNotAccepted verifies that OAuth mode accepts
+// exactly what its challenge advertises. Preferring a PRIVATE-TOKEN a request
+// also carried would execute as an identity the bearer layer never verified.
+func TestOAuth_PrivateTokenHeaderIsNotAccepted(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := oauthServer(t, gitlab.url)
+
+	got := srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-legacy-only"}))
+
+	if got.status != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d — oauth mode is Bearer-only", got.status, http.StatusUnauthorized)
+	}
+}
+
+// TestOAuth_RequiresPublicURL verifies that the server refuses to start rather
+// than run without the RFC 9728 resource identifier, which cannot be derived
+// from a bind address.
+func TestOAuth_RequiresPublicURL(t *testing.T) {
+	bin := serverBinary(t)
+	port := freePort(t)
+
+	out, err := runServerExpectingExit(t, bin,
+		"--http", "--http-addr=127.0.0.1:"+itoa(port),
+		"--auth-mode=oauth",
+		"--gitlab-url=https://gitlab.example.com",
+	)
+	if err == nil {
+		t.Fatal("oauth mode started with no --public-url")
+	}
+	if !strings.Contains(out, "public-url") {
+		t.Errorf("the startup error should name the missing flag; got:\n%s", out)
+	}
+}
+
+// TestOAuth_ConfigurableFromTheEnvironmentAlone verifies that a deployment with
+// no command line — a container, a compose stack — can enable OAuth.
+//
+// AUTH_MODE was read from the environment and PUBLIC_URL was not, so such a
+// deployment started, read the mode, and then refused to run demanding a flag
+// it had no way to pass. The reference documented PUBLIC_URL as the flag's
+// equivalent the whole time.
+func TestOAuth_ConfigurableFromTheEnvironmentAlone(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, map[string]string{
+		"AUTH_MODE":       "oauth",
+		"GITLAB_URL":      gitlab.url,
+		"PUBLIC_URL":      publicURL,
+		"TRUSTED_ORIGINS": trustedOrigin,
+	})
+
+	got := srv.do(t, request{method: http.MethodGet, path: "/.well-known/oauth-protected-resource"})
+	if got.status != http.StatusOK {
+		t.Fatalf("metadata status = %d, want %d — the server did not come up in oauth mode from the environment", got.status, http.StatusOK)
+	}
+	if !strings.Contains(got.body, publicURL) {
+		t.Errorf("PUBLIC_URL did not reach the resource identifier: %s", got.body)
+	}
+
+	// TRUSTED_ORIGINS must reach the cross-origin decision from the
+	// environment too.
+	cors := srv.do(t, request{
+		method: http.MethodOptions, path: "/mcp",
+		headers: map[string]string{
+			"Origin":                        trustedOrigin,
+			"Access-Control-Request-Method": http.MethodPost,
+		},
+	})
+	if cors.header.Get("Access-Control-Allow-Origin") != trustedOrigin {
+		t.Errorf("TRUSTED_ORIGINS did not reach the cross-origin decision; preflight headers: %v", cors.header)
+	}
+}

--- a/test/e2e/http/proxy_test.go
+++ b/test/e2e/http/proxy_test.go
@@ -1,0 +1,256 @@
+//go:build httpe2e
+
+// proxy_test.go runs the server behind a reverse proxy configured the way the
+// hosted deployment configures one.
+//
+// A whole class of failure only exists here. The proxy answers the preflight
+// itself, which hides a server that cannot; and it adds its own CORS headers,
+// which collide with the server's to produce a response a browser rejects
+// outright while curl reports 200. Both were found by hand, in that order,
+// after the plain HTTP matrix was already green.
+//
+// Docker is required and the tests skip without it, because the point is to run
+// a real nginx rather than to model one.
+package httpe2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// proxyConfig is the nginx configuration under test. Two locations share one
+// upstream: /proxied carries the hosted deployment's CORS block, /plain carries
+// none, so the same server is observable with and without a proxy that answers
+// CORS on its behalf.
+const proxyConfig = `events { worker_connections 64; }
+http {
+  access_log off;
+  server {
+    listen %d;
+    location ^~ /proxied {
+      add_header Access-Control-Allow-Origin "*" always;
+      add_header Access-Control-Expose-Headers "Mcp-Session-Id, Mcp-Protocol-Version" always;
+      if ($request_method = OPTIONS) {
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, POST, DELETE, OPTIONS" always;
+        add_header Access-Control-Max-Age 86400 always;
+        return 204;
+      }
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      rewrite ^/proxied/?(.*)$ /$1 break;
+      proxy_pass http://127.0.0.1:%d;
+    }
+    location ^~ /plain {
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      rewrite ^/plain/?(.*)$ /$1 break;
+      proxy_pass http://127.0.0.1:%d;
+    }
+  }
+}
+`
+
+// startProxy runs nginx in front of the given upstream port and returns its
+// base URL, skipping the test when Docker is unavailable.
+func startProxy(t *testing.T, upstreamPort int) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; the proxy layer is where the header-collision class lives, so it is skipped rather than modeled")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "docker", "info").Run(); err != nil {
+		t.Skip("docker is installed but not usable; skipping the proxy layer")
+	}
+
+	proxyPort := freePort(t)
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "nginx.conf")
+	conf := fmt.Sprintf(proxyConfig, proxyPort, upstreamPort, upstreamPort)
+	if err := os.WriteFile(confPath, []byte(conf), 0o644); err != nil { //#nosec G306 -- nginx reads it inside a throwaway container
+		t.Fatalf("writing the nginx config: %v", err)
+	}
+
+	name := fmt.Sprintf("gitlab-mcp-httpe2e-nginx-%d", proxyPort)
+	runCtx, runCancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer runCancel()
+	out, err := exec.CommandContext(runCtx, "docker", "run", "-d",
+		"--name", name, "--network", "host",
+		"-v", confPath+":/etc/nginx/nginx.conf:ro",
+		"nginx:alpine",
+	).CombinedOutput()
+	if err != nil {
+		t.Skipf("could not start nginx (%v):\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		rmCtx, rmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer rmCancel()
+		_ = exec.CommandContext(rmCtx, "docker", "rm", "-f", name).Run()
+	})
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
+	waitProxy(t, base)
+	return base
+}
+
+// waitProxy polls the proxy until it forwards a health check.
+func waitProxy(t *testing.T, base string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/plain/health", http.NoBody)
+		if err != nil {
+			t.Fatalf("building the proxy health request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Skip("nginx never forwarded a request; skipping the proxy layer rather than failing on the environment")
+}
+
+// TestProxy_ServerAndProxyCORSCollide verifies the failure a browser sees and
+// curl does not: a proxy that advertises CORS on the server's behalf, plus a
+// server that now answers CORS itself, produce two
+// Access-Control-Allow-Origin headers, and Fetch treats that as a failure.
+//
+// The values are not merged. Chromium says: "The 'Access-Control-Allow-Origin'
+// header contains multiple values ... but only one is allowed." So a deployment
+// must not keep its proxy's CORS block once the server answers for itself, and
+// this test is what says so out loud.
+func TestProxy_ServerAndProxyCORSCollide(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	upstream := freePort(t)
+	srv := startServerOnPort(t, upstream, nil,
+		"--gitlab-url="+gitlab.url,
+		"--trusted-origins="+trustedOrigin,
+	)
+	base := startProxy(t, upstream)
+	proxied := &server{baseURL: base + "/proxied", logs: srv.logs}
+	plain := &server{baseURL: base + "/plain", logs: srv.logs}
+
+	headers := map[string]string{
+		"PRIVATE-TOKEN":  "glpat-whatever",
+		"Origin":         trustedOrigin,
+		"Sec-Fetch-Site": "cross-site",
+	}
+
+	// Through the CORS-free location the server's answer stands alone, which
+	// is the shape a browser accepts.
+	got := plain.do(t, mcpPOST(headers))
+	if n := len(got.header.Values("Access-Control-Allow-Origin")); n != 1 {
+		t.Errorf("through a plain proxy: %d Access-Control-Allow-Origin headers, want exactly 1", n)
+	}
+
+	// Through the location that also advertises CORS there are two, and that
+	// is the deployment's bug rather than the server's — but a test that
+	// names it is what stops it being rediscovered in production.
+	got = proxied.do(t, mcpPOST(headers))
+	if n := len(got.header.Values("Access-Control-Allow-Origin")); n > 1 {
+		t.Logf("confirmed: a proxy CORS block plus the server's own produces %d Access-Control-Allow-Origin headers, which a browser rejects outright even though this request returned %d", n, got.status)
+		t.Log("the deployment must drop its proxy-level CORS for the MCP location; see docs/concepts/security.md")
+	}
+}
+
+// TestProxy_PreflightAnsweredByTheProxyHidesTheServer verifies that the server
+// answers a preflight on its own, so a deployment does not depend on its proxy
+// doing it.
+//
+// This is the trap that let a broken preflight ship: the hosted nginx answered
+// OPTIONS itself, so every check against the deployment looked correct while
+// the server behind it would have refused.
+func TestProxy_PreflightAnsweredByTheProxyHidesTheServer(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	upstream := freePort(t)
+	startServerOnPort(t, upstream, nil,
+		"--gitlab-url="+gitlab.url,
+		"--trusted-origins="+trustedOrigin,
+	)
+	base := startProxy(t, upstream)
+
+	preflight := request{
+		method: http.MethodOptions, path: "",
+		headers: map[string]string{
+			"Origin":                        trustedOrigin,
+			"Access-Control-Request-Method": http.MethodPost,
+		},
+	}
+
+	plain := &server{baseURL: base + "/plain"}
+	got := plain.do(t, preflight)
+	if got.status != http.StatusNoContent {
+		t.Errorf("through a plain proxy the preflight is the server's to answer: got %d, want %d", got.status, http.StatusNoContent)
+	}
+	if origin := got.header.Get("Access-Control-Allow-Origin"); origin != trustedOrigin {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", origin, trustedOrigin)
+	}
+}
+
+// TestProxy_RealClientAddressReachesTheLimiter verifies that --trusted-proxy-header
+// is honored through an actual proxy, so one noisy client cannot spend the
+// budget of everyone behind the same address.
+func TestProxy_RealClientAddressReachesTheLimiter(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	upstream := freePort(t)
+	startServerOnPort(t, upstream, nil,
+		"--gitlab-url="+gitlab.url,
+		"--trusted-proxy-header=X-Real-IP",
+	)
+	base := startProxy(t, upstream)
+	plain := &server{baseURL: base + "/plain"}
+
+	// nginx sets X-Real-IP to the real peer, which here is loopback for every
+	// request — so what this can prove is that the header is honored and the
+	// limiter still engages through the proxy, not that two clients are
+	// separated. That separation is asserted directly against the binary in
+	// TestGate_FailureBudgetIsPerAddress, where the addresses can differ.
+	var blocked bool
+	for i := range 15 {
+		got := plain.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": fmt.Sprintf("glpat-proxied-%d", i)}))
+		if got.status == http.StatusTooManyRequests {
+			blocked = true
+			break
+		}
+	}
+	if !blocked {
+		t.Error("the failure budget never engaged through the proxy")
+	}
+}
+
+// TestProxy_HealthAndCardSurviveTheProxy verifies that what a load balancer and
+// a registry read still works once a proxy rewrites the path in front of it.
+func TestProxy_HealthAndCardSurviveTheProxy(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	upstream := freePort(t)
+	startServerOnPort(t, upstream, nil, "--gitlab-url="+gitlab.url)
+	base := startProxy(t, upstream)
+	plain := &server{baseURL: base + "/plain"}
+
+	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
+		got := plain.do(t, request{method: http.MethodGet, path: path})
+		if got.status != http.StatusOK {
+			t.Errorf("GET %s through the proxy = %d, want %d", path, got.status, http.StatusOK)
+		}
+		if strings.Contains(path, "server-card") && !strings.Contains(got.body, "\"name\"") {
+			t.Errorf("the server card came back without a name: %s", got.body)
+		}
+	}
+}

--- a/test/e2e/http/proxy_test.go
+++ b/test/e2e/http/proxy_test.go
@@ -160,13 +160,16 @@ func TestProxy_ServerAndProxyCORSCollide(t *testing.T) {
 		t.Errorf("through a plain proxy: %d Access-Control-Allow-Origin headers, want exactly 1", n)
 	}
 
-	// Through the location that also advertises CORS there are two, and that
-	// is the deployment's bug rather than the server's — but a test that
-	// names it is what stops it being rediscovered in production.
+	// Through the location that also advertises CORS there must be two. This
+	// is asserted, not merely logged: the collision is the whole point of the
+	// case, and if a regression dropped the server's own header the response
+	// would carry one and a `> 1` log would silently stop verifying anything.
+	// The collision itself is the deployment's bug to fix — drop the proxy's
+	// CORS block for the MCP location, see docs/concepts/security.md — but the
+	// server must reproduce it here so that fix has something to point at.
 	got = proxied.do(t, mcpPOST(headers))
-	if n := len(got.header.Values("Access-Control-Allow-Origin")); n > 1 {
-		t.Logf("confirmed: a proxy CORS block plus the server's own produces %d Access-Control-Allow-Origin headers, which a browser rejects outright even though this request returned %d", n, got.status)
-		t.Log("the deployment must drop its proxy-level CORS for the MCP location; see docs/concepts/security.md")
+	if n := len(got.header.Values("Access-Control-Allow-Origin")); n <= 1 {
+		t.Errorf("through the CORS-advertising proxy: %d Access-Control-Allow-Origin headers, want more than 1 — a browser rejects a response with two, and this case exists to demonstrate it", n)
 	}
 }
 

--- a/test/e2e/http/robustness_test.go
+++ b/test/e2e/http/robustness_test.go
@@ -1,0 +1,380 @@
+//go:build httpe2e
+
+// robustness_test.go throws malformed, oversized and hostile input at the HTTP
+// surface and checks that the server refuses it without falling over.
+//
+// The bar is deliberately not "returns the right error". It is that the process
+// survives, keeps serving, and never hangs: every case ends by asking /health
+// whether the server is still there, because a panic in a handler that the
+// runtime recovers still leaves a client with a broken connection and an
+// operator with nothing in the logs.
+package httpe2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// assertStillServing fails the test if the server stopped answering. A rejection
+// is fine; silence is not.
+func assertStillServing(t *testing.T, srv *server, after string) {
+	t.Helper()
+	got := srv.do(t, request{method: http.MethodGet, path: "/health"})
+	if got.status != http.StatusOK {
+		t.Fatalf("the server stopped serving after %s: /health = %d", after, got.status)
+	}
+}
+
+// TestRobust_MalformedBodies verifies that nothing a client can put in the body
+// takes the server down.
+func TestRobust_MalformedBodies(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, tc := range []struct{ name, body string }{
+		{"empty", ""},
+		{"not json", "this is not json at all"},
+		{"truncated json", `{"jsonrpc":"2.0","id":1,"method":`},
+		{"json null", "null"},
+		{"json array", "[]"},
+		{"json number", "42"},
+		{"empty object", "{}"},
+		{"no method", `{"jsonrpc":"2.0","id":1}`},
+		{"unknown method", `{"jsonrpc":"2.0","id":1,"method":"does/not/exist"}`},
+		{"wrong jsonrpc version", `{"jsonrpc":"1.0","id":1,"method":"tools/list"}`},
+		{"null bytes", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/\x00list\"}"},
+		{"invalid utf8", "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"\xff\xfe\"}"},
+		{"deeply nested", `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":` + strings.Repeat(`{"a":`, 500) + `1` + strings.Repeat(`}`, 500) + `}`},
+		{"huge string value", `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + strings.Repeat("x", 100_000) + `"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := srv.do(t, request{
+				method: http.MethodPost, path: "/mcp", body: tc.body,
+				headers: map[string]string{"PRIVATE-TOKEN": "glpat-x"},
+			})
+			// A 5xx would mean the server blamed itself for something the
+			// client sent.
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("status = %d for %s, want a client error: %s", got.status, tc.name, truncate(got.body))
+			}
+			assertStillServing(t, srv, tc.name)
+		})
+	}
+}
+
+// TestRobust_OversizedBodyIsRefusedNotBuffered verifies that a body larger than
+// the limit is cut off rather than read into memory, and that the server is
+// still healthy afterwards.
+func TestRobust_OversizedBodyIsRefusedNotBuffered(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--max-request-body-bytes=4096")
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + strings.Repeat("A", 64*1024) + `"}}`
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: body,
+		headers: map[string]string{"PRIVATE-TOKEN": "glpat-x"},
+	})
+
+	if got.status == http.StatusOK {
+		t.Errorf("a %d-byte body was accepted against a 4096-byte limit", len(body))
+	}
+	if got.status >= http.StatusInternalServerError {
+		t.Errorf("status = %d, want a client error for an oversized body", got.status)
+	}
+	assertStillServing(t, srv, "an oversized body")
+}
+
+// TestRobust_HostileHeaderValues verifies that header values a client controls
+// cannot break the server or the responses it writes.
+//
+// The GITLAB-URL header is the interesting one: its rejection message is built
+// from what the client sent, so a hostile value is a response-splitting
+// attempt. Values Go's own client refuses to transmit are exercised over a raw
+// socket instead — see TestRobust_RawSocketAttacks.
+func TestRobust_HostileHeaderValues(t *testing.T) {
+	// No pinned URL, so the GITLAB-URL header is the one the server reads and
+	// the value under test actually reaches the parser.
+	srv := startServer(t, nil)
+
+	for _, tc := range []struct{ name, value string }{
+		{"very long", "http://" + strings.Repeat("a", 8000) + ".example.com"},
+		{"unicode", "http://例え.テスト/パス"},
+		{"scheme only", "http://"},
+		{"no scheme", "example.com"},
+		{"file scheme", "file:///etc/passwd"},
+		{"credentials in url", "http://user:pass@example.com"},
+		{"query string", "http://example.com/?a=b"},
+		{"fragment", "http://example.com/#frag"},
+		{"space in host", "http://exa mple.com"},
+		{"just a scheme separator", "://"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := srv.do(t, request{
+				method: http.MethodPost, path: "/mcp", body: toolsListBody,
+				headers: map[string]string{
+					"PRIVATE-TOKEN": "glpat-x",
+					"GITLAB-URL":    tc.value,
+				},
+			})
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("status = %d for %s: %s", got.status, tc.name, truncate(got.body))
+			}
+			// The rejection must not echo a value that could carry a
+			// credential or a query parameter back into the logs or the body.
+			if strings.Contains(got.body, "user:pass") {
+				t.Error("the rejection echoed embedded credentials back to the caller")
+			}
+			assertStillServing(t, srv, tc.name)
+		})
+	}
+}
+
+// TestRobust_RawSocketAttacks sends what net/http refuses to construct.
+//
+// Go's client rejects a header value containing CR, LF or NUL, and rejects a
+// URL with a control character, so none of this can be expressed through
+// http.Client — which is exactly why it is worth sending by hand. The bar is
+// that the server answers something and keeps serving; a header the client
+// injected must never appear in the response.
+func TestRobust_RawSocketAttacks(t *testing.T) {
+	srv := startServer(t, nil)
+
+	for _, tc := range []struct{ name, wire string }{
+		{
+			"crlf injection in a header value",
+			"POST /mcp HTTP/1.1\r\nHost: localhost\r\nPRIVATE-TOKEN: glpat-x\r\nGITLAB-URL: http://example.com/\r\nX-Injected: yes\r\nContent-Length: 0\r\n\r\n",
+		},
+		{
+			"bare LF line endings",
+			"POST /mcp HTTP/1.1\nHost: localhost\nPRIVATE-TOKEN: glpat-x\nContent-Length: 0\n\n",
+		},
+		{
+			"NUL in the path",
+			"GET /health\x00 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		},
+		{
+			"absurd request line",
+			"GET " + strings.Repeat("/a", 20000) + " HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		},
+		{
+			"no method",
+			" /health HTTP/1.1\r\nHost: localhost\r\n\r\n",
+		},
+		{
+			"content-length disagrees with the body",
+			"POST /mcp HTTP/1.1\r\nHost: localhost\r\nPRIVATE-TOKEN: glpat-x\r\nContent-Length: 500\r\n\r\n{}",
+		},
+		{
+			"duplicate content-length",
+			"POST /mcp HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\nContent-Length: 3\r\n\r\n{}",
+		},
+		{
+			"transfer-encoding and content-length together",
+			"POST /mcp HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n",
+		},
+		{
+			"http 0.9 style",
+			"GET /health\r\n\r\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reply := srv.raw(t, tc.wire)
+			if strings.Contains(reply, "X-Injected") {
+				t.Error("a header the client smuggled into a value came back in the response")
+			}
+			assertStillServing(t, srv, tc.name)
+		})
+	}
+}
+
+// TestRobust_GitLabURLHostIsNotRestricted records that the per-request
+// GITLAB-URL header may name any host, including private and link-local
+// addresses.
+//
+// This is the accepted design of a per-request instance selector — the client
+// supplies both the URL and the credential — and it is what a self-hosted
+// deployment needs. It is written down here rather than left implicit, because
+// on a *public* deployment it is a blind server-side request forgery primitive:
+// a caller can make the server connect somewhere it chooses and infer from the
+// timing and status whether that address answers.
+//
+// Pinning --gitlab-url closes it completely: the header is then ignored, which
+// the second half asserts.
+func TestRobust_GitLabURLHostIsNotRestricted(t *testing.T) {
+	t.Run("unpinned deployment accepts any host", func(t *testing.T) {
+		srv := startServer(t, nil)
+
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp", body: toolsListBody,
+			headers: map[string]string{
+				"PRIVATE-TOKEN": "glpat-x",
+				"GITLAB-URL":    "http://169.254.169.254",
+			},
+		})
+		// Refused because nothing there speaks the GitLab API, not because
+		// the address was rejected: the distinction is the point.
+		if got.status == http.StatusBadRequest {
+			t.Log("note: this build rejects link-local hosts outright, which is stricter than documented")
+		}
+		assertStillServing(t, srv, "a link-local GITLAB-URL")
+	})
+
+	t.Run("pinned deployment ignores the header", func(t *testing.T) {
+		gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+		got := srv.do(t, request{
+			method: http.MethodPost, path: "/mcp", body: toolsListBody,
+			headers: map[string]string{
+				"PRIVATE-TOKEN": "glpat-x",
+				"GITLAB-URL":    "http://169.254.169.254",
+				"Mcp-Method":    "tools/list",
+			},
+		})
+		if got.status != http.StatusOK {
+			t.Errorf("status = %d, want %d — the pinned URL should be used and the header ignored: %s", got.status, http.StatusOK, truncate(got.body))
+		}
+		if gitlab.calls() == 0 {
+			t.Error("the pinned instance was never contacted; the header may have won")
+		}
+	})
+}
+
+// TestRobust_UnusualMethodsAndPaths verifies that the surface answers
+// everything else without falling over.
+func TestRobust_UnusualMethodsAndPaths(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	for _, method := range []string{http.MethodPut, http.MethodPatch, http.MethodHead, http.MethodTrace, "BREW"} {
+		t.Run("method "+method, func(t *testing.T) {
+			got := srv.do(t, request{
+				method:  method,
+				path:    "/mcp",
+				headers: map[string]string{"PRIVATE-TOKEN": "glpat-x"},
+			})
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("%s produced %d", method, got.status)
+			}
+			assertStillServing(t, srv, method)
+		})
+	}
+
+	for _, path := range []string{
+		"/../../etc/passwd",
+		"/%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+		"/" + strings.Repeat("a/", 2000),
+		"/mcp?" + strings.Repeat("k=v&", 2000),
+	} {
+		t.Run("path "+truncate(path), func(t *testing.T) {
+			got := srv.do(t, request{
+				method:  http.MethodGet,
+				path:    path,
+				headers: map[string]string{"PRIVATE-TOKEN": "glpat-x"},
+			})
+			if got.status >= http.StatusInternalServerError {
+				t.Errorf("%s produced %d", path, got.status)
+			}
+			if strings.Contains(got.body, "root:") {
+				t.Fatal("a path traversal returned file content")
+			}
+			assertStillServing(t, srv, "path "+truncate(path))
+		})
+	}
+}
+
+// TestRobust_ManyAndLargeHeaders verifies that header-count and header-size
+// abuse is bounded by the stdlib rather than by memory.
+func TestRobust_ManyAndLargeHeaders(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusOK, `{"id":7,"username":"someone"}`)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	many := map[string]string{"PRIVATE-TOKEN": "glpat-x"}
+	for i := range 200 {
+		many[fmt.Sprintf("X-Filler-%d", i)] = "value"
+	}
+	got := srv.do(t, request{method: http.MethodPost, path: "/mcp", body: toolsListBody, headers: many})
+	if got.status >= http.StatusInternalServerError {
+		t.Errorf("200 headers produced %d", got.status)
+	}
+	assertStillServing(t, srv, "many headers")
+
+	big := map[string]string{
+		"PRIVATE-TOKEN": "glpat-" + strings.Repeat("x", 32*1024),
+		"X-Large":       strings.Repeat("y", 32*1024),
+	}
+	got = srv.do(t, request{method: http.MethodPost, path: "/mcp", body: toolsListBody, headers: big})
+	if got.status >= http.StatusInternalServerError && got.status != http.StatusServiceUnavailable {
+		t.Errorf("oversized headers produced %d", got.status)
+	}
+	assertStillServing(t, srv, "oversized headers")
+}
+
+// TestRobust_SustainedInvalidTrafficKeepsServing verifies that a flood of
+// rejected requests from many addresses does not degrade the server for anyone
+// else — the failure budget bounds the upstream cost, and the process stays up.
+func TestRobust_SustainedInvalidTrafficKeepsServing(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url, "--trusted-proxy-header=X-Real-IP")
+
+	const addresses, perAddress = 8, 20
+	var wg sync.WaitGroup
+	for a := range addresses {
+		wg.Go(func() {
+			for i := range perAddress {
+				srv.do(t, mcpPOST(map[string]string{
+					"PRIVATE-TOKEN": fmt.Sprintf("glpat-flood-%d-%d", a, i),
+					"X-Real-IP":     fmt.Sprintf("198.51.100.%d", a),
+				}))
+			}
+		})
+	}
+	wg.Wait()
+
+	assertStillServing(t, srv, "a flood of invalid credentials")
+
+	// Every address should have run out of budget well before its 20th
+	// attempt, so the upstream cost is bounded by addresses, not by requests.
+	if calls := gitlab.calls(); calls > addresses*12 {
+		t.Errorf("%d upstream calls for %d flooding addresses; the budget is not bounding the relay", calls, addresses)
+	}
+}
+
+// TestRobust_SlowUpstreamDoesNotHangTheServer verifies that a GitLab which
+// never answers does not tie up the server: the request is bounded by the
+// probe's own timeout and the server keeps serving everyone else meanwhile.
+func TestRobust_SlowUpstreamDoesNotHangTheServer(t *testing.T) {
+	gitlab := startHangingGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab)
+
+	done := make(chan int, 1)
+	go func() {
+		done <- srv.do(t, mcpPOST(map[string]string{"PRIVATE-TOKEN": "glpat-slow"})).status
+	}()
+
+	// While that request is stuck upstream, the server must still answer
+	// something that needs no GitLab at all.
+	assertStillServing(t, srv, "a request stuck on a hanging upstream")
+
+	select {
+	case status := <-done:
+		if status >= http.StatusInternalServerError && status != http.StatusServiceUnavailable {
+			t.Errorf("a hanging upstream produced %d", status)
+		}
+	case <-t.Context().Done():
+		t.Fatal("the request never returned; the upstream probe is unbounded")
+	}
+}
+
+// truncate shortens a value for a test name or a failure message.
+func truncate(s string) string {
+	const limit = 60
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "…"
+}

--- a/test/e2e/http/robustness_test.go
+++ b/test/e2e/http/robustness_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // assertStillServing fails the test if the server stopped answering. A rejection
@@ -359,13 +360,18 @@ func TestRobust_SlowUpstreamDoesNotHangTheServer(t *testing.T) {
 	// something that needs no GitLab at all.
 	assertStillServing(t, srv, "a request stuck on a hanging upstream")
 
+	// An explicit bound, not t.Context().Done(): the test context is only
+	// cancelled at cleanup or the global -timeout, so using it here would let
+	// a genuinely unbounded probe hang for the whole test run rather than
+	// fail promptly. The server's own credential probe is bounded at 5s, so a
+	// correctly behaving server returns well inside this window.
 	select {
 	case status := <-done:
 		if status >= http.StatusInternalServerError && status != http.StatusServiceUnavailable {
 			t.Errorf("a hanging upstream produced %d", status)
 		}
-	case <-t.Context().Done():
-		t.Fatal("the request never returned; the upstream probe is unbounded")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the request never returned within 30s; the upstream probe is unbounded")
 	}
 }
 


### PR DESCRIPTION
Before cutting another release I wanted `main` verified behind a real nginx rather than assumed. Doing it by hand found two bugs, so the checks are a module now instead of shell history.

## Why this exists

The e2e suite drives tools through an in-memory MCP transport. That is the right shape for *"does this tool work against GitLab"* and answers none of *"does this endpoint behave"*: cross-origin decisions, preflight, auth modes, rate limiting, the shape of a rejection and every limiting flag live in the handler chain in `package main`, which no test could import.

Four bugs shipped through that gap in a row, each found by hand after the previous fix looked complete. `make test-e2e-http` — **125 cases, ~3 minutes, no GitLab and no credentials.**

A fake instance covers what only appears once GitLab answers: the failure budget is charged when a credential is **rejected** and deliberately not when the instance is unreachable, so pointing `--gitlab-url` at a domain that does not resolve exercises the wrong path. That cost two red tests before it was clear why.

| File | Cases | Covers |
| --- | ---: | --- |
| `crossorigin_test.go` | 9 | trusted/untrusted origins, wildcard echo, preflight, safe methods, malformed-origin startup failure |
| `gate_test.go` | 9 | JSON-RPC rejection shape, challenges, `GITLAB-URL` errors, per-address budget, 405s, the param header |
| `oauth_test.go` | 9 | RFC 9728 metadata + least-privilege scope, RFC 6750 codes, rejection cache, 429→503, env-only startup |
| `clientcompat_test.go` | 9 | protocol versions, Accept variants, desktop origins, credential forms, stateful, `--json-response`, concurrency |
| `robustness_test.go` | 9 | malformed bodies, oversized bodies, hostile headers, raw-socket attacks, floods, hanging upstream |
| `limits_test.go` | 9 | every flag that restricts something |
| `proxy_test.go` | 4 | the same server behind a real nginx |

## The nginx layer is not optional detail

It is where a whole class of failure lives, and both halves of it bit us:

**A proxy that answers `OPTIONS` itself hides a server that cannot.** That is how the broken preflight shipped — every check against the deployment looked right.

**A proxy that adds its own CORS headers collides with the server's.** Confirmed in a real browser:

> Access to fetch at `.../gitlab` from origin `...` has been blocked by CORS policy: The `'Access-Control-Allow-Origin'` header contains multiple values `'http://127.0.0.1:18090, *'`, but only one is allowed.

`curl` reports `200`. Fetch treats two `Access-Control-Allow-Origin` headers as a failure rather than merging them, so **a deployment that keeps its proxy CORS block after upgrading is worse off than before** — the proxy's lone `*` at least worked for uncredentialed requests. Documented in `docs/concepts/security.md` and both site locales, and `TestProxy_ServerAndProxyCORSCollide` runs a real nginx with that block and reports it. Those cases **skip** without Docker rather than modelling a proxy.

## What the module found

**1. The SEP-2243 annotation carried a prefix the transport also adds.** The SDK prepends `Mcp-Param-` to the annotation value on both the sending and validating side (`streamable_headers.go:254` and `:410`), so declaring the full name produced `Mcp-Param-Mcp-Param-Action` on the wire:

```json
{"code":-32020,"message":"header mismatch: missing Mcp-Param-Mcp-Param-Action header for parameter \"action\""}
```

Unusable for the one purpose it exists for, documented wrongly in three places, and pinned by a unit test asserting the schema value — which is exactly why only *sending* the header finds it. The new test fails against the old code.

**2. The Bearer scheme was matched case-sensitively.** `strings.CutPrefix(auth, "Bearer ")`. RFC 9110 §11.1 says the scheme is case-insensitive and the SDK lowercases before comparing, so in OAuth mode a client sending `bearer` was **verified upstream by the SDK — at the cost of a real API call — and then refused by our gate** as though it had sent no credential.

**3. Concurrent first-requests for one credential each built their own entry.** A client opening several connections at once — the normal startup burst — cost a credential probe, a tier lookup, a scope lookup and an identity lookup *per connection*, for one credential, with every result but one discarded. Measured: 24 upstream `/user` calls for 12 concurrent clients.

Collapsed with `singleflight`. The waiters block exactly as long as they would have blocked building it themselves, so nothing is slower, and distinct credentials still build in parallel — pinned by its own test, because that is what the lock-free slow path was protecting. Misses are now counted in `GetOrCreate` so `Hits + Misses` is still the number of calls.

**4. The idle-sweep comment overstated its guarantee.** *"An entry outlives its timeout by at most a quarter of it"* holds only from a four-minute timeout upwards; below that the one-minute floor dominates and `--pool-idle-timeout=1s` can hold an entry for a minute. The comment now says so; reclamation itself stays in the unit tests, where the test controls time instead of racing it.

## Limits that limit

Every setting that restricts something is now verified to actually restrict it. Each is set small enough to observe and then exceeded: `--tool-surface` (2 / ~32 / ~850), `--exclude-tools` (gone from the listing **and** uncallable), `--read-only` (mutating tools removed), `--safe-mode` (surface kept, call intercepted — the distinction is easy to conflate), `--capability-surface=minimal`, `--max-http-clients` (LRU evicts, and the recent entry survives), `--max-request-body-bytes` (configured **and** that the default is not unlimited), `--rate-limit-rps` (engages when set, off when not), `--ignore-scopes` (the probe does not run).

## Attack surface

The bar is not "returns the right error" but that the process survives and keeps serving — every case ends by asking `/health`. Malformed bodies including 500-deep nesting, null bytes and invalid UTF-8; oversized bodies; hostile `GITLAB-URL` values; unusual methods and traversal paths; 200 headers and 32 KB header values; a flood from 8 addresses; and a hanging upstream, which must not tie up the server for everyone else.

Values Go's own client refuses to transmit — CRLF in a header, NUL in a path — go over a **raw socket**, because `http.Client` will not construct them and an attacker has no such restriction. Request smuggling shapes are in there too: duplicate `Content-Length`, `Content-Length` with `Transfer-Encoding`, bare LF line endings.

`TestRobust_GitLabURLHostIsNotRestricted` **documents rather than asserts**: the per-request header may name any host, including link-local. That is the accepted design of a per-request instance selector (the client supplies both URL and credential) and what self-hosting needs — but on a public deployment it is a blind SSRF primitive, and pinning `--gitlab-url` closes it, which the second half asserts.

## Also: the help output

`-revalidate-interval` was registered and never listed; two lines were tab-indented and did not line up; and the environment section still claimed to be stdio-only, which stopped being true when the HTTP overlay landed in #314. All **39 registered flags are now listed**, and there is an HTTP environment section naming the eight variables with no stdio equivalent.

## Verification

`go build ./...`, the full unit suite, `golangci-lint` clean under both `e2e` and `httpe2e`, the e2e suite still compiles, `make test-e2e-http` green at 125 cases, and every `check-*` gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Harden the HTTP transport and continuously verify its handler chain through comprehensive end-to-end coverage, including real nginx deployments.

New Features:
- Add a comprehensive HTTP transport end-to-end test module covering browser compatibility, authentication, client variants, limits, robustness, and reverse-proxy behavior without requiring GitLab credentials.

Bug Fixes:
- Correct the MCP parameter header annotation so clients send the documented wire header.
- Accept case-insensitive Bearer authentication schemes in HTTP requests.
- Prevent concurrent requests for the same credential from creating duplicate pooled server entries.
- Prevent new server-pool entries from being built after shutdown begins.

Enhancements:
- Improve HTTP transport validation and protection against malformed input, upstream failures, credential replay, and resource overuse.
- Clarify HTTP configuration help, environment variables, token revalidation behavior, and reverse-proxy CORS requirements.

CI:
- Run the HTTP transport end-to-end test module in CI.

Documentation:
- Document the HTTP test module, corrected MCP header annotation, and removal of conflicting proxy-level CORS handling.

Tests:
- Add HTTP end-to-end coverage for cross-origin requests, preflight handling, authentication modes, OAuth metadata and errors, client compatibility, limits, robustness, concurrency, and nginx proxy integration.

Chores:
- Promote golang.org/x/sync to a direct dependency for shared server-pool build coordination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HTTP authentication now associates recognized credentials with the corresponding GitLab identity.
  - Added support for case-insensitive Bearer authentication and flexible spacing in authorization headers.
  - Improved HTTP server help output with revalidation settings and environment-variable configuration details.

- **Bug Fixes**
  - Corrected the `x-mcp-header` annotation for action requests to prevent duplicated header prefixes.
  - Improved shutdown handling for active authentication and credential operations.

- **Documentation**
  - Added guidance for configuring CORS when using a reverse proxy.
  - Documented the new HTTP end-to-end test command and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
