### PR TITLE
Assert a real OpenTelemetry Collector accepts what we emit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run brand brand-check brand-rasters test test-short test-race test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run brand brand-check brand-rasters test test-short test-race test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -30,7 +30,7 @@ GO_ANALYSIS_PKGS=./...
 # `stdioe2e` until the stdio suite did, and `orbitlive` had never been listed
 # at all, so test/e2e/orbit had gone unlinted since it was written. The same
 # list lives in cmd/gen_testing_docs as e2eTags, for the same reason.
-GO_ANALYSIS_TAGS=e2e,httpe2e,orbitlive,stdioe2e
+GO_ANALYSIS_TAGS=e2e,collectore2e,httpe2e,orbitlive,stdioe2e
 PROJECT_GO_VERSION := $(shell awk '/^go / {print $$2; exit}' go.mod)
 GO_TOOLCHAIN ?= go$(PROJECT_GO_VERSION)
 export GOTOOLCHAIN := $(GO_TOOLCHAIN)
@@ -164,6 +164,18 @@ test-e2e-http: ensure-gotestsum
 	  --format testdox \
 	  --junitfile $(E2E_REPORT_DIR)/e2e-http-junit.xml \
 	  -- -tags httpe2e -count=1 -timeout 900s ./test/e2e/http/'
+
+## test-e2e-collector: run this server's telemetry into a real OpenTelemetry Collector (Docker required; skips cleanly without it).
+# Deliberately absent from the push-triggered CI jobs, which run the httpe2e and
+# stdioe2e tags and never this one. Those two need no daemon; this one pulls a
+# container image, which belongs with the Docker-mode targets rather than in the
+# path every commit waits on.
+test-e2e-collector: ensure-gotestsum
+	$(call MKDIR_P,$(E2E_REPORT_DIR))
+	bash -o pipefail -c '$(GOTESTSUM) \
+	  --format testdox \
+	  --junitfile $(E2E_REPORT_DIR)/e2e-collector-junit.xml \
+	  -- -tags collectore2e -count=1 -timeout 900s ./test/e2e/collector/'
 
 ## validate-http-stateless: smoke-validate stateless streamable HTTP with the compiled binary (reads GITLAB_URL, GITLAB_TOKEN from .env)
 validate-http-stateless:

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -61,9 +61,11 @@ The full detail, including what each mode exports, is in
   [GitLab Privacy Statement](https://about.gitlab.com/privacy/) (for
   GitLab.com) or by your organization's own policies (for self-managed
   instances).
-Your GitLab instance is the only destination. The server contacts nothing else,
-and nothing it does is optional in that respect: there is no update check, no
-license check, no registry ping and no default that reaches any other host.
+Your GitLab instance is the only destination, with one opt-in exception you
+control: telemetry, when you enable it, exports operation data to the collector
+you configure, described in its own section above. Beyond that the server
+contacts nothing else: there is no update check, no registry ping and no
+default that reaches any other host.
 
 This used to be untrue in one narrow way worth recording rather than quietly
 dropping. The server carried a self-update feature that was **on by default**
@@ -117,7 +119,8 @@ TTL and are never persisted to disk.
 ## Data retention and sharing
 
 The server retains nothing after it exits and shares data with no third
-parties beyond the GitLab instance you explicitly configure.
+parties beyond the GitLab instance you explicitly configure and, if you enable
+telemetry, the collector you explicitly configure.
 
 ## Changes
 

