### PR TITLE
ci: give the SonarCloud job room to finish its upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,16 @@ jobs:
   sonarcloud:
     name: "SA: SonarCloud"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # The only job here with a bound, because a hung scanner would otherwise
+    # sit on a runner for the six-hour default. It has to leave room for the
+    # scan to grow with the repository: at 5 minutes it started failing every
+    # attempt once the analysis reached 250s on top of ~51s of setup — 302s
+    # against a 300s ceiling. The scan itself had finished; what was cut off
+    # was the upload of the 8 MB report, so the run was killed after doing
+    # all the work and before recording any of it. 15 keeps the guard against
+    # a genuine hang while giving the scan roughly three times its current
+    # runtime, so ordinary growth does not re-break it.
+    timeout-minutes: 15
     needs: [test]
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
`main` has been red since v2.7.5 merged, and re-running could never fix it: the job overruns its own bound by two seconds.

## What is actually happening

The job carries `timeout-minutes: 5`. Measured on the last attempt:

| Step | Time |
| --- | ---: |
| Setup (checkout, artifact, pnpm, node) | 51s |
| **SonarCloud Scan** | **250s** |
| **Total** | **302s** — ceiling **300s** |

The interesting part is *where* it died. The scan had already finished — every sensor ran, `Analysis report generated in 3630ms, dir size=27 MB`, `Analysis report compressed in 1817ms, zip size=8 MB` — and then, twenty seconds into uploading that report:

```
16:01:02.789 INFO  Analysis report compressed in 1817ms, zip size=8 MB
16:01:22.561 ##[error]The operation was canceled.
```

So the run performed the entire analysis and recorded none of it. It surfaces as a SonarCloud failure when it is a budget one, which is why it looked worth re-running.

## Why 15 and not 6

The bound is worth keeping — this is the only job in the workflow that sets one, and without it a hung scanner sits on a runner for the six-hour default. But a limit two seconds above the real runtime is not a guard against hangs, it is a guard against the repository growing. The scan is a function of how much code there is, and it will keep growing.

15 minutes leaves the scan roughly three times its current runtime, so ordinary growth does not walk into this again, while still cutting off anything genuinely stuck long before the default would.

No behaviour change beyond the number; the comment records the measurement so the next person to look at it does not have to re-derive it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Give the SonarCloud CI job sufficient time to complete analysis uploads while retaining a bounded execution time.

Bug Fixes:
- Prevent the SonarCloud CI job from being canceled while uploading a completed analysis report.

Enhancements:
- Increase the SonarCloud job timeout from five to fifteen minutes while retaining protection against genuinely hung scans.

CI:
- Adjust the SonarCloud workflow timeout to accommodate current analysis and upload duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the code quality analysis time limit to allow scans and report uploads to complete reliably.
  * Added documentation explaining the updated time allowance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
