### PR TITLE
refactor: fold trailing field assignments into their struct literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,10 +434,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       992 |     202,109 |
-| Unit tests (`_test.go`)  |       553 |     314,659 |
+| Source (`.go`, non-test) |       992 |     202,111 |
+| Unit tests (`_test.go`)  |       553 |     314,660 |
 | End-to-end tests         |       182 |      47,508 |
-| **Total**                | **1,727** | **564,276** |
+| **Total**                | **1,727** | **564,279** |
 
 ### Functions
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/run_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/run_test.go
@@ -89,8 +89,9 @@ func TestIsRetriableModelOutputFailure(t *testing.T) {
 		{"empty args", withModelError("gitlab_execute_action tool call call_1 " + markerEmptyToolArgs), true},
 		{"success not retried", taskResult{FinalSuccess: true}, false},
 		{"wrong choice not retried", func() taskResult {
-			r := taskResult{}
-			r.Notes = []string{"expected action issue.create but model called issue.list"}
+			r := taskResult{
+				Notes: []string{"expected action issue.create but model called issue.list"},
+			}
 			r.Trace.Events = []traceEvent{{Kind: "validation", Content: "action mismatch"}}
 			return r
 		}(), false},

--- a/internal/tools/groupvariables/markdown.go
+++ b/internal/tools/groupvariables/markdown.go
@@ -21,16 +21,17 @@ func FormatListMarkdown(out ListOutput) string {
 }
 
 func toMarkdownVariable(v Output) toolutil.CICDVariableMarkdown {
-	markdown := toolutil.CICDVariableMarkdown{}
-	markdown.Key = v.Key
-	markdown.Value = v.Value
-	markdown.VariableType = v.VariableType
-	markdown.Protected = v.Protected
-	markdown.Masked = v.Masked
-	markdown.Hidden = v.Hidden
-	markdown.Raw = v.Raw
-	markdown.EnvironmentScope = v.EnvironmentScope
-	markdown.Description = v.Description
+	markdown := toolutil.CICDVariableMarkdown{
+		Key:              v.Key,
+		Value:            v.Value,
+		VariableType:     v.VariableType,
+		Protected:        v.Protected,
+		Masked:           v.Masked,
+		Hidden:           v.Hidden,
+		Raw:              v.Raw,
+		EnvironmentScope: v.EnvironmentScope,
+		Description:      v.Description,
+	}
 	return markdown
 }
 

--- a/internal/tools/mrdiscussions/mr_discussions.go
+++ b/internal/tools/mrdiscussions/mr_discussions.go
@@ -131,11 +131,11 @@ func NoteToOutput(n *gl.Note) NoteOutput {
 		CommitID:     n.CommitID,
 		Position:     toolutil.NewNotePositionOutput(n.Position),
 		ProjectID:    n.ProjectID,
+		CreatedAt:    toolutil.FormatTimePtr(n.CreatedAt),
+		UpdatedAt:    toolutil.FormatTimePtr(n.UpdatedAt),
+		ExpiresAt:    toolutil.FormatTimePtr(n.ExpiresAt),
+		ResolvedAt:   toolutil.FormatTimePtr(n.ResolvedAt),
 	}
-	out.CreatedAt = toolutil.FormatTimePtr(n.CreatedAt)
-	out.UpdatedAt = toolutil.FormatTimePtr(n.UpdatedAt)
-	out.ExpiresAt = toolutil.FormatTimePtr(n.ExpiresAt)
-	out.ResolvedAt = toolutil.FormatTimePtr(n.ResolvedAt)
 	return out
 }
 

--- a/internal/tools/protectedenvs/protectedenvs.go
+++ b/internal/tools/protectedenvs/protectedenvs.go
@@ -176,8 +176,8 @@ func toOutput(pe *gl.ProtectedEnvironment) Output {
 	out := Output{
 		Name:                  pe.Name,
 		RequiredApprovalCount: pe.RequiredApprovalCount,
+		DeployAccessLevels:    make([]AccessLevelOutput, 0, len(pe.DeployAccessLevels)),
 	}
-	out.DeployAccessLevels = make([]AccessLevelOutput, 0, len(pe.DeployAccessLevels))
 	for _, a := range pe.DeployAccessLevels {
 		out.DeployAccessLevels = append(out.DeployAccessLevels, toAccessLevelOutput(a))
 	}

--- a/internal/tools/snippetnotes/snippet_notes.go
+++ b/internal/tools/snippetnotes/snippet_notes.go
@@ -115,11 +115,12 @@ func toOutput(n *gl.Note) Output {
 		NoteableIID:  n.NoteableIID,
 		ProjectID:    n.ProjectID,
 		Confidential: n.Confidential, //nolint:staticcheck // mirror deprecated SDK field for 1:1 fidelity
+
+		CreatedAt:  toolutil.FormatTimePtr(n.CreatedAt),
+		UpdatedAt:  toolutil.FormatTimePtr(n.UpdatedAt),
+		ExpiresAt:  toolutil.FormatTimePtr(n.ExpiresAt),
+		ResolvedAt: toolutil.FormatTimePtr(n.ResolvedAt),
 	}
-	out.CreatedAt = toolutil.FormatTimePtr(n.CreatedAt)
-	out.UpdatedAt = toolutil.FormatTimePtr(n.UpdatedAt)
-	out.ExpiresAt = toolutil.FormatTimePtr(n.ExpiresAt)
-	out.ResolvedAt = toolutil.FormatTimePtr(n.ResolvedAt)
 	return out
 }
 

