### PR TITLE
docs: link tracker references instead of writing them bare

### DIFF
--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -3,7 +3,7 @@
 Defects and missing capabilities found in projects this server depends on, kept
 here so they are contributed back rather than only worked around.
 
-**This register is permanent.** An entry is never deleted — when a fix lands
+**This register is permanent.** An entry is never deleted. When a fix lands
 upstream it is marked merged with the version that carries it, and the entry
 stays as the record of why the workaround existed and when it could go.
 
@@ -13,20 +13,40 @@ because the dependency does not expose what it needs. Each one records where the
 evidence is, so a contributor does not have to rediscover it.
 
 See the [upstream contribution skill](../../.github/skills/upstream-contribution/)
-for the fork → branch → fix → test → MR workflow.
+for the fork, branch, fix, test and MR workflow.
+
+## Writing an entry
+
+**Always link a tracker item, never write a bare reference.** This repository
+lives on GitHub and is mirrored to GitLab, and each forge autolinks the other's
+reference syntax against *itself*. A bare `!2996` renders on the mirror as a
+merge request of the mirror, and a bare `#58` renders on GitHub as an issue of
+this repository. Both point at something that does not exist, or worse, at
+something unrelated that does.
+
+A markdown link is not reprocessed as a reference by either forge, so put the
+project path in the link text and the full URL in the target:
+
+```markdown
+[gitlab-org/api/client-go!2996](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/2996)
+[creativeprojects/go-selfupdate#58](https://github.com/creativeprojects/go-selfupdate/pull/58)
+```
+
+That stays readable as a mention, resolves from either forge, and creates no
+cross-reference anywhere.
 
 ## What each entry records
 
 Every entry carries the same five facts, so the state of a contribution is
 readable without opening the tracker:
 
-| Field          | Meaning                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **Reported**   | Whether it has been raised upstream at all, with a link to the issue                                                            |
-| **In review**  | Whether an upstream change was opened for review, with a link to the MR or PR. Historical: it stays yes after the change merges |
-| **Merged**     | Whether it has landed, and **in which version**. Merged implies Reported and In review are both yes                             |
-| **Blocking**   | Whether it blocks this MCP server, or only costs us a workaround                                                                |
-| **Workaround** | Whether we carry one while waiting, where it lives, and what retires it                                                         |
+| Field          | Meaning                                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Reported**   | Whether it has been raised upstream at all, with a link to the issue                                            |
+| **In review**  | Whether an upstream change was opened for review, with a link. Historical: it stays yes after the change merges |
+| **Merged**     | Whether it has landed, and **in which version**. Merged implies Reported and In review are both yes             |
+| **Blocking**   | Whether it blocks this MCP server, or only costs us a workaround                                                |
+| **Workaround** | Whether we carry one while waiting, where it lives, and what retires it                                         |
 
 ## Summary
 
