### PR TITLE
refactor: remove the dead alias check and the duplicated issue table

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,18 +434,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       992 |     202,109 |
+| Source (`.go`, non-test) |       992 |     202,107 |
 | Unit tests (`_test.go`)  |       553 |     314,659 |
 | End-to-end tests         |       182 |      47,508 |
-| **Total**                | **1,727** | **564,276** |
+| **Total**                | **1,727** | **564,274** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,692 |
+| Source functions                |  7,693 |
 | — exported (public)             |  2,675 |
-| — unexported (private)          |  5,017 |
+| — unexported (private)          |  5,018 |
 | Unit test functions (`TestXxx`) | 11,985 |
 | Subtests (`t.Run(...)`)         |  2,986 |
 | End-to-end test functions       |    439 |
@@ -457,7 +457,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.56× more tests than code |
 | Average source file length         |                 ~203 lines |
 | Average test file length           |                 ~569 lines |
-| Comment lines in source            |  23,551 (~11.7% of source) |
+| Comment lines in source            |  23,569 (~11.7% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns

--- a/internal/tools/issues/markdown.go
+++ b/internal/tools/issues/markdown.go
@@ -33,10 +33,17 @@ func FormatTodoMarkdown(t TodoOutput) string {
 	return b.String()
 }
 
-// FormatListAllMarkdown renders a list of globally-scoped issues as a Markdown table.
-func FormatListAllMarkdown(out ListOutput) string {
+// formatIssueList renders an issue list under the given heading, closing with
+// the caller's hints.
+//
+// The two list surfaces differ only in those two things; the table between
+// them is the same. Rendering it once is what keeps them that way: the row
+// format carries the issue link, the state emoji and the escaping, and a
+// change applied to one copy and not the other would silently leave the
+// project and global listings rendering differently.
+func formatIssueList(out ListOutput, heading string, hints ...string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## All Issues (%d)\n\n", out.Pagination.TotalItems)
+	fmt.Fprintf(&b, "## %s (%d)\n\n", heading, out.Pagination.TotalItems)
 	toolutil.WriteListSummary(&b, len(out.Issues), out.Pagination)
 	if len(out.Issues) == 0 {
 		b.WriteString(msgNoIssuesFound)
@@ -49,13 +56,16 @@ func FormatListAllMarkdown(out ListOutput) string {
 		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s %s | %s | %s |\n", i.IID, i.WebURL, toolutil.EscapeMdTableCell(i.Title), toolutil.IssueStateEmoji(i.State), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
+	toolutil.WriteHints(&b, append([]string{toolutil.HintPreserveLinks}, hints...)...)
+	return b.String()
+}
+
+// FormatListAllMarkdown renders a list of globally-scoped issues as a Markdown table.
+func FormatListAllMarkdown(out ListOutput) string {
+	return formatIssueList(out, "All Issues",
 		"Use `gitlab_issue_get` to view issue details",
 		"Use `gitlab_issue_update` to change state or labels",
 	)
-	return b.String()
 }
 
 // AuthorName returns the issue author's display username for Markdown, read from
@@ -227,28 +237,11 @@ func formatGetMarkdownResult(out getOutput) *mcp.CallToolResult {
 
 // FormatListMarkdown renders a list of issues as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Issues (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Issues), out.Pagination)
-	if len(out.Issues) == 0 {
-		b.WriteString(msgNoIssuesFound)
-		return b.String()
-	}
-	b.WriteString(tblHeaderIssues)
-	b.WriteString(toolutil.TblSep5Col)
-	for _, i := range out.Issues {
-		labels := strings.Join(i.Labels, ", ")
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s %s | %s | %s |\n", i.IID, i.WebURL, toolutil.EscapeMdTableCell(i.Title), toolutil.IssueStateEmoji(i.State), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
+	return formatIssueList(out, "Issues",
 		"Use action 'get' with an issue_iid to see full details and description",
 		"Use action 'create' to create a new issue",
 		"Use gitlab_issue action 'note_create' to add a comment",
 	)
-	return b.String()
 }
 
 // FormatListGroupMarkdown renders a paginated list of group issues as a Markdown table.

--- a/internal/toolutil/action_spec.go
+++ b/internal/toolutil/action_spec.go
@@ -763,9 +763,18 @@ func validateActionSpecCompatibility(spec ActionSpec) error {
 	return validateParameterAliasSpecs(spec.Name, spec.Route.InputSchema, spec.Compatibility.ParameterAliases)
 }
 
+// validateActionAliasSpecs checks the compatibility aliases declared for one
+// action.
+//
+// Unlike [validateParameterAliasSpecs], it keeps no map of aliases already
+// seen. It cannot need one: every alias here must target the action's own
+// canonical name — the check below rejects anything else outright — so two
+// aliases sharing a name necessarily share a target too, and there is no
+// conflict left to detect. A duplicate declaration is therefore accepted as
+// the no-op it is. Parameter aliases have no such constraint (each may point
+// at a different parameter), which is why the sibling does track them.
 func validateActionAliasSpecs(actionName string, aliases []ActionAliasSpec) error {
 	canonicalName := strings.ToLower(strings.TrimSpace(actionName))
-	seen := make(map[string]string, len(aliases))
 	for _, alias := range aliases {
 		aliasName := strings.TrimSpace(strings.ToLower(alias.Alias))
 		target := strings.TrimSpace(strings.ToLower(alias.Target))
@@ -787,10 +796,6 @@ func validateActionAliasSpecs(actionName string, aliases []ActionAliasSpec) erro
 		if alias.Deprecated && strings.TrimSpace(alias.RemovalVersion) == "" {
 			return fmt.Errorf("action spec %q deprecated compatibility action alias %q has no removal version", actionName, aliasName)
 		}
-		if existingTarget, ok := seen[aliasName]; ok && existingTarget != target {
-			return fmt.Errorf("action spec %q compatibility action alias %q targets both %q and %q", actionName, aliasName, existingTarget, target)
-		}
-		seen[aliasName] = target
 	}
 	return nil
 }


### PR DESCRIPTION
Checked whether coverage or duplication still had room. Mostly they do not, and the history says so rather than my judgement:

| Date | dup % | dup lines | coverage | uncovered |
| --- | ---: | ---: | ---: | ---: |
| 13 Aug | 0.4 | 832 | 99.7 | 208 |
| 17 Aug | 0.4 | 832 | 99.7 | 208 |
| 21 Aug | 0.4 | 808 | 99.6 | 335 |
| 26 Aug | 0.4 | 808 | 99.6 | 347 |
| **27 Aug** | **0.4** | **760** | **99.8** | **144** |

Duplication has been flat at 0.4% for a fortnight and is falling in absolute terms. Three earlier rounds inspected every remaining cluster and recorded a per-file justification, and re-opening that wholesale would be re-litigating a decision made with evidence. But two entries in the list turned out to be worth acting on, so this is the narrow follow-up rather than a fourth round.

## The dead check and the duplication were the same bug

`validateActionAliasSpecs` kept a `seen` map so it could reject one alias name targeting two different actions:

```go
if existingTarget, ok := seen[aliasName]; ok && existingTarget != target {
	return fmt.Errorf("... targets both %q and %q", existingTarget, target)
}
```

It can never fire. Three lines earlier, `if target != canonicalName { return ... }` rejects anything whose target is not the action's own name, so by the time this runs both sides of the comparison are provably the same string.

What makes it interesting is *why* it is there: the function is a copy of `validateParameterAliasSpecs`, where the same check is live and necessary — parameter aliases may each point at a different parameter, so a name collision is a genuine conflict. The copy inherited the check along with a constraint that makes it meaningless. So the 18-line duplicated block and the permanently-uncoverable branch were one problem with one cause.

Removing it takes `validateActionAliasSpecs` to 100%, and the comment left behind records why its sibling still tracks aliases. Behaviour is unchanged by construction — an unreachable branch cannot be reached — and `TestValidateActionAliasSpecs_DuplicateAliasSameTarget`, which pins that duplicates are accepted, still passes.

## The issue table was copied, and had to stay in lockstep

`FormatListMarkdown` and `FormatListAllMarkdown` shared twenty lines and differed in a heading and their hints. That row format carries the issue link, the state emoji and the cell escaping; a change applied to one copy and not the other would leave the project and global listings rendering differently, with nothing to catch it.

Now rendered once. **Verified byte-identical against `main`** — both surfaces, populated and empty — by rendering the same fixture on each side and comparing.

## What was looked at and deliberately left

- `commits.go` — two struct literals with identical field sets building `Output` and `DetailOutput`. Different named types; collapsing them would also break the `audit_1to1` R-OUTPUT pairing, which matches MCP↔SDK structs through package-local converters.
- `resources.go` — two resource registrations differing in URI template, name, title and description. Sonar's CPD normalizes Go string literals, so text-only differences read as duplication. Parameterizing would hide the per-resource metadata the catalog and the audit depend on seeing.
- `epicdiscussions` / `epicnotes` list prologues, and the smaller markdown formatters — below the size where extraction pays for the indirection, and already recorded as deliberate.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored issue list rendering in `internal/tools/issues/markdown.go` by introducing a shared `formatIssueList` function to reduce code duplication.</li>
<li>Updated `internal/toolutil/action_spec.go` to remove redundant alias tracking in `validateActionAliasSpecs`, allowing duplicate alias declarations as no-ops.</li>
<li>Updated `README.md` statistics to reflect minor changes in source lines, function counts, and comment lines.</li>
</ul></div>

## Summary by Sourcery

Remove dead alias validation and centralize issue-list rendering to eliminate duplicated logic without changing output behavior.

Enhancements:
- Remove the unreachable action-alias conflict check and document why action aliases do not require duplicate-target validation.
- Consolidate project and global issue-list Markdown rendering into a shared formatter while preserving their distinct headings and hints.

Documentation:
- Update README codebase statistics to reflect the refactoring.

Tests:
- Preserve existing issue-list output and action-alias validation behavior, including acceptance of duplicate aliases targeting the same action.
