### PR TITLE
fix(dynamic): replace semicolons with periods in tool descriptions

### DIFF
--- a/internal/resources/tool_manifest.go
+++ b/internal/resources/tool_manifest.go
@@ -879,7 +879,7 @@ func enrichDynamicSchema(schema map[string]any, action actioncatalog.Action) map
 		schema["x_destructive"] = true
 		schema["x_confirmation"] = map[string]any{
 			"location":    "gitlab_execute_action.confirm",
-			"description": "Set top-level confirm=true on gitlab_execute_action after explicit user approval; do not put confirm inside params.",
+			"description": "Set top-level confirm=true on gitlab_execute_action after explicit user approval. Do not put confirm inside params.",
 		}
 	}
 	return schema

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -56,9 +56,9 @@ const (
 	// xMCPHeaderKeyword is the JSON Schema keyword defined by SEP-2243.
 	xMCPHeaderKeyword = "x-mcp-header"
 
-	findToolDescription          = "Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples."
-	executeActionToolDescription = "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear."
-	dynamicExecuteEnvelopeHint   = "Execute matches with top-level `action` and one `params` object; every Required Params key below belongs inside `params`, not beside it. Use top-level `confirm` only for destructive actions."
+	findToolDescription          = "Search the local GitLab action catalog. Read-only and no GitLab API call. Use when the action ID or params are unclear. Returns schemas, hints, destructive flags, and execute examples."
+	executeActionToolDescription = "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object. Destructive actions require top-level confirm=true. Use find first only when action or params are unclear."
+	dynamicExecuteEnvelopeHint   = "Execute matches with top-level `action` and one `params` object. Every Required Params key below belongs inside `params`, not beside it. Use top-level `confirm` only for destructive actions."
 
 	defaultLimit                 = 20
 	maxLimit                     = 50
@@ -197,7 +197,7 @@ type FindOutput struct {
 type ExecuteInput struct {
 	Action  string         `json:"action" jsonschema:"Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close."`
 	Params  map[string]any `json:"params" jsonschema:"Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters."`
-	Confirm bool           `json:"confirm,omitempty" jsonschema:"Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action."`
+	Confirm bool           `json:"confirm,omitempty" jsonschema:"Set top-level confirm=true to explicitly approve destructive actions. Do not put confirm inside params for gitlab_execute_action."`
 }
 
 type scoredActionEntry struct {
@@ -2034,7 +2034,7 @@ func dynamicInputSchema(entry actionEntry) map[string]any {
 		schema["x_destructive"] = true
 		schema["x_confirmation"] = map[string]any{
 			"location":    "gitlab_execute_action.confirm",
-			"description": "Set top-level confirm=true on gitlab_execute_action after explicit user approval; do not put confirm inside params.",
+			"description": "Set top-level confirm=true on gitlab_execute_action after explicit user approval. Do not put confirm inside params.",
 		}
 	}
 	return schema

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -2490,7 +2490,7 @@ func TestRegisterCatalogFindExecuteTools_ExposesDynamicTools(t *testing.T) {
 		t.Fatalf("tool count = %d, want 2", len(tools.Tools))
 	}
 	findTool := listedTool(t, tools.Tools, findToolName)
-	if findTool.Description != findToolDescription || !strings.Contains(findTool.Description, "read-only") {
+	if findTool.Description != findToolDescription || !strings.Contains(strings.ToLower(findTool.Description), "read-only") {
 		t.Fatalf("gitlab_find_action description = %q, want read-only lookup guidance", findTool.Description)
 	}
 	findSchema := listedToolInputSchema(t, tools.Tools, findToolName)

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -23,7 +23,7 @@
     {
       "name": "gitlab_execute_action",
       "title": "GitLab Execute Action",
-      "description": "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.",
+      "description": "Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object. Destructive actions require top-level confirm=true. Use find first only when action or params are unclear.",
       "inputSchema": {
         "additionalProperties": false,
         "properties": {
@@ -33,7 +33,7 @@
             "x-mcp-header": "Action"
           },
           "confirm": {
-            "description": "Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.",
+            "description": "Set top-level confirm=true to explicitly approve destructive actions. Do not put confirm inside params for gitlab_execute_action.",
             "type": "boolean"
           },
           "params": {
@@ -59,7 +59,7 @@
     {
       "name": "gitlab_find_action",
       "title": "GitLab Find Action",
-      "description": "Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.",
+      "description": "Search the local GitLab action catalog. Read-only and no GitLab API call. Use when the action ID or params are unclear. Returns schemas, hints, destructive flags, and execute examples.",
       "inputSchema": {
         "additionalProperties": false,
         "properties": {

--- a/llms-full-meta-tools.txt
+++ b/llms-full-meta-tools.txt
@@ -10,7 +10,7 @@ Dynamic mode is the default when `TOOL_SURFACE` is unset or set to `dynamic`. It
 
 **GitLab Find Action**
 
-Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.
+Search the local GitLab action catalog. Read-only and no GitLab API call. Use when the action ID or params are unclear. Returns schemas, hints, destructive flags, and execute examples.
 
 **Parameters:**
 
@@ -24,12 +24,12 @@ Annotations: readOnly=true, destructive=false, idempotent=true, openWorld=true
 
 **GitLab Execute Action**
 
-Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
+Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object. Destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
 
 **Parameters:**
 
 - `action` (string) (required): Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.
-- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.
+- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions. Do not put confirm inside params for gitlab_execute_action.
 - `params` (object) (required): Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.
 
 Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10,7 +10,7 @@ Dynamic mode is the default when `TOOL_SURFACE` is unset or set to `dynamic`. It
 
 **GitLab Find Action**
 
-Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.
+Search the local GitLab action catalog. Read-only and no GitLab API call. Use when the action ID or params are unclear. Returns schemas, hints, destructive flags, and execute examples.
 
 **Parameters:**
 
@@ -24,12 +24,12 @@ Annotations: readOnly=true, destructive=false, idempotent=true, openWorld=true
 
 **GitLab Execute Action**
 
-Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
+Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object. Destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
 
 **Parameters:**
 
 - `action` (string) (required): Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.
-- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.
+- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions. Do not put confirm inside params for gitlab_execute_action.
 - `params` (object) (required): Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.
 
 Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true

--- a/llms-medium.txt
+++ b/llms-medium.txt
@@ -13,7 +13,7 @@ Dynamic mode is the default when `TOOL_SURFACE` is unset or set to `dynamic`. It
 
 **GitLab Find Action**
 
-Search the local GitLab action catalog; read-only and no GitLab API call. Use when the action ID or params are unclear; returns schemas, hints, destructive flags, and execute examples.
+Search the local GitLab action catalog. Read-only and no GitLab API call. Use when the action ID or params are unclear. Returns schemas, hints, destructive flags, and execute examples.
 
 **Parameters:**
 
@@ -27,12 +27,12 @@ Annotations: readOnly=true, destructive=false, idempotent=true, openWorld=true
 
 **GitLab Execute Action**
 
-Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object; destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
+Execute one GitLab catalog action by canonical ID or alias. Always pass params as an object. Destructive actions require top-level confirm=true. Use find first only when action or params are unclear.
 
 **Parameters:**
 
 - `action` (string) (required): Canonical action ID returned by gitlab_find_action, or a supported compatibility alias, such as project.list, issue.update, or issue.close.
-- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions; do not put confirm inside params for gitlab_execute_action.
+- `confirm` (boolean): Set top-level confirm=true to explicitly approve destructive actions. Do not put confirm inside params for gitlab_execute_action.
 - `params` (object) (required): Required action-specific parameters object validated by the selected action schema. Use an empty object for actions with no parameters.
 
 Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true

--- a/llms.txt
+++ b/llms.txt
@@ -61,7 +61,7 @@ Dynamic toolset (default mode):
 
 When TOOL_SURFACE is unset or set to dynamic, the server exposes only gitlab_find_action and gitlab_execute_action while keeping the same canonical GitLab action catalog. Models should find an action with its exact schema, then execute the canonical domain.action ID returned by find. Set TOOL_SURFACE=meta to use consolidated domain meta-tools instead.
 
-- gitlab_find_action: Search the local GitLab action catalog; read-only and no GitLab API call.
+- gitlab_find_action: Search the local GitLab action catalog.
 - gitlab_execute_action: Execute one GitLab catalog action by canonical ID or alias.
 
 Meta-tool overview:


### PR DESCRIPTION
Some MCP gateway implementations validate the tool descriptions returned by tools/list and reject characters they treat as unsafe, including the semicolon. When such a gateway introspects this server it fails with an error like:

    All tools failed validation. First error:
    gitlab_execute_action: Description contains unsafe characters: ';'

This blocks onboarding the server behind those gateways even though the semicolons are ordinary English punctuation in the dynamic toolset's descriptions.

Replace the semicolons with periods in the dynamic surface descriptions (gitlab_find_action, gitlab_execute_action), the execute-envelope hint, the confirm parameter schema, and the destructive-action x_confirmation note in the resource tool manifest. The wording and meaning are preserved; only punctuation changes.

Regenerate the LLM catalog files (llms*.txt) and the LHM plugin manifest so the freshness gates stay green, and relax the case-sensitive "read-only" assertion in the dynamic register test since the phrase now starts a sentence.

## Description

<!-- What does this PR do? Provide a clear summary of the change -->

## Related Issue

<!-- Link to the issue this PR addresses (use "Closes #N" or "Refs #N") -->
Closes #

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [ ] CI / build / tooling

## Changes Made

<!-- List the key changes made in this PR -->

- Replaced semicolons with periods in the dynamic surface tool descriptions (`gitlab_find_action`, `gitlab_execute_action`), the execute-envelope hint, and the `confirm` parameter `jsonschema` tag in `internal/tools/dynamic/register.go`
- Replaced the semicolon in the destructive-action `x_confirmation` description in `internal/resources/tool_manifest.go`
- Relaxed the case-sensitive `"read-only"` assertion in `internal/tools/dynamic/register_test.go` (the phrase now begins a sentence, so it is capitalised)
- Regenerated `llms.txt`, `llms-full.txt`, `llms-medium.txt`, `llms-full-meta-tools.txt`, and `lhm.plugin.json` via `cmd/gen_llms` and `cmd/gen_lhm_manifest`

## How to Test

<!-- Steps for the reviewer to verify the changes -->

1. Run `go run ./cmd/gen_llms/ --check` and `go run ./cmd/gen_lhm_manifest/ --check` — both report current. `grep "action catalog" llms.txt` shows periods, not semicolons.
2. Run `go test ./internal/tools/ ./internal/tools/dynamic/ ./internal/resources/ -count=1` — all pass, including `TestToolSnapshots`.
3. Register the server behind an MCP gateway that validates tool descriptions (verified against IBM ContextForge / mcp-context-forge). Before this change onboarding failed with `Description contains unsafe characters: ';'`. After, the gateway onboards the server, lists both tools, and routes a live `project.get` call through to a self-managed GitLab instance.

## Breaking Changes / Migration Notes

<!-- If this is a breaking change, describe the migration path. Otherwise, write "N/A". -->

N/A

## Checklist

### Code Quality

- [ ] Code compiles: `go build ./...`
- [ ] Consolidated Go analysis passes on changed packages (or `make golangci-lint` / `make analyze`)
- [ ] Code is formatted: `make analyze-fix` (runs configured `golangci-lint` formatters: `goimports`, `gofumpt`, and `gci`)
- [ ] Follows idiomatic Go patterns and the conventions documented in `CLAUDE.md` / `.github/instructions/`

### Testing

- [ ] All existing tests pass: `go test ./... -count=1`
- [ ] New tests added for new functionality (table-driven, with `httptest` mocks)
- [ ] Coverage on modified packages is ≥ 90% (per project policy)
- [ ] Edge cases and error scenarios covered
- [ ] If applicable, E2E tests updated/added under `test/e2e/suite/`

### Documentation

- [ ] Doc comments added for exported types/functions (godoc)
- [ ] `docs/` updated if public API or behavior changed
- [ ] `README.md` / Starlight site (`site/src/content/docs/`) updated if user-facing behavior changed
- [ ] If introducing/removing a tool: `docs/tools/{domain}.md` and tool counts updated
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [ ] No secrets, tokens, or credentials in code, tests, fixtures, or logs
- [ ] Input validation for user-provided parameters
- [ ] Error messages do not leak sensitive information
- [ ] No new dependencies with known vulnerabilities (verify with `govulncheck`)

## Screenshots / Logs (if applicable)

<!-- Add screenshots, terminal output, or log snippets that help explain the change -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified descriptions for GitLab action discovery and execution.
  - Improved guidance for destructive actions, including placing `confirm=true` at the top level rather than inside parameters.
  - Reformatted tool documentation into clearer, easier-to-read sentences.
  - Updated descriptions consistently across generated tool metadata and reference documentation.

- **Style**
  - Improved wording, punctuation, and readability without changing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->