@@ -34,35 +54,35 @@ readable without opening the tracker:
 | - | ------- | ----- | -------- | --------- | ------ | -------- | ---------- |
 | 1 | gitlab-org/gitlab | [403 carries no `WWW-Authenticate`](#403-responses-carry-no-www-authenticate-header) | No | No | No | No | Yes |
 | 2 | gitlab-org/gitlab | [No `resource_indicators_supported`](#no-resource_indicators_supported-in-authorization-server-metadata) | No | No | No | No | Yes |
-| 3 | client-go | [Panic unmarshalling an issue](#panic-unmarshalling-an-issue-with-no-id) | Yes | Yes | **Yes — v2.59.1** | Was yes | Retired |
-| 4 | client-go | [`UpdateIssueBoardList` cannot decode its own response](#updateissueboardlist-cannot-decode-a-successful-response) | Yes | Yes — !2996 | No | No | Yes |
+| 3 | client-go | [Panic unmarshalling an issue](#panic-unmarshalling-an-issue-with-no-id) | Yes | Yes | **Yes, v2.59.1** | Was yes | Retired |
+| 4 | client-go | [`UpdateIssueBoardList` cannot decode its own response](#updateissueboardlist-cannot-decode-a-successful-response) | Yes | Yes, open | No | No | Yes |
 | 5 | client-go | [`GetNamespace` breaks on a path lookup](#getnamespace-cannot-decode-a-path-based-lookup) | No | No | No | No | Yes |
 | 6 | client-go | [`SetFeatureFlagOptions` lacks `omitempty`](#setfeatureflagoptions-fields-lack-omitempty) | No | No | No | No | Yes |
 | 7 | client-go | [`ApplicationStatistics` assumes numeric JSON](#applicationstatistics-assumes-numeric-json) | No | No | No | No | Yes |
 | 8 | go-sdk | [No SSE keep-alive option](#no-keep-alive-interval-for-sse-streams-on-streamablehttpoptions) | No | No | No | No | Yes |
-| 9 | go-selfupdate | [Deprecated `x/crypto/openpgp`](#go-selfupdate-depends-on-the-deprecated-xcryptoopenpgp) | Yes — #57 | Yes — #58 | No | No | Yes |
+| 9 | go-selfupdate | [Deprecated `x/crypto/openpgp`](#go-selfupdate-depends-on-the-deprecated-xcryptoopenpgp) | Yes | Yes, open | No | No | Yes |
 
 States verified against the upstream trackers on 2026-08-29.
 
 ## GitLab (`gitlab-org/gitlab`)
 
-### 403 responses carry no `WWW-Authenticate` header
+### 403 responses carry no WWW-Authenticate header
 
 - **Reported**: no.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no. Our detection does not depend on the header, so this is a
   contribution rather than a fix we need.
-- **Workaround**: yes — `internal/oauth.isInsufficientScope` reads the response
+- **Workaround**: yes. `internal/oauth.isInsufficientScope` reads the response
   body instead of the challenge. It is not a stopgap: the body is the only place
   the distinction appears, so it stays whatever upstream does.
 
 **Where**: `lib/api/api_guard.rb`, around the `ForbiddenError` handling.
 
-**What**: GitLab's own comment states it —
+**What**: GitLab's own comment states it.
 `# FIXME: ForbiddenError (inherited from Bearer::Forbidden of Rack::Oauth2)
 does not include WWW-Authenticate header, which breaks the standard.`
-RFC 6750 §3 requires a protected resource that refuses a request for
+RFC 6750 section 3 requires a protected resource that refuses a request for
 insufficient scope to return `WWW-Authenticate: Bearer
 error="insufficient_scope"`. GitLab returns the error in the JSON body only.
 
@@ -71,20 +91,20 @@ challenge; `Forbidden` does not. Fixable in GitLab's own handler without
 changing the gem.
 
 **How we found it**: implementing insufficient-scope detection. The obvious
-implementation — parse `error="insufficient_scope"` out of the challenge —
-would have compiled, passed a hand-written fake that emitted the header, and
-never once fired against a real GitLab.
+implementation, parsing `error="insufficient_scope"` out of the challenge, would
+have compiled, passed a hand-written fake that emitted the header, and never
+once fired against a real GitLab.
 
 **Effort**: small. Observable API behaviour change, so it needs a maintainer
 from the authentication area and a changelog entry.
 
-### No `resource_indicators_supported` in authorization-server metadata
+### No resource_indicators_supported in authorization-server metadata
 
 - **Reported**: no. It is a feature request rather than a defect.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes — the specification's own alternative. `--oauth-client-uid`
+- **Workaround**: yes, the specification's own alternative. `--oauth-client-uid`
   pins the OAuth applications whose tokens are admitted, compared against
   `application.uid`. Off by default, since enabling it refuses personal access
   tokens.
@@ -106,47 +126,47 @@ MUST cannot be met by its named mechanism. Recorded as
 ### Panic unmarshalling an issue with no id
 
 - **Reported**: yes.
-- **In review**: yes —
-  [!3006](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3006).
+- **In review**: yes,
+  [gitlab-org/api/client-go!3006](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3006).
 - **Merged**: **yes**, on 2026-08-25 into `main`, shipped in **v2.59.1**.
-- **Blocking**: it was — the panic took the process down rather than failing one
+- **Blocking**: it was. The panic took the process down rather than failing one
   call.
 - **Workaround**: retired. The dependency is pinned at v2.60.0 and the local
   guard is gone.
 
 Kept here as the record: this is what the round trip looks like when it works.
 
-### `UpdateIssueBoardList` cannot decode a successful response
+### UpdateIssueBoardList cannot decode a successful response
 
 - **Reported**: yes.
-- **In review**: yes —
-  [!2996](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/2996),
+- **In review**: yes,
+  [gitlab-org/api/client-go!2996](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/2996),
   **still open**, targeting `release-client-3.0`.
 - **Merged**: no. It is accepted for the v3 line, so it will not appear in any
   v2 release.
 - **Blocking**: no.
-- **Workaround**: yes — `internal/tools/groupboards.UpdateGroupBoardList` issues
+- **Workaround**: yes. `internal/tools/groupboards.UpdateGroupBoardList` issues
   the `PUT` directly instead of calling the wrapper. Retire it, and the
   `acceptedMissingMethods` entry in `cmd/audit_1to1/internal/actions/analyze.go`,
-  once the client-go version this project depends on actually contains !2996 —
-  not merely when the v3 bump happens. The MR is still open, so it may land in
-  a later v3 minor, or not at all; check the release before removing either.
+  once the client-go version this project depends on actually contains the fix,
+  not merely when the v3 bump happens. The MR is still open, so it may land in a
+  later v3 minor, or not at all; check the release before removing either.
 
 **What**: the group-level wrapper declares `[]*BoardList`, while GitLab returns
 the single updated list object, so the wrapper can never unmarshal a successful
 response. The project-level equivalent already returns `*BoardList`.
 
 **Note**: the major-version policy in `CLAUDE.md` ties this project's major to
-client-go's, so the v3 bump is the moment to *check* — but the condition is the
-fix being present, not the bump having happened.
+client-go's, so the v3 bump is the moment to *check*. The condition is the fix
+being present, not the bump having happened.
 
-### `GetNamespace` cannot decode a path-based lookup
+### GetNamespace cannot decode a path-based lookup
 
 - **Reported**: no.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes — `internal/tools/namespaces.Get` issues the request
+- **Workaround**: yes. `internal/tools/namespaces.Get` issues the request
   directly.
 
 **What**: `GetNamespace` expects a single JSON object, but some GitLab versions
@@ -155,27 +175,27 @@ answer a path-based lookup with an array.
 **Before reporting**: establish which GitLab versions return the array, so the
 report names a reproduction rather than a symptom.
 
-### `SetFeatureFlagOptions` fields lack `omitempty`
+### SetFeatureFlagOptions fields lack omitempty
 
 - **Reported**: no.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes — `internal/tools/features.Set` builds the request body
+- **Workaround**: yes. `internal/tools/features.Set` builds the request body
   itself.
 
 **What**: the option struct's fields carry no `omitempty`, so empty strings are
 serialized and GitLab rejects the request with a "mutually exclusive" error.
 
-**Effort**: small — struct tags plus a test. A good first contribution.
+**Effort**: small, struct tags plus a test. A good first contribution.
 
-### `ApplicationStatistics` assumes numeric JSON
+### ApplicationStatistics assumes numeric JSON
 
 - **Reported**: no.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes — `internal/tools/appstatistics.Get` decodes the response
+- **Workaround**: yes. `internal/tools/appstatistics.Get` decodes the response
   itself.
 
 **What**: the struct uses `int64` fields, while some GitLab versions return the
@@ -186,13 +206,13 @@ strings.
 
 ## MCP Go SDK (`github.com/modelcontextprotocol/go-sdk`)
 
-### No keep-alive interval for SSE streams on `StreamableHTTPOptions`
+### No keep-alive interval for SSE streams on StreamableHTTPOptions
 
 - **Reported**: no.
 - **In review**: no.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes, and it covers more than the requested option would —
+- **Workaround**: yes, and it covers more than the requested option would.
   `sseAwareWriter` in `cmd/server/main.go` emits a comment frame every 25s on
   **any** response that commits to `text/event-stream`, guarding its writes with
   the same mutex the handler's writes take. It would stay even if the option
@@ -200,8 +220,8 @@ strings.
 
 **What**: the SDK emits keep-alives only on the standalone GET stream, not on
 streamed POST responses, and offers no option to configure the interval. An idle
-SSE response therefore puts no bytes on the wire, and a proxy's read timeout —
-nginx's `proxy_read_timeout` is 60s by default — severs it. Worse, with nothing
+SSE response therefore puts no bytes on the wire, and a proxy's read timeout
+severs it; nginx's `proxy_read_timeout` is 60s by default. Worse, with nothing
 written the response headers are not flushed either, so the client hangs before
 the first read rather than after.
 
@@ -210,14 +230,14 @@ The test hung instead of failing, which is how the header-flush half surfaced.
 
 ## Other
 
-### `go-selfupdate` depends on the deprecated `x/crypto/openpgp`
+### go-selfupdate depends on the deprecated x/crypto/openpgp
 
-- **Reported**: yes —
-  [issue #57](https://github.com/creativeprojects/go-selfupdate/issues/57).
-- **In review**: yes —
-  [PR #58](https://github.com/creativeprojects/go-selfupdate/pull/58),
+- **Reported**: yes,
+  [creativeprojects/go-selfupdate#57](https://github.com/creativeprojects/go-selfupdate/issues/57).
+- **In review**: yes,
+  [creativeprojects/go-selfupdate#58](https://github.com/creativeprojects/go-selfupdate/pull/58),
   still open.
 - **Merged**: no.
 - **Blocking**: no.
-- **Workaround**: yes — the `GO-2026-5932` entry in the govulncheck allowlist.
+- **Workaround**: yes, the `GO-2026-5932` entry in the govulncheck allowlist.
   Retire it when the PR merges.

--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -164,7 +164,7 @@ Page 1 of 1 (20 per page) · 5 items
 
 ### Detail Response
 
-When you ask *"Show me merge request !243"*:
+When you ask *"Show me merge request `!243`"*:
 
 **Markdown content**:
 

--- a/site/src/content/docs/es/examples/code-review-workflows.mdx
+++ b/site/src/content/docs/es/examples/code-review-workflows.mdx
@@ -202,7 +202,7 @@ gitlab_merge_request → action: rebase, project_id: "my-group/backend",
 
 ### Cerrar sin fusionar
 
-**Prompt**: "Cierra el MR !99 — el enfoque fue reemplazado por el MR !105"
+**Prompt**: "Cierra el MR `!99`, el enfoque fue reemplazado por el MR `!105`"
 
 ```text
 gitlab_merge_request → action: update, project_id: "my-group/backend",

--- a/site/src/content/docs/examples/code-review-workflows.mdx
+++ b/site/src/content/docs/examples/code-review-workflows.mdx
@@ -202,7 +202,7 @@ gitlab_merge_request → action: rebase, project_id: "my-group/backend",
 
 ### Close without merging
 
-**Prompt**: "Close MR !99 — the approach was superseded by MR !105"
+**Prompt**: "Close MR `!99`, the approach was superseded by MR `!105`"
 
 ```text
 gitlab_merge_request → action: update, project_id: "my-group/backend",


### PR DESCRIPTION
This repository lives on GitHub and is mirrored to GitLab, and each forge autolinks the other's reference syntax against *itself*. A bare `!2996` renders on the mirror as merge request 2996 **of the mirror**, and a bare `#58` renders on GitHub as issue 58 **of this repository**. Both resolve to something unrelated, or to nothing, and the upstream register I added in #329 was full of them.

Every tracker reference is now a markdown link carrying the project path in its text and the full URL as its target:

```markdown
[gitlab-org/api/client-go!2996](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/2996)
[creativeprojects/go-selfupdate#58](https://github.com/creativeprojects/go-selfupdate/pull/58)
```

Neither forge reprocesses the text of a link, so it stays readable as a mention and creates no cross-reference anywhere. The rule is written into the register itself, under "Writing an entry", since that is the file most likely to accumulate them.

## Three illustrative numbers in prose

`!243`, `!99` and `!105` are examples in sample prompts, not real merge requests, so a link would be wrong. They are wrapped in backticks instead, which stops the autolink and still reads as an identifier. The same references inside fenced code blocks and mermaid diagrams were already safe and are untouched.

I swept the whole of `docs/`, `site/src`, `CLAUDE.md` and `README.md` for bare references. Those three were the only ones in prose; everything else was already either a link, a code span, or inside a fenced block.

## Also

Em dashes are gone from the register.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Prevent cross-forge tracker misreferences by documenting and applying unambiguous link formatting throughout the upstream bug register.

New Features:
- Add guidance for recording upstream tracker references as fully qualified Markdown links to avoid incorrect GitHub/GitLab autolinking.

Enhancements:
- Standardize upstream bug register wording, punctuation, formatting, and status presentation.
- Clarify illustrative merge request references in documentation by rendering them as code spans instead of tracker links.

Documentation:
- Update upstream bug records with project-qualified links for reported issues and open merge requests.
- Revise documentation examples to prevent accidental autolinking of sample tracker references.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added guidance on writing upstream bug entries to avoid forge-specific autolinking issues.</li>
<li>Updated the upstream bugs register with current status information for several dependencies.</li>
<li>Refined documentation and examples to use backticks for reference syntax (e.g., `!243`) to improve clarity and avoid accidental cross-referencing.</li>
<li>Improved phrasing and formatting throughout the upstream bugs documentation.</li>
</ul></div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded upstream issue documentation with guidance for writing entries, clearer tracker links, updated fix statuses, and additional workaround details.
  * Improved formatting and readability across documented issue summaries and references.
  * Updated examples to format merge request identifiers as inline code and use clearer punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->