--- a/internal/tools/snippets/snippets.go
+++ b/internal/tools/snippets/snippets.go
@@ -108,8 +108,8 @@ func convertSnippet(s *gl.Snippet) Output {
 		RepositoryStorage: s.RepositoryStorage,
 		CreatedAt:         s.CreatedAt,
 		UpdatedAt:         s.UpdatedAt,
+		Author:            snippetAuthorOutput(s.Author),
 	}
-	out.Author = snippetAuthorOutput(s.Author)
 	for _, f := range s.Files {
 		out.Files = append(out.Files, FileOutput{Path: f.Path, RawURL: f.RawURL})
 	}

--- a/internal/tools/tags/tags.go
+++ b/internal/tools/tags/tags.go
@@ -301,13 +301,13 @@ func GetSignature(ctx context.Context, client *gitlabclient.Client, input Signat
 	out := SignatureOutput{
 		SignatureType:      sig.SignatureType,
 		VerificationStatus: sig.VerificationStatus,
-	}
-	out.X509Certificate = X509CertificateOutput{
-		ID:                   sig.X509Certificate.ID,
-		Subject:              sig.X509Certificate.Subject,
-		SubjectKeyIdentifier: sig.X509Certificate.SubjectKeyIdentifier,
-		Email:                sig.X509Certificate.Email,
-		CertificateStatus:    sig.X509Certificate.CertificateStatus,
+		X509Certificate: X509CertificateOutput{
+			ID:                   sig.X509Certificate.ID,
+			Subject:              sig.X509Certificate.Subject,
+			SubjectKeyIdentifier: sig.X509Certificate.SubjectKeyIdentifier,
+			Email:                sig.X509Certificate.Email,
+			CertificateStatus:    sig.X509Certificate.CertificateStatus,
+		},
 	}
 	if sig.X509Certificate.SerialNumber != nil {
 		out.X509Certificate.SerialNumber = sig.X509Certificate.SerialNumber.String()

--- a/internal/toolutil/noteshapes.go
+++ b/internal/toolutil/noteshapes.go
@@ -170,11 +170,11 @@ func NoteOutputFromGitLab(n *gl.Note) NoteOutput {
 		Position:     NewNotePositionOutput(n.Position),
 		ProjectID:    n.ProjectID,
 		Confidential: n.Internal,
+		CreatedAt:    FormatTimePtr(n.CreatedAt),
+		UpdatedAt:    FormatTimePtr(n.UpdatedAt),
+		ExpiresAt:    FormatTimePtr(n.ExpiresAt),
+		ResolvedAt:   FormatTimePtr(n.ResolvedAt),
 	}
-	out.CreatedAt = FormatTimePtr(n.CreatedAt)
-	out.UpdatedAt = FormatTimePtr(n.UpdatedAt)
-	out.ExpiresAt = FormatTimePtr(n.ExpiresAt)
-	out.ResolvedAt = FormatTimePtr(n.ResolvedAt)
 	return out
 }
 


### PR DESCRIPTION
`make analyze` runs `modernize` — it is enabled in `.golangci.yml` and `golangci-lint linters` confirms it is in the enabled set, and all six gates pass. But the copy golangci-lint bundles is older than upstream, and running gopls v0.23.0's `modernize` directly reports eight sites it does not see, all from one newer analyzer:

```
internal/toolutil/noteshapes.go:153:9: embedded field assignment can be moved to struct literal
internal/tools/groupvariables/markdown.go:24:14: ...
internal/tools/mrdiscussions/mr_discussions.go:114:9: ...
internal/tools/protectedenvs/protectedenvs.go:176:9: ...
internal/tools/snippetnotes/snippet_notes.go:98:9: ...
internal/tools/snippets/snippets.go:99:9: ...
internal/tools/tags/tags.go:301:9: ...
cmd/eval_mcp_surfaces/internal/evaluator/run_test.go:92:9: ...
```

Each is a struct built by literal and then completed by assigning a field on the next line.

## Why now

These become CI failures the day golangci-lint updates its bundled copy — and they land on whoever happens to do the bump, not on anyone who wrote them. Eight mechanical findings in an unrelated PR is exactly the kind of thing that makes a routine dependency update look risky.

## The fix is the analyzer's, the formatting is mine

`modernize -fix` produced the change. Its output is gofmt-valid but reads worse than what it replaced: it leaves a blank line where the old closing brace was, and merges the literal's closing brace onto the last field —

```go
		ResolvedAt: toolutil.FormatTimePtr(n.ResolvedAt)}
```

— so every site was tidied afterwards and the result re-formatted.

## No behaviour change

Every moved assignment already ran immediately after its literal with nothing reading the field in between; that is the condition the analyzer checks before firing. Package tests pass, `golangci-lint` is clean on all eight packages, and `modernize` is now silent.

Also ran in this pass, both clean: `make audit-1to1` reports **0 gaps** across all four streams, and `make analyze` passes all six gates.

## Summary by Sourcery

Move trailing field initialization into struct literals across the affected Go code to keep modernize checks clean.

Enhancements:
- Fold eight trailing struct field assignments into their struct literals to satisfy the newer modernize analyzer without changing behavior.

Chores:
- Refresh the README source and test line-count totals.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored multiple Go files to use struct literal initialization instead of post-initialization field assignments for improved readability and consistency.</li>
<li>Updated time field formatting in MR discussions, snippet notes, and note shapes to be included directly within struct literals.</li>
<li>Minor documentation update in README.md reflecting changes in file counts and line totals.</li>
<li>Minor cleanup in test code and protected environment initialization.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the file-count statistics in the README.

* **Refactor**
  * Streamlined internal data initialization without changing functionality or outputs.
  * Preserved existing timestamp, author, certificate, deployment access, and note-handling behavior.

* **Tests**
  * Simplified test data setup while maintaining existing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->