--- a/README.md
+++ b/README.md
@@ -446,39 +446,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,003 |     207,476 |
-| Unit tests (`_test.go`)  |       562 |     313,590 |
-| End-to-end tests         |       211 |      56,350 |
-| **Total**                | **1,776** | **577,416** |
+| Source (`.go`, non-test) |     1,003 |     207,932 |
+| Unit tests (`_test.go`)  |       562 |     313,964 |
+| End-to-end tests         |       211 |      56,486 |
+| **Total**                | **1,776** | **578,382** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,806 |
-| — exported (public)             |  2,697 |
-| — unexported (private)          |  5,109 |
-| Unit test functions (`TestXxx`) | 11,757 |
-| Subtests (`t.Run(...)`)         |  3,114 |
-| End-to-end test functions       |    535 |
+| Source functions                |  7,821 |
+| — exported (public)             |  2,702 |
+| — unexported (private)          |  5,119 |
+| Unit test functions (`TestXxx`) | 11,773 |
+| Subtests (`t.Run(...)`)         |  3,117 |
+| End-to-end test functions       |    537 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
-| Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~557 lines |
-| Comment lines in source            |  27,901 (~13.4% of source) |
+| Average source file length         |                 ~207 lines |
+| Average test file length           |                 ~558 lines |
+| Comment lines in source            |  28,096 (~13.5% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,621 |
-| `defer` statements                 | 1,017 |
-| `struct` types defined             | 2,756 |
+| `if err != nil` checks             | 6,626 |
+| `defer` statements                 | 1,018 |
+| `struct` types defined             | 2,757 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,772 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,753 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,780 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,764 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,854 |
 | Unit tests (`_test.go`)  |       572 |     312,085 |
-| End-to-end tests         |       201 |      53,981 |
-| **Total**                | **1,775** | **572,920** |
+| End-to-end tests         |       202 |      54,250 |
+| **Total**                | **1,776** | **573,189** |
 
 ### Functions
 
@@ -459,8 +459,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,691 |
 | — unexported (private)          |  5,093 |
 | Unit test functions (`TestXxx`) | 11,712 |
-| Subtests (`t.Run(...)`)         |  3,060 |
-| End-to-end test functions       |    512 |
+| Subtests (`t.Run(...)`)         |  3,065 |
+| End-to-end test functions       |    514 |
 
 ### Ratios worth noting
 

--- a/README.md
+++ b/README.md
@@ -446,20 +446,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,001 |     206,588 |
-| Unit tests (`_test.go`)  |       569 |     311,670 |
-| End-to-end tests         |       201 |      53,973 |
-| **Total**                | **1,771** | **572,231** |
+| Source (`.go`, non-test) |     1,002 |     206,854 |
+| Unit tests (`_test.go`)  |       572 |     312,085 |
+| End-to-end tests         |       201 |      53,981 |
+| **Total**                | **1,775** | **572,920** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,779 |
-| — exported (public)             |  2,689 |
-| — unexported (private)          |  5,090 |
-| Unit test functions (`TestXxx`) | 11,704 |
-| Subtests (`t.Run(...)`)         |  3,058 |
+| Source functions                |  7,784 |
+| — exported (public)             |  2,691 |
+| — unexported (private)          |  5,093 |
+| Unit test functions (`TestXxx`) | 11,712 |
+| Subtests (`t.Run(...)`)         |  3,060 |
 | End-to-end test functions       |    512 |
 
 ### Ratios worth noting
@@ -468,16 +468,16 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~547 lines |
-| Comment lines in source            |  27,523 (~13.3% of source) |
+| Average test file length           |                 ~545 lines |
+| Comment lines in source            |  27,639 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,584 |
-| `defer` statements                 | 1,002 |
+| `if err != nil` checks             | 6,586 |
+| `defer` statements                 | 1,003 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,756 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,745 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,760 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,746 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,002 |     207,068 |
-| Unit tests (`_test.go`)  |       560 |     313,031 |
-| End-to-end tests         |       211 |      56,209 |
-| **Total**                | **1,773** | **576,308** |
+| Source (`.go`, non-test) |     1,002 |     207,148 |
+| Unit tests (`_test.go`)  |       561 |     313,287 |
+| End-to-end tests         |       211 |      56,256 |
+| **Total**                | **1,774** | **576,691** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,791 |
+| Source functions                |  7,793 |
 | — exported (public)             |  2,693 |
-| — unexported (private)          |  5,098 |
-| Unit test functions (`TestXxx`) | 11,739 |
-| Subtests (`t.Run(...)`)         |  3,107 |
-| End-to-end test functions       |    533 |
+| — unexported (private)          |  5,100 |
+| Unit test functions (`TestXxx`) | 11,745 |
+| Subtests (`t.Run(...)`)         |  3,109 |
+| End-to-end test functions       |    534 |
 
 ### Ratios worth noting
 
@@ -469,7 +469,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
 | Average test file length           |                 ~558 lines |
-| Comment lines in source            |  27,735 (~13.4% of source) |
+| Comment lines in source            |  27,765 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,764 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,750 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,766 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,751 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,897 |
 | Unit tests (`_test.go`)  |       573 |     312,153 |
-| End-to-end tests         |       209 |      55,707 |
-| **Total**                | **1,784** | **574,757** |
+| End-to-end tests         |       210 |      55,870 |
+| **Total**                | **1,785** | **574,920** |
 
 ### Functions
 
@@ -459,8 +459,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,692 |
 | — unexported (private)          |  5,093 |
 | Unit test functions (`TestXxx`) | 11,715 |
-| Subtests (`t.Run(...)`)         |  3,084 |
-| End-to-end test functions       |    528 |
+| Subtests (`t.Run(...)`)         |  3,087 |
+| End-to-end test functions       |    529 |
 
 ### Ratios worth noting
 

--- a/README.md
+++ b/README.md
@@ -446,20 +446,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,001 |     206,459 |
-| Unit tests (`_test.go`)  |       566 |     311,359 |
-| End-to-end tests         |       201 |      53,900 |
-| **Total**                | **1,768** | **571,718** |
+| Source (`.go`, non-test) |     1,001 |     206,588 |
+| Unit tests (`_test.go`)  |       569 |     311,670 |
+| End-to-end tests         |       201 |      53,973 |
+| **Total**                | **1,771** | **572,231** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,775 |
-| — exported (public)             |  2,688 |
-| — unexported (private)          |  5,087 |
-| Unit test functions (`TestXxx`) | 11,698 |
-| Subtests (`t.Run(...)`)         |  3,055 |
+| Source functions                |  7,779 |
+| — exported (public)             |  2,689 |
+| — unexported (private)          |  5,090 |
+| Unit test functions (`TestXxx`) | 11,704 |
+| Subtests (`t.Run(...)`)         |  3,058 |
 | End-to-end test functions       |    512 |
 
 ### Ratios worth noting
@@ -468,16 +468,16 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~550 lines |
-| Comment lines in source            |  27,447 (~13.3% of source) |
+| Average test file length           |                 ~547 lines |
+| Comment lines in source            |  27,523 (~13.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,585 |
-| `defer` statements                 | 1,001 |
+| `if err != nil` checks             | 6,584 |
+| `defer` statements                 | 1,002 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,753 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,739 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,756 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,745 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |       999 |     206,130 |
-| Unit tests (`_test.go`)  |       563 |     310,985 |
-| End-to-end tests         |       200 |      53,589 |
-| **Total**                | **1,762** | **570,704** |
+| Source (`.go`, non-test) |     1,001 |     206,459 |
+| Unit tests (`_test.go`)  |       566 |     311,359 |
+| End-to-end tests         |       201 |      53,900 |
+| **Total**                | **1,768** | **571,718** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,767 |
-| — exported (public)             |  2,684 |
-| — unexported (private)          |  5,083 |
-| Unit test functions (`TestXxx`) | 11,684 |
-| Subtests (`t.Run(...)`)         |  3,047 |
-| End-to-end test functions       |    510 |
+| Source functions                |  7,775 |
+| — exported (public)             |  2,688 |
+| — unexported (private)          |  5,087 |
+| Unit test functions (`TestXxx`) | 11,698 |
+| Subtests (`t.Run(...)`)         |  3,055 |
+| End-to-end test functions       |    512 |
 
 ### Ratios worth noting
 
@@ -468,17 +468,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~552 lines |
-| Comment lines in source            |  27,261 (~13.2% of source) |
+| Average test file length           |                 ~550 lines |
+| Comment lines in source            |  27,447 (~13.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,584 |
-| `defer` statements                 |   998 |
-| `struct` types defined             | 2,751 |
+| `if err != nil` checks             | 6,585 |
+| `defer` statements                 | 1,001 |
+| `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,747 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,737 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,753 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,739 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -447,9 +447,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,897 |
-| Unit tests (`_test.go`)  |       573 |     312,153 |
-| End-to-end tests         |       210 |      55,870 |
-| **Total**                | **1,785** | **574,920** |
+| Unit tests (`_test.go`)  |       561 |     312,592 |
+| End-to-end tests         |       211 |      55,952 |
+| **Total**                | **1,774** | **575,441** |
 
 ### Functions
 
@@ -458,9 +458,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,785 |
 | — exported (public)             |  2,692 |
 | — unexported (private)          |  5,093 |
-| Unit test functions (`TestXxx`) | 11,715 |
-| Subtests (`t.Run(...)`)         |  3,087 |
-| End-to-end test functions       |    529 |
+| Unit test functions (`TestXxx`) | 11,728 |
+| Subtests (`t.Run(...)`)         |  3,100 |
+| End-to-end test functions       |    530 |
 
 ### Ratios worth noting
 
@@ -468,7 +468,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~544 lines |
+| Average test file length           |                 ~557 lines |
 | Comment lines in source            |  27,661 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
@@ -476,8 +476,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,606 |
-| `defer` statements                 | 1,012 |
+| `if err != nil` checks             | 6,610 |
+| `defer` statements                 | 1,015 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Yes. Set `GITLAB_URL` to your instance URL. When `GITLAB_URL` is omitted, stdio 
 <details>
 <summary><strong>Is my data safe?</strong></summary>
 
-When you run it yourself, locally over stdio or on your own infrastructure over HTTP, every request goes to your GitLab instance and nowhere else. There is no update check and no phoning home; telemetry exists but is off by default, and turning it on exports to a collector you configure, never to anyone else.
+When you run it yourself, locally over stdio or on your own infrastructure over HTTP, every request goes to your GitLab instance and nowhere else. There is no update check, no license check and no telemetry: your instance is the only host this server contacts.
 
 The exception is the <a href="#try-it-without-installing-anything-hosted-endpoint">hosted endpoint</a>: using <code>https://mcp.jmrp.io/gitlab</code> means your token and every request pass through that machine. Nothing is stored there, but it is someone else's server, which is why the hosted section says to keep using it locally.
 
@@ -423,11 +423,10 @@ The published container image is `ghcr.io/jmrplens/gitlab-mcp-server:latest`. Se
 
 ## Privacy Policy
 
-The server runs entirely on your machine and has **no analytics and no backend
-of its own**: data flows only between your MCP client and the GitLab instance
-you configure. OpenTelemetry export exists, off by default, and when you enable
-it the data goes to a collector you run; nothing in any code path carries the
-maintainer's address. Your token is used solely to authenticate GitLab requests
+The server runs entirely on your machine and has **no telemetry, analytics, or
+backend of its own** — data flows only between your MCP client and the GitLab
+instance you configure (plus an optional signed-binary update check against
+GitHub Releases). Your token is used solely to authenticate GitLab requests
 and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 ## Contributing & Security
@@ -447,47 +446,47 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,003 |     207,932 |
-| Unit tests (`_test.go`)  |       562 |     313,964 |
-| End-to-end tests         |       197 |      52,830 |
-| **Total**                | **1,762** | **574,726** |
+| Source (`.go`, non-test) |       999 |     206,130 |
+| Unit tests (`_test.go`)  |       563 |     310,985 |
+| End-to-end tests         |       200 |      53,589 |
+| **Total**                | **1,762** | **570,704** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,821 |
-| — exported (public)             |  2,702 |
-| — unexported (private)          |  5,119 |
-| Unit test functions (`TestXxx`) | 11,773 |
-| Subtests (`t.Run(...)`)         |  3,068 |
-| End-to-end test functions       |    512 |
+| Source functions                |  7,767 |
+| — exported (public)             |  2,684 |
+| — unexported (private)          |  5,083 |
+| Unit test functions (`TestXxx`) | 11,684 |
+| Subtests (`t.Run(...)`)         |  3,047 |
+| End-to-end test functions       |    510 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
-| Average source file length         |                 ~207 lines |
-| Average test file length           |                 ~558 lines |
-| Comment lines in source            |  28,096 (~13.5% of source) |
+| Average source file length         |                 ~206 lines |
+| Average test file length           |                 ~552 lines |
+| Comment lines in source            |  27,261 (~13.2% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,597 |
-| `defer` statements                 | 1,001 |
-| `struct` types defined             | 2,757 |
-| `//nolint` suppressions            |   249 |
+| `if err != nil` checks             | 6,584 |
+| `defer` statements                 |   998 |
+| `struct` types defined             | 2,751 |
+| `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   238 |
+| Go packages                    |   239 |
 | Direct dependencies (`go.mod`) |    29 |
 | Indirect dependencies          |    31 |
 
@@ -502,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,780 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,765 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,747 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,737 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,854 |
 | Unit tests (`_test.go`)  |       572 |     312,085 |
-| End-to-end tests         |       204 |      54,657 |
-| **Total**                | **1,778** | **573,596** |
+| End-to-end tests         |       206 |      55,169 |
+| **Total**                | **1,780** | **574,108** |
 
 ### Functions
 
@@ -459,8 +459,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,691 |
 | — unexported (private)          |  5,093 |
 | Unit test functions (`TestXxx`) | 11,712 |
-| Subtests (`t.Run(...)`)         |  3,072 |
-| End-to-end test functions       |    520 |
+| Subtests (`t.Run(...)`)         |  3,078 |
+| End-to-end test functions       |    523 |
 
 ### Ratios worth noting
 
@@ -476,8 +476,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,589 |
-| `defer` statements                 | 1,004 |
+| `if err != nil` checks             | 6,599 |
+| `defer` statements                 | 1,009 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,854 |
 | Unit tests (`_test.go`)  |       572 |     312,085 |
-| End-to-end tests         |       202 |      54,250 |
-| **Total**                | **1,776** | **573,189** |
+| End-to-end tests         |       204 |      54,657 |
+| **Total**                | **1,778** | **573,596** |
 
 ### Functions
 
@@ -459,8 +459,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — exported (public)             |  2,691 |
 | — unexported (private)          |  5,093 |
 | Unit test functions (`TestXxx`) | 11,712 |
-| Subtests (`t.Run(...)`)         |  3,065 |
-| End-to-end test functions       |    514 |
+| Subtests (`t.Run(...)`)         |  3,072 |
+| End-to-end test functions       |    520 |
 
 ### Ratios worth noting
 
@@ -476,8 +476,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,586 |
-| `defer` statements                 | 1,003 |
+| `if err != nil` checks             | 6,589 |
+| `defer` statements                 | 1,004 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -446,10 +446,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,003 |     207,932 |
+| Source (`.go`, non-test) |     1,003 |     207,936 |
 | Unit tests (`_test.go`)  |       562 |     313,964 |
-| End-to-end tests         |       211 |      56,486 |
-| **Total**                | **1,776** | **578,382** |
+| End-to-end tests         |       211 |      56,515 |
+| **Total**                | **1,776** | **578,415** |
 
 ### Functions
 
@@ -469,7 +469,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~207 lines |
 | Average test file length           |                 ~558 lines |
-| Comment lines in source            |  28,096 (~13.5% of source) |
+| Comment lines in source            |  28,099 (~13.5% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -494,7 +494,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                                     |
 | ------------------- | -------------------------------------------------------- |
-| Longest source file | `internal/tools/dynamic/register.go` — 3,878 lines       |
+| Longest source file | `internal/tools/dynamic/register.go` — 3,882 lines       |
 | Longest test file   | `internal/tools/projects/projects_test.go` — 8,183 lines |
 
 ### Because why not
@@ -502,7 +502,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~3,780 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,764 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 12,765 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,002 |     207,148 |
-| Unit tests (`_test.go`)  |       561 |     313,287 |
-| End-to-end tests         |       211 |      56,256 |
-| **Total**                | **1,774** | **576,691** |
+| Source (`.go`, non-test) |     1,003 |     207,476 |
+| Unit tests (`_test.go`)  |       562 |     313,590 |
+| End-to-end tests         |       211 |      56,350 |
+| **Total**                | **1,776** | **577,416** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,793 |
-| — exported (public)             |  2,693 |
-| — unexported (private)          |  5,100 |
-| Unit test functions (`TestXxx`) | 11,745 |
-| Subtests (`t.Run(...)`)         |  3,109 |
-| End-to-end test functions       |    534 |
+| Source functions                |  7,806 |
+| — exported (public)             |  2,697 |
+| — unexported (private)          |  5,109 |
+| Unit test functions (`TestXxx`) | 11,757 |
+| Subtests (`t.Run(...)`)         |  3,114 |
+| End-to-end test functions       |    535 |
 
 ### Ratios worth noting
 
@@ -468,17 +468,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~558 lines |
-| Comment lines in source            |  27,765 (~13.4% of source) |
+| Average test file length           |                 ~557 lines |
+| Comment lines in source            |  27,901 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,612 |
+| `if err != nil` checks             | 6,621 |
 | `defer` statements                 | 1,017 |
-| `struct` types defined             | 2,755 |
+| `struct` types defined             | 2,756 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,766 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,751 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,772 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,753 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,002 |     206,854 |
-| Unit tests (`_test.go`)  |       572 |     312,085 |
-| End-to-end tests         |       206 |      55,169 |
-| **Total**                | **1,780** | **574,108** |
+| Source (`.go`, non-test) |     1,002 |     206,897 |
+| Unit tests (`_test.go`)  |       573 |     312,153 |
+| End-to-end tests         |       208 |      55,507 |
+| **Total**                | **1,783** | **574,557** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,784 |
-| — exported (public)             |  2,691 |
+| Source functions                |  7,785 |
+| — exported (public)             |  2,692 |
 | — unexported (private)          |  5,093 |
-| Unit test functions (`TestXxx`) | 11,712 |
-| Subtests (`t.Run(...)`)         |  3,078 |
-| End-to-end test functions       |    523 |
+| Unit test functions (`TestXxx`) | 11,715 |
+| Subtests (`t.Run(...)`)         |  3,084 |
+| End-to-end test functions       |    527 |
 
 ### Ratios worth noting
 
@@ -468,16 +468,16 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~545 lines |
-| Comment lines in source            |  27,639 (~13.4% of source) |
+| Average test file length           |                 ~544 lines |
+| Comment lines in source            |  27,661 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,599 |
-| `defer` statements                 | 1,009 |
+| `if err != nil` checks             | 6,605 |
+| `defer` statements                 | 1,012 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,760 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,746 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,761 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,748 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,002 |     206,992 |
-| Unit tests (`_test.go`)  |       561 |     312,764 |
-| End-to-end tests         |       211 |      56,031 |
-| **Total**                | **1,774** | **575,787** |
+| Source (`.go`, non-test) |     1,002 |     207,068 |
+| Unit tests (`_test.go`)  |       560 |     313,031 |
+| End-to-end tests         |       211 |      56,209 |
+| **Total**                | **1,773** | **576,308** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,789 |
+| Source functions                |  7,791 |
 | — exported (public)             |  2,693 |
-| — unexported (private)          |  5,096 |
-| Unit test functions (`TestXxx`) | 11,732 |
-| Subtests (`t.Run(...)`)         |  3,102 |
-| End-to-end test functions       |    531 |
+| — unexported (private)          |  5,098 |
+| Unit test functions (`TestXxx`) | 11,739 |
+| Subtests (`t.Run(...)`)         |  3,107 |
+| End-to-end test functions       |    533 |
 
 ### Ratios worth noting
 
@@ -468,17 +468,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
-| Average test file length           |                 ~557 lines |
-| Comment lines in source            |  27,693 (~13.4% of source) |
+| Average test file length           |                 ~558 lines |
+| Comment lines in source            |  27,735 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,610 |
-| `defer` statements                 | 1,015 |
-| `struct` types defined             | 2,753 |
+| `if err != nil` checks             | 6,612 |
+| `defer` statements                 | 1,017 |
+| `struct` types defined             | 2,755 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,763 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,749 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,764 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,750 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -448,8 +448,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,002 |     206,897 |
 | Unit tests (`_test.go`)  |       573 |     312,153 |
-| End-to-end tests         |       208 |      55,507 |
-| **Total**                | **1,783** | **574,557** |
+| End-to-end tests         |       209 |      55,707 |
+| **Total**                | **1,784** | **574,757** |
 
 ### Functions
 
@@ -460,7 +460,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | — unexported (private)          |  5,093 |
 | Unit test functions (`TestXxx`) | 11,715 |
 | Subtests (`t.Run(...)`)         |  3,084 |
-| End-to-end test functions       |    527 |
+| End-to-end test functions       |    528 |
 
 ### Ratios worth noting
 
@@ -476,7 +476,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,605 |
+| `if err != nil` checks             | 6,606 |
 | `defer` statements                 | 1,012 |
 | `struct` types defined             | 2,753 |
 | `//nolint` suppressions            |   250 |

--- a/README.md
+++ b/README.md
@@ -446,21 +446,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,002 |     206,897 |
-| Unit tests (`_test.go`)  |       561 |     312,592 |
-| End-to-end tests         |       211 |      55,952 |
-| **Total**                | **1,774** | **575,441** |
+| Source (`.go`, non-test) |     1,002 |     206,992 |
+| Unit tests (`_test.go`)  |       561 |     312,764 |
+| End-to-end tests         |       211 |      56,031 |
+| **Total**                | **1,774** | **575,787** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,785 |
-| — exported (public)             |  2,692 |
-| — unexported (private)          |  5,093 |
-| Unit test functions (`TestXxx`) | 11,728 |
-| Subtests (`t.Run(...)`)         |  3,100 |
-| End-to-end test functions       |    530 |
+| Source functions                |  7,789 |
+| — exported (public)             |  2,693 |
+| — unexported (private)          |  5,096 |
+| Unit test functions (`TestXxx`) | 11,732 |
+| Subtests (`t.Run(...)`)         |  3,102 |
+| End-to-end test functions       |    531 |
 
 ### Ratios worth noting
 
@@ -469,7 +469,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~206 lines |
 | Average test file length           |                 ~557 lines |
-| Comment lines in source            |  27,661 (~13.4% of source) |
+| Comment lines in source            |  27,693 (~13.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,761 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,748 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,763 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,749 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/gen_testing_docs/main.go
+++ b/cmd/gen_testing_docs/main.go
@@ -62,7 +62,7 @@ const (
 	// the Makefile, or the tooling silently measures a smaller project than
 	// the one in the repository. None of these tags gates anything outside
 	// test/e2e, so cmd/ and internal/ resolve identically with them.
-	e2eTags = "e2e,orbitlive,httpe2e,stdioe2e"
+	e2eTags = "e2e,orbitlive,httpe2e,stdioe2e,collectore2e"
 
 	goFileSuffix     = ".go"
 	goTestFileSuffix = "_test.go"

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,13 +18,13 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,285 |
-| Unit test functions                                   | 11,773 |
-| E2E test functions                                    |    512 |
-| cmd test functions                                    |  1,155 |
+| Total test functions                                  | 12,267 |
+| Unit test functions                                   | 11,736 |
+| E2E test functions                                    |    531 |
+| cmd test functions                                    |  1,145 |
 | Test files (internal/)                                |    475 |
-| Test files (cmd/)                                     |     87 |
-| Test files (test/e2e/)                                |    195 |
+| Test files (cmd/)                                     |     86 |
+| Test files (test/e2e/)                                |    209 |
 | Tool sub-packages tested                              |    173 |
 | Core packages tested                                  |     20 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  90.1% |
@@ -35,8 +35,8 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,696 | 87.1% |
-| `TestFunc` (no underscore)             |    951 |  7.7% |
+| `TestFunc_Scenario` (2-part)           | 10,678 | 87.0% |
+| `TestFunc` (no underscore)             |    951 |  7.8% |
 | `TestFunc_Scenario_Expected` (3+ part) |    638 |  5.2% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,983 |        116 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,956 |        115 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            293 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (173) |          8,342 |        345 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            512 |        195 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,155 |         87 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,285** |    **757** |                                                                                                 |
+| Tool sub-packages (173) |          8,342 |        346 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            531 |        209 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          1,145 |         86 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,267** |    **770** |                                                                                                 |
 
 ### Core Packages
 
@@ -64,19 +64,19 @@
 | completions   |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                   |
 | config        |        80 |    96.9% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                           |
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                              |
-| elicitation   |       124 |    96.2% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                               |
+| elicitation   |       122 |    96.4% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                               |
 | gitlab        |        47 |    98.4% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                    |
-| mcpotel       |        64 |    95.7% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
+| mcpotel       |        58 |    95.9% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
 | oauth         |        57 |    89.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                    |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                              |
 | prompts       |       266 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data. |
 | resources     |       176 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                        |
 | serverpool    |        73 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                            |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                   |
-| telemetry     |        83 |    90.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
+| telemetry     |        66 |    91.6% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
 | testutil      |        34 |    88.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                              |
-| toolutil      |       736 |    97.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
-| **Subtotal**  | **1,983** |          |                                                                                                                                                                            |
+| toolutil      |       734 |    97.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
+| **Subtotal**  | **1,956** |          |                                                                                                                                                                            |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -233,7 +233,7 @@
 | namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
-| packages                |       127 |          6 |    99.6% |         9 |
+| packages                |       127 |          7 |    99.6% |         9 |
 | pages                   |        54 |          2 |   100.0% |         9 |
 | pipelines               |       110 |          3 |   100.0% |        12 |
 | pipelineschedules       |        94 |          2 |    99.7% |        11 |
@@ -288,7 +288,7 @@
 | waitpoll                |        13 |          1 |    99.2% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        93 |          3 |   100.0% |         6 |
-| **Total**               | **8,342** |    **345** |          | **1,167** |
+| **Total**               | **8,342** |    **346** |          | **1,167** |
 
 </details>
 
@@ -346,18 +346,18 @@
 | completions   |   100.0% |
 | config        |    96.9% |
 | edition       |    87.0% |
-| elicitation   |    96.2% |
+| elicitation   |    96.4% |
 | gitlab        |    98.4% |
-| mcpotel       |    95.7% |
+| mcpotel       |    95.9% |
 | oauth         |    89.4% |
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.4% |
 | serverpool    |    98.3% |
 | subscriptions |    98.5% |
-| telemetry     |    90.3% |
+| telemetry     |    91.6% |
 | testutil      |    88.7% |
-| toolutil      |    97.9% |
+| toolutil      |    97.8% |
 
 ### Tool Sub-Packages
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,12 +18,12 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,267 |
-| Unit test functions                                   | 11,736 |
-| E2E test functions                                    |    531 |
-| cmd test functions                                    |  1,145 |
+| Total test functions                                  | 12,292 |
+| Unit test functions                                   | 11,757 |
+| E2E test functions                                    |    535 |
+| cmd test functions                                    |  1,153 |
 | Test files (internal/)                                |    475 |
-| Test files (cmd/)                                     |     86 |
+| Test files (cmd/)                                     |     87 |
 | Test files (test/e2e/)                                |    209 |
 | Tool sub-packages tested                              |    173 |
 | Core packages tested                                  |     20 |
@@ -35,8 +35,8 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,678 | 87.0% |
-| `TestFunc` (no underscore)             |    951 |  7.8% |
+| `TestFunc_Scenario` (2-part)           | 10,703 | 87.1% |
+| `TestFunc` (no underscore)             |    951 |  7.7% |
 | `TestFunc_Scenario_Expected` (3+ part) |    638 |  5.2% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,956 |        115 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,969 |        116 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            293 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (173) |          8,342 |        346 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            531 |        209 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,145 |         86 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,267** |    **770** |                                                                                                 |
+| Tool sub-packages (173) |          8,342 |        345 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            535 |        209 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          1,153 |         87 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,292** |    **771** |                                                                                                 |
 
 ### Core Packages
 
@@ -66,17 +66,17 @@
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                              |
 | elicitation   |       122 |    96.4% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                               |
 | gitlab        |        47 |    98.4% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                    |
-| mcpotel       |        58 |    95.9% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
+| mcpotel       |        60 |    95.9% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
 | oauth         |        57 |    89.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                    |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                              |
 | prompts       |       266 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data. |
 | resources     |       176 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                        |
 | serverpool    |        73 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                            |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                   |
-| telemetry     |        66 |    91.6% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
+| telemetry     |        76 |    91.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
 | testutil      |        34 |    88.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                              |
-| toolutil      |       734 |    97.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
-| **Subtotal**  | **1,956** |          |                                                                                                                                                                            |
+| toolutil      |       735 |    97.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
+| **Subtotal**  | **1,969** |          |                                                                                                                                                                            |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -233,7 +233,7 @@
 | namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
-| packages                |       127 |          7 |    99.6% |         9 |
+| packages                |       127 |          6 |    99.6% |         9 |
 | pages                   |        54 |          2 |   100.0% |         9 |
 | pipelines               |       110 |          3 |   100.0% |        12 |
 | pipelineschedules       |        94 |          2 |    99.7% |        11 |
@@ -288,7 +288,7 @@
 | waitpoll                |        13 |          1 |    99.2% |         0 |
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        93 |          3 |   100.0% |         6 |
-| **Total**               | **8,342** |    **346** |          | **1,167** |
+| **Total**               | **8,342** |    **345** |          | **1,167** |
 
 </details>
 
@@ -332,7 +332,7 @@
 | cmd/internal/apidocs                           |    87.3% |
 | cmd/internal/docgen                            |    99.6% |
 | cmd/internal/mcpsurface                        |    85.0% |
-| cmd/server                                     |    87.9% |
+| cmd/server                                     |    88.4% |
 
 ### Core Packages
 
@@ -355,7 +355,7 @@
 | resources     |    99.4% |
 | serverpool    |    98.3% |
 | subscriptions |    98.5% |
-| telemetry     |    91.6% |
+| telemetry     |    91.3% |
 | testutil      |    88.7% |
 | toolutil      |    97.8% |
 
@@ -568,8 +568,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/server** (87.9%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/gen_docker_tools** (88.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/server** (88.4%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **testutil** (88.7%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **oauth** (89.4%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 12,292 |
-| Unit test functions                                   | 11,757 |
-| E2E test functions                                    |    535 |
-| cmd test functions                                    |  1,153 |
+| Total test functions                                  | 12,310 |
+| Unit test functions                                   | 11,773 |
+| E2E test functions                                    |    537 |
+| cmd test functions                                    |  1,155 |
 | Test files (internal/)                                |    475 |
 | Test files (cmd/)                                     |     87 |
 | Test files (test/e2e/)                                |    209 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 10,703 | 87.1% |
+| `TestFunc_Scenario` (2-part)           | 10,721 | 87.1% |
 | `TestFunc` (no underscore)             |    951 |  7.7% |
 | `TestFunc_Scenario_Expected` (3+ part) |    638 |  5.2% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          1,969 |        116 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          1,983 |        116 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            293 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (173) |          8,342 |        345 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            535 |        209 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,153 |         87 | server entry point and developer command utilities                                              |
-| **Total**               |     **12,292** |    **771** |                                                                                                 |
+| E2E integration         |            537 |        209 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          1,155 |         87 | server entry point and developer command utilities                                              |
+| **Total**               |     **12,310** |    **771** |                                                                                                 |
 
 ### Core Packages
 
@@ -64,19 +64,19 @@
 | completions   |        96 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                   |
 | config        |        80 |    96.9% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                           |
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                              |
-| elicitation   |       122 |    96.4% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                               |
+| elicitation   |       124 |    96.2% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                               |
 | gitlab        |        47 |    98.4% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                    |
-| mcpotel       |        60 |    95.9% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
+| mcpotel       |        64 |    95.7% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                       |
 | oauth         |        57 |    89.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                    |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                              |
 | prompts       |       266 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data. |
 | resources     |       176 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                        |
 | serverpool    |        73 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                            |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                   |
-| telemetry     |        76 |    91.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
+| telemetry     |        83 |    90.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                         |
 | testutil      |        34 |    88.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                              |
-| toolutil      |       735 |    97.8% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
-| **Subtotal**  | **1,969** |          |                                                                                                                                                                            |
+| toolutil      |       736 |    97.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                              |
+| **Subtotal**  | **1,983** |          |                                                                                                                                                                            |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -332,7 +332,7 @@
 | cmd/internal/apidocs                           |    87.3% |
 | cmd/internal/docgen                            |    99.6% |
 | cmd/internal/mcpsurface                        |    85.0% |
-| cmd/server                                     |    88.4% |
+| cmd/server                                     |    88.0% |
 
 ### Core Packages
 
@@ -346,18 +346,18 @@
 | completions   |   100.0% |
 | config        |    96.9% |
 | edition       |    87.0% |
-| elicitation   |    96.4% |
+| elicitation   |    96.2% |
 | gitlab        |    98.4% |
-| mcpotel       |    95.9% |
+| mcpotel       |    95.7% |
 | oauth         |    89.4% |
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.4% |
 | serverpool    |    98.3% |
 | subscriptions |    98.5% |
-| telemetry     |    91.3% |
+| telemetry     |    90.3% |
 | testutil      |    88.7% |
-| toolutil      |    97.8% |
+| toolutil      |    97.9% |
 
 ### Tool Sub-Packages
 
@@ -568,8 +568,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/server** (88.0%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **cmd/gen_docker_tools** (88.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/server** (88.4%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
 - **testutil** (88.7%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **oauth** (89.4%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -616,6 +616,7 @@ func (r *Registry) Execute(ctx context.Context, req *mcp.CallToolRequest, input 
 	if stateEvent, lifecycleAlias := issueLifecycleAliasStateEvent(requestedActionID); lifecycleAlias && entry.ID == "issue.update" {
 		if existing, hasStateEvent := params["state_event"]; hasStateEvent {
 			if existingStateEvent, converted := actioncompat.IssueStateEventValue(existing); converted && existingStateEvent != stateEvent {
+				toolutil.LogToolRefusal(ctx, req, executeCallName(entry.ID), toolutil.RefusalInvalidParams)
 				return toolutil.ErrorResult(fmt.Sprintf("gitlab_execute_action: action %q implies state_event=%q, but params.state_event was %q. Use the canonical issue.update action for explicit state_event control.", requestedActionID, stateEvent, existingStateEvent)), nil, nil
 			}
 		} else {
@@ -634,7 +635,10 @@ func (r *Registry) Execute(ctx context.Context, req *mcp.CallToolRequest, input 
 		params["confirm"] = true
 	}
 	if entry.Destructive && !hasExplicitConfirm(params) {
-		slog.WarnContext(ctx, "blocked destructive dynamic action without explicit confirmation", "action", entry.ID)
+		// A refusal like the surface-tool one, and recorded like it: this is
+		// the default surface, so leaving it out meant the most common
+		// needs_confirmation refusals never reached the refusal metric at all.
+		toolutil.LogToolRefusal(ctx, req, executeCallName(entry.ID), toolutil.RefusalNeedsConfirmation)
 		return toolutil.ErrorResult(fmt.Sprintf("gitlab_execute_action: action %q is destructive. Re-send with confirm=true only after the user explicitly approves this operation.", entry.ID)), nil, nil
 	}
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -35,6 +35,18 @@ Also no GitLab and no credentials. It builds the binary, starts it with the envi
 
 stdio is this project's primary transport and nothing anywhere drove it until this module existed. The in-memory suite runs in one process, so it has no pipes, no separation of stdout from stderr, no process to exit, and no environment-variable configuration, since HTTP mode takes flags instead. Every case here corresponds to something that shipped broken and was found by hand against a binary: a nil dereference that killed the process on an ordinary eliciting tool call; a keepalive ping that closed the session of any client speaking `2026-07-28` after 45 idle seconds, held in place by a unit test asserting the ping ought to be there; an exit status of 1 on every normal shutdown; and a log stream whose steady state was entirely the SDK's own session chatter.
 
+## Collector module
+
+```bash
+make test-e2e-collector
+```
+
+No GitLab and no credentials either, but Docker is required: it starts a pinned `otel/opentelemetry-collector-contrib` with an OTLP receiver and file exporters, points the real binary at it, drives traffic, and asserts on the OTLP JSON the collector wrote after parsing what it was sent. Without Docker it **skips**, with the reason, rather than modeling a receiver.
+
+It exists because every other telemetry test in this repository is graded by code we wrote. The in-process receiver in `test/e2e/http` answers `200` to whatever it is handed and stores the bytes, which is right for the two questions it asks (was the collector credential sent, did anything private leak) and is no evidence that the export is well formed. A malformed protobuf, a resource missing an attribute a backend requires, or a metric whose unit contradicts its name all pass a stub and all ship telemetry an operator cannot use. So this module asserts acceptance and shape, and deliberately repeats none of the credential or privacy assertions.
+
+Unlike the two transport modules it is **not** in the push-triggered CI jobs, because it pulls a container image. It belongs with the Docker-mode targets.
+
 ## Quick Start
 
 ### Self-Hosted Mode

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -10,6 +10,7 @@ There are five modules, answering different questions:
 | `test/e2e/http`      | `httpe2e`      | no           | The HTTP transport itself: cross-origin, preflight, auth modes, rate limiting, proxy  |
 | `test/e2e/stdio`     | `stdioe2e`     | no           | The stdio transport: pipes, process lifetime, exit status, environment configuration  |
 | `test/e2e/orbit`     | `orbitlive`    | gitlab.com   | The experimental Knowledge Graph API                                                  |
+| `test/e2e/collector` | `collectore2e` | no           | That a real OpenTelemetry Collector accepts and parses what this server exports (Docker) |
 
 Each tag has to be listed in `GO_ANALYSIS_TAGS` in the Makefile and in `e2eTags` in `cmd/gen_testing_docs`, or the module is invisible to `go vet`, to `golangci-lint` and to the generated test metrics. A file behind a tag nothing names is analysed by nothing.
 

--- a/test/e2e/collector/acceptance_test.go
+++ b/test/e2e/collector/acceptance_test.go
@@ -1,0 +1,244 @@
+//go:build collectore2e
+
+// acceptance_test.go asks the one question the in-process OTLP stub in
+// test/e2e/http cannot: does a real receiver accept this, and does what it
+// parses out mean anything.
+package collectore2e
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// telemetryEnv points a server at the collector and makes it export promptly.
+//
+// The timeouts are integers because the specification defines every OTEL_ one
+// as an integer number of milliseconds. Writing "200ms" parses as nothing and
+// silently keeps the ten-second default, which here means a test that times out
+// with no export to look at and no hint as to why.
+func telemetryEnv(c *collector) map[string]string {
+	return map[string]string{
+		"GITLAB_MCP_TELEMETRY":        "true",
+		"OTEL_EXPORTER_OTLP_ENDPOINT": c.endpoint,
+		"OTEL_EXPORTER_OTLP_TIMEOUT":  "2000",
+		"OTEL_BSP_SCHEDULE_DELAY":     "100",
+		"OTEL_METRIC_EXPORT_INTERVAL": "100",
+	}
+}
+
+// exportDeadline bounds every wait for parsed telemetry.
+//
+// It is long because three schedules have to line up before a document exists
+// to read: the span batcher, the metric reader, and the collector's own file
+// flush. It is bounded because the alternative to a deadline here is a suite
+// that hangs when the server exports nothing at all, which is the single most
+// likely thing to break.
+const exportDeadline = 60 * time.Second
+
+// durationMetric is the instrument the MCP semantic convention defines for a
+// server's request duration.
+const durationMetric = "mcp.server.operation.duration"
+
+// TestRealCollector_AcceptsAndParsesWhatThisServerEmits drives real traffic
+// into a real OpenTelemetry Collector and asserts on what came out the far side
+// of its pipeline.
+//
+// # The failure this exists to prevent
+//
+// Every telemetry test in this repository until now has been graded by code we
+// wrote. The in-process receiver in test/e2e/http answers 200 to whatever it is
+// handed and stores the bytes, which is exactly right for the two questions it
+// asks (was the credential sent, did anything private leak) and is no evidence
+// at all that the export is well formed. A protobuf we encode wrongly, a
+// resource missing an attribute a backend requires, a metric whose unit
+// contradicts its name: all three pass a stub, and all three ship a server
+// whose telemetry an operator cannot use, with a green suite behind them.
+//
+// A collector is not a stub. It decodes the protobuf, builds pdata out of it,
+// routes it through a pipeline and re-encodes it, and every one of those steps
+// can reject. So the assertions below are deliberately about acceptance and
+// shape rather than about content: that the export was taken without complaint,
+// that a span survived with the kind and the name the convention requires, that
+// the attributes an operator groups by are on it, that the duration metric
+// arrived in the unit its name promises, and that the resource says which
+// service and which instance produced all of it.
+//
+// The subtests share one collector, one server and one burst of traffic. They
+// are facts about a single export rather than independent scenarios, and
+// restarting the stack six times to assert them separately would buy nothing
+// but five more container starts.
+func TestRealCollector_AcceptsAndParsesWhatThisServerEmits(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	// A canonical catalog action, because on the default surface the tool name
+	// is gitlab_execute_action for every call and gitlab_mcp.action is the only
+	// thing on the span that says what was done. Several calls, so a batch is
+	// certainly non-empty rather than probably.
+	const action = "issue.list"
+	for i := range 5 {
+		srv.callAction(t, i+1, action, "some-group/some-project")
+	}
+
+	// Both logs go into either failure message. A collector that refused the
+	// export and a server that never sent one present identically from here, as
+	// an empty file, and only the two logs together tell them apart.
+	spanResource, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("the collector parsed no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	metricResource, duration, ok := c.awaitMetric(t, exportDeadline, durationMetric)
+	if !ok {
+		t.Fatalf("the collector parsed no %s metric.\nCollector:\n%s\nServer:\n%s", durationMetric, c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the collector accepted every export without complaint", func(t *testing.T) {
+		assertNothingWasRefused(t, c, srv)
+	})
+	t.Run("a server span is named for the MCP method", func(t *testing.T) {
+		assertServerSpan(t, span)
+	})
+	t.Run("the span carries the method and the canonical action", func(t *testing.T) {
+		assertSpanNamesTheOperation(t, span, action)
+	})
+	t.Run("the duration metric arrives in seconds", func(t *testing.T) {
+		assertDurationInSeconds(t, duration)
+	})
+	t.Run("the resource names the service and the instance", func(t *testing.T) {
+		// Asserted on both signals rather than once. They are built from one
+		// resource, so a divergence means the resource is being assembled per
+		// provider, and a metric that cannot be joined to the trace it came
+		// from is most of the value of having both.
+		assertResourceIdentifiesTheProcess(t, "traces", spanResource.Resource.Attributes)
+		assertResourceIdentifiesTheProcess(t, "metrics", metricResource.Resource.Attributes)
+	})
+	t.Run("the spans are attributed to this server's instrumentation scope", func(t *testing.T) {
+		assertInstrumentationScope(t, spanResource)
+	})
+}
+
+// assertNothingWasRefused reads the same fact from both ends of the export.
+//
+// Either reading alone can be wrong in a way the other catches. The collector
+// says whether it refused anything it was sent; the server says whether
+// anything it sent came back as an error, which covers a refusal the collector
+// recorded at a level this scan does not look at, or did not log at all.
+func assertNothingWasRefused(t *testing.T, c *collector, srv *server) {
+	t.Helper()
+
+	for line := range strings.SplitSeq(c.containerLogs(t), "\n") {
+		// The collector's console encoding is tab-separated with the level
+		// second, so matching on delimited fields cannot be tripped by the word
+		// "error" appearing inside a message.
+		if strings.Contains(line, "\terror\t") || strings.Contains(line, "\tfatal\t") {
+			t.Errorf("the collector logged a failure while receiving our export:\n%s", line)
+		}
+	}
+
+	// The server routes every OTel SDK error to its own logger, so a rejected
+	// export is visible from this side too, and is the sharper signal: it means
+	// a batch came back as something other than success.
+	if logs := srv.logs(); strings.Contains(logs, "opentelemetry sdk error") {
+		t.Errorf("the server reported an SDK error, so the collector did not accept what it sent:\n%s", logs)
+	}
+}
+
+// assertServerSpan pins the name and the kind, which are what a backend files a
+// span by before anybody looks at an attribute.
+func assertServerSpan(t *testing.T, span otlpSpan) {
+	t.Helper()
+
+	// The convention's rule is "{mcp.method.name} {target}", with the tool as
+	// the target for a call. A span the collector will not parse has no name at
+	// all here, so this asserts the parse as much as the name.
+	if want := "tools/call gitlab_execute_action"; span.Name != want {
+		t.Errorf("span name is %q, want %q", span.Name, want)
+	}
+	// SERVER, because this process is the one being called. A client-kind or
+	// internal span here would put every MCP operation in the wrong half of any
+	// service map built from these traces.
+	if span.Kind != spanKindServer {
+		t.Errorf("span kind is %d, want %d (SPAN_KIND_SERVER)", span.Kind, spanKindServer)
+	}
+}
+
+// assertSpanNamesTheOperation pins the two attributes an operator groups by.
+func assertSpanNamesTheOperation(t *testing.T, span otlpSpan, action string) {
+	t.Helper()
+
+	if got, present := attr(span.Attributes, "mcp.method.name"); !present || got != "tools/call" {
+		t.Errorf("mcp.method.name is %q (present=%t), want %q. The span carries %v",
+			got, present, "tools/call", keys(span.Attributes))
+	}
+	// Without this attribute the default surface's traces cannot tell listing
+	// issues from deleting a branch: gen_ai.tool.name is gitlab_execute_action
+	// for both.
+	if got, present := attr(span.Attributes, "gitlab_mcp.action"); !present || got != action {
+		t.Errorf("gitlab_mcp.action is %q (present=%t), want %q. The span carries %v",
+			got, present, action, keys(span.Attributes))
+	}
+}
+
+// assertDurationInSeconds pins the unit, and that there is a measurement in it.
+func assertDurationInSeconds(t *testing.T, duration otlpMetric) {
+	t.Helper()
+
+	// The unit is the assertion that matters. This server logs durations in
+	// milliseconds everywhere else, the convention fixes this instrument at
+	// seconds, and a mismatch is invisible in a dashboard until somebody reads
+	// a p99 of 400 and cannot tell which it is.
+	if duration.Unit != "s" {
+		t.Errorf("%s has unit %q, want %q", durationMetric, duration.Unit, "s")
+	}
+	// A histogram with no points would satisfy the unit check while carrying no
+	// measurement, which is the shape a broken instrument takes rather than an
+	// absent one.
+	if duration.Histogram == nil {
+		t.Fatalf("%s arrived without histogram data; the convention defines it as a histogram", durationMetric)
+	}
+	if len(duration.Histogram.DataPoints) == 0 {
+		t.Errorf("%s arrived with no data points, after five calls were served", durationMetric)
+	}
+}
+
+// assertResourceIdentifiesTheProcess pins what every signal has to say about
+// where it came from.
+func assertResourceIdentifiesTheProcess(t *testing.T, signal string, attrs []otlpAttr) {
+	t.Helper()
+
+	// service.name is what every backend groups by, and a resource without one
+	// is filed under "unknown_service" beside every other unlabeled process
+	// reporting to the same collector.
+	if got, present := attr(attrs, "service.name"); !present || got == "" {
+		t.Errorf("the %s resource has no service.name; it carries %v", signal, keys(attrs))
+	}
+	// service.instance.id is what separates two replicas of this server from
+	// one replica serving twice the traffic.
+	if _, present := attr(attrs, "service.instance.id"); !present {
+		t.Errorf("the %s resource has no service.instance.id; it carries %v", signal, keys(attrs))
+	}
+}
+
+// assertInstrumentationScope pins who the spans say instrumented them.
+//
+// The scope names the code doing the instrumenting, which is how an operator
+// tells our spans from those of a library that also instruments this process.
+// An empty scope makes that impossible, and is what an incorrectly built
+// provider produces.
+func assertInstrumentationScope(t *testing.T, resourceSpans otlpResourceSpans) {
+	t.Helper()
+
+	const want = "github.com/jmrplens/gitlab-mcp-server/v2/internal/mcpotel"
+	scopes := make([]string, 0, len(resourceSpans.ScopeSpans))
+	for _, scopeSpans := range resourceSpans.ScopeSpans {
+		scopes = append(scopes, scopeSpans.Scope.Name)
+	}
+	if !slices.Contains(scopes, want) {
+		t.Errorf("no scope named %q among %v", want, scopes)
+	}
+}

--- a/test/e2e/collector/clientspan_test.go
+++ b/test/e2e/collector/clientspan_test.go
@@ -1,0 +1,94 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRealCollector_AServerInitiatedNotificationIsAClientSpan covers the half of
+// the convention's split that nothing here reached, and the instrument that
+// went with it.
+//
+// The split is by initiator, not by role: this process is the receiver for a
+// tools/call and the initiator for a notification, so it produces both kinds of
+// span with different rules. Every case in this module had driven only the
+// receiving half, so mcp.client.operation.duration was documented, implemented,
+// and exercised by nothing.
+//
+// A notification is the cheap way in. An elicitation needs a client that
+// answers, which this module's caller is not; a notification is sent and not
+// waited on, so a subscription noticing a change produces one with no client
+// cooperation at all.
+func TestRealCollector_AServerInitiatedNotificationIsAClientSpan(t *testing.T) {
+	c := startCollector(t)
+	fake := startMutableFakeGitLab(t)
+	srv := startServer(t, telemetryEnv(c),
+		"--gitlab-url="+fake.URL(),
+		// Subscriptions are the legacy path and need a session.
+		"--stateless=false",
+	)
+
+	sess := srv.openSession(t)
+	sess.call(t, 2, "resources/subscribe", `{"uri":"`+resourceURI+`"}`)
+
+	// The watcher notices on its next poll, and the base cadence is 15 seconds,
+	// so this is the one case here that is slow by design rather than by
+	// accident.
+	fake.change("changed after the subscription was established")
+
+	_, span, ok := c.awaitSpan(t, 90*time.Second, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.Kind == spanKindClient && strings.HasPrefix(s.Name, "notifications/")
+	})
+	if !ok {
+		t.Fatalf("no client span for a server-initiated notification.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span is named for the method and is CLIENT kind", func(t *testing.T) {
+		if got, _ := attr(span.Attributes, "mcp.method.name"); !strings.HasPrefix(got, "notifications/") {
+			t.Errorf("mcp.method.name = %q, want a notifications/ method", got)
+		}
+		// SERVER would be the natural default and is wrong here. The convention
+		// splits by who initiated, and this process initiated.
+		if span.Kind != spanKindClient {
+			t.Errorf("kind = %d, want %d for something this server initiated", span.Kind, spanKindClient)
+		}
+	})
+
+	t.Run("the client instrument is recorded", func(t *testing.T) {
+		_, duration, found := c.awaitMetric(t, exportDeadline, "mcp.client.operation.duration")
+		if !found {
+			t.Fatalf("mcp.client.operation.duration was never recorded, so the second half of the convention is unmeasured.\nCollector:\n%s",
+				c.containerLogs(t))
+		}
+		if duration.Unit != "s" {
+			t.Errorf("unit = %q, want %q", duration.Unit, "s")
+		}
+	})
+
+	t.Run("the poll that noticed is its own rooted span", func(t *testing.T) {
+		_, poll, found := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+			return s.Name == "subscription poll"
+		})
+		if !found {
+			t.Fatal("no subscription poll span; the watcher is invisible")
+		}
+		// Rooted with a link rather than nested, because a poll outlives the
+		// request that created the subscription and nesting it would attach
+		// every poll to a span that ended minutes ago.
+		if poll.ParentSpanID != "" {
+			t.Errorf("the poll span has parent %s; it should be rooted and linked", poll.ParentSpanID)
+		}
+		if len(poll.Links) != 1 {
+			t.Errorf("recorded %d links, want 1 back to the subscribe that created it", len(poll.Links))
+		}
+		if _, present := attr(poll.Attributes, "gitlab_mcp.subscription.kind"); !present {
+			t.Errorf("the poll span does not say what kind of resource it polls; recorded %v", keys(poll.Attributes))
+		}
+	})
+
+	sess.close(t)
+}

--- a/test/e2e/collector/collector_test.go
+++ b/test/e2e/collector/collector_test.go
@@ -1,0 +1,445 @@
+//go:build collectore2e
+
+// collector_test.go runs a genuine OpenTelemetry Collector and reads back what
+// it parsed out of this server's exports.
+//
+// The receiver is the thing under test here, which is why the pipeline ends in
+// a file exporter: the collector writes OTLP JSON only after decoding the
+// protobuf, routing it through a pipeline and re-encoding it, so a document
+// appearing in that file is evidence that a real implementation understood what
+// we sent. Reading raw bytes off a socket, which is what the in-process stub in
+// test/e2e/http does, proves the bytes were delivered and nothing about whether
+// they mean anything.
+package collectore2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// collectorImage pins the receiver under test.
+//
+// Never latest. A floating tag makes the suite's meaning change without a
+// commit, so a collector release that tightened validation would either fail a
+// run nobody had changed anything in, or, worse, relax one and let a defect
+// through unannounced. Bumping this is a deliberate act with a diff.
+const collectorImage = "otel/opentelemetry-collector-contrib:0.159.0"
+
+// The container-side paths. The receiver binds 0.0.0.0 rather than the image
+// default of localhost, because a published port reaches the container from
+// outside its loopback and a receiver on localhost would simply never be
+// reached, which presents as a timeout with a perfectly healthy collector.
+//
+// Three file exporters rather than one shared instance: the collector builds a
+// separate exporter per pipeline, so a single path would have three writers
+// appending to one file and the interleaving would be ours to untangle.
+const (
+	collectorOTLPPort = "4318"
+	tracesFile        = "traces.json"
+	metricsFile       = "metrics.json"
+	logsFile          = "logs.json"
+)
+
+// collectorConfig is the pipeline the container runs.
+//
+// All three signal types are wired even though only traces and metrics are
+// asserted on, and the third one is insurance rather than need. This server
+// starts a logs provider and publishes "logs" among the signals on its server
+// card, but nothing in it currently bridges slog to that provider, so no log
+// record is ever exported: the suite passes today with the logs pipeline
+// removed. The day a bridge is added, a receiver without a logs pipeline
+// answers /v1/logs with 404 (measured against this image, not assumed), the
+// server's SDK error handler records the refusal, and the acceptance subtest
+// below fails, reporting a defect in this file as though the server had emitted
+// something invalid. Wiring the pipeline costs three lines and removes that.
+//
+// The debug exporter is at basic verbosity, not detailed. It prints one counted
+// line per batch, which is a readable trace of what traversed the pipeline and
+// leaves the container log small enough that "no error line appears in it" is
+// an assertion a human can also check by eye.
+const collectorConfig = `receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:` + collectorOTLPPort + `
+
+exporters:
+  file/traces:
+    path: /out/` + tracesFile + `
+  file/metrics:
+    path: /out/` + metricsFile + `
+  file/logs:
+    path: /out/` + logsFile + `
+  debug:
+    verbosity: basic
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file/traces, debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [file/metrics, debug]
+    logs:
+      receivers: [otlp]
+      exporters: [file/logs, debug]
+`
+
+// collector is a running OpenTelemetry Collector container.
+type collector struct {
+	// endpoint is what OTEL_EXPORTER_OTLP_ENDPOINT is set to.
+	endpoint string
+	// outDir is the host side of the bind mount the file exporters write into.
+	outDir string
+	name   string
+}
+
+// startCollector runs the collector for the duration of the test.
+//
+// Docker unavailability is a skip and never a failure: a developer without a
+// daemon should be told why this suite did not run, not handed a red test they
+// cannot act on. A container that starts and then refuses to serve is the
+// opposite, and fails: at that point the configuration above is wrong, which is
+// this module's own defect rather than the environment's.
+func startCollector(t *testing.T) *collector {
+	t.Helper()
+
+	requireDocker(t)
+
+	hostPort := freePort(t)
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "out")
+	if err := os.MkdirAll(outDir, 0o777); err != nil { //#nosec G301 -- a throwaway container writes here as its own user
+		t.Fatalf("creating the collector output directory: %v", err)
+	}
+	// MkdirAll applies the process umask, which on most machines clears the
+	// group and other write bits the container's user needs. Chmod does not.
+	if err := os.Chmod(outDir, 0o777); err != nil { //#nosec G302 -- same
+		t.Fatalf("opening the collector output directory to the container: %v", err)
+	}
+
+	confPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(confPath, []byte(collectorConfig), 0o644); err != nil { //#nosec G306 -- read by a throwaway container
+		t.Fatalf("writing the collector config: %v", err)
+	}
+
+	name := "gitlab-mcp-collectore2e-" + strconv.Itoa(hostPort)
+	args := []string{
+		"run", "-d", "--name", name,
+		"-p", "127.0.0.1:" + strconv.Itoa(hostPort) + ":" + collectorOTLPPort,
+	}
+	// Run as the invoking user so the exported files are readable here and
+	// removable by t.TempDir's cleanup. Without this the image's own uid 10001
+	// owns them, and the cleanup of a suite run by an ordinary user fails on
+	// files it may not delete.
+	if uid := os.Getuid(); uid >= 0 {
+		args = append(args, "--user", strconv.Itoa(uid)+":"+strconv.Itoa(os.Getgid()))
+	}
+	args = append(args,
+		"-v", confPath+":/etc/otelcol-contrib/config.yaml:ro",
+		"-v", outDir+":/out",
+		collectorImage,
+	)
+
+	// Generous, because this may include pulling the image on a cold machine.
+	runCtx, runCancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer runCancel()
+	if out, err := exec.CommandContext(runCtx, "docker", args...).CombinedOutput(); err != nil {
+		t.Skipf("could not start %s (%v):\n%s", collectorImage, err, out)
+	}
+
+	c := &collector{
+		endpoint: "http://127.0.0.1:" + strconv.Itoa(hostPort),
+		outDir:   outDir,
+		name:     name,
+	}
+	t.Cleanup(func() {
+		// Not t.Context: cleanup runs after the test context is cancelled, and
+		// a container left behind would collide with the next run by name.
+		rmCtx, rmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer rmCancel()
+		//#nosec G204 -- the container name is this file's own literal plus a port number
+		_ = exec.CommandContext(rmCtx, "docker", "rm", "-f", c.name).Run()
+	})
+
+	c.waitReceiving(t)
+	return c
+}
+
+// requireDocker skips unless a usable daemon is present.
+func requireDocker(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("this module bind-mounts POSIX paths into a Linux container; run it from WSL or a Linux machine")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; a real collector is the whole point here, so this is skipped rather than modeled")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "docker", "info").Run(); err != nil {
+		t.Skip("docker is installed but not usable; skipping the real-collector suite")
+	}
+}
+
+// waitReceiving polls the OTLP endpoint until it accepts an export.
+//
+// The probe is an empty but well-formed OTLP JSON document rather than a health
+// endpoint, because what the tests need to know is that the receiver is taking
+// exports, not that the process is up. Those differ for several seconds while
+// the collector builds its pipelines, and a server that exported into that
+// window would have its batch refused for reasons that are nobody's defect.
+func (c *collector) waitReceiving(t *testing.T) {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+			c.endpoint+"/v1/traces", strings.NewReader(`{"resourceSpans":[]}`))
+		if err != nil {
+			t.Fatalf("building the collector readiness probe: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("the collector never accepted an export. Container output:\n%s", c.containerLogs(t))
+}
+
+// containerLogs returns everything the collector has written to its own log.
+func (c *collector) containerLogs(t *testing.T) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	//#nosec G204 -- the container name is this file's own literal plus a port number
+	out, err := exec.CommandContext(ctx, "docker", "logs", c.name).CombinedOutput()
+	if err != nil {
+		return "could not read the container log: " + err.Error()
+	}
+	return string(out)
+}
+
+// documents decodes the OTLP JSON the file exporter has written so far.
+//
+// A line that will not parse is skipped rather than reported. The exporter
+// appends whole documents, so the only way to see a broken one is to read the
+// file while a line is mid-write; every caller polls, so the next read has it
+// intact. Failing on it would turn a timing artifact into a test failure, and
+// nothing is hidden by the tolerance, since a document that never becomes
+// parseable is a document the caller times out waiting for.
+func documents[T any](t *testing.T, path string) []T {
+	t.Helper()
+
+	raw, err := os.ReadFile(path) //#nosec G304 -- a path this test created
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	var out []T
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var doc T
+		if json.Unmarshal([]byte(line), &doc) != nil {
+			continue
+		}
+		out = append(out, doc)
+	}
+	return out
+}
+
+// awaitSpan blocks until the collector has parsed a span the predicate accepts,
+// and reports whether one arrived.
+//
+// Waiting is not optional. The batch processor exports on a schedule and the
+// file exporter flushes on another, so a test that read immediately would find
+// an empty file and could only assert emptiness, which every broken server also
+// satisfies.
+//
+// The outcome is returned rather than fataled on, because the interesting
+// failure is diagnosed from two logs this type can only see one of. A collector
+// that refuses the export produces exactly this timeout, and the sentence that
+// explains it is in the server's log, not in the collector's.
+func (c *collector) awaitSpan(t *testing.T, within time.Duration, match func(otlpResourceSpans, otlpSpan) bool) (rs otlpResourceSpans, found otlpSpan, ok bool) {
+	t.Helper()
+
+	var seen int
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		seen = 0
+		for _, doc := range documents[traceDocument](t, filepath.Join(c.outDir, tracesFile)) {
+			for _, resourceSpans := range doc.ResourceSpans {
+				for _, scopeSpans := range resourceSpans.ScopeSpans {
+					for _, span := range scopeSpans.Spans {
+						seen++
+						if match(resourceSpans, span) {
+							return resourceSpans, span, true
+						}
+					}
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Logged rather than returned: it separates "the collector parsed nothing"
+	// from "it parsed spans and none was the one asked for", which are
+	// different defects, and the caller's message is about neither.
+	t.Logf("waited %s for a matching span; the collector parsed %d span(s) in total", within, seen)
+	return otlpResourceSpans{}, otlpSpan{}, false
+}
+
+// awaitMetric blocks until the collector has parsed a metric with this name,
+// and reports whether one arrived. It returns rather than fatals for the reason
+// [collector.awaitSpan] gives.
+func (c *collector) awaitMetric(t *testing.T, within time.Duration, name string) (rm otlpResourceMetrics, found otlpMetric, ok bool) {
+	t.Helper()
+
+	var seen []string
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		seen = nil
+		for _, doc := range documents[metricDocument](t, filepath.Join(c.outDir, metricsFile)) {
+			for _, resourceMetrics := range doc.ResourceMetrics {
+				for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+					for _, metric := range scopeMetrics.Metrics {
+						seen = append(seen, metric.Name)
+						if metric.Name == name {
+							return resourceMetrics, metric, true
+						}
+					}
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Logf("waited %s for a metric named %q; the collector parsed %v", within, name, seen)
+	return otlpResourceMetrics{}, otlpMetric{}, false
+}
+
+// The OTLP JSON the file exporter writes, decoded down to the fields under
+// assertion and no further.
+//
+// These are hand-written rather than taken from a pdata or proto module on
+// purpose. Importing the collector's own types to check the collector's own
+// output would make both halves agree by construction, and this suite exists
+// precisely to compare what we emit against an independent reading of it.
+type (
+	// otlpAttr is one key-value attribute. Only the string case is decoded:
+	// every attribute asserted on here is a string, and a non-string one still
+	// shows up by key, which is what a presence check needs.
+	otlpAttr struct {
+		Key   string `json:"key"`
+		Value struct {
+			StringValue string `json:"stringValue"`
+		} `json:"value"`
+	}
+
+	otlpResource struct {
+		Attributes []otlpAttr `json:"attributes"`
+	}
+
+	otlpSpan struct {
+		Name string `json:"name"`
+		// Kind is the SpanKind enum. The exporter writes it as a number, so
+		// SPAN_KIND_SERVER arrives as 2 rather than by name.
+		Kind       int        `json:"kind"`
+		Attributes []otlpAttr `json:"attributes"`
+	}
+
+	otlpScopeSpans struct {
+		Scope otlpScope  `json:"scope"`
+		Spans []otlpSpan `json:"spans"`
+	}
+
+	otlpResourceSpans struct {
+		Resource   otlpResource     `json:"resource"`
+		ScopeSpans []otlpScopeSpans `json:"scopeSpans"`
+	}
+
+	traceDocument struct {
+		ResourceSpans []otlpResourceSpans `json:"resourceSpans"`
+	}
+
+	otlpScope struct {
+		Name string `json:"name"`
+	}
+
+	otlpHistogram struct {
+		DataPoints []json.RawMessage `json:"dataPoints"`
+	}
+
+	otlpMetric struct {
+		Name      string         `json:"name"`
+		Unit      string         `json:"unit"`
+		Histogram *otlpHistogram `json:"histogram"`
+	}
+
+	otlpScopeMetrics struct {
+		Scope   otlpScope    `json:"scope"`
+		Metrics []otlpMetric `json:"metrics"`
+	}
+
+	otlpResourceMetrics struct {
+		Resource     otlpResource       `json:"resource"`
+		ScopeMetrics []otlpScopeMetrics `json:"scopeMetrics"`
+	}
+
+	metricDocument struct {
+		ResourceMetrics []otlpResourceMetrics `json:"resourceMetrics"`
+	}
+)
+
+// spanKindServer is SPAN_KIND_SERVER in the OTLP enum.
+const spanKindServer = 2
+
+// attr returns the string value recorded under a key, and whether the key was
+// present at all. The two are separate answers: an attribute set to the empty
+// string and an attribute nobody set are different defects.
+func attr(attrs []otlpAttr, key string) (value string, present bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value.StringValue, true
+		}
+	}
+	return "", false
+}
+
+// keys lists what was recorded, for a failure message that says what arrived
+// instead of only what did not.
+func keys(attrs []otlpAttr) []string {
+	out := make([]string, 0, len(attrs))
+	for _, a := range attrs {
+		out = append(out, a.Key)
+	}
+	return out
+}

--- a/test/e2e/collector/collector_test.go
+++ b/test/e2e/collector/collector_test.go
@@ -387,6 +387,16 @@ type (
 		// SPAN_KIND_SERVER arrives as 2 rather than by name.
 		Kind       int        `json:"kind"`
 		Attributes []otlpAttr `json:"attributes"`
+		// The identifiers, which are what makes a tree a tree. An empty
+		// parentSpanId is how the exporter writes a root, so the zero value
+		// carries meaning here rather than being an absence.
+		TraceID      string `json:"traceId"`
+		SpanID       string `json:"spanId"`
+		ParentSpanID string `json:"parentSpanId"`
+		Links        []struct {
+			TraceID string `json:"traceId"`
+			SpanID  string `json:"spanId"`
+		} `json:"links"`
 	}
 
 	otlpScopeSpans struct {

--- a/test/e2e/collector/collector_test.go
+++ b/test/e2e/collector/collector_test.go
@@ -428,14 +428,17 @@ type (
 		Name string `json:"name"`
 	}
 
-	otlpHistogram struct {
+	otlpMetricBody struct {
 		DataPoints []json.RawMessage `json:"dataPoints"`
 	}
 
 	otlpMetric struct {
-		Name      string         `json:"name"`
-		Unit      string         `json:"unit"`
-		Histogram *otlpHistogram `json:"histogram"`
+		Name                 string          `json:"name"`
+		Unit                 string          `json:"unit"`
+		Histogram            *otlpMetricBody `json:"histogram"`
+		Sum                  *otlpMetricBody `json:"sum"`
+		Gauge                *otlpMetricBody `json:"gauge"`
+		ExponentialHistogram *otlpMetricBody `json:"exponentialHistogram"`
 	}
 
 	otlpScopeMetrics struct {

--- a/test/e2e/collector/collector_test.go
+++ b/test/e2e/collector/collector_test.go
@@ -160,7 +160,20 @@ func startCollector(t *testing.T) *collector {
 	runCtx, runCancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer runCancel()
 	if out, err := exec.CommandContext(runCtx, "docker", args...).CombinedOutput(); err != nil {
-		t.Skipf("could not start %s (%v):\n%s", collectorImage, err, out)
+		// requireDocker has already established that a daemon answers, so a
+		// failure here is usually this module's own: a configuration the
+		// collector rejects, a flag it does not know, a bind mount it cannot
+		// make. Reporting those as an environmental skip is how a broken
+		// harness stays green, which is the failure this module exists to
+		// prevent in the server and should not commit itself.
+		//
+		// The exception is reaching the registry. A machine with a working
+		// daemon and no route to the image cannot run this and has nothing to
+		// fix in the code, so that stays a skip.
+		if isRegistryFailure(out) {
+			t.Skipf("could not pull %s (%v):\n%s", collectorImage, err, out)
+		}
+		t.Fatalf("could not start %s (%v):\n%s", collectorImage, err, out)
 	}
 
 	c := &collector{
@@ -442,4 +455,30 @@ func keys(attrs []otlpAttr) []string {
 		out = append(out, a.Key)
 	}
 	return out
+}
+
+// isRegistryFailure reports whether docker failed because it could not obtain
+// the image rather than because it could not run it.
+//
+// Matching on the message is coarse, and it is the only signal available:
+// docker exits 125 for both "cannot pull" and "bad configuration", so the exit
+// status cannot separate them. The list is deliberately narrow, because the
+// cost of a wrong match in this direction is a skipped test that should have
+// failed.
+func isRegistryFailure(output []byte) bool {
+	text := strings.ToLower(string(output))
+	for _, marker := range []string{
+		"pull access denied",
+		"manifest unknown",
+		"no such host",
+		"connection refused while trying to connect",
+		"timeout exceeded while awaiting headers",
+		"error pulling image",
+		"failed to resolve reference",
+	} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/collector/collector_test.go
+++ b/test/e2e/collector/collector_test.go
@@ -46,6 +46,9 @@ const collectorImage = "otel/opentelemetry-collector-contrib:0.159.0"
 // appending to one file and the interleaving would be ours to untangle.
 const (
 	collectorOTLPPort = "4318"
+	// The gRPC receiver's port, published alongside the HTTP one so a single
+	// collector serves both protocols and a test picks by endpoint.
+	collectorGRPCPort = "4317"
 	tracesFile        = "traces.json"
 	metricsFile       = "metrics.json"
 	logsFile          = "logs.json"
@@ -73,6 +76,8 @@ const collectorConfig = `receivers:
     protocols:
       http:
         endpoint: 0.0.0.0:` + collectorOTLPPort + `
+      grpc:
+        endpoint: 0.0.0.0:` + collectorGRPCPort + `
 
 exporters:
   file/traces:
@@ -104,6 +109,9 @@ service:
 type collector struct {
 	// endpoint is what OTEL_EXPORTER_OTLP_ENDPOINT is set to.
 	endpoint string
+	// grpcEndpoint is the same collector reached over the other protocol,
+	// which nothing exercised until it existed.
+	grpcEndpoint string
 	// outDir is the host side of the bind mount the file exporters write into.
 	outDir string
 	name   string
@@ -122,6 +130,7 @@ func startCollector(t *testing.T) *collector {
 	requireDocker(t)
 
 	hostPort := freePort(t)
+	grpcPort := freePort(t)
 	dir := t.TempDir()
 	outDir := filepath.Join(dir, "out")
 	if err := os.MkdirAll(outDir, 0o777); err != nil { //#nosec G301 -- a throwaway container writes here as its own user
@@ -142,6 +151,7 @@ func startCollector(t *testing.T) *collector {
 	args := []string{
 		"run", "-d", "--name", name,
 		"-p", "127.0.0.1:" + strconv.Itoa(hostPort) + ":" + collectorOTLPPort,
+		"-p", "127.0.0.1:" + strconv.Itoa(grpcPort) + ":" + collectorGRPCPort,
 	}
 	// Run as the invoking user so the exported files are readable here and
 	// removable by t.TempDir's cleanup. Without this the image's own uid 10001
@@ -177,9 +187,10 @@ func startCollector(t *testing.T) *collector {
 	}
 
 	c := &collector{
-		endpoint: "http://127.0.0.1:" + strconv.Itoa(hostPort),
-		outDir:   outDir,
-		name:     name,
+		endpoint:     "http://127.0.0.1:" + strconv.Itoa(hostPort),
+		grpcEndpoint: "127.0.0.1:" + strconv.Itoa(grpcPort),
+		outDir:       outDir,
+		name:         name,
 	}
 	t.Cleanup(func() {
 		// Not t.Context: cleanup runs after the test context is cancelled, and

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -226,4 +227,97 @@ func TestRealCollector_TheIdentityPolicyGovernsEverySignal(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRealCollector_AConfiguredKeyMakesTwoProcessesAgree is the replica
+// scenario, run as two processes rather than reasoned about.
+//
+// A unit test can show that two keyrings built from one secret compute the same
+// digest. What it cannot show is that two independently started servers,
+// exporting into the same collector, put the same value on the wire: that
+// depends on the environment reaching the keyring, on the keyring reaching both
+// redactors, and on nothing in between regenerating a key. Each of those has
+// been wrong at least once in this package's history.
+//
+// Both halves are asserted, because the interesting failure is one-sided. A
+// build that ignored the key entirely would fail the first; a build that
+// somehow shared state between processes would fail the second, and would be a
+// far stranger defect.
+func TestRealCollector_AConfiguredKeyMakesTwoProcessesAgree(t *testing.T) {
+	t.Run("with a key, two processes agree", func(t *testing.T) {
+		digests := digestsFromTwoServers(t, map[string]string{
+			"GITLAB_MCP_TELEMETRY_IDENTITY":     "pseudonymous",
+			"GITLAB_MCP_TELEMETRY_IDENTITY_KEY": "a deployment-wide secret",
+		})
+		if len(digests) != 1 {
+			t.Errorf("two replicas sharing a key produced %d digests (%v); one caller must read as one person",
+				len(digests), digests)
+		}
+	})
+
+	t.Run("without a key, they do not", func(t *testing.T) {
+		digests := digestsFromTwoServers(t, map[string]string{
+			"GITLAB_MCP_TELEMETRY_IDENTITY": "pseudonymous",
+		})
+		if len(digests) != 2 {
+			t.Errorf("two replicas without a shared key produced %d digests (%v); the default is a per-process key",
+				len(digests), digests)
+		}
+	})
+}
+
+// digestsFromTwoServers runs two servers into one collector and returns the set
+// of user.hash values they exported.
+func digestsFromTwoServers(t *testing.T, extra map[string]string) []string {
+	t.Helper()
+
+	c := startCollector(t)
+	gitlab := startFakeGitLab(t)
+
+	for range 2 {
+		env := telemetryEnv(c)
+		maps.Copy(env, extra)
+		srv := startServer(t, env, "--gitlab-url="+gitlab)
+		for i := range 2 {
+			srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+		}
+	}
+
+	// Both processes have to have reported before the digests mean anything:
+	// reading after only the faster one exported would find one digest and
+	// call that agreement. The instance id is what distinguishes them, and it
+	// is independent of the digest being asked about.
+	reported := map[string]bool{}
+	if _, _, ok := c.awaitSpan(t, exportDeadline, func(rs otlpResourceSpans, s otlpSpan) bool {
+		if _, present := attr(s.Attributes, "user.hash"); !present {
+			return false
+		}
+		if instance, present := attr(rs.Resource.Attributes, "service.instance.id"); present {
+			reported[instance] = true
+		}
+		return len(reported) == 2
+	}); !ok {
+		t.Fatalf("only %d of 2 processes exported a user.hash.\nCollector:\n%s",
+			len(reported), c.containerLogs(t))
+	}
+
+	seen := map[string]bool{}
+	for _, doc := range documents[traceDocument](t, filepath.Join(c.outDir, tracesFile)) {
+		for _, rs := range doc.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				for _, span := range ss.Spans {
+					if digest, present := attr(span.Attributes, "user.hash"); present {
+						seen[digest] = true
+					}
+				}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for digest := range seen {
+		out = append(out, digest)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -1,0 +1,182 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// driveDynamic starts a stack with the given extra environment and makes a few
+// dynamic-surface calls through it.
+//
+// One collector and one server per configuration, because these differ in what
+// the process was started with and there is no way to change that afterwards:
+// the identity policy, the tool-name policy and the surface are all fixed
+// before the first request, which is exactly why they are worth covering here
+// rather than in a unit test that can set them per case.
+func driveDynamic(t *testing.T, extra map[string]string) (*collector, *server) {
+	t.Helper()
+
+	c := startCollector(t)
+	env := telemetryEnv(c)
+	maps.Copy(env, extra)
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+	return c, srv
+}
+
+// TestRealCollector_ToolNamePolicyOff covers the View that exists to stop the
+// individual surface exhausting the SDK's series budget.
+//
+// Both keys, because filtering one and keeping the other is what the View did
+// until recently: the individual surface projects one visible tool per catalog
+// action, so gen_ai.tool.name and gitlab_mcp.action carry the same eleven
+// hundred values and dropping either alone sheds nothing. The span keeps both,
+// which is the point of doing this with a View rather than by not recording
+// them.
+func TestRealCollector_ToolNamePolicyOff(t *testing.T) {
+	c, srv := driveDynamic(t, map[string]string{"GITLAB_MCP_TELEMETRY_TOOL_NAME": "off"})
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span keeps both", func(t *testing.T) {
+		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
+			if _, present := attr(span.Attributes, key); !present {
+				t.Errorf("%s is absent from the span; the policy is about metric series, not about hiding the value", key)
+			}
+		}
+	})
+
+	t.Run("the metric keeps neither", func(t *testing.T) {
+		if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
+		}
+		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
+			if instrument := metricDimensionExists(t, c, key); instrument != "" {
+				t.Errorf("%s is still a dimension of %s under the off policy", key, instrument)
+			}
+		}
+	})
+}
+
+// TestRealCollector_IdentityFullExportsTheReadableUser is the third identity
+// policy, and the one an operator reaches for when they have decided to record
+// who calls.
+//
+// The assertion that matters is the same under every policy: whatever reaches a
+// span, nothing about the caller reaches a metric. A per-user dimension is
+// unbounded by the number of people using the deployment, which is the number
+// an operator cannot predict.
+func TestRealCollector_IdentityFullExportsTheReadableUser(t *testing.T) {
+	c, srv := driveDynamic(t, map[string]string{"GITLAB_MCP_TELEMETRY_IDENTITY": "full"})
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span names the user", func(t *testing.T) {
+		if name, present := attr(span.Attributes, "user.name"); !present || name == "" {
+			t.Errorf("user.name is absent under the full policy; recorded %v", keys(span.Attributes))
+		}
+		if _, present := attr(span.Attributes, "user.hash"); present {
+			t.Error("the pseudonym is recorded alongside the readable name, which says the same thing twice")
+		}
+	})
+
+	t.Run("no identity key is a metric dimension", func(t *testing.T) {
+		if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
+		}
+		for _, key := range []string{"user.id", "user.name", "user.hash"} {
+			if instrument := metricDimensionExists(t, c, key); instrument != "" {
+				t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
+			}
+		}
+	})
+}
+
+// TestRealCollector_TelemetryOffExportsNothing covers the default, which is the
+// configuration almost every deployment runs.
+//
+// Nothing else asserts it. Every other case here turns telemetry on, so a
+// change that started an exporter regardless of the flag would be invisible to
+// this module while being the most serious thing it could miss: a server that
+// exports without being asked to.
+func TestRealCollector_TelemetryOffExportsNothing(t *testing.T) {
+	c := startCollector(t)
+
+	// The endpoint is configured and the switch is not, which is the shape that
+	// catches a provider started from the environment alone.
+	env := telemetryEnv(c)
+	env["GITLAB_MCP_TELEMETRY"] = "false"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+
+	assertNothingExported(t, c, srv)
+}
+
+// TestRealCollector_SDKDisabledVetoesAnEnabledDeployment covers the standard
+// variable that overrides this server's own switch.
+//
+// It is a veto rather than a second on switch, and the direction is easy to get
+// backwards: OTEL_SDK_DISABLED defaults to "enabled" while telemetry here
+// defaults to off, so adopting it as the switch would invert its meaning. This
+// asserts the composition, with the operator explicitly asking for telemetry.
+func TestRealCollector_SDKDisabledVetoesAnEnabledDeployment(t *testing.T) {
+	c := startCollector(t)
+
+	env := telemetryEnv(c)
+	env["OTEL_SDK_DISABLED"] = "true"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+
+	assertNothingExported(t, c, srv)
+}
+
+// assertNothingExported waits out the export schedules and then fails if any
+// file has content.
+//
+// The wait is what makes this an assertion rather than a race: the exporters
+// batch, so a check that ran immediately would pass against a server that was
+// about to export.
+func assertNothingExported(t *testing.T, c *collector, srv *server) {
+	t.Helper()
+
+	// Comfortably past the batch schedule and the metric interval this module
+	// configures, both of which are 100ms.
+	time.Sleep(5 * time.Second)
+
+	for _, name := range []string{tracesFile, metricsFile, logsFile} {
+		path := filepath.Join(c.outDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue // never created, which is the expected outcome
+		}
+		if info.Size() > 0 {
+			t.Errorf("%s holds %d bytes; the deployment exported telemetry it was not asked for.\nServer:\n%s",
+				name, info.Size(), srv.logs())
+		}
+	}
+}

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -180,3 +180,50 @@ func assertNothingExported(t *testing.T, c *collector, srv *server) {
 		}
 	}
 }
+
+// TestRealCollector_TheIdentityPolicyGovernsEverySignal is the end-to-end form
+// of a gap two of the three signals hid.
+//
+// A hosted deployment ran with the policy on pseudonymous, which by definition
+// names nobody. Its spans carried user.hash and its metrics carried no identity
+// at all, exactly as designed, while 48 exported log records carried user_id
+// and 38 carried the username in the clear. The policy had been applied where
+// it was written and never to the log bridge.
+//
+// So the assertion is deliberately about the whole log stream rather than one
+// record: what must hold is that nothing exported names the caller under a
+// policy that promises not to, not that a particular line was fixed. This is
+// the same shape as the resource-URI leak this module already guards, and it is
+// the second time the log signal has been the one that leaked.
+func TestRealCollector_TheIdentityPolicyGovernsEverySignal(t *testing.T) {
+	for _, tc := range []struct {
+		policy  string
+		forbids []string
+	}{
+		{policy: "none", forbids: []string{"user.id", "user.name", "user.hash", "user_id"}},
+		{policy: "pseudonymous", forbids: []string{"user.id", "user.name", "user_id"}},
+	} {
+		t.Run(tc.policy, func(t *testing.T) {
+			c, srv := driveDynamic(t, map[string]string{"GITLAB_MCP_TELEMETRY_IDENTITY": tc.policy})
+
+			// A log record has to have arrived, or an empty stream passes for a
+			// clean one. The tool call the driver makes writes one.
+			if _, ok := c.awaitLog(t, exportDeadline, func(r otlpLogRecord) bool {
+				return strings.Contains(r.Body.StringValue, "tool call")
+			}); !ok {
+				t.Fatalf("no tool call log record arrived.\nCollector:\n%s\nServer:\n%s",
+					c.containerLogs(t), srv.logs())
+			}
+
+			for _, record := range allLogRecords(t, c) {
+				rendered := renderLogRecord(record)
+				for _, forbidden := range tc.forbids {
+					if strings.Contains(rendered, forbidden) {
+						t.Errorf("an exported log record carries %q under policy %q: %s",
+							forbidden, tc.policy, rendered)
+					}
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -3,6 +3,7 @@
 package collectore2e
 
 import (
+	"errors"
 	"maps"
 	"os"
 	"path/filepath"
@@ -172,8 +173,13 @@ func assertNothingExported(t *testing.T, c *collector, srv *server) {
 	for _, name := range []string{tracesFile, metricsFile, logsFile} {
 		path := filepath.Join(c.outDir, name)
 		info, err := os.Stat(path)
-		if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
 			continue // never created, which is the expected outcome
+		}
+		if err != nil {
+			// Any other failure means the output cannot be inspected, and a
+			// test that treats that as "nothing was exported" passes blind.
+			t.Fatalf("inspecting %s: %v", name, err)
 		}
 		if info.Size() > 0 {
 			t.Errorf("%s holds %d bytes; the deployment exported telemetry it was not asked for.\nServer:\n%s",

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -321,3 +321,38 @@ func digestsFromTwoServers(t *testing.T, extra map[string]string) []string {
 	sort.Strings(out)
 	return out
 }
+
+// TestRealCollector_TheKeyChoiceIsVisibleToAnOperator covers the line an
+// operator reads to confirm a setting took effect, in the place they read it.
+//
+// The hosted deployment showed the setting working, two processes agreeing on a
+// digest, while the line announcing it appeared in no exported log record. A
+// setting that works and cannot be confirmed is a setting somebody will
+// configure twice, or will believe is on when a typo turned it off.
+//
+// Both legs are checked, because they can disagree and did: stderr is where the
+// line is written and the collector is where an operator running three replicas
+// actually looks.
+func TestRealCollector_TheKeyChoiceIsVisibleToAnOperator(t *testing.T) {
+	c, srv := driveDynamic(t, map[string]string{
+		"GITLAB_MCP_TELEMETRY_IDENTITY":     "pseudonymous",
+		"GITLAB_MCP_TELEMETRY_IDENTITY_KEY": "a deployment-wide secret",
+	})
+
+	const line = "telemetry pseudonyms use the configured key"
+
+	t.Run("the server writes it", func(t *testing.T) {
+		if logs := srv.logs(); !strings.Contains(logs, line) {
+			t.Errorf("the server never announced the configured key.\nServer:\n%s", logs)
+		}
+	})
+
+	t.Run("the collector receives it", func(t *testing.T) {
+		if _, ok := c.awaitLog(t, exportDeadline, func(r otlpLogRecord) bool {
+			return strings.Contains(r.Body.StringValue, line)
+		}); !ok {
+			t.Errorf("the line reached stderr and not the collector, which is where an operator running replicas looks.\nCollector:\n%s",
+				c.containerLogs(t))
+		}
+	})
+}

--- a/test/e2e/collector/documented_test.go
+++ b/test/e2e/collector/documented_test.go
@@ -174,14 +174,19 @@ func driveStatelessNames(t *testing.T, c *collector) {
 	// A tool call, a prompt fetch and a resource read each carry attributes the
 	// others do not.
 	for i := range 3 {
-		srv.callAction(t, i*4+1, "issue.list", "some-group/some-project")
-		srv.readResource(t, i*4+2, resourceURI)
-		srv.getPromptExpectingRefusal(t, i*4+3, "not-a-prompt-this-server-has")
+		srv.callAction(t, i*5+1, "issue.list", "some-group/some-project")
+		srv.readResource(t, i*5+2, resourceURI)
+		srv.getPromptExpectingRefusal(t, i*5+3, "not-a-prompt-this-server-has")
 		// A GitLab failure, which is the only thing that produces error.type:
 		// a caller fault deliberately does not, since a model naming an action
 		// that does not exist is an ordinary event rather than a malfunction.
-		srv.callToolTolerant(t, i*4+4, "gitlab_execute_action",
+		srv.callToolTolerant(t, i*5+4, "gitlab_execute_action",
 			`{"action":"issue.list","params":{"project_id":"`+failingProject+`"}}`)
+		// And a refusal, which is neither of those: the call was well formed
+		// and this server declined it. It carries an attribute the other four
+		// do not, and no error.type, since nothing malfunctioned.
+		srv.callToolTolerant(t, i*5+5, "gitlab_execute_action",
+			`{"action":"no.such.action.exists","params":{}}`)
 	}
 
 	if _, _, ok := c.awaitMetric(t, exportDeadline, durationMetric); !ok {

--- a/test/e2e/collector/documented_test.go
+++ b/test/e2e/collector/documented_test.go
@@ -1,0 +1,188 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// documentedButNotDrivenHere are names the guide documents that this module
+// cannot produce, each with the reason.
+//
+// The list is the review. Anything on it is a claim in the documentation that
+// nothing here checks, so it should be short and every entry should be
+// uncomfortable to write. Adding a name to silence a failure is the failure.
+var documentedButNotDrivenHere = map[string]string{
+	// Server-initiated, so producing one means a client that answers an
+	// elicitation. The stdio module drives that; this one speaks HTTP to a
+	// server whose caller is a bare HTTP client.
+	"mcp.client.operation.duration": "requires a client that answers a server-initiated request",
+
+	// Recorded only when a session exists, which the stateful case covers in
+	// its own test rather than in this sweep: it needs a different protocol
+	// revision and a handshake, so folding it in here would make one case
+	// depend on two transports.
+	"mcp.session.id":              "covered by the stateful case, which needs its own transport",
+	"mcp.server.session.duration": "covered by the stateful case, which needs its own transport",
+}
+
+// TestRealCollector_EveryDocumentedNameIsReallyEmitted turns the operator guide
+// into an artifact this suite checks.
+//
+// The reason is a defect that has now appeared three times in this work, each
+// time as something that read as implemented and was not: an attribute key
+// declared and set by nothing, a second one the same, and a safe-mode path that
+// accepted a context and discarded it. None produced a compiler warning,
+// because Go says nothing about an unused declaration, and none produced a test
+// failure, because nothing asserted the claim.
+//
+// Documentation is where that class is most expensive. A reader has no way to
+// tell a documented attribute from an emitted one, and an operator building a
+// dashboard on a name that is never exported gets an empty panel and no reason.
+// So the guide's own tables are read here and every name in them has to appear
+// in something a real collector parsed.
+func TestRealCollector_EveryDocumentedNameIsReallyEmitted(t *testing.T) {
+	guide := readGuide(t)
+	documented := documentedNames(t, guide)
+	if len(documented) < 8 {
+		t.Fatalf("only %d names were parsed out of the guide; the tables have probably changed shape and this test is now checking nothing",
+			len(documented))
+	}
+
+	c := startCollector(t)
+	env := telemetryEnv(c)
+	// The policy that records the most, so a name absent here is absent
+	// because nothing emits it rather than because a policy suppressed it.
+	env["GITLAB_MCP_TELEMETRY_IDENTITY"] = "full"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	// A spread wide enough to reach every documented name: a tool call, a
+	// prompt fetch and a resource read each carry attributes the others do not.
+	for i := range 3 {
+		srv.callAction(t, i*4+1, "issue.list", "some-group/some-project")
+		srv.readResource(t, i*4+2, resourceURI)
+		srv.getPromptExpectingRefusal(t, i*4+3, "not-a-prompt-this-server-has")
+		// A GitLab failure, which is the only thing that produces error.type:
+		// a caller fault deliberately does not, since a model naming an action
+		// that does not exist is an ordinary event rather than a malfunction.
+		srv.callToolTolerant(t, i*4+4, "gitlab_execute_action",
+			`{"action":"issue.list","params":{"project_id":"`+failingProject+`"}}`)
+	}
+
+	// Give the exporters their schedules before reading.
+	if _, _, ok := c.awaitMetric(t, exportDeadline, durationMetric); !ok {
+		t.Fatalf("no metric arrived at all.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	emitted := emittedNames(t, c)
+
+	for _, name := range documented {
+		if emitted[name] {
+			continue
+		}
+		if reason, excused := documentedButNotDrivenHere[name]; excused {
+			t.Logf("not driven here: %s (%s)", name, reason)
+			continue
+		}
+		t.Errorf("the guide documents %q and nothing exported it. Either it is not wired, or this module does not drive the path that emits it and the exclusion list should say so",
+			name)
+	}
+}
+
+// readGuide returns the operator guide's text.
+func readGuide(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(repoRoot(), "docs", "guides", "telemetry.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the telemetry guide: %v", err)
+	}
+	return string(body)
+}
+
+// documentedNameRow matches a table row whose first cell is a backticked name.
+var documentedNameRow = regexp.MustCompile(`(?m)^\|\s*` + "`" + `([a-z][a-z0-9_.]+)` + "`" + `\s*\|`)
+
+// documentedNames extracts the attribute and instrument names the guide's
+// tables list.
+//
+// Read out of the tables rather than kept in a second list here, so the guide
+// stays the single statement of what this server records. A list in the test
+// would be a copy, and a copy is the thing that drifts.
+func documentedNames(t *testing.T, guide string) []string {
+	t.Helper()
+
+	seen := map[string]bool{}
+	var names []string
+	for _, match := range documentedNameRow.FindAllStringSubmatch(guide, -1) {
+		name := match[1]
+		// Only dotted names: the tables also carry environment variables and
+		// flag names, which are not telemetry keys.
+		if !strings.Contains(name, ".") || strings.HasPrefix(name, "otel_") {
+			continue
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// emittedNames collects every attribute key and instrument name the collector
+// parsed, across all three signals.
+func emittedNames(t *testing.T, c *collector) map[string]bool {
+	t.Helper()
+
+	found := map[string]bool{}
+	collectSpanNames(t, c, found)
+	collectMetricNames(t, c, found)
+	return found
+}
+
+// collectSpanNames adds every resource and span attribute key to found.
+func collectSpanNames(t *testing.T, c *collector, found map[string]bool) {
+	t.Helper()
+
+	for _, doc := range documents[traceDocument](t, filepath.Join(c.outDir, tracesFile)) {
+		for _, rs := range doc.ResourceSpans {
+			addKeys(found, rs.Resource.Attributes)
+			for _, ss := range rs.ScopeSpans {
+				for _, span := range ss.Spans {
+					addKeys(found, span.Attributes)
+				}
+			}
+		}
+	}
+}
+
+// collectMetricNames adds every instrument name and dimension key to found.
+func collectMetricNames(t *testing.T, c *collector, found map[string]bool) {
+	t.Helper()
+
+	for _, doc := range documents[metricDocument](t, metricsPath(c)) {
+		for _, rm := range doc.ResourceMetrics {
+			for _, sm := range rm.ScopeMetrics {
+				for _, m := range sm.Metrics {
+					found[m.Name] = true
+					for _, point := range dataPointAttributes(t, m) {
+						addKeys(found, point)
+					}
+				}
+			}
+		}
+	}
+}
+
+// addKeys records the keys of one attribute set.
+func addKeys(found map[string]bool, attrs []otlpAttr) {
+	for _, kv := range attrs {
+		found[kv.Key] = true
+	}
+}

--- a/test/e2e/collector/documented_test.go
+++ b/test/e2e/collector/documented_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // documentedButNotDrivenHere are names the guide documents that this module
@@ -16,19 +17,7 @@ import (
 // The list is the review. Anything on it is a claim in the documentation that
 // nothing here checks, so it should be short and every entry should be
 // uncomfortable to write. Adding a name to silence a failure is the failure.
-var documentedButNotDrivenHere = map[string]string{
-	// Server-initiated, so producing one means a client that answers an
-	// elicitation. The stdio module drives that; this one speaks HTTP to a
-	// server whose caller is a bare HTTP client.
-	"mcp.client.operation.duration": "requires a client that answers a server-initiated request",
-
-	// Recorded only when a session exists, which the stateful case covers in
-	// its own test rather than in this sweep: it needs a different protocol
-	// revision and a handshake, so folding it in here would make one case
-	// depend on two transports.
-	"mcp.session.id":              "covered by the stateful case, which needs its own transport",
-	"mcp.server.session.duration": "covered by the stateful case, which needs its own transport",
-}
+var documentedButNotDrivenHere = map[string]string{}
 
 // TestRealCollector_EveryDocumentedNameIsReallyEmitted turns the operator guide
 // into an artifact this suite checks.
@@ -53,30 +42,14 @@ func TestRealCollector_EveryDocumentedNameIsReallyEmitted(t *testing.T) {
 			len(documented))
 	}
 
+	// One collector, two servers. Some documented names exist only under a
+	// stateful transport and some only under a stateless one, so a sweep that
+	// ran a single server would have to excuse the other half, and an exclusion
+	// list that fills up with bookkeeping stops being a review. Pointing both
+	// at one collector makes the union happen where the names are read.
 	c := startCollector(t)
-	env := telemetryEnv(c)
-	// The policy that records the most, so a name absent here is absent
-	// because nothing emits it rather than because a policy suppressed it.
-	env["GITLAB_MCP_TELEMETRY_IDENTITY"] = "full"
-	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
-
-	// A spread wide enough to reach every documented name: a tool call, a
-	// prompt fetch and a resource read each carry attributes the others do not.
-	for i := range 3 {
-		srv.callAction(t, i*4+1, "issue.list", "some-group/some-project")
-		srv.readResource(t, i*4+2, resourceURI)
-		srv.getPromptExpectingRefusal(t, i*4+3, "not-a-prompt-this-server-has")
-		// A GitLab failure, which is the only thing that produces error.type:
-		// a caller fault deliberately does not, since a model naming an action
-		// that does not exist is an ordinary event rather than a malfunction.
-		srv.callToolTolerant(t, i*4+4, "gitlab_execute_action",
-			`{"action":"issue.list","params":{"project_id":"`+failingProject+`"}}`)
-	}
-
-	// Give the exporters their schedules before reading.
-	if _, _, ok := c.awaitMetric(t, exportDeadline, durationMetric); !ok {
-		t.Fatalf("no metric arrived at all.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
-	}
+	driveStatelessNames(t, c)
+	driveStatefulNames(t, c)
 
 	emitted := emittedNames(t, c)
 
@@ -184,5 +157,67 @@ func collectMetricNames(t *testing.T, c *collector, found map[string]bool) {
 func addKeys(found map[string]bool, attrs []otlpAttr) {
 	for _, kv := range attrs {
 		found[kv.Key] = true
+	}
+}
+
+// driveStatelessNames exercises everything the default transport emits.
+//
+// The identity policy that records the most, so a name missing afterwards is
+// missing because nothing emits it rather than because a policy suppressed it.
+func driveStatelessNames(t *testing.T, c *collector) {
+	t.Helper()
+
+	env := telemetryEnv(c)
+	env["GITLAB_MCP_TELEMETRY_IDENTITY"] = "full"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	// A tool call, a prompt fetch and a resource read each carry attributes the
+	// others do not.
+	for i := range 3 {
+		srv.callAction(t, i*4+1, "issue.list", "some-group/some-project")
+		srv.readResource(t, i*4+2, resourceURI)
+		srv.getPromptExpectingRefusal(t, i*4+3, "not-a-prompt-this-server-has")
+		// A GitLab failure, which is the only thing that produces error.type:
+		// a caller fault deliberately does not, since a model naming an action
+		// that does not exist is an ordinary event rather than a malfunction.
+		srv.callToolTolerant(t, i*4+4, "gitlab_execute_action",
+			`{"action":"issue.list","params":{"project_id":"`+failingProject+`"}}`)
+	}
+
+	if _, _, ok := c.awaitMetric(t, exportDeadline, durationMetric); !ok {
+		t.Fatalf("no metric arrived from the stateless server.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+}
+
+// driveStatefulNames exercises what only exists when a deployment has sessions:
+// the session identifier, the session instrument, and the client span a
+// server-initiated notification produces.
+//
+// This is the slow half, and unavoidably so: the notification comes from a
+// subscription noticing a change, and the watcher's base cadence is fifteen
+// seconds.
+func driveStatefulNames(t *testing.T, c *collector) {
+	t.Helper()
+
+	fake := startMutableFakeGitLab(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+fake.URL(), "--stateless=false")
+
+	sess := srv.openSession(t)
+	sess.call(t, 2, "resources/subscribe", `{"uri":"`+resourceURI+`"}`)
+	fake.change("changed so the watcher has something to notice")
+
+	if _, _, ok := c.awaitSpan(t, 90*time.Second, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.Kind == spanKindClient && strings.HasPrefix(s.Name, "notifications/")
+	}); !ok {
+		t.Fatalf("no server-initiated notification arrived.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	// Ending the session is what records its duration.
+	sess.close(t)
+	if _, _, ok := c.awaitMetric(t, exportDeadline, "mcp.server.session.duration"); !ok {
+		t.Fatalf("no session duration arrived.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
 	}
 }

--- a/test/e2e/collector/grpc_test.go
+++ b/test/e2e/collector/grpc_test.go
@@ -1,0 +1,71 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRealCollector_GRPCIsAnExportPathToo drives the protocol nothing here had
+// driven.
+//
+// resolveProtocol builds a gRPC exporter for each signal when the environment
+// asks for one, and every case in this module and every unit test speaks
+// http/protobuf. So the whole gRPC path could be broken and the suite would
+// stay green: the exporters are constructed, the configuration is honored, and
+// nothing ever put a byte through them.
+//
+// It is not a variation on a theme. A different transport means different
+// framing, different error surfaces and a different port, and the endpoint is a
+// trap in the other direction from the obvious one: the programmatic option
+// takes a bare host and port, and this environment variable requires a URL for
+// every protocol, so an endpoint written the way the Go API accepts it is
+// rejected before a single byte is sent.
+func TestRealCollector_GRPCIsAnExportPathToo(t *testing.T) {
+	c := startCollector(t)
+
+	env := telemetryEnv(c)
+	// A URL, with the scheme deciding whether the connection is encrypted.
+	//
+	// The programmatic option takes a bare host and port, and this variable
+	// does not: the configuration specification requires a URL here for every
+	// protocol, and the SDK refuses "127.0.0.1:4317" outright with "first path
+	// segment in URL cannot contain colon". Measured rather than assumed, after
+	// writing it the other way round and watching the exporter reject it.
+	env["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://" + c.grpcEndpoint
+	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
+
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 5 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+
+	t.Run("spans arrive", func(t *testing.T) {
+		_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+			return strings.HasPrefix(s.Name, "tools/call")
+		})
+		if !ok {
+			t.Fatalf("no span arrived over gRPC.\nCollector:\n%s\nServer:\n%s",
+				c.containerLogs(t), srv.logs())
+		}
+		// The same attributes as over HTTP. A transport that delivered spans
+		// with a different shape would be worse than one that delivered none.
+		if got, _ := attr(span.Attributes, "gitlab_mcp.action"); got != "issue.list" {
+			t.Errorf("gitlab_mcp.action = %q over gRPC, want issue.list", got)
+		}
+	})
+
+	t.Run("metrics arrive", func(t *testing.T) {
+		if _, duration, ok := c.awaitMetric(t, exportDeadline, durationMetric); !ok {
+			t.Fatalf("no metric arrived over gRPC.\nCollector:\n%s", c.containerLogs(t))
+		} else if duration.Unit != "s" {
+			t.Errorf("unit = %q over gRPC, want %q", duration.Unit, "s")
+		}
+	})
+
+	t.Run("the collector accepted every export", func(t *testing.T) {
+		assertNothingWasRefused(t, c, srv)
+	})
+}

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -1,0 +1,312 @@
+//go:build collectore2e
+
+// Package collectore2e exports this server's telemetry into a real
+// OpenTelemetry Collector and asserts on what that collector parsed.
+//
+// # What this module is for, and what it must not duplicate
+//
+// test/e2e/http already has an OTLP receiver: an in-process stub that keeps
+// every payload it is sent. It runs on every push, needs no daemon, and proves
+// two things a real collector cannot, because it never decodes anything. It can
+// report the raw Authorization header, which a collector consumes. It can be
+// searched byte by byte for a value that must never leave the process, which a
+// collector forwards onward rather than handing back.
+//
+// Never decoding anything is also its blind spot, and this module is that blind
+// spot's test. A stub answers 200 to a malformed protobuf, to a resource
+// missing an attribute a pipeline requires, to a metric whose unit contradicts
+// its name, and to a span kind that is out of range. Every one of those ships a
+// server whose telemetry no real backend can read, with a green suite behind
+// it. So nothing here asserts credentials or searches for leaks: it asserts
+// that a genuine receiver accepted the export, and that what it parsed out is
+// the shape an operator's dashboards will be built on.
+//
+// # Why its own build tag
+//
+// httpe2e and stdioe2e both run in CI on every push, which is the right place
+// for a suite that needs no daemon. This one pulls a container image and starts
+// a collector, so it belongs to the deliberate Docker-mode targets rather than
+// to the fast path. A separate collectore2e tag is what keeps it out of both:
+// out of the default go test ./... build, since no file here compiles without
+// the tag, and out of the push-triggered jobs, which pass httpe2e and stdioe2e
+// and never this one. Putting it behind httpe2e with a runtime skip would have
+// worked too, and would have made every fast-path run pay a docker probe and
+// then report a skip that means nothing to anyone reading CI output.
+//
+// # Why the harness is duplicated rather than shared
+//
+// This is the third small build-and-drive harness in test/e2e, after http and
+// stdio. Each module owning its own is the existing convention, and it is worth
+// the hundred lines: the alternative is a shared package compiled with no build
+// tag, which the default go test ./... would then build, and a change to it
+// would reach across three suites at once.
+package collectore2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The protocol a 2026-07-28 client speaks. A request missing any of this is
+// answered by the SDK before the instrumentation runs, so a harness that got it
+// wrong could only ever observe rejections, and a rejected request produces no
+// span at all.
+const (
+	protocolVersion = "2026-07-28"
+	protocolMeta    = `"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}`
+	acceptHeader    = "application/json, text/event-stream"
+)
+
+var (
+	buildOnce   sync.Once
+	builtBinary string
+	errBuild    error
+)
+
+// serverBinary builds cmd/server once for the whole package.
+//
+// Building rather than importing is the point of every module under test/e2e
+// that drives a transport: the telemetry pipeline is assembled in package main
+// from flags and environment variables, and a test that reassembled it would be
+// testing its own copy of the wiring rather than the wiring that ships.
+func serverBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		// Not t.TempDir: the binary is built once for the package under
+		// sync.Once, so the first test to arrive would own a directory removed
+		// when that test ends, leaving every later test pointing at nothing.
+		dir, err := os.MkdirTemp("", "gitlab-mcp-collectore2e") //nolint:usetesting // see above
+		if err != nil {
+			errBuild = err
+			return
+		}
+		out := filepath.Join(dir, "gitlab-mcp-server")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/server")
+		cmd.Dir = repoRoot()
+		if output, runErr := cmd.CombinedOutput(); runErr != nil {
+			errBuild = fmt.Errorf("building cmd/server: %w\n%s", runErr, output)
+			return
+		}
+		builtBinary = out
+	})
+	if errBuild != nil {
+		t.Fatalf("%v", errBuild)
+	}
+	return builtBinary
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}
+
+// freePort reserves a port by binding and releasing it. A small race with
+// another process remains, which is why every caller here waits for readiness
+// rather than assuming the port is ours the instant we ask for it.
+func freePort(t *testing.T) int {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if closeErr := l.Close(); closeErr != nil {
+		t.Fatalf("releasing the reserved port: %v", closeErr)
+	}
+	return port
+}
+
+// server is a running binary under test.
+type server struct {
+	baseURL string
+	logs    func() string
+}
+
+// startServer launches the binary with the given flags and environment, waits
+// for /health, and stops it when the test ends.
+func startServer(t *testing.T, env map[string]string, flags ...string) *server {
+	t.Helper()
+
+	bin := serverBinary(t)
+	addr := "127.0.0.1:" + strconv.Itoa(freePort(t))
+
+	args := append([]string{"--http", "--http-addr=" + addr}, flags...)
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(),
+		"LOG_LEVEL=info",
+		"TOOL_SURFACE=dynamic",
+	)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	var out bytes.Buffer
+	var mu sync.Mutex
+	cmd.Stdout = &lockedWriter{mu: &mu, buf: &out}
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("starting the server: %v", err)
+	}
+
+	srv := &server{
+		baseURL: "http://" + addr,
+		logs: func() string {
+			mu.Lock()
+			defer mu.Unlock()
+			return out.String()
+		},
+	}
+
+	t.Cleanup(func() {
+		// Cancel first, then wait: the process flushes its last telemetry
+		// batch on the way out, and a test that killed it without waiting
+		// would race that flush against its own assertions.
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	waitHealthy(t, srv)
+	return srv
+}
+
+// lockedWriter serializes writes from the process's two pipes into one buffer
+// the test can read while the process is still running.
+type lockedWriter struct {
+	mu  *sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+// waitHealthy polls /health until the server answers or the deadline passes. A
+// failure dumps the process output, because a server that refuses to start has
+// already said why and nobody should have to go looking.
+func waitHealthy(t *testing.T, s *server) {
+	t.Helper()
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.baseURL+"/health", http.NoBody)
+		if err != nil {
+			t.Fatalf("building the health request: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("server never became healthy. Output:\n%s", s.logs())
+}
+
+// callAction drives one tools/call that reaches the instrumentation.
+//
+// Three things beyond a credential are required before a handler runs, and
+// getting any of them wrong yields a refusal rather than a span: the _meta
+// block carrying the protocol version, the Mcp-Method and Mcp-Name headers that
+// protocol 2026-07-28 makes required on a POST, and the Mcp-Param-Action header
+// mirroring the action argument, without which the transport answers -32020
+// before any middleware sees the request.
+func (s *server) callAction(t *testing.T, id int, action, projectID string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"tools/call","params":{` + protocolMeta +
+		`,"name":"gitlab_execute_action","arguments":{"action":"` + action +
+		`","project_id":"` + projectID + `"}}}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the tools/call request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "gitlab_execute_action")
+	req.Header.Set("Mcp-Param-Action", action)
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+	// The body is drained and discarded on purpose. Whether GitLab would have
+	// answered is not what this module tests; a call that reached the handler
+	// produced a span either way, and asserting on the result here would make
+	// this a test of the fake instance below.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		t.Fatalf("the call was refused with %d, so it never reached the instrumentation and no span exists to assert on. Server output:\n%s",
+			resp.StatusCode, s.logs())
+	}
+}
+
+// startFakeGitLab serves the endpoints the server probes when it builds a pool
+// entry, so a credential is admitted and the call reaches the middleware.
+//
+// The instrumentation sits inside the authentication gate. Without an instance
+// that accepts the token there is no span to collect, which is a deliberate
+// property of the design and an obstacle to testing it.
+func startFakeGitLab(t *testing.T) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":7,"username":"collector-e2e"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// Scope and tier probes hit other paths; 404 means "unavailable",
+		// which every caller handles.
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -250,10 +250,20 @@ func waitHealthy(t *testing.T, s *server) {
 func (s *server) callAction(t *testing.T, id int, action, projectID string) {
 	t.Helper()
 
+	// The action's own parameters go under params, which is the shape
+	// gitlab_execute_action declares. They used to be siblings of action, and
+	// the server refused every call with "unexpected additional properties":
+	// the request never reached a handler, never called GitLab, and never
+	// logged anything.
+	//
+	// Nothing here noticed for the life of the module, because every assertion
+	// was about the MCP span and the middleware creates that before the handler
+	// runs. A module whose reason for existing is not to be graded by our own
+	// code was driving a request our own code rejected.
 	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
 		`,"method":"tools/call","params":{` + protocolMeta +
 		`,"name":"gitlab_execute_action","arguments":{"action":"` + action +
-		`","project_id":"` + projectID + `"}}}`
+		`","params":{"project_id":"` + projectID + `"}}}}`
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
 	if err != nil {
@@ -273,15 +283,35 @@ func (s *server) callAction(t *testing.T, id int, action, projectID string) {
 	}
 	defer resp.Body.Close()
 	// The body is drained and discarded on purpose. Whether GitLab would have
-	// answered is not what this module tests; a call that reached the handler
-	// produced a span either way, and asserting on the result here would make
-	// this a test of the fake instance below.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	// answered is not what this module tests. What is read here is whether the
+	// call reached a handler at all, which the two checks below decide.
+	payload, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		t.Fatalf("the call was refused with %d, so it never reached the instrumentation and no span exists to assert on. Server output:\n%s",
 			resp.StatusCode, s.logs())
 	}
+
+	// A 200 is not enough, and assuming it was is how the malformed request
+	// above survived. MCP reports a refused call inside a successful response,
+	// so a schema rejection arrives as isError with the reason in the text and
+	// every assertion in this module goes on passing against a server that
+	// never ran a handler.
+	if bytes.Contains(payload, []byte(`"isError":true`)) {
+		t.Fatalf("the server answered with an error result, so no handler ran and no GitLab call was made:\n%s",
+			tailOfPayload(payload))
+	}
+}
+
+// tailOfPayload returns the end of a response body, where the content sits
+// after the server-info preamble every result carries.
+func tailOfPayload(payload []byte) string {
+	const want = 400
+	flat := strings.ReplaceAll(string(payload), "\n", " ")
+	if len(flat) <= want {
+		return flat
+	}
+	return flat[len(flat)-want:]
 }
 
 // startFakeGitLab serves the endpoints the server probes when it builds a pool
@@ -301,6 +331,25 @@ func startFakeGitLab(t *testing.T) string {
 	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":7,"username":"collector-e2e"}`))
+	})
+	// The endpoint the driven action actually calls, answered with an empty
+	// page so the tool call succeeds.
+	//
+	// It used to fall through to the 404 below, which made every driven call
+	// fail. That was invisible while the assertions were about the MCP span
+	// alone, and it hid two things the moment anything looked further: a failed
+	// call makes no GitLab request, so no client span exists to check the trace
+	// tree against, and it takes the "tool call completed" record with it, so
+	// there is no correlated log record either. The fake answering the call is
+	// what makes those two observable at all.
+	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/issues") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total", "0")
+		_, _ = w.Write([]byte(`[]`))
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		// Scope and tier probes hit other paths; 404 means "unavailable",

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -73,6 +73,7 @@ const (
 var (
 	buildOnce   sync.Once
 	builtBinary string
+	builtDir    string
 	errBuild    error
 )
 
@@ -90,9 +91,10 @@ func serverBinary(t *testing.T) string {
 		// when that test ends, leaving every later test pointing at nothing.
 		dir, err := os.MkdirTemp("", "gitlab-mcp-collectore2e") //nolint:usetesting // see above
 		if err != nil {
-			errBuild = err
+			errBuild = fmt.Errorf("creating the collector e2e build directory: %w", err)
 			return
 		}
+		builtDir = dir
 		out := filepath.Join(dir, "gitlab-mcp-server")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
@@ -309,4 +311,36 @@ func startFakeGitLab(t *testing.T) string {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv.URL
+}
+
+// TestMain removes the binary this package builds once the suite has finished.
+//
+// serverBinary deliberately does not use t.TempDir, because the binary outlives
+// the test that happened to build it, so nothing else is in a position to clean
+// up. The server binary is tens of megabytes, /tmp is not always cleared between
+// runs, and a machine running this module through a working day accumulates a
+// copy per run. test/e2e/http carries the same teardown for the same reason.
+//
+// The exit code is preserved, so a failing suite still fails.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	removeBuiltBinary()
+	os.Exit(code)
+}
+
+// removeBuiltBinary deletes the temporary directory serverBinary created, if it
+// created one.
+//
+// Keyed on the directory rather than on the binary so a build that failed is
+// cleaned up too: MkdirTemp succeeds before the compile does, so a failing build
+// leaves a directory and no binary.
+//
+// Failure is ignored: this runs after the tests have reported, so there is
+// nobody left to tell, and a leaked temporary file is not worth turning a
+// passing suite red.
+func removeBuiltBinary() {
+	if builtDir == "" {
+		return
+	}
+	_ = os.RemoveAll(builtDir)
 }

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -57,6 +57,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -390,6 +391,25 @@ func tailOfPayload(payload []byte) string {
 // the cases that need a failure this server counts as its own.
 const failingProject = "always-failing-project"
 
+// fakeGitLab is a running fake instance whose project payload can be changed.
+//
+// Only the project changes, and only because a subscription is defined by
+// noticing that a read returned something different. The rest stays static:
+// a fake that can drift in several places is a fake whose failures need
+// diagnosing.
+type fakeGitLab struct {
+	url         string
+	description atomic.Pointer[string]
+}
+
+// URL is where the server should point.
+func (f *fakeGitLab) URL() string { return f.url }
+
+// change makes the next read of the project return something different.
+func (f *fakeGitLab) change(text string) {
+	f.description.Store(&text)
+}
+
 // startFakeGitLab serves the endpoints the server probes when it builds a pool
 // entry, so a credential is admitted and the call reaches the middleware.
 //
@@ -398,7 +418,15 @@ const failingProject = "always-failing-project"
 // property of the design and an obstacle to testing it.
 func startFakeGitLab(t *testing.T) string {
 	t.Helper()
+	return startMutableFakeGitLab(t).URL()
+}
 
+// startMutableFakeGitLab is the same instance, returned so a test can change
+// what it answers.
+func startMutableFakeGitLab(t *testing.T) *fakeGitLab {
+	t.Helper()
+
+	fake := &fakeGitLab{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -436,8 +464,13 @@ func startFakeGitLab(t *testing.T) string {
 			// The project itself, which the gitlab://project/{ref} resource
 			// reads. Enough fields for the handler to render it; the test is
 			// about what telemetry says, not about the payload.
+			description := ""
+			if current := fake.description.Load(); current != nil {
+				description = *current
+			}
 			_, _ = w.Write([]byte(`{"id":1,"name":"some-project",` +
 				`"path_with_namespace":"some-group/some-project","default_branch":"main",` +
+				`"description":"` + description + `",` +
 				`"visibility":"private","web_url":"http://example.invalid/some-group/some-project"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -451,7 +484,8 @@ func startFakeGitLab(t *testing.T) string {
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv.URL
+	fake.url = srv.URL
+	return fake
 }
 
 // TestMain removes the binary this package builds once the suite has finished.

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -677,3 +677,87 @@ func (s *server) getPromptExpectingRefusal(t *testing.T, id int, name string) {
 func metricsPath(c *collector) string {
 	return filepath.Join(c.outDir, metricsFile)
 }
+
+// callToolTolerant posts a tools/call and requires only that it reached the
+// instrumentation.
+//
+// The counterpart to callTool, for the cases whose subject is a refusal: safe
+// mode answers with a preview and read-only removes the tool, so both come back
+// as failures and neither is a defect. Named for the difference rather than
+// taking a flag, because a boolean at the call site says nothing about which
+// way it points.
+func (s *server) callToolTolerant(t *testing.T, id int, tool, arguments string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"tools/call","params":{` + protocolMeta +
+		`,"name":"` + tool + `","arguments":` + arguments + `}}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the tools/call request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", tool)
+	if action := topLevelAction(arguments); action != "" {
+		req.Header.Set("Mcp-Param-Action", action)
+	}
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		t.Fatalf("the call was refused with %d before any instrumentation ran. Server output:\n%s",
+			resp.StatusCode, s.logs())
+	}
+}
+
+// callWithTraceContext posts a tools/call carrying W3C trace context in
+// params._meta.
+//
+// Unprefixed keys, which is the exception MCP grants: "the keys traceparent,
+// tracestate, and baggage are reserved for OpenTelemetry trace context
+// propagation". Sending a DNS-prefixed variant instead would be wrong rather
+// than merely unusual, and would test nothing.
+func (s *server) callWithTraceContext(t *testing.T, id int, traceparent string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"tools/call","params":{` +
+		`"_meta":{"io.modelcontextprotocol/protocolVersion":"` + protocolVersion + `",` +
+		`"io.modelcontextprotocol/clientCapabilities":{},` +
+		`"traceparent":"` + traceparent + `"},` +
+		`"name":"gitlab_execute_action","arguments":{"action":"issue.list",` +
+		`"params":{"project_id":"some-group/some-project"}}}}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the tools/call request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "gitlab_execute_action")
+	req.Header.Set("Mcp-Param-Action", "issue.list")
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	payload, _ := io.ReadAll(resp.Body)
+	if bytes.Contains(payload, []byte(`"error":{`)) || bytes.Contains(payload, []byte(`"isError":true`)) {
+		t.Fatalf("the call was refused, so no span carries the caller's context:\n%s", tailOfPayload(payload))
+	}
+}

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -415,13 +415,21 @@ func startFakeGitLab(t *testing.T) string {
 	// there is no correlated log record either. The fake answering the call is
 	// what makes those two observable at all.
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/issues") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-Total", "0")
-		_, _ = w.Write([]byte(`[]`))
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/issues"):
+			w.Header().Set("X-Total", "0")
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Count(strings.Trim(r.URL.Path, "/"), "/") == 3:
+			// The project itself, which the gitlab://project/{ref} resource
+			// reads. Enough fields for the handler to render it; the test is
+			// about what telemetry says, not about the payload.
+			_, _ = w.Write([]byte(`{"id":1,"name":"some-project",` +
+				`"path_with_namespace":"some-group/some-project","default_branch":"main",` +
+				`"visibility":"private","web_url":"http://example.invalid/some-group/some-project"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		// Scope and tier probes hit other paths; 404 means "unavailable",
@@ -464,4 +472,208 @@ func removeBuiltBinary() {
 		return
 	}
 	_ = os.RemoveAll(builtDir)
+}
+
+// legacyProtocolVersion is the newest revision that has sessions.
+//
+// Revision 2026-07-28 is stateless only, so a server started with
+// --stateless=false does not advertise it and answers "unsupported protocol
+// version" to a client that insists. Anything about session identity or session
+// duration has to be driven over this one.
+const legacyProtocolVersion = "2025-11-25"
+
+// session is an established MCP session on a stateful deployment.
+type session struct {
+	srv *server
+	id  string
+}
+
+// openSession performs the handshake and returns the session.
+//
+// The initialized notification is not optional: the SDK treats a session as
+// incomplete until it arrives, and a tools/call before it is refused, which
+// would look from here exactly like the refusals this module has already
+// mistaken for success twice.
+func (s *server) openSession(t *testing.T) *session {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{` +
+		`"protocolVersion":"` + legacyProtocolVersion + `",` +
+		`"capabilities":{},"clientInfo":{"name":"collector-e2e","version":"1"}}}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the initialize request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", legacyProtocolVersion)
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST initialize: %v", err)
+	}
+	defer resp.Body.Close()
+	payload, _ := io.ReadAll(resp.Body)
+
+	id := resp.Header.Get("Mcp-Session-Id")
+	if id == "" {
+		t.Fatalf("the deployment issued no session id (status %d); it is not running statefully.\nResponse:\n%s\nServer:\n%s",
+			resp.StatusCode, tailOfPayload(payload), s.logs())
+	}
+
+	sess := &session{srv: s, id: id}
+	sess.notify(t, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	return sess
+}
+
+// notify posts a notification, which has no response to check.
+func (sess *session) notify(t *testing.T, body string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, sess.srv.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the notification: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", legacyProtocolVersion)
+	req.Header.Set("Mcp-Session-Id", sess.id)
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST notification: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+// call posts one request inside the session and fails on either kind of
+// refusal, for the reason callTool does.
+func (sess *session) call(t *testing.T, id int, method, params string) []byte {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"` + method + `","params":` + params + `}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, sess.srv.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the %s request: %v", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", legacyProtocolVersion)
+	req.Header.Set("Mcp-Session-Id", sess.id)
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", method, err)
+	}
+	defer resp.Body.Close()
+	payload, _ := io.ReadAll(resp.Body)
+
+	if bytes.Contains(payload, []byte(`"error":{`)) {
+		t.Fatalf("%s was refused with a JSON-RPC error:\n%s", method, tailOfPayload(payload))
+	}
+	return payload
+}
+
+// close ends the session, which is what makes its duration observable.
+//
+// A session that is merely abandoned ends when the idle timeout fires, which is
+// minutes away and longer than any test should wait.
+func (sess *session) close(t *testing.T) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, sess.srv.baseURL+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("building the delete: %v", err)
+	}
+	req.Header.Set("MCP-Protocol-Version", legacyProtocolVersion)
+	req.Header.Set("Mcp-Session-Id", sess.id)
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+// post sends one JSON-RPC request and returns the response body, asserting
+// nothing about it.
+//
+// The helpers built on this decide what counts as failure, because they differ:
+// most calls must succeed, and the one driving an unknown prompt must not.
+func (s *server) post(t *testing.T, method, name, body string) []byte {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the %s request: %v", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	req.Header.Set("Mcp-Method", method)
+	if name != "" {
+		req.Header.Set("Mcp-Name", name)
+	}
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", method, err)
+	}
+	defer resp.Body.Close()
+
+	payload, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		t.Fatalf("%s was refused with %d, so no span exists to assert on. Server output:\n%s",
+			method, resp.StatusCode, s.logs())
+	}
+	return payload
+}
+
+// readResource reads one resource and fails if the read was refused.
+func (s *server) readResource(t *testing.T, id int, uri string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"resources/read","params":{` + protocolMeta + `,"uri":"` + uri + `"}}`
+
+	payload := s.post(t, "resources/read", uri, body)
+	if bytes.Contains(payload, []byte(`"error":{`)) {
+		t.Fatalf("the read was refused, so no handler ran:\n%s", tailOfPayload(payload))
+	}
+}
+
+// getPromptExpectingRefusal asks for a prompt by a name this server does not
+// have, and requires the refusal.
+//
+// Named for what it does because it inverts the rule every other helper here
+// follows. The subject is the refusal: a name that names nothing is how a
+// caller would mint metric series, so the assertion is about what the refused
+// call recorded, and a call that unexpectedly succeeded would mean the fixture
+// had stopped being an unknown name.
+func (s *server) getPromptExpectingRefusal(t *testing.T, id int, name string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"prompts/get","params":{` + protocolMeta +
+		`,"name":"` + name + `","arguments":{}}}`
+
+	payload := s.post(t, "prompts/get", name, body)
+	if !bytes.Contains(payload, []byte(`"error":{`)) {
+		t.Fatalf("prompts/get %q was served; the fixture is no longer an unknown name:\n%s",
+			name, tailOfPayload(payload))
+	}
+}
+
+// metricsPath is where the collector writes the metric documents.
+func metricsPath(c *collector) string {
+	return filepath.Join(c.outDir, metricsFile)
 }

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -386,6 +386,10 @@ func tailOfPayload(payload []byte) string {
 	return flat[len(flat)-want:]
 }
 
+// failingProject is the project id the fake instance answers with a 500, for
+// the cases that need a failure this server counts as its own.
+const failingProject = "always-failing-project"
+
 // startFakeGitLab serves the endpoints the server probes when it builds a pool
 // entry, so a credential is admitted and the call reaches the middleware.
 //
@@ -417,6 +421,14 @@ func startFakeGitLab(t *testing.T) string {
 	mux.HandleFunc("/api/v4/projects/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		// One project that fails, so the failure path has somewhere to happen.
+		// Without it every call here either succeeds or is refused for a
+		// caller fault, and this server deliberately records no error.type for
+		// those: a model naming an action that does not exist is an ordinary
+		// event, not a malfunction. So nothing exercised error.type at all.
+		case strings.Contains(r.URL.Path, failingProject):
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"500 Internal Server Error"}`))
 		case strings.HasSuffix(r.URL.Path, "/issues"):
 			w.Header().Set("X-Total", "0")
 			_, _ = w.Write([]byte(`[]`))

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -45,6 +45,7 @@ package collectore2e
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -247,6 +248,77 @@ func waitHealthy(t *testing.T, s *server) {
 // protocol 2026-07-28 makes required on a POST, and the Mcp-Param-Action header
 // mirroring the action argument, without which the transport answers -32020
 // before any middleware sees the request.
+// callTool posts one tools/call with the given tool name and arguments.
+//
+// callAction is this with the dynamic surface's envelope filled in. The meta
+// and individual surfaces name a different tool and nest their parameters
+// differently, and the whole point of covering them is that those shapes are
+// not interchangeable: the surface decides what a call looks like, which is
+// also what decides whether gitlab_mcp.action can be resolved from it.
+func (s *server) callTool(t *testing.T, id int, tool, arguments string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":` + strconv.Itoa(id) +
+		`,"method":"tools/call","params":{` + protocolMeta +
+		`,"name":"` + tool + `","arguments":` + arguments + `}}`
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, s.baseURL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building the tools/call request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", acceptHeader)
+	req.Header.Set("MCP-Protocol-Version", protocolVersion)
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", tool)
+	if action := topLevelAction(arguments); action != "" {
+		req.Header.Set("Mcp-Param-Action", action)
+	}
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	payload, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		t.Fatalf("the call was refused with %d, so no span exists to assert on. Server output:\n%s",
+			resp.StatusCode, s.logs())
+	}
+	// Both ways a call can fail, because they are different mechanisms and
+	// checking one is how a refusal travels unnoticed: a JSON-RPC error means
+	// the request never reached a handler, and isError means a handler ran and
+	// reported failure to the model.
+	if bytes.Contains(payload, []byte(`"error":{`)) {
+		t.Fatalf("%s was refused with a JSON-RPC error, so no handler ran:\n%s", tool, tailOfPayload(payload))
+	}
+	if bytes.Contains(payload, []byte(`"isError":true`)) {
+		t.Fatalf("%s answered with an error result, so no handler ran:\n%s", tool, tailOfPayload(payload))
+	}
+}
+
+// topLevelAction returns the action named at the top level of a call's
+// arguments, or "".
+//
+// Protocol revision 2026-07-28 mirrors a call's parameters into Mcp-Param-*
+// headers, and the stateless transport requires the ones the tool declares. The
+// dynamic and meta surfaces both take an action there; the individual surface
+// does not, so its calls carry no such header and must not be given one.
+//
+// Read with a decoder rather than by string matching, so a project path that
+// happens to contain the word does not produce a header.
+func topLevelAction(arguments string) string {
+	var decoded struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &decoded); err != nil {
+		return ""
+	}
+	return decoded.Action
+}
+
 func (s *server) callAction(t *testing.T, id int, action, projectID string) {
 	t.Helper()
 

--- a/test/e2e/collector/harness_test.go
+++ b/test/e2e/collector/harness_test.go
@@ -223,13 +223,14 @@ func (w *lockedWriter) Write(p []byte) (int, error) {
 // already said why and nobody should have to go looking.
 func waitHealthy(t *testing.T, s *server) {
 	t.Helper()
+	healthClient := &http.Client{Timeout: 5 * time.Second}
 	deadline := time.Now().Add(45 * time.Second)
 	for time.Now().Before(deadline) {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.baseURL+"/health", http.NoBody)
 		if err != nil {
 			t.Fatalf("building the health request: %v", err)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := healthClient.Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -283,7 +284,10 @@ func (s *server) callTool(t *testing.T, id int, tool, arguments string) {
 	}
 	defer resp.Body.Close()
 
-	payload, _ := io.ReadAll(resp.Body)
+	payload, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		t.Fatalf("reading the MCP response: %v (got %d bytes)", readErr, len(payload))
+	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		t.Fatalf("the call was refused with %d, so no span exists to assert on. Server output:\n%s",
 			resp.StatusCode, s.logs())
@@ -460,7 +464,7 @@ func startMutableFakeGitLab(t *testing.T) *fakeGitLab {
 		case strings.HasSuffix(r.URL.Path, "/issues"):
 			w.Header().Set("X-Total", "0")
 			_, _ = w.Write([]byte(`[]`))
-		case strings.Count(strings.Trim(r.URL.Path, "/"), "/") == 3:
+		case strings.Count(strings.Trim(r.URL.EscapedPath(), "/"), "/") == 3:
 			// The project itself, which the gitlab://project/{ref} resource
 			// reads. Enough fields for the handler to render it; the test is
 			// about what telemetry says, not about the payload.

--- a/test/e2e/collector/inventory_test.go
+++ b/test/e2e/collector/inventory_test.go
@@ -91,6 +91,14 @@ var (
 		"mcp.session.id",
 		"jsonrpc.request.id",
 		"mcp.resource.uri",
+		// Added after this list failed to catch the thing it was written for.
+		// The resource attribute reached a metric on the hosted endpoint while
+		// this test passed, because the list named the convention's key and not
+		// the one this server invented for the digest a few commits later. A
+		// closed list only closes over what somebody remembered to write in it,
+		// which is an argument for keeping it short and reviewing it whenever
+		// an attribute is added rather than for trusting it.
+		"gitlab_mcp.resource.ref",
 		"client.address",
 		"client.port",
 	}

--- a/test/e2e/collector/inventory_test.go
+++ b/test/e2e/collector/inventory_test.go
@@ -214,11 +214,15 @@ func assertInventory(t *testing.T, what string, got, want []string) {
 func dataPointAttributes(t *testing.T, m otlpMetric) [][]otlpAttr {
 	t.Helper()
 
-	if m.Histogram == nil {
-		return nil
+	var raws []json.RawMessage
+	for _, body := range []*otlpMetricBody{m.Histogram, m.Sum, m.Gauge, m.ExponentialHistogram} {
+		if body != nil {
+			raws = append(raws, body.DataPoints...)
+		}
 	}
-	out := make([][]otlpAttr, 0, len(m.Histogram.DataPoints))
-	for _, raw := range m.Histogram.DataPoints {
+
+	out := make([][]otlpAttr, 0, len(raws))
+	for _, raw := range raws {
 		var point struct {
 			Attributes []otlpAttr `json:"attributes"`
 		}

--- a/test/e2e/collector/inventory_test.go
+++ b/test/e2e/collector/inventory_test.go
@@ -1,0 +1,311 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The pinned inventories.
+//
+// # Why an exact set rather than a handful of assertions
+//
+// Every other assertion in this module names an attribute and checks it is
+// there, which catches a removal and is blind to an addition. An addition is the
+// dangerous direction: a new attribute is a new metric dimension, a new thing a
+// client can influence, and possibly a new thing that should never have left the
+// process. Nothing failed when gen_ai.prompt.name started being emitted, and
+// nothing would have failed if a project path had started being emitted beside
+// it.
+//
+// So this is a closed set, and adding an attribute is meant to fail here. The
+// failure is the review: whoever adds one states, by editing this list, that
+// they considered its cardinality and whether it is safe to export.
+//
+// # Why this module and not a unit test
+//
+// A unit test asserts what the code passes to the SDK. This asserts what a real
+// collector parsed out of a real OTLP export, which is the same thing an
+// operator's backend sees and the same thing this project verifies by hand
+// against the hosted endpoint. That correspondence is the point: when the two
+// disagree, one of them is wrong and the question is which, rather than a shrug.
+var (
+	// wantToolCallSpanAttributes is what a tools/call span carries on the
+	// default dynamic surface with the default identity policy, which records
+	// nobody. The identity keys are absent because of that default, and
+	// neverOnAnyMetric asserts they stay off metrics under every policy.
+	wantToolCallSpanAttributes = []string{
+		"gen_ai.operation.name",
+		"gen_ai.tool.name",
+		"gitlab_mcp.action",
+		"gitlab_mcp.tool_surface",
+		"mcp.method.name",
+		"mcp.protocol.version",
+		"network.transport",
+	}
+
+	// wantDurationMetricDimensions is the label set of the convention's server
+	// instrument. Every entry here multiplies the number of stored time series,
+	// so the list is short by design and each addition is a cost decision.
+	wantDurationMetricDimensions = []string{
+		"gen_ai.operation.name",
+		"gen_ai.tool.name",
+		"gitlab_mcp.action",
+		"gitlab_mcp.tool_surface",
+		"mcp.method.name",
+		"mcp.protocol.version",
+		"network.transport",
+	}
+
+	// neverOnAnyMetric are keys that may appear on a span and must never become
+	// a metric dimension.
+	//
+	// mcp.session.id and jsonrpc.request.id are unbounded by construction: one
+	// value per connected client, one per request. The user keys are unbounded
+	// by the number of people using a deployment, which is exactly the number an
+	// operator cannot predict. The SDK does not refuse an exhausted series
+	// budget, it collapses the overflow into a single otel.metric.overflow
+	// bucket on a first-come-wins basis under cumulative temporality, so the
+	// failure mode is silent data destruction rather than an error anyone sees.
+	// conditionallyAllowed are keys the convention defines as Conditionally
+	// Required, so they are present exactly when their condition holds and
+	// absent otherwise. They belong in the inventory as permitted rather than as
+	// expected: asserting error.type is always there would demand that every
+	// call fail, and asserting it is never there would demand that none does.
+	//
+	// The traffic this test drives runs against the harness's fake GitLab and
+	// fails, which is why error.type shows up here rather than in theory.
+	conditionallyAllowed = []string{
+		"error.type",
+		"rpc.response.status_code",
+	}
+
+	neverOnAnyMetric = []string{
+		"user.id",
+		"user.name",
+		"user.hash",
+		"mcp.session.id",
+		"jsonrpc.request.id",
+		"mcp.resource.uri",
+		"client.address",
+		"client.port",
+	}
+)
+
+// TestRealCollector_TheExportedInventoryIsExactlyThis pins what leaves this
+// process, in both directions, as parsed by a real collector.
+func TestRealCollector_TheExportedInventoryIsExactlyThis(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	const action = "issue.list"
+	for i := range 5 {
+		srv.callAction(t, i+1, action, "some-group/some-project")
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("the collector parsed no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	_, duration, ok := c.awaitMetric(t, exportDeadline, durationMetric)
+	if !ok {
+		t.Fatalf("the collector parsed no %s metric.\nCollector:\n%s\nServer:\n%s", durationMetric, c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("a tool-call span carries exactly the pinned attributes", func(t *testing.T) {
+		assertInventory(t, "tools/call span", keys(span.Attributes), wantToolCallSpanAttributes)
+	})
+
+	t.Run("the duration metric carries exactly the pinned dimensions", func(t *testing.T) {
+		points := dataPointAttributes(t, duration)
+		if len(points) == 0 {
+			t.Fatalf("%s arrived with no data points", durationMetric)
+		}
+		for _, point := range points {
+			assertInventory(t, durationMetric+" data point", keys(point), wantDurationMetricDimensions)
+		}
+	})
+
+	t.Run("no unbounded key is a dimension of any metric", func(t *testing.T) {
+		for _, forbidden := range neverOnAnyMetric {
+			if found := metricDimensionExists(t, c, forbidden); found != "" {
+				t.Errorf("%q is a dimension of %s; it is unbounded and mints one time series per distinct value",
+					forbidden, found)
+			}
+		}
+	})
+
+	t.Run("the negotiated protocol version is recorded and is one this build serves", func(t *testing.T) {
+		version, present := attr(span.Attributes, "mcp.protocol.version")
+		if !present {
+			t.Fatal("mcp.protocol.version is absent; the convention marks it Recommended and the key was declared long before it was set")
+		}
+		// Any admitted revision is acceptable: which one the SDK client
+		// negotiates is its business, and pinning one here would make this test
+		// fail on an SDK bump rather than on a defect of ours.
+		if !strings.HasPrefix(version, "202") || len(version) != len("2026-07-28") {
+			t.Errorf("mcp.protocol.version = %q, which is not a revision string; an unvalidated caller value reached a metric dimension", version)
+		}
+	})
+
+	t.Run("a stateless deployment reports no session", func(t *testing.T) {
+		// The default HTTP transport is stateless: each POST is its own session
+		// with no id, so the convention's condition ("part of a session") is not
+		// met and the attribute must be absent rather than invented per POST.
+		if value, present := attr(span.Attributes, "mcp.session.id"); present {
+			t.Errorf("mcp.session.id = %q on a stateless deployment; there is no session to name", value)
+		}
+		// Same reasoning for the instrument: a session that is one POST would
+		// make this histogram a copy of the operation one under a name that
+		// promises something else.
+		if _, _, found := c.awaitMetric(t, 2*exportDeadline/10, "mcp.server.session.duration"); found {
+			t.Error("mcp.server.session.duration was recorded for stateless POSTs; it duplicates mcp.server.operation.duration")
+		}
+	})
+}
+
+// assertInventory checks both directions, which mean opposite things: a missing
+// key is a regression in what gets recorded, an unexpected one is a dimension or
+// a disclosure nobody reviewed.
+//
+// Required keys must all be present. Anything present must be either required or
+// conditionally allowed, so a key that arrives from nowhere fails even though a
+// conditional one does not.
+func assertInventory(t *testing.T, what string, got, want []string) {
+	t.Helper()
+
+	gotSorted := slices.Clone(got)
+	slices.Sort(gotSorted)
+	gotSorted = slices.Compact(gotSorted)
+
+	for _, key := range want {
+		if !slices.Contains(gotSorted, key) {
+			t.Errorf("%s is missing %q; recorded %v", what, key, gotSorted)
+		}
+	}
+	for _, key := range gotSorted {
+		if !slices.Contains(want, key) && !slices.Contains(conditionallyAllowed, key) {
+			t.Errorf("%s carries %q, which is not in the pinned inventory. If it belongs there, add it and say why: it becomes a metric dimension or an exported value that nobody has reviewed",
+				what, key)
+		}
+	}
+}
+
+// dataPointAttributes decodes the attribute set of each data point.
+//
+// The harness leaves data points as raw JSON because nothing needed them until
+// now, and decoding only the attributes keeps that restraint: the values are
+// bucket counts and sums, which this test has no opinion about.
+func dataPointAttributes(t *testing.T, m otlpMetric) [][]otlpAttr {
+	t.Helper()
+
+	if m.Histogram == nil {
+		return nil
+	}
+	out := make([][]otlpAttr, 0, len(m.Histogram.DataPoints))
+	for _, raw := range m.Histogram.DataPoints {
+		var point struct {
+			Attributes []otlpAttr `json:"attributes"`
+		}
+		if err := json.Unmarshal(raw, &point); err != nil {
+			t.Fatalf("decoding a data point of %s: %v", m.Name, err)
+		}
+		out = append(out, point.Attributes)
+	}
+	return out
+}
+
+// metricDimensionExists reports the first instrument carrying a key, or "".
+//
+// It sweeps every metric the collector parsed rather than the one instrument
+// under test: an assertion about what must never be a dimension has to look
+// everywhere, because the instrument that acquires a forbidden key by accident
+// is by definition not the one anybody suspected.
+func metricDimensionExists(t *testing.T, c *collector, key string) string {
+	t.Helper()
+
+	for _, doc := range documents[metricDocument](t, filepath.Join(c.outDir, metricsFile)) {
+		for _, resourceMetrics := range doc.ResourceMetrics {
+			for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+				for _, m := range scopeMetrics.Metrics {
+					for _, point := range dataPointAttributes(t, m) {
+						if _, present := attr(point, key); present {
+							return m.Name
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// TestRealCollector_IdentityReachesSpansAndNeverMetrics closes the last
+// difference between this module and the hosted endpoint.
+//
+// The inventory above is recorded under the default identity policy, which
+// records nobody, so it says nothing about the policies that do. The hosted
+// deployment runs pseudonymous, and comparing its exported keys against the
+// pinned set leaves user.hash unaccounted for: explained by the policy, but
+// explained in prose rather than by a test. This is the test.
+//
+// The asymmetry is the point. Identity on a span is bounded by the trace it
+// belongs to and is what makes a report of "this user's calls are slow"
+// answerable. Identity on a metric is a dimension whose cardinality is the
+// number of people using the deployment, which is the number an operator cannot
+// predict, and the SDK responds to an exhausted series budget by collapsing the
+// overflow into one bucket rather than by complaining.
+func TestRealCollector_IdentityReachesSpansAndNeverMetrics(t *testing.T) {
+	c := startCollector(t)
+
+	env := telemetryEnv(c)
+	env["GITLAB_MCP_TELEMETRY_IDENTITY"] = "pseudonymous"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 5 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("the collector parsed no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span carries the pseudonym and neither of the readable keys", func(t *testing.T) {
+		digest, present := attr(span.Attributes, "user.hash")
+		if !present {
+			t.Fatalf("user.hash is absent under the pseudonymous policy; recorded %v", keys(span.Attributes))
+		}
+		if digest == "" {
+			t.Error("user.hash is present but empty, which correlates nothing while still claiming to")
+		}
+		for _, readable := range []string{"user.id", "user.name"} {
+			if value, leaked := attr(span.Attributes, readable); leaked {
+				t.Errorf("%s = %q under the pseudonymous policy; the whole point of the policy is that this key is not exported", readable, value)
+			}
+		}
+	})
+
+	t.Run("no identity key is a dimension of any metric", func(t *testing.T) {
+		// awaitMetric first, so the sweep runs against a file the exporter has
+		// actually written to rather than an empty one, which would pass for the
+		// wrong reason.
+		if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+			t.Fatalf("the collector parsed no %s metric, so this assertion would pass vacuously", durationMetric)
+		}
+		for _, key := range []string{"user.hash", "user.id", "user.name"} {
+			if instrument := metricDimensionExists(t, c, key); instrument != "" {
+				t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
+			}
+		}
+	})
+}

--- a/test/e2e/collector/inventory_test.go
+++ b/test/e2e/collector/inventory_test.go
@@ -42,6 +42,11 @@ var (
 		"gen_ai.operation.name",
 		"gen_ai.tool.name",
 		"gitlab_mcp.action",
+		// The catalog domain. Bounded by the catalog's domain count, and the
+		// coarse dimension that survives on metrics where the action id is too
+		// many values; also what remains of a call whose action does not
+		// resolve, so a model inventing an action still names a real domain.
+		"gitlab_mcp.domain",
 		"gitlab_mcp.tool_surface",
 		"mcp.method.name",
 		"mcp.protocol.version",
@@ -55,6 +60,11 @@ var (
 		"gen_ai.operation.name",
 		"gen_ai.tool.name",
 		"gitlab_mcp.action",
+		// Bounded by the catalog's domain count (at most a few dozen values),
+		// and the dimension worth the cost: it is what an operator groups by
+		// on the individual surface, where the tool name and action id are
+		// dropped by the cardinality policy.
+		"gitlab_mcp.domain",
 		"gitlab_mcp.tool_surface",
 		"mcp.method.name",
 		"mcp.protocol.version",

--- a/test/e2e/collector/propagation_test.go
+++ b/test/e2e/collector/propagation_test.go
@@ -1,0 +1,139 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The trace a client claims to be part of. Fixed rather than generated, so a
+// failure names the value that was supposed to arrive.
+const (
+	clientTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	clientSpanID  = "00f067aa0ba902b7"
+	clientTrace   = "00-" + clientTraceID + "-" + clientSpanID + "-01"
+)
+
+// TestRealCollector_TraceContextArrivesInMetaAndTheHTTPSpanIsLinked covers the
+// propagation rule, which has two halves and had one.
+//
+// The convention asks a server to parent its MCP span on the context from
+// params._meta and to link the ambient one. Extract replaces the ambient
+// context, so an implementation that reads it afterwards finds the extracted
+// one and links nothing: the parenting looked right and the HTTP request that
+// carried the call disappeared from the record.
+//
+// The keys are unprefixed, which is the exception MCP grants: "the keys
+// traceparent, tracestate, and baggage are reserved for OpenTelemetry trace
+// context propagation". A prefixed variant would be wrong rather than merely
+// unusual, so this drives the real one.
+func TestRealCollector_TraceContextArrivesInMetaAndTheHTTPSpanIsLinked(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.callWithTraceContext(t, i+1, clientTrace)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the MCP span joins the caller's trace", func(t *testing.T) {
+		if span.TraceID != clientTraceID {
+			t.Errorf("trace = %s, want the caller's %s: the context in params._meta was not adopted",
+				span.TraceID, clientTraceID)
+		}
+		if span.ParentSpanID != clientSpanID {
+			t.Errorf("parent = %s, want the caller's span %s", span.ParentSpanID, clientSpanID)
+		}
+	})
+
+	t.Run("the HTTP span it arrived on is linked", func(t *testing.T) {
+		if len(span.Links) != 1 {
+			t.Fatalf("recorded %d links, want 1: the ambient HTTP span is dropped rather than linked, so nothing records which request carried this call",
+				len(span.Links))
+		}
+		link := span.Links[0]
+		if link.TraceID == clientTraceID {
+			t.Error("the link points into the caller's trace; it should point at this server's own HTTP span")
+		}
+		if _, found := c.spanByID(t, link.TraceID, link.SpanID); !found {
+			t.Errorf("the link names span %s in trace %s, which was never exported", link.SpanID, link.TraceID)
+		}
+	})
+}
+
+// TestRealCollector_AnInventedHTTPMethodIsBounded covers the substitution the
+// HTTP convention requires and the cardinality hole it closes here.
+//
+// net/http accepts any token as a method, so that string is chosen by the
+// caller, and it sat on the one instrument every request touches. A client
+// could mint one time series per invented verb until the budget ran out, and
+// the SDK answers an exhausted budget by collapsing everything past the limit
+// into otel.metric.overflow rather than refusing it.
+func TestRealCollector_AnInventedHTTPMethodIsBounded(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	const invented = "FROBNICATE"
+	srv.rawRequest(t, invented, "/mcp")
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		value, _ := attr(s.Attributes, "http.request.method_original")
+		return value == invented
+	})
+	if !ok {
+		t.Fatalf("no span records http.request.method_original; nothing says what the client sent.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the recorded method is the bucket", func(t *testing.T) {
+		if got, _ := attr(span.Attributes, "http.request.method"); got != "_OTHER" {
+			t.Errorf("http.request.method = %q, want _OTHER", got)
+		}
+		// Stated separately from the attribute by the convention, and the
+		// distinction is real: a span name is a label a backend groups by, and
+		// _OTHER there reads as a method rather than as the absence of one.
+		if span.Name != "HTTP" {
+			t.Errorf("span name = %q, want HTTP", span.Name)
+		}
+	})
+
+	t.Run("the verb never reaches a metric", func(t *testing.T) {
+		if _, _, found := c.awaitMetric(t, exportDeadline, "http.server.request.duration"); !found {
+			t.Fatal("no http.server.request.duration metric, so this would pass vacuously")
+		}
+		if instrument, key := metricValueExists(t, c, invented); instrument != "" {
+			t.Errorf("%s carries the caller's verb on %s; a client then chooses the label space", key, instrument)
+		}
+		if instrument, _ := metricValueExists(t, c, "_OTHER"); instrument == "" {
+			t.Error("no metric carries _OTHER, so the request was not measured at all")
+		}
+	})
+}
+
+// rawRequest sends a bare request with an arbitrary method, which is the shape
+// this server must survive rather than serve.
+func (s *server) rawRequest(t *testing.T, method, path string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, s.baseURL+path, nil)
+	if err != nil {
+		t.Fatalf("building the %s request: %v", method, err)
+	}
+	req.Header.Set("PRIVATE-TOKEN", "glpat-collector-e2e-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	// The status is not the subject: whatever the server answers, the question
+	// is what it recorded about being asked.
+}

--- a/test/e2e/collector/protective_test.go
+++ b/test/e2e/collector/protective_test.go
@@ -71,6 +71,38 @@ func TestRealCollector_SafeModeSaysWhyItRefused(t *testing.T) {
 			t.Errorf("gitlab_mcp.action = %q, want issue.create", got)
 		}
 	})
+
+	t.Run("the reason is a metric dimension, not only a span attribute", func(t *testing.T) {
+		// The span answers "what happened to this one call". Counting is a
+		// different question and needs a different signal: a deployment whose
+		// safe mode is blocking something somebody needs shows up as a rate,
+		// and a rate cannot be computed from an attribute that only exists on
+		// individual traces, which are sampled.
+		_, duration, found := c.awaitMetric(t, exportDeadline, durationMetric)
+		if !found {
+			t.Fatalf("%s never arrived.\nCollector:\n%s\nServer:\n%s",
+				durationMetric, c.containerLogs(t), srv.logs())
+		}
+
+		points := dataPointAttributes(t, duration)
+		if len(points) == 0 {
+			t.Fatal("the instrument arrived with no data points")
+		}
+
+		refused := 0
+		for _, point := range points {
+			if value, carried := attr(point, "gitlab_mcp.refusal_reason"); carried {
+				refused++
+				if value != "safe_mode" {
+					t.Errorf("gitlab_mcp.refusal_reason = %q on a data point, want safe_mode", value)
+				}
+			}
+		}
+		if refused == 0 {
+			t.Errorf("no data point of %s carries the refusal reason, so a refusal rate cannot be computed",
+				durationMetric)
+		}
+	})
 }
 
 // TestRealCollector_ReadOnlyRemovesTheToolRatherThanRefusingIt pins the

--- a/test/e2e/collector/protective_test.go
+++ b/test/e2e/collector/protective_test.go
@@ -1,0 +1,115 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRealCollector_SafeModeSaysWhyItRefused covers the protective mode from
+// the only side that matters to an operator: what the telemetry says happened.
+//
+// A refusal travels as an error result, which is a successful JSON-RPC response
+// carrying a failure meant for the model. From outside the handler it is
+// indistinguishable from a call that ran and failed, so without the reason on
+// the span a deployment refusing every third request looks exactly like one
+// whose GitLab is erroring.
+//
+// gitlab_mcp.refusal_reason existed as a declared attribute key that nothing
+// set, which is why this had to be built before it could be tested.
+func TestRealCollector_SafeModeSaysWhyItRefused(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c),
+		"--gitlab-url="+startFakeGitLab(t),
+		"--safe-mode",
+	)
+
+	// A mutating action, because safe mode intercepts those and leaves reads
+	// alone. Nothing is created: the point of the mode is that the call is
+	// answered with a preview instead of being performed.
+	for i := range 3 {
+		srv.callToolTolerant(t, i+1, "gitlab_execute_action",
+			`{"action":"issue.create","params":{"project_id":"some-group/some-project","title":"never created"}}`)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span under safe mode.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	reason, present := attr(span.Attributes, "gitlab_mcp.refusal_reason")
+	if !present {
+		t.Fatalf("gitlab_mcp.refusal_reason is absent; the span cannot say this server declined rather than failed. Recorded %v",
+			keys(span.Attributes))
+	}
+	if reason != "safe_mode" {
+		t.Errorf("gitlab_mcp.refusal_reason = %q, want %q", reason, "safe_mode")
+	}
+
+	t.Run("the reason is bounded, so it can be a metric dimension", func(t *testing.T) {
+		// The set is closed on purpose: an operator computing a refusal rate
+		// groups by this, and free text does not group. The assertion is that
+		// the value is one of the five, not merely present.
+		known := map[string]bool{
+			"safe_mode": true, "needs_confirmation": true, "invalid_params": true,
+			"unknown_action": true, "rate_limited": true,
+		}
+		if !known[reason] {
+			t.Errorf("%q is not one of this server's five refusal reasons", reason)
+		}
+	})
+
+	t.Run("the action is still recorded", func(t *testing.T) {
+		// A refused call is still a call, and which action was refused is the
+		// whole content of a report that safe mode is blocking something
+		// somebody needs.
+		if got, _ := attr(span.Attributes, "gitlab_mcp.action"); got != "issue.create" {
+			t.Errorf("gitlab_mcp.action = %q, want issue.create", got)
+		}
+	})
+}
+
+// TestRealCollector_ReadOnlyRemovesTheToolRatherThanRefusingIt pins the
+// difference between the two protective modes, which is easy to conflate and
+// produces different telemetry.
+//
+// Read-only removes mutating operations from the catalog, so the tool is not
+// there to call and the refusal comes from the SDK as an unknown tool. Safe
+// mode keeps them and intercepts, which is what produces a refusal reason. An
+// operator seeing no refusal_reason under read-only is looking at the mode
+// working, not at a missing attribute.
+func TestRealCollector_ReadOnlyRemovesTheToolRatherThanRefusingIt(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c),
+		"--gitlab-url="+startFakeGitLab(t),
+		"--read-only",
+	)
+
+	for i := range 3 {
+		srv.callToolTolerant(t, i+1, "gitlab_execute_action",
+			`{"action":"issue.create","params":{"project_id":"some-group/some-project","title":"never created"}}`)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span under read-only.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	// Whatever the mode answers, the span must not claim the server failed: a
+	// caller asking for something this deployment does not offer is the
+	// deployment working.
+	if errorType, present := attr(span.Attributes, "error.type"); present {
+		for _, serverFault := range []string{"-32603", "_OTHER"} {
+			if errorType == serverFault {
+				t.Errorf("error.type = %q under read-only; refusing a mutating call is not this server failing", errorType)
+			}
+		}
+	}
+}

--- a/test/e2e/collector/redaction_test.go
+++ b/test/e2e/collector/redaction_test.go
@@ -1,0 +1,207 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// resourceURI is a resource this server exposes whose identifier is the whole
+// point: it embeds a project path.
+const resourceURI = "gitlab://project/some-group%2Fsome-project"
+
+// TestRealCollector_ResourceURIsFollowTheIdentityPolicy covers the rule a live
+// deployment broke while every test passed.
+//
+// A subscription poll span carried gitlab://project/82077663 verbatim, which
+// contradicted this server's documented position that resource URIs are not
+// exported, and did so on the worst span for it: a poll repeats for the life of
+// the watch, so one subscription wrote a project id into a backend hundreds of
+// times.
+//
+// What replaced it is not a removal. Without something naming the resource, two
+// watchers of one kind are indistinguishable and "one subscription is failing"
+// and "all of them are" look the same. So the identity policy decides: a keyed
+// digest by default, the URI itself under full, and never either on a metric.
+func TestRealCollector_ResourceURIsFollowTheIdentityPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		identity  string
+		wantKey   string
+		absentKey string
+	}{
+		{
+			name:      "the default policy names the resource indirectly",
+			identity:  "",
+			wantKey:   "gitlab_mcp.resource.ref",
+			absentKey: "mcp.resource.uri",
+		},
+		{
+			// The same decision the operator already made about the caller's
+			// name. A URI says what somebody is working on, which is the same
+			// class of disclosure as saying who they are.
+			name:      "full exports the convention's own attribute",
+			identity:  "full",
+			wantKey:   "mcp.resource.uri",
+			absentKey: "gitlab_mcp.resource.ref",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, span := readOneResource(t, tc.identity)
+
+			assertResourceAttribute(t, span, tc.wantKey, tc.absentKey, tc.identity)
+			assertNoResourceMetricDimension(t, c)
+
+			// The span name never carries it, under either policy: a name built
+			// per resource is one span name per project, which the convention
+			// calls out for this attribute specifically.
+			if span.Name != "resources/read" {
+				t.Errorf("span name = %q, want %q", span.Name, "resources/read")
+			}
+		})
+	}
+}
+
+// readOneResource starts a stack under an identity policy, reads a resource,
+// and returns the span it produced.
+func readOneResource(t *testing.T, identity string) (*collector, otlpSpan) {
+	t.Helper()
+
+	c := startCollector(t)
+	env := telemetryEnv(c)
+	if identity != "" {
+		env["GITLAB_MCP_TELEMETRY_IDENTITY"] = identity
+	}
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.readResource(t, i+1, resourceURI)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.Name == "resources/read"
+	})
+	if !ok {
+		t.Fatalf("no resources/read span.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+	return c, span
+}
+
+// assertResourceAttribute checks that exactly one of the two keys is present
+// and that its value is what the policy allows.
+func assertResourceAttribute(t *testing.T, span otlpSpan, wantKey, absentKey, identity string) {
+	t.Helper()
+
+	value, present := attr(span.Attributes, wantKey)
+	if !present {
+		t.Fatalf("%s is absent; recorded %v", wantKey, keys(span.Attributes))
+	}
+	if _, leaked := attr(span.Attributes, absentKey); leaked {
+		t.Errorf("%s is recorded as well, which says the same thing twice", absentKey)
+	}
+
+	if identity == "full" {
+		if value != resourceURI {
+			t.Errorf("mcp.resource.uri = %q, want the URI the client asked for", value)
+		}
+		return
+	}
+	if strings.Contains(value, "some-group") {
+		t.Errorf("the digest %q contains the project path it stands for", value)
+	}
+}
+
+// assertNoResourceMetricDimension checks both keys against every instrument.
+func assertNoResourceMetricDimension(t *testing.T, c *collector) {
+	t.Helper()
+
+	if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+		t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
+	}
+	for _, key := range []string{"mcp.resource.uri", "gitlab_mcp.resource.ref"} {
+		if instrument := metricDimensionExists(t, c, key); instrument != "" {
+			t.Errorf("%s is a dimension of %s; it is one series per resource a client touches",
+				key, instrument)
+		}
+	}
+}
+
+// TestRealCollector_UnknownNamesDoNotBecomeDimensionValues covers the bound that
+// stops a caller choosing how many time series this process stores.
+//
+// gen_ai.tool.name and gen_ai.prompt.name are copied off the request and the
+// convention puts both on the duration metric, and nothing checked that either
+// named anything. A prompts/get for a prompt that does not exist recorded the
+// invented name as a dimension value, which was found by driving the hosted
+// deployment and reading its collector.
+//
+// The span keeps the name, because that is where an operator finds out what a
+// misbehaving client is actually sending.
+func TestRealCollector_UnknownNamesDoNotBecomeDimensionValues(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	const invented = "not-a-prompt-this-server-has"
+	for i := range 3 {
+		srv.getPromptExpectingRefusal(t, i+1, invented)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "prompts/get")
+	})
+	if !ok {
+		t.Fatalf("no prompts/get span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span records what the client sent", func(t *testing.T) {
+		if got, _ := attr(span.Attributes, "gen_ai.prompt.name"); got != invented {
+			t.Errorf("gen_ai.prompt.name = %q on the span, want the name the client sent", got)
+		}
+	})
+
+	t.Run("the metric records the bucket instead", func(t *testing.T) {
+		if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
+		}
+		if instrument, key := metricValueExists(t, c, invented); instrument != "" {
+			t.Errorf("%s carries the invented name on %s; a caller then chooses the label space",
+				key, instrument)
+		}
+	})
+}
+
+// metricValueExists reports the first instrument and key recording a value.
+func metricValueExists(t *testing.T, c *collector, value string) (instrument, key string) {
+	t.Helper()
+
+	for _, doc := range documents[metricDocument](t, metricsPath(c)) {
+		for _, resourceMetrics := range doc.ResourceMetrics {
+			for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+				if name, found := metricInScopeCarrying(t, scopeMetrics, value); name != "" {
+					return name, found
+				}
+			}
+		}
+	}
+	return "", ""
+}
+
+// metricInScopeCarrying searches one scope's instruments for a value.
+func metricInScopeCarrying(t *testing.T, scope otlpScopeMetrics, value string) (instrument, key string) {
+	t.Helper()
+
+	for _, m := range scope.Metrics {
+		for _, point := range dataPointAttributes(t, m) {
+			for _, kv := range point {
+				if kv.Value.StringValue == value {
+					return m.Name, kv.Key
+				}
+			}
+		}
+	}
+	return "", ""
+}

--- a/test/e2e/collector/redaction_test.go
+++ b/test/e2e/collector/redaction_test.go
@@ -110,8 +110,10 @@ func assertResourceAttribute(t *testing.T, span otlpSpan, wantKey, absentKey, id
 		}
 		return
 	}
-	if strings.Contains(value, "some-group") {
-		t.Errorf("the digest %q contains the project path it stands for", value)
+	for _, component := range []string{"some-group", "some-project"} {
+		if strings.Contains(value, component) {
+			t.Errorf("the digest %q contains %q, part of the project path it stands for", value, component)
+		}
 	}
 }
 

--- a/test/e2e/collector/signals_test.go
+++ b/test/e2e/collector/signals_test.go
@@ -208,3 +208,82 @@ func (c *collector) childOf(t *testing.T, traceID, parentID string, kind int) (o
 
 // spanKindClient is SPAN_KIND_CLIENT in the OTLP enum.
 const spanKindClient = 3
+
+// TestRealCollector_NoExportedLogNamesAResource is the end-to-end form of a
+// leak this module could not have found, because the record was not ours.
+//
+// Subscribing on the hosted deployment produced an exported log record carrying
+// uri = gitlab://project/82077663, while the span for the same subscribe carried
+// the digest. The Go SDK writes that record, through the logger this server
+// installs, and a policy applied only where this repository calls slog leaves a
+// dependency's records untouched.
+//
+// So the assertion is deliberately about the whole log stream rather than about
+// one message: what must hold is that nothing exported names a resource, not
+// that a particular line was fixed.
+func TestRealCollector_NoExportedLogNamesAResource(t *testing.T) {
+	c := startCollector(t)
+	fake := startMutableFakeGitLab(t)
+	srv := startServer(t, telemetryEnv(c),
+		"--gitlab-url="+fake.URL(),
+		// Subscriptions are the path that logs a URI, and they need a session.
+		"--stateless=false",
+	)
+
+	sess := srv.openSession(t)
+	sess.call(t, 2, "resources/subscribe", `{"uri":"`+resourceURI+`"}`)
+	sess.call(t, 3, "resources/read", `{"uri":"`+resourceURI+`"}`)
+	fake.change("changed so the watcher logs about noticing")
+
+	// Wait for the record that carries the URI rather than for any record at
+	// all. The startup lines arrive first and satisfy a "something is here"
+	// wait immediately, which read the stream before the subscribe record was
+	// exported and made this pass against unredacted code.
+	//
+	// Matched on the message, which the redaction leaves alone: only the URI is
+	// replaced, so waiting for the URI itself would be waiting for the defect.
+	if _, ok := c.awaitLog(t, exportDeadline, func(r otlpLogRecord) bool {
+		return strings.Contains(r.Body.StringValue, "subscri")
+	}); !ok {
+		t.Fatalf("no record about the subscription arrived.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+	sess.close(t)
+
+	for _, record := range allLogRecords(t, c) {
+		rendered := renderLogRecord(record)
+		if strings.Contains(rendered, "some-group") {
+			t.Errorf("an exported log record names the project: %s", rendered)
+		}
+		if strings.Contains(rendered, "gitlab://") && !strings.Contains(rendered, "gitlab://[redacted]") {
+			t.Errorf("an exported log record carries a resource URI: %s", rendered)
+		}
+	}
+}
+
+// allLogRecords returns every record the collector parsed.
+func allLogRecords(t *testing.T, c *collector) []otlpLogRecord {
+	t.Helper()
+
+	var records []otlpLogRecord
+	for _, doc := range documents[logDocument](t, filepath.Join(c.outDir, logsFile)) {
+		for _, rl := range doc.ResourceLogs {
+			for _, sl := range rl.ScopeLogs {
+				records = append(records, sl.LogRecords...)
+			}
+		}
+	}
+	return records
+}
+
+// renderLogRecord flattens a record into one string, so an assertion about what
+// must not appear looks at the message and every attribute rather than at
+// whichever one the author remembered.
+func renderLogRecord(record otlpLogRecord) string {
+	parts := make([]string, 0, len(record.Attributes)+1)
+	parts = append(parts, record.Body.StringValue)
+	for _, kv := range record.Attributes {
+		parts = append(parts, kv.Key+"="+kv.Value.StringValue)
+	}
+	return strings.Join(parts, " ")
+}

--- a/test/e2e/collector/signals_test.go
+++ b/test/e2e/collector/signals_test.go
@@ -1,0 +1,210 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The OTLP log documents the file exporter writes, decoded to the fields under
+// assertion. Hand-written for the same reason the trace and metric types are:
+// importing the collector's own types to check the collector's own output would
+// make both halves agree by construction.
+type (
+	otlpLogRecord struct {
+		TimeUnixNano string `json:"timeUnixNano"`
+		SeverityText string `json:"severityText"`
+		Body         struct {
+			StringValue string `json:"stringValue"`
+		} `json:"body"`
+		Attributes []otlpAttr `json:"attributes"`
+		TraceID    string     `json:"traceId"`
+		SpanID     string     `json:"spanId"`
+	}
+
+	otlpScopeLogs struct {
+		Scope      otlpScope       `json:"scope"`
+		LogRecords []otlpLogRecord `json:"logRecords"`
+	}
+
+	otlpResourceLogs struct {
+		Resource  otlpResource    `json:"resource"`
+		ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+	}
+
+	logDocument struct {
+		ResourceLogs []otlpResourceLogs `json:"resourceLogs"`
+	}
+)
+
+// awaitLog waits for a log record whose body matches, and returns it.
+func (c *collector) awaitLog(t *testing.T, within time.Duration, match func(otlpLogRecord) bool) (otlpLogRecord, bool) {
+	t.Helper()
+
+	var seen []string
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		seen = nil
+		for _, doc := range documents[logDocument](t, filepath.Join(c.outDir, logsFile)) {
+			for _, resourceLogs := range doc.ResourceLogs {
+				for _, scopeLogs := range resourceLogs.ScopeLogs {
+					for _, record := range scopeLogs.LogRecords {
+						seen = append(seen, record.Body.StringValue)
+						if match(record) {
+							return record, true
+						}
+					}
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Logf("waited %s; the collector parsed these log bodies: %v", within, seen)
+	return otlpLogRecord{}, false
+}
+
+// TestRealCollector_LogsArriveAndNameTheSpanTheyHappenedIn is the end-to-end
+// form of the defect that motivated the log signal's existence.
+//
+// A collector receiving real traffic showed 235 exported records with not one
+// trace id among them. The bridge was correct and every caller was not: the
+// whole server logged through the context-free slog family, which passes
+// context.Background(), so no record could ever name the span it happened
+// inside. That is the only thing the OTLP log leg does that stderr cannot, so
+// the signal was being paid for and delivering nothing.
+//
+// Nothing here could see it. The unit test that now covers it asserts on a
+// record the bridge produced; this asserts on a record a real collector parsed,
+// against a span the same collector parsed, which is the join an operator
+// actually performs. The comment on this module's collector configuration says
+// as much: "the suite passes today with the logs pipeline removed".
+func TestRealCollector_LogsArriveAndNameTheSpanTheyHappenedIn(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	const action = "issue.list"
+	for i := range 5 {
+		srv.callAction(t, i+1, action, "some-group/some-project")
+	}
+
+	record, ok := c.awaitLog(t, exportDeadline, func(r otlpLogRecord) bool {
+		return strings.Contains(r.Body.StringValue, "tool call") && r.TraceID != ""
+	})
+	if !ok {
+		t.Fatalf("no correlated tool-call log record reached the collector.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the record carries a span, not only a trace", func(t *testing.T) {
+		if record.SpanID == "" {
+			t.Error("the record names a trace and no span, so it can be found in the trace and not against the operation")
+		}
+	})
+
+	t.Run("the trace it names was really exported", func(t *testing.T) {
+		// The join, which is the whole point. A record carrying a trace id that
+		// belongs to no exported span would look correlated in every listing
+		// and resolve to nothing in a backend.
+		_, _, found := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+			return s.TraceID == record.TraceID && s.SpanID == record.SpanID
+		})
+		if !found {
+			t.Errorf("no exported span has trace %s span %s; the record points at nothing",
+				record.TraceID, record.SpanID)
+		}
+	})
+
+	t.Run("the record is one this server wrote", func(t *testing.T) {
+		if record.SeverityText == "" {
+			t.Error("the record has no severity, so a backend cannot filter it")
+		}
+		if _, present := attr(record.Attributes, "tool"); !present {
+			t.Errorf("the record carries no tool attribute; recorded %v", keys(record.Attributes))
+		}
+	})
+}
+
+// TestRealCollector_TheSpanTreeIsWhatTheConventionDescribes asserts the shape
+// three separate instrumentations produce together, which no one of them can be
+// tested for alone.
+//
+// One HTTP server span per request, the MCP operation inside it, and the GitLab
+// call inside that. Each piece is covered by its own unit test and the tree is
+// the thing that silently degrades: passing the wrong context onward compiles,
+// runs, and yields a flat trace where every GitLab call is a root, which reads
+// as a working system until somebody tries to find out what a slow request was
+// waiting on.
+func TestRealCollector_TheSpanTreeIsWhatTheConventionDescribes(t *testing.T) {
+	c := startCollector(t)
+	srv := startServer(t, telemetryEnv(c), "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 5 {
+		srv.callAction(t, i+1, "issue.list", "some-group/some-project")
+	}
+
+	_, mcpSpan, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("the collector parsed no tools/call span.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the MCP span hangs off the HTTP span", func(t *testing.T) {
+		if mcpSpan.ParentSpanID == "" {
+			t.Fatal("the MCP span is a root; the HTTP middleware's context did not reach the MCP middleware")
+		}
+		parent, found := c.spanByID(t, mcpSpan.TraceID, mcpSpan.ParentSpanID)
+		if !found {
+			t.Fatalf("the MCP span's parent %s was never exported", mcpSpan.ParentSpanID)
+		}
+		if parent.Kind != spanKindServer {
+			t.Errorf("the parent's kind is %d, want %d: an MCP request should sit under an HTTP server span",
+				parent.Kind, spanKindServer)
+		}
+		if method, _ := attr(parent.Attributes, "http.request.method"); method != http.MethodPost {
+			t.Errorf("the parent records http.request.method = %q, want POST", method)
+		}
+	})
+
+	t.Run("the GitLab call hangs off the MCP span", func(t *testing.T) {
+		client, found := c.childOf(t, mcpSpan.TraceID, mcpSpan.SpanID, spanKindClient)
+		if !found {
+			t.Fatal("no client span is a child of the MCP span; a GitLab call parented elsewhere is a flat trace")
+		}
+		if host, present := attr(client.Attributes, "server.address"); !present || host == "" {
+			t.Errorf("the client span names no server.address; recorded %v", keys(client.Attributes))
+		}
+		// The privacy rule, asserted where it is actually enforced rather than
+		// only where it is written down: a GitLab URL carries project paths.
+		if value, present := attr(client.Attributes, "url.full"); present {
+			t.Errorf("the client span carries url.full = %q; a GitLab URL names the project", value)
+		}
+	})
+}
+
+// spanByID finds one exported span by its identifiers.
+func (c *collector) spanByID(t *testing.T, traceID, spanID string) (otlpSpan, bool) {
+	t.Helper()
+	_, span, ok := c.awaitSpan(t, exportDeadline/6, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.TraceID == traceID && s.SpanID == spanID
+	})
+	return span, ok
+}
+
+// childOf finds a span of the given kind whose parent is the one named.
+func (c *collector) childOf(t *testing.T, traceID, parentID string, kind int) (otlpSpan, bool) {
+	t.Helper()
+	_, span, ok := c.awaitSpan(t, exportDeadline/6, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.TraceID == traceID && s.ParentSpanID == parentID && s.Kind == kind
+	})
+	return span, ok
+}
+
+// spanKindClient is SPAN_KIND_CLIENT in the OTLP enum.
+const spanKindClient = 3

--- a/test/e2e/collector/stateful_test.go
+++ b/test/e2e/collector/stateful_test.go
@@ -1,0 +1,93 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"testing"
+)
+
+// TestRealCollector_StatefulSessionIsNamedAndMeasured covers the two things
+// that only exist when a deployment has sessions, and that every other case in
+// this module asserts the absence of.
+//
+// The absence is the easy half and it is what was covered: under the default
+// stateless transport each POST is its own session with no id, so the
+// convention's condition is not met and neither the attribute nor the
+// instrument should appear. A rule with only its negative tested passes just as
+// well when the positive never happens either.
+func TestRealCollector_StatefulSessionIsNamedAndMeasured(t *testing.T) {
+	c := startCollector(t)
+	// --stateless=false, and the session is driven over revision 2025-11-25:
+	// 2026-07-28 is stateless only, so a deployment with sessions does not
+	// advertise it and refuses a client that insists. That the transports
+	// diverge this way is asserted in test/e2e/http, which is where transport
+	// behavior belongs; here it is only the reason the handshake looks
+	// different from every other call in this module.
+	srv := startServer(t, telemetryEnv(c),
+		"--gitlab-url="+startFakeGitLab(t),
+		"--stateless=false",
+	)
+
+	sess := srv.openSession(t)
+	for i := range 3 {
+		sess.call(t, i+2, "tools/call",
+			`{"name":"gitlab_execute_action","arguments":{"action":"issue.list",`+
+				`"params":{"project_id":"some-group/some-project"}}}`)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return s.Name == "tools/call gitlab_execute_action"
+	})
+	if !ok {
+		t.Fatalf("no tools/call span on a stateful deployment.\nCollector:\n%s\nServer:\n%s",
+			c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span names the session", func(t *testing.T) {
+		id, present := attr(span.Attributes, "mcp.session.id")
+		if !present {
+			t.Fatalf("mcp.session.id is absent while a session exists; recorded %v", keys(span.Attributes))
+		}
+		if id != sess.id {
+			t.Errorf("mcp.session.id = %q, want the id the server issued (%q)", id, sess.id)
+		}
+	})
+
+	t.Run("the protocol version is the one negotiated", func(t *testing.T) {
+		// Not the newest this build supports. The value is the revision this
+		// session actually speaks, and reporting the build's own would make the
+		// attribute a constant.
+		if got, _ := attr(span.Attributes, "mcp.protocol.version"); got != legacyProtocolVersion {
+			t.Errorf("mcp.protocol.version = %q, want %q", got, legacyProtocolVersion)
+		}
+	})
+
+	// Ending the session is what produces the measurement: the instrument is
+	// recorded from a goroutine parked on the session's own lifetime, so an
+	// abandoned session would only be measured when the idle timeout fired.
+	sess.close(t)
+
+	t.Run("the session duration is recorded", func(t *testing.T) {
+		_, duration, found := c.awaitMetric(t, exportDeadline, "mcp.server.session.duration")
+		if !found {
+			t.Fatalf("mcp.server.session.duration was never recorded.\nCollector:\n%s\nServer:\n%s",
+				c.containerLogs(t), srv.logs())
+		}
+		if duration.Unit != "s" {
+			t.Errorf("unit = %q, want %q", duration.Unit, "s")
+		}
+
+		points := dataPointAttributes(t, duration)
+		if len(points) == 0 {
+			t.Fatal("the instrument arrived with no data points")
+		}
+		for _, point := range points {
+			// The convention's own instrument table omits the session id, and
+			// it has to: one value per connected client is a series count that
+			// grows with the number of people using the deployment.
+			if value, present := attr(point, "mcp.session.id"); present {
+				t.Errorf("mcp.session.id = %q is a dimension of the session instrument", value)
+			}
+		}
+	})
+}

--- a/test/e2e/collector/surfaces_test.go
+++ b/test/e2e/collector/surfaces_test.go
@@ -1,0 +1,153 @@
+//go:build collectore2e
+
+package collectore2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRealCollector_EverySurfaceResolvesTheAction covers the one attribute that
+// cannot be derived from the request on any surface but the individual one.
+//
+// gitlab_mcp.action is what makes a metric readable, and how it is resolved
+// differs completely between the three: on the dynamic surface it is an
+// argument, on the meta surface it is the domain tool plus an argument, and on
+// the individual surface it is looked up from a declared tool name. A resolver
+// that silently returns nothing produces spans that are structurally perfect
+// and say only that some tool was called, which is what shipped once already:
+// the individual surface recorded no action at all because the catalog handed
+// to the identifier was nil.
+//
+// The tool name matters as much. It is declared per surface, never derived, so
+// a call that names the wrong tool is refused rather than mislabelled, and the
+// harness fails on a refusal.
+func TestRealCollector_EverySurfaceResolvesTheAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		surface    string
+		tool       string
+		arguments  string
+		wantTool   string
+		wantAction string
+	}{
+		{
+			name:      "dynamic names two tools and carries the action as an argument",
+			surface:   "dynamic",
+			tool:      "gitlab_execute_action",
+			arguments: `{"action":"issue.list","params":{"project_id":"some-group/some-project"}}`,
+			wantTool:  "gitlab_execute_action",
+			// The reason this attribute exists. On this surface the tool name
+			// is the same for listing issues and for deleting a branch.
+			wantAction: "issue.list",
+		},
+		{
+			name:       "meta names the domain and carries the operation as an argument",
+			surface:    "meta",
+			tool:       "gitlab_issue",
+			arguments:  `{"action":"list","params":{"project_id":"some-group/some-project"}}`,
+			wantTool:   "gitlab_issue",
+			wantAction: "issue.list",
+		},
+		{
+			name:       "individual declares the tool and the action is looked up",
+			surface:    "individual",
+			tool:       "gitlab_issue_list",
+			arguments:  `{"project_id":"some-group/some-project"}`,
+			wantTool:   "gitlab_issue_list",
+			wantAction: "issue.list",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := startCollector(t)
+			env := telemetryEnv(c)
+			env["TOOL_SURFACE"] = tc.surface
+			// Pinned, so the individual case tests the resolver rather than the
+			// auto policy's decision to drop the attribute on that surface.
+			env["GITLAB_MCP_TELEMETRY_TOOL_NAME"] = "on"
+			srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+			for i := range 3 {
+				srv.callTool(t, i+1, tc.tool, tc.arguments)
+			}
+
+			_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+				return strings.HasPrefix(s.Name, "tools/call")
+			})
+			if !ok {
+				t.Fatalf("no tools/call span on the %s surface.\nCollector:\n%s\nServer:\n%s",
+					tc.surface, c.containerLogs(t), srv.logs())
+			}
+
+			if got, _ := attr(span.Attributes, "gitlab_mcp.tool_surface"); got != tc.surface {
+				t.Errorf("gitlab_mcp.tool_surface = %q, want %q", got, tc.surface)
+			}
+			if got, _ := attr(span.Attributes, "gen_ai.tool.name"); got != tc.wantTool {
+				t.Errorf("gen_ai.tool.name = %q, want %q", got, tc.wantTool)
+			}
+			action, present := attr(span.Attributes, "gitlab_mcp.action")
+			if !present {
+				t.Fatalf("gitlab_mcp.action is absent on the %s surface; the span says a tool was called and not what it did. Recorded %v",
+					tc.surface, keys(span.Attributes))
+			}
+			if action != tc.wantAction {
+				t.Errorf("gitlab_mcp.action = %q, want %q", action, tc.wantAction)
+			}
+
+			// The span name follows the tool, not the action, which is what the
+			// convention asks for and is worth pinning because the action is
+			// the more informative of the two and the temptation is real.
+			if want := "tools/call " + tc.wantTool; span.Name != want {
+				t.Errorf("span name = %q, want %q", span.Name, want)
+			}
+		})
+	}
+}
+
+// TestRealCollector_IndividualSurfaceDropsTheNameFromMetricsByDefault is the
+// auto policy, on the surface it exists for.
+//
+// About a thousand tools, one visible per catalog action, against an SDK limit
+// of 2000 series per instrument. The policy's answer is to drop both keys from
+// metrics and keep them on spans, and this is the only place that decision is
+// exercised end to end: every other case here runs the dynamic surface, where
+// auto keeps them.
+func TestRealCollector_IndividualSurfaceDropsTheNameFromMetricsByDefault(t *testing.T) {
+	c := startCollector(t)
+	env := telemetryEnv(c)
+	env["TOOL_SURFACE"] = "individual"
+	srv := startServer(t, env, "--gitlab-url="+startFakeGitLab(t))
+
+	for i := range 3 {
+		srv.callTool(t, i+1, "gitlab_issue_list", `{"project_id":"some-group/some-project"}`)
+	}
+
+	_, span, ok := c.awaitSpan(t, exportDeadline, func(_ otlpResourceSpans, s otlpSpan) bool {
+		return strings.HasPrefix(s.Name, "tools/call")
+	})
+	if !ok {
+		t.Fatalf("no tools/call span.\nCollector:\n%s\nServer:\n%s", c.containerLogs(t), srv.logs())
+	}
+
+	t.Run("the span still says what was called", func(t *testing.T) {
+		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
+			if _, present := attr(span.Attributes, key); !present {
+				t.Errorf("%s is absent from the span; the policy bounds series and does not hide values", key)
+			}
+		}
+	})
+
+	t.Run("the metric carries neither", func(t *testing.T) {
+		if _, _, found := c.awaitMetric(t, exportDeadline, durationMetric); !found {
+			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
+		}
+		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
+			if instrument := metricDimensionExists(t, c, key); instrument != "" {
+				t.Errorf("%s is a dimension of %s on the individual surface; about a thousand values against a 2000-series budget",
+					key, instrument)
+			}
+		}
+	})
+}


### PR DESCRIPTION
A fourth end-to-end module, on its own build tag and out of the fast CI path, that runs this server's telemetry into a pinned `otel/opentelemetry-collector-contrib` and asserts on what the collector wrote after parsing it.

## Why a stub is not enough

Every other telemetry test in this repository is graded by code we wrote. The in-process receiver in `test/e2e/http` answers `200` to whatever it is handed and keeps the bytes. That is exactly right for the two questions it asks, was the collector credential sent and did anything private leak, and it is no evidence that the export is well formed.

A malformed protobuf, a resource missing an attribute a backend requires, or a metric whose unit contradicts its name all pass a stub, and all ship telemetry an operator cannot use.

So this module asserts acceptance and shape, and deliberately repeats none of the credential or privacy assertions. A real collector cannot answer those: it consumes the `Authorization` header rather than reporting it, and forwards payloads rather than handing them back.

## What it checks

- The collector logged no rejection, checked in its own output **and** in the server's `opentelemetry sdk error` line.
- A span named `tools/call gitlab_execute_action`, kind SERVER.
- `mcp.method.name` and `gitlab_mcp.action` present as attributes.
- `mcp.server.operation.duration` with unit `s` and non-empty histogram points.
- `service.name` and `service.instance.id` on both the trace and metric resources.
- The `internal/mcpotel` instrumentation scope.

## The guide is now a checked artifact

`docs/guides/telemetry.md` describes what an operator will see. Its tables are
read by a test here, and every dotted name in them has to appear in telemetry a
real collector received. Adding a row is therefore a claim this module has to
satisfy, and the drive loop grew a refusal to satisfy the newest one:
`gitlab_mcp.refusal_reason`, which is now on the duration metric and not only on
spans.

That direction matters more than it sounds. Documenting an attribute that is
never emitted costs an operator an afternoon and looks identical to a working
feature until they go looking for it.

## What running it against a real collector kept finding

The safe-mode test gained the half that was missing: asserting the refusal
reason on a span proves a trace can explain one call, while an operator asking
whether safe mode is blocking something somebody needs is asking for a rate, and
a rate comes from a metric the attribute was absent from.

## Running it

```bash
make test-e2e-collector
```

Roughly eight seconds once the image is cached. Absent from `go test ./...` by build constraint, and absent from the push-triggered CI jobs, which pass only `httpe2e` and `stdioe2e`: those need no daemon, this one pulls an image and belongs with the Docker-mode targets. Without Docker it **skips**, with the reason, rather than failing.

## Verified by breaking

Each assertion was confirmed to fail for its stated reason before being kept:

- `metric.WithUnit("s")` changed to `"ms"`: fails naming the wrong unit.
- The action attribute key renamed: fails listing the attributes the span actually carried.
- Both log detectors inverted to needles known to be present: both halves fail, proving each scan reads the buffer it claims to.
- Docker removed from `PATH`: skips with the reason, no failure.

One deliberate break did **not** fire and taught us something. Removing the logs pipeline from the collector config left the suite green, because at the time nothing bridged `slog` to the logger provider and no log record was ever exported. That became one of two findings fixed on the branch below this one; the other was the missing `collectore2e` tag in `cmd/gen_testing_docs`, without which `go list` silently omits this module and the generated test metrics under-count.

## Not exercised

Only linux/amd64. The `runtime.GOOS == "windows"` skip and the bind-mount path under Docker Desktop on macOS are written and unrun.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Validate the server's emitted telemetry against a real pinned OpenTelemetry Collector and enforce the expected exported shape.

New Features:
- Add a Docker-backed end-to-end module that sends server telemetry through a pinned OpenTelemetry Collector and validates the parsed trace and metric output.
- Add coverage for exported telemetry shape, resource identity, instrumentation scope, attribute inventories, and identity-policy behavior.

Bug Fixes:
- Ensure the collector-tagged end-to-end package is included in analysis and generated testing metrics.

Enhancements:
- Provide independent validation of telemetry acceptance and semantic shape instead of relying only on an in-process OTLP stub.
- Skip the collector suite cleanly when Docker is unavailable while keeping it outside the fast push-triggered CI path.

Build:
- Add the `test-e2e-collector` Make target for running the collector-backed suite and reporting JUnit results.

Documentation:
- Document how to run the collector-backed end-to-end module and why it is separate from transport and privacy tests.
- Refresh generated project test metrics.

Tests:
- Add collector integration tests covering OTLP acceptance, spans, metrics, resources, instrumentation scope, attribute inventories, and identity handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end telemetry validation using a real OpenTelemetry Collector.
  * Verified traces, metrics, and logs, including service identity, operations, durations, relationships, sessions, and privacy-sensitive attributes.
  * Added coverage for telemetry configuration, propagation, redaction, protective modes, and tool surfaces.
  * Added Docker-based testing with automatic skipping when Docker or registry access is unavailable.
  * Added a dedicated command for running Collector tests and generating JUnit reports.

* **Documentation**
  * Documented Collector testing requirements and execution guidance.
  * Refreshed project testing and codebase statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
