### PR TITLE
test(quality): deterministic coverage and a 23% faster unit suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,19 +451,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,008 |     209,027 |
-| Unit tests (`_test.go`)  |       561 |     314,642 |
+| Source (`.go`, non-test) |     1,008 |     209,045 |
+| Unit tests (`_test.go`)  |       561 |     314,674 |
 | End-to-end tests         |       212 |      56,627 |
-| **Total**                | **1,781** | **580,296** |
+| **Total**                | **1,781** | **580,346** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,857 |
-| . Exported (public)             |  2,710 |
+| Source functions                |  7,859 |
+| . Exported (public)             |  2,712 |
 | . Unexported (private)          |  5,147 |
-| Unit test functions (`TestXxx`) | 11,788 |
+| Unit test functions (`TestXxx`) | 11,789 |
 | Subtests (`t.Run(...)`)         |  3,122 |
 | End-to-end test functions       |    539 |
 
@@ -474,7 +474,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~207 lines |
 | Average test file length           |                 ~560 lines |
-| Comment lines in source            |  28,380 (~13.6% of source) |
+| Comment lines in source            |  28,389 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/README.md
+++ b/README.md
@@ -451,18 +451,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,008 |     209,001 |
-| Unit tests (`_test.go`)  |       561 |     314,616 |
+| Source (`.go`, non-test) |     1,008 |     209,027 |
+| Unit tests (`_test.go`)  |       561 |     314,642 |
 | End-to-end tests         |       212 |      56,627 |
-| **Total**                | **1,781** | **580,244** |
+| **Total**                | **1,781** | **580,296** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
 | Source functions                |  7,857 |
-| . Exported (public)             |  2,709 |
-| . Unexported (private)          |  5,148 |
+| . Exported (public)             |  2,710 |
+| . Unexported (private)          |  5,147 |
 | Unit test functions (`TestXxx`) | 11,788 |
 | Subtests (`t.Run(...)`)         |  3,122 |
 | End-to-end test functions       |    539 |
@@ -474,15 +474,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~207 lines |
 | Average test file length           |                 ~560 lines |
-| Comment lines in source            |  28,369 (~13.6% of source) |
+| Comment lines in source            |  28,380 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,657 |
-| `defer` statements                 | 1,021 |
+| `if err != nil` checks             | 6,652 |
+| `defer` statements                 | 1,022 |
 | `struct` types defined             | 2,763 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -451,18 +451,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,008 |     208,849 |
-| Unit tests (`_test.go`)  |       561 |     314,598 |
+| Source (`.go`, non-test) |     1,008 |     209,001 |
+| Unit tests (`_test.go`)  |       561 |     314,616 |
 | End-to-end tests         |       212 |      56,627 |
-| **Total**                | **1,781** | **580,074** |
+| **Total**                | **1,781** | **580,244** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,851 |
-| . Exported (public)             |  2,707 |
-| . Unexported (private)          |  5,144 |
+| Source functions                |  7,857 |
+| . Exported (public)             |  2,709 |
+| . Unexported (private)          |  5,148 |
 | Unit test functions (`TestXxx`) | 11,788 |
 | Subtests (`t.Run(...)`)         |  3,122 |
 | End-to-end test functions       |    539 |
@@ -474,16 +474,16 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~207 lines |
 | Average test file length           |                 ~560 lines |
-| Comment lines in source            |  28,324 (~13.6% of source) |
+| Comment lines in source            |  28,369 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,658 |
-| `defer` statements                 | 1,020 |
-| `struct` types defined             | 2,760 |
+| `if err != nil` checks             | 6,657 |
+| `defer` statements                 | 1,021 |
+| `struct` types defined             | 2,763 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -506,8 +506,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,797 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 12,782 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,800 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 12,785 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_1to1/internal/metadata/analyze.go
+++ b/cmd/audit_1to1/internal/metadata/analyze.go
@@ -21,7 +21,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -77,13 +76,13 @@ func buildReport(gapsOnly bool) (report, error) {
 	}
 	defer cleanup()
 
-	projected, err := auditshared.ProjectIndividualDescriptions(client)
+	projected, err := auditshared.CachedIndividualDescriptions(client)
 	if err != nil {
 		return report{}, err
 	}
 
 	byPackage := map[string]*packageReport{}
-	for _, group := range tools.CollectActionSpecs(client, true) {
+	for _, group := range auditshared.CachedActionSpecs(client, true) {
 		for _, spec := range group.Actions {
 			owner := auditshared.OwnerPackage(group, spec)
 			pr := packageFor(byPackage, owner)

--- a/cmd/audit_1to1/internal/shared/shared.go
+++ b/cmd/audit_1to1/internal/shared/shared.go
@@ -5,9 +5,23 @@ package shared
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"golang.org/x/tools/go/packages"
 )
+
+// loadCache memoizes LoadToolPackages per root. Loading the typed package
+// set for ./internal/tools/... costs 10-20s, and every analyzer plus every
+// test that calls buildReport twice used to pay it again. The audits treat
+// the loaded packages as read-only type information, which is what makes a
+// process-lifetime shared result safe; the CLIs are one-shot anyway.
+var loadCache sync.Map // root -> *loadResult
+
+type loadResult struct {
+	once sync.Once
+	pkgs []*packages.Package
+	err  error
+}
 
 const (
 	ClientGoPkgPath = "gitlab.com/gitlab-org/api/client-go"
@@ -19,7 +33,18 @@ const (
 // with full type information, returning only the tool sub-packages that resolved
 // types successfully. It is shared by the structs and actions analyzers, which
 // both need the same typed package set. A package-load error aborts the run.
+// The result is memoized per root and must be treated as read-only.
 func LoadToolPackages(root string) ([]*packages.Package, error) {
+	entry, _ := loadCache.LoadOrStore(root, &loadResult{})
+	result, _ := entry.(*loadResult)
+	result.once.Do(func() {
+		result.pkgs, result.err = loadToolPackages(root)
+	})
+	return result.pkgs, result.err
+}
+
+// loadToolPackages performs the actual load; see LoadToolPackages.
+func loadToolPackages(root string) ([]*packages.Package, error) {
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
 			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports,

--- a/cmd/audit_catalog_first/main.go
+++ b/cmd/audit_catalog_first/main.go
@@ -817,7 +817,7 @@ func collectPackageActionCoverage() (map[string]packageActionCoverage, error) {
 	}
 
 	coverage := make(map[string]packageActionCoverage)
-	for _, group := range tools.CollectActionSpecs(client, true) {
+	for _, group := range auditshared.CachedActionSpecs(client, true) {
 		kind := normalizedSurfaceKind(group.SurfaceKind)
 		for _, spec := range group.Actions {
 			owner := strings.TrimSpace(spec.OwnerPackage)

--- a/cmd/audit_discovery_completeness/main.go
+++ b/cmd/audit_discovery_completeness/main.go
@@ -60,7 +60,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/auditclient"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -297,7 +296,7 @@ func buildReport(gapsOnly bool, minAliases int) (report, error) {
 	}
 	defer cleanup()
 
-	projected, err := auditshared.ProjectIndividualDescriptions(client)
+	projected, err := auditshared.CachedIndividualDescriptions(client)
 	if err != nil {
 		return report{}, err
 	}
@@ -322,7 +321,7 @@ func buildReport(gapsOnly bool, minAliases int) (report, error) {
 func collectAllClusters(client *gitlabclient.Client) []clusterRecord {
 	specsByOwner := map[string][]toolutil.ActionSpec{}
 	seen := map[string]bool{}
-	for _, group := range tools.CollectActionSpecs(client, true) {
+	for _, group := range auditshared.CachedActionSpecs(client, true) {
 		for _, spec := range group.Actions {
 			owner := auditshared.OwnerPackage(group, spec)
 			key := owner + "\x00" + spec.Name
@@ -340,7 +339,7 @@ func collectAllClusters(client *gitlabclient.Client) []clusterRecord {
 // ready for JSON output. Gaps-only mode filters clean packages.
 func buildPackageReports(client *gitlabclient.Client, allClusters []clusterRecord, projected map[string]string, minAliases int, gapsOnly bool) []packageReport {
 	byPackage := map[string]*packageReport{}
-	for _, group := range tools.CollectActionSpecs(client, true) {
+	for _, group := range auditshared.CachedActionSpecs(client, true) {
 		for _, spec := range group.Actions {
 			owner := auditshared.OwnerPackage(group, spec)
 			clusterMembers := clusterMembersFor(allClusters, owner, spec.Name)

--- a/cmd/audit_metrics/main.go
+++ b/cmd/audit_metrics/main.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -442,7 +443,31 @@ func listToolsFromServer(server *mcp.Server) []*mcp.Tool {
 // listServerTools registers tools on an in-memory MCP server and returns
 // the full tool list. When meta is true, meta-tools are registered.
 // Enterprise controls whether Enterprise/Premium meta-tools are included.
+// listedToolsCache memoizes listServerTools per (client, surface, tier):
+// registering a full surface costs seconds, the result depends only on the
+// compiled-in catalog and those inputs, and callers only read it. The audit
+// itself repeats one combination (meta enterprise for the schema-modes
+// section), and the test binary repeats several.
+var listedToolsCache sync.Map // listKey -> []*mcp.Tool
+
+type listKey struct {
+	client     *gitlabclient.Client
+	meta       bool
+	enterprise bool
+}
+
 func listServerTools(client *gitlabclient.Client, meta, enterprise bool) []*mcp.Tool {
+	key := listKey{client: client, meta: meta, enterprise: enterprise}
+	if cached, ok := listedToolsCache.Load(key); ok {
+		listed, _ := cached.([]*mcp.Tool)
+		return listed
+	}
+	listed := listServerToolsUncached(client, meta, enterprise)
+	listedToolsCache.Store(key, listed)
+	return listed
+}
+
+func listServerToolsUncached(client *gitlabclient.Client, meta, enterprise bool) []*mcp.Tool {
 	opts := &mcp.ServerOptions{PageSize: 2000, Capabilities: &mcp.ServerCapabilities{}}
 	server := mcp.NewServer(&mcp.Implementation{Name: auditServerName, Version: auditVersion}, opts)
 

--- a/cmd/audit_metrics/main.go
+++ b/cmd/audit_metrics/main.go
@@ -443,21 +443,25 @@ func listToolsFromServer(server *mcp.Server) []*mcp.Tool {
 // listServerTools registers tools on an in-memory MCP server and returns
 // the full tool list. When meta is true, meta-tools are registered.
 // Enterprise controls whether Enterprise/Premium meta-tools are included.
-// listedToolsCache memoizes listServerTools per (client, surface, tier):
-// registering a full surface costs seconds, the result depends only on the
-// compiled-in catalog and those inputs, and callers only read it. The audit
-// itself repeats one combination (meta enterprise for the schema-modes
-// section), and the test binary repeats several.
+// listedToolsCache memoizes listServerTools per (client, surface, tier,
+// meta schema mode): registering a full surface costs seconds, the result
+// depends only on the compiled-in catalog and those inputs, and callers only
+// read it. The schema mode is part of the key because printMetaSchemaModes
+// re-registers the meta surface under each mode to size its input schemas;
+// a key without it would hand every mode the first listing and report three
+// identical sizes. The audit repeats the opaque meta enterprise listing, and
+// the test binary repeats several combinations.
 var listedToolsCache sync.Map // listKey -> []*mcp.Tool
 
 type listKey struct {
 	client     *gitlabclient.Client
 	meta       bool
 	enterprise bool
+	schemaMode string
 }
 
 func listServerTools(client *gitlabclient.Client, meta, enterprise bool) []*mcp.Tool {
-	key := listKey{client: client, meta: meta, enterprise: enterprise}
+	key := listKey{client: client, meta: meta, enterprise: enterprise, schemaMode: tools.MetaParamSchema()}
 	if cached, ok := listedToolsCache.Load(key); ok {
 		listed, _ := cached.([]*mcp.Tool)
 		return listed

--- a/cmd/audit_metrics/main_test.go
+++ b/cmd/audit_metrics/main_test.go
@@ -537,6 +537,38 @@ func TestPrintMetaSchemaModes_ListsActiveAndAllModes(t *testing.T) {
 	}
 }
 
+// TestPrintMetaSchemaModes_ReportsDistinctSizesPerMode verifies that the
+// schema-modes section measures each META_PARAM_SCHEMA mode on its own
+// registration rather than reusing one memoized tool list for all three:
+// the opaque, compact and full strategies produce input schemas of
+// different sizes, so three equal totals would mean the memo returned the
+// first listing to every mode.
+func TestPrintMetaSchemaModes_ReportsDistinctSizesPerMode(t *testing.T) {
+	t.Setenv("META_PARAM_SCHEMA", "opaque")
+
+	output := captureStdout(t, func() {
+		printMetaSchemaModes(newAuditMetricsClient(t))
+	})
+
+	totals := map[string]string{}
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[0] {
+		case "opaque", "compact", "full":
+			totals[fields[0]] = fields[1]
+		}
+	}
+	if len(totals) != 3 {
+		t.Fatalf("printMetaSchemaModes() reported %d modes, want 3:\n%s", len(totals), output)
+	}
+	if totals["opaque"] == totals["compact"] || totals["compact"] == totals["full"] || totals["opaque"] == totals["full"] {
+		t.Fatalf("printMetaSchemaModes() reported equal totals across modes, want one measurement per mode: %v\n%s", totals, output)
+	}
+}
+
 // TestPrintMetaSchemaModes_DefaultsToOpaqueWhenUnset verifies the reporter
 // falls back to opaque mode when META_PARAM_SCHEMA is empty or invalid.
 func TestPrintMetaSchemaModes_DefaultsToOpaqueWhenUnset(t *testing.T) {

--- a/cmd/audit_metrics/main_test.go
+++ b/cmd/audit_metrics/main_test.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -28,22 +29,31 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
-// newAuditMetricsClient creates a [gitlabclient.Client] backed by a mock
-// /api/v4/version endpoint for audit_metrics tests.
+// newAuditMetricsClient returns the binary-lifetime [gitlabclient.Client]
+// backed by a mock /api/v4/version endpoint. Shared across tests (process
+// teardown reclaims the httptest server) so listServerTools' per-client
+// memo can serve every test from one surface registration, the same
+// pattern cmd/server's createServer tests use.
 func newAuditMetricsClient(t *testing.T) *gitlabclient.Client {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"version":"17.0.0"}`)
-	}))
-	t.Cleanup(srv.Close)
-
-	client, err := gitlabclient.NewClient(&config.Config{GitLabURL: srv.URL, GitLabToken: "audit-token"})
-	if err != nil {
-		t.Fatalf("NewClient() error: %v", err)
+	sharedClientOnce.Do(func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"version":"17.0.0"}`)
+		}))
+		sharedClient, errSharedClient = gitlabclient.NewClient(&config.Config{GitLabURL: srv.URL, GitLabToken: "audit-token"})
+	})
+	if errSharedClient != nil {
+		t.Fatalf("NewClient() error: %v", errSharedClient)
 	}
-	return client
+	return sharedClient
 }
+
+var (
+	sharedClientOnce sync.Once
+	sharedClient     *gitlabclient.Client
+	errSharedClient  error
+)
 
 // TestCountResources_IncludesToolManifest verifies resource metrics include the
 // surface-aware tool manifest registration path used by the audit command.

--- a/cmd/audit_tokens/main.go
+++ b/cmd/audit_tokens/main.go
@@ -1016,9 +1016,13 @@ func measureTokenFootprintRows(client *gitlabclient.Client) ([]tokenFootprintRow
 		{"Ultimate", edition.Ultimate},
 	}
 
+	promptTokens, err := fpMeasurePrompts(client)
+	if err != nil {
+		return nil, err
+	}
 	for i, t := range tiers {
 		cmdutil.Progressf("audit_tokens: measuring footprint [%d/%d] %s tier (all surfaces x schema modes)...", i+1, len(tiers), t.label)
-		rows, err := measureTierFootprint(client, t.tier, t.label)
+		rows, err := measureTierFootprintWithPrompts(client, t.tier, t.label, promptTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -1028,6 +1032,13 @@ func measureTokenFootprintRows(client *gitlabclient.Client) ([]tokenFootprintRow
 }
 
 func measureTierFootprint(client *gitlabclient.Client, tier edition.Tier, tierLabel string) ([]tokenFootprintRow, error) {
+	return measureTierFootprintWithPrompts(client, tier, tierLabel, -1)
+}
+
+// measureTierFootprintWithPrompts measures one tier; promptTokens carries the
+// tier-independent prompt measurement so the caller pays it once for all
+// three tiers (a negative value measures it here, for standalone callers).
+func measureTierFootprintWithPrompts(client *gitlabclient.Client, tier edition.Tier, tierLabel string, promptTokens int) ([]tokenFootprintRow, error) {
 	metaCatalog, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{
 		Tier:       tier,
 		IncludeMCP: true,
@@ -1061,9 +1072,12 @@ func measureTierFootprint(client *gitlabclient.Client, tier edition.Tier, tierLa
 	if err != nil {
 		return nil, err
 	}
-	promptTokens, err := fpMeasurePrompts(client)
-	if err != nil {
-		return nil, err
+	if promptTokens < 0 {
+		measured, promptErr := fpMeasurePrompts(client)
+		if promptErr != nil {
+			return nil, promptErr
+		}
+		promptTokens = measured
 	}
 
 	dynamicFullShared, err := measureSharedTokens(client, sharedTokenMeasureOptions{

--- a/cmd/audit_tokens/main.go
+++ b/cmd/audit_tokens/main.go
@@ -1022,22 +1022,18 @@ func measureTokenFootprintRows(client *gitlabclient.Client) ([]tokenFootprintRow
 	}
 	for i, t := range tiers {
 		cmdutil.Progressf("audit_tokens: measuring footprint [%d/%d] %s tier (all surfaces x schema modes)...", i+1, len(tiers), t.label)
-		rows, err := measureTierFootprintWithPrompts(client, t.tier, t.label, promptTokens)
-		if err != nil {
-			return nil, err
+		rows, tierErr := measureTierFootprintWithPrompts(client, t.tier, t.label, promptTokens)
+		if tierErr != nil {
+			return nil, tierErr
 		}
 		allRows = append(allRows, rows...)
 	}
 	return allRows, nil
 }
 
-func measureTierFootprint(client *gitlabclient.Client, tier edition.Tier, tierLabel string) ([]tokenFootprintRow, error) {
-	return measureTierFootprintWithPrompts(client, tier, tierLabel, -1)
-}
-
 // measureTierFootprintWithPrompts measures one tier; promptTokens carries the
 // tier-independent prompt measurement so the caller pays it once for all
-// three tiers (a negative value measures it here, for standalone callers).
+// three tiers (a negative value measures it here, for a standalone caller).
 func measureTierFootprintWithPrompts(client *gitlabclient.Client, tier edition.Tier, tierLabel string, promptTokens int) ([]tokenFootprintRow, error) {
 	metaCatalog, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{
 		Tier:       tier,

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
@@ -390,6 +390,10 @@ func buildCatalog(client *gitlabclient.Client, toolSurface, serverMode string) (
 	return toolsResult, routes, nil
 }
 
+// evalSchemaCache caches resolved tool schemas across every catalog
+// session; see the SchemaCache option below.
+var evalSchemaCache = mcp.NewSchemaCache()
+
 // newCatalogSession constructs catalog session.
 func newCatalogSession(client *gitlabclient.Client, toolSurface, serverMode string) (*mcp.ClientSession, func(), error) {
 	session, closeSession, _, _, err := buildCatalogSession(client, toolSurface, serverMode)
@@ -416,6 +420,11 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface, serverMode st
 	completionHandler := completions.NewHandler(client)
 	server := mcp.NewServer(&mcp.Implementation{Name: "eval-mcp-surfaces", Version: "0.0.1"}, &mcp.ServerOptions{
 		PageSize: 2000,
+		// Shared across every catalog session this process builds: resolved
+		// tool schemas depend only on the compiled-in catalog, and reusing
+		// them skips schema resolution on every registration after the
+		// first (the same cache cmd/server shares across its pool).
+		SchemaCache: evalSchemaCache,
 		Capabilities: &mcp.ServerCapabilities{
 			Tools:     &mcp.ToolCapabilities{ListChanged: true},
 			Resources: &mcp.ResourceCapabilities{ListChanged: true},

--- a/cmd/gen_lhm_manifest/main.go
+++ b/cmd/gen_lhm_manifest/main.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -162,13 +163,30 @@ func run(checkOnly bool) error {
 // generate returns the manifest bytes that current should have, with the
 // capability arrays replaced by the registered surface and every other field
 // left untouched.
+// surfaceCache memoizes readSurface: the listed capability arrays depend
+// only on the compiled-in catalog, the round-trip costs seconds, and this
+// one-shot command (and its test binary) may assemble more than one
+// manifest from the same surface.
+var surfaceCache struct {
+	once       sync.Once
+	registered surface
+	err        error
+}
+
+func cachedSurface() (surface, error) {
+	surfaceCache.once.Do(func() {
+		surfaceCache.registered, surfaceCache.err = readSurface()
+	})
+	return surfaceCache.registered, surfaceCache.err
+}
+
 func generate(current []byte) (out []byte, counts string, err error) {
 	m, err := decodeManifest(current)
 	if err != nil {
 		return nil, "", err
 	}
 
-	registered, err := readSurface()
+	registered, err := cachedSurface()
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/internal/auditshared/auditshared.go
+++ b/cmd/internal/auditshared/auditshared.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -50,9 +51,52 @@ func WeakIndividualDescription(spec toolutil.ActionSpec, projected map[string]st
 	return !strings.Contains(description, "Returns:") || !strings.Contains(description, "See also:")
 }
 
+// projectionCache memoizes ProjectIndividualDescriptions. Projecting the
+// individual surface registers ~1071 tools with schema compilation (~10s),
+// the output depends only on the compiled-in catalog (the client is an
+// offline stub), and the audits only read the map. One projection per
+// process therefore serves every analyzer and every test in a package; the
+// one-shot CLIs are unaffected.
+var projectionCache struct {
+	once         sync.Once
+	descriptions map[string]string
+	err          error
+}
+
+// specsCache memoizes CachedActionSpecs per enterprise flag, same contract:
+// the returned groups are shared and must be treated as read-only.
+var specsCache sync.Map // enterprise bool -> *specsResult
+
+type specsResult struct {
+	once   sync.Once
+	groups []tools.ActionSpecGroup
+}
+
+// CachedIndividualDescriptions returns the projected individual-tool
+// descriptions, computed once per process. The map is shared: read-only.
+func CachedIndividualDescriptions(client *gitlabclient.Client) (map[string]string, error) {
+	projectionCache.once.Do(func() {
+		projectionCache.descriptions, projectionCache.err = ProjectIndividualDescriptions(client)
+	})
+	return projectionCache.descriptions, projectionCache.err
+}
+
+// CachedActionSpecs returns the collected action specs for the given tier
+// selector, computed once per process and per flag. The slice and everything
+// it references are shared: read-only.
+func CachedActionSpecs(client *gitlabclient.Client, enterprise bool) []tools.ActionSpecGroup {
+	entry, _ := specsCache.LoadOrStore(enterprise, &specsResult{})
+	result, _ := entry.(*specsResult)
+	result.once.Do(func() {
+		result.groups = tools.CollectActionSpecs(client, enterprise)
+	})
+	return result.groups
+}
+
 // ProjectIndividualDescriptions registers the individual-tool surface on an
 // in-memory MCP server and returns the projected description per tool name —
-// the exact text the model consumes.
+// the exact text the model consumes. Prefer CachedIndividualDescriptions
+// unless a fresh projection is the point.
 func ProjectIndividualDescriptions(client *gitlabclient.Client) (map[string]string, error) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "audit", Version: "0.0.1"}, &mcp.ServerOptions{Capabilities: &mcp.ServerCapabilities{}})
 	tools.RegisterAll(server, client, edition.Ultimate)

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -66,15 +66,15 @@
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                                                                      |
 | elicitation   |       124 |    96.2% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                                                                       |
 | gatewaycompat |        12 |    95.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
-| gitlab        |        47 |    98.4% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
+| gitlab        |        47 |    98.1% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        64 |    95.7% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
 | oauth         |        57 |    89.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       266 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       176 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
-| serverpool    |        73 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
+| serverpool    |        73 |    98.4% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
-| telemetry     |        83 |    90.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
+| telemetry     |        83 |    90.4% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        34 |    88.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       736 |    97.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
 | **Subtotal**  | **1,995** |          |                                                                                                                                                                                                                                                                    |
@@ -349,15 +349,15 @@
 | edition       |    87.0% |
 | elicitation   |    96.2% |
 | gatewaycompat |    95.4% |
-| gitlab        |    98.4% |
+| gitlab        |    98.1% |
 | mcpotel       |    95.7% |
 | oauth         |    89.4% |
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.4% |
-| serverpool    |    98.3% |
+| serverpool    |    98.4% |
 | subscriptions |    98.5% |
-| telemetry     |    90.3% |
+| telemetry     |    90.4% |
 | testutil      |    88.6% |
 | toolutil      |    97.9% |
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -27,7 +27,7 @@
 | Test files (test/e2e/)                                |    210 |
 | Tool sub-packages tested                              |    173 |
 | Core packages tested                                  |     21 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  89.9% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  89.8% |
 | Overall coverage (`go test ./internal/...`)           |  95.4% |
 | Average package coverage                              |  94.6% |
 
@@ -75,7 +75,7 @@
 | serverpool    |        73 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |        83 |    90.3% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
-| testutil      |        34 |    88.2% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
+| testutil      |        34 |    88.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       736 |    97.9% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
 | **Subtotal**  | **1,995** |          |                                                                                                                                                                                                                                                                    |
 
@@ -310,12 +310,12 @@
 | cmd/audit_dynamic_aliases                      |    48.4% |
 | cmd/audit_e2e_gaps                             |    81.2% |
 | cmd/audit_edition_tier                         |    32.7% |
-| cmd/audit_metrics                              |    29.5% |
+| cmd/audit_metrics                              |    30.1% |
 | cmd/audit_string_dupes                         |    91.1% |
 | cmd/audit_surface_quality                      |    63.6% |
 | cmd/audit_test_goroutines                      |    65.2% |
 | cmd/audit_test_names                           |    37.6% |
-| cmd/audit_tokens                               |    51.2% |
+| cmd/audit_tokens                               |    51.1% |
 | cmd/eval_mcp_surfaces/internal/evalrun         |    88.9% |
 | cmd/eval_mcp_surfaces/internal/evaluator       |    80.5% |
 | cmd/eval_mcp_surfaces/internal/evaluator/cases |    99.6% |
@@ -325,7 +325,7 @@
 | cmd/gen_brand                                  |    68.6% |
 | cmd/gen_docker_tools                           |    88.3% |
 | cmd/gen_icon_webp                              |    90.2% |
-| cmd/gen_lhm_manifest                           |    78.5% |
+| cmd/gen_lhm_manifest                           |    79.1% |
 | cmd/gen_llms                                   |    13.1% |
 | cmd/gen_stats                                  |    36.2% |
 | cmd/gen_testing_docs                           |    25.5% |
@@ -358,7 +358,7 @@
 | serverpool    |    98.3% |
 | subscriptions |    98.5% |
 | telemetry     |    90.3% |
-| testutil      |    88.2% |
+| testutil      |    88.6% |
 | toolutil      |    97.9% |
 
 ### Tool Sub-Packages
@@ -544,7 +544,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 
 - **cmd/gen_llms** (13.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_testing_docs** (25.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_metrics** (29.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_metrics** (30.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_edition_tier** (32.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1** (34.8%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_action_catalog_manifest** (35.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -552,14 +552,14 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_test_names** (37.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/termio** (45.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (48.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_tokens** (51.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_tokens** (51.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/godoc_tool** (57.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_surface_quality** (63.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_goroutines** (65.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_brand** (68.6%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/metadata** (70.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_discovery_completeness** (78.0%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/gen_lhm_manifest** (78.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/gen_lhm_manifest** (79.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_catalog_first** (80.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/eval_mcp_surfaces/internal/evaluator** (80.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_e2e_gaps** (81.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -571,8 +571,8 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/internal/apidocs** (87.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1/internal/actions** (87.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/server** (87.9%) - entry-point glue, signal handling, and transport startup are validated mostly through integration and E2E coverage.
-- **testutil** (88.2%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/gen_docker_tools** (88.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **testutil** (88.6%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **oauth** (89.4%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -178,6 +178,15 @@ func NewClient(cfg *config.Config) (*Client, error) {
 // The client includes a resilience transport that enables automatic recovery
 // when GitLab becomes available after being unreachable.
 func NewClientWithToken(baseURL, token string, skipTLSVerify bool) (*Client, error) {
+	return NewClientWithTokenRetries(baseURL, token, skipTLSVerify, false)
+}
+
+// NewClientWithTokenRetries is [NewClientWithToken] with the retry policy
+// exposed: disableRetries turns off client-go's retryablehttp wrapper
+// (RetryMax 5, linear backoff), which unit tests need — a pooled client
+// probing a mock that answers 5xx otherwise sleeps through the whole
+// credential-check deadline instead of reading the answer it already has.
+func NewClientWithTokenRetries(baseURL, token string, skipTLSVerify, disableRetries bool) (*Client, error) {
 	base := buildBaseTransport(skipTLSVerify)
 
 	c := &Client{
@@ -189,10 +198,17 @@ func NewClientWithToken(baseURL, token string, skipTLSVerify bool) (*Client, err
 
 	sdkHTTPClient := &http.Client{Transport: apiTransport(base, c)}
 
-	inner, err := gl.NewClient(
-		token,
+	options := []gl.ClientOptionFunc{
 		gl.WithBaseURL(baseURL),
 		gl.WithHTTPClient(sdkHTTPClient),
+	}
+	if disableRetries {
+		options = append(options, gl.WithoutRetries())
+	}
+
+	inner, err := gl.NewClient(
+		token,
+		options...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating gitlab client: %w", err)

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1157,9 +1157,10 @@ func newTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
 	t.Cleanup(srv.Close)
 
 	cfg := &config.Config{
-		GitLabURL:     srv.URL,
-		GitLabToken:   "test-token",
-		SkipTLSVerify: false,
+		GitLabURL:      srv.URL,
+		GitLabToken:    "test-token",
+		SkipTLSVerify:  false,
+		DisableRetries: true,
 	}
 
 	client, err := gitlabclient.NewClient(cfg)

--- a/internal/resources/registrar_test.go
+++ b/internal/resources/registrar_test.go
@@ -28,8 +28,9 @@ import (
 func registrarTestClient(t *testing.T) *gitlabclient.Client {
 	t.Helper()
 	client, err := gitlabclient.NewClient(&config.Config{
-		GitLabURL:   "http://127.0.0.1:1", // deliberately unreachable: registration must not dial
-		GitLabToken: "glpat-test",
+		GitLabURL:      "http://127.0.0.1:1", // deliberately unreachable: registration must not dial
+		GitLabToken:    "glpat-test",
+		DisableRetries: true,
 	})
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1478,9 +1478,10 @@ func newTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
 	t.Cleanup(srv.Close)
 
 	cfg := &config.Config{
-		GitLabURL:     srv.URL,
-		GitLabToken:   "test-token",
-		SkipTLSVerify: false,
+		GitLabURL:      srv.URL,
+		GitLabToken:    "test-token",
+		SkipTLSVerify:  false,
+		DisableRetries: true,
 	}
 
 	client, err := gitlabclient.NewClient(cfg)

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -352,7 +352,9 @@ func (p *ServerPool) buildEntry(token, gitlabURL string, knownScopes []string) (
 	// the pool must forward it the same way: an OAuth access token is only
 	// valid as Bearer (GitLab rejects gloas- tokens in PRIVATE-TOKEN, which
 	// is what NewClientWithToken sends), while PATs work in both schemes.
-	newClient := gitlabclient.NewClientWithToken
+	newClient := func(baseURL, token string, skipTLSVerify bool) (*gitlabclient.Client, error) {
+		return gitlabclient.NewClientWithTokenRetries(baseURL, token, skipTLSVerify, p.cfg.DisableRetries)
+	}
 	if p.cfg.AuthMode == "oauth" {
 		newClient = gitlabclient.NewOAuthClientWithToken
 	}

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -42,12 +42,13 @@ func testFactory() ServerFactory {
 // false).
 func testConfig(baseURL string) *config.Config {
 	return &config.Config{
-		GitLabURL:     baseURL,
-		GitLabToken:   "default-token",
-		SkipTLSVerify: false,
-		Tier:          edition.Free,
-		TierExplicit:  true,
-		IgnoreScopes:  true,
+		GitLabURL:      baseURL,
+		GitLabToken:    "default-token",
+		SkipTLSVerify:  false,
+		Tier:           edition.Free,
+		TierExplicit:   true,
+		IgnoreScopes:   true,
+		DisableRetries: true,
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -385,7 +385,13 @@ func (p *Provider) Signals() Signals {
 	return p.signals
 }
 
-// Shutdown flushes and retires every exporter, bounded by [shutdownTimeout].
+// Shutdown flushes and retires every exporter, bounded by [shutdownTimeout]
+// or by the caller's deadline, whichever comes first. The caller's
+// cancellation is deliberately detached (a dying request must not abort the
+// final flush), but a deadline the caller chose is a bound to honor: before
+// this, the internal five seconds silently overrode any tighter one, which
+// made cmd/server's own shutdown bound dead code and held every test that
+// pointed an exporter at an unreachable collector for the full five seconds.
 //
 // Errors are joined rather than returned on the first failure: each exporter
 // owns a connection of its own, and stopping the rest matters more than
@@ -394,7 +400,13 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 	if p == nil || len(p.shutdowns) == 0 {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
+	bound := shutdownTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < bound {
+			bound = remaining
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), bound)
 	defer cancel()
 
 	var errs []error

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -259,7 +259,15 @@ func startForSnapshot(t *testing.T, signals Signals) Snapshot {
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	t.Cleanup(func() { _ = p.Shutdown(boundedShutdown(t)) })
+	// A tight teardown bound: these tests point exporters at .invalid hosts
+	// and assert on the snapshot, so the final flush has nowhere to deliver
+	// and waiting shutdownTimeout for it bought each test five silent
+	// seconds. Shutdown honors the tighter caller deadline.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
 	return p.Snapshot()
 }
 

--- a/internal/testutil/legacy_client.go
+++ b/internal/testutil/legacy_client.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -90,7 +91,25 @@ func ConnectLegacyElicitationClient(ctx context.Context, t *testing.T, server *m
 		t.Fatalf("legacy client: write initialized notification: %v", notifyErr)
 	}
 
-	go serveLegacyClient(ctx, conn, handler)
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		serveLegacyClient(ctx, conn, handler)
+	}()
+	// Registered after the connection-closing cleanup, so it runs before it
+	// (LIFO): close the connection here and join the serve goroutine. The
+	// join is what makes coverage deterministic across GOMAXPROCS — without
+	// it, on a single P the test ends before the goroutine ever observes the
+	// closed connection, and its exit path counts on some runs and not
+	// others. It also stops the goroutine from leaking into later tests.
+	t.Cleanup(func() {
+		_ = conn.Close()
+		select {
+		case <-served:
+		case <-time.After(5 * time.Second):
+			t.Error("legacy client: serve goroutine did not exit after connection close")
+		}
+	})
 	return ss
 }
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -587,8 +587,9 @@ func mustBuildActionCatalog(t *testing.T, client *gitlabclient.Client, opts Acti
 func newGitLabDotComClient(t *testing.T) *gitlabclient.Client {
 	t.Helper()
 	client, err := gitlabclient.NewClient(&config.Config{
-		GitLabURL:   "https://gitlab.com",
-		GitLabToken: "test-token",
+		GitLabURL:      "https://gitlab.com",
+		GitLabToken:    "test-token",
+		DisableRetries: true,
 	})
 	if err != nil {
 		t.Fatalf("NewClient(gitlab.com) error = %v", err)

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -371,23 +371,9 @@ func TestSearch_CurrentHighConfidenceQueriesRemainStable(t *testing.T) {
 //	go test ./internal/tools/dynamic/ -run TestDynamicSearchCorpus -count=1
 func TestDynamicSearchCorpus(t *testing.T) {
 	cases := loadDynamicSearchCorpus(t)
-	baseCatalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
-	if err != nil {
-		t.Fatalf("BuildActionCatalog() error = %v", err)
-	}
-	baseCatalog, err = AddStandaloneCatalog(baseCatalog, nil, StandaloneOptions{})
-	if err != nil {
-		t.Fatalf("AddStandaloneCatalog() error = %v", err)
-	}
+	baseCatalog := mustCachedCatalog(t, false)
 	baseRegistry := NewRegistryFromCatalog(baseCatalog)
-	enterpriseCatalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		t.Fatalf("BuildActionCatalog(enterprise) error = %v", err)
-	}
-	enterpriseCatalog, err = AddStandaloneCatalog(enterpriseCatalog, nil, StandaloneOptions{})
-	if err != nil {
-		t.Fatalf("AddStandaloneCatalog(enterprise) error = %v", err)
-	}
+	enterpriseCatalog := mustCachedCatalog(t, true)
 	enterpriseRegistry := NewRegistryFromCatalog(enterpriseCatalog)
 
 	for _, tc := range cases {
@@ -3065,14 +3051,7 @@ func TestSearch_ProviderConfusionQueries_PrioritizeExactTopResult(t *testing.T) 
 // registry is built from the larger enterprise catalog, ensuring the extra enterprise actions
 // do not displace the exact match.
 func TestSearch_ProviderConfusionQueries_PrioritizeExactTopResult_EnterpriseCatalog(t *testing.T) {
-	enterpriseCatalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		t.Fatalf("BuildActionCatalog(enterprise) error = %v", err)
-	}
-	enterpriseCatalog, err = AddStandaloneCatalog(enterpriseCatalog, nil, StandaloneOptions{})
-	if err != nil {
-		t.Fatalf("AddStandaloneCatalog(enterprise) error = %v", err)
-	}
+	enterpriseCatalog := mustCachedCatalog(t, true)
 	registry := NewRegistryFromCatalog(enterpriseCatalog)
 
 	result, output, err := registry.Search(t.Context(), nil, SearchInput{Query: "project list search gitlab-mcp-server", Limit: 20})
@@ -3214,6 +3193,41 @@ func actionDescriptionByID(t *testing.T, output DescribeOutput, id string) Actio
 	}
 	t.Fatalf("DescribeOutput missing action %q: %+v", id, output.Actions)
 	return ActionDescription{}
+}
+
+// cachedBaseCatalog and cachedEnterpriseCatalog memoize the two standard
+// full catalogs (base and enterprise, standalone actions included) that the
+// search tests exercise read-only: building one resolves ~850+ action
+// schemas, and dozens of tests used to rebuild it each. Tests that mutate a
+// catalog keep building their own.
+var cachedBaseCatalog = sync.OnceValues(func() (*actioncatalog.Catalog, error) {
+	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{IncludeMCP: true})
+	if err != nil {
+		return nil, fmt.Errorf("BuildActionCatalog() error = %w", err)
+	}
+	return AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
+})
+
+var cachedEnterpriseCatalog = sync.OnceValues(func() (*actioncatalog.Catalog, error) {
+	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
+	if err != nil {
+		return nil, fmt.Errorf("BuildActionCatalog(enterprise) error = %w", err)
+	}
+	return AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
+})
+
+// mustCachedCatalog unwraps one of the cached catalogs for a test.
+func mustCachedCatalog(t *testing.T, enterprise bool) *actioncatalog.Catalog {
+	t.Helper()
+	get := cachedBaseCatalog
+	if enterprise {
+		get = cachedEnterpriseCatalog
+	}
+	catalog, err := get()
+	if err != nil {
+		t.Fatalf("cached catalog: %v", err)
+	}
+	return catalog
 }
 
 var cachedRealCatalogRegistry = sync.OnceValues(func() (*Registry, error) {
@@ -5983,14 +5997,7 @@ func TestCompactParameterGuidance_AlphabeticalTieBreaker(t *testing.T) {
 // top hit for this query, and it must not depend on the result window — the
 // limit-sensitivity that prompted the investigation in the first place.
 func TestRegistrySearch_ProjectListSearchQuery_RanksSearchProjectsFirst(t *testing.T) {
-	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	if err != nil {
-		t.Fatalf("BuildActionCatalog() error = %v", err)
-	}
-	catalog, err = AddStandaloneCatalog(catalog, nil, StandaloneOptions{})
-	if err != nil {
-		t.Fatalf("AddStandaloneCatalog() error = %v", err)
-	}
+	catalog := mustCachedCatalog(t, true)
 	reg := NewRegistryFromCatalog(catalog)
 
 	const query = "project list search gitlab-mcp-server"

--- a/internal/tools/individual_catalog_test.go
+++ b/internal/tools/individual_catalog_test.go
@@ -32,7 +32,7 @@ func TestRegisterIndividualCatalogTools_GoldenSnapshotParity(t *testing.T) {
 		t.Fatalf("parse golden file %s: %v", goldenPath, unmarshalErr)
 	}
 	catalog := mustBuildActionCatalog(t, nil, ActionCatalogOptions{Enterprise: true, IncludeMCP: true})
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{
 		IncludeStandaloneUtilities: true,
 	})
@@ -68,12 +68,12 @@ func TestRegisterAll_CatalogBackedMatchesCatalogProjectionToolNames(t *testing.T
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			catalog := mustBuildActionCatalog(t, tc.client, ActionCatalogOptions{Enterprise: tc.enterprise, IncludeMCP: true})
-			expectedServer := mcp.NewServer(&mcp.Implementation{Name: "expected", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+			expectedServer := mcp.NewServer(&mcp.Implementation{Name: "expected", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 			RegisterIndividualCatalogTools(expectedServer, catalog, IndividualCatalogRegisterOptions{IncludeStandaloneUtilities: true})
 			RegisterMetaStandaloneTools(expectedServer, tc.client)
 			expectedNames := toolNamesFromServer(t, expectedServer)
 
-			catalogServer := mcp.NewServer(&mcp.Implementation{Name: "catalog", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+			catalogServer := mcp.NewServer(&mcp.Implementation{Name: "catalog", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 			RegisterAll(catalogServer, tc.client, edition.TierForEnterprise(tc.enterprise))
 			catalogNames := toolNamesFromServer(t, catalogServer)
 
@@ -107,7 +107,7 @@ func TestRegisterIndividualCatalogTools_ExecutesCatalogHandler(t *testing.T) {
 		IndividualTool: toolutil.IndividualToolSpec{Name: "gitlab_test_echo", Title: "Echo", Description: "Echo a value."},
 	}))
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{})
 	session := connectServerForTools(t, server)
 	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
@@ -169,14 +169,14 @@ func TestRegisterIndividualCatalogTools_ReadOnlyAndSafeModePolicies(t *testing.T
 	})
 	catalog := testIndividualCatalog(t, readSpec, writeSpec)
 
-	readOnlyServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	readOnlyServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(readOnlyServer, catalog, IndividualCatalogRegisterOptions{ReadOnlyOnly: true})
 	readOnlyNames := toolNamesFromServer(t, readOnlyServer)
 	if strings.Join(readOnlyNames, ",") != "gitlab_test_read" {
 		t.Fatalf("read-only registered tools = %v, want only gitlab_test_read", readOnlyNames)
 	}
 
-	safeServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	safeServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(safeServer, catalog, IndividualCatalogRegisterOptions{SafeMode: true})
 	session := connectServerForTools(t, safeServer)
 	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
@@ -231,7 +231,7 @@ func TestRegisterIndividualCatalogTools_EditionFilters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 			RegisterIndividualCatalogTools(server, catalog, tc.opts)
 			names := toolNamesFromServer(t, server)
 			if strings.Join(names, ",") != strings.Join(tc.want, ",") {
@@ -271,7 +271,7 @@ func TestRegisterIndividualCatalogTools_AllowExcludeAndDuplicateTools(t *testing
 		newSpec("duplicate_b", "gitlab_test_duplicate"),
 	)
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{
 		AllowedToolNames: []string{"gitlab_test_keep", "gitlab_test_excluded", "gitlab_test_duplicate"},
 		ExcludeToolNames: []string{"gitlab_test_excluded"},
@@ -314,7 +314,7 @@ func TestRegisterIndividualCatalogTools_SkipsIneligibleGroup(t *testing.T) {
 		t.Fatalf("AddGroup() error = %v", err)
 	}
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{})
 	if names := toolNamesFromServer(t, server); len(names) != 0 {
 		t.Fatalf("registered tools = %v, want none", names)
@@ -339,7 +339,7 @@ func TestRegisterIndividualCatalogTools_DestructiveConfirmationDeclined(t *testi
 		IndividualTool: toolutil.IndividualToolSpec{Name: "gitlab_test_delete", Title: "Delete", Description: "Delete test."},
 	})
 	catalog := testIndividualCatalog(t, spec)
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{})
 
 	st, ct := mcp.NewInMemoryTransports()
@@ -427,7 +427,7 @@ func TestRegisterIndividualCatalogTools_InputRequiredResultSurfaced(t *testing.T
 		IndividualTool: toolutil.IndividualToolSpec{Name: "gitlab_test_confirm_thing", Title: "Confirm Thing", Description: "Confirm thing test."},
 	})
 	catalog := testIndividualCatalog(t, spec)
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{})
 
 	st, ct := mcp.NewInMemoryTransports()
@@ -574,7 +574,7 @@ func TestIndividualCatalogActionReadOnly_AnnotationOverride(t *testing.T) {
 // inputs are ignored without panicking.
 func TestRegisterIndividualCatalogTools_NilInputs(t *testing.T) {
 	RegisterIndividualCatalogTools(nil, nil, IndividualCatalogRegisterOptions{})
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	RegisterIndividualCatalogTools(server, nil, IndividualCatalogRegisterOptions{})
 }
 

--- a/internal/tools/metatool.go
+++ b/internal/tools/metatool.go
@@ -76,6 +76,12 @@ func SetMetaParamSchema(mode string) {
 	toolutil.SetMetaParamSchemaMode(mode)
 }
 
+// MetaParamSchema reports the strategy [SetMetaParamSchema] selected:
+// "opaque", "compact" or "full".
+func MetaParamSchema() string {
+	return toolutil.MetaParamSchemaMode()
+}
+
 // SetMetaParamSchemaScoped selects the meta-tool input schema strategy and
 // returns a restore function for tests that temporarily override the global
 // mode. Valid modes match SetMetaParamSchema: "opaque", "compact", and

--- a/internal/tools/metatool_test.go
+++ b/internal/tools/metatool_test.go
@@ -228,7 +228,7 @@ func TestPackageMeta_UnmarshalErrors(t *testing.T) {
 		respondJSON(w, http.StatusOK, `{}`)
 	}))
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	if err := RegisterAllMeta(server, client, edition.Free); err != nil {
 		t.Fatalf("RegisterAllMeta() error = %v", err)
 	}

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -3,6 +3,12 @@
 // presence, and end-to-end MCP call flow using in-memory transports.
 package tools
 
+// testSchemaCache shares resolved tool schemas across every server these
+// tests register: the resolutions depend only on the compiled-in catalog,
+// and re-resolving ~1000 schemas per registration was most of the package's
+// test time. The benchmark in register_meta_test.go keeps its own caches on
+// purpose, because cold-versus-warm is what it measures.
+
 import (
 	"bytes"
 	"context"
@@ -39,6 +45,8 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/uploads"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
+
+var testSchemaCache = mcp.NewSchemaCache()
 
 const (
 	// fmtListToolsErr is the format string used when ListTools returns an error.
@@ -155,7 +163,7 @@ func newMCPSession(t *testing.T, handler http.Handler, enterprise ...bool) *mcp.
 			return
 		}
 
-		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 		RegisterAll(server, client, edition.TierForEnterprise(ent))
 		toolutil.LockdownInputSchemas(server)
 
@@ -231,7 +239,7 @@ func newMetaMCPSession(t *testing.T, handler http.Handler, enterprise bool) *mcp
 			return
 		}
 
-		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+		server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 		if registerErr := RegisterAllMeta(server, client, edition.TierForEnterprise(enterprise)); registerErr != nil {
 			slot.err = fmt.Errorf("RegisterAllMeta() error = %w", registerErr)
 			return
@@ -277,7 +285,7 @@ func newIsolatedMetaMCPSession(t *testing.T, handler http.Handler, enterprise bo
 	t.Helper()
 	client := newTestClient(t, handler)
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	if err := RegisterAllMeta(server, client, edition.TierForEnterprise(enterprise)); err != nil {
 		t.Fatalf("RegisterAllMeta() error = %v", err)
 	}
@@ -363,7 +371,7 @@ func TestRegisterAll_OrbitToolsRequireGitLabDotComEnterprise(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewClientWithToken() error: %v", err)
 			}
-			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 			RegisterAll(server, client, edition.TierForEnterprise(tt.enterprise))
 			names := toolNamesFromServer(t, server)
 			if gotOrbit := slices.Contains(names, "gitlab_orbit_status"); gotOrbit != tt.wantOrbit {
@@ -443,7 +451,7 @@ func TestRegisterAllMeta_OrbitMetaToolRequiresGitLabDotComEnterprise(t *testing.
 			if err != nil {
 				t.Fatalf("NewClientWithToken() error: %v", err)
 			}
-			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 			if registerErr := RegisterAllMeta(server, client, edition.TierForEnterprise(tt.enterprise)); registerErr != nil {
 				t.Fatalf("RegisterAllMeta() error = %v", registerErr)
 			}
@@ -4627,7 +4635,7 @@ func BenchmarkRegisterAll_Ultimate(b *testing.B) {
 	client := benchClient(b)
 	b.ResetTimer()
 	for range b.N {
-		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{PageSize: 2000})
+		server := mcp.NewServer(&mcp.Implementation{Name: "bench", Version: "0"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 		RegisterAll(server, client, edition.Ultimate)
 	}
 }

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -154,9 +154,10 @@ func newMCPSession(t *testing.T, handler http.Handler, enterprise ...bool) *mcp.
 		// binary; process teardown reclaims them.
 		srv := httptest.NewServer(delegate)
 		client, err := gitlabclient.NewClient(&config.Config{
-			GitLabURL:     srv.URL,
-			GitLabToken:   "test-token",
-			SkipTLSVerify: false,
+			GitLabURL:      srv.URL,
+			GitLabToken:    "test-token",
+			SkipTLSVerify:  false,
+			DisableRetries: true,
 		})
 		if err != nil {
 			slot.err = fmt.Errorf("create test gitlab client: %w", err)
@@ -230,9 +231,10 @@ func newMetaMCPSession(t *testing.T, handler http.Handler, enterprise bool) *mcp
 		})
 		srv := httptest.NewServer(delegate)
 		client, err := gitlabclient.NewClient(&config.Config{
-			GitLabURL:     srv.URL,
-			GitLabToken:   "test-token",
-			SkipTLSVerify: false,
+			GitLabURL:      srv.URL,
+			GitLabToken:    "test-token",
+			SkipTLSVerify:  false,
+			DisableRetries: true,
 		})
 		if err != nil {
 			slot.err = fmt.Errorf("create test gitlab client: %w", err)
@@ -4592,9 +4594,10 @@ func newTestClient(t *testing.T, handler http.Handler) *gitlabclient.Client {
 	t.Cleanup(srv.Close)
 
 	cfg := &config.Config{
-		GitLabURL:     srv.URL,
-		GitLabToken:   "test-token",
-		SkipTLSVerify: false,
+		GitLabURL:      srv.URL,
+		GitLabToken:    "test-token",
+		SkipTLSVerify:  false,
+		DisableRetries: true,
 	}
 
 	client, err := gitlabclient.NewClient(cfg)
@@ -4621,7 +4624,10 @@ func benchClient(b *testing.B) *gitlabclient.Client {
 		_, _ = w.Write([]byte(`{"version":"17.0.0"}`))
 	}))
 	b.Cleanup(srv.Close)
-	client, err := gitlabclient.NewClient(&config.Config{GitLabURL: srv.URL, GitLabToken: "bench-token"})
+	client, err := gitlabclient.NewClient(&config.Config{
+		GitLabURL: srv.URL, GitLabToken: "bench-token",
+		DisableRetries: true,
+	})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/tools/safemode_test.go
+++ b/internal/tools/safemode_test.go
@@ -16,7 +16,7 @@ import (
 // TestWrapMutatingToolsForSafeMode_ReadOnlyToolPassesThrough verifies that
 // read-only tools are not wrapped by SafeMode and still call the real handler.
 func TestWrapMutatingToolsForSafeMode_ReadOnlyToolPassesThrough(t *testing.T) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	called := false
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_list_projects",
@@ -48,7 +48,7 @@ func TestWrapMutatingToolsForSafeMode_ReadOnlyToolPassesThrough(t *testing.T) {
 // TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview verifies that
 // mutating tools return a SafeModePreview instead of executing.
 func TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview(t *testing.T) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	var mutatingCalls atomic.Int64
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_create_issue",
@@ -110,7 +110,7 @@ func TestWrapMutatingToolsForSafeMode_MutatingToolReturnsPreview(t *testing.T) {
 // TestWrapMutatingToolsForSafeMode_NilAnnotations verifies that tools with nil
 // annotations are treated as mutating and get wrapped.
 func TestWrapMutatingToolsForSafeMode_NilAnnotations(t *testing.T) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 	var handlerCalls atomic.Int64
 	server.AddTool(&mcp.Tool{
 		Name:        "gitlab_delete_project",
@@ -142,7 +142,7 @@ func TestWrapMutatingToolsForSafeMode_NilAnnotations(t *testing.T) {
 // TestWrapMutatingToolsForSafeMode_MixedTools verifies that only mutating tools
 // are wrapped when a mix of read-only and mutating tools are registered.
 func TestWrapMutatingToolsForSafeMode_MixedTools(t *testing.T) {
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, &mcp.ServerOptions{SchemaCache: testSchemaCache})
 
 	readOnlyCalled := false
 	server.AddTool(&mcp.Tool{

--- a/internal/tools/scope_filter_test.go
+++ b/internal/tools/scope_filter_test.go
@@ -205,7 +205,7 @@ func newMetaServer(t *testing.T) *mcp.Server {
 		_, _ = w.Write([]byte(`{"version":"17.0.0"}`))
 	})
 	client := newTestClient(t, handler)
-	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000})
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
 	if err := RegisterAllMeta(server, client, edition.Ultimate); err != nil {
 		t.Fatalf("RegisterAllMeta() error = %v", err)
 	}

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -2519,6 +2519,14 @@ var (
 // other value is coerced to opaque so that misconfiguration cannot break the
 // tools/list payload. Must be called before meta-tools are registered; later
 // calls only affect schemas built after the call returns.
+// MetaParamSchemaMode reports the meta-tool input schema strategy currently
+// selected by [SetMetaParamSchemaMode]: "opaque", "compact" or "full".
+// Callers that memoize a registered surface must key on it, because the
+// same registration produces different input schemas under each mode.
+func MetaParamSchemaMode() string {
+	return metaParamSchemaMode
+}
+
 func SetMetaParamSchemaMode(mode string) {
 	metaParamSchemaMu.Lock()
 	defer metaParamSchemaMu.Unlock()


### PR DESCRIPTION
Two quality workstreams on the unit-test suite. Every number below is measured on the same machine, isolated per package (revert the change, measure, re-apply, measure again), not estimated.

## 1. Coverage is now deterministic

`internal/testutil`'s legacy client served each connection on a goroutine nobody joined, so its exit paths were only counted by the coverage runtime when the scheduler happened to run them before teardown. Coverage differed between `-cpu 1` and multi-core runs. The serve goroutine is now joined in `t.Cleanup`: close the connection, then wait on the served channel with a 5-second guard. A whole-project sweep of all 230 packages, multi-core versus `-cpu 1`, now shows zero coverage differences.

## 2. The slow tail, one test at a time

I ranked every unit test by wall time and worked the top of the list down until what remained was intrinsic (semantic catalog builds that resolve 850+ action schemas). Three root-cause classes fell out:

- **Tests were sleeping through client-go retries.** retryablehttp retries 5xx five times with linear backoff, so a test provoking an error waited through the backoff instead of reading the answer it already had. Fixed in three places: `DisableRetries: true` in six test configs that were missing it, a `NewClientWithTokenRetries` constructor so the server pool can honor the knob, and telemetry `Shutdown` now honors a caller deadline tighter than its own 5-second bound instead of ignoring it.
- **Pure builds were recomputed per test.** Process-lifetime memos for catalog projections, collected action specs, `packages.Load` of the tools tree, surface listings, prompt measurement, and the standard catalogs the dynamic search tests read.
- **Schema resolution was recomputed per server.** One shared `mcp.NewSchemaCache()` across the test servers in `internal/tools` and across the evaluator's catalog sessions.

Two commits are behavior fixes rather than test-only changes: the retry knob threaded through `internal/gitlab` and `internal/serverpool`, and the telemetry `Shutdown` deadline fix.

## Scoreboard (isolated before/after)

| Scope                                     | Before | After |
| ----------------------------------------- | -----: | ----: |
| 1:1 / catalog / discovery audit packages  |  54.6s | 19.5s |
| `cmd/audit_metrics`                       |  34.0s | 22.2s |
| `cmd/audit_tokens`                        |  29.1s | 25.2s |
| `cmd/gen_lhm_manifest`                    |  27.6s |  3.1s |
| `cmd/eval_mcp_surfaces`                   |  16.0s | 14.6s |
| `internal/tools`                          |  72.7s | 67.7s |
| `internal/tools/dynamic`                  |  24.5s | 20.8s |
| `internal/resources`                      |  27.7s |  3.3s |
| `internal/prompts`                        |  12.3s |  0.7s |
| `internal/serverpool`                     |  10.7s |  0.7s |
| `internal/telemetry`                      |  15.1s |  0.3s |

Full suite, summing package wall times across all 230 packages and 11,784 top-level tests: **1116.1s before, 855.2s after** (23% less). The top of the final ranking is now the catalog parity and search-corpus tests, whose cost is the semantic build itself; I stopped there on purpose rather than caching away what those tests exist to build.

## Summary by Sourcery

Improve test determinism and reduce unit-suite runtime through reliable teardown, deadline handling, retry control, and reuse of expensive immutable test data.

Bug Fixes:
- Make legacy client teardown join its serving goroutine so coverage results are consistent across CPU configurations.
- Honor tighter caller deadlines during telemetry shutdown.
- Expose retry disabling through GitLab clients and propagate it through the server pool to avoid unnecessary retry delays in tests and callers.

Enhancements:
- Reduce unit-test and audit execution time by reusing immutable catalog, schema, surface, projection, action-spec, package-load, and prompt results within processes.
- Add coverage for distinct meta-schema measurements and update generated project quality metrics.

Documentation:
- Update testing and repository statistics documentation to reflect the current coverage and code metrics.

Tests:
- Configure mock-backed tests to disable client retries and share schema/catalog resources where safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness for repeated audits, catalog generation, schema resolution, and metrics collection.
  - Reduced repeated prompt measurements during token analysis.

- **Reliability**
  - Added configurable retry behavior for GitLab connections.
  - Shutdown operations now honor tighter caller deadlines.
  - Improved cleanup handling for legacy client connections.

- **Documentation**
  - Updated repository statistics and testing coverage figures.

- **Testing**
  - Expanded validation for schema modes, caching behavior, and connection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->