### PR TITLE
test: run every case table as subtests

### DIFF
--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -322,7 +322,7 @@ func TestCovListMetricImagesWithPagination(t *testing.T) { ... }
 ### Writing Tests
 
 - Use table-driven tests for multiple test cases
-- Use subtests with `t.Run` for better organization
+- Use subtests with `t.Run` for better organization: every range over a case table that asserts opens one subtest per case (`make check-test-subtests` fails otherwise). Name cases with a `name` field, or let the string element or map key be the name; mark a loop of dependent steps with `// sequential: <reason>` on the line above it
 - Test both success and error cases
 - Consider using `testify` or similar libraries when they add value, but don't over-complicate simple tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
         run: make check-stats
       - name: Check test-goroutine aborts
         run: make check-test-goroutines
+      - name: Check case loops run as subtests
+        run: make check-test-subtests
       - name: Check gateway-safe served characters
         run: make check-gateway-chars
       - name: Check test-file naming convention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ gitlab-mcp-server/
 │   ├── audit_surface_quality/   # Consolidated surface audit: metadata violations + output quality (was audit_tools + audit_output)
 │   ├── audit_test_goroutines/   # Audits testing.T aborts made off the test goroutine (A/B categories, --check gate)
 │   ├── audit_test_names/        # Audits test function naming compliance; -check-files gates test-file naming (make check-test-file-names)
+│   ├── audit_test_subtests/     # Audits case loops that assert without a t.Run subtest; -fix rewrites the unambiguous ones (make check-test-subtests)
 │   ├── audit_tokens/            # Audits token usage for model-facing surfaces (+ --compare-schemas sizing spike)
 │   ├── eval_mcp_surfaces/       # Evaluates model-facing MCP surface behavior
 │   ├── audit_string_dupes/      # Finds duplicated string literals missing constants
@@ -244,6 +245,7 @@ All tests use `httptest` to mock GitLab API responses. Shared helpers in `intern
 - `testutil.RespondJSON()` — responds with JSON body
 - `testutil.RespondJSONWithPagination()` — responds with pagination headers
 - **Never `t.Fatal`/`FailNow` off the test goroutine** (httptest handlers, `go` statements, MCP handlers): follow the six-rule contract in `.github/instructions/test-goroutines.instructions.md` — `t.Errorf` + deterministic response + `return`, or record with atomics and assert afterwards. `make check-test-goroutines` detects violations; `make audit-test-goroutines` writes the work list
+- **Every case table runs under `t.Run`**: a range over a slice or map literal that asserts must open one subtest per case, named by a `name` field, the string element, or the map key. `go run ./cmd/audit_test_subtests/ -fix` rewrites the unambiguous shapes; `// sequential: <reason>` on the line above a loop declares dependent steps rather than cases; `make check-test-subtests` gates it in CI
 - Test naming: `TestToolName_Scenario_ExpectedResult`
 - Test-file naming: a `_test.go` exists only under the name of a module it tests (`register.go` → `register_test.go`); `export_test.go`, build-constrained qualifiers (`fileutils_unix_test.go`), external-package qualifiers (`kind_integration_test.go`), and `test/e2e/` are the codified exemptions. `make check-test-file-names` gates it in CI
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 	analyze analyze-fix analyze-report install-tools \
 	audit-output audit-tokens audit-tools audit-surface-quality audit-metrics audit-dynamic-aliases audit-test-names audit-godocs audit-godocs-check fix-godocs \
 	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-validate-docs audit-edition-tier \
-	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names \
+	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names audit-test-subtests check-test-subtests \
 	audit-doc-coverage audit-doc-coverage-check \
 	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest gen-icon-webp check-icon-webp check-server-json check-server-json-packages check-openplugin audit-doc-tool-names check-doc-tool-names check-mcpb mcpb gen-npm sync-npm-version validate-npm validate-npm-local publish-npm-dry publish-npm gen-pypi validate-pypi validate-pypi-local publish-pypi-dry publish-pypi publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
 	docs-local-go \
@@ -555,12 +555,13 @@ analyze:
 	echo "Go analysis packages: $(GO_ANALYSIS_PKGS)"; \
 	echo "Go analysis build tags: $(GO_ANALYSIS_TAGS)"; \
 	echo ""; \
-	run_check "[1/6] golangci-lint config verify" golangci-lint config verify; \
-	run_check "[2/6] golangci-lint fmt" golangci-lint fmt --diff; \
-	run_check "[3/6] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[4/6] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[5/6] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
-	run_check "[6/6] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
+	run_check "[1/7] golangci-lint config verify" golangci-lint config verify; \
+	run_check "[2/7] golangci-lint fmt" golangci-lint fmt --diff; \
+	run_check "[3/7] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[4/7] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[5/7] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
+	run_check "[6/7] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
+	run_check "[7/7] case loops without subtests" go run ./cmd/audit_test_subtests --check; \
 	echo "============================================================"; \
 	if [ "$$analysis_status" -ne 0 ]; then \
 		echo "Analysis failed. Review findings above."; \
@@ -1034,6 +1035,18 @@ audit-test-goroutines:
 ## goroutine. Wired into CI once the sweep lands (phase 4 of the plan).
 check-test-goroutines:
 	go run ./cmd/audit_test_goroutines/ -check
+
+## audit-test-subtests: report case loops in Test functions that assert
+## without opening a t.Run subtest (the table-driven rule), with the JSON work
+## list. `go run ./cmd/audit_test_subtests/ -fix` rewrites the unambiguous
+## sites; a `// sequential:` comment above a loop declares dependent steps.
+audit-test-subtests:
+	go run ./cmd/audit_test_subtests/ -json plan/test-subtests-backlog.json
+
+## check-test-subtests: fail when any case loop still asserts without a
+## subtest. CI gate.
+check-test-subtests:
+	go run ./cmd/audit_test_subtests/ -check
 
 ## audit-gateway-chars: report served descriptions and titles violating the
 ## gateway-safe text policy (pure ASCII prose, no semicolons), across every

--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,009 |     209,889 |
-| Unit tests (`_test.go`)  |       562 |     317,218 |
+| Unit tests (`_test.go`)  |       562 |     317,390 |
 | End-to-end tests         |       212 |      56,705 |
-| **Total**                | **1,783** | **583,812** |
+| **Total**                | **1,783** | **583,984** |
 
 ### Functions
 
@@ -471,8 +471,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  7,894 |
 | . Exported (public)             |  2,712 |
 | . Unexported (private)          |  5,182 |
-| Unit test functions (`TestXxx`) | 11,798 |
-| Subtests (`t.Run(...)`)         |  4,007 |
+| Unit test functions (`TestXxx`) | 11,803 |
+| Subtests (`t.Run(...)`)         |  4,008 |
 | End-to-end test functions       |    539 |
 
 ### Ratios worth noting
@@ -489,8 +489,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,671 |
-| `defer` statements                 | 1,022 |
+| `if err != nil` checks             | 6,674 |
+| `defer` statements                 | 1,023 |
 | `struct` types defined             | 2,771 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -459,20 +459,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,008 |     209,160 |
-| Unit tests (`_test.go`)  |       561 |     314,826 |
-| End-to-end tests         |       212 |      56,627 |
-| **Total**                | **1,781** | **580,613** |
+| Source (`.go`, non-test) |     1,009 |     209,866 |
+| Unit tests (`_test.go`)  |       562 |     317,218 |
+| End-to-end tests         |       212 |      56,705 |
+| **Total**                | **1,783** | **583,789** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  7,863 |
+| Source functions                |  7,894 |
 | . Exported (public)             |  2,712 |
-| . Unexported (private)          |  5,151 |
-| Unit test functions (`TestXxx`) | 11,793 |
-| Subtests (`t.Run(...)`)         |  3,125 |
+| . Unexported (private)          |  5,182 |
+| Unit test functions (`TestXxx`) | 11,798 |
+| Subtests (`t.Run(...)`)         |  4,007 |
 | End-to-end test functions       |    539 |
 
 ### Ratios worth noting
@@ -481,17 +481,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~207 lines |
-| Average test file length           |                 ~561 lines |
-| Comment lines in source            |  28,422 (~13.6% of source) |
+| Average test file length           |                 ~564 lines |
+| Comment lines in source            |  28,516 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,656 |
+| `if err != nil` checks             | 6,671 |
 | `defer` statements                 | 1,022 |
-| `struct` types defined             | 2,763 |
+| `struct` types defined             | 2,770 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -499,7 +499,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   241 |
+| Go packages                    |   242 |
 | Direct dependencies (`go.mod`) |    29 |
 | Indirect dependencies          |    31 |
 
@@ -508,13 +508,13 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Record              | File                                                    |
 | ------------------- | ------------------------------------------------------- |
 | Longest source file | `internal/tools/dynamic/register.go`. 3,882 lines       |
-| Longest test file   | `internal/tools/projects/projects_test.go`. 8,183 lines |
+| Longest test file   | `internal/tools/projects/projects_test.go`. 8,229 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,802 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,815 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,787 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,009 |     209,878 |
+| Source (`.go`, non-test) |     1,009 |     209,889 |
 | Unit tests (`_test.go`)  |       562 |     317,218 |
 | End-to-end tests         |       212 |      56,705 |
-| **Total**                | **1,783** | **583,801** |
+| **Total**                | **1,783** | **583,812** |
 
 ### Functions
 
@@ -482,7 +482,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.51× more tests than code |
 | Average source file length         |                 ~208 lines |
 | Average test file length           |                 ~564 lines |
-| Comment lines in source            |  28,518 (~13.6% of source) |
+| Comment lines in source            |  28,520 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -491,7 +491,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 6,671 |
 | `defer` statements                 | 1,022 |
-| `struct` types defined             | 2,770 |
+| `struct` types defined             | 2,771 |
 | `//nolint` suppressions            |   250 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -514,7 +514,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,815 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~3,816 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 12,787 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,009 |     209,866 |
+| Source (`.go`, non-test) |     1,009 |     209,878 |
 | Unit tests (`_test.go`)  |       562 |     317,218 |
 | End-to-end tests         |       212 |      56,705 |
-| **Total**                | **1,783** | **583,789** |
+| **Total**                | **1,783** | **583,801** |
 
 ### Functions
 
@@ -480,9 +480,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.51× more tests than code |
-| Average source file length         |                 ~207 lines |
+| Average source file length         |                 ~208 lines |
 | Average test file length           |                 ~564 lines |
-| Comment lines in source            |  28,516 (~13.6% of source) |
+| Comment lines in source            |  28,518 (~13.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/cmd/audit_1to1/docvalidate_test.go
+++ b/cmd/audit_1to1/docvalidate_test.go
@@ -33,9 +33,11 @@ func TestScanDocCitations(t *testing.T) {
 		}
 	}
 	for a, found := range want {
-		if !found {
-			t.Errorf("expected citation %q not found in %v", a, areas)
-		}
+		t.Run(a, func(t *testing.T) {
+			if !found {
+				t.Errorf("expected citation %q not found in %v", a, areas)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_1to1/internal/actions/analyze_test.go
+++ b/cmd/audit_1to1/internal/actions/analyze_test.go
@@ -17,9 +17,11 @@ func TestShortPackage_ExtractsDomain(t *testing.T) {
 		"a/b/c":                                                            "c",
 	}
 	for input, want := range cases {
-		if got := shortPackage(input); got != want {
-			t.Errorf("shortPackage(%q) = %q, want %q", input, got, want)
-		}
+		t.Run(input, func(t *testing.T) {
+			if got := shortPackage(input); got != want {
+				t.Errorf("shortPackage(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_1to1/internal/merge/merge_test.go
+++ b/cmd/audit_1to1/internal/merge/merge_test.go
@@ -73,10 +73,12 @@ func TestBuildBacklog_MergesThreeStreams(t *testing.T) {
 		t.Errorf("branches metadata not merged: %+v", branches.Metadata)
 	}
 	for _, name := range []string{"mrdiscussions", "issuediscussions"} {
-		pkg, found := pkgs[name]
-		if !found || len(pkg.Actions) != 1 || len(pkg.Actions[0].MissingMethods) != 2 {
-			t.Errorf("%s did not receive shared service gap: %+v", name, pkg.Actions)
-		}
+		t.Run(name, func(t *testing.T) {
+			pkg, found := pkgs[name]
+			if !found || len(pkg.Actions) != 1 || len(pkg.Actions[0].MissingMethods) != 2 {
+				t.Errorf("%s did not receive shared service gap: %+v", name, pkg.Actions)
+			}
+		})
 	}
 	if _, found := pkgs["clean"]; found {
 		t.Error("clean service has no missing methods and must not appear")

--- a/cmd/audit_1to1/internal/metadata/analyze_test.go
+++ b/cmd/audit_1to1/internal/metadata/analyze_test.go
@@ -20,18 +20,22 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"use to execute markdown_render action",
 	}
 	for _, usage := range generic {
-		if !auditshared.IsGenericUsage(usage) {
-			t.Errorf("isGenericUsage(%q) = false, want true", usage)
-		}
+		t.Run(usage, func(t *testing.T) {
+			if !auditshared.IsGenericUsage(usage) {
+				t.Errorf("isGenericUsage(%q) = false, want true", usage)
+			}
+		})
 	}
 	specific := []string{
 		"List branches for a project with optional search and pagination.",
 		"Create a new branch from a ref. Returns the created branch.",
 	}
 	for _, usage := range specific {
-		if auditshared.IsGenericUsage(usage) {
-			t.Errorf("isGenericUsage(%q) = true, want false", usage)
-		}
+		t.Run(usage, func(t *testing.T) {
+			if auditshared.IsGenericUsage(usage) {
+				t.Errorf("isGenericUsage(%q) = true, want false", usage)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_1to1/internal/structs/analyze_test.go
+++ b/cmd/audit_1to1/internal/structs/analyze_test.go
@@ -80,29 +80,37 @@ func TestScalarLike_ClassifiesGoScalars(t *testing.T) {
 // int/string, and SDK time types projected onto string. Genuinely divergent
 // struct types are reported as incompatible.
 func TestTypesCompatible_AcceptsKnownProjections(t *testing.T) {
-	compatible := [][2]string{
-		{"string", "*string"},
-		{"int", "int64"},
-		{"int", "*v2.AccessLevelValue"},
-		{"string", "v2.VisibilityValue"},
-		{"string", "*v2.ISOTime"},
-		{"string", "time.Time"},
-		{"bool", "*bool"},
+	compatible := []struct {
+		name, mcpType, sdkType string
+	}{
+		{"string_to_pointer", "string", "*string"},
+		{"int_to_int64", "int", "int64"},
+		{"int_to_access_level_pointer", "int", "*v2.AccessLevelValue"},
+		{"string_to_visibility", "string", "v2.VisibilityValue"},
+		{"string_to_isotime_pointer", "string", "*v2.ISOTime"},
+		{"string_to_time", "string", "time.Time"},
+		{"bool_to_pointer", "bool", "*bool"},
 	}
-	for _, pair := range compatible {
-		if !typesCompatible(pair[0], pair[1]) {
-			t.Errorf("typesCompatible(%q, %q) = false, want true", pair[0], pair[1])
-		}
+	for _, tc := range compatible {
+		t.Run(tc.name, func(t *testing.T) {
+			if !typesCompatible(tc.mcpType, tc.sdkType) {
+				t.Errorf("typesCompatible(%q, %q) = false, want true", tc.mcpType, tc.sdkType)
+			}
+		})
 	}
-	incompatible := [][2]string{
-		{"string", "*v2.Commit"},
-		{"int", "[]string"},
-		{"v2.Foo", "v2.Bar"},
+	incompatible := []struct {
+		name, mcpType, sdkType string
+	}{
+		{"string_vs_struct_pointer", "string", "*v2.Commit"},
+		{"int_vs_string_slice", "int", "[]string"},
+		{"distinct_structs", "v2.Foo", "v2.Bar"},
 	}
-	for _, pair := range incompatible {
-		if typesCompatible(pair[0], pair[1]) {
-			t.Errorf("typesCompatible(%q, %q) = true, want false", pair[0], pair[1])
-		}
+	for _, tc := range incompatible {
+		t.Run(tc.name, func(t *testing.T) {
+			if typesCompatible(tc.mcpType, tc.sdkType) {
+				t.Errorf("typesCompatible(%q, %q) = true, want false", tc.mcpType, tc.sdkType)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_1to1/internal/structs/analyze_test.go
+++ b/cmd/audit_1to1/internal/structs/analyze_test.go
@@ -48,9 +48,11 @@ func TestNormalizeType_StripsPointerAndCase(t *testing.T) {
 		"*v2.AccessLevelV": "v2.accesslevelv",
 	}
 	for input, want := range cases {
-		if got := normalizeType(input); got != want {
-			t.Errorf("normalizeType(%q) = %q, want %q", input, got, want)
-		}
+		t.Run(input, func(t *testing.T) {
+			if got := normalizeType(input); got != want {
+				t.Errorf("normalizeType(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -58,14 +60,18 @@ func TestNormalizeType_StripsPointerAndCase(t *testing.T) {
 // pointer/value scalar projections as compatible.
 func TestScalarLike_ClassifiesGoScalars(t *testing.T) {
 	for _, ok := range []string{"int", "int64", "int32", "float64", "float32", "bool", "string"} {
-		if !scalarLike(ok) {
-			t.Errorf("scalarLike(%q) = false, want true", ok)
-		}
+		t.Run(ok, func(t *testing.T) {
+			if !scalarLike(ok) {
+				t.Errorf("scalarLike(%q) = false, want true", ok)
+			}
+		})
 	}
 	for _, no := range []string{"v2.commit", "[]string", "map[string]int", ""} {
-		if scalarLike(no) {
-			t.Errorf("scalarLike(%q) = true, want false", no)
-		}
+		t.Run(no, func(t *testing.T) {
+			if scalarLike(no) {
+				t.Errorf("scalarLike(%q) = true, want false", no)
+			}
+		})
 	}
 }
 
@@ -240,15 +246,19 @@ func TestExtraOutputFields_FlagsInventedScalars(t *testing.T) {
 	}
 	wantExtra := []string{"author_username", "milestone_title"}
 	for _, tag := range wantExtra {
-		if !gotTags[tag] {
-			t.Errorf("expected %q reported as extra output field, got %v", tag, extras)
-		}
+		t.Run(tag, func(t *testing.T) {
+			if !gotTags[tag] {
+				t.Errorf("expected %q reported as extra output field, got %v", tag, extras)
+			}
+		})
 	}
 	wantNotExtra := []string{"id", "iids", "pagination", "next_steps", "-"}
 	for _, tag := range wantNotExtra {
-		if gotTags[tag] {
-			t.Errorf("did not expect %q reported as extra output field, got %v", tag, extras)
-		}
+		t.Run(tag, func(t *testing.T) {
+			if gotTags[tag] {
+				t.Errorf("did not expect %q reported as extra output field, got %v", tag, extras)
+			}
+		})
 	}
 	if len(extras) != len(wantExtra) {
 		t.Errorf("extra count = %d (%v), want %d", len(extras), extras, len(wantExtra))
@@ -283,15 +293,19 @@ func TestNonResultStructName_ExcludesWrapperOptionsAndTime(t *testing.T) {
 		"Time",                           // time.Time value type
 	}
 	for _, name := range nonResult {
-		if !nonResultStructName(name) {
-			t.Errorf("nonResultStructName(%q) = false, want true", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !nonResultStructName(name) {
+				t.Errorf("nonResultStructName(%q) = false, want true", name)
+			}
+		})
 	}
 	result := []string{"Issue", "MergeRequest", "Branch", "PersonalAccessToken", "Response2", "OptionsList"}
 	for _, name := range result {
-		if nonResultStructName(name) {
-			t.Errorf("nonResultStructName(%q) = true, want false", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if nonResultStructName(name) {
+				t.Errorf("nonResultStructName(%q) = true, want false", name)
+			}
+		})
 	}
 }
 
@@ -388,16 +402,18 @@ func TestBuildReport_NoFalsePositiveExtras(t *testing.T) {
 
 	// The issue family must report zero extras after the family cleanup.
 	for _, name := range []string{"issues", "issuenotes", "issuediscussions"} {
-		pr := findPackage(t, rep, name)
-		if pr.ExtraOutputCount != 0 {
-			var tags []string
-			for _, g := range pr.Gaps {
-				for _, e := range g.ExtraFields {
-					tags = append(tags, e.Tag)
+		t.Run(name, func(t *testing.T) {
+			pr := findPackage(t, rep, name)
+			if pr.ExtraOutputCount != 0 {
+				var tags []string
+				for _, g := range pr.Gaps {
+					for _, e := range g.ExtraFields {
+						tags = append(tags, e.Tag)
+					}
 				}
+				t.Errorf("package %q has %d extra output fields, want 0 (tags: %v)", name, pr.ExtraOutputCount, tags)
 			}
-			t.Errorf("package %q has %d extra output fields, want 0 (tags: %v)", name, pr.ExtraOutputCount, tags)
-		}
+		})
 	}
 }
 
@@ -574,16 +590,18 @@ func TestDisjointPhantomInput_SkipsDisjointHelperOptions(t *testing.T) {
 func TestBuildReport_NoDiffPositionPhantomInput(t *testing.T) {
 	rep := cachedBuildReport(t, false)
 	for _, name := range []string{"mrdiscussions", "mrdraftnotes"} {
-		pr := findPackage(t, rep, name)
-		for _, g := range pr.Gaps {
-			if g.Kind != "input" || g.MCPType != "DiffPosition" {
-				continue
+		t.Run(name, func(t *testing.T) {
+			pr := findPackage(t, rep, name)
+			for _, g := range pr.Gaps {
+				if g.Kind != "input" || g.MCPType != "DiffPosition" {
+					continue
+				}
+				if g.SDKType != "v2.PositionOptions" {
+					t.Errorf("%s: DiffPosition paired against %q, want only v2.PositionOptions (phantom not suppressed): missing=%v",
+						name, g.SDKType, g.MissingFields)
+				}
 			}
-			if g.SDKType != "v2.PositionOptions" {
-				t.Errorf("%s: DiffPosition paired against %q, want only v2.PositionOptions (phantom not suppressed): missing=%v",
-					name, g.SDKType, g.MissingFields)
-			}
-		}
+		})
 	}
 }
 
@@ -708,9 +726,11 @@ func TestBuildReport_AuditedPairFloors(t *testing.T) {
 		"users":               5,
 	}
 	for name, floor := range outputFloors {
-		pr := findPackage(t, rep, name)
-		if pr.OutputPairs < floor {
-			t.Errorf("%s output_pairs = %d, want >= %d (lost audited pair; check the package-local converter wrappers for its toolutil-shared shapes)", name, pr.OutputPairs, floor)
-		}
+		t.Run(name, func(t *testing.T) {
+			pr := findPackage(t, rep, name)
+			if pr.OutputPairs < floor {
+				t.Errorf("%s output_pairs = %d, want >= %d (lost audited pair; check the package-local converter wrappers for its toolutil-shared shapes)", name, pr.OutputPairs, floor)
+			}
+		})
 	}
 }

--- a/cmd/audit_discovery_completeness/main_test.go
+++ b/cmd/audit_discovery_completeness/main_test.go
@@ -32,18 +32,22 @@ func TestIsGenericUsage_FlagsPlaceholders(t *testing.T) {
 		"use to execute markdown_render action",
 	}
 	for _, usage := range generic {
-		if !auditshared.IsGenericUsage(usage) {
-			t.Errorf("isGenericUsage(%q) = false, want true", usage)
-		}
+		t.Run(usage, func(t *testing.T) {
+			if !auditshared.IsGenericUsage(usage) {
+				t.Errorf("isGenericUsage(%q) = false, want true", usage)
+			}
+		})
 	}
 	specific := []string{
 		"List branches for a project with optional search and pagination.",
 		"Create MULTIPLE release asset links in one call. Use this instead of repeated link_create.",
 	}
 	for _, usage := range specific {
-		if auditshared.IsGenericUsage(usage) {
-			t.Errorf("isGenericUsage(%q) = true, want false", usage)
-		}
+		t.Run(usage, func(t *testing.T) {
+			if auditshared.IsGenericUsage(usage) {
+				t.Errorf("isGenericUsage(%q) = true, want false", usage)
+			}
+		})
 	}
 }
 
@@ -96,9 +100,11 @@ func TestBaseActionStem_StripsVariantAndCRUDSuffixes(t *testing.T) {
 		"link_create":               "link",
 	}
 	for in, want := range cases {
-		if got := baseActionStem(in); got != want {
-			t.Errorf("baseActionStem(%q) = %q, want %q", in, got, want)
-		}
+		t.Run(in, func(t *testing.T) {
+			if got := baseActionStem(in); got != want {
+				t.Errorf("baseActionStem(%q) = %q, want %q", in, got, want)
+			}
+		})
 	}
 }
 
@@ -275,9 +281,11 @@ func TestHasNonCRUDVariantSuffix(t *testing.T) {
 		"notes.delete_all",
 	}
 	for _, name := range variant {
-		if !hasNonCRUDVariantSuffix(name) {
-			t.Errorf("hasNonCRUDVariantSuffix(%q) = false, want true", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !hasNonCRUDVariantSuffix(name) {
+				t.Errorf("hasNonCRUDVariantSuffix(%q) = false, want true", name)
+			}
+		})
 	}
 	crud := []string{
 		"branch.list",
@@ -289,9 +297,11 @@ func TestHasNonCRUDVariantSuffix(t *testing.T) {
 		"deploy_key_get",
 	}
 	for _, name := range crud {
-		if hasNonCRUDVariantSuffix(name) {
-			t.Errorf("hasNonCRUDVariantSuffix(%q) = true, want false", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if hasNonCRUDVariantSuffix(name) {
+				t.Errorf("hasNonCRUDVariantSuffix(%q) = true, want false", name)
+			}
+		})
 	}
 }
 
@@ -311,9 +321,11 @@ func TestBaseActionStem_StripsScopeSuffixes(t *testing.T) {
 		"pages_domain_list_project": "pages_domain",
 	}
 	for in, want := range cases {
-		if got := baseActionStem(in); got != want {
-			t.Errorf("baseActionStem(%q) = %q, want %q", in, got, want)
-		}
+		t.Run(in, func(t *testing.T) {
+			if got := baseActionStem(in); got != want {
+				t.Errorf("baseActionStem(%q) = %q, want %q", in, got, want)
+			}
+		})
 	}
 }
 
@@ -335,9 +347,11 @@ func TestSiblingMatches_AcceptsPrefixedAndUnderscoreForms(t *testing.T) {
 		"totally_unrelated":    false, // no match
 	}
 	for in, want := range cases {
-		if got := siblingMatches(strings.ToLower(in), siblings); got != want {
-			t.Errorf("siblingMatches(%q) = %v, want %v", in, got, want)
-		}
+		t.Run(in, func(t *testing.T) {
+			if got := siblingMatches(strings.ToLower(in), siblings); got != want {
+				t.Errorf("siblingMatches(%q) = %v, want %v", in, got, want)
+			}
+		})
 	}
 }
 
@@ -398,9 +412,11 @@ func TestUsageHasSignal_DetectsDistinguishingPhrases(t *testing.T) {
 		"Publish all assets in a directory.":               true,
 	}
 	for in, want := range cases {
-		if got := usageHasSignal(in); got != want {
-			t.Errorf("usageHasSignal(%q) = %v, want %v", in, got, want)
-		}
+		t.Run(in, func(t *testing.T) {
+			if got := usageHasSignal(in); got != want {
+				t.Errorf("usageHasSignal(%q) = %v, want %v", in, got, want)
+			}
+		})
 	}
 }
 
@@ -430,9 +446,11 @@ func TestEmptyParamDescription_FlagsBoilerplate(t *testing.T) {
 	// "nested.deep" (nested empty). "good" should pass.
 	wantContains := []string{"name", "id", "nested.deep"}
 	for _, w := range wantContains {
-		if !containsStr(got, w) {
-			t.Errorf("emptyParamDescriptions missing %q in %v", w, got)
-		}
+		t.Run(w, func(t *testing.T) {
+			if !containsStr(got, w) {
+				t.Errorf("emptyParamDescriptions missing %q in %v", w, got)
+			}
+		})
 	}
 	for _, g := range got {
 		if g == "good" {
@@ -823,14 +841,18 @@ func TestIsScopeSuggestiveName(t *testing.T) {
 	}
 	no := []string{"name", "color", "description", "content", "labels"}
 	for _, n := range yes {
-		if !isScopeSuggestiveName(n) {
-			t.Errorf("%q should be scope-suggestive", n)
-		}
+		t.Run(n, func(t *testing.T) {
+			if !isScopeSuggestiveName(n) {
+				t.Errorf("%q should be scope-suggestive", n)
+			}
+		})
 	}
 	for _, n := range no {
-		if isScopeSuggestiveName(n) {
-			t.Errorf("%q should NOT be scope-suggestive", n)
-		}
+		t.Run(n, func(t *testing.T) {
+			if isScopeSuggestiveName(n) {
+				t.Errorf("%q should NOT be scope-suggestive", n)
+			}
+		})
 	}
 }
 
@@ -854,14 +876,18 @@ func TestDescriptionImpliesEnum(t *testing.T) {
 		"Numeric merge request IID",
 	}
 	for _, d := range yes {
-		if !descriptionImpliesEnum(d) {
-			t.Errorf("descriptionImpliesEnum(%q) = false, want true", d)
-		}
+		t.Run(d, func(t *testing.T) {
+			if !descriptionImpliesEnum(d) {
+				t.Errorf("descriptionImpliesEnum(%q) = false, want true", d)
+			}
+		})
 	}
 	for _, d := range no {
-		if descriptionImpliesEnum(d) {
-			t.Errorf("descriptionImpliesEnum(%q) = true, want false", d)
-		}
+		t.Run(d, func(t *testing.T) {
+			if descriptionImpliesEnum(d) {
+				t.Errorf("descriptionImpliesEnum(%q) = true, want false", d)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_discovery_completeness/main_test.go
+++ b/cmd/audit_discovery_completeness/main_test.go
@@ -239,11 +239,13 @@ func TestMissingDisambiguation_OnlyFlagsNonCRUDVariants(t *testing.T) {
 		t.Fatalf("expected 1 cluster, got %+v", clusters)
 	}
 	for _, spec := range crud {
-		members := clusterMembersFor(clusters, spec.OwnerPackage, spec.Name)
-		finding := analyzeSpec(spec, nil, members, 3)
-		if containsStr(finding.Flags, "missing_disambiguation") {
-			t.Errorf("pure CRUD member %q should NOT be flagged missing_disambiguation: %+v", spec.Name, finding.Flags)
-		}
+		t.Run(spec.Name, func(t *testing.T) {
+			members := clusterMembersFor(clusters, spec.OwnerPackage, spec.Name)
+			finding := analyzeSpec(spec, nil, members, 3)
+			if containsStr(finding.Flags, "missing_disambiguation") {
+				t.Errorf("pure CRUD member %q should NOT be flagged missing_disambiguation: %+v", spec.Name, finding.Flags)
+			}
+		})
 	}
 
 	// Base-vs-variant cluster: link_create (base) + link_create_batch (variant).

--- a/cmd/audit_doc_coverage/main_test.go
+++ b/cmd/audit_doc_coverage/main_test.go
@@ -271,23 +271,26 @@ Body.
 // trip the auditor.
 func TestTier_Badge_Matches(t *testing.T) {
 	tests := []struct {
+		name    string
 		edition string
 		badge   string
 		want    bool
 	}{
-		{"", "", true},
-		{"", "Premium", true}, // free tools tolerate any badge (no badge expected)
-		{"premium", "Premium", true},
-		{"premium", "Ultimate", false},
-		{"ultimate", "Ultimate", true},
-		{"ultimate", "Premium", false},
-		{"ultimate", "", true}, // missing badge on Ultimate is not flagged here
+		{"free_without_badge", "", "", true},
+		{"free_tolerates_any_badge", "", "Premium", true}, // no badge is expected on a free tool
+		{"premium_matches", "premium", "Premium", true},
+		{"premium_badged_ultimate", "premium", "Ultimate", false},
+		{"ultimate_matches", "ultimate", "Ultimate", true},
+		{"ultimate_badged_premium", "ultimate", "Premium", false},
+		{"ultimate_missing_badge", "ultimate", "", true}, // a missing badge on Ultimate is not flagged here
 	}
 	for _, tc := range tests {
-		got := tierBadgeMatches(tc.badge, tc.edition)
-		if got != tc.want {
-			t.Errorf("tierBadgeMatches(%q, %q) = %v, want %v", tc.badge, tc.edition, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := tierBadgeMatches(tc.badge, tc.edition)
+			if got != tc.want {
+				t.Errorf("tierBadgeMatches(%q, %q) = %v, want %v", tc.badge, tc.edition, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -504,19 +507,22 @@ func TestCheck_FailsWhenFindingsPresent(t *testing.T) {
 // canonical docs/reference/tools/<name>.md path used everywhere else.
 func TestRelative_DocPath(t *testing.T) {
 	tests := []struct {
+		name string
 		link string
 		want string
 	}{
-		{"projects.md", "docs/reference/tools/projects.md"},
-		{"branch-rules.md", "docs/reference/tools/branch-rules.md"},
-		{"branches.md", "docs/reference/tools/branches.md"},
-		{"", "docs/reference/tools/"},
+		{"plain_doc", "projects.md", "docs/reference/tools/projects.md"},
+		{"hyphenated_doc", "branch-rules.md", "docs/reference/tools/branch-rules.md"},
+		{"sibling_doc", "branches.md", "docs/reference/tools/branches.md"},
+		{"empty_link", "", "docs/reference/tools/"},
 	}
 	for _, tc := range tests {
-		got := relativeDocPath(tc.link)
-		if got != tc.want {
-			t.Errorf("relativeDocPath(%q) = %q, want %q", tc.link, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := relativeDocPath(tc.link)
+			if got != tc.want {
+				t.Errorf("relativeDocPath(%q) = %q, want %q", tc.link, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_edition_tier/main_test.go
+++ b/cmd/audit_edition_tier/main_test.go
@@ -116,10 +116,12 @@ func TestClassifyDomain_Buckets(t *testing.T) {
 		{"mixed", domainReport{}, []tier{tierUltimate}, tierFree, true, "mixed", true},
 	}
 	for _, c := range cases {
-		gotClass, gotWork := classifyDomain(c.dr, c.overrides, c.page, c.fetched)
-		if gotClass != c.wantClass || gotWork != c.wantWork {
-			t.Errorf("%s: classifyDomain = (%q, %v); want (%q, %v)", c.name, gotClass, gotWork, c.wantClass, c.wantWork)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			gotClass, gotWork := classifyDomain(c.dr, c.overrides, c.page, c.fetched)
+			if gotClass != c.wantClass || gotWork != c.wantWork {
+				t.Errorf("%s: classifyDomain = (%q, %v); want (%q, %v)", c.name, gotClass, gotWork, c.wantClass, c.wantWork)
+			}
+		})
 	}
 }
 
@@ -143,11 +145,13 @@ func TestDocOverrideForAction_PrefixMatch(t *testing.T) {
 		{"project.hook_list", "", false, false},
 	}
 	for _, c := range cases {
-		ref, ok := docOverrideForAction(c.id)
-		if ok != c.wantOK || ref.area != c.wantArea || ref.userDoc != c.wantUser {
-			t.Errorf("docOverrideForAction(%q) = (%+v, %v); want (area %q, userDoc %v, %v)",
-				c.id, ref, ok, c.wantArea, c.wantUser, c.wantOK)
-		}
+		t.Run(c.id, func(t *testing.T) {
+			ref, ok := docOverrideForAction(c.id)
+			if ok != c.wantOK || ref.area != c.wantArea || ref.userDoc != c.wantUser {
+				t.Errorf("docOverrideForAction(%q) = (%+v, %v); want (area %q, userDoc %v, %v)",
+					c.id, ref, ok, c.wantArea, c.wantUser, c.wantOK)
+			}
+		})
 	}
 }
 
@@ -215,13 +219,15 @@ func TestExpectedTierForAction_DocOverride_GradesAgainstReferencedPage(t *testin
 		{"merge_request.dependencies_list", tierPremium, "doc/user/project/merge_requests/dependencies.md"},
 	}
 	for _, c := range cases {
-		got, note := res.expectedTierForAction(context.Background(), c.id, tierFree)
-		if got != c.wantTier {
-			t.Errorf("expectedTierForAction(%q) tier = %v; want %v", c.id, got, c.wantTier)
-		}
-		if !strings.Contains(note, c.wantNote) {
-			t.Errorf("expectedTierForAction(%q) note = %q; want it to cite %q", c.id, note, c.wantNote)
-		}
+		t.Run(c.id, func(t *testing.T) {
+			got, note := res.expectedTierForAction(context.Background(), c.id, tierFree)
+			if got != c.wantTier {
+				t.Errorf("expectedTierForAction(%q) tier = %v; want %v", c.id, got, c.wantTier)
+			}
+			if !strings.Contains(note, c.wantNote) {
+				t.Errorf("expectedTierForAction(%q) note = %q; want it to cite %q", c.id, note, c.wantNote)
+			}
+		})
 	}
 }
 
@@ -256,15 +262,17 @@ func TestExpectedTierForAction_ExceptionWinsOverPageTier(t *testing.T) {
 		{"merge_request.approval_state", "live-verified Premium"},
 	}
 	for _, c := range cases {
-		got, note := res.expectedTierForAction(context.Background(), c.id, tierFree)
-		if got != tierPremium {
-			t.Errorf("expectedTierForAction(%q) tier = %v; want premium", c.id, got)
-		}
-		if note == "" {
-			t.Errorf("expectedTierForAction(%q) note is empty; want the audited rationale", c.id)
-		}
-		if c.wantNote != "" && !strings.Contains(note, c.wantNote) {
-			t.Errorf("expectedTierForAction(%q) note = %q; want it to contain %q", c.id, note, c.wantNote)
-		}
+		t.Run(c.id, func(t *testing.T) {
+			got, note := res.expectedTierForAction(context.Background(), c.id, tierFree)
+			if got != tierPremium {
+				t.Errorf("expectedTierForAction(%q) tier = %v; want premium", c.id, got)
+			}
+			if note == "" {
+				t.Errorf("expectedTierForAction(%q) note is empty; want the audited rationale", c.id)
+			}
+			if c.wantNote != "" && !strings.Contains(note, c.wantNote) {
+				t.Errorf("expectedTierForAction(%q) note = %q; want it to contain %q", c.id, note, c.wantNote)
+			}
+		})
 	}
 }

--- a/cmd/audit_edition_tier/main_test.go
+++ b/cmd/audit_edition_tier/main_test.go
@@ -15,22 +15,25 @@ import (
 // because a badge lists every tier the endpoint is available in.
 func TestParseTierBadge_Values_MapToMinimumTier(t *testing.T) {
 	cases := []struct {
+		name  string
 		value string
 		want  tier
 		ok    bool
 	}{
-		{"Free, Premium, Ultimate", tierFree, true},
-		{"Premium, Ultimate", tierPremium, true},
-		{"Ultimate", tierUltimate, true},
-		{"premium, ultimate", tierPremium, true},
-		{"", tierFree, false},
-		{"Something else", tierFree, false},
+		{"all_tiers_is_free", "Free, Premium, Ultimate", tierFree, true},
+		{"premium_and_ultimate_is_premium", "Premium, Ultimate", tierPremium, true},
+		{"ultimate_only", "Ultimate", tierUltimate, true},
+		{"lowercase_names", "premium, ultimate", tierPremium, true},
+		{"empty_value", "", tierFree, false},
+		{"unknown_value", "Something else", tierFree, false},
 	}
 	for _, c := range cases {
-		got, ok := parseTierBadge(c.value)
-		if got != c.want || ok != c.ok {
-			t.Errorf("parseTierBadge(%q) = (%v, %v); want (%v, %v)", c.value, got, ok, c.want, c.ok)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseTierBadge(c.value)
+			if got != c.want || ok != c.ok {
+				t.Errorf("parseTierBadge(%q) = (%v, %v); want (%v, %v)", c.value, got, ok, c.want, c.ok)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_metrics/main_test.go
+++ b/cmd/audit_metrics/main_test.go
@@ -86,9 +86,11 @@ func TestListDynamicTools_ExposesTwoTools(t *testing.T) {
 	}
 	sort.Strings(names)
 	for _, want := range []string{"gitlab_execute_action", "gitlab_find_action"} {
-		if !slices.Contains(names, want) {
-			t.Fatalf("listDynamicTools() names = %v, missing %q", names, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !slices.Contains(names, want) {
+				t.Fatalf("listDynamicTools() names = %v, missing %q", names, want)
+			}
+		})
 	}
 }
 
@@ -199,9 +201,11 @@ func TestPrintDynamicSearchMetrics_IncludesAllSurfaces(t *testing.T) {
 		"Dynamic aliases ambiguous (GitLab.com enterprise)",
 		"18",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printDynamicSearchMetrics() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printDynamicSearchMetrics() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 
@@ -269,9 +273,11 @@ func TestPrintEnterpriseActionSpecAudit_IncludesMissingSpecZeroSection(t *testin
 		"Enterprise actions missing ActionSpec (0)",
 		"none",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printEnterpriseActionSpecAudit() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printEnterpriseActionSpecAudit() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 
@@ -420,9 +426,11 @@ func TestPrintActionIDList_ListsAllIDs(t *testing.T) {
 	})
 
 	for _, want := range []string{"alpha.list", "beta.get", "gamma.create"} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printActionIDList() missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printActionIDList() missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 
@@ -483,9 +491,11 @@ func TestPrintDomainTable_FewerThan20DomainsPrintsAll(t *testing.T) {
 	})
 
 	for _, want := range []string{"alpha", "beta", "gamma"} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printDomainTable() missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printDomainTable() missing %q:\n%s", want, output)
+			}
+		})
 	}
 	if strings.Contains(output, "and") {
 		t.Fatalf("printDomainTable() should not show overflow:\n%s", output)
@@ -531,9 +541,11 @@ func TestPrintMetaSchemaModes_ListsActiveAndAllModes(t *testing.T) {
 		"mode",
 		"total bytes",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printMetaSchemaModes() missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printMetaSchemaModes() missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_surface_quality/metadata_audit_test.go
+++ b/cmd/audit_surface_quality/metadata_audit_test.go
@@ -266,9 +266,11 @@ func TestPrintReport_EmptyViolationsWritesNoViolationsMessage(t *testing.T) {
 		"| Total violations | 0 |",
 		"**No violations found.**",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printReport() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printReport() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 
@@ -298,9 +300,11 @@ func TestPrintReport_GroupsViolationsByCategory(t *testing.T) {
 		"`tool_b` | too short",
 		"### Individual Tools (2)",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printReport() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printReport() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_surface_quality/metadata_register_meta_test.go
+++ b/cmd/audit_surface_quality/metadata_register_meta_test.go
@@ -172,9 +172,11 @@ func TestPrintRegisterMetaDefinitions_WritesInventorySummary(t *testing.T) {
 		"| unexpected | `runners` | `internal/tools/runners/register.go` | `-` |",
 	}
 	for _, expected := range expectedFragments {
-		if !strings.Contains(output, expected) {
-			t.Fatalf("output missing %q:\n%s", expected, output)
-		}
+		t.Run(expected, func(t *testing.T) {
+			if !strings.Contains(output, expected) {
+				t.Fatalf("output missing %q:\n%s", expected, output)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_surface_quality/output_audit_test.go
+++ b/cmd/audit_surface_quality/output_audit_test.go
@@ -291,9 +291,11 @@ func TestPrintReport_EmptyFindingsWritesNoFindingsMessage(t *testing.T) {
 		"| Total tools | 1 | 0 |",
 		"**No findings. All quality checks pass.**",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printReport() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printReport() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 
@@ -322,9 +324,11 @@ func TestPrintReport_GroupsFindingsByCategory(t *testing.T) {
 		"`tool_a` | missing Title",
 		"`tool_c` | no Returns",
 	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("printReport() output missing %q:\n%s", want, output)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(output, want) {
+				t.Fatalf("printReport() output missing %q:\n%s", want, output)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_test_goroutines/main_test.go
+++ b/cmd/audit_test_goroutines/main_test.go
@@ -102,9 +102,11 @@ func TestScan_FixtureClassification(t *testing.T) {
 		boundaries[f.Boundary] = true
 	}
 	for _, want := range []string{"http.HandlerFunc", "go statement", ".Go(...)", "handler field ElicitationHandler"} {
-		if !boundaries[want] {
-			t.Errorf("missing boundary kind %q in %v", want, boundaries)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !boundaries[want] {
+				t.Errorf("missing boundary kind %q in %v", want, boundaries)
+			}
+		})
 	}
 }
 

--- a/cmd/audit_test_names/main_test.go
+++ b/cmd/audit_test_names/main_test.go
@@ -189,9 +189,11 @@ func TestCreateIssueReturnsIssue(t *testing.T) {}
 		t.Fatalf("CSV header = %v, want %v", records[0], wantHeader)
 	}
 	for i, col := range wantHeader {
-		if records[0][i] != col {
-			t.Errorf("CSV header[%d] = %q, want %q", i, records[0][i], col)
-		}
+		t.Run(col, func(t *testing.T) {
+			if records[0][i] != col {
+				t.Errorf("CSV header[%d] = %q, want %q", i, records[0][i], col)
+			}
+		})
 	}
 	patterns := map[string]string{}
 	for _, rec := range records[1:] {

--- a/cmd/audit_test_subtests/main.go
+++ b/cmd/audit_test_subtests/main.go
@@ -1,0 +1,706 @@
+// Command audit_test_subtests finds case loops in test functions that assert
+// without opening a subtest, and can rewrite the mechanical ones.
+//
+// The project's Go guidelines ask for table-driven tests whose cases run
+// under t.Run: a failing case then names itself, a t.Fatal inside one case
+// stops that case rather than the whole table, and `go test -run` can select
+// a single case. The shape that violates the rule is a range over a table
+// (a slice or map literal, inline or bound to a local variable) whose body
+// calls t.Error, t.Errorf, t.Fatal, t.Fatalf, t.Fail or t.FailNow, or hands
+// t to a helper, with no t.Run anywhere inside the loop body.
+//
+// A loop that walks a sequence of dependent steps rather than independent
+// cases is not a table. Mark it with a comment on the line before the loop
+// or at the end of its first line:
+//
+//	// sequential: each step depends on the state the previous one left
+//	for _, step := range []step{...} {
+//
+// and the auditor records it as declared-sequential instead of reporting it.
+// A loop inside a synctest.Test bubble is skipped too: the testing package
+// panics on t.Run called inside a bubble, so the rule cannot apply there and
+// the site is counted separately.
+//
+// -fix rewrites the sites whose subtest name is unambiguous: a []string
+// table names each case after its element, a struct table after a string
+// field called name, desc, description, label, title or id, and a
+// map[string]... table after its key. The body is wrapped in
+// t.Run(name, func(t *testing.T) { ... }) and a bare continue becomes
+// return; bodies that break, goto, or use a table without such a name are
+// left for a hand rewrite and stay in the report.
+//
+// Usage:
+//
+//	go run ./cmd/audit_test_subtests [-json out.json] [-check] [-fix] [dirs...]
+//
+// With no directories the module's test files under ./cmd, ./internal and
+// ./test are scanned. -check exits non-zero when any site remains, so the
+// tool gates CI.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Finding is one case loop that asserts without a subtest.
+type Finding struct {
+	File  string `json:"file"`
+	Line  int    `json:"line"`
+	Test  string `json:"test"`
+	Table string `json:"table"` // inline | named
+	// Fix says how -fix would rewrite the site, or why it cannot:
+	// element | field:<name> | key | needs-name | break | goto | blank-var.
+	Fix string `json:"fix"`
+}
+
+// Report is the JSON work list.
+type Report struct {
+	Findings   []Finding `json:"findings"`
+	Sequential []Finding `json:"sequential"`
+	Synctest   []Finding `json:"synctest"`
+	Summary    Summary   `json:"summary"`
+}
+
+// Summary aggregates what the sweep tracks.
+type Summary struct {
+	Sites      int `json:"sites"`
+	Fixable    int `json:"fixable"`
+	Sequential int `json:"sequential"`
+	Synctest   int `json:"synctest"`
+	Compliant  int `json:"compliant"`
+	Files      int `json:"files"`
+}
+
+// sequentialMarker declares a loop of dependent steps rather than cases.
+const sequentialMarker = "sequential:"
+
+// nameFields are the struct fields, in order of preference, that name a case.
+var nameFields = []string{"name", "desc", "description", "label", "title", "id"}
+
+// assertMethods are the testing.TB methods that record a failure.
+var assertMethods = map[string]bool{"Error": true, "Errorf": true, "Fatal": true, "Fatalf": true, "Fail": true, "FailNow": true}
+
+func main() {
+	jsonPath := flag.String("json", "", "write the JSON work list to this path")
+	check := flag.Bool("check", false, "exit non-zero when any case loop still asserts without a subtest")
+	fix := flag.Bool("fix", false, "rewrite the sites whose subtest name is unambiguous, then report what remains")
+	flag.Parse()
+
+	dirs := flag.Args()
+	if len(dirs) == 0 {
+		dirs = []string{"./cmd", "./internal", "./test"}
+	}
+
+	if *fix {
+		rewritten, err := fixAll(dirs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "audit_test_subtests: fix: %v\n", err)
+			os.Exit(2)
+		}
+		fmt.Printf("fix: rewrote %d site(s)\n", rewritten)
+	}
+
+	report, err := scan(dirs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "audit_test_subtests: %v\n", err)
+		os.Exit(2)
+	}
+
+	printHuman(report)
+
+	if *jsonPath != "" {
+		data, marshalErr := json.MarshalIndent(report, "", "  ")
+		if marshalErr != nil {
+			fmt.Fprintf(os.Stderr, "audit_test_subtests: marshal: %v\n", marshalErr)
+			os.Exit(2)
+		}
+		if writeErr := os.WriteFile(*jsonPath, append(data, '\n'), 0o600); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "audit_test_subtests: write %s: %v\n", *jsonPath, writeErr)
+			os.Exit(2)
+		}
+		fmt.Printf("work list written to %s\n", *jsonPath)
+	}
+
+	if *check && len(report.Findings) > 0 {
+		fmt.Printf("check: FAIL. %d case loop(s) assert without a subtest (%d declared sequential)\n",
+			len(report.Findings), len(report.Sequential))
+		os.Exit(1)
+	}
+	if *check {
+		fmt.Printf("check: PASS. Every case loop runs its cases under t.Run (%d declared sequential)\n",
+			len(report.Sequential))
+	}
+}
+
+// scan walks every _test.go file under dirs and collects findings.
+func scan(dirs []string) (*Report, error) {
+	report := &Report{}
+	files := map[string]bool{}
+	for _, dir := range dirs {
+		if err := filepath.WalkDir(dir, visitTestFiles(report, files)); err != nil {
+			return nil, err
+		}
+	}
+	sortFindings(report.Findings)
+	sortFindings(report.Sequential)
+	sortFindings(report.Synctest)
+	report.Summary.Sites = len(report.Findings)
+	report.Summary.Sequential = len(report.Sequential)
+	report.Summary.Synctest = len(report.Synctest)
+	report.Summary.Files = len(files)
+	return report, nil
+}
+
+// visitTestFiles is the WalkDir callback that parses each test file and
+// records its sites in the report.
+func visitTestFiles(report *Report, files map[string]bool) fs.WalkDirFunc {
+	return func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		for _, s := range scanFile(fset, path, file) {
+			files[path] = true
+			recordSite(report, s)
+		}
+		return nil
+	}
+}
+
+// skipDir reports directories the walk never enters.
+func skipDir(name string) bool {
+	return name == "node_modules" || name == "dist" || (strings.HasPrefix(name, ".") && name != ".")
+}
+
+// recordSite files one site under the report list its classification names.
+func recordSite(report *Report, s site) {
+	switch {
+	case s.sequential:
+		report.Sequential = append(report.Sequential, s.finding)
+	case s.synctest:
+		report.Synctest = append(report.Synctest, s.finding)
+	case s.compliant:
+		report.Summary.Compliant++
+	default:
+		report.Findings = append(report.Findings, s.finding)
+		if fixable(s.finding.Fix) {
+			report.Summary.Fixable++
+		}
+	}
+}
+
+// site is one case loop as found in a file, with the AST handles -fix needs.
+type site struct {
+	finding    Finding
+	sequential bool
+	synctest   bool
+	compliant  bool
+	loop       *ast.RangeStmt
+	continues  []*ast.BranchStmt // bare continue statements targeting this loop
+	nameExpr   string            // subtest name expression when fixable
+}
+
+// scanFile returns every case loop in the file's Test functions.
+func scanFile(fset *token.FileSet, path string, file *ast.File) []site {
+	var sites []site
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+			continue
+		}
+		tables := localTables(fn.Body)
+		bubbles := synctestBubbles(fn.Body)
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			loop, isLoop := n.(*ast.RangeStmt)
+			if !isLoop {
+				return true
+			}
+			lit, kind := tableOf(loop.X, tables)
+			if lit == nil {
+				return true
+			}
+			s, keep := classify(fset, file, fn.Name.Name, path, loop, lit, kind, bubbles)
+			if keep {
+				sites = append(sites, s)
+			}
+			return false
+		})
+	}
+	return sites
+}
+
+// classify decides what one table loop is: declared sequential, inside a
+// synctest bubble, already compliant, a non-asserting setup loop (dropped),
+// or a finding with the rewrite it qualifies for.
+func classify(fset *token.FileSet, file *ast.File, test, path string, loop *ast.RangeStmt, lit *ast.CompositeLit, kind string, bubbles []*ast.FuncLit) (s site, keep bool) {
+	s = site{loop: loop, finding: Finding{File: path, Line: fset.Position(loop.Pos()).Line, Test: test, Table: kind}}
+	switch {
+	case declaredSequential(fset, file, loop):
+		s.sequential = true
+	case insideAny(loop, bubbles):
+		s.synctest = true
+	case hasRun(loop.Body):
+		s.compliant = true
+	case !asserts(loop.Body):
+		return s, false
+	default:
+		s.nameExpr, s.finding.Fix = subtestName(loop, lit, file)
+		if fixable(s.finding.Fix) {
+			if reason, continues := bodyControlFlow(loop.Body); reason != "" {
+				s.finding.Fix = reason
+			} else {
+				s.continues = continues
+			}
+		}
+	}
+	return s, true
+}
+
+// localTables maps identifiers bound to a table literal inside the function.
+func localTables(body *ast.BlockStmt) map[string]*ast.CompositeLit {
+	tables := map[string]*ast.CompositeLit{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, rhs := range assign.Rhs {
+			if lit := tableLiteral(rhs); lit != nil && i < len(assign.Lhs) {
+				if id, isIdent := assign.Lhs[i].(*ast.Ident); isIdent {
+					tables[id.Name] = lit
+				}
+			}
+		}
+		return true
+	})
+	return tables
+}
+
+// tableOf resolves the ranged expression to a table literal, inline or named.
+func tableOf(x ast.Expr, tables map[string]*ast.CompositeLit) (lit *ast.CompositeLit, kind string) {
+	if inline := tableLiteral(x); inline != nil {
+		return inline, "inline"
+	}
+	if id, ok := x.(*ast.Ident); ok {
+		if named := tables[id.Name]; named != nil {
+			return named, "named"
+		}
+	}
+	return nil, ""
+}
+
+// tableLiteral reports a slice, array or map literal holding at least two
+// elements: one element is a single case, not a table.
+func tableLiteral(e ast.Expr) *ast.CompositeLit {
+	lit, ok := e.(*ast.CompositeLit)
+	if !ok || len(lit.Elts) < 2 {
+		return nil
+	}
+	switch lit.Type.(type) {
+	case *ast.ArrayType, *ast.MapType:
+		return lit
+	}
+	return nil
+}
+
+// declaredSequential reports the escape-hatch comment on the loop line or the
+// line before it.
+func declaredSequential(fset *token.FileSet, file *ast.File, loop *ast.RangeStmt) bool {
+	line := fset.Position(loop.Pos()).Line
+	for _, group := range file.Comments {
+		for _, c := range group.List {
+			at := fset.Position(c.Pos()).Line
+			if (at == line || at == line-1) && strings.Contains(c.Text, sequentialMarker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// synctestBubbles returns the function literals handed to synctest.Test or
+// synctest.Run: everything inside runs in a bubble where t.Run panics.
+func synctestBubbles(body *ast.BlockStmt) []*ast.FuncLit {
+	var bubbles []*ast.FuncLit
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel || (sel.Sel.Name != "Test" && sel.Sel.Name != "Run") {
+			return true
+		}
+		if pkg, isIdent := sel.X.(*ast.Ident); !isIdent || pkg.Name != "synctest" {
+			return true
+		}
+		for _, arg := range call.Args {
+			if lit, isLit := arg.(*ast.FuncLit); isLit {
+				bubbles = append(bubbles, lit)
+			}
+		}
+		return true
+	})
+	return bubbles
+}
+
+// insideAny reports whether the loop sits inside one of the literals.
+func insideAny(loop *ast.RangeStmt, lits []*ast.FuncLit) bool {
+	for _, lit := range lits {
+		if loop.Pos() >= lit.Pos() && loop.End() <= lit.End() {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRun reports a t.Run (any receiver's Run) call inside the body.
+func hasRun(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			if sel, isSel := call.Fun.(*ast.SelectorExpr); isSel && sel.Sel.Name == "Run" {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// asserts reports whether the body records a failure on t directly or hands t
+// to a helper that may.
+func asserts(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return !found
+		}
+		if sel, isSel := call.Fun.(*ast.SelectorExpr); isSel {
+			if id, isIdent := sel.X.(*ast.Ident); isIdent && (id.Name == "t" || id.Name == "tb") && assertMethods[sel.Sel.Name] {
+				found = true
+			}
+		}
+		for _, arg := range call.Args {
+			if id, isIdent := arg.(*ast.Ident); isIdent && id.Name == "t" {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// subtestName derives the subtest name expression for the loop, or the reason
+// none is unambiguous.
+func subtestName(loop *ast.RangeStmt, lit *ast.CompositeLit, file *ast.File) (expr, fix string) {
+	switch typ := lit.Type.(type) {
+	case *ast.MapType:
+		return mapCaseName(loop, typ)
+	case *ast.ArrayType:
+		return arrayCaseName(loop, typ, file)
+	}
+	return "", "needs-name"
+}
+
+// mapCaseName names a case after the key of a map[string]... table.
+func mapCaseName(loop *ast.RangeStmt, typ *ast.MapType) (expr, fix string) {
+	if !isString(typ.Key) {
+		return "", "needs-name"
+	}
+	key, _ := loop.Key.(*ast.Ident)
+	if key == nil || key.Name == "_" {
+		return "", "blank-var"
+	}
+	return key.Name, "key"
+}
+
+// arrayCaseName names a case after the element of a []string table or after
+// a name-like string field of a struct table.
+func arrayCaseName(loop *ast.RangeStmt, typ *ast.ArrayType, file *ast.File) (expr, fix string) {
+	value, _ := loop.Value.(*ast.Ident)
+	blank := value == nil || value.Name == "_"
+	if isString(typ.Elt) {
+		if blank {
+			return "", "blank-var"
+		}
+		return value.Name, "element"
+	}
+	field := nameField(structFields(typ.Elt, file))
+	if field == "" {
+		return "", "needs-name"
+	}
+	if blank {
+		return "", "blank-var"
+	}
+	return value.Name + "." + field, "field:" + field
+}
+
+// nameField picks the preferred name-like string field, or "" when none.
+func nameField(fields []field) string {
+	for _, want := range nameFields {
+		for _, f := range fields {
+			if f.name == want && f.isString {
+				return f.name
+			}
+		}
+	}
+	return ""
+}
+
+// field is a struct field the name search looks at.
+type field struct {
+	name     string
+	isString bool
+}
+
+// structFields lists the fields of an inline struct type, or of a struct type
+// declared in the same file under the element's type name.
+func structFields(elt ast.Expr, file *ast.File) []field {
+	var st *ast.StructType
+	switch t := elt.(type) {
+	case *ast.StructType:
+		st = t
+	case *ast.Ident:
+		st = declaredStruct(file, t.Name)
+	}
+	if st == nil {
+		return nil
+	}
+	var fields []field
+	for _, f := range st.Fields.List {
+		for _, name := range f.Names {
+			fields = append(fields, field{name: name.Name, isString: isString(f.Type)})
+		}
+	}
+	return fields
+}
+
+// declaredStruct finds a struct type declared in the file under name.
+func declaredStruct(file *ast.File, name string) *ast.StructType {
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			if ts, isType := spec.(*ast.TypeSpec); isType && ts.Name.Name == name {
+				st, _ := ts.Type.(*ast.StructType)
+				return st
+			}
+		}
+	}
+	return nil
+}
+
+// isString reports the string type.
+func isString(e ast.Expr) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == "string"
+}
+
+// bodyControlFlow returns the reason a body cannot be wrapped in a closure
+// (break or goto aimed at the loop, or labels), and otherwise the bare
+// continue statements that must become returns.
+func bodyControlFlow(body *ast.BlockStmt) (reason string, continues []*ast.BranchStmt) {
+	c := &controlFlow{}
+	c.walk(body, false, false)
+	return c.reason, c.continues
+}
+
+// controlFlow accumulates the verdict of one loop body.
+type controlFlow struct {
+	reason    string
+	continues []*ast.BranchStmt
+}
+
+// walk visits a body. nested is true inside an inner loop, whose break and
+// continue are its own; inSwitch is true inside a switch or select, where a
+// bare break targets that statement and only continue reaches the loop.
+func (c *controlFlow) walk(n ast.Node, nested, inSwitch bool) {
+	ast.Inspect(n, func(m ast.Node) bool {
+		if m == n {
+			return true
+		}
+		if c.reason != "" {
+			return false
+		}
+		switch v := m.(type) {
+		case *ast.FuncLit:
+			return false // its own control flow
+		case *ast.ForStmt, *ast.RangeStmt:
+			c.walk(v, true, false)
+			return false
+		case *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt:
+			c.walk(v, nested, true)
+			return false
+		case *ast.LabeledStmt:
+			c.reason = "goto"
+			return false
+		case *ast.BranchStmt:
+			c.branch(v, nested, inSwitch)
+		}
+		return true
+	})
+}
+
+// branch classifies one branch statement.
+func (c *controlFlow) branch(b *ast.BranchStmt, nested, inSwitch bool) {
+	switch {
+	case b.Tok == token.GOTO || b.Label != nil:
+		c.reason = "goto"
+	case b.Tok == token.BREAK && !nested && !inSwitch:
+		c.reason = "break"
+	case b.Tok == token.CONTINUE && !nested:
+		c.continues = append(c.continues, b)
+	}
+}
+
+// fixable reports whether a Fix value names a rewrite rather than a blocker.
+func fixable(fix string) bool {
+	return fix == "element" || fix == "key" || strings.HasPrefix(fix, "field:")
+}
+
+// fixAll rewrites every fixable site under dirs and returns how many.
+func fixAll(dirs []string) (int, error) {
+	total := 0
+	for _, dir := range dirs {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if skipDir(d.Name()) {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			n, fixErr := fixFile(path)
+			total += n
+			return fixErr
+		})
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// fixFile rewrites the fixable sites of one file in place.
+func fixFile(path string) (int, error) {
+	src, err := os.ReadFile(path) //#nosec G304,G703 -- a test file found by walking the scanned directories, never a user-supplied path
+	if err != nil {
+		return 0, err
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	var edits []edit
+	count := 0
+	for _, s := range scanFile(fset, path, file) {
+		if s.sequential || s.synctest || s.compliant || !fixable(s.finding.Fix) {
+			continue
+		}
+		count++
+		body := s.loop.Body
+		edits = append(edits,
+			edit{at: fset.Position(body.Lbrace).Offset + 1, insert: "\nt.Run(" + s.nameExpr + ", func(t *testing.T) {"},
+			edit{at: fset.Position(body.Rbrace).Offset, insert: "})\n"},
+		)
+		for _, c := range s.continues {
+			edits = append(edits, edit{at: fset.Position(c.Pos()).Offset, cut: len("continue"), insert: "return"})
+		}
+	}
+	if count == 0 {
+		return 0, nil
+	}
+	formatted, err := format.Source(apply(src, edits))
+	if err != nil {
+		return 0, fmt.Errorf("%s: rewritten source does not parse: %w", path, err)
+	}
+	if writeErr := os.WriteFile(path, formatted, 0o600); writeErr != nil { //#nosec G306,G703 -- rewriting the test file the walk found, never a user-supplied path
+		return 0, writeErr
+	}
+	return count, nil
+}
+
+// edit is one byte-offset splice: cut bytes at `at`, then insert text there.
+type edit struct {
+	at     int
+	cut    int
+	insert string
+}
+
+// apply performs the edits from the end of the file backwards so earlier
+// offsets stay valid.
+func apply(src []byte, edits []edit) []byte {
+	sort.Slice(edits, func(i, j int) bool { return edits[i].at > edits[j].at })
+	out := append([]byte(nil), src...)
+	for _, e := range edits {
+		out = append(out[:e.at], append([]byte(e.insert), out[e.at+e.cut:]...)...)
+	}
+	return out
+}
+
+func sortFindings(findings []Finding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		return findings[i].Line < findings[j].Line
+	})
+}
+
+// printHuman writes the per-file tallies and the summary.
+func printHuman(report *Report) {
+	perFile := map[string][2]int{}
+	for _, f := range report.Findings {
+		c := perFile[f.File]
+		c[0]++
+		if fixable(f.Fix) {
+			c[1]++
+		}
+		perFile[f.File] = c
+	}
+	files := make([]string, 0, len(perFile))
+	for f := range perFile {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		c := perFile[f]
+		fmt.Printf("%-72s sites=%-3d fixable=%d\n", f, c[0], c[1])
+	}
+	fmt.Printf("\nsummary: %d case loop(s) assert without a subtest (%d fixable by -fix), %d declared sequential, %d inside synctest bubbles, %d compliant, across %d file(s)\n",
+		report.Summary.Sites, report.Summary.Fixable, report.Summary.Sequential, report.Summary.Synctest, report.Summary.Compliant, report.Summary.Files)
+}

--- a/cmd/audit_test_subtests/main.go
+++ b/cmd/audit_test_subtests/main.go
@@ -236,6 +236,16 @@ type site struct {
 	nameExpr   string            // subtest name expression when fixable
 }
 
+// testScan is what classifying a loop needs to know about the test function
+// it sits in: where the file is, and which literals are synctest bubbles.
+type testScan struct {
+	fset    *token.FileSet
+	file    *ast.File
+	path    string
+	test    string
+	bubbles []*ast.FuncLit
+}
+
 // scanFile returns every case loop in the file's Test functions.
 func scanFile(fset *token.FileSet, path string, file *ast.File) []site {
 	var sites []site
@@ -245,7 +255,7 @@ func scanFile(fset *token.FileSet, path string, file *ast.File) []site {
 			continue
 		}
 		tables := localTables(fn.Body)
-		bubbles := synctestBubbles(fn.Body)
+		scan := &testScan{fset: fset, file: file, path: path, test: fn.Name.Name, bubbles: synctestBubbles(fn.Body)}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			loop, isLoop := n.(*ast.RangeStmt)
 			if !isLoop {
@@ -255,7 +265,7 @@ func scanFile(fset *token.FileSet, path string, file *ast.File) []site {
 			if lit == nil {
 				return true
 			}
-			s, keep := classify(fset, file, fn.Name.Name, path, loop, lit, kind, bubbles)
+			s, keep := scan.classify(loop, lit, kind)
 			if keep {
 				sites = append(sites, s)
 			}
@@ -268,12 +278,13 @@ func scanFile(fset *token.FileSet, path string, file *ast.File) []site {
 // classify decides what one table loop is: declared sequential, inside a
 // synctest bubble, already compliant, a non-asserting setup loop (dropped),
 // or a finding with the rewrite it qualifies for.
-func classify(fset *token.FileSet, file *ast.File, test, path string, loop *ast.RangeStmt, lit *ast.CompositeLit, kind string, bubbles []*ast.FuncLit) (s site, keep bool) {
-	s = site{loop: loop, finding: Finding{File: path, Line: fset.Position(loop.Pos()).Line, Test: test, Table: kind}}
+func (sc *testScan) classify(loop *ast.RangeStmt, lit *ast.CompositeLit, kind string) (s site, keep bool) {
+	fset, file := sc.fset, sc.file
+	s = site{loop: loop, finding: Finding{File: sc.path, Line: fset.Position(loop.Pos()).Line, Test: sc.test, Table: kind}}
 	switch {
 	case declaredSequential(fset, file, loop):
 		s.sequential = true
-	case insideAny(loop, bubbles):
+	case insideAny(loop, sc.bubbles):
 		s.synctest = true
 	case hasRun(loop.Body):
 		s.compliant = true

--- a/cmd/audit_test_subtests/main.go
+++ b/cmd/audit_test_subtests/main.go
@@ -85,6 +85,18 @@ type Summary struct {
 // sequentialMarker declares a loop of dependent steps rather than cases.
 const sequentialMarker = "sequential:"
 
+// The Fix vocabulary: the first three name a rewrite -fix can perform, the
+// rest name why it cannot.
+const (
+	fixElement     = "element"    // a []string table: the element is the name
+	fixKey         = "key"        // a map[string]... table: the key is the name
+	fixFieldPrefix = "field:"     // a struct table: the named string field
+	fixNeedsName   = "needs-name" // no name-like field to derive a name from
+	fixBlankVar    = "blank-var"  // the loop variable is blank or absent
+	fixBreak       = "break"      // a break aimed at the loop cannot cross a closure
+	fixGoto        = "goto"       // a goto or a label cannot cross a closure
+)
+
 // nameFields are the struct fields, in order of preference, that name a case.
 var nameFields = []string{"name", "desc", "description", "label", "title", "id"}
 
@@ -425,19 +437,19 @@ func subtestName(loop *ast.RangeStmt, lit *ast.CompositeLit, file *ast.File) (ex
 	case *ast.ArrayType:
 		return arrayCaseName(loop, typ, file)
 	}
-	return "", "needs-name"
+	return "", fixNeedsName
 }
 
 // mapCaseName names a case after the key of a map[string]... table.
 func mapCaseName(loop *ast.RangeStmt, typ *ast.MapType) (expr, fix string) {
 	if !isString(typ.Key) {
-		return "", "needs-name"
+		return "", fixNeedsName
 	}
 	key, _ := loop.Key.(*ast.Ident)
 	if key == nil || key.Name == "_" {
-		return "", "blank-var"
+		return "", fixBlankVar
 	}
-	return key.Name, "key"
+	return key.Name, fixKey
 }
 
 // arrayCaseName names a case after the element of a []string table or after
@@ -447,18 +459,18 @@ func arrayCaseName(loop *ast.RangeStmt, typ *ast.ArrayType, file *ast.File) (exp
 	blank := value == nil || value.Name == "_"
 	if isString(typ.Elt) {
 		if blank {
-			return "", "blank-var"
+			return "", fixBlankVar
 		}
-		return value.Name, "element"
+		return value.Name, fixElement
 	}
 	field := nameField(structFields(typ.Elt, file))
 	if field == "" {
-		return "", "needs-name"
+		return "", fixNeedsName
 	}
 	if blank {
-		return "", "blank-var"
+		return "", fixBlankVar
 	}
-	return value.Name + "." + field, "field:" + field
+	return value.Name + "." + field, fixFieldPrefix + field
 }
 
 // nameField picks the preferred name-like string field, or "" when none.
@@ -560,7 +572,7 @@ func (c *controlFlow) walk(n ast.Node, nested, inSwitch bool) {
 			c.walk(v, nested, true)
 			return false
 		case *ast.LabeledStmt:
-			c.reason = "goto"
+			c.reason = fixGoto
 			return false
 		case *ast.BranchStmt:
 			c.branch(v, nested, inSwitch)
@@ -573,9 +585,9 @@ func (c *controlFlow) walk(n ast.Node, nested, inSwitch bool) {
 func (c *controlFlow) branch(b *ast.BranchStmt, nested, inSwitch bool) {
 	switch {
 	case b.Tok == token.GOTO || b.Label != nil:
-		c.reason = "goto"
+		c.reason = fixGoto
 	case b.Tok == token.BREAK && !nested && !inSwitch:
-		c.reason = "break"
+		c.reason = fixBreak
 	case b.Tok == token.CONTINUE && !nested:
 		c.continues = append(c.continues, b)
 	}
@@ -583,7 +595,7 @@ func (c *controlFlow) branch(b *ast.BranchStmt, nested, inSwitch bool) {
 
 // fixable reports whether a Fix value names a rewrite rather than a blocker.
 func fixable(fix string) bool {
-	return fix == "element" || fix == "key" || strings.HasPrefix(fix, "field:")
+	return fix == fixElement || fix == fixKey || strings.HasPrefix(fix, fixFieldPrefix)
 }
 
 // fixAll rewrites every fixable site under dirs and returns how many.

--- a/cmd/audit_test_subtests/main_test.go
+++ b/cmd/audit_test_subtests/main_test.go
@@ -1,0 +1,333 @@
+// Package main tests the case-loop subtest auditor and its rewriter against
+// fixture files covering every table shape, the escape hatch, and the
+// control-flow blockers.
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixtureSource exercises: a []string table (fixable, named after the
+// element), a struct table with a name field (fixable), a map[string] table
+// (fixable, named after the key), a struct table without a name field
+// (needs-name), a loop with a bare break (break), a declared-sequential
+// loop, a compliant loop already under t.Run, a setup loop that never
+// asserts, a single-element literal that is not a table, and a loop inside
+// a synctest bubble, where t.Run is not allowed.
+const fixtureSource = `package fixture
+
+import (
+	"strings"
+	"testing"
+	"testing/synctest"
+)
+
+type step struct {
+	label string
+	in    string
+}
+
+func TestFixture(t *testing.T) {
+	out := "alpha beta"
+	for _, want := range []string{"alpha", "beta"} { // element
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{{"one", "a"}, {"two", "b"}} { // field:name
+		if tc.in == "" {
+			continue
+		}
+		if !strings.Contains(out, tc.in) {
+			t.Fatalf("%s: missing", tc.name)
+		}
+	}
+
+	for key, want := range map[string]string{"k1": "alpha", "k2": "beta"} { // key
+		if !strings.Contains(out, want) {
+			t.Errorf("%s: missing %q", key, want)
+		}
+	}
+
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{{"a", true}, {"b", true}} { // needs-name
+		if strings.Contains(out, tc.in) != tc.want {
+			t.Errorf("%q", tc.in)
+		}
+	}
+
+	for _, want := range []string{"alpha", "gamma"} { // break
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+			break
+		}
+	}
+
+	// sequential: every step reads what the previous one wrote
+	for _, s := range []step{{"a", "1"}, {"b", "2"}} {
+		if s.in == "" {
+			t.Fatal("empty")
+		}
+	}
+
+	for _, want := range []string{"alpha", "beta"} { // compliant
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing %q", want)
+			}
+		})
+	}
+
+	seen := map[string]bool{}
+	for _, name := range []string{"x", "y"} { // setup only
+		seen[name] = true
+	}
+
+	for _, want := range []string{"alpha"} { // one element: not a table
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+
+	synctest.Test(t, func(t *testing.T) { // synctest bubble: t.Run would panic
+		for _, want := range []string{"alpha", "beta"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing %q", want)
+			}
+		}
+	})
+}
+`
+
+// writeFixture writes the fixture into a temporary directory and returns
+// the file path.
+func writeFixture(t *testing.T, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture_test.go")
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+// TestScan_ClassifiesEveryTableShape verifies that scan reports each
+// asserting case loop with the rewrite it qualifies for, records the
+// declared-sequential and synctest-bubble loops separately, counts the
+// compliant loop, and skips the setup loop and the single-element literal.
+func TestScan_ClassifiesEveryTableShape(t *testing.T) {
+	path := writeFixture(t, fixtureSource)
+	report, err := scan([]string{filepath.Dir(path)})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	byLine := map[int]Finding{}
+	for _, f := range report.Findings {
+		byLine[f.Line] = f
+	}
+	for _, tc := range []struct {
+		name string
+		line int
+		fix  string
+	}{
+		{"string_slice", 16, "element"},
+		{"struct_with_name", 22, "field:name"},
+		{"string_map", 34, "key"},
+		{"struct_without_name", 40, "needs-name"},
+		{"bare_break", 49, "break"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := byLine[tc.line]
+			if !ok {
+				t.Fatalf("no finding at line %d; findings: %+v", tc.line, report.Findings)
+			}
+			if got.Fix != tc.fix {
+				t.Errorf("finding at line %d: Fix = %q, want %q", tc.line, got.Fix, tc.fix)
+			}
+			if got.Test != "TestFixture" {
+				t.Errorf("finding at line %d: Test = %q, want TestFixture", tc.line, got.Test)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"sites", report.Summary.Sites, 5},
+		{"fixable", report.Summary.Fixable, 3},
+		{"sequential", report.Summary.Sequential, 1},
+		{"synctest", report.Summary.Synctest, 1},
+		{"compliant", report.Summary.Compliant, 1},
+		{"files", report.Summary.Files, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("summary %s = %d, want %d", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFixFile_RewritesFixableSitesOnly verifies that -fix wraps the three
+// unambiguous loops in t.Run with the derived name, turns the bare continue
+// into a return, leaves the needs-name and break loops untouched, and yields
+// a file that parses and that a second scan reports as only those two.
+func TestFixFile_RewritesFixableSitesOnly(t *testing.T) {
+	path := writeFixture(t, fixtureSource)
+	n, err := fixFile(path)
+	if err != nil {
+		t.Fatalf("fixFile: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("fixFile rewrote %d site(s), want 3", n)
+	}
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten fixture: %v", err)
+	}
+	got := string(src)
+	if _, parseErr := parser.ParseFile(token.NewFileSet(), path, src, parser.ParseComments); parseErr != nil {
+		t.Fatalf("rewritten fixture does not parse: %v\n%s", parseErr, got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{"element_name", "t.Run(want, func(t *testing.T) {"},
+		{"field_name", "t.Run(tc.name, func(t *testing.T) {"},
+		{"key_name", "t.Run(key, func(t *testing.T) {"},
+		{"continue_becomes_return", "if tc.in == \"\" {\n\t\t\t\treturn\n\t\t\t}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("rewritten fixture lacks %q:\n%s", tc.want, got)
+			}
+		})
+	}
+	if strings.Contains(got, "continue") {
+		t.Errorf("a bare continue survived the rewrite:\n%s", got)
+	}
+
+	report, err := scan([]string{filepath.Dir(path)})
+	if err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	remaining := map[string]int{}
+	for _, f := range report.Findings {
+		remaining[f.Fix]++
+	}
+	for _, tc := range []struct {
+		name string
+		want int
+	}{{"needs-name", 1}, {"break", 1}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if remaining[tc.name] != tc.want {
+				t.Errorf("after fix, %s sites = %d, want %d (findings %+v)", tc.name, remaining[tc.name], tc.want, report.Findings)
+			}
+		})
+	}
+	if report.Summary.Fixable != 0 {
+		t.Errorf("after fix, fixable = %d, want 0", report.Summary.Fixable)
+	}
+	if report.Summary.Compliant != 4 {
+		t.Errorf("after fix, compliant = %d, want 4 (one original plus three rewritten)", report.Summary.Compliant)
+	}
+	if report.Summary.Synctest != 1 {
+		t.Errorf("after fix, synctest = %d, want 1 (the bubble loop must stay untouched)", report.Summary.Synctest)
+	}
+}
+
+// TestFixFile_LeavesCleanFilesAlone verifies that a file with nothing to
+// rewrite is neither touched nor counted.
+func TestFixFile_LeavesCleanFilesAlone(t *testing.T) {
+	const clean = `package fixture
+
+import "testing"
+
+func TestClean(t *testing.T) {
+	for _, want := range []string{"a", "b"} {
+		t.Run(want, func(t *testing.T) {
+			if want == "" {
+				t.Fatal("empty")
+			}
+		})
+	}
+}
+`
+	path := writeFixture(t, clean)
+	n, err := fixFile(path)
+	if err != nil {
+		t.Fatalf("fixFile: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("fixFile rewrote %d site(s) in a clean file, want 0", n)
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(src) != clean {
+		t.Errorf("clean file was modified:\n%s", src)
+	}
+}
+
+// TestBodyControlFlow_ClassifiesBranches verifies the control-flow gate:
+// a break aimed at the loop blocks the rewrite, a goto or label blocks it,
+// a continue inside a nested loop is that loop's business, and a bare
+// continue is collected for conversion.
+func TestBodyControlFlow_ClassifiesBranches(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		body      string
+		reason    string
+		continues int
+	}{
+		{"bare_continue", "for _, x := range xs { if x == 0 { continue }; t.Error(x) }", "", 1},
+		{"continue_in_switch", "for _, x := range xs { switch x { case 0: continue }; t.Error(x) }", "", 1},
+		{"nested_loop_continue", "for _, x := range xs { for range 2 { continue }; t.Error(x) }", "", 0},
+		{"bare_break", "for _, x := range xs { if x == 0 { break }; t.Error(x) }", "break", 0},
+		{"break_in_switch_is_fine", "for _, x := range xs { switch x { case 0: break }; t.Error(x) }", "", 0},
+		{"goto", "for _, x := range xs { if x == 0 { goto done }; t.Error(x); done: }", "goto", 0},
+		{"closure_is_opaque", "for _, x := range xs { f := func() { for { break } }; f(); t.Error(x) }", "", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package p\nimport \"testing\"\nfunc TestX(t *testing.T) { xs := []int{1, 2}; " + tc.body + " }\n"
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "x_test.go", src, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			var loop *ast.RangeStmt
+			ast.Inspect(file, func(n ast.Node) bool {
+				if rs, ok := n.(*ast.RangeStmt); ok && loop == nil {
+					loop = rs
+				}
+				return loop == nil
+			})
+			reason, continues := bodyControlFlow(loop.Body)
+			if reason != tc.reason {
+				t.Errorf("reason = %q, want %q", reason, tc.reason)
+			}
+			if len(continues) != tc.continues {
+				t.Errorf("continues = %d, want %d", len(continues), tc.continues)
+			}
+		})
+	}
+}

--- a/cmd/audit_tokens/main_test.go
+++ b/cmd/audit_tokens/main_test.go
@@ -757,14 +757,16 @@ func TestMeasureTokenFootprintRows_AllTiersAllModes_CoversEveryCombination(t *te
 		})
 	}
 	// Verify mode ordering within each tier: opaque < compact < full tokens.
-	for ti := range tiers {
-		base := ti * 9
-		opaque := rows[base+2].ToolSchemaTokens
-		compact := rows[base+4].ToolSchemaTokens
-		full := rows[base+6].ToolSchemaTokens
-		if compact <= opaque || full <= compact {
-			t.Fatalf("tier %s: meta tokens not increasing opaque(%d) < compact(%d) < full(%d)", tiers[ti], opaque, compact, full)
-		}
+	for ti, tier := range tiers {
+		t.Run(tier+" meta modes increase", func(t *testing.T) {
+			base := ti * 9
+			opaque := rows[base+2].ToolSchemaTokens
+			compact := rows[base+4].ToolSchemaTokens
+			full := rows[base+6].ToolSchemaTokens
+			if compact <= opaque || full <= compact {
+				t.Fatalf("tier %s: meta tokens not increasing opaque(%d) < compact(%d) < full(%d)", tier, opaque, compact, full)
+			}
+		})
 	}
 	// Verify tier scaling: Free individual tools < Premium < Ultimate.
 	freeIndiv := rows[8].VisibleTools
@@ -793,11 +795,13 @@ func TestMeasureToolSchemaTokens_RealTokenizer_ReturnsNonZeroCounts(t *testing.T
 
 	fallback := 0
 	for _, tl := range toolList {
-		b, marshalErr := json.Marshal(tl)
-		if marshalErr != nil {
-			t.Fatalf("marshal: %v", marshalErr)
-		}
-		fallback += len(b) / 4
+		t.Run(tl.Name, func(t *testing.T) {
+			b, marshalErr := json.Marshal(tl)
+			if marshalErr != nil {
+				t.Fatalf("marshal: %v", marshalErr)
+			}
+			fallback += len(b) / 4
+		})
 	}
 	if got == fallback {
 		t.Fatalf("measureToolSchemaTokens() = %d == bytes/4 fallback; cl100k_base tokenizer did not engage", got)

--- a/cmd/audit_tokens/main_test.go
+++ b/cmd/audit_tokens/main_test.go
@@ -236,9 +236,11 @@ func TestMeasureTools_AssignsDomainAndComputesTokens(t *testing.T) {
 		}
 	}
 	for _, want := range []string{"gitlab_project_get", "gitlab_issue_create"} {
-		if !names[want] {
-			t.Errorf("measureTools() missing %q in results: %+v", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !names[want] {
+				t.Errorf("measureTools() missing %q in results: %+v", want, got)
+			}
+		})
 	}
 }
 
@@ -411,9 +413,11 @@ func TestRenderReadmeFootprint_DynamicOnlyRows_KeepsOneRowPerTier(t *testing.T) 
 		"Free/CE",
 		"Token Footprint Reference",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("renderReadmeFootprint() missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("renderReadmeFootprint() missing %q", want)
+			}
+		})
 	}
 	if strings.Contains(got, "`meta`") {
 		t.Fatal("renderReadmeFootprint() should not include meta rows")
@@ -503,9 +507,11 @@ func TestRenderReadmeTokenClaim_TiersAgree_StatesOneFigure(t *testing.T) {
 		t.Fatalf("renderReadmeTokenClaim() = %q, want prefix %q", got, wantPrefix)
 	}
 	for _, want := range []string{"cl100k_base", "[How it is measured](#token-footprint)"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("renderReadmeTokenClaim() missing %q in %q", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("renderReadmeTokenClaim() missing %q in %q", want, got)
+			}
+		})
 	}
 	if strings.Contains(got, "from ") || strings.Contains(got, "From ") {
 		t.Errorf("renderReadmeTokenClaim() = %q, must not render a span when the tiers agree", got)
@@ -741,12 +747,14 @@ func TestMeasureTokenFootprintRows_AllTiersAllModes_CoversEveryCombination(t *te
 	// Verify tier ordering: Free/CE first 9, Premium next 9, Ultimate last 9.
 	tiers := []string{"Free/CE", "Premium", "Ultimate"}
 	for ti, tier := range tiers {
-		for i := range 9 {
-			row := rows[ti*9+i]
-			if row.Tier != tier {
-				t.Fatalf("row[%d].Tier = %q, want %q", ti*9+i, row.Tier, tier)
+		t.Run(tier, func(t *testing.T) {
+			for i := range 9 {
+				row := rows[ti*9+i]
+				if row.Tier != tier {
+					t.Fatalf("row[%d].Tier = %q, want %q", ti*9+i, row.Tier, tier)
+				}
 			}
-		}
+		})
 	}
 	// Verify mode ordering within each tier: opaque < compact < full tokens.
 	for ti := range tiers {

--- a/cmd/audit_tokens/modelfacing_test.go
+++ b/cmd/audit_tokens/modelfacing_test.go
@@ -92,9 +92,11 @@ func TestMarshalModelFacing_KeepsEverythingElse(t *testing.T) {
 		t.Fatalf("unmarshal: %v", unmarshalErr)
 	}
 	for _, key := range []string{"name", "title", "description", "inputSchema", "annotations"} {
-		if _, ok := got[key]; !ok {
-			t.Errorf("%q was dropped alongside the icons: %s", key, raw)
-		}
+		t.Run(key, func(t *testing.T) {
+			if _, ok := got[key]; !ok {
+				t.Errorf("%q was dropped alongside the icons: %s", key, raw)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/bridge_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/bridge_test.go
@@ -19,9 +19,11 @@ func TestAppendCapabilityBridgeTools_AddsSupportedBridgeSchemas(t *testing.T) {
 		got[tool.Name] = tool
 	}
 	for _, name := range []string{capabilityListTool, resourceListTool, resourceReadTool, promptListTool, promptGetTool, completionTool, dynamicExecuteActionTool} {
-		if _, ok := got[name]; !ok {
-			t.Fatalf("appendCapabilityBridgeTools() missing %s in %#v", name, got)
-		}
+		t.Run(name, func(t *testing.T) {
+			if _, ok := got[name]; !ok {
+				t.Fatalf("appendCapabilityBridgeTools() missing %s in %#v", name, got)
+			}
+		})
 	}
 	if schema := got[capabilityListTool].InputSchema.(map[string]any); schema["additionalProperties"] != false {
 		t.Fatalf("capability schema = %#v, want strict object", schema)

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixture_context_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixture_context_test.go
@@ -52,9 +52,11 @@ func TestMergeRequestSourceFixture_EnsuresAttemptBranchAndFile(t *testing.T) {
 		t.Fatalf("output = %+v, want suffixed MR source values", output)
 	}
 	for _, want := range []string{"POST /api/v4/projects/101/repository/branches", "POST " + mrSourceFixtureTestFilePath} {
-		if !strings.Contains(strings.Join(calls, ","), want) {
-			t.Fatalf("calls = %s, want %s", strings.Join(calls, ","), want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(strings.Join(calls, ","), want) {
+				t.Fatalf("calls = %s, want %s", strings.Join(calls, ","), want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
@@ -42,13 +42,15 @@ func TestBaseMutatingFixtureSpecs_DefineRequiredResourceBuilders(t *testing.T) {
 		"pipeline_schedule",
 		"member",
 	} {
-		fixture, ok := byName[name]
-		if !ok {
-			t.Fatalf("fixture %q missing from %s", name, fixtureNames(fixtures))
-		}
-		if fixture.Ensure == nil || fixture.Validate == nil || fixture.Cleanup == nil {
-			t.Fatalf("fixture %q callbacks = ensure:%t validate:%t cleanup:%t", name, fixture.Ensure != nil, fixture.Validate != nil, fixture.Cleanup != nil)
-		}
+		t.Run(name, func(t *testing.T) {
+			fixture, ok := byName[name]
+			if !ok {
+				t.Fatalf("fixture %q missing from %s", name, fixtureNames(fixtures))
+			}
+			if fixture.Ensure == nil || fixture.Validate == nil || fixture.Cleanup == nil {
+				t.Fatalf("fixture %q callbacks = ensure:%t validate:%t cleanup:%t", name, fixture.Ensure != nil, fixture.Validate != nil, fixture.Cleanup != nil)
+			}
+		})
 	}
 }
 
@@ -89,9 +91,11 @@ func TestFixtureOutputFromLiveState_ExposesTypedPromptValues(t *testing.T) {
 		"package_release_dir":     "/tmp/pkg",
 		"package_release_files":   "a.txt,b.txt",
 	} {
-		if got := output[key]; got != want {
-			t.Fatalf("output[%s] = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := output[key]; got != want {
+				t.Fatalf("output[%s] = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 
@@ -117,9 +121,11 @@ func TestAttemptNameFixtureOutput_UsesModelRunSuffix(t *testing.T) {
 		"package_release_name":     "eval-release-package-qwen36flash-r3-abc123",
 		"package_release_tag":      "v0.0.0-eval-packages-qwen36flash-r3-abc123",
 	} {
-		if got := output[key]; got != want {
-			t.Fatalf("output[%s] = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := output[key]; got != want {
+				t.Fatalf("output[%s] = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 
@@ -138,9 +144,11 @@ func TestAttemptNameFixtureOutput_IsolatesCaseResources(t *testing.T) {
 		"release_tag_name":  "v0.0.0-eval-qwen36flash-r1-abc123-ms018",
 		"release_link_name": "eval-crud-link-qwen36flash-r1-abc123-ms018",
 	} {
-		if got := output[key]; got != want {
-			t.Fatalf("output[%s] = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := output[key]; got != want {
+				t.Fatalf("output[%s] = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 
@@ -171,9 +179,11 @@ func TestBaseMutatingPromptTemplate_RendersAttemptNamesWithoutChangingStoredProm
 		t.Fatalf("RenderCasePrompt() error = %v", err)
 	}
 	for _, want := range []string{"v0.0.0-eval-gpt54mini-r1-abc123", liveFixtureProjectPath, liveFixtureDefaultRef} {
-		if !strings.Contains(rendered, want) {
-			t.Fatalf("rendered prompt = %q, want %q", rendered, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("rendered prompt = %q, want %q", rendered, want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_prompt_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_prompt_test.go
@@ -82,9 +82,11 @@ func TestAddPromptData_HandlesPointersAndNonStructValues(t *testing.T) {
 		t.Fatalf("Project data = %#v, want pointer struct fields", out["Project"])
 	}
 	for _, name := range []string{"NilPointer", "Text", "Nil"} {
-		if _, exists := out[name]; exists {
-			t.Fatalf("out[%q] exists in %#v, want skipped", name, out)
-		}
+		t.Run(name, func(t *testing.T) {
+			if _, exists := out[name]; exists {
+				t.Fatalf("out[%q] exists in %#v, want skipped", name, out)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_registry_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_registry_test.go
@@ -33,9 +33,11 @@ func TestValidateEvalCaseRegistry_DetectsInvalidDefinitions(t *testing.T) {
 	}
 	problems := strings.Join(validateEvalCaseRegistry(cases, nil), "\n")
 	for _, want := range []string{"duplicate ID", "empty prompt", "no expected steps", "does not list confirm", "unknown preset", "non-capability bridge step as optional", "must be followed by another capability bridge step"} {
-		if !strings.Contains(problems, want) {
-			t.Fatalf("problems missing %q:\n%s", want, problems)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(problems, want) {
+				t.Fatalf("problems missing %q:\n%s", want, problems)
+			}
+		})
 	}
 }
 
@@ -54,9 +56,11 @@ func TestAllEvalCases_ContainsMigratedReadMutatingAndCapabilityCases(t *testing.
 		t.Fatalf("len(AllEvalCases()) = %d, want at least 173", len(cases))
 	}
 	for _, id := range []string{"MT-001", "MT-002", "MT-003", "MT-004", "MT-010", "MT-017", "MT-026", "MT-070", "MT-117", "MT-125", "MT-188", "MT-192", "MT-196", "MS-008", "MS-010", "MS-028", "MS-038", "MS-039", "MS-040", "MS-041", "MS-042"} {
-		if _, ok := CaseByID(id); !ok {
-			t.Fatalf("CaseByID(%s) = false, want migrated typed case", id)
-		}
+		t.Run(id, func(t *testing.T) {
+			if _, ok := CaseByID(id); !ok {
+				t.Fatalf("CaseByID(%s) = false, want migrated typed case", id)
+			}
+		})
 	}
 	if got := len(CasesByPreset(presetDockerRead)); got < 40 {
 		t.Fatalf("CasesByPreset(docker-read) = %d, want at least 40", got)
@@ -212,9 +216,11 @@ func TestReleaseAssetLinkCRUDCaseUsesAttemptScopedURLs(t *testing.T) {
 		t.Fatalf("MS-018 attempt_names scope = %q, want %q", fixture.Scope, FixtureScopeAttempt)
 	}
 	for _, want := range []string{"{{ .Values.release_link_url }}", "{{ .Values.release_link_updated_url }}"} {
-		if !strings.Contains(evalCase.PromptTemplate.Text, want) {
-			t.Fatalf("MS-018 prompt template = %q, want %q", evalCase.PromptTemplate.Text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(evalCase.PromptTemplate.Text, want) {
+				t.Fatalf("MS-018 prompt template = %q, want %q", evalCase.PromptTemplate.Text, want)
+			}
+		})
 	}
 	if strings.Contains(evalCase.PromptTemplate.Text, "only after the release exists, add asset link `eval-crud-link`") {
 		t.Fatalf("MS-018 prompt template keeps legacy static release link text: %q", evalCase.PromptTemplate.Text)
@@ -276,9 +282,11 @@ func TestInteractiveMergeRequestCaseUsesGuidedOnlyParams(t *testing.T) {
 		t.Fatalf("MT-081 fixtures = %s, want merge_request_source", fixtureNames(evalCase.Fixtures))
 	}
 	for _, want := range []string{"Do not pass `source_branch`", "guided prompts will use source branch"} {
-		if !strings.Contains(evalCase.PromptTemplate.Text, want) {
-			t.Fatalf("MT-081 prompt template = %q, want %q", evalCase.PromptTemplate.Text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(evalCase.PromptTemplate.Text, want) {
+				t.Fatalf("MT-081 prompt template = %q, want %q", evalCase.PromptTemplate.Text, want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_types_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_types_test.go
@@ -144,26 +144,31 @@ func TestExpectedStepTypedAssertionFields_ProjectIntoTaskSteps(t *testing.T) {
 // CaseAssertionType constant introduced for the Phase 11 typed-assertion
 // rules is non-empty so the runtime can dispatch on each rule.
 //
-// The test enumerates the expected assertion type constants and asserts
-// none of them is the empty string. This protects downstream registries
-// from silently dropping a rule when a future rename leaves an empty
-// constant in place.
+// The test enumerates the expected assertion type constants, one subtest
+// per constant, and asserts none of them is the empty string. This protects
+// downstream registries from silently dropping a rule when a future rename
+// leaves an empty constant in place.
 func TestCaseAssertionTypes_CoverPhaseElevenRules(t *testing.T) {
-	want := []CaseAssertionType{
-		CaseAssertionExpectedAction,
-		CaseAssertionRequiredParams,
-		CaseAssertionOptionalParams,
-		CaseAssertionForbiddenParams,
-		CaseAssertionDestructiveConfirm,
-		CaseAssertionOutputContains,
-		CaseAssertionProducedValue,
-		CaseAssertionNoExtraToolCall,
-		CaseAssertionAllowRepair,
+	want := []struct {
+		name  string
+		value CaseAssertionType
+	}{
+		{"expected_action", CaseAssertionExpectedAction},
+		{"required_params", CaseAssertionRequiredParams},
+		{"optional_params", CaseAssertionOptionalParams},
+		{"forbidden_params", CaseAssertionForbiddenParams},
+		{"destructive_confirm", CaseAssertionDestructiveConfirm},
+		{"output_contains", CaseAssertionOutputContains},
+		{"produced_value", CaseAssertionProducedValue},
+		{"no_extra_tool_call", CaseAssertionNoExtraToolCall},
+		{"allow_repair", CaseAssertionAllowRepair},
 	}
-	for _, assertionType := range want {
-		if assertionType == "" {
-			t.Fatalf("empty assertion type in %v", want)
-		}
+	for _, tc := range want {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == "" {
+				t.Fatalf("empty assertion type in %v", want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/comparison_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/comparison_test.go
@@ -43,9 +43,11 @@ func TestWriteComparisonReport_BuildsEvaluationAndTokenSections(t *testing.T) {
 	contentB = strings.ReplaceAll(contentB, "`dynamic`", "`meta`")
 	contentB = strings.ReplaceAll(contentB, "90.0%", "95.0%")
 	for path, content := range map[string]string{evalA: contentA, evalB: contentB} {
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			t.Fatalf("write input %s: %v", path, err)
-		}
+		t.Run(path, func(t *testing.T) {
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatalf("write input %s: %v", path, err)
+			}
+		})
 	}
 	out := filepath.Join(dir, "nested", "comparison.md")
 	if err := writeComparisonReport(out, []string{evalA, evalB}); err != nil {
@@ -57,9 +59,11 @@ func TestWriteComparisonReport_BuildsEvaluationAndTokenSections(t *testing.T) {
 	}
 	content := string(data)
 	for _, want := range []string{"# MCP Surface Evaluation Comparison", "## Evaluation Metrics", "### Delta Versus", "## API Usage", "+5.0 pp"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("comparison missing %q:\n%s", want, content)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("comparison missing %q:\n%s", want, content)
+			}
+		})
 	}
 	oneInputErr := writeComparisonReport(filepath.Join(dir, "bad.md"), []string{evalA})
 	if oneInputErr == nil {
@@ -194,9 +198,11 @@ Tools file: ` + "`dist/evaluation/mcp-surfaces/snapshots/current-abc123/tools.js
 
 	comparison := buildComparisonReport([]comparisonInput{tokenInput, evalInput})
 	for _, want := range []string{"Catalog Token Metrics", "Evaluation Metrics", "current-abc123", "18021"} {
-		if !strings.Contains(comparison, want) {
-			t.Fatalf("comparison missing %q:\n%s", want, comparison)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(comparison, want) {
+				t.Fatalf("comparison missing %q:\n%s", want, comparison)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/docker_runtime_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/docker_runtime_test.go
@@ -71,8 +71,10 @@ func TestDockerRuntimeEnv_EnterpriseImageDefault(t *testing.T) {
 	t.Setenv("EVAL_DOCKER_GITLAB_IMAGE", "")
 	env := strings.Join(dockerRuntimeEnv(options{Preset: presetDockerEnterpriseRead, Edition: editionEnterprise}), "\n")
 	for _, want := range []string{"GITLAB_TIER=ultimate", "GITLAB_IMAGE=gitlab/gitlab-ee:latest", "E2E_DOCKER_COMPOSE_FILE=test/e2e/docker-compose.yml"} {
-		if !strings.Contains(env, want) {
-			t.Fatalf("dockerRuntimeEnv() = %q, want %q", env, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(env, want) {
+				t.Fatalf("dockerRuntimeEnv() = %q, want %q", env, want)
+			}
+		})
 	}
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/efficiency_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/efficiency_test.go
@@ -87,9 +87,11 @@ func TestRunEfficiencyCheck_WritesPassingReport(t *testing.T) {
 	}
 	text := string(content)
 	for _, want := range []string{"# Trace Efficiency Check", "Status: `pass`", "| Attempts | 1 |", "## By Model"} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("efficiency report = %q, want %q", text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Fatalf("efficiency report = %q, want %q", text, want)
+			}
+		})
 	}
 }
 
@@ -110,9 +112,11 @@ func TestRunEfficiencyCheck_WritesViolationReportAndFails(t *testing.T) {
 	}
 	text := string(content)
 	for _, want := range []string{"Status: `fail`", "## Violations", "per_attempt_call_budget"} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("efficiency report = %q, want %q", text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Fatalf("efficiency report = %q, want %q", text, want)
+			}
+		})
 	}
 }
 
@@ -208,9 +212,11 @@ func TestRunTraceComparison_WritesReport(t *testing.T) {
 		t.Fatalf("read comparison report: %v", err)
 	}
 	for _, want := range []string{"# Trace Surface Comparison", "| Comparable rows | 1 |", "## Largest Dynamic Overheads"} {
-		if !strings.Contains(string(content), want) {
-			t.Fatalf("comparison report = %q, want %q", string(content), want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(string(content), want) {
+				t.Fatalf("comparison report = %q, want %q", string(content), want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/fixtures_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/fixtures_test.go
@@ -298,9 +298,11 @@ func TestEnsureCIVariables_RecreatesProjectGroupAndInstanceVariables(t *testing.
 		t.Fatalf("ensureCIVariables() error = %v", err)
 	}
 	for _, scope := range []string{"project", "group", "instance"} {
-		if !created[scope] {
-			t.Fatalf("%s variable was not recreated", scope)
-		}
+		t.Run(scope, func(t *testing.T) {
+			if !created[scope] {
+				t.Fatalf("%s variable was not recreated", scope)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/options_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/options_test.go
@@ -81,9 +81,11 @@ func TestParseFlags_RecordsExplicitFlags(t *testing.T) {
 		t.Fatalf("parseFlags() = %+v, want parsed model/task/repeat/execute", opts)
 	}
 	for _, name := range []string{"model", "task", "repeat", "execute-tools", "fixture-smoke"} {
-		if !opts.explicitFlags[name] {
-			t.Fatalf("explicit flags = %#v, want %s", opts.explicitFlags, name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !opts.explicitFlags[name] {
+				t.Fatalf("explicit flags = %#v, want %s", opts.explicitFlags, name)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/providers_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/providers_test.go
@@ -83,9 +83,11 @@ func TestModelSpecStringAndReportLabel(t *testing.T) {
 // configuration errors instead of silently selecting a provider.
 func TestParseModelSpec_Errors(t *testing.T) {
 	for _, raw := range []string{"", "openai:", "unknown:model"} {
-		if _, err := parseModelSpec(raw); err == nil {
-			t.Fatalf("parseModelSpec(%q) error = nil, want error", raw)
-		}
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseModelSpec(raw); err == nil {
+				t.Fatalf("parseModelSpec(%q) error = nil, want error", raw)
+			}
+		})
 	}
 }
 
@@ -535,9 +537,11 @@ func TestOpenAITools_HardensExecuteSchema(t *testing.T) {
 	}
 	paramProperties := paramsSchema["properties"].(map[string]any)
 	for _, want := range []string{"project_id", "trigger_id", "schedule_id", "file_path", "ref"} {
-		if _, hasProperty := paramProperties[want]; !hasProperty {
-			t.Fatalf("params properties missing %s: %#v", want, paramProperties)
-		}
+		t.Run(want, func(t *testing.T) {
+			if _, hasProperty := paramProperties[want]; !hasProperty {
+				t.Fatalf("params properties missing %s: %#v", want, paramProperties)
+			}
+		})
 	}
 }
 
@@ -1335,9 +1339,11 @@ func TestGoogleEmptyResponseError_IncludesFinishAndBlockReasons(t *testing.T) {
 	err := googleEmptyResponseError(decoded, "no tool calls or output tokens")
 	message := err.Error()
 	for _, want := range []string{"no tool calls or output tokens", "finishReason=MALFORMED_FUNCTION_CALL", "finishMessage=malformed tool call", "blockReason=SAFETY", "blockReasonMessage=blocked"} {
-		if !strings.Contains(message, want) {
-			t.Fatalf("error = %q, want %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Fatalf("error = %q, want %q", message, want)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
@@ -455,9 +455,11 @@ func TestReadPublishReport_SplitsFullRunByPresetFromTraceArtifacts(t *testing.T)
 		rows[row.Preset] = row
 	}
 	for _, preset := range []string{presetDockerRead, presetDockerMutatingSafe, presetDockerDestructiveSafe} {
-		if rows[preset].Attempts != 1 {
-			t.Fatalf("row[%s] = %+v, want one attempt", preset, rows[preset])
-		}
+		t.Run(preset, func(t *testing.T) {
+			if rows[preset].Attempts != 1 {
+				t.Fatalf("row[%s] = %+v, want one attempt", preset, rows[preset])
+			}
+		})
 	}
 	if rows[presetDockerMutatingSafe].ModelRequests != 2 || rows[presetDockerMutatingSafe].ToolCalls != 2 {
 		t.Fatalf("mutating row counts = %+v, want requests/tools 2", rows[presetDockerMutatingSafe])
@@ -616,10 +618,12 @@ func TestPublishFormattingHelpers_CoverBranchLabels(t *testing.T) {
 		presetSchemaEnterprise,
 	}
 	for index, preset := range orderedPresets {
-		wantRank := index + 1
-		if got := presetRank(preset); got != wantRank {
-			t.Fatalf("presetRank(%q) = %d, want %d", preset, got, wantRank)
-		}
+		t.Run(preset, func(t *testing.T) {
+			wantRank := index + 1
+			if got := presetRank(preset); got != wantRank {
+				t.Fatalf("presetRank(%q) = %d, want %d", preset, got, wantRank)
+			}
+		})
 	}
 
 	providerCases := map[string][2]string{
@@ -632,10 +636,12 @@ func TestPublishFormattingHelpers_CoverBranchLabels(t *testing.T) {
 		"plain-model":      {"Unknown", "plain-model"},
 	}
 	for input, want := range providerCases {
-		provider, model := providerModel(input)
-		if provider != want[0] || model != want[1] {
-			t.Fatalf("providerModel(%q) = %q/%q, want %q/%q", input, provider, model, want[0], want[1])
-		}
+		t.Run(input, func(t *testing.T) {
+			provider, model := providerModel(input)
+			if provider != want[0] || model != want[1] {
+				t.Fatalf("providerModel(%q) = %q/%q, want %q/%q", input, provider, model, want[0], want[1])
+			}
+		})
 	}
 
 	if got := dockerLiveStatus(publishModelSummary{DockerBacked: false}); got != "Not Docker-backed" {

--- a/cmd/eval_mcp_surfaces/internal/evaluator/report_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/report_test.go
@@ -25,9 +25,11 @@ func TestWriteStatusReport_WritesStartupAndErrorSections(t *testing.T) {
 	}
 	content := string(data)
 	for _, want := range []string{"# Dynamic Surface Model Evaluation", "Status: `failed`", "Trace artifacts: `traces`", "    line one", "MCP capability bridge: `enabled`"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("report missing %q:\n%s", want, content)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("report missing %q:\n%s", want, content)
+			}
+		})
 	}
 }
 
@@ -53,9 +55,11 @@ func TestWriteReport_WritesFullEvaluationMarkdown(t *testing.T) {
 	}
 	content := string(data)
 	for _, want := range []string{"# Dynamic Surface Model Evaluation", "Catalog tools: 1", "## Metrics", "## Failure Diagnostics", "## Fixture Tool Coverage", "MT-001", "missing final text"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("report missing %q:\n%s", want, content)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("report missing %q:\n%s", want, content)
+			}
+		})
 	}
 }
 
@@ -180,9 +184,11 @@ func TestReportMetricSections_RenderRunModelUsageAndBridgeTables(t *testing.T) {
 	writeCapabilityBridgeUsage(&b, results, false)
 	content := b.String()
 	for _, want := range []string{"## Per-Run Metrics", "## Per-Model Metrics", "## API Usage", "$0.0160", "gitlab://tools/project.get", "completion:ref/prompt"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("report content missing %q:\n%s", want, content)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("report content missing %q:\n%s", want, content)
+			}
+		})
 	}
 	if !resultsHaveMultipleModels(results) || len(resultsByModel(results)) != 2 {
 		t.Fatalf("model grouping failed: %#v", resultsByModel(results))
@@ -310,9 +316,11 @@ func TestBuildRouteCoverageReport_ListsUncoveredHighRiskRoutes(t *testing.T) {
 
 	report := buildRouteCoverageReport(options{TasksPath: "fixture.md", Partition: "base-read"}, results, routes)
 	for _, want := range []string{"Schema Route Coverage Report", "project.delete", "repository.file_get", "merge_train.list_project", "enterprise_schema_only"} {
-		if !strings.Contains(report, want) {
-			t.Fatalf("coverage report missing %q:\n%s", want, report)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(report, want) {
+				t.Fatalf("coverage report missing %q:\n%s", want, report)
+			}
+		})
 	}
 }
 
@@ -467,13 +475,15 @@ func TestWriteTraceArtifacts_WritesJSONLIndexAndPerTaskFiles(t *testing.T) {
 	}
 
 	for _, name := range []string{"index.md", "traces.jsonl", "run-002-MT-002.json"} {
-		data, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
-		}
-		if !strings.Contains(string(data), "MT-002") {
-			t.Fatalf("%s = %s, want task ID", name, data)
-		}
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			if !strings.Contains(string(data), "MT-002") {
+				t.Fatalf("%s = %s, want task ID", name, data)
+			}
+		})
 	}
 
 	index, err := os.ReadFile(filepath.Join(dir, "index.md"))

--- a/cmd/eval_mcp_surfaces/internal/evaluator/runner_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/runner_test.go
@@ -322,9 +322,11 @@ func TestDynamicDiscoveryResult_FindIncludesSchema(t *testing.T) {
 		t.Fatalf("dynamicDiscoveryResult(find) error = %v", err)
 	}
 	for _, want := range []string{"project.get", "project_id", dynamicExecuteActionTool, "input_schema"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("find result = %s, want %q", content, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("find result = %s, want %q", content, want)
+			}
+		})
 	}
 }
 
@@ -396,9 +398,11 @@ func TestDynamicDiscoveryResult_Find(t *testing.T) {
 		t.Fatalf("dynamicDiscoveryResult(find) error = %v", err)
 	}
 	for _, want := range []string{"project.get", "project_id", dynamicExecuteActionTool} {
-		if !strings.Contains(find, want) {
-			t.Fatalf("find result = %s, want %q", find, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(find, want) {
+				t.Fatalf("find result = %s, want %q", find, want)
+			}
+		})
 	}
 }
 
@@ -582,9 +586,11 @@ func TestSuccessfulSimulatedToolContent_IncludesDiscoveredProject(t *testing.T) 
 		},
 	}, 2, 3)
 	for _, want := range []string{"my-org/tools/gitlab-mcp-server", `"projects"`, `"environments"`} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("successfulSimulatedToolContent(prelude) = %s, want %q", content, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Fatalf("successfulSimulatedToolContent(prelude) = %s, want %q", content, want)
+			}
+		})
 	}
 }
 
@@ -673,9 +679,11 @@ func TestEvaluateTask_RecordsTraceForPromptToolUseAndValidation(t *testing.T) {
 	}
 	wantKinds := []string{"user_prompt", "assistant_message", "tool_use", "validation"}
 	for _, kind := range wantKinds {
-		if !traceHasKind(result.Trace, kind) {
-			t.Fatalf("trace events = %+v, want kind %s", result.Trace.Events, kind)
-		}
+		t.Run(kind, func(t *testing.T) {
+			if !traceHasKind(result.Trace, kind) {
+				t.Fatalf("trace events = %+v, want kind %s", result.Trace.Events, kind)
+			}
+		})
 	}
 	assistantEvent, ok := traceEventByKind(result.Trace, "assistant_message")
 	if !ok || assistantEvent.Provider == nil {

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
@@ -103,17 +103,23 @@ func TestToolResultContent_HandlesStructuredTextAndEmptyResults(t *testing.T) {
 // TestParseToolsSnapshot_AcceptsRawAndWrappedShapes verifies snapshots can be
 // loaded from both tools/list-compatible and plain array fixtures.
 func TestParseToolsSnapshot_AcceptsRawAndWrappedShapes(t *testing.T) {
-	for _, data := range [][]byte{
-		[]byte(`[{"name":"gitlab_project","inputSchema":{"type":"object"}}]`),
-		[]byte(`{"tools":[{"name":"gitlab_project","inputSchema":{"type":"object"}}]}`),
-	} {
-		snapshot, err := parseToolsSnapshot(data)
-		if err != nil {
-			t.Fatalf("parseToolsSnapshot(%s) error = %v", data, err)
-		}
-		if len(snapshot) != 1 || snapshot[0].Name != "gitlab_project" {
-			t.Fatalf("snapshot = %#v, want gitlab_project", snapshot)
-		}
+	shapes := []struct {
+		name string
+		data []byte
+	}{
+		{"plain_array", []byte(`[{"name":"gitlab_project","inputSchema":{"type":"object"}}]`)},
+		{"tools_list_wrapper", []byte(`{"tools":[{"name":"gitlab_project","inputSchema":{"type":"object"}}]}`)},
+	}
+	for _, tc := range shapes {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot, err := parseToolsSnapshot(tc.data)
+			if err != nil {
+				t.Fatalf("parseToolsSnapshot(%s) error = %v", tc.data, err)
+			}
+			if len(snapshot) != 1 || snapshot[0].Name != "gitlab_project" {
+				t.Fatalf("snapshot = %#v, want gitlab_project", snapshot)
+			}
+		})
 	}
 	if _, err := parseToolsSnapshot([]byte(`{"tools":`)); err == nil {
 		t.Fatal("parseToolsSnapshot(invalid) error = nil, want error")

--- a/cmd/eval_mcp_surfaces/internal/evaluator/task_prompts_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/task_prompts_test.go
@@ -13,9 +13,11 @@ func TestTaskPromptForSurface_DynamicBridgeGuidance(t *testing.T) {
 	task := evalTask{ID: "MS-039", Prompt: "Read `gitlab://tools`.", Steps: []evalStep{{ExpectedTool: resourceReadTool, RequiredParams: []string{"uri"}}}}
 	got := taskPromptForSurface(task, config.ToolSurfaceDynamic)
 	for _, want := range []string{"Use MCP capability bridge tools directly", "do not use bridge tools as a substitute for a required catalog action", "gitlab://tools"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("dynamic prompt missing %q:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("dynamic prompt missing %q:\n%s", want, got)
+			}
+		})
 	}
 }
 
@@ -31,9 +33,11 @@ func TestTaskPromptForSurface_DynamicRemoteURLDiscoveryGuidance(t *testing.T) {
 	task := evalTask{ID: "MS-002", Prompt: "Resolve remote URL `https://gitlab.example.com/group/project.git` then inspect pipeline `1`.", Steps: []evalStep{{ExpectedTool: "gitlab_execute_action", ExpectedAction: "discover_project.resolve", RequiredParams: []string{"remote_url"}}, {ExpectedTool: "gitlab_execute_action", ExpectedAction: "pipeline.get", RequiredParams: []string{"project_id", "pipeline_id"}}}}
 	got := taskPromptForSurface(task, config.ToolSurfaceDynamic)
 	for _, want := range []string{"first gitlab_find_action query for that discovery step must explicitly describe resolving the provided remote URL", "must use the project-discovery action with params.remote_url set to that exact URL"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("dynamic prompt missing %q:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("dynamic prompt missing %q:\n%s", want, got)
+			}
+		})
 	}
 	if strings.Contains(got, "discover_project.resolve") {
 		t.Fatalf("dynamic prompt leaked exact discovery action:\n%s", got)
@@ -54,9 +58,11 @@ func TestTaskPromptForSurface_DynamicRemoteURLGuidanceIsScoped(t *testing.T) {
 	got := taskPromptForSurface(task, config.ToolSurfaceDynamic)
 	forbidden := []string{"first gitlab_find_action query for that discovery step must explicitly describe resolving the provided remote URL", "must use the project-discovery action with params.remote_url set to that exact URL"}
 	for _, text := range forbidden {
-		if strings.Contains(got, text) {
-			t.Fatalf("dynamic prompt unexpectedly included remote URL guidance %q:\n%s", text, got)
-		}
+		t.Run(text, func(t *testing.T) {
+			if strings.Contains(got, text) {
+				t.Fatalf("dynamic prompt unexpectedly included remote URL guidance %q:\n%s", text, got)
+			}
+		})
 	}
 	if strings.Contains(got, "discover_project.resolve") {
 		t.Fatalf("dynamic prompt unexpectedly leaked exact discovery action:\n%s", got)
@@ -160,9 +166,11 @@ func TestCompactExactTaskPrompt_UsesExpectedToolName(t *testing.T) {
 func TestSchemaFirstTaskPrompt_RendersFallbackGuidance(t *testing.T) {
 	got := schemaFirstTaskPrompt(evalTask{ID: "MT-999", Prompt: "Find the thing."}, "no", evalStep{ExpectedTool: "", ExpectedAction: "project.get"})
 	for _, want := range []string{"Task MT-999", "Do not use placeholder values", "call gitlab with action project.get"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("schemaFirstTaskPrompt() missing %q:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("schemaFirstTaskPrompt() missing %q:\n%s", want, got)
+			}
+		})
 	}
 }
 
@@ -214,9 +222,11 @@ func TestDynamicTaskPrompt_MultiStepUsesFindFirst(t *testing.T) {
 		"Do not use action IDs from memory",
 	})
 	for _, unwanted := range []string{"Dynamic workflow plan:", "action=issue.create", "do not call gitlab_find_action for these planned actions"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPromptForSurface() = %q, want no exact dynamic plan content %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPromptForSurface() = %q, want no exact dynamic plan content %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -360,9 +370,11 @@ func TestDynamicTaskPrompt_MultiStepOmitsExactActionPlan(t *testing.T) {
 		"Do not use action IDs from memory",
 	})
 	for _, unwanted := range []string{"Dynamic first-step exact call", "pipeline.schedule_create", "do not call gitlab_find_action for these planned actions"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPromptForSurface() = %q, want no exact dynamic plan content %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPromptForSurface() = %q, want no exact dynamic plan content %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -561,9 +573,11 @@ func TestTaskPrompt_MultiStepAvoidsImplicitPagination(t *testing.T) {
 		"do not fetch additional pagination pages",
 		"unless the task explicitly asks for every page",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want pagination guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want pagination guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -593,9 +607,11 @@ func TestTaskPrompt_BroadInventoryUsesExactOrderAndSmallPages(t *testing.T) {
 		"Use params.per_page=1 on list/tree/package steps",
 		"one page is enough for this evaluation",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want broad inventory guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want broad inventory guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -645,9 +661,11 @@ func TestTaskPrompt_PackageReleaseWorkflowUsesExactOrderDynamic(t *testing.T) {
 		"Do not use action IDs from memory",
 	})
 	for _, unwanted := range []string{"Dynamic workflow plan:", "package.publish_directory", "release.link_create_batch"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPromptForSurface(dynamic) = %q, want no exact action guidance %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPromptForSurface(dynamic) = %q, want no exact action guidance %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -674,9 +692,11 @@ func TestTaskPrompt_MergeRequestTimeEmojiUsesExactOrder(t *testing.T) {
 		"using the returned award emoji id as params.award_id with params.confirm=true",
 		"After emoji_mr_delete, call spent_time_reset before time_estimate_reset",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want MR time/emoji guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want MR time/emoji guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -700,9 +720,11 @@ func TestTaskPrompt_MergeRequestNoteCRUDUsesExactOrder(t *testing.T) {
 		"call note_update with params.body set to the updated note text and without params.confirm",
 		"Only note_delete is destructive; call note_delete last with params.confirm=true",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want MR note CRUD guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want MR note CRUD guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -723,9 +745,11 @@ func TestTaskPrompt_MergeRequestNotePrefersNoteCreate(t *testing.T) {
 		`"body":"<body>"`,
 		"Do not use discussion_create unless the task explicitly says threaded discussion or discussion",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want MR note guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want MR note guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -749,9 +773,11 @@ func TestTaskPrompt_RunnerListProjectAvoidsImplicitFilters(t *testing.T) {
 		"Do not send params.paused, params.type, params.tag_list, status all, status active, or empty filter strings for runner.list_project",
 		"For runner jobs, use runner.jobs with params.runner_id only",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want runner filter guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want runner filter guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -776,9 +802,11 @@ func TestTaskPrompt_PipelineTriggerCreateOmitsRef(t *testing.T) {
 		"Use the returned trigger_id for trigger_get, trigger_update, and trigger_delete",
 		"trigger_delete also requires params.confirm=true",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want pipeline trigger guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want pipeline trigger guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -804,9 +832,11 @@ func TestTaskPrompt_RepositoryFileCRUDUsesRefAndDeletesAfterUpdate(t *testing.T)
 		`"action":"file_delete","params":{"project_id":"<project_id>","file_path":"<file_path>","branch":"<branch>","commit_message":"<commit_message>","confirm":true}`,
 		"Do not call file_get again after the update",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want repository file CRUD guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want repository file CRUD guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -829,9 +859,11 @@ func TestTaskPrompt_SingleFileCreateUsesExactToolCall(t *testing.T) {
 		`"branch":"feature/eval"`,
 		`"commit_message":"Create evaluation file"`,
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want exact file_create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want exact file_create guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -853,9 +885,11 @@ func TestTaskPrompt_ProjectGetUsesExactToolCall(t *testing.T) {
 		`"project_id":"my-org/tools/gitlab-mcp-server"`,
 		"do not call gitlab_discover_project",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want exact project_get guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want exact project_get guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -878,9 +912,11 @@ func TestTaskPrompt_InstanceVariableCreateUsesExactToolCall(t *testing.T) {
 		`"value":"masked-value-123"`,
 		"Return exactly one tool call and no text answer",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want exact instance_create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want exact instance_create guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -912,9 +948,11 @@ func TestTaskPrompt_PipelineScheduleCRUDAvoidsProjectPrefetchAndConfirmsDeletes(
 		"Use the returned id as params.schedule_id",
 		"Both schedule_delete_variable and schedule_delete are destructive and require confirm:true according to the active tool surface",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want pipeline schedule guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want pipeline schedule guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -938,9 +976,11 @@ func TestTaskPrompt_DiscoverProjectUsesStandaloneInput(t *testing.T) {
 		"call gitlab_project/get to verify metadata before calling gitlab_repository/file_get",
 		"do not skip the project metadata verification step",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want discover_project guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want discover_project guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -969,9 +1009,11 @@ func TestTaskPrompt_FeatureFlagLifecycleOmitsArrayStrategies(t *testing.T) {
 		"omit params.strategies unless the task gives an exact strategies JSON string",
 		`must be a JSON string such as "[{\"name\":\"default\"}]", never an array or object`,
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want feature flag lifecycle guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want feature flag lifecycle guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -994,9 +1036,11 @@ func TestTaskPrompt_DeployTokenLifecycleAvoidsInventedTimestamp(t *testing.T) {
 		"Do not add params.expires_at unless the task gives an explicit expiry date",
 		"must be YYYY-MM-DD only, never a timestamp",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want deploy token lifecycle guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want deploy token lifecycle guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1115,9 +1159,11 @@ func TestTaskPrompt_ProjectSnippetCRUDAvoidsProjectPrefetch(t *testing.T) {
 		"project_update params should contain project_id, snippet_id, and files",
 		"never send params.file_path or params.content at top level when using files[]",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want project snippet CRUD guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want project snippet CRUD guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1139,9 +1185,11 @@ func TestTaskPrompt_ProjectHookCRUDAvoidsGroupHooks(t *testing.T) {
 		"For project hook CRUD, use gitlab_project actions hook_add, hook_get, hook_edit, and hook_delete with params.project_id",
 		"Do not use gitlab_group hook actions for a project hook workflow",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want project hook guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want project hook guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1184,9 +1232,11 @@ func TestTaskPrompt_SplitDiscussionResolveUsesExactToolCall(t *testing.T) {
 		`"resolved":true`,
 		"Return exactly one tool call and no text answer",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want split discussion_resolve guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want split discussion_resolve guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1247,9 +1297,11 @@ func TestTaskPrompt_ArtifactFromNumericJobUsesSingleArtifact(t *testing.T) {
 
 	prompt := taskPrompt(task)
 	for _, want := range []string{"Exact required call", "use the gitlab_job tool once", `"action":"download_single_artifact"`, `"job_id":999`, `"artifact_path":"coverage/report.xml"`} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want artifact guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want artifact guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1267,9 +1319,11 @@ func TestTaskPrompt_FailedPipelineJobsUseJobList(t *testing.T) {
 
 	prompt := taskPrompt(task)
 	for _, want := range []string{"gitlab_job", `"action":"list"`, `"scope":"failed"`, "do not call gitlab_pipeline list with pipeline_id"} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want failed-job guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want failed-job guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1294,9 +1348,11 @@ func TestTaskPrompt_SingleFailedPipelineJobsUsesExactToolCall(t *testing.T) {
 		`"scope":"failed"`,
 		"Return exactly one tool call and no text answer",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want single failed-job guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want single failed-job guidance containing %q", prompt, want)
+			}
+		})
 	}
 
 	system := systemPromptForTask(task, config.ToolSurfaceMeta)
@@ -1377,20 +1433,26 @@ func TestTaskPrompt_PipelineTriggerDeleteUsesTriggerID(t *testing.T) {
 		"Exact required call",
 		"The supplied ID maps to the matching *_id param",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want pipeline trigger delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want pipeline trigger delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact pipeline trigger delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact pipeline trigger delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 	system := systemPromptForTask(task, config.ToolSurfaceMeta)
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(system, unwanted) {
-			t.Fatalf("systemPromptForTask() = %q, want compact pipeline trigger delete system prompt without %q", system, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(system, unwanted) {
+				t.Fatalf("systemPromptForTask() = %q, want compact pipeline trigger delete system prompt without %q", system, unwanted)
+			}
+		})
 	}
 }
 
@@ -1413,20 +1475,26 @@ func TestTaskPrompt_PipelineScheduleDeleteUsesScheduleID(t *testing.T) {
 		"Exact required call",
 		"The supplied ID maps to the matching *_id param",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want pipeline schedule delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want pipeline schedule delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact pipeline schedule delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact pipeline schedule delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 	system := systemPromptForTask(task, config.ToolSurfaceMeta)
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(system, unwanted) {
-			t.Fatalf("systemPromptForTask() = %q, want compact pipeline schedule delete system prompt without %q", system, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(system, unwanted) {
+				t.Fatalf("systemPromptForTask() = %q, want compact pipeline schedule delete system prompt without %q", system, unwanted)
+			}
+		})
 	}
 }
 
@@ -1448,14 +1516,18 @@ func TestTaskPrompt_UserBlockUsesUserID(t *testing.T) {
 		`"user_id":69`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want user block guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want user block guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"runner_id", "target_branch", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact user block guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact user block guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1479,14 +1551,18 @@ func TestTaskPrompt_FeatureFlagDeleteUsesName(t *testing.T) {
 		"Exact required call",
 		"The supplied values map to the matching params",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want feature flag delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want feature flag delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact feature flag delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact feature flag delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1510,14 +1586,18 @@ func TestTaskPrompt_WikiDeleteUsesSlug(t *testing.T) {
 		"Exact required call",
 		"The supplied values map to the matching params",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want wiki delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want wiki delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"target_branch", "tag_name", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact wiki delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact wiki delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1541,14 +1621,18 @@ func TestTaskPrompt_MRAwardDeleteUsesAwardID(t *testing.T) {
 		`"award_id":21`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want MR award delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want MR award delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"mr_review.emoji_mr_note_delete", "note_id", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact MR award delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact MR award delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1572,14 +1656,18 @@ func TestTaskPrompt_IssueAwardDeleteUsesAwardID(t *testing.T) {
 		`"award_id":22`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want issue award delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want issue award delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"note_id", "target_branch", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact issue award delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact issue award delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1602,9 +1690,11 @@ func TestTaskPrompt_DeployKeyDeleteUsesDeployKeyID(t *testing.T) {
 		`"deploy_key_id":32`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want deploy key delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want deploy key delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1627,9 +1717,11 @@ func TestTaskPrompt_DeployTokenDeleteUsesDeployTokenID(t *testing.T) {
 		`"deploy_token_id":66`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want deploy token delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want deploy token delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1654,14 +1746,18 @@ func TestTaskPrompt_CommitDiscussionDeleteUsesDiscussionAndNote(t *testing.T) {
 		`"note_id":999`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want commit discussion delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want commit discussion delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"issue.discussion_delete_note", "merge_request_iid", "params.variables"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want compact commit discussion delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want compact commit discussion delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1682,9 +1778,11 @@ func TestTaskPrompt_AttestationDownloadUsesAttestationIID(t *testing.T) {
 		`"attestation_iid":5`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want attestation guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want attestation guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1704,9 +1802,11 @@ func TestTaskPrompt_AuditEventGetUsesEventID(t *testing.T) {
 		`"event_id":77`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want audit event get guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want audit event get guidance containing %q", prompt, want)
+			}
+		})
 	}
 	if strings.Contains(prompt, "user_id") {
 		t.Fatalf("taskPrompt() = %q, want event_id guidance without user_id", prompt)
@@ -1732,9 +1832,11 @@ func TestTaskPrompt_AuditEventListUsesCreatedRange(t *testing.T) {
 		`"created_before":"2026-02-01"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want audit event list guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want audit event list guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1754,9 +1856,11 @@ func TestTaskPrompt_CompliancePolicyUpdateUsesNamespaceID(t *testing.T) {
 		`"csp_namespace_id":123`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want compliance policy guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want compliance policy guidance containing %q", prompt, want)
+			}
+		})
 	}
 	if strings.Contains(prompt, "issue_iid") {
 		t.Fatalf("taskPrompt() = %q, want csp_namespace_id guidance without issue_iid", prompt)
@@ -1780,9 +1884,11 @@ func TestTaskPrompt_DependencyExportCreateUsesPipelineID(t *testing.T) {
 		`"pipeline_id":12345`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want dependency export create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want dependency export create guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1802,14 +1908,18 @@ func TestTaskPrompt_DependencyExportDownloadUsesExportID(t *testing.T) {
 		`"export_id":987`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want dependency export download guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want dependency export download guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"project_id", "attestation_iid"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want export_id guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want export_id guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1833,9 +1943,11 @@ func TestTaskPrompt_DORAMetricsGroupUsesMetric(t *testing.T) {
 		`"end_date":"2026-01-31"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want DORA guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want DORA guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1856,9 +1968,11 @@ func TestTaskPrompt_EnterpriseUserGetUsesGroupAndUserID(t *testing.T) {
 		`"user_id":55`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want enterprise user guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want enterprise user guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1882,9 +1996,11 @@ func TestTaskPrompt_EnterpriseUserDisable2FAUsesEnterpriseAction(t *testing.T) {
 		`"confirm":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want enterprise 2FA guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want enterprise 2FA guidance containing %q", prompt, want)
+			}
+		})
 	}
 	if strings.Contains(prompt, "user.disable_two_factor") {
 		t.Fatalf("taskPrompt() = %q, want enterprise action guidance without base user 2FA action", prompt)
@@ -1910,9 +2026,11 @@ func TestTaskPrompt_ExternalStatusCheckCreateUsesExternalURL(t *testing.T) {
 		`"external_url":"https://example.com/check"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want external check create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want external check create guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1936,9 +2054,11 @@ func TestTaskPrompt_ExternalStatusCheckStatusUsesCheckID(t *testing.T) {
 		`"status":"passed"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want external check status guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want external check status guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -1962,14 +2082,18 @@ func TestTaskPrompt_ExternalStatusCheckDeleteUsesCheckID(t *testing.T) {
 		`"confirm":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want external check delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want external check delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"rule_id", "deploy_key_id"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want check_id guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want check_id guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -1989,9 +2113,11 @@ func TestTaskPrompt_GeoGetUsesID(t *testing.T) {
 		`"id":3`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want Geo get guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want Geo get guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2015,9 +2141,11 @@ func TestTaskPrompt_GeoCreateUsesEnabledAndPrimary(t *testing.T) {
 		`"primary":false`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want Geo create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want Geo create guidance containing %q", prompt, want)
+			}
+		})
 	}
 	if strings.Contains(prompt, "paused") {
 		t.Fatalf("taskPrompt() = %q, want Geo create guidance without paused", prompt)
@@ -2043,14 +2171,18 @@ func TestTaskPrompt_GeoDeleteUsesID(t *testing.T) {
 		`"confirm":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want Geo delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want Geo delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"geo_node_id", "site_id", "path"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want Geo delete guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want Geo delete guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -2072,9 +2204,11 @@ func TestTaskPrompt_GroupCredentialListUsesCredentialAction(t *testing.T) {
 		`"state":"active"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group credential list guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group credential list guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2098,9 +2232,11 @@ func TestTaskPrompt_GroupCredentialRevokeUsesTokenID(t *testing.T) {
 		`"confirm":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group credential revoke guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group credential revoke guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2121,9 +2257,11 @@ func TestTaskPrompt_GroupEpicBoardListUsesEpicBoardAction(t *testing.T) {
 		`"group_id":"my-org"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic board list guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic board list guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2145,14 +2283,18 @@ func TestTaskPrompt_GroupEpicListUsesFullPath(t *testing.T) {
 		`"include_descendants":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic list guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic list guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"group_path", "group_id", "include_descendant_groups"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want group epic list guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want group epic list guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -2174,9 +2316,11 @@ func TestTaskPrompt_GroupEpicCreateUsesFullPathAndTitle(t *testing.T) {
 		`"title":"Evaluation Epic"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic create guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic create guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2199,9 +2343,11 @@ func TestTaskPrompt_GroupEpicUpdateUsesEpicIID(t *testing.T) {
 		`"state_event":"close"`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic update guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic update guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2225,9 +2371,11 @@ func TestTaskPrompt_GroupEpicDeleteUsesEpicIID(t *testing.T) {
 		`"confirm":true`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic delete guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic delete guidance containing %q", prompt, want)
+			}
+		})
 	}
 }
 
@@ -2250,13 +2398,17 @@ func TestTaskPrompt_GroupEpicIssueAssignUsesChildParams(t *testing.T) {
 		`"child_iid":99`,
 		"Exact required call",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("taskPrompt() = %q, want group epic issue assign guidance containing %q", prompt, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("taskPrompt() = %q, want group epic issue assign guidance containing %q", prompt, want)
+			}
+		})
 	}
 	for _, unwanted := range []string{"project_id", "issue_iid", "target_full_path"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPrompt() = %q, want group epic issue assign guidance without %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPrompt() = %q, want group epic issue assign guidance without %q", prompt, unwanted)
+			}
+		})
 	}
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/tasks_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/tasks_test.go
@@ -39,14 +39,18 @@ func TestTaskRoutePredicates_ClassifyEnterpriseMutationAndDestruction(t *testing
 // readiness waits only for statuses GitLab can still advance asynchronously.
 func TestLiveMergeStatusStillPreparing_CoversTransientStatuses(t *testing.T) {
 	for _, status := range []string{"", "checking", "unchecked", "preparing", "ci_still_running", "approvals_syncing"} {
-		if !liveMergeStatusStillPreparing(status) {
-			t.Fatalf("liveMergeStatusStillPreparing(%q) = false, want true", status)
-		}
+		t.Run(status, func(t *testing.T) {
+			if !liveMergeStatusStillPreparing(status) {
+				t.Fatalf("liveMergeStatusStillPreparing(%q) = false, want true", status)
+			}
+		})
 	}
 	for _, status := range []string{"cannot_be_merged", "not_open", "not_approved"} {
-		if liveMergeStatusStillPreparing(status) {
-			t.Fatalf("liveMergeStatusStillPreparing(%q) = true, want false", status)
-		}
+		t.Run(status, func(t *testing.T) {
+			if liveMergeStatusStillPreparing(status) {
+				t.Fatalf("liveMergeStatusStillPreparing(%q) = true, want false", status)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/tasks_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/tasks_test.go
@@ -304,15 +304,20 @@ func TestOrderSharedFixtureDestructiveLast_UsesTypedFixtureDependencies(t *testi
 // TestCatalogHasEnterpriseRoutes_DetectsRouteMapShapes verifies Enterprise
 // detection works for unified, dynamic, and split meta route maps.
 func TestCatalogHasEnterpriseRoutes_DetectsRouteMapShapes(t *testing.T) {
-	cases := []map[string]toolutil.ActionMap{
-		{"gitlab": {"merge_train.list_project": toolutil.ActionRoute{}}},
-		{dynamicExecuteActionTool: {"merge_train.list_project": toolutil.ActionRoute{}}},
-		{"gitlab_merge_train": {"list_project": toolutil.ActionRoute{}}},
+	cases := []struct {
+		name   string
+		routes map[string]toolutil.ActionMap
+	}{
+		{"unified_meta_map", map[string]toolutil.ActionMap{"gitlab": {"merge_train.list_project": toolutil.ActionRoute{}}}},
+		{"dynamic_map", map[string]toolutil.ActionMap{dynamicExecuteActionTool: {"merge_train.list_project": toolutil.ActionRoute{}}}},
+		{"split_meta_map", map[string]toolutil.ActionMap{"gitlab_merge_train": {"list_project": toolutil.ActionRoute{}}}},
 	}
-	for _, routes := range cases {
-		if !catalogHasEnterpriseRoutes(routes) {
-			t.Fatalf("catalogHasEnterpriseRoutes(%v) = false, want true", routes)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !catalogHasEnterpriseRoutes(tc.routes) {
+				t.Fatalf("catalogHasEnterpriseRoutes(%v) = false, want true", tc.routes)
+			}
+		})
 	}
 	if catalogHasEnterpriseRoutes(map[string]toolutil.ActionMap{"gitlab_project": {"get": toolutil.ActionRoute{}}}) {
 		t.Fatal("catalogHasEnterpriseRoutes(base route) = true, want false")

--- a/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/types_test.go
@@ -250,9 +250,11 @@ func TestDynamicSingleTaskPrompt_TerraformStateUnlockExactCallAvoidsLegacyEnvelo
 	}
 	requireContainsAll(t, "taskPromptForSurface()", prompt, required)
 	for _, unwanted := range []string{`"action":"terraform_state.unlock"`, `"terraform_state_name":`, `"action":"admin.terraform_state_unlock"`} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPromptForSurface() = %q, want no legacy terraform state envelope %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPromptForSurface() = %q, want no legacy terraform state envelope %q", prompt, unwanted)
+			}
+		})
 	}
 }
 
@@ -325,9 +327,11 @@ func TestDynamicRepositoryFileCRUDPrompt_UsesFilePathFromOperation(t *testing.T)
 		"my-org/tools/gitlab-mcp-server",
 	})
 	for _, unwanted := range []string{`"action":"repository.file_create"`, `"file_path":"my-org/tools/gitlab-mcp-server"`, "repository.file_create"} {
-		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("taskPromptForSurface() = %q, want no exact file CRUD content %q", prompt, unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(prompt, unwanted) {
+				t.Fatalf("taskPromptForSurface() = %q, want no exact file CRUD content %q", prompt, unwanted)
+			}
+		})
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/validation_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/validation_test.go
@@ -860,9 +860,11 @@ func TestValidationRepairMessage_DynamicWrongActionIncludesOrderingHint(t *testi
 		"not the current scenario step",
 		"do not skip ahead",
 	} {
-		if !strings.Contains(message, want) {
-			t.Fatalf("message = %q, want substring %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Fatalf("message = %q, want substring %q", message, want)
+			}
+		})
 	}
 }
 
@@ -877,9 +879,11 @@ func TestValidationRepairMessage_UnknownParamsDropsCarriedFields(t *testing.T) {
 		"Remove every unknown param",
 		"do not carry IDs from a previous action",
 	} {
-		if !strings.Contains(message, want) {
-			t.Fatalf("message = %q, want substring %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Fatalf("message = %q, want substring %q", message, want)
+			}
+		})
 	}
 }
 
@@ -894,9 +898,11 @@ func TestValidationRepairMessage_PreservesAttemptedRequiredParams(t *testing.T) 
 	})
 
 	for _, want := range []string{`"action":"pipeline.trigger_get"`, `"project_id":"my-org/tools/gitlab-mcp-server"`, `"trigger_id":67`} {
-		if !strings.Contains(message, want) {
-			t.Fatalf("message = %q, want substring %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Fatalf("message = %q, want substring %q", message, want)
+			}
+		})
 	}
 }
 

--- a/cmd/gen_action_catalog_manifest/main_test.go
+++ b/cmd/gen_action_catalog_manifest/main_test.go
@@ -55,9 +55,11 @@ func TestGenerateManifest_IsDeterministic(t *testing.T) {
 		"buildAccessActionSpecs,",
 		"buildWikiActionSpecs,",
 	} {
-		if !bytes.Contains(first, []byte(want)) {
-			t.Fatalf("generated manifest missing %q:\n%s", want, first)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !bytes.Contains(first, []byte(want)) {
+				t.Fatalf("generated manifest missing %q:\n%s", want, first)
+			}
+		})
 	}
 }
 

--- a/cmd/gen_brand/main_test.go
+++ b/cmd/gen_brand/main_test.go
@@ -63,14 +63,18 @@ func TestAssets_SharedGeometryReachesEveryEmitter(t *testing.T) {
 func TestAssets_CanonicalCarriesNoColor(t *testing.T) {
 	canonical := canonicalSVG()
 	for _, forbidden := range []string{"#", "currentColor"} {
-		if strings.Contains(canonical, forbidden) {
-			t.Errorf("canonical mark contains %q; it must be painted by site CSS tokens only", forbidden)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if strings.Contains(canonical, forbidden) {
+				t.Errorf("canonical mark contains %q; it must be painted by site CSS tokens only", forbidden)
+			}
+		})
 	}
 	for _, class := range []string{"m-node", "m-branch", "m-tip"} {
-		if !strings.Contains(canonical, class) {
-			t.Errorf("canonical mark is missing the %q class", class)
-		}
+		t.Run(class, func(t *testing.T) {
+			if !strings.Contains(canonical, class) {
+				t.Errorf("canonical mark is missing the %q class", class)
+			}
+		})
 	}
 }
 
@@ -99,17 +103,21 @@ func TestRun_WriteThenCheck_RoundTrips(t *testing.T) {
 // every renderer fails on silently.
 func TestEmbeddedBackgrounds_AreValidJPEGs(t *testing.T) {
 	for name, art := range map[string][]byte{"bg-wide": bgWide, "bg-tall": bgTall} {
-		if len(art) < 4 || art[0] != 0xff || art[1] != 0xd8 {
-			t.Errorf("%s does not start with the JPEG SOI marker", name)
-		}
-		if _, err := jpeg.DecodeConfig(bytes.NewReader(art)); err != nil {
-			t.Errorf("%s does not decode as JPEG: %v", name, err)
-		}
+		t.Run(name, func(t *testing.T) {
+			if len(art) < 4 || art[0] != 0xff || art[1] != 0xd8 {
+				t.Errorf("%s does not start with the JPEG SOI marker", name)
+			}
+			if _, err := jpeg.DecodeConfig(bytes.NewReader(art)); err != nil {
+				t.Errorf("%s does not decode as JPEG: %v", name, err)
+			}
+		})
 	}
 	for _, card := range []string{bannerSVG(), ogSVG(), socialSVG()} {
-		if !strings.Contains(card, "data:image/jpeg;base64,") {
-			t.Error("a card is missing its embedded background layer")
-		}
+		t.Run(card, func(t *testing.T) {
+			if !strings.Contains(card, "data:image/jpeg;base64,") {
+				t.Error("a card is missing its embedded background layer")
+			}
+		})
 	}
 }
 

--- a/cmd/gen_icon_webp/main_test.go
+++ b/cmd/gen_icon_webp/main_test.go
@@ -114,10 +114,12 @@ func TestExtractIcons_FindsSVGConstantsInDeclarationOrder(t *testing.T) {
 	if len(names) != len(want) {
 		t.Fatalf("extractIcons() names = %v, want %v", names, want)
 	}
-	for i := range want {
-		if names[i] != want[i] {
-			t.Fatalf("extractIcons() names = %v, want %v", names, want)
-		}
+	for i, name := range want {
+		t.Run(name, func(t *testing.T) {
+			if names[i] != name {
+				t.Fatalf("extractIcons() names = %v, want %v", names, want)
+			}
+		})
 	}
 	if icons[0].svg != "<svg>branch</svg>" {
 		t.Errorf("icons[0].svg = %q, want %q", icons[0].svg, "<svg>branch</svg>")

--- a/cmd/gen_icon_webp/main_test.go
+++ b/cmd/gen_icon_webp/main_test.go
@@ -218,13 +218,15 @@ func TestGenerateAll_WritesEveryVariant(t *testing.T) {
 	}
 
 	for _, name := range []string{"branch-light.webp", "branch-dark.webp", "mr-light.webp", "mr-dark.webp"} {
-		data, readErr := os.ReadFile(filepath.Join(dir, name))
-		if readErr != nil {
-			t.Fatalf("expected %s to exist: %v", name, readErr)
-		}
-		if len(data) == 0 {
-			t.Errorf("%s is empty", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			data, readErr := os.ReadFile(filepath.Join(dir, name))
+			if readErr != nil {
+				t.Fatalf("expected %s to exist: %v", name, readErr)
+			}
+			if len(data) == 0 {
+				t.Errorf("%s is empty", name)
+			}
+		})
 	}
 	branchLight, _ := os.ReadFile(filepath.Join(dir, "branch-light.webp"))
 	if string(branchLight) != "<svg>branch</svg>|"+colorLight {

--- a/cmd/gen_lhm_manifest/main_test.go
+++ b/cmd/gen_lhm_manifest/main_test.go
@@ -108,9 +108,11 @@ func TestGenerate_ReportsCapabilityCounts(t *testing.T) {
 		t.Fatalf("generate() error: %v", err)
 	}
 	for _, want := range []string{"tools", "prompts", "resources"} {
-		if !strings.Contains(counts, want) {
-			t.Fatalf("counts summary = %q, want it to mention %q", counts, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(counts, want) {
+				t.Fatalf("counts summary = %q, want it to mention %q", counts, want)
+			}
+		})
 	}
 }
 
@@ -161,13 +163,15 @@ func TestGenerate_OmitsOutputSchemaAndIcons(t *testing.T) {
 		"tool": raw.Tools, "prompt": raw.Prompts, "resource": raw.Resources,
 	}
 	for kind, entries := range groups {
-		for _, entry := range entries {
-			for _, unwanted := range []string{"outputSchema", "icons", "_meta"} {
-				if _, found := entry[unwanted]; found {
-					t.Fatalf("%s entry carries %q, want it dropped", kind, unwanted)
+		t.Run(kind, func(t *testing.T) {
+			for _, entry := range entries {
+				for _, unwanted := range []string{"outputSchema", "icons", "_meta"} {
+					if _, found := entry[unwanted]; found {
+						t.Fatalf("%s entry carries %q, want it dropped", kind, unwanted)
+					}
 				}
 			}
-		}
+		})
 	}
 }
 

--- a/cmd/gen_lhm_manifest/main_test.go
+++ b/cmd/gen_lhm_manifest/main_test.go
@@ -132,10 +132,12 @@ func TestGenerate_DeclaresDefaultDynamicSurface(t *testing.T) {
 	}
 	names := []string{m.Tools[0].Name, m.Tools[1].Name}
 	want := []string{"gitlab_execute_action", "gitlab_find_action"}
-	for i := range want {
-		if names[i] != want[i] {
-			t.Fatalf("tools = %v, want %v", names, want)
-		}
+	for i, name := range want {
+		t.Run(name, func(t *testing.T) {
+			if names[i] != name {
+				t.Fatalf("tools = %v, want %v", names, want)
+			}
+		})
 	}
 }
 
@@ -257,10 +259,12 @@ func TestManifestPrompts_SortedByName(t *testing.T) {
 	})
 
 	want := []string{"audit_project_full", "my_open_mrs", "review_mr"}
-	for i := range want {
-		if got[i].Name != want[i] {
-			t.Fatalf("position %d = %q, want %q", i, got[i].Name, want[i])
-		}
+	for i, name := range want {
+		t.Run(name, func(t *testing.T) {
+			if got[i].Name != name {
+				t.Fatalf("position %d = %q, want %q", i, got[i].Name, name)
+			}
+		})
 	}
 }
 

--- a/cmd/gen_llms/main_test.go
+++ b/cmd/gen_llms/main_test.go
@@ -345,14 +345,18 @@ func TestIsGeneratedLLMSFile_CoversEveryCompanion(t *testing.T) {
 		llmsFileName, llmsFullFileName, llmsMediumFileName,
 		llmsFullMetaFileName, llmsFullIndividualFileName, llmsFullCapabilityFileName,
 	} {
-		if !isGeneratedLLMSFile(name) {
-			t.Errorf("isGeneratedLLMSFile(%q) = false, want true", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !isGeneratedLLMSFile(name) {
+				t.Errorf("isGeneratedLLMSFile(%q) = false, want true", name)
+			}
+		})
 	}
 	for _, name := range []string{"README.md", "llms.txt.bak", "../llms.txt", ""} {
-		if isGeneratedLLMSFile(name) {
-			t.Errorf("isGeneratedLLMSFile(%q) = true, want false", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if isGeneratedLLMSFile(name) {
+				t.Errorf("isGeneratedLLMSFile(%q) = true, want false", name)
+			}
+		})
 	}
 }
 
@@ -376,17 +380,21 @@ func TestWriteLLMSMediumMetaTools_OmitsSchemas(t *testing.T) {
 	got := b.String()
 
 	for _, want := range []string{"### gitlab_issue", "**Issue**", "Actions (3):", "create, get, list"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("medium meta-tools output missing %q\ngot:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("medium meta-tools output missing %q\ngot:\n%s", want, got)
+			}
+		})
 	}
 	// Actions must be sorted so regeneration is deterministic.
 	if strings.Index(got, "create") > strings.Index(got, "get") {
 		t.Error("actions are not sorted alphabetically")
 	}
 	for _, unwanted := range []string{"inputSchema", "\"properties\"", "Input Schema"} {
-		if strings.Contains(got, unwanted) {
-			t.Errorf("medium meta-tools output must not embed schemas, found %q", unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(got, unwanted) {
+				t.Errorf("medium meta-tools output must not embed schemas, found %q", unwanted)
+			}
+		})
 	}
 }

--- a/cmd/gen_testing_docs/main_test.go
+++ b/cmd/gen_testing_docs/main_test.go
@@ -85,9 +85,11 @@ func TestMain(m *testing.M) {}
 		patternTestCov:      1,
 	}
 	for pattern, want := range expected {
-		if got := counts[pattern]; got != want {
-			t.Fatalf("pattern %s count = %d, want %d", pattern, got, want)
-		}
+		t.Run(pattern, func(t *testing.T) {
+			if got := counts[pattern]; got != want {
+				t.Fatalf("pattern %s count = %d, want %d", pattern, got, want)
+			}
+		})
 	}
 }
 
@@ -194,9 +196,11 @@ func TestReplaceGeneratedBlock_MigratesLegacySection(t *testing.T) {
 		t.Fatalf("replaceGeneratedBlock() error = %v", err)
 	}
 	for _, want := range []string{startMarker, "new metrics", endMarker, "## Test Types", "manual content"} {
-		if !strings.Contains(updated, want) {
-			t.Fatalf("updated content missing %q:\n%s", want, updated)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(updated, want) {
+				t.Fatalf("updated content missing %q:\n%s", want, updated)
+			}
+		})
 	}
 	if strings.Contains(updated, "old metrics") {
 		t.Fatalf("legacy metrics should have been replaced:\n%s", updated)

--- a/cmd/godoc_tool/audit_test.go
+++ b/cmd/godoc_tool/audit_test.go
@@ -126,6 +126,7 @@ func (BadType) Run() {}
 	}
 	for _, category := range []string{categoryConstMissing, categoryConstForm, categoryVarMissing, categoryVarForm, categoryFuncMissing, categoryMethodForm} {
 		t.Run(category, func(t *testing.T) {
+			t.Parallel()
 			if !hasCategory(findings, category) {
 				t.Fatalf("missing category %q in %#v", category, findings)
 			}
@@ -207,6 +208,7 @@ func ExampleWidget() {
 	}
 	for _, category := range []string{categoryTestMissing, categoryBenchmarkMissing, categoryFuzzMissing, categoryExampleOutput} {
 		t.Run(category, func(t *testing.T) {
+			t.Parallel()
 			if !hasCategory(withTests, category) {
 				t.Fatalf("missing category %q in %#v", category, withTests)
 			}

--- a/cmd/godoc_tool/audit_test.go
+++ b/cmd/godoc_tool/audit_test.go
@@ -125,9 +125,11 @@ func (BadType) Run() {}
 		t.Fatalf("auditPackage() error = %v", err)
 	}
 	for _, category := range []string{categoryConstMissing, categoryConstForm, categoryVarMissing, categoryVarForm, categoryFuncMissing, categoryMethodForm} {
-		if !hasCategory(findings, category) {
-			t.Fatalf("missing category %q in %#v", category, findings)
-		}
+		t.Run(category, func(t *testing.T) {
+			if !hasCategory(findings, category) {
+				t.Fatalf("missing category %q in %#v", category, findings)
+			}
+		})
 	}
 }
 
@@ -204,9 +206,11 @@ func ExampleWidget() {
 		t.Fatalf("auditPackage(includeTests=true) error = %v", err)
 	}
 	for _, category := range []string{categoryTestMissing, categoryBenchmarkMissing, categoryFuzzMissing, categoryExampleOutput} {
-		if !hasCategory(withTests, category) {
-			t.Fatalf("missing category %q in %#v", category, withTests)
-		}
+		t.Run(category, func(t *testing.T) {
+			if !hasCategory(withTests, category) {
+				t.Fatalf("missing category %q in %#v", category, withTests)
+			}
+		})
 	}
 }
 

--- a/cmd/internal/apidocs/apidocs_test.go
+++ b/cmd/internal/apidocs/apidocs_test.go
@@ -237,9 +237,11 @@ func TestParseRetryAfter(t *testing.T) {
 		t.Errorf("padded: got %v, want 10s", got)
 	}
 	for _, v := range []string{"", "0", "-3", "garbage"} {
-		if got := parseRetryAfter(v); got != 0 {
-			t.Errorf("parseRetryAfter(%q) = %v, want 0", v, got)
-		}
+		t.Run(v, func(t *testing.T) {
+			if got := parseRetryAfter(v); got != 0 {
+				t.Errorf("parseRetryAfter(%q) = %v, want 0", v, got)
+			}
+		})
 	}
 	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
 	if got := parseRetryAfter(future); got <= 0 || got > 31*time.Second {

--- a/cmd/internal/mcpsurface/surface_test.go
+++ b/cmd/internal/mcpsurface/surface_test.go
@@ -57,9 +57,11 @@ func TestDynamicTools_ExposesFindAndExecute(t *testing.T) {
 		t.Fatalf("execute InputSchema properties has type %T, want map[string]any", executeSchema["properties"])
 	}
 	for _, property := range []string{"action", "params", "confirm"} {
-		if _, exists := executeProperties[property]; !exists {
-			t.Fatalf("execute InputSchema missing %q property: %v", property, executeProperties)
-		}
+		t.Run(property, func(t *testing.T) {
+			if _, exists := executeProperties[property]; !exists {
+				t.Fatalf("execute InputSchema missing %q property: %v", property, executeProperties)
+			}
+		})
 	}
 	required, ok := executeSchema["required"].([]any)
 	if !ok {
@@ -87,9 +89,11 @@ func TestSortDynamicTools_PutsFindBeforeExecute(t *testing.T) {
 
 	want := []string{DynamicFindToolName, DynamicExecuteActionToolName, "aaa_unexpected", "zzz_unexpected"}
 	for i, name := range want {
-		if dynamicTools[i].Name != name {
-			t.Fatalf("position %d = %q, want %q", i, dynamicTools[i].Name, name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if dynamicTools[i].Name != name {
+				t.Fatalf("position %d = %q, want %q", i, dynamicTools[i].Name, name)
+			}
+		})
 	}
 }
 

--- a/cmd/server/authgate_test.go
+++ b/cmd/server/authgate_test.go
@@ -153,9 +153,11 @@ func TestMCPServerGate_MissingCredential_Returns401WithBearerChallenge(t *testin
 	}
 	// The message is the only place the caller learns the accepted headers.
 	for _, want := range []string{"PRIVATE-TOKEN", "Bearer"} {
-		if !strings.Contains(decoded.Error.Message, want) {
-			t.Errorf("message %q does not mention %q", decoded.Error.Message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(decoded.Error.Message, want) {
+				t.Errorf("message %q does not mention %q", decoded.Error.Message, want)
+			}
+		})
 	}
 }
 
@@ -439,12 +441,14 @@ func TestGateErrorCodes_AllocatedOutsideReservedRange(t *testing.T) {
 		"errCodeTooManyRequests":     errCodeTooManyRequests,
 		"errCodeUpstreamUnavailable": errCodeUpstreamUnavailable,
 	} {
-		if standard[code] {
-			continue
-		}
-		if code >= -32768 && code <= -32000 {
-			t.Errorf("%s = %d is inside the JSON-RPC reserved range; application codes must be outside it", name, code)
-		}
+		t.Run(name, func(t *testing.T) {
+			if standard[code] {
+				return
+			}
+			if code >= -32768 && code <= -32000 {
+				t.Errorf("%s = %d is inside the JSON-RPC reserved range; application codes must be outside it", name, code)
+			}
+		})
 	}
 }
 

--- a/cmd/server/bearerguard_test.go
+++ b/cmd/server/bearerguard_test.go
@@ -125,6 +125,7 @@ func TestBearerGuard_InvalidToken_ChallengesWithInvalidTokenCode(t *testing.T) {
 	challenge := failure.header.Get("WWW-Authenticate")
 	for _, want := range []string{`error="invalid_token"`, `error_description="`, `resource_metadata="`} {
 		t.Run(want, func(t *testing.T) {
+			t.Parallel()
 			if !strings.Contains(challenge, want) {
 				t.Errorf("challenge %q is missing %s", challenge, want)
 			}
@@ -288,6 +289,7 @@ func TestBearerGuard_NoAPIScope_IsForbiddenNotUnauthorized(t *testing.T) {
 	challenge := failure.header.Get("WWW-Authenticate")
 	for _, want := range []string{`error="insufficient_scope"`, `scope="` + oauth.MinimumScope + `"`} {
 		t.Run(want, func(t *testing.T) {
+			t.Parallel()
 			if !strings.Contains(challenge, want) {
 				t.Errorf("challenge %q is missing %s", challenge, want)
 			}

--- a/cmd/server/bearerguard_test.go
+++ b/cmd/server/bearerguard_test.go
@@ -124,9 +124,11 @@ func TestBearerGuard_InvalidToken_ChallengesWithInvalidTokenCode(t *testing.T) {
 	}
 	challenge := failure.header.Get("WWW-Authenticate")
 	for _, want := range []string{`error="invalid_token"`, `error_description="`, `resource_metadata="`} {
-		if !strings.Contains(challenge, want) {
-			t.Errorf("challenge %q is missing %s", challenge, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(challenge, want) {
+				t.Errorf("challenge %q is missing %s", challenge, want)
+			}
+		})
 	}
 }
 
@@ -285,9 +287,11 @@ func TestBearerGuard_NoAPIScope_IsForbiddenNotUnauthorized(t *testing.T) {
 	// error_description.
 	challenge := failure.header.Get("WWW-Authenticate")
 	for _, want := range []string{`error="insufficient_scope"`, `scope="` + oauth.MinimumScope + `"`} {
-		if !strings.Contains(challenge, want) {
-			t.Errorf("challenge %q is missing %s", challenge, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(challenge, want) {
+				t.Errorf("challenge %q is missing %s", challenge, want)
+			}
+		})
 	}
 	if strings.Contains(challenge, `scope="`+oauth.ScopeAPI+`"`) {
 		t.Errorf("challenge %q demands the write scope for a request that only needs %s", challenge, oauth.MinimumScope)

--- a/cmd/server/bearerguard_test.go
+++ b/cmd/server/bearerguard_test.go
@@ -446,16 +446,19 @@ func TestBearerGuard_Middleware_AuthenticatedRequestContinues(t *testing.T) {
 func TestQuotedStringEscape_EscapesQuotesAndBackslashes(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct{ in, want string }{
-		{"plain", "plain"},
-		{`with "quotes"`, `with \"quotes\"`},
-		{`back\slash`, `back\\slash`},
-		{"", ""},
+	tests := []struct{ name, in, want string }{
+		{"no_special_characters", "plain", "plain"},
+		{"double_quotes", `with "quotes"`, `with \"quotes\"`},
+		{"backslash", `back\slash`, `back\\slash`},
+		{"empty", "", ""},
 	}
 	for _, tt := range tests {
-		if got := quotedStringEscape(tt.in); got != tt.want {
-			t.Errorf("quotedStringEscape(%q) = %q, want %q", tt.in, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := quotedStringEscape(tt.in); got != tt.want {
+				t.Errorf("quotedStringEscape(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/server/envflags_test.go
+++ b/cmd/server/envflags_test.go
@@ -74,9 +74,11 @@ func TestEnvBackedFlags_AnUnpassedFlagLeavesTheEnvironmentAlone(t *testing.T) {
 		"UPLOAD_MAX_FILE_SIZE": "1048576",
 		"YOLO_MODE":            "true",
 	} {
-		if got := os.Getenv(name); got != want {
-			t.Errorf("%s = %q, want %q; an unpassed flag cleared a variable the operator set", name, got, want)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got := os.Getenv(name); got != want {
+				t.Errorf("%s = %q, want %q; an unpassed flag cleared a variable the operator set", name, got, want)
+			}
+		})
 	}
 }
 
@@ -102,9 +104,11 @@ func TestEnvBackedFlags_EverySettingIsReachableFromTheCommandLine(t *testing.T) 
 	}
 
 	for flagName, envName := range want {
-		if got[flagName] != envName {
-			t.Errorf("-%s maps to %q, want %q", flagName, got[flagName], envName)
-		}
+		t.Run(flagName, func(t *testing.T) {
+			if got[flagName] != envName {
+				t.Errorf("-%s maps to %q, want %q", flagName, got[flagName], envName)
+			}
+		})
 	}
 	if len(got) != len(want) {
 		t.Errorf("%d env-backed flags declared, expected %d; a new one needs a case here", len(got), len(want))

--- a/cmd/server/firstrun_test.go
+++ b/cmd/server/firstrun_test.go
@@ -80,9 +80,11 @@ func TestFirstRunGuidance_NamesWhatItNeeds(t *testing.T) {
 	got := out.String()
 
 	for _, want := range []string{"GITLAB_URL", "GITLAB_TOKEN", "2.7.5", "--help"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("the screen never mentions %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("the screen never mentions %q", want)
+			}
+		})
 	}
 	if strings.Contains(got, "/guides/") {
 		t.Errorf("the screen links into /guides/, a path the documentation site does not serve:\n%s", got)

--- a/cmd/server/instructions_test.go
+++ b/cmd/server/instructions_test.go
@@ -159,9 +159,11 @@ func TestBuildInstructions_SurfacesDifferInNamesNotAdvice(t *testing.T) {
 		text := buildInstructions(surface, config.CapabilitySurfaceFull, false)
 		rendered[surface] = text
 		for _, section := range sections {
-			if !strings.Contains(text, section) {
-				t.Errorf("surface %q instructions are missing the %q section", surface, section)
-			}
+			t.Run(section, func(t *testing.T) {
+				if !strings.Contains(text, section) {
+					t.Errorf("surface %q instructions are missing the %q section", surface, section)
+				}
+			})
 		}
 	}
 
@@ -179,16 +181,20 @@ func TestBuildInstructions_SurfacesDifferInNamesNotAdvice(t *testing.T) {
 func TestBuildInstructions_DynamicExplainsTheTwoToolWorkflow(t *testing.T) {
 	dynamic := buildInstructions(config.ToolSurfaceDynamic, config.CapabilitySurfaceFull, false)
 	for _, want := range []string{"gitlab_find_action", "gitlab_execute_action", "FINDING TOOLS"} {
-		if !strings.Contains(dynamic, want) {
-			t.Errorf("dynamic instructions missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(dynamic, want) {
+				t.Errorf("dynamic instructions missing %q", want)
+			}
+		})
 	}
 
 	// The other surfaces must not advertise a workflow they cannot run.
 	for _, surface := range []string{config.ToolSurfaceMeta, config.ToolSurfaceIndividual} {
-		if strings.Contains(buildInstructions(surface, config.CapabilitySurfaceFull, false), "gitlab_find_action") {
-			t.Errorf("surface %q instructions mention gitlab_find_action, which only dynamic mode exposes", surface)
-		}
+		t.Run(surface, func(t *testing.T) {
+			if strings.Contains(buildInstructions(surface, config.CapabilitySurfaceFull, false), "gitlab_find_action") {
+				t.Errorf("surface %q instructions mention gitlab_find_action, which only dynamic mode exposes", surface)
+			}
+		})
 	}
 }
 

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"io/fs"
 	"net"
@@ -57,7 +58,9 @@ func TestIsUnixSocketAddr_DistinguishesPathsFromHostPort(t *testing.T) {
 // reach the server and one that cannot — and, in the other direction, between
 // a socket only the proxy's group can open and one every local account can.
 func TestListenHTTP_UnixSocket_ServesAndAppliesTheMode(t *testing.T) {
-	t.Parallel()
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
 
 	path := filepath.Join(t.TempDir(), "mcp.sock")
 	listener, err := listenHTTP(t.Context(), path, config.DefaultSocketMode)
@@ -117,7 +120,9 @@ func TestClearStaleSocket_AbsentPathIsFine(t *testing.T) {
 // exists to allow: a restart after a process died without unlinking its
 // socket, which would otherwise fail to bind forever.
 func TestClearStaleSocket_DeadSocketIsRemoved(t *testing.T) {
-	t.Parallel()
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
 
 	path := filepath.Join(t.TempDir(), "dead.sock")
 	listener := listenUnixForTest(t, path)
@@ -143,7 +148,9 @@ func TestClearStaleSocket_DeadSocketIsRemoved(t *testing.T) {
 // running server is still serving, leaving it holding a listener nobody can
 // reach. A successful connect is the proof somebody is there.
 func TestClearStaleSocket_LiveSocketIsRefused(t *testing.T) {
-	t.Parallel()
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
 
 	path := filepath.Join(t.TempDir(), "live.sock")
 	listener := listenUnixForTest(t, path)
@@ -179,7 +186,9 @@ func TestClearStaleSocket_LiveSocketIsRefused(t *testing.T) {
 // racing restart. Here the probe is cancelled before it can complete, which
 // stands in for every unanswered question.
 func TestClearStaleSocket_UnansweredProbeIsRefused(t *testing.T) {
-	t.Parallel()
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
 
 	path := filepath.Join(t.TempDir(), "unanswered.sock")
 	listener := listenUnixForTest(t, path)
@@ -336,5 +345,168 @@ func TestRepeatedFlag_AcceptsRepetitionAndCommas(t *testing.T) {
 	}
 	if got := flagValue.String(); got != strings.Join(want, ",") {
 		t.Errorf("String() = %q, want %q", got, strings.Join(want, ","))
+	}
+}
+
+// TestListenUnix_RefusesAPathItCannotOwn covers the failures that stop a unix
+// socket from being bound, each of which has to arrive as an error naming
+// --http-addr rather than as a partially started server.
+//
+// The cases are the ones an operator actually produces: a path whose directory
+// is not a directory (a typo, or a file where a directory was expected), a path
+// already occupied by something that is not a socket, and a path longer than
+// the address family allows. None of them is reachable through permission bits
+// here, because the tests run as root in CI containers, where permissions do
+// not refuse anything.
+func TestListenUnix_RefusesAPathItCannotOwn(t *testing.T) {
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
+
+	dir := t.TempDir()
+	notADirectory := filepath.Join(dir, "file")
+	if err := os.WriteFile(notADirectory, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("writing the blocking file: %v", err)
+	}
+	occupied := filepath.Join(dir, "occupied.sock")
+	if err := os.WriteFile(occupied, []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("writing the blocking file: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{
+			name:    "its directory does not exist",
+			path:    filepath.Join(dir, "absent", "mcp.sock"),
+			wantErr: "its directory is not usable",
+		},
+		{
+			name:    "its directory is a file",
+			path:    filepath.Join(notADirectory, "mcp.sock"),
+			wantErr: "--http-addr",
+		},
+		{
+			name:    "the path is already something else",
+			path:    occupied,
+			wantErr: "refusing to replace it",
+		},
+		{
+			name: "the path is longer than a unix address",
+			path: filepath.Join(dir, strings.Repeat("a", 120)+".sock"),
+			// The kernel's message, not ours: what matters is that the bind
+			// failure surfaces instead of a listener nobody can reach.
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, err := listenHTTP(t.Context(), tt.path, config.DefaultSocketMode)
+
+			if err == nil {
+				_ = listener.Close()
+				t.Fatalf("listenHTTP(%q) bound a path it must refuse", tt.path)
+			}
+			if tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to say %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestListenHTTP_UnixSocketWithoutAMode_TakesTheDefault covers the zero mode,
+// which is what a Config assembled without the flag carries.
+//
+// The default is the one that matters for a same-host proxy: a socket only the
+// proxy's group can open, rather than one every local account can.
+func TestListenHTTP_UnixSocketWithoutAMode_TakesTheDefault(t *testing.T) {
+	// Deliberately not parallel: binding sets the process-global umask for
+	// the duration of the bind (see bindUnixSocket), and a directory another
+	// test creates inside that window comes back missing its execute bit.
+
+	path := filepath.Join(t.TempDir(), "default-mode.sock")
+	listener, err := listenHTTP(t.Context(), path, 0)
+	if err != nil {
+		t.Fatalf("listenHTTP: %v", err)
+	}
+	defer listener.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if got := info.Mode().Perm(); got != config.DefaultSocketMode {
+		t.Errorf("socket mode = %#o, want the default %#o", got, config.DefaultSocketMode)
+	}
+}
+
+// TestClearStaleSocket_AnUnreadablePath_IsRefusedRatherThanRemoved covers the
+// lstat failing for a reason other than the path being absent.
+//
+// Absent is the ordinary case and means "nothing to clear". Anything else means
+// the question went unanswered, and removing on an unanswered question is how a
+// running deployment loses its socket to a racing restart.
+func TestClearStaleSocket_AnUnreadablePath_IsRefusedRatherThanRemoved(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	blocking := filepath.Join(dir, "file")
+	if err := os.WriteFile(blocking, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("writing the blocking file: %v", err)
+	}
+
+	err := clearStaleSocket(t.Context(), filepath.Join(blocking, "mcp.sock"))
+
+	if err == nil {
+		t.Fatal("clearStaleSocket accepted a path it could not examine")
+	}
+	if !strings.Contains(err.Error(), "--http-addr") {
+		t.Errorf("error = %q, want it to name the flag the operator typed", err)
+	}
+}
+
+// TestRepeatedFlag_TheZeroValueRenders covers String on a flag nobody set,
+// which the flag package calls while printing usage.
+//
+// Usage printing happens on the help path, before any value exists, so a nil
+// receiver here would turn --help into a panic.
+func TestRepeatedFlag_TheZeroValueRenders(t *testing.T) {
+	t.Parallel()
+
+	var absent *repeatedFlag
+	if got := absent.String(); got != "" {
+		t.Errorf("(*repeatedFlag)(nil).String() = %q, want the empty string", got)
+	}
+	empty := repeatedFlag{}
+	if got := empty.String(); got != "" {
+		t.Errorf("repeatedFlag{}.String() = %q, want the empty string", got)
+	}
+}
+
+// TestValidateTLSFiles_ALoadablePairIsAccepted covers the success path of the
+// startup check.
+//
+// The pair is loaded at startup precisely so a typo becomes an error naming the
+// file, instead of a TLS handshake failure on the first request that nobody
+// sees until a client reports it. The loader is stubbed because what is under
+// test is the decision, not crypto/tls.
+func TestValidateTLSFiles_ALoadablePairIsAccepted(t *testing.T) {
+	original := loadTLSKeyPair
+	t.Cleanup(func() { loadTLSKeyPair = original })
+	var loadedCert, loadedKey string
+	loadTLSKeyPair = func(cert, key string) (tls.Certificate, error) {
+		loadedCert, loadedKey = cert, key
+		return tls.Certificate{}, nil
+	}
+
+	err := validateTLSFiles(&config.Config{TLSCertFile: "/etc/ssl/mcp.crt", TLSKeyFile: "/etc/ssl/mcp.key"})
+	if err != nil {
+		t.Fatalf("validateTLSFiles = %v, want nil for a loadable pair", err)
+	}
+	if loadedCert != "/etc/ssl/mcp.crt" || loadedKey != "/etc/ssl/mcp.key" {
+		t.Errorf("loaded (%q, %q), want the configured pair", loadedCert, loadedKey)
 	}
 }

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -328,6 +328,7 @@ func TestRepeatedFlag_AcceptsRepetitionAndCommas(t *testing.T) {
 	}
 	for i, value := range want {
 		t.Run(value, func(t *testing.T) {
+			t.Parallel()
 			if flagValue[i] != value {
 				t.Errorf("entry %d = %q, want %q", i, flagValue[i], value)
 			}

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -327,9 +327,11 @@ func TestRepeatedFlag_AcceptsRepetitionAndCommas(t *testing.T) {
 		t.Fatalf("collected %v, want %v", got, want)
 	}
 	for i, value := range want {
-		if flagValue[i] != value {
-			t.Errorf("entry %d = %q, want %q", i, flagValue[i], value)
-		}
+		t.Run(value, func(t *testing.T) {
+			if flagValue[i] != value {
+				t.Errorf("entry %d = %q, want %q", i, flagValue[i], value)
+			}
+		})
 	}
 	if got := flagValue.String(); got != strings.Join(want, ",") {
 		t.Errorf("String() = %q, want %q", got, strings.Join(want, ","))

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -463,14 +463,16 @@ func TestHTTPHandler_Initialize_AdvertisesListChangedCapabilities(t *testing.T) 
 	}
 
 	for _, key := range []string{"tools", "resources", "prompts"} {
-		group, gok := caps[key].(map[string]any)
-		if !gok {
-			t.Errorf("capabilities.%s missing or not an object: %v", key, caps[key])
-			continue
-		}
-		if got := group["listChanged"]; got != true {
-			t.Errorf("capabilities.%s.listChanged = %v, want true", key, got)
-		}
+		t.Run(key, func(t *testing.T) {
+			group, gok := caps[key].(map[string]any)
+			if !gok {
+				t.Errorf("capabilities.%s missing or not an object: %v", key, caps[key])
+				return
+			}
+			if got := group["listChanged"]; got != true {
+				t.Errorf("capabilities.%s.listChanged = %v, want true", key, got)
+			}
+		})
 	}
 }
 
@@ -1177,9 +1179,11 @@ func TestPrintHelp_ContainsExpectedSections(t *testing.T) {
 		{"opencode example", "OpenCode"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(output, c.want) {
-			t.Errorf("printHelp missing %s: want substring %q", c.name, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(output, c.want) {
+				t.Errorf("printHelp missing %s: want substring %q", c.name, c.want)
+			}
+		})
 	}
 }
 
@@ -1390,9 +1394,11 @@ func TestCreateServer_DynamicToolSurface(t *testing.T) {
 		wantTools[tool.Name] = true
 	}
 	for name, found := range wantTools {
-		if !found {
-			t.Fatalf("dynamic tool %q was not registered", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !found {
+				t.Fatalf("dynamic tool %q was not registered", name)
+			}
+		})
 	}
 
 	_, err = session.ReadResource(t.Context(), &mcp.ReadResourceParams{URI: "gitlab://tools/project.get"})
@@ -1441,9 +1447,11 @@ func TestCreateServer_MetaToolSurfaceIncludesStandaloneUtilities(t *testing.T) {
 		}
 	}
 	for name, found := range wantTools {
-		if !found {
-			t.Fatalf("meta standalone tool %q was not registered", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !found {
+				t.Fatalf("meta standalone tool %q was not registered", name)
+			}
+		})
 	}
 }
 
@@ -3626,9 +3634,11 @@ func TestSecurityHeaders_CoverRejectionsToo(t *testing.T) {
 		"Referrer-Policy":         "no-referrer",
 	}
 	for name, value := range want {
-		if got := rr.Header().Get(name); got != value {
-			t.Errorf("%s = %q, want %q", name, got, value)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got := rr.Header().Get(name); got != value {
+				t.Errorf("%s = %q, want %q", name, got, value)
+			}
+		})
 	}
 }
 
@@ -4206,17 +4216,19 @@ func TestServeHTTP_ServerCardEndpoint_ReturnsToolList(t *testing.T) {
 	// every icon-bearing entry; the card must not show less on any of the
 	// four collections that carry them.
 	for _, collection := range []string{"tools", "prompts", "resources", "resourceTemplates"} {
-		entries, _ := card[collection].([]any)
-		if len(entries) == 0 {
-			t.Errorf("card %s array missing or empty", collection)
-			continue
-		}
-		for i, raw := range entries {
-			entry, _ := raw.(map[string]any)
-			if icons, _ := entry["icons"].([]any); len(icons) != 3 {
-				t.Errorf("card %s[%d] icons = %d entries, want 3", collection, i, len(icons))
+		t.Run(collection, func(t *testing.T) {
+			entries, _ := card[collection].([]any)
+			if len(entries) == 0 {
+				t.Errorf("card %s array missing or empty", collection)
+				return
 			}
-		}
+			for i, raw := range entries {
+				entry, _ := raw.(map[string]any)
+				if icons, _ := entry["icons"].([]any); len(icons) != 3 {
+					t.Errorf("card %s[%d] icons = %d entries, want 3", collection, i, len(icons))
+				}
+			}
+		})
 	}
 
 	// Verify serverInfo presence
@@ -5397,9 +5409,11 @@ func TestCorsMiddleware_TrustedOriginPreflight_IsAnswered(t *testing.T) {
 		"Access-Control-Max-Age": corsMaxAge,
 	}
 	for name, value := range want {
-		if got := rec.Header().Get(name); got != value {
-			t.Errorf("%s = %q, want %q", name, got, value)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got := rec.Header().Get(name); got != value {
+				t.Errorf("%s = %q, want %q", name, got, value)
+			}
+		})
 	}
 	// The origin is echoed, never "*": these requests carry Authorization,
 	// and a browser rejects the wildcard on a credentialed request.
@@ -6486,9 +6500,11 @@ func TestServerCard_AnnouncesTelemetryWithoutNamingTheCollector(t *testing.T) {
 		t.Error("the telemetry block names no signals, so a reader cannot tell what is recorded")
 	}
 	for _, key := range []string{"recorded", "not_recorded"} {
-		if text, _ := block[key].(string); text == "" {
-			t.Errorf("the telemetry block has no %q line; the point of announcing is to say what is captured", key)
-		}
+		t.Run(key, func(t *testing.T) {
+			if text, _ := block[key].(string); text == "" {
+				t.Errorf("the telemetry block has no %q line; the point of announcing is to say what is captured", key)
+			}
+		})
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3635,6 +3635,7 @@ func TestSecurityHeaders_CoverRejectionsToo(t *testing.T) {
 	}
 	for name, value := range want {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			if got := rr.Header().Get(name); got != value {
 				t.Errorf("%s = %q, want %q", name, got, value)
 			}
@@ -5410,6 +5411,7 @@ func TestCorsMiddleware_TrustedOriginPreflight_IsAnswered(t *testing.T) {
 	}
 	for name, value := range want {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			if got := rec.Header().Get(name); got != value {
 				t.Errorf("%s = %q, want %q", name, got, value)
 			}

--- a/cmd/server/sdklog_test.go
+++ b/cmd/server/sdklog_test.go
@@ -190,9 +190,11 @@ func TestSDKLogHandler_PassesEverythingElseThrough(t *testing.T) {
 		t.Fatalf("%d records, want 3; nothing here is session chatter", len(records))
 	}
 	for i, want := range []string{"ERROR", "WARN", "INFO"} {
-		if got := records[i]["level"]; got != want {
-			t.Errorf("record %d logged at %v, want %s", i, got, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if got := records[i]["level"]; got != want {
+				t.Errorf("record %d logged at %v, want %s", i, got, want)
+			}
+		})
 	}
 	if got := records[2]["uri"]; got != "gitlab://project/42" {
 		t.Errorf("attributes were not preserved: uri = %v", got)

--- a/cmd/server/stdio_test.go
+++ b/cmd/server/stdio_test.go
@@ -188,9 +188,11 @@ func TestResilientStdio_RecoversAndKeepsReading(t *testing.T) {
 		t.Fatalf("reading: %v", err)
 	}
 	for _, want := range []string{`"id":1`, `"id":2`, `"id":3`} {
-		if !strings.Contains(string(got), want) {
-			t.Errorf("message %s did not survive the bad lines around it:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(string(got), want) {
+				t.Errorf("message %s did not survive the bad lines around it:\n%s", want, got)
+			}
+		})
 	}
 	if strings.Contains(string(got), "not json") || strings.Contains(string(got), "hello") {
 		t.Errorf("a bad line was forwarded:\n%s", got)
@@ -252,9 +254,11 @@ func TestScalarID_ObjectsAndArraysAreNotEchoed(t *testing.T) {
 		`[1,2]`:    ``,
 		` {"a":1}`: ``,
 	} {
-		got := string(scalarID(json.RawMessage(raw)))
-		if got != want {
-			t.Errorf("scalarID(%s) = %q, want %q", raw, got, want)
-		}
+		t.Run(raw, func(t *testing.T) {
+			got := string(scalarID(json.RawMessage(raw)))
+			if got != want {
+				t.Errorf("scalarID(%s) = %q, want %q", raw, got, want)
+			}
+		})
 	}
 }

--- a/cmd/server/stdio_test.go
+++ b/cmd/server/stdio_test.go
@@ -255,6 +255,7 @@ func TestScalarID_ObjectsAndArraysAreNotEchoed(t *testing.T) {
 		` {"a":1}`: ``,
 	} {
 		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
 			got := string(scalarID(json.RawMessage(raw)))
 			if got != want {
 				t.Errorf("scalarID(%s) = %q, want %q", raw, got, want)

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -620,10 +620,12 @@ func TestSubscribe_ActiveSession_WatcherStaysFast(t *testing.T) {
 // TestSessionBridge_ALegacySubscribeStillFollowsTheLease.
 func TestKeepalive_IsNotRenewalActivity(t *testing.T) {
 	for _, method := range []string{"ping", "notifications/initialized", "notifications/cancelled"} {
-		req := &mcp.ServerRequest[*mcp.CallToolParams]{Session: &mcp.ServerSession{}}
-		if _, ok := activeSession(method, req); ok {
-			t.Errorf("%q was treated as evidence that a subscriber is still there", method)
-		}
+		t.Run(method, func(t *testing.T) {
+			req := &mcp.ServerRequest[*mcp.CallToolParams]{Session: &mcp.ServerSession{}}
+			if _, ok := activeSession(method, req); ok {
+				t.Errorf("%q was treated as evidence that a subscriber is still there", method)
+			}
+		})
 	}
 
 	// The control: something a client only sends because it wants an answer.

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -1310,6 +1310,7 @@ func TestSessionBridge_OneListenTeardownKeepsAnothersWatch(t *testing.T) {
 	// Two listen streams, as two subscriptions/listen requests on one session.
 	first := &listenStream{cancel: func() {}}
 	second := &listenStream{cancel: func() {}}
+	// sequential: the second listen joins the watcher the first one created, and the teardown below needs both in place
 	for _, stream := range []*listenStream{first, second} {
 		ctx := withListenStream(context.Background(), stream)
 		if err := bridge.Subscribe(ctx, &mcp.SubscribeRequest{

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -449,7 +449,7 @@ Human report to stdout (per-site `file:line [category] boundary`), summary line,
 #### Make targets
 
 - `make audit-test-goroutines` — writes `plan/test-goroutines-backlog.json`.
-- `make check-test-goroutines` — CI gate; also step [6/6] of `make analyze`.
+- `make check-test-goroutines` — CI gate; also step [6/7] of `make analyze`.
 
 ### audit_test_names
 
@@ -479,6 +479,36 @@ CSV to stdout (`file,current_name,pattern,suggested_name`), with a summary print
 #### Make targets
 
 - `make audit-test-names` — runs with `cmd internal test`.
+
+### audit_test_subtests
+
+Finds range loops over case tables (slice or map literals, inline or bound to a local) inside `Test*` functions whose body asserts (`t.Error*`, `t.Fatal*`, or a helper that receives `t`) without opening a `t.Run` subtest, which is the shape the table-driven rule in `go.instructions.md` forbids. A `// sequential: <reason>` comment on the line above a loop declares a sequence of dependent steps and is reported separately instead of failing, and so is a loop inside a `synctest.Test` bubble, where the testing package panics on `t.Run`.
+
+```bash
+go run ./cmd/audit_test_subtests/
+go run ./cmd/audit_test_subtests/ -json plan/test-subtests-backlog.json
+go run ./cmd/audit_test_subtests/ -fix
+go run ./cmd/audit_test_subtests/ -check ./internal/toolutil
+```
+
+#### Flags
+
+| Flag     | Type   | Default | Description                                                      |
+| -------- | ------ | ------- | ---------------------------------------------------------------- |
+| `-json`  | string | _(off)_ | Write the JSON work list to this path                            |
+| `-check` | bool   | `false` | Exit non-zero when any case loop still asserts without a subtest |
+| `-fix`   | bool   | `false` | Rewrite the unambiguous sites in place, then report what remains |
+
+`-fix` wraps the loop body in `t.Run(name, func(t *testing.T) { ... })` when the name is unambiguous: a `[]string` table names each case after its element, a struct table after a string field called `name`, `desc`, `description`, `label`, `title` or `id`, and a `map[string]...` table after its key. A bare `continue` becomes `return`. Loops that `break` or `goto`, and tables with no such field, stay in the report for a hand rewrite (add a `name` field). The mechanical pass of 2026-09-01 rewrote 827 of 911 sites this way.
+
+#### Output
+
+Per-file tallies (`sites`, `fixable`), a summary line, and optionally the JSON work list (`findings` with the rewrite each site qualifies for, `sequential`, `summary`).
+
+#### Make targets
+
+- `make audit-test-subtests` — writes `plan/test-subtests-backlog.json`.
+- `make check-test-subtests` — CI gate; also step [7/7] of `make analyze`.
 
 ### audit_string_dupes
 

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -115,6 +115,8 @@ gotestsum --version
 | `make audit-test-names`      | Audit test function naming convention compliance                                                   |
 | `make audit-test-goroutines` | Report `testing.T` aborts (`t.Fatal`/`FailNow`) made off the test goroutine, with a JSON work list |
 | `make check-test-goroutines` | Fail when any off-goroutine abort site remains (errorf-without-return stays advisory)              |
+| `make audit-test-subtests`   | Report case loops in Test functions that assert without a `t.Run` subtest, with a JSON work list   |
+| `make check-test-subtests`   | Fail when any case loop still asserts without a subtest                                            |
 | `make audit-godocs`          | Generate `dist/analysis/godoc.md` with package, exported symbol, and test documentation findings   |
 | `make audit-godocs-check`    | Run the same Godoc audit and fail if findings remain                                               |
 

--- a/internal/clientcompat/clientcompat_test.go
+++ b/internal/clientcompat/clientcompat_test.go
@@ -350,7 +350,8 @@ func TestCallTool_CodexClient_RoundsEveryContentBlockType(t *testing.T) {
 	if len(res.Content) != 6 {
 		t.Fatalf("content length = %d, want 6", len(res.Content))
 	}
-	annotationsOf := func(block mcp.Content) *mcp.Annotations {
+	annotationsOf := func(t *testing.T, block mcp.Content) *mcp.Annotations {
+		t.Helper()
 		switch c := block.(type) {
 		case *mcp.TextContent:
 			return c.Annotations
@@ -367,18 +368,32 @@ func TestCallTool_CodexClient_RoundsEveryContentBlockType(t *testing.T) {
 			return nil
 		}
 	}
-	wantPriorities := []float64{0, 1, 1, 1, 1, 1}
-	for i, want := range wantPriorities {
-		a := annotationsOf(res.Content[i])
-		if a == nil {
-			t.Fatalf("content[%d] annotations dropped; want audience preserved", i)
-		}
-		if a.Priority != want {
-			t.Errorf("content[%d] priority = %v, want %v", i, a.Priority, want)
-		}
-		if len(a.Audience) == 0 {
-			t.Errorf("content[%d] audience dropped", i)
-		}
+	// One case per block addMixedContentTool returns, in order.
+	cases := []struct {
+		name  string
+		index int
+		want  float64
+	}{
+		{"text_low_rounds_down", 0, 0},
+		{"text_integer_preserved", 1, 1},
+		{"image_rounds_up", 2, 1},
+		{"audio_rounds_up", 3, 1},
+		{"resource_link_rounds_up", 4, 1},
+		{"embedded_resource_rounds_up", 5, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := annotationsOf(t, res.Content[tc.index])
+			if a == nil {
+				t.Fatalf("content[%d] annotations dropped; want audience preserved", tc.index)
+			}
+			if a.Priority != tc.want {
+				t.Errorf("content[%d] priority = %v, want %v", tc.index, a.Priority, tc.want)
+			}
+			if len(a.Audience) == 0 {
+				t.Errorf("content[%d] audience dropped", tc.index)
+			}
+		})
 	}
 }
 

--- a/internal/config/http_overlay_test.go
+++ b/internal/config/http_overlay_test.go
@@ -50,9 +50,11 @@ func TestLoadHTTPEnvOverlay_AbsentVariablesReportNothing(t *testing.T) {
 		"RateLimitBurst":     overlay.RateLimitBurst == nil,
 	}
 	for field, isNil := range nilFields {
-		if !isNil {
-			t.Errorf("%s was reported despite its variable being unset", field)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !isNil {
+				t.Errorf("%s was reported despite its variable being unset", field)
+			}
+		})
 	}
 	if overlay.TierExplicit {
 		t.Error("TierExplicit = true with no tier variable set")

--- a/internal/elicitation/elicitation_test.go
+++ b/internal/elicitation/elicitation_test.go
@@ -886,9 +886,11 @@ func TestValidateGitLabURL_ValidPaths(t *testing.T) {
 		"http://gitlab.example.com/test", // http allowed for self-hosted
 	}
 	for _, u := range valid {
-		if err := validateGitLabURL(base, u); err != nil {
-			t.Errorf("validateGitLabURL(%q) = %v, want nil", u, err)
-		}
+		t.Run(u, func(t *testing.T) {
+			if err := validateGitLabURL(base, u); err != nil {
+				t.Errorf("validateGitLabURL(%q) = %v, want nil", u, err)
+			}
+		})
 	}
 }
 
@@ -903,9 +905,11 @@ func TestValidateGitLabURL_ExternalHost(t *testing.T) {
 		"javascript:alert(1)",
 	}
 	for _, u := range invalid {
-		if err := validateGitLabURL(base, u); err == nil {
-			t.Errorf("validateGitLabURL(%q) = nil, want error", u)
-		}
+		t.Run(u, func(t *testing.T) {
+			if err := validateGitLabURL(base, u); err == nil {
+				t.Errorf("validateGitLabURL(%q) = nil, want error", u)
+			}
+		})
 	}
 }
 

--- a/internal/elicitation/flow_test.go
+++ b/internal/elicitation/flow_test.go
@@ -993,19 +993,25 @@ func TestConfirmSchema_DefaultsToDeclining(t *testing.T) {
 		t.Errorf("default = %v, want false: a destructive dialog must not open pre-approved", value)
 	}
 
-	for _, other := range []map[string]any{
-		textSchema("m", "f"),
-		selectOneSchema("m", []string{"a"}),
-		numberSchema("m", "f", 0, 10),
-	} {
-		otherProps, _ := other["properties"].(map[string]any)
-		for name, raw := range otherProps {
-			if otherField, isMap := raw.(map[string]any); isMap {
-				if _, hasDefault := otherField["default"]; hasDefault {
-					t.Errorf("%q carries a default; only the confirmation is meant to suggest an answer", name)
+	others := []struct {
+		name   string
+		schema map[string]any
+	}{
+		{name: "text", schema: textSchema("m", "f")},
+		{name: "select_one", schema: selectOneSchema("m", []string{"a"})},
+		{name: "number", schema: numberSchema("m", "f", 0, 10)},
+	}
+	for _, tc := range others {
+		t.Run(tc.name, func(t *testing.T) {
+			otherProps, _ := tc.schema["properties"].(map[string]any)
+			for name, raw := range otherProps {
+				if otherField, isMap := raw.(map[string]any); isMap {
+					if _, hasDefault := otherField["default"]; hasDefault {
+						t.Errorf("%q carries a default; only the confirmation is meant to suggest an answer", name)
+					}
 				}
 			}
-		}
+		})
 	}
 }
 

--- a/internal/elicitation/flow_test.go
+++ b/internal/elicitation/flow_test.go
@@ -632,9 +632,11 @@ func TestFlow_MRTR_MultiStepAccumulatesState(t *testing.T) {
 		t.Fatalf("elicitation messages = %v, want %v", messages, want)
 	}
 	for i, msg := range want {
-		if messages[i] != msg {
-			t.Errorf("elicitation %d = %q, want %q", i, messages[i], msg)
-		}
+		t.Run(msg, func(t *testing.T) {
+			if messages[i] != msg {
+				t.Errorf("elicitation %d = %q, want %q", i, messages[i], msg)
+			}
+		})
 	}
 }
 

--- a/internal/gatewaycompat/middleware_test.go
+++ b/internal/gatewaycompat/middleware_test.go
@@ -154,9 +154,11 @@ func TestMiddleware_ToolsList_RewritesProseAndPreservesContract(t *testing.T) {
 		`"pattern":"^[a-z;]+$"`,               // pattern is contract
 		`"open;now"`,                          // enum value and default are data
 	} {
-		if !strings.Contains(schema, want) {
-			t.Errorf("input schema %s\nmissing %s", schema, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(schema, want) {
+				t.Errorf("input schema %s\nmissing %s", schema, want)
+			}
+		})
 	}
 
 	rawOut, err := json.Marshal(tool.OutputSchema)

--- a/internal/mcpotel/carrier_test.go
+++ b/internal/mcpotel/carrier_test.go
@@ -35,7 +35,9 @@ func TestMetaCarrier_KeysNamesOnlyThePropagationKeys(t *testing.T) {
 		delete(want, key)
 	}
 	for missing := range want {
-		t.Errorf("Keys did not report %q, which is present and readable", missing)
+		t.Run(missing, func(t *testing.T) {
+			t.Errorf("Keys did not report %q, which is present and readable", missing)
+		})
 	}
 }
 

--- a/internal/mcpotel/identity_test.go
+++ b/internal/mcpotel/identity_test.go
@@ -30,14 +30,16 @@ func TestMiddleware_IdentityReachesTheSpan(t *testing.T) {
 		&mcp.CallToolResult{}, nil)
 
 	for key, want := range map[attribute.Key]string{"user.id": "42", "user.name": "jane"} {
-		value, ok := attrOf(span, key)
-		if !ok {
-			t.Errorf("%s is absent from the span; the identity policy is wired to nothing", key)
-			continue
-		}
-		if value.AsString() != want {
-			t.Errorf("%s = %q, want %q", key, value.AsString(), want)
-		}
+		t.Run(string(key), func(t *testing.T) {
+			value, ok := attrOf(span, key)
+			if !ok {
+				t.Errorf("%s is absent from the span; the identity policy is wired to nothing", key)
+				return
+			}
+			if value.AsString() != want {
+				t.Errorf("%s = %q, want %q", key, value.AsString(), want)
+			}
+		})
 	}
 }
 
@@ -54,9 +56,11 @@ func TestMiddleware_IdentityIsAbsentByDefault(t *testing.T) {
 		&mcp.CallToolResult{}, nil)
 
 	for _, key := range []attribute.Key{"user.id", "user.name", "user.hash"} {
-		if _, ok := attrOf(span, key); ok {
-			t.Errorf("%s was recorded with no identity policy configured", key)
-		}
+		t.Run(string(key), func(t *testing.T) {
+			if _, ok := attrOf(span, key); ok {
+				t.Errorf("%s was recorded with no identity policy configured", key)
+			}
+		})
 	}
 }
 

--- a/internal/mcpotel/middleware_test.go
+++ b/internal/mcpotel/middleware_test.go
@@ -884,9 +884,11 @@ func TestMiddleware_DurationCarriesTheMethodAndTheAction(t *testing.T) {
 		string(AttrActionID):      "issue.list",
 		string(AttrToolSurface):   "dynamic",
 	} {
-		if found[key] != want {
-			t.Errorf("%s = %q on the metric, want %q", key, found[key], want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if found[key] != want {
+				t.Errorf("%s = %q on the metric, want %q", key, found[key], want)
+			}
+		})
 	}
 }
 

--- a/internal/mcpotel/middleware_test.go
+++ b/internal/mcpotel/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -137,14 +138,16 @@ func TestMiddleware_ToolCallSpanShape(t *testing.T) {
 		AttrToolSurface:        "dynamic",
 		AttrNetworkTransport:   "pipe",
 	} {
-		value, ok := attrOf(span, key)
-		if !ok {
-			t.Errorf("%s is absent", key)
-			continue
-		}
-		if value.AsString() != want {
-			t.Errorf("%s = %q, want %q", key, value.AsString(), want)
-		}
+		t.Run(string(key), func(t *testing.T) {
+			value, ok := attrOf(span, key)
+			if !ok {
+				t.Errorf("%s is absent", key)
+				return
+			}
+			if value.AsString() != want {
+				t.Errorf("%s = %q, want %q", key, value.AsString(), want)
+			}
+		})
 	}
 }
 
@@ -342,17 +345,27 @@ func TestMiddleware_AdoptsTraceContextFromMeta(t *testing.T) {
 // sees: refusing a tools/call because its traceparent was malformed would let
 // anyone disable a client by corrupting one header.
 func TestMiddleware_MalformedTraceContextIsIgnored(t *testing.T) {
-	for _, value := range []any{"not-a-traceparent", "", 42, map[string]any{"nested": true}} {
-		span := runOnce(t, Options{}, "tools/call",
-			callToolRequest("gitlab_issue_list", map[string]any{}, map[string]any{"traceparent": value}),
-			&mcp.CallToolResult{}, nil)
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{"garbage_string", "not-a-traceparent"},
+		{"empty_string", ""},
+		{"integer", 42},
+		{"object", map[string]any{"nested": true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			span := runOnce(t, Options{}, "tools/call",
+				callToolRequest("gitlab_issue_list", map[string]any{}, map[string]any{"traceparent": tc.value}),
+				&mcp.CallToolResult{}, nil)
 
-		if span.Parent().IsValid() {
-			t.Errorf("traceparent %v produced a parent; a malformed value must leave the context untouched", value)
-		}
-		if got := span.Status().Code; got != codes.Unset {
-			t.Errorf("traceparent %v turned a successful call into status %v", value, got)
-		}
+			if span.Parent().IsValid() {
+				t.Errorf("traceparent %v produced a parent; a malformed value must leave the context untouched", tc.value)
+			}
+			if got := span.Status().Code; got != codes.Unset {
+				t.Errorf("traceparent %v turned a successful call into status %v", tc.value, got)
+			}
+		})
 	}
 }
 
@@ -845,10 +858,12 @@ func TestMiddleware_DurationHistogramMatchesTheConvention(t *testing.T) {
 		t.Fatalf("%d bucket boundaries, want %d; the SDK default was used instead of the convention's",
 			len(got), len(want))
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("boundary %d = %v, want %v", i, got[i], want[i])
-		}
+	for i, bound := range want {
+		t.Run(fmt.Sprint(bound), func(t *testing.T) {
+			if got[i] != bound {
+				t.Errorf("boundary %d = %v, want %v", i, got[i], bound)
+			}
+		})
 	}
 }
 

--- a/internal/mcpotel/outcome_test.go
+++ b/internal/mcpotel/outcome_test.go
@@ -125,11 +125,13 @@ func TestRedactResourceURIs_AgreesWithTheHandler(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		here := redactResourceURIs(input)
-		there := telemetry.RedactResourceURIs(input)
-		if here != there {
-			t.Errorf("the two implementations disagree on %q: mcpotel gives %q and telemetry gives %q",
-				input, here, there)
-		}
+		t.Run(input, func(t *testing.T) {
+			here := redactResourceURIs(input)
+			there := telemetry.RedactResourceURIs(input)
+			if here != there {
+				t.Errorf("the two implementations disagree on %q: mcpotel gives %q and telemetry gives %q",
+					input, here, there)
+			}
+		})
 	}
 }

--- a/internal/mcpotel/roundtripper_test.go
+++ b/internal/mcpotel/roundtripper_test.go
@@ -72,12 +72,14 @@ func TestNewTransport_TheGitLabCallIsAChildSpanThatNamesNoURL(t *testing.T) {
 		// carries the project path and often the query, which is why the whole
 		// URL is left out and the host kept.
 		for _, forbidden := range []string{"url.full", "url.path", "url.query"} {
-			for _, kv := range span.Attributes() {
-				if string(kv.Key) == forbidden {
-					t.Errorf("the span carries %s = %q; a GitLab URL names the project and can carry a search term",
-						forbidden, kv.Value.AsString())
+			t.Run(forbidden, func(t *testing.T) {
+				for _, kv := range span.Attributes() {
+					if string(kv.Key) == forbidden {
+						t.Errorf("the span carries %s = %q; a GitLab URL names the project and can carry a search term",
+							forbidden, kv.Value.AsString())
+					}
 				}
-			}
+			})
 		}
 	})
 
@@ -234,12 +236,14 @@ func TestServerPort_SchemeDefaultsCollapse(t *testing.T) {
 		"http://gitlab.example.com":       80,
 		"https://gitlab.example.com:8443": 8443,
 	} {
-		parsed, err := url.Parse(raw)
-		if err != nil {
-			t.Fatalf("parsing %q: %v", raw, err)
-		}
-		if got := serverPort(parsed); got != want {
-			t.Errorf("serverPort(%q) = %d, want %d", raw, got, want)
-		}
+		t.Run(raw, func(t *testing.T) {
+			parsed, err := url.Parse(raw)
+			if err != nil {
+				t.Fatalf("parsing %q: %v", raw, err)
+			}
+			if got := serverPort(parsed); got != want {
+				t.Errorf("serverPort(%q) = %d, want %d", raw, got, want)
+			}
+		})
 	}
 }

--- a/internal/mcpotel/sending_test.go
+++ b/internal/mcpotel/sending_test.go
@@ -154,8 +154,10 @@ func TestIsNotification(t *testing.T) {
 		"notifications":                      false,
 		"my/notifications/resources/updated": false,
 	} {
-		if got := IsNotification(method); got != want {
-			t.Errorf("IsNotification(%q) = %v, want %v", method, got, want)
-		}
+		t.Run(method, func(t *testing.T) {
+			if got := IsNotification(method); got != want {
+				t.Errorf("IsNotification(%q) = %v, want %v", method, got, want)
+			}
+		})
 	}
 }

--- a/internal/oauth/metadata_test.go
+++ b/internal/oauth/metadata_test.go
@@ -214,9 +214,11 @@ func TestProtectedResourceHandler_OptionalLinksAreOmittedUnlessNamed(t *testing.
 	t.Run("neither is published by default", func(t *testing.T) {
 		document := read(t, ResourceLinks{})
 		for _, field := range []string{"resource_policy_uri", "resource_tos_uri"} {
-			if value, present := document[field]; present {
-				t.Errorf("%s = %v, want it omitted when no page was named", field, value)
-			}
+			t.Run(field, func(t *testing.T) {
+				if value, present := document[field]; present {
+					t.Errorf("%s = %v, want it omitted when no page was named", field, value)
+				}
+			})
 		}
 		// The one that does have a default is still there.
 		if document["resource_documentation"] != DefaultResourceDocumentation {

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -421,14 +421,25 @@ func TestUpdate_MonotonicEnforcement(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	want := []float64{1, 2, 3}
+	// Each surviving notification is named after the handler's message for
+	// the update that produced it; the regressions between them must be gone.
+	want := []struct {
+		name     string
+		progress float64
+	}{
+		{"first", 1},
+		{"second", 2},
+		{"third", 3},
+	}
 	if len(received) != len(want) {
 		t.Fatalf("received = %v, want %v", received, want)
 	}
-	for i, v := range want {
-		if received[i] != v {
-			t.Errorf("received[%d] = %v, want %v (full=%v)", i, received[i], v, received)
-		}
+	for i, tc := range want {
+		t.Run(tc.name, func(t *testing.T) {
+			if received[i] != tc.progress {
+				t.Errorf("received[%d] = %v, want %v (full=%v)", i, received[i], tc.progress, received)
+			}
+		})
 	}
 }
 

--- a/internal/prompts/prompt_audit_test.go
+++ b/internal/prompts/prompt_audit_test.go
@@ -616,21 +616,24 @@ func TestAuditProject_Full(t *testing.T) {
 // TestAccessLevelName covers AccessLevelName with table-driven subtests.
 func TestAccessLevelName(t *testing.T) {
 	tests := []struct {
+		name  string
 		level gl.AccessLevelValue
 		want  string
 	}{
-		{10, "Guest"},
-		{20, "Reporter"},
-		{30, "Developer"},
-		{40, "Maintainer"},
-		{50, "Owner"},
-		{99, "Unknown(99)"},
+		{"guest", 10, "Guest"},
+		{"reporter", 20, "Reporter"},
+		{"developer", 30, "Developer"},
+		{"maintainer", 40, "Maintainer"},
+		{"owner", 50, "Owner"},
+		{"unknown_level", 99, "Unknown(99)"},
 	}
 	for _, tc := range tests {
-		got := accessLevelName(tc.level)
-		if got != tc.want {
-			t.Errorf("accessLevelName(%d) = %q, want %q", tc.level, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := accessLevelName(tc.level)
+			if got != tc.want {
+				t.Errorf("accessLevelName(%d) = %q, want %q", tc.level, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -647,20 +650,23 @@ func TestEmptyDash(t *testing.T) {
 // TestFormatBytes covers FormatBytes with table-driven subtests.
 func TestFormatBytes(t *testing.T) {
 	tests := []struct {
+		name  string
 		bytes int64
 		want  string
 	}{
-		{0, "0 B"},
-		{500, "500 B"},
-		{1024, "1.0 KB"},
-		{1048576, "1.0 MB"},
-		{1073741824, "1.0 GB"},
+		{"zero", 0, "0 B"},
+		{"below_one_kilobyte", 500, "500 B"},
+		{"one_kilobyte", 1024, "1.0 KB"},
+		{"one_megabyte", 1048576, "1.0 MB"},
+		{"one_gigabyte", 1073741824, "1.0 GB"},
 	}
 	for _, tc := range tests {
-		got := formatBytes(tc.bytes)
-		if got != tc.want {
-			t.Errorf("formatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatBytes(tc.bytes)
+			if got != tc.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/prompts/prompt_audit_test.go
+++ b/internal/prompts/prompt_audit_test.go
@@ -114,9 +114,11 @@ func TestAuditProject_Settings(t *testing.T) {
 			"Storage Statistics",
 		}
 		for _, want := range checks {
-			if !strings.Contains(text, want) {
-				t.Errorf(assertContains, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(text, want) {
+					t.Errorf(assertContains, want)
+				}
+			})
 		}
 	})
 
@@ -227,9 +229,11 @@ func TestAuditBranch_Protection(t *testing.T) {
 			"Code owner approval required",
 		}
 		for _, want := range checks {
-			if !strings.Contains(text, want) {
-				t.Errorf(assertContains, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(text, want) {
+					t.Errorf(assertContains, want)
+				}
+			})
 		}
 	})
 
@@ -323,9 +327,11 @@ func TestAuditProject_Access(t *testing.T) {
 			"devops-team",
 		}
 		for _, want := range checks {
-			if !strings.Contains(text, want) {
-				t.Errorf(assertContains, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(text, want) {
+					t.Errorf(assertContains, want)
+				}
+			})
 		}
 	})
 
@@ -570,9 +576,11 @@ func TestAuditProject_Full(t *testing.T) {
 			"Prevent secrets | ✅",
 		}
 		for _, want := range checks {
-			if !strings.Contains(text, want) {
-				t.Errorf(assertContains, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(text, want) {
+					t.Errorf(assertContains, want)
+				}
+			})
 		}
 	})
 

--- a/internal/prompts/prompt_helpers_test.go
+++ b/internal/prompts/prompt_helpers_test.go
@@ -560,18 +560,21 @@ func TestIssueAge_NilCreatedAt(t *testing.T) {
 // TestReadinessLabel covers all three branches of readinessLabel.
 func TestReadinessLabel(t *testing.T) {
 	tests := []struct {
+		name     string
 		blockers int
 		wantSub  string
 	}{
-		{10, "Not Ready"},
-		{3, "Needs Attention"},
-		{0, "Ready"},
+		{"many_blockers_not_ready", 10, "Not Ready"},
+		{"few_blockers_needs_attention", 3, "Needs Attention"},
+		{"no_blockers_ready", 0, "Ready"},
 	}
 	for _, tt := range tests {
-		got := readinessLabel(tt.blockers)
-		if !strings.Contains(got, tt.wantSub) {
-			t.Errorf("readinessLabel(%d) = %q, want containing %q", tt.blockers, got, tt.wantSub)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := readinessLabel(tt.blockers)
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("readinessLabel(%d) = %q, want containing %q", tt.blockers, got, tt.wantSub)
+			}
+		})
 	}
 }
 

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -757,9 +757,11 @@ func TestUserStats_Success(t *testing.T) {
 		{"overall summary", "Overall Summary"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(text, c.substr) {
-			t.Errorf("[%s] expected output to contain %q", c.name, c.substr)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(text, c.substr) {
+				t.Errorf("[%s] expected output to contain %q", c.name, c.substr)
+			}
+		})
 	}
 }
 

--- a/internal/resources/registrar_test.go
+++ b/internal/resources/registrar_test.go
@@ -55,9 +55,11 @@ func TestNewHandlerIndex_CapturesEveryRegistration(t *testing.T) {
 		"gitlab://user/current",                                // static resource
 		"gitlab://project/{project_id}/pipeline/{pipeline_id}", // template
 	} {
-		if index[key] == nil {
-			t.Errorf("index has no handler for %q", key)
-		}
+		t.Run(key, func(t *testing.T) {
+			if index[key] == nil {
+				t.Errorf("index has no handler for %q", key)
+			}
+		})
 	}
 }
 

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -1310,9 +1310,11 @@ func TestEvictIdle_ReclaimsOnlyStaleEntries(t *testing.T) {
 	pool := New(cfg, testFactory(), WithIdleTimeout(30*time.Minute))
 
 	for _, token := range []string{"stale-token", "fresh-token"} {
-		if _, err := pool.GetOrCreate(token, stubGitLabBase); err != nil {
-			t.Fatalf("GetOrCreate(%s) error: %v", token, err)
-		}
+		t.Run(token, func(t *testing.T) {
+			if _, err := pool.GetOrCreate(token, stubGitLabBase); err != nil {
+				t.Fatalf("GetOrCreate(%s) error: %v", token, err)
+			}
+		})
 	}
 
 	// Age one entry past the timeout without waiting for wall-clock time.
@@ -1901,9 +1903,11 @@ func TestPool_OnEvictFiresOnEveryRemovalPath(t *testing.T) {
 
 		pool := newRecordingPool(&evicted, &mu)
 		for _, token := range []string{"glpat-a", "glpat-b"} {
-			if _, err := pool.GetOrCreate(token, stubGitLabBase); err != nil {
-				t.Fatalf("entry %s: %v", token, err)
-			}
+			t.Run(token, func(t *testing.T) {
+				if _, err := pool.GetOrCreate(token, stubGitLabBase); err != nil {
+					t.Fatalf("entry %s: %v", token, err)
+				}
+			})
 		}
 		pool.Close()
 

--- a/internal/subscriptions/manager_test.go
+++ b/internal/subscriptions/manager_test.go
@@ -175,9 +175,11 @@ func TestSubscribe_AtCapacity_IsRejected(t *testing.T) {
 		"gitlab://project/42/pipeline/1",
 		"gitlab://project/42/pipeline/2",
 	} {
-		if err := m.Subscribe(ctx, subA, uri); err != nil {
-			t.Fatalf("Subscribe(#%d) error: %v", i, err)
-		}
+		t.Run(uri, func(t *testing.T) {
+			if err := m.Subscribe(ctx, subA, uri); err != nil {
+				t.Fatalf("Subscribe(#%d) error: %v", i, err)
+			}
+		})
 	}
 
 	err := m.Subscribe(ctx, subA, "gitlab://project/42/pipeline/3")
@@ -269,14 +271,18 @@ func TestUnsubscribeAll_SubscriberLeaves_StopsOnlyItsWatchers(t *testing.T) {
 	shared := "gitlab://project/42/pipeline/2"
 	theirs := "gitlab://project/42/pipeline/3"
 	for _, uri := range []string{mine, shared} {
-		if err := m.Subscribe(ctx, subA, uri); err != nil {
-			t.Fatalf("Subscribe(%s): %v", uri, err)
-		}
+		t.Run(uri, func(t *testing.T) {
+			if err := m.Subscribe(ctx, subA, uri); err != nil {
+				t.Fatalf("Subscribe(%s): %v", uri, err)
+			}
+		})
 	}
 	for _, uri := range []string{shared, theirs} {
-		if err := m.Subscribe(ctx, subB, uri); err != nil {
-			t.Fatalf("Subscribe(%s): %v", uri, err)
-		}
+		t.Run(uri, func(t *testing.T) {
+			if err := m.Subscribe(ctx, subB, uri); err != nil {
+				t.Fatalf("Subscribe(%s): %v", uri, err)
+			}
+		})
 	}
 
 	if stopped := m.UnsubscribeAll(subA); stopped != 1 {
@@ -295,9 +301,11 @@ func TestUnsubscribe_LastSubscriberLeaves_StopsWatcher(t *testing.T) {
 	ctx := context.Background()
 
 	for _, subscriber := range []string{subA, subB} {
-		if err := m.Subscribe(ctx, subscriber, testURI); err != nil {
-			t.Fatalf("Subscribe: %v", err)
-		}
+		t.Run(subscriber, func(t *testing.T) {
+			if err := m.Subscribe(ctx, subscriber, testURI); err != nil {
+				t.Fatalf("Subscribe: %v", err)
+			}
+		})
 	}
 
 	if err := m.Unsubscribe(subA, testURI); err != nil {
@@ -1276,9 +1284,11 @@ func TestSubscribe_AtCapacity_AllActive_IsStillRejected(t *testing.T) {
 	ctx := context.Background()
 
 	for _, uri := range []string{"gitlab://project/42/pipeline/1", "gitlab://project/42/pipeline/2"} {
-		if err := m.Subscribe(ctx, subA, uri); err != nil {
-			t.Fatalf("Subscribe(%s): %v", uri, err)
-		}
+		t.Run(uri, func(t *testing.T) {
+			if err := m.Subscribe(ctx, subA, uri); err != nil {
+				t.Fatalf("Subscribe(%s): %v", uri, err)
+			}
+		})
 	}
 
 	err := m.Subscribe(ctx, subA, testURI)

--- a/internal/telemetry/cardinality_test.go
+++ b/internal/telemetry/cardinality_test.go
@@ -28,9 +28,11 @@ func TestDropToolName_AutoProtectsTheSurfaceThatNeedsIt(t *testing.T) {
 		"dynamic":    false,
 		"":           false,
 	} {
-		if got := DropToolName(ToolNameAuto, surface); got != wantDropped {
-			t.Errorf("auto on the %q surface drops the tool name = %v, want %v", surface, got, wantDropped)
-		}
+		t.Run(surface, func(t *testing.T) {
+			if got := DropToolName(ToolNameAuto, surface); got != wantDropped {
+				t.Errorf("auto on the %q surface drops the tool name = %v, want %v", surface, got, wantDropped)
+			}
+		})
 	}
 }
 
@@ -40,12 +42,14 @@ func TestDropToolName_AutoProtectsTheSurfaceThatNeedsIt(t *testing.T) {
 // footprint whatever they are running.
 func TestDropToolName_ExplicitPoliciesOverrideTheSurface(t *testing.T) {
 	for _, surface := range []string{"individual", "meta", "dynamic"} {
-		if DropToolName(ToolNameOn, surface) {
-			t.Errorf("on dropped the tool name on the %q surface", surface)
-		}
-		if !DropToolName(ToolNameOff, surface) {
-			t.Errorf("off kept the tool name on the %q surface", surface)
-		}
+		t.Run(surface, func(t *testing.T) {
+			if DropToolName(ToolNameOn, surface) {
+				t.Errorf("on dropped the tool name on the %q surface", surface)
+			}
+			if !DropToolName(ToolNameOff, surface) {
+				t.Errorf("off kept the tool name on the %q surface", surface)
+			}
+		})
 	}
 }
 
@@ -70,14 +74,16 @@ func TestParseToolNamePolicy_RefusesAnUnknownValueByName(t *testing.T) {
 		"Off":    ToolNameOff,
 		"auto":   ToolNameAuto,
 	} {
-		got, err := ParseToolNamePolicy(input)
-		if err != nil {
-			t.Errorf("ParseToolNamePolicy(%q): %v", input, err)
-			continue
-		}
-		if got != want {
-			t.Errorf("ParseToolNamePolicy(%q) = %q, want %q", input, got, want)
-		}
+		t.Run(input, func(t *testing.T) {
+			got, err := ParseToolNamePolicy(input)
+			if err != nil {
+				t.Errorf("ParseToolNamePolicy(%q): %v", input, err)
+				return
+			}
+			if got != want {
+				t.Errorf("ParseToolNamePolicy(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -116,9 +122,11 @@ func TestToolNameView_RemovesTheToolNameAndTheAction(t *testing.T) {
 	// catalog action, so the two keys carry the same eleven hundred values and
 	// filtering one of them sheds no series whatever.
 	for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
-		if _, present := found[key]; present {
-			t.Errorf("%s survived the view; on the individual surface it mints one series per tool", key)
-		}
+		t.Run(key, func(t *testing.T) {
+			if _, present := found[key]; present {
+				t.Errorf("%s survived the view; on the individual surface it mints one series per tool", key)
+			}
+		})
 	}
 
 	// The allow-list concern is real and is what this half keeps: an attribute

--- a/internal/telemetry/diagnostics_test.go
+++ b/internal/telemetry/diagnostics_test.go
@@ -102,9 +102,11 @@ func TestSetDiagnosticSinks_NeverWritesToStdout(t *testing.T) {
 
 	out := buf.String()
 	for _, want := range []string{"handled error", "parse duration"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("%q did not reach the provided handler; a sink is writing somewhere else", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("%q did not reach the provided handler; a sink is writing somewhere else", want)
+			}
+		})
 	}
 }
 

--- a/internal/telemetry/identity_test.go
+++ b/internal/telemetry/identity_test.go
@@ -77,9 +77,11 @@ func TestRedactor_FullUsesTheRegistryNames(t *testing.T) {
 		t.Errorf("%s = %q, want the username", AttrUserName, attrs[AttrUserName])
 	}
 	for _, forbidden := range []string{"enduser.id", "enduser.name", "enduser.pseudo_id"} {
-		if _, present := attrs[forbidden]; present {
-			t.Errorf("%s is emitted; it is either misspelled or invented inside a namespace we do not own", forbidden)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if _, present := attrs[forbidden]; present {
+				t.Errorf("%s is emitted; it is either misspelled or invented inside a namespace we do not own", forbidden)
+			}
+		})
 	}
 }
 
@@ -193,9 +195,11 @@ func TestParseIdentityPolicy_RefusesAnUnknownValueByName(t *testing.T) {
 		t.Fatal("a misspelled policy was accepted")
 	}
 	for _, want := range []string{"pseudonimous", string(IdentityNone), string(IdentityPseudonymous), string(IdentityFull)} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("the error does not mention %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("the error does not mention %q: %v", want, err)
+			}
+		})
 	}
 }
 
@@ -211,14 +215,16 @@ func TestParseIdentityPolicy_AcceptsTheSpellingsOperatorsWrite(t *testing.T) {
 		"Pseudonymous":   IdentityPseudonymous,
 		"PSEUDONYMOUS  ": IdentityPseudonymous,
 	} {
-		got, err := ParseIdentityPolicy(input)
-		if err != nil {
-			t.Errorf("ParseIdentityPolicy(%q): %v", input, err)
-			continue
-		}
-		if got != want {
-			t.Errorf("ParseIdentityPolicy(%q) = %q, want %q", input, got, want)
-		}
+		t.Run(input, func(t *testing.T) {
+			got, err := ParseIdentityPolicy(input)
+			if err != nil {
+				t.Errorf("ParseIdentityPolicy(%q): %v", input, err)
+				return
+			}
+			if got != want {
+				t.Errorf("ParseIdentityPolicy(%q) = %q, want %q", input, got, want)
+			}
+		})
 	}
 }
 
@@ -255,9 +261,11 @@ func TestPolicyDescription_SaysWhatEachPolicyExports(t *testing.T) {
 		// The words that would make it wrong: a default whose description
 		// mentioned a digest would be describing pseudonymous.
 		for _, wrong := range []string{"digest", "username", "user id"} {
-			if strings.Contains(descriptions[IdentityNone], wrong) {
-				t.Errorf("the default's description mentions %q: %q", wrong, descriptions[IdentityNone])
-			}
+			t.Run(wrong, func(t *testing.T) {
+				if strings.Contains(descriptions[IdentityNone], wrong) {
+					t.Errorf("the default's description mentions %q: %q", wrong, descriptions[IdentityNone])
+				}
+			})
 		}
 	})
 

--- a/internal/telemetry/identity_test.go
+++ b/internal/telemetry/identity_test.go
@@ -238,13 +238,17 @@ func TestParseIdentityPolicy_AcceptsTheSpellingsOperatorsWrite(t *testing.T) {
 // policy's behavior: a line telling somebody their deployment records nobody
 // while it records names is worse than no line at all.
 func TestPolicyDescription_SaysWhatEachPolicyExports(t *testing.T) {
+	// The subtests below read this map, and subtests run in order, so every
+	// policy that has a description is in it before they start.
 	descriptions := map[IdentityPolicy]string{}
 	for _, policy := range []IdentityPolicy{IdentityNone, IdentityPseudonymous, IdentityFull} {
-		description := PolicyDescription(policy)
-		if description == "" {
-			t.Fatalf("policy %q has no description, so the startup line says nothing", policy)
-		}
-		descriptions[policy] = description
+		t.Run(string(policy)+" has a description", func(t *testing.T) {
+			description := PolicyDescription(policy)
+			if description == "" {
+				t.Fatalf("policy %q has no description, so the startup line says nothing", policy)
+			}
+			descriptions[policy] = description
+		})
 	}
 
 	t.Run("the three are distinguishable", func(t *testing.T) {

--- a/internal/telemetry/pseudonym_test.go
+++ b/internal/telemetry/pseudonym_test.go
@@ -35,9 +35,11 @@ func TestResourcePseudonym_DoesNotContainTheURI(t *testing.T) {
 	// The distinctive part is the project id, and eight hex characters landing
 	// in the right order by chance is around one in four billion per position.
 	for _, fragment := range []string{"gitlab", "project", "82077663"} {
-		if strings.Contains(digest, fragment) {
-			t.Errorf("digest %q contains %q from the URI", digest, fragment)
-		}
+		t.Run(fragment, func(t *testing.T) {
+			if strings.Contains(digest, fragment) {
+				t.Errorf("digest %q contains %q from the URI", digest, fragment)
+			}
+		})
 	}
 	if strings.Contains(uri, digest) {
 		t.Errorf("digest %q is a substring of the URI it stands for", digest)

--- a/internal/telemetry/sloghandler_test.go
+++ b/internal/telemetry/sloghandler_test.go
@@ -192,9 +192,11 @@ func TestSlogHandler_ADerivedLoggerStillExports(t *testing.T) {
 			want: func(t *testing.T, record sdklog.Record) {
 				t.Helper()
 				for key, value := range map[string]string{"component": "telemetry", "phase": "startup"} {
-					if !recordHasAttr(record, key, value) {
-						t.Errorf("%s=%s did not reach the exported record", key, value)
-					}
+					t.Run(key, func(t *testing.T) {
+						if !recordHasAttr(record, key, value) {
+							t.Errorf("%s=%s did not reach the exported record", key, value)
+						}
+					})
 				}
 			},
 		},
@@ -489,9 +491,11 @@ func TestSlogHandler_TheTerminalStillNamesTheCaller(t *testing.T) {
 
 	written := terminal.String()
 	for _, want := range []string{"jane", "42", LogFieldUser, LogFieldUserID} {
-		if !strings.Contains(written, want) {
-			t.Errorf("stderr lost %q under the strictest policy: %s", want, written)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(written, want) {
+				t.Errorf("stderr lost %q under the strictest policy: %s", want, written)
+			}
+		})
 	}
 }
 
@@ -544,9 +548,11 @@ func TestSlogHandler_ADerivedLoggerObeysTheIdentityPolicy(t *testing.T) {
 	})
 
 	for _, forbidden := range []string{"jane", AttrUserID, AttrUserName} {
-		if strings.Contains(exported, forbidden) {
-			t.Errorf("%s reached the collector through a derived logger: %s", forbidden, exported)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if strings.Contains(exported, forbidden) {
+				t.Errorf("%s reached the collector through a derived logger: %s", forbidden, exported)
+			}
+		})
 	}
 	if !strings.Contains(exported, AttrUserHash) {
 		t.Errorf("the digest is absent, so the derived handler lost the redactor: %s", exported)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -565,9 +565,11 @@ func TestStart_RefusesAnUnhonorableProtocolBeforeBuildingAnything(t *testing.T) 
 		t.Fatal("Start accepted an unknown protocol")
 	}
 	for _, want := range []string{"http/protobuff", ProtocolHTTP, ProtocolGRPC} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q does not mention %q", err, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not mention %q", err, want)
+			}
+		})
 	}
 }
 

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -46,9 +46,11 @@ func TestCaptureSlog(t *testing.T) {
 	slog.Info("test message", "key", "val")
 	out := buf.String()
 	for _, want := range []string{`"msg":"test message"`, `"key":"val"`, `"level":"INFO"`} {
-		if !strings.Contains(out, want) {
-			t.Errorf("slog output missing %q, got: %s", want, out)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("slog output missing %q, got: %s", want, out)
+			}
+		})
 	}
 }
 
@@ -222,10 +224,12 @@ func TestRespondJSONWithPagination(t *testing.T) {
 		"X-Prev-Page":   "1",
 	}
 	for header, want := range checks {
-		got := w.Header().Get(header)
-		if got != want {
-			t.Errorf("header %s = %q, want %q", header, got, want)
-		}
+		t.Run(header, func(t *testing.T) {
+			got := w.Header().Get(header)
+			if got != want {
+				t.Errorf("header %s = %q, want %q", header, got, want)
+			}
+		})
 	}
 }
 
@@ -249,9 +253,11 @@ func TestRespondJSONWithPagination_PartialHeaders(t *testing.T) {
 	}
 	// Omitted headers should not be set.
 	for _, header := range []string{"X-Total", "X-Total-Pages", "X-Next-Page", "X-Prev-Page"} {
-		if got := w.Header().Get(header); got != "" {
-			t.Errorf("header %s = %q, want empty (not set)", header, got)
-		}
+		t.Run(header, func(t *testing.T) {
+			if got := w.Header().Get(header); got != "" {
+				t.Errorf("header %s = %q, want empty (not set)", header, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/accessrequests/accessrequests_test.go
+++ b/internal/tools/accessrequests/accessrequests_test.go
@@ -769,9 +769,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"| Requested At | 16 Jun 2026 08:00 UTC |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -822,9 +824,11 @@ func TestFormatListMarkdown_WithItems(t *testing.T) {
 		"| 2 | bob | Bob | approved | 20 |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/accesstokens/accesstokens_test.go
+++ b/internal/tools/accesstokens/accesstokens_test.go
@@ -1817,9 +1817,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"glpat-secret123",
 	}
 	for _, s := range checks {
-		if !strings.Contains(md, s) {
-			t.Errorf("FormatOutputMarkdown missing %q in:\n%s", s, md)
-		}
+		t.Run(s, func(t *testing.T) {
+			if !strings.Contains(md, s) {
+				t.Errorf("FormatOutputMarkdown missing %q in:\n%s", s, md)
+			}
+		})
 	}
 }
 
@@ -2069,9 +2071,11 @@ func TestGroupList_WithAllFilters(t *testing.T) {
 				"page_token":       "xyz",
 			}
 			for key, want := range checks {
-				if got := q.Get(key); got != want {
-					t.Errorf("expected %s=%s, got %s", key, want, got)
-				}
+				t.Run(key, func(t *testing.T) {
+					if got := q.Get(key); got != want {
+						t.Errorf("expected %s=%s, got %s", key, want, got)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusOK, `[]`)
 			return
@@ -2135,9 +2139,11 @@ func TestPersonalList_WithAllFilters(t *testing.T) {
 				"page_token":       "pat-cursor",
 			}
 			for key, want := range checks {
-				if got := q.Get(key); got != want {
-					t.Errorf("expected %s=%s, got %s", key, want, got)
-				}
+				t.Run(key, func(t *testing.T) {
+					if got := q.Get(key); got != want {
+						t.Errorf("expected %s=%s, got %s", key, want, got)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusOK, `[]`)
 			return

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -167,9 +167,11 @@ func TestBuildActionCatalog_EnterpriseAndGitLabDotComGates(t *testing.T) {
 	}
 
 	for _, actionID := range []actioncatalog.ActionID{"orbit.status", "orbit.dsl"} {
-		assertCatalogMissingAction(t, base, actionID)
-		assertCatalogMissingAction(t, enterprise, actionID)
-		assertCatalogHasAction(t, gitLabDotComEnterprise, actionID)
+		t.Run(string(actionID), func(t *testing.T) {
+			assertCatalogMissingAction(t, base, actionID)
+			assertCatalogMissingAction(t, enterprise, actionID)
+			assertCatalogHasAction(t, gitLabDotComEnterprise, actionID)
+		})
 	}
 }
 
@@ -707,29 +709,24 @@ func TestCentralTierFilter_Invariants(t *testing.T) {
 	// Landmark actions: canonical IDs that must resolve to a specific tier. These
 	// encode the audited Wave 1/2 decisions (see cmd/audit_edition_tier).
 	landmarks := []struct {
+		name      string
 		id        actioncatalog.ActionID
 		freeOK    bool // present on a Free instance
 		premiumOK bool // present on a Premium instance
 	}{
-		{"issue.list", true, true},                          // core, all tiers
-		{"merge_request.approval_config", true, true},       // basic approval state is Free
-		{"project.service_account_list", true, true},        // service accounts are Free
-		{"group.epic_list", false, true},                    // epics are Premium
-		{"merge_request.approval_rule_create", false, true}, // approval rules are Premium
-		{"vulnerability.list", false, false},                // Ultimate only
-		{"dependency.list", false, false},                   // Ultimate only
-		{"security_finding.list", false, false},             // Ultimate only
+		{name: "core_action_on_every_tier", id: "issue.list", freeOK: true, premiumOK: true},
+		{name: "basic_approval_state_is_free", id: "merge_request.approval_config", freeOK: true, premiumOK: true},
+		{name: "service_accounts_are_free", id: "project.service_account_list", freeOK: true, premiumOK: true},
+		{name: "epics_are_premium", id: "group.epic_list", freeOK: false, premiumOK: true},
+		{name: "approval_rules_are_premium", id: "merge_request.approval_rule_create", freeOK: false, premiumOK: true},
+		{name: "vulnerabilities_are_ultimate", id: "vulnerability.list", freeOK: false, premiumOK: false},
+		{name: "dependencies_are_ultimate", id: "dependency.list", freeOK: false, premiumOK: false},
+		{name: "security_findings_are_ultimate", id: "security_finding.list", freeOK: false, premiumOK: false},
 	}
 	for _, lm := range landmarks {
-		if _, ok := free.Action(lm.id); ok != lm.freeOK {
-			t.Errorf("Free: action %s present=%v, want %v", lm.id, ok, lm.freeOK)
-		}
-		if _, ok := premium.Action(lm.id); ok != lm.premiumOK {
-			t.Errorf("Premium: action %s present=%v, want %v", lm.id, ok, lm.premiumOK)
-		}
-		if _, ok := ultimate.Action(lm.id); !ok {
-			t.Errorf("Ultimate: action %s must be present", lm.id)
-		}
+		t.Run(lm.name, func(t *testing.T) {
+			assertLandmarkTiers(t, free, premium, ultimate, lm.id, lm.freeOK, lm.premiumOK)
+		})
 	}
 
 	// Field-level (Phase 3): issue.create exists in all tiers, but its Premium
@@ -749,12 +746,29 @@ func TestCentralTierFilter_Invariants(t *testing.T) {
 	// reviewer_assignment_strategy (client-go v2.46.0) is Premium: pruned from
 	// the Free project.create/project.update input schemas, present on Premium.
 	for _, id := range []actioncatalog.ActionID{"project.create", "project.update"} {
-		if actionHasInputProp(t, free, id, "reviewer_assignment_strategy") {
-			t.Errorf("Free %s schema must not advertise Premium field reviewer_assignment_strategy", id)
-		}
-		if !actionHasInputProp(t, premium, id, "reviewer_assignment_strategy") {
-			t.Errorf("Premium %s schema must include field reviewer_assignment_strategy", id)
-		}
+		t.Run(string(id), func(t *testing.T) {
+			if actionHasInputProp(t, free, id, "reviewer_assignment_strategy") {
+				t.Errorf("Free %s schema must not advertise Premium field reviewer_assignment_strategy", id)
+			}
+			if !actionHasInputProp(t, premium, id, "reviewer_assignment_strategy") {
+				t.Errorf("Premium %s schema must include field reviewer_assignment_strategy", id)
+			}
+		})
+	}
+}
+
+// assertLandmarkTiers checks one landmark action against the three tier
+// catalogs: present on Free and Premium exactly as declared, always on Ultimate.
+func assertLandmarkTiers(t *testing.T, free, premium, ultimate *actioncatalog.Catalog, id actioncatalog.ActionID, freeOK, premiumOK bool) {
+	t.Helper()
+	if _, ok := free.Action(id); ok != freeOK {
+		t.Errorf("Free: action %s present=%v, want %v", id, ok, freeOK)
+	}
+	if _, ok := premium.Action(id); ok != premiumOK {
+		t.Errorf("Premium: action %s present=%v, want %v", id, ok, premiumOK)
+	}
+	if _, ok := ultimate.Action(id); !ok {
+		t.Errorf("Ultimate: action %s must be present", id)
 	}
 }
 

--- a/internal/tools/action_catalog_test.go
+++ b/internal/tools/action_catalog_test.go
@@ -58,9 +58,11 @@ func TestBuildActionCatalog_DoesNotUseMetaRegistrationCapture(t *testing.T) {
 		t.Fatalf("ReadFile(action_catalog.go) error = %v", err)
 	}
 	for _, forbidden := range []string{"CaptureMetaToolDefinitions", "registerAllMetaGroups("} {
-		if strings.Contains(string(source), forbidden) {
-			t.Fatalf("action_catalog.go contains %q; catalog construction must use ActionSpec groups directly", forbidden)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if strings.Contains(string(source), forbidden) {
+				t.Fatalf("action_catalog.go contains %q; catalog construction must use ActionSpec groups directly", forbidden)
+			}
+		})
 	}
 }
 
@@ -181,9 +183,11 @@ func TestBuildActionCatalog_EnterpriseAndGitLabDotComGates(t *testing.T) {
 func TestBuildMCPActionGroup_IsReadOnlyDiagnostics(t *testing.T) {
 	group := BuildMCPActionGroup(nil)
 	for _, want := range []string{"status", "health_check"} {
-		if _, ok := group.Actions[want]; !ok {
-			t.Errorf("BuildMCPActionGroup is missing the %s action", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if _, ok := group.Actions[want]; !ok {
+				t.Errorf("BuildMCPActionGroup is missing the %s action", want)
+			}
+		})
 	}
 	if len(group.Actions) != 2 {
 		t.Errorf("gitlab_server carries %d actions, want only status and health_check: %v",
@@ -732,12 +736,14 @@ func TestCentralTierFilter_Invariants(t *testing.T) {
 	// input fields (weight, epic_id) must be pruned from the Free schema and
 	// present on Premium/Ultimate.
 	for _, field := range []string{"weight", "epic_id"} {
-		if issueCreateHasInputProp(t, free, field) {
-			t.Errorf("Free issue.create schema must not advertise Premium field %q", field)
-		}
-		if !issueCreateHasInputProp(t, premium, field) {
-			t.Errorf("Premium issue.create schema must include field %q", field)
-		}
+		t.Run(field, func(t *testing.T) {
+			if issueCreateHasInputProp(t, free, field) {
+				t.Errorf("Free issue.create schema must not advertise Premium field %q", field)
+			}
+			if !issueCreateHasInputProp(t, premium, field) {
+				t.Errorf("Premium issue.create schema must include field %q", field)
+			}
+		})
 	}
 
 	// reviewer_assignment_strategy (client-go v2.46.0) is Premium: pruned from

--- a/internal/tools/action_specs_test.go
+++ b/internal/tools/action_specs_test.go
@@ -156,9 +156,11 @@ func TestActionSpecGroupsByTool_RejectsInvalidSpecs(t *testing.T) {
 		t.Fatal("expected grouped validation errors")
 	}
 	for _, want := range []string{"tool name", "action spec name is required", "duplicate action"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error = %q, want %q", err.Error(), want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %q, want %q", err.Error(), want)
+			}
+		})
 	}
 	specs := byTool["gitlab_test"]
 	if len(specs) != 4 {

--- a/internal/tools/actioncatalog/catalog_test.go
+++ b/internal/tools/actioncatalog/catalog_test.go
@@ -504,10 +504,11 @@ func TestCatalog_FiltersCloneWithoutMutatingSource(t *testing.T) {
 	readGroup.SetAction(Action{Name: "code", Route: testRoute(false)})
 	writeGroup := NewGroup(GroupOptions{ToolName: "gitlab_project"})
 	writeGroup.SetAction(Action{Name: "create", Route: testRoute(false)})
-	for _, group := range []Group{readGroup, writeGroup} {
-		if err := catalog.AddGroup(group); err != nil {
-			t.Fatalf("AddGroup() error = %v", err)
-		}
+	if err := catalog.AddGroup(readGroup); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
+	}
+	if err := catalog.AddGroup(writeGroup); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
 	}
 
 	if got := catalog.FilterExcludedTools([]string{"gitlab_project"}).CountGroups(); got != 1 {
@@ -596,10 +597,14 @@ func TestCatalog_FilterReadOnlyActionsKeepsReadsInMixedGroups(t *testing.T) {
 	readOnly := NewGroup(GroupOptions{ToolName: "gitlab_search", ReadOnly: true})
 	readOnly.SetAction(Action{Name: "code", Route: testRoute(false), ReadOnly: true})
 
-	for _, group := range []Group{mixed, writeOnly, readOnly} {
-		if err := catalog.AddGroup(group); err != nil {
-			t.Fatalf("AddGroup() error = %v", err)
-		}
+	if err := catalog.AddGroup(mixed); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
+	}
+	if err := catalog.AddGroup(writeOnly); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
+	}
+	if err := catalog.AddGroup(readOnly); err != nil {
+		t.Fatalf("AddGroup() error = %v", err)
 	}
 
 	filtered := catalog.FilterReadOnlyActions()

--- a/internal/tools/actioncompat/apply_test.go
+++ b/internal/tools/actioncompat/apply_test.go
@@ -100,9 +100,11 @@ func TestApplyToActionSpecs_ProjectsPackageReleaseWorkflowAliases(t *testing.T) 
 	})
 	packageAliases := packageSpecs[0].Compatibility.ActionAliases
 	for _, alias := range []string{"generic_packages.publish_directory", "gitlab_package/publish_directory"} {
-		if !hasAlias(packageAliases, alias, "publish_directory") {
-			t.Fatalf("package aliases = %+v, want %s -> publish_directory", packageAliases, alias)
-		}
+		t.Run(alias, func(t *testing.T) {
+			if !hasAlias(packageAliases, alias, "publish_directory") {
+				t.Fatalf("package aliases = %+v, want %s -> publish_directory", packageAliases, alias)
+			}
+		})
 	}
 
 	releaseSpecs := ApplyToActionSpecs("gitlab_release_link", "release", []toolutil.ActionSpec{
@@ -110,9 +112,11 @@ func TestApplyToActionSpecs_ProjectsPackageReleaseWorkflowAliases(t *testing.T) 
 	})
 	releaseAliases := releaseSpecs[0].Compatibility.ActionAliases
 	for _, alias := range []string{"release_link.create_batch", "release_link.link_create_batch", "gitlab_release/link_create_batch", "gitlab_release_link/link_create_batch"} {
-		if !hasAlias(releaseAliases, alias, "link_create_batch") {
-			t.Fatalf("release aliases = %+v, want %s -> link_create_batch", releaseAliases, alias)
-		}
+		t.Run(alias, func(t *testing.T) {
+			if !hasAlias(releaseAliases, alias, "link_create_batch") {
+				t.Fatalf("release aliases = %+v, want %s -> link_create_batch", releaseAliases, alias)
+			}
+		})
 	}
 }
 
@@ -190,10 +194,12 @@ func TestNormalizeActionAlias_UsesCompatibilityPolicy(t *testing.T) {
 		"release_link.link_create_batch":        "release.link_create_batch",
 		"terraform_state.unlock":                "admin.terraform_state_unlock",
 	} {
-		canonical, ok = NormalizeActionAlias(alias)
-		if !ok || canonical != want {
-			t.Fatalf("NormalizeActionAlias(%s) = %q, %t; want %s, true", alias, canonical, ok, want)
-		}
+		t.Run(alias, func(t *testing.T) {
+			canonical, ok = NormalizeActionAlias(alias)
+			if !ok || canonical != want {
+				t.Fatalf("NormalizeActionAlias(%s) = %q, %t; want %s, true", alias, canonical, ok, want)
+			}
+		})
 	}
 	unchanged, aliasOK := NormalizeActionAlias("project.get")
 	if aliasOK || unchanged != "project.get" {

--- a/internal/tools/actioncompat/parameter_aliases_test.go
+++ b/internal/tools/actioncompat/parameter_aliases_test.go
@@ -601,9 +601,11 @@ func TestDefaultPaginationValue_PageVsOthers(t *testing.T) {
 		t.Fatalf("defaultPaginationValue(page) = %d, want 1", got)
 	}
 	for _, name := range []string{"first", "last", "per_page"} {
-		if got := defaultPaginationValue(name); got != 100 {
-			t.Fatalf("defaultPaginationValue(%q) = %d, want 100", name, got)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got := defaultPaginationValue(name); got != 100 {
+				t.Fatalf("defaultPaginationValue(%q) = %d, want 100", name, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/actioncompat/parameter_aliases_test.go
+++ b/internal/tools/actioncompat/parameter_aliases_test.go
@@ -1076,28 +1076,31 @@ func TestReleaseLinkBatchEntries_DuplicateRecord(t *testing.T) {
 // environment access level value parser accepts both label strings and numbers.
 func TestEnvironmentAccessLevelValue_RoleLabelsAndNumericValues(t *testing.T) {
 	cases := []struct {
+		name      string
 		value     any
 		wantLevel int
 		wantOK    bool
 	}{
-		{value: float64(40), wantLevel: 40, wantOK: true},
-		{value: int(30), wantLevel: 30, wantOK: true},
-		{value: int64(20), wantLevel: 20, wantOK: true},
-		{value: "developer", wantLevel: 30, wantOK: true},
-		{value: "guest", wantLevel: 10, wantOK: true},
-		{value: "reporter", wantLevel: 20, wantOK: true},
-		{value: "owner", wantLevel: 50, wantOK: true},
-		{value: "admin", wantLevel: 60, wantOK: true},
-		{value: "no access", wantLevel: 0, wantOK: true},
-		{value: "unknown-role", wantOK: false},
-		{value: 99, wantOK: false},
-		{value: true, wantOK: false},
+		{name: "float64", value: float64(40), wantLevel: 40, wantOK: true},
+		{name: "int", value: int(30), wantLevel: 30, wantOK: true},
+		{name: "int64", value: int64(20), wantLevel: 20, wantOK: true},
+		{name: "developer_label", value: "developer", wantLevel: 30, wantOK: true},
+		{name: "guest_label", value: "guest", wantLevel: 10, wantOK: true},
+		{name: "reporter_label", value: "reporter", wantLevel: 20, wantOK: true},
+		{name: "owner_label", value: "owner", wantLevel: 50, wantOK: true},
+		{name: "admin_label", value: "admin", wantLevel: 60, wantOK: true},
+		{name: "no_access_label", value: "no access", wantLevel: 0, wantOK: true},
+		{name: "unknown_label", value: "unknown-role", wantOK: false},
+		{name: "unknown_number", value: 99, wantOK: false},
+		{name: "bool", value: true, wantOK: false},
 	}
 	for _, tc := range cases {
-		got, ok := environmentAccessLevelValue(tc.value)
-		if ok != tc.wantOK || got != tc.wantLevel {
-			t.Fatalf("environmentAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := environmentAccessLevelValue(tc.value)
+			if ok != tc.wantOK || got != tc.wantLevel {
+				t.Fatalf("environmentAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
+			}
+		})
 	}
 }
 
@@ -1106,30 +1109,33 @@ func TestEnvironmentAccessLevelValue_RoleLabelsAndNumericValues(t *testing.T) {
 // unknown values consistently.
 func TestGitLabBranchProtectionAccessLevelValue_Defaults(t *testing.T) {
 	cases := []struct {
+		name      string
 		value     any
 		wantLevel int
 		wantOK    bool
 	}{
-		{value: int(30), wantLevel: 30, wantOK: true},
-		{value: int(40), wantLevel: 40, wantOK: true},
-		{value: int(0), wantLevel: 0, wantOK: true},
-		{value: int(99), wantOK: false},
-		{value: int64(40), wantLevel: 40, wantOK: true},
-		{value: float64(30.0), wantLevel: 30, wantOK: true},
-		{value: float64(30.5), wantOK: false},
-		{value: "developer", wantLevel: 30, wantOK: true},
-		{value: "maintainer", wantLevel: 40, wantOK: true},
-		{value: "no_access", wantLevel: 0, wantOK: true},
-		{value: "30", wantLevel: 30, wantOK: true},
-		{value: "99", wantOK: false},
-		{value: "unknown", wantOK: false},
-		{value: true, wantOK: false},
+		{name: "int_developer", value: int(30), wantLevel: 30, wantOK: true},
+		{name: "int_maintainer", value: int(40), wantLevel: 40, wantOK: true},
+		{name: "int_no_access", value: int(0), wantLevel: 0, wantOK: true},
+		{name: "int_unknown", value: int(99), wantOK: false},
+		{name: "int64", value: int64(40), wantLevel: 40, wantOK: true},
+		{name: "whole_float", value: float64(30.0), wantLevel: 30, wantOK: true},
+		{name: "fractional_float", value: float64(30.5), wantOK: false},
+		{name: "developer_label", value: "developer", wantLevel: 30, wantOK: true},
+		{name: "maintainer_label", value: "maintainer", wantLevel: 40, wantOK: true},
+		{name: "no_access_label", value: "no_access", wantLevel: 0, wantOK: true},
+		{name: "numeric_string", value: "30", wantLevel: 30, wantOK: true},
+		{name: "unknown_numeric_string", value: "99", wantOK: false},
+		{name: "unknown_label", value: "unknown", wantOK: false},
+		{name: "bool", value: true, wantOK: false},
 	}
 	for _, tc := range cases {
-		got, ok := gitLabBranchProtectionAccessLevelValue(tc.value)
-		if ok != tc.wantOK || got != tc.wantLevel {
-			t.Fatalf("gitLabBranchProtectionAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := gitLabBranchProtectionAccessLevelValue(tc.value)
+			if ok != tc.wantOK || got != tc.wantLevel {
+				t.Fatalf("gitLabBranchProtectionAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
+			}
+		})
 	}
 }
 
@@ -1161,53 +1167,60 @@ func TestGitLabAccessLevelValue_InvalidLevel(t *testing.T) {
 // variant must resolve to the documented numeric value.
 func TestGitLabAccessLevelValue_ExtendedAliases(t *testing.T) {
 	cases := []struct {
+		name      string
 		value     any
 		wantLevel int
 		wantOK    bool
 	}{
-		{value: "minimal access", wantLevel: 5, wantOK: true},
-		{value: "Minimal Access", wantLevel: 5, wantOK: true},
-		{value: "minimal", wantLevel: 5, wantOK: true},
-		{value: "planner", wantLevel: 15, wantOK: true},
-		{value: "Planners", wantLevel: 15, wantOK: true},
-		{value: "security manager", wantLevel: 25, wantOK: true},
-		{value: "security_manager", wantLevel: 25, wantOK: true},
-		{value: "SecurityManager", wantLevel: 25, wantOK: true},
+		{name: "minimal_access_label", value: "minimal access", wantLevel: 5, wantOK: true},
+		{name: "minimal_access_title_case", value: "Minimal Access", wantLevel: 5, wantOK: true},
+		{name: "minimal_short_form", value: "minimal", wantLevel: 5, wantOK: true},
+		{name: "planner_label", value: "planner", wantLevel: 15, wantOK: true},
+		{name: "planner_plural", value: "Planners", wantLevel: 15, wantOK: true},
+		{name: "security_manager_label", value: "security manager", wantLevel: 25, wantOK: true},
+		{name: "security_manager_underscore", value: "security_manager", wantLevel: 25, wantOK: true},
+		{name: "security_manager_camel_case", value: "SecurityManager", wantLevel: 25, wantOK: true},
 		// Numeric string of a newly-valid level should also resolve.
-		{value: "5", wantLevel: 5, wantOK: true},
-		{value: "15", wantLevel: 15, wantOK: true},
-		{value: "60", wantLevel: 60, wantOK: true},
+		{name: "numeric_string_minimal_access", value: "5", wantLevel: 5, wantOK: true},
+		{name: "numeric_string_planner", value: "15", wantLevel: 15, wantOK: true},
+		{name: "numeric_string_admin", value: "60", wantLevel: 60, wantOK: true},
 	}
 	for _, tc := range cases {
-		got, ok := gitlabAccessLevelValue(tc.value)
-		if ok != tc.wantOK || got != tc.wantLevel {
-			t.Errorf("gitlabAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := gitlabAccessLevelValue(tc.value)
+			if ok != tc.wantOK || got != tc.wantLevel {
+				t.Errorf("gitlabAccessLevelValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantLevel, tc.wantOK)
+			}
+		})
 	}
 }
 
-// TestIntegerValue_TypeCoverage verifies the IntegerValue_TypeCoverage handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
+// TestIntegerValue_TypeCoverage verifies integerValue accepts every
+// integer-bearing input type (int, int64, a whole float64, and numeric strings
+// with or without padding) and rejects a fractional float, a non-numeric
+// string, and a bool, one subtest per input type.
 func TestIntegerValue_TypeCoverage(t *testing.T) {
 	cases := []struct {
+		name    string
 		value   any
 		wantInt int
 		wantOK  bool
 	}{
-		{value: int(7), wantInt: 7, wantOK: true},
-		{value: int64(42), wantInt: 42, wantOK: true},
-		{value: float64(10.0), wantInt: 10, wantOK: true},
-		{value: float64(10.5), wantInt: 10, wantOK: false},
-		{value: "5", wantInt: 5, wantOK: true},
-		{value: " 8 ", wantInt: 8, wantOK: true},
-		{value: "abc", wantOK: false},
-		{value: true, wantOK: false},
+		{name: "int", value: int(7), wantInt: 7, wantOK: true},
+		{name: "int64", value: int64(42), wantInt: 42, wantOK: true},
+		{name: "whole_float", value: float64(10.0), wantInt: 10, wantOK: true},
+		{name: "fractional_float", value: float64(10.5), wantInt: 10, wantOK: false},
+		{name: "numeric_string", value: "5", wantInt: 5, wantOK: true},
+		{name: "padded_numeric_string", value: " 8 ", wantInt: 8, wantOK: true},
+		{name: "non_numeric_string", value: "abc", wantOK: false},
+		{name: "bool", value: true, wantOK: false},
 	}
 	for _, tc := range cases {
-		got, ok := integerValue(tc.value)
-		if ok != tc.wantOK || got != tc.wantInt {
-			t.Fatalf("integerValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantInt, tc.wantOK)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := integerValue(tc.value)
+			if ok != tc.wantOK || got != tc.wantInt {
+				t.Fatalf("integerValue(%#v) = %d, %v; want %d, %v", tc.value, got, ok, tc.wantInt, tc.wantOK)
+			}
+		})
 	}
 }

--- a/internal/tools/adminspecs/action_specs_test.go
+++ b/internal/tools/adminspecs/action_specs_test.go
@@ -134,9 +134,11 @@ func TestActionSpecs_SettingsAndMetadataUsageGuidance(t *testing.T) {
 		t.Fatalf("metadata_get RelatedActions = %v", metadataSpec.RelatedActions)
 	}
 	for _, want := range []string{"Returns:", "See also:"} {
-		if !strings.Contains(metadataSpec.IndividualTool.Description, want) {
-			t.Fatalf("metadata_get description = %q, want %q", metadataSpec.IndividualTool.Description, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(metadataSpec.IndividualTool.Description, want) {
+				t.Fatalf("metadata_get description = %q, want %q", metadataSpec.IndividualTool.Description, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/alertmanagement/alertmanagement_test.go
+++ b/internal/tools/alertmanagement/alertmanagement_test.go
@@ -413,9 +413,11 @@ func TestListMetricImages_KeysetAndCreatedAt(t *testing.T) {
 		t.Errorf("expected created_at 2024-01-02T03:04:05Z, got %q", out.Images[0].CreatedAt)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "pagination=keyset", "page_token=42"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("expected query to contain %q, got %q", want, gotQuery)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("expected query to contain %q, got %q", want, gotQuery)
+			}
+		})
 	}
 }
 

--- a/internal/tools/applications/applications_test.go
+++ b/internal/tools/applications/applications_test.go
@@ -155,10 +155,19 @@ func TestRenewSecret(t *testing.T) {
 // before touching the GitLab API.
 func TestRenewSecret_ValidationError(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, id := range []int64{0, -1} {
-		if _, err := RenewSecret(t.Context(), client, RenewSecretInput{ID: id}); err == nil {
-			t.Errorf("ID=%d: expected error, got nil", id)
-		}
+	ids := []struct {
+		name string
+		id   int64
+	}{
+		{"zero_id", 0},
+		{"negative_id", -1},
+	}
+	for _, tc := range ids {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := RenewSecret(t.Context(), client, RenewSecretInput{ID: tc.id}); err == nil {
+				t.Errorf("ID=%d: expected error, got nil", tc.id)
+			}
+		})
 	}
 }
 
@@ -179,16 +188,24 @@ func TestRenewSecret_Error(t *testing.T) {
 	}
 }
 
-// TestDelete_ValidationError verifies that Delete_ValidationError returns a wrapped error when the GitLab API responds with an error status.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts that the returned error is wrapped and contains a useful hint.
+// TestDelete_ValidationError verifies Delete rejects non-positive ids before
+// touching the GitLab API.
 func TestDelete_ValidationError(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, id := range []int64{0, -1} {
-		err := Delete(t.Context(), client, DeleteInput{ID: id})
-		if err == nil {
-			t.Errorf("ID=%d: expected error, got nil", id)
-		}
+	ids := []struct {
+		name string
+		id   int64
+	}{
+		{"zero_id", 0},
+		{"negative_id", -1},
+	}
+	for _, tc := range ids {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Delete(t.Context(), client, DeleteInput{ID: tc.id})
+			if err == nil {
+				t.Errorf("ID=%d: expected error, got nil", tc.id)
+			}
+		})
 	}
 }
 

--- a/internal/tools/attestations/attestations_test.go
+++ b/internal/tools/attestations/attestations_test.go
@@ -594,8 +594,10 @@ func TestDownload_APIError(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"attestation_iid", "gitlab_attestation", "gitlab_list_attestations"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }

--- a/internal/tools/auditevents/auditevents_test.go
+++ b/internal/tools/auditevents/auditevents_test.go
@@ -766,9 +766,11 @@ func TestFormatMarkdown_Full(t *testing.T) {
 		"| Entity Path | group/project |",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/awardemoji/awardemoji_test.go
+++ b/internal/tools/awardemoji/awardemoji_test.go
@@ -1507,9 +1507,11 @@ func TestListIssueAwardEmoji_ForwardsListQuery(t *testing.T) {
 		"pagination": "keyset",
 		"page_token": "42",
 	} {
-		if got := gotQuery.Get(key); got != want {
-			t.Errorf("query %s = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := gotQuery.Get(key); got != want {
+				t.Errorf("query %s = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/badges/badges_test.go
+++ b/internal/tools/badges/badges_test.go
@@ -1100,9 +1100,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		}
 	}
 	for _, toolName := range []string{"gitlab_delete_project_badge", "gitlab_delete_group_badge"} {
-		if !byTool[toolName].Route.Destructive {
-			t.Fatalf("%s should be destructive", toolName)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			if !byTool[toolName].Route.Destructive {
+				t.Fatalf("%s should be destructive", toolName)
+			}
+		})
 	}
 	assertBadgeEditNameGuidance(t, byTool)
 	assertBadgeCreateScopeGuidance(t, byTool)
@@ -1361,14 +1363,16 @@ func TestBadgeActionDescription_AllBranches(t *testing.T) {
 func TestBadgeIndividualDescription_AllBranches(t *testing.T) {
 	verbs := []string{"list", "get", "add", "edit", "delete", "preview", "rotate"}
 	for _, scope := range []string{"project", "group"} {
-		for _, verb := range verbs {
-			got := badgeIndividualDescription(verb, scope)
-			if !strings.Contains(got, "Returns:") || !strings.Contains(got, "See also:") {
-				t.Errorf("badgeIndividualDescription(%q, %q) missing Returns:/See also:: %q", verb, scope, got)
+		t.Run(scope, func(t *testing.T) {
+			for _, verb := range verbs {
+				got := badgeIndividualDescription(verb, scope)
+				if !strings.Contains(got, "Returns:") || !strings.Contains(got, "See also:") {
+					t.Errorf("badgeIndividualDescription(%q, %q) missing Returns:/See also:: %q", verb, scope, got)
+				}
+				if !strings.Contains(got, scope) {
+					t.Errorf("badgeIndividualDescription(%q, %q) does not mention scope: %q", verb, scope, got)
+				}
 			}
-			if !strings.Contains(got, scope) {
-				t.Errorf("badgeIndividualDescription(%q, %q) does not mention scope: %q", verb, scope, got)
-			}
-		}
+		})
 	}
 }

--- a/internal/tools/boards/boards_test.go
+++ b/internal/tools/boards/boards_test.go
@@ -1233,9 +1233,11 @@ func TestFormatBoardListMarkdown_AllFields(t *testing.T) {
 	}
 	md := FormatBoardListMarkdown(out)
 	for _, want := range []string{"To Do", "Max Issue Count", "Max Issue Weight", "alice", "v1.0"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatBoardListMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatBoardListMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "(ID:") {
 		t.Errorf("should not contain redundant (ID:) patterns:\n%s", md)

--- a/internal/tools/branches/branches_test.go
+++ b/internal/tools/branches/branches_test.go
@@ -1303,9 +1303,11 @@ func TestMarkdownRegistry_BranchNotFound(t *testing.T) {
 		t.Fatalf("content type = %T, want TextContent", result.Content[0])
 	}
 	for _, want := range []string{"Branch Not Found", `"missing" in project 42`, "gitlab_branch_list"} {
-		if !strings.Contains(content.Text, want) {
-			t.Fatalf("markdown missing %q:\n%s", want, content.Text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content.Text, want) {
+				t.Fatalf("markdown missing %q:\n%s", want, content.Text)
+			}
+		})
 	}
 }
 
@@ -1960,9 +1962,11 @@ func TestBranchProtect_SerializesAllOptions(t *testing.T) {
 		t.Fatalf(fmtProtectErr, err)
 	}
 	for _, want := range []string{`"name":"release/*"`, `"unprotect_access_level":40`, `"allowed_to_push"`, `"user_id":7`, `"allowed_to_merge"`, `"allowed_to_unprotect"`, `"_destroy":true`} {
-		if !strings.Contains(gotBody, want) {
-			t.Errorf("request body missing %q\nbody=%s", want, gotBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotBody, want) {
+				t.Errorf("request body missing %q\nbody=%s", want, gotBody)
+			}
+		})
 	}
 }
 
@@ -1998,9 +2002,11 @@ func TestProtectedUpdate_SerializesAllOptions(t *testing.T) {
 		t.Fatalf("ProtectedUpdate() unexpected error: %v", err)
 	}
 	for _, want := range []string{`"name":"main-renamed"`, `"allowed_to_push"`, `"group_id":3`, `"allowed_to_merge"`, `"allowed_to_unprotect"`, `"deploy_key_id":3`} {
-		if !strings.Contains(gotBody, want) {
-			t.Errorf("request body missing %q\nbody=%s", want, gotBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotBody, want) {
+				t.Errorf("request body missing %q\nbody=%s", want, gotBody)
+			}
+		})
 	}
 }
 
@@ -2029,9 +2035,11 @@ func TestBranchList_KeysetAndOrdering(t *testing.T) {
 		t.Fatalf(fmtBranchListErr, err)
 	}
 	for _, want := range []string{"search=feat", "regex=", "order_by=updated", "sort=desc", "pagination=keyset", "page_token=tok"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query missing %q: %s", want, gotQuery)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query missing %q: %s", want, gotQuery)
+			}
+		})
 	}
 }
 
@@ -2059,9 +2067,11 @@ func TestProtectedList_SearchKeysetAndOrdering(t *testing.T) {
 		t.Fatalf(fmtProtBranchListErr, err)
 	}
 	for _, want := range []string{"search=main", "order_by=name", "sort=asc", "pagination=keyset", "page_token=tok"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query missing %q: %s", want, gotQuery)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query missing %q: %s", want, gotQuery)
+			}
+		})
 	}
 }
 
@@ -2112,25 +2122,27 @@ func TestProtectedFlaggedTools_Metadata(t *testing.T) {
 		"gitlab_protected_branch_update",
 	}
 	for _, tool := range flagged {
-		spec, ok := byTool[tool]
-		if !ok {
-			t.Fatalf("missing spec for %s", tool)
-		}
-		if spec.Usage == "" || strings.Contains(spec.Usage, "Use to execute branches domain action") {
-			t.Errorf("%s: generic/empty usage %q", tool, spec.Usage)
-		}
-		if len(spec.Aliases) == 0 {
-			t.Errorf("%s: no aliases", tool)
-		}
-		for _, a := range spec.Aliases {
-			if a == tool {
-				t.Errorf("%s: alias duplicates tool name", tool)
+		t.Run(tool, func(t *testing.T) {
+			spec, ok := byTool[tool]
+			if !ok {
+				t.Fatalf("missing spec for %s", tool)
 			}
-		}
-		desc := spec.IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: description missing Returns:/See also: form: %q", tool, desc)
-		}
+			if spec.Usage == "" || strings.Contains(spec.Usage, "Use to execute branches domain action") {
+				t.Errorf("%s: generic/empty usage %q", tool, spec.Usage)
+			}
+			if len(spec.Aliases) == 0 {
+				t.Errorf("%s: no aliases", tool)
+			}
+			for _, a := range spec.Aliases {
+				if a == tool {
+					t.Errorf("%s: alias duplicates tool name", tool)
+				}
+			}
+			desc := spec.IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s: description missing Returns:/See also: form: %q", tool, desc)
+			}
+		})
 	}
 }
 

--- a/internal/tools/broadcastmessages/broadcastmessages_test.go
+++ b/internal/tools/broadcastmessages/broadcastmessages_test.go
@@ -106,9 +106,11 @@ func TestList_PaginationAndOrdering(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "page=2", "per_page=50", "pagination=keyset", "page_token=100"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("expected query to contain %q, got %q", want, gotQuery)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("expected query to contain %q, got %q", want, gotQuery)
+			}
+		})
 	}
 }
 
@@ -462,9 +464,11 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 		t.Errorf("expected notification, got %s", out.Message.BroadcastType)
 	}
 	for _, want := range []string{"starts_at", "ends_at", "font", "target_access_levels", "target_path", "broadcast_type", "dismissable", "theme"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/bulkimports/action_specs_test.go
+++ b/internal/tools/bulkimports/action_specs_test.go
@@ -54,9 +54,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		"gitlab_get_bulk_import_entity",
 		"gitlab_list_bulk_import_entity_failures",
 	} {
-		if !byTool[name].ReadOnly || !byTool[name].Idempotent {
-			t.Errorf("%s should be read-only and idempotent", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly || !byTool[name].Idempotent {
+				t.Errorf("%s should be read-only and idempotent", name)
+			}
+		})
 	}
 	if !byTool["gitlab_cancel_bulk_import"].Idempotent {
 		t.Error("gitlab_cancel_bulk_import should be idempotent")

--- a/internal/tools/catalog_identity_test.go
+++ b/internal/tools/catalog_identity_test.go
@@ -210,18 +210,24 @@ func TestNewCallIdentifier_ReadsTheWireShape(t *testing.T) {
 func TestNewCallIdentifier_MalformedArgumentsResolveToNothing(t *testing.T) {
 	identifier := NewCallIdentifier(buildTestCatalog(t), config.ToolSurfaceDynamic)
 
-	for _, arguments := range []any{
-		json.RawMessage(`{"action":`),
-		json.RawMessage(`[]`),
-		json.RawMessage(`{"action":42}`),
-		json.RawMessage(``),
-		json.RawMessage(`null`),
-		42,
-		nil,
-	} {
-		if identity, ok := identifier.Identify("gitlab_execute_action", arguments); ok {
-			t.Errorf("arguments %v resolved to %+v", arguments, identity)
-		}
+	cases := []struct {
+		name      string
+		arguments any
+	}{
+		{name: "truncated_object", arguments: json.RawMessage(`{"action":`)},
+		{name: "array_not_object", arguments: json.RawMessage(`[]`)},
+		{name: "numeric_action", arguments: json.RawMessage(`{"action":42}`)},
+		{name: "empty_payload", arguments: json.RawMessage(``)},
+		{name: "json_null", arguments: json.RawMessage(`null`)},
+		{name: "not_json_at_all", arguments: 42},
+		{name: "nil_arguments", arguments: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if identity, ok := identifier.Identify("gitlab_execute_action", tc.arguments); ok {
+				t.Errorf("arguments %v resolved to %+v", tc.arguments, identity)
+			}
+		})
 	}
 }
 

--- a/internal/tools/catalog_identity_test.go
+++ b/internal/tools/catalog_identity_test.go
@@ -327,10 +327,12 @@ func TestNewCallIdentifier_AliasNeverShadowsACanonicalID(t *testing.T) {
 // path.
 func TestNewCallIdentifier_NilCatalogIsUsable(t *testing.T) {
 	for _, surface := range []string{config.ToolSurfaceIndividual, config.ToolSurfaceMeta, config.ToolSurfaceDynamic} {
-		identifier := NewCallIdentifier(nil, surface)
-		if identity, ok := identifier.Identify("gitlab_issue_list", nil); ok {
-			t.Errorf("a nil catalog resolved something on %s: %+v", surface, identity)
-		}
+		t.Run(surface, func(t *testing.T) {
+			identifier := NewCallIdentifier(nil, surface)
+			if identity, ok := identifier.Identify("gitlab_issue_list", nil); ok {
+				t.Errorf("a nil catalog resolved something on %s: %+v", surface, identity)
+			}
+		})
 	}
 }
 

--- a/internal/tools/cilint/cilint_test.go
+++ b/internal/tools/cilint/cilint_test.go
@@ -457,9 +457,11 @@ func TestFormatOutputMarkdown_ValidAllSections(t *testing.T) {
 		"```yaml",
 		"stages:",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	if strings.Contains(md, "### Errors") {
@@ -486,9 +488,11 @@ func TestFormatOutputMarkdown_InvalidWithErrors(t *testing.T) {
 		"- syntax error on line 5",
 		"- unknown key: foo",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	if strings.Contains(md, mdHeadingWarnings) {

--- a/internal/tools/civariables/civariables_test.go
+++ b/internal/tools/civariables/civariables_test.go
@@ -778,9 +778,11 @@ func TestFormatOutputMarkdown_FullUnmasked(t *testing.T) {
 		"| Description | Database host |",
 		"| Value | localhost |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "| Hidden | ✅ |") {
 		t.Error("should not contain Hidden line when hidden=false")
@@ -869,9 +871,11 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		"env_var",
 		testEnvScope,
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/ciyamltemplates/ciyamltemplates_test.go
+++ b/internal/tools/ciyamltemplates/ciyamltemplates_test.go
@@ -309,9 +309,11 @@ func TestFormatListMarkdown_WithPagination(t *testing.T) {
 		"| Go | Go |",
 		"| Python | Python |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -350,9 +352,11 @@ func TestFormatGetMarkdown_AllFields(t *testing.T) {
 		"rspec",
 		"```",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/clusteragents/clusteragents_test.go
+++ b/internal/tools/clusteragents/clusteragents_test.go
@@ -518,9 +518,11 @@ func TestListAgents_KeysetAndOrdering(t *testing.T) {
 		for key, want := range map[string]string{
 			"pagination": "keyset", "page_token": "42", "order_by": "id", "sort": "desc",
 		} {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[{"id":1,"name":"agent1","created_at":"2024-01-02T03:04:05Z","created_by_user_id":10,"config_project":{"id":99,"name":"cfg","path_with_namespace":"grp/cfg","created_at":"2023-01-01T00:00:00Z"}}]`)
 	}))
@@ -562,9 +564,11 @@ func TestListAgentTokens_KeysetAndOrdering(t *testing.T) {
 		for key, want := range map[string]string{
 			"pagination": "keyset", "page_token": "7", "order_by": "id", "sort": "asc",
 		} {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[{"id":1,"name":"tok","agent_id":5,"status":"active","created_at":"2024-02-03T04:05:06Z","created_by_user_id":11,"last_used_at":"2024-03-04T05:06:07Z"}]`)
 	}))
@@ -623,9 +627,11 @@ func TestFormatAgentMarkdown_Content(t *testing.T) {
 		ConfigProject:   ConfigProjectOutput{ID: 99, Name: "cfg", PathWithNamespace: "grp/cfg"},
 	})
 	for _, want := range []string{"test-agent", "2024-01-02T03:04:05Z", "grp/cfg", "Created By User ID"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected %q in markdown, got: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("expected %q in markdown, got: %s", want, md)
+			}
+		})
 	}
 }
 
@@ -646,9 +652,11 @@ func TestFormatTokenMarkdown_AllFields(t *testing.T) {
 		Description: "desc", CreatedAt: "2024-02-03T04:05:06Z", LastUsedAt: "2024-03-04T05:06:07Z",
 	})
 	for _, want := range []string{"desc", "2024-02-03T04:05:06Z", "2024-03-04T05:06:07Z"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected %q in markdown, got: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("expected %q in markdown, got: %s", want, md)
+			}
+		})
 	}
 }
 
@@ -693,9 +701,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		t.Fatalf("unique individual tools = %d, want %d", len(byTool), len(specs))
 	}
 	for _, toolName := range []string{"gitlab_delete_cluster_agent", "gitlab_revoke_cluster_agent_token"} {
-		if !byTool[toolName].Route.Destructive {
-			t.Fatalf("%s should be destructive", toolName)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			if !byTool[toolName].Route.Destructive {
+				t.Fatalf("%s should be destructive", toolName)
+			}
+		})
 	}
 	if byTool["gitlab_list_cluster_agents"].Usage == "" {
 		t.Fatal("gitlab_list_cluster_agents should define usage")

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -1472,9 +1472,11 @@ func TestCommitCreate_WithAllOptions(t *testing.T) {
 		t.Errorf(fmtOutShortIDWant, out.ShortID, "opt1")
 	}
 	for _, want := range []string{"start_branch", "start_sha", "start_project", "author_email", "author_name", "stats", "force", "actions", "previous_path", "encoding", "execute_filemode"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -1787,9 +1789,11 @@ func TestSetStatus_WithAllOptions(t *testing.T) {
 		t.Error("CreatedAt is empty")
 	}
 	for _, want := range []string{"ref", "name", "context", "target_url", "description", "coverage", "pipeline_id"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -2298,9 +2302,11 @@ func TestFormatGPGSignatureMarkdown_SSH(t *testing.T) {
 	}
 	md := FormatGPGSignatureMarkdown(sig)
 	for _, want := range []string{"SSH", "verified", "MyKey", "auth_and_signing", "gitaly"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected Markdown to contain %q\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("expected Markdown to contain %q\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2318,9 +2324,11 @@ func TestFormatGPGSignatureMarkdown_X509(t *testing.T) {
 	}
 	md := FormatGPGSignatureMarkdown(sig)
 	for _, want := range []string{"X509", "unverified", "CN=gitlab@example.org", "gitlab@example.org"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("expected Markdown to contain %q\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("expected Markdown to contain %q\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/compliancepolicy/compliance_policy_test.go
+++ b/internal/tools/compliancepolicy/compliance_policy_test.go
@@ -220,9 +220,11 @@ func TestUpdate_BadRequestHint(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"csp_namespace_id", "top-level group", "lock"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/containerregistry/containerregistry_test.go
+++ b/internal/tools/containerregistry/containerregistry_test.go
@@ -580,9 +580,11 @@ func TestFormatRepositoryMarkdown_Full(t *testing.T) {
 	}
 	md := FormatRepositoryMarkdown(out)
 	for _, want := range []string{"Registry Repository: " + testCovRepoPath, "img", testCovRepoPath, "loc", "3", "delete_scheduled", "15 Jan 2026"} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtExpectedInMarkdown, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtExpectedInMarkdown, want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "| ID |") {
 		t.Error("should not contain numeric ID column")
@@ -631,9 +633,11 @@ func TestFormatRepositoryListMarkdown_WithItems(t *testing.T) {
 		t.Error("should not contain numeric ID column in list")
 	}
 	for _, want := range []string{"| a |", "| x/a |", "| b |", "| x/b |"} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtExpectedInMarkdown, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtExpectedInMarkdown, want, md)
+			}
+		})
 	}
 }
 
@@ -663,9 +667,11 @@ func TestFormatTagMarkdown_Full(t *testing.T) {
 	}
 	md := FormatTagMarkdown(out)
 	for _, want := range []string{"v1.0", "sha256:abc", "rev1", "1024", "1 Feb 2026"} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtExpectedInMarkdown, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtExpectedInMarkdown, want, md)
+			}
+		})
 	}
 }
 
@@ -1163,9 +1169,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		t.Fatalf("unique individual tools = %d, want %d", len(byTool), len(specs))
 	}
 	for _, toolName := range []string{"gitlab_registry_delete_repository", "gitlab_registry_delete_tag", "gitlab_registry_delete_tags_bulk", "gitlab_registry_protection_delete", "gitlab_registry_tag_protection_delete"} {
-		if !byTool[toolName].Route.Destructive {
-			t.Fatalf("%s should be destructive", toolName)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			if !byTool[toolName].Route.Destructive {
+				t.Fatalf("%s should be destructive", toolName)
+			}
+		})
 	}
 	for _, spec := range byTool {
 		if spec.Usage == "" {
@@ -1367,9 +1375,11 @@ func TestFormatProtectionRuleMarkdown_NoNumericIDs(t *testing.T) {
 		t.Error("should not contain numeric Project ID column")
 	}
 	for _, want := range []string{testStagingPattern, "owner", "admin"} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtExpectedInMarkdown, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtExpectedInMarkdown, want, md)
+			}
+		})
 	}
 }
 
@@ -1388,9 +1398,11 @@ func TestFormatProtectionRuleListMarkdown_NoNumericIDs(t *testing.T) {
 		t.Error("should not contain numeric ID column in list")
 	}
 	for _, want := range []string{testProdPattern, testStagingPattern, "maintainer", "owner"} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtExpectedInMarkdown, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtExpectedInMarkdown, want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/containerregistry/tag_protection_rules_test.go
+++ b/internal/tools/containerregistry/tag_protection_rules_test.go
@@ -358,9 +358,11 @@ func TestUpdateTagProtectionRule_AccessLevels(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, field := range []string{"minimum_access_level_for_push", "minimum_access_level_for_delete"} {
-		if !strings.Contains(body, field) {
-			t.Errorf("expected %s in request body, got: %s", field, body)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !strings.Contains(body, field) {
+				t.Errorf("expected %s in request body, got: %s", field, body)
+			}
+		})
 	}
 	if out.MinimumAccessLevelForPush != "owner" {
 		t.Errorf("expected push level owner, got %s", out.MinimumAccessLevelForPush)

--- a/internal/tools/dependencies/dependencies_test.go
+++ b/internal/tools/dependencies/dependencies_test.go
@@ -325,9 +325,11 @@ func TestCreateExport_NotFoundHint(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"pipeline_id", "gitlab_pipeline", "dependency scanning", "SBOM"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/deploykeys/action_specs_test.go
+++ b/internal/tools/deploykeys/action_specs_test.go
@@ -53,14 +53,16 @@ func TestActionSpecs_DeployKeyIDGuidance(t *testing.T) {
 	}
 
 	for _, toolName := range []string{"gitlab_deploy_key_get", "gitlab_deploy_key_update", "gitlab_deploy_key_delete", "gitlab_deploy_key_enable"} {
-		spec := byTool[toolName]
-		if !strings.Contains(spec.Usage, "deploy_key_id") || !strings.Contains(spec.Usage, "deploy_token_id") {
-			t.Fatalf("%s Usage = %q, want deploy_key_id vs deploy_token_id guidance", toolName, spec.Usage)
-		}
-		guidance := spec.ParameterGuidance["deploy_key_id"]
-		if guidance.SemanticRole != "deploy_key" || !deployKeyContainsText(guidance.CommonConfusions, "deploy_token_id") {
-			t.Fatalf("%s deploy_key_id guidance = %+v, want deploy_token_id warning", toolName, guidance)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			spec := byTool[toolName]
+			if !strings.Contains(spec.Usage, "deploy_key_id") || !strings.Contains(spec.Usage, "deploy_token_id") {
+				t.Fatalf("%s Usage = %q, want deploy_key_id vs deploy_token_id guidance", toolName, spec.Usage)
+			}
+			guidance := spec.ParameterGuidance["deploy_key_id"]
+			if guidance.SemanticRole != "deploy_key" || !deployKeyContainsText(guidance.CommonConfusions, "deploy_token_id") {
+				t.Fatalf("%s deploy_key_id guidance = %+v, want deploy_token_id warning", toolName, guidance)
+			}
+		})
 	}
 }
 

--- a/internal/tools/deploykeys/deploykeys_test.go
+++ b/internal/tools/deploykeys/deploykeys_test.go
@@ -889,9 +889,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"| Created | 1 Jan 2026 00:00 UTC |",
 		"| Expires | 1 Jan 2027 00:00 UTC |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -908,9 +910,11 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		t.Errorf("missing header:\n%s", md)
 	}
 	for _, absent := range []string{"Fingerprint", "SHA256", "Created", "Expires"} {
-		if strings.Contains(md, "| "+absent+" |") {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, "| "+absent+" |") {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -939,9 +943,11 @@ func TestFormatListMarkdown_WithKeys(t *testing.T) {
 		"key-a",
 		"key-b",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -995,9 +1001,11 @@ func TestFormatInstanceOutputMarkdown_AllFields(t *testing.T) {
 		"### Projects with Readonly Access",
 		"| 200 | proj-r | group/proj-r |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1014,9 +1022,11 @@ func TestFormatInstanceOutputMarkdown_MinimalFields(t *testing.T) {
 		t.Errorf("missing header:\n%s", md)
 	}
 	for _, absent := range []string{"Fingerprint", "SHA256", "Created", "Expires", "Write Access", "Readonly Access"} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1045,9 +1055,11 @@ func TestFormatInstanceListMarkdown_WithKeys(t *testing.T) {
 		"inst-a",
 		"inst-b",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1414,9 +1426,11 @@ func TestListProject_OrderingAndKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "pagination=keyset", "page_token=tok"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -1442,9 +1456,11 @@ func TestListAll_OrderingAndKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=title", "sort=asc", "pagination=keyset", "page_token=tok"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -1471,8 +1487,10 @@ func TestListUserProject_OrderingAndKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=id", "sort=desc", "pagination=keyset", "page_token=tok"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }

--- a/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
+++ b/internal/tools/deploymentmergerequests/deploymentmergerequests_test.go
@@ -350,9 +350,11 @@ func TestList_MergeRequestFilters(t *testing.T) {
 			"draft":           "true",
 		}
 		for key, want := range checks {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		if got := q.Get("approver_ids[]"); got != "11" {
 			t.Errorf("approver_ids[] = %q, want 11", got)
@@ -430,9 +432,11 @@ func TestList_AdditionalMergeRequestFilters(t *testing.T) {
 			"non_archived":              "true",
 		}
 		for key, want := range checks {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		if got := q.Get("updated_after"); !strings.HasPrefix(got, "2025-02-01") {
 			t.Errorf("updated_after = %q, want 2025-02-01 prefix", got)
@@ -651,9 +655,11 @@ func TestFormatListMarkdown_MultipleItems(t *testing.T) {
 		"fix-b -> develop",
 		"hotfix-c -> main",
 	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown missing %q:\n%s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown missing %q:\n%s", want, text)
+			}
+		})
 	}
 }
 

--- a/internal/tools/deployments/deployments_test.go
+++ b/internal/tools/deployments/deployments_test.go
@@ -1095,9 +1095,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"| Created | 1 Jun 2026 00:00 UTC |",
 		"| Updated | 1 Jun 2026 01:00 UTC |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1132,9 +1134,11 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		"| Created |",
 		"| Updated |",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1197,9 +1201,11 @@ func TestFormatListMarkdown_WithDeployments(t *testing.T) {
 		"admin",
 		"dev",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1301,9 +1307,11 @@ func TestToOutput_AllOptionalFields(t *testing.T) {
 		"| Created | 1 Dec 2026 00:00 UTC |",
 		"| Updated | 1 Dec 2026 12:00 UTC |",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("markdown missing %q:\n%s", want, out)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("markdown missing %q:\n%s", want, out)
+			}
+		})
 	}
 }
 

--- a/internal/tools/deploytokens/action_specs_test.go
+++ b/internal/tools/deploytokens/action_specs_test.go
@@ -240,13 +240,15 @@ func TestDeployTokenDescription_AllActions(t *testing.T) {
 		"deploy_token_delete_group",
 	}
 	for _, action := range actions {
-		desc := deployTokenDescription(action)
-		if desc == "" {
-			t.Errorf("action %q has empty description", action)
-		}
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("action %q description missing Returns/See also: %q", action, desc)
-		}
+		t.Run(action, func(t *testing.T) {
+			desc := deployTokenDescription(action)
+			if desc == "" {
+				t.Errorf("action %q has empty description", action)
+			}
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("action %q description missing Returns/See also: %q", action, desc)
+			}
+		})
 	}
 	if got := deployTokenDescription("unknown_action"); got != "" {
 		t.Errorf("unknown action description = %q, want empty", got)

--- a/internal/tools/deploytokens/deploytokens_test.go
+++ b/internal/tools/deploytokens/deploytokens_test.go
@@ -529,9 +529,11 @@ func TestListProject_WithKeyset(t *testing.T) {
 		t.Fatalf("expected 1 token, got %d", len(out.DeployTokens))
 	}
 	for _, want := range []string{"order_by=id", "sort=desc", "pagination=keyset", "page_token=5"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -640,9 +642,11 @@ func TestListGroup_WithKeyset(t *testing.T) {
 		t.Fatalf("expected 1 token, got %d", len(out.DeployTokens))
 	}
 	for _, want := range []string{"order_by=id", "sort=asc", "pagination=keyset", "page_token=3"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -1046,9 +1050,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"| Expired | false |",
 		"| Expires | 15 Jun 2027 00:00 UTC |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1133,9 +1139,11 @@ func TestFormatListMarkdown_WithTokens(t *testing.T) {
 		"read_repository",
 		"read_registry, write_registry",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/dorametrics/dorametrics_test.go
+++ b/internal/tools/dorametrics/dorametrics_test.go
@@ -257,9 +257,11 @@ func TestGetProjectMetrics_BadRequestHint(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"environment_tiers", "omit environment_tiers", "deployment environment tiers"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 
@@ -438,9 +440,11 @@ func TestGetGroupMetrics_BadRequestHint(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"environment_tiers", "omit environment_tiers", "deployment environment tiers"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/dynamic/alias_audit_test.go
+++ b/internal/tools/dynamic/alias_audit_test.go
@@ -41,9 +41,11 @@ func TestAuditActionAliases_ReportsGovernanceFindings(t *testing.T) {
 		"unsearchable_alias",
 	}
 	for _, problem := range wantProblems {
-		if !slices.ContainsFunc(findings, func(finding AliasAuditFinding) bool { return finding.Problem == problem }) {
-			t.Fatalf("findings = %+v, want problem %q", findings, problem)
-		}
+		t.Run(problem, func(t *testing.T) {
+			if !slices.ContainsFunc(findings, func(finding AliasAuditFinding) bool { return finding.Problem == problem }) {
+				t.Fatalf("findings = %+v, want problem %q", findings, problem)
+			}
+		})
 	}
 
 	for index := 1; index < len(findings); index++ {
@@ -133,9 +135,11 @@ func TestAuditCatalogDiscoveryTerms_FlagsDenseActionsWithoutSignals(t *testing.T
 		t.Fatalf("AuditCatalogDiscoveryTerms() returned %d findings, want 14: %+v", len(findings), findings)
 	}
 	for _, ignored := range []string{"project.weak_action_a", "project.weak_action_b"} {
-		if slices.ContainsFunc(findings, func(finding CatalogDiscoveryFinding) bool { return finding.ID == ignored }) {
-			t.Fatalf("findings = %+v, want %s ignored because it has discovery signals", findings, ignored)
-		}
+		t.Run(ignored, func(t *testing.T) {
+			if slices.ContainsFunc(findings, func(finding CatalogDiscoveryFinding) bool { return finding.ID == ignored }) {
+				t.Fatalf("findings = %+v, want %s ignored because it has discovery signals", findings, ignored)
+			}
+		})
 	}
 	for _, finding := range findings {
 		if finding.Severity != "warning" || finding.Problem != "weak_discovery_terms" || finding.Message == "" {

--- a/internal/tools/dynamic/fuzzy_test.go
+++ b/internal/tools/dynamic/fuzzy_test.go
@@ -75,20 +75,23 @@ func TestBoundedLevenshtein_CoversThresholdBranches(t *testing.T) {
 // so future scoring changes do not silently accept out-of-range distances.
 func TestFuzzyDistanceScore_MapsDistanceToScore(t *testing.T) {
 	tests := []struct {
+		name     string
 		distance int
 		want     int
 	}{
-		{distance: 0, want: 40},
-		{distance: 1, want: 34},
-		{distance: 2, want: 28},
-		{distance: 3, want: 0},
+		{name: "exact_match", distance: 0, want: 40},
+		{name: "one_edit", distance: 1, want: 34},
+		{name: "two_edits", distance: 2, want: 28},
+		{name: "beyond_bound", distance: 3, want: 0},
 	}
 
 	for _, tt := range tests {
-		got := fuzzyDistanceScore(tt.distance)
-		if got != tt.want {
-			t.Fatalf("fuzzyDistanceScore(%d) = %d, want %d", tt.distance, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := fuzzyDistanceScore(tt.distance)
+			if got != tt.want {
+				t.Fatalf("fuzzyDistanceScore(%d) = %d, want %d", tt.distance, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -97,19 +100,22 @@ func TestFuzzyDistanceScore_MapsDistanceToScore(t *testing.T) {
 // runes in non-English project or action terms.
 func TestFirstRuneString_HandlesUnicodeTokens(t *testing.T) {
 	tests := []struct {
+		name  string
 		value string
 		want  string
 	}{
-		{value: "merge", want: "m"},
-		{value: "ñandú", want: "ñ"},
-		{value: "", want: ""},
+		{name: "ascii_token", value: "merge", want: "m"},
+		{name: "multibyte_leading_rune", value: "ñandú", want: "ñ"},
+		{name: "empty_token", value: "", want: ""},
 	}
 
 	for _, tt := range tests {
-		got := firstRuneString(tt.value)
-		if got != tt.want {
-			t.Fatalf("firstRuneString(%q) = %q, want %q", tt.value, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstRuneString(tt.value)
+			if got != tt.want {
+				t.Fatalf("firstRuneString(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -4545,12 +4545,21 @@ func TestDynamicParamValidation_DefensiveBranches(t *testing.T) {
 // helpers for issue state events, GitLab access levels, and boolean strings. It
 // covers accepted inputs and rejected edge cases without external fixtures.
 func TestActionScopedParamValueConversions(t *testing.T) {
-	stateCases := map[any]string{"closed": "close", "OPEN": "reopen"}
-	for input, want := range stateCases {
-		got, ok := actioncompat.IssueStateEventValue(input)
-		if !ok || got != want {
-			t.Fatalf("issueStateEventValue(%v) = %q, %t; want %q, true", input, got, ok, want)
-		}
+	stateCases := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{name: "state_closed_becomes_close", input: "closed", want: "close"},
+		{name: "state_uppercase_open_becomes_reopen", input: "OPEN", want: "reopen"},
+	}
+	for _, tc := range stateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := actioncompat.IssueStateEventValue(tc.input)
+			if !ok || got != tc.want {
+				t.Fatalf("issueStateEventValue(%v) = %q, %t; want %q, true", tc.input, got, ok, tc.want)
+			}
+		})
 	}
 	if _, ok := actioncompat.IssueStateEventValue(123); ok {
 		t.Fatal("issueStateEventValue(non-string) converted unexpectedly")
@@ -4559,36 +4568,64 @@ func TestActionScopedParamValueConversions(t *testing.T) {
 		t.Fatal("issueStateEventValue(archived) converted unexpectedly")
 	}
 
-	accessCases := map[any]int{
-		10:             10,
-		int64(20):      20,
-		float64(30):    30,
-		"40":           40,
-		"guest":        10,
-		"reporter":     20,
-		"developer":    30,
-		" maintainer ": 40,
-		"owner":        50,
+	accessCases := []struct {
+		name  string
+		input any
+		want  int
+	}{
+		{name: "access_int", input: 10, want: 10},
+		{name: "access_int64", input: int64(20), want: 20},
+		{name: "access_float64", input: float64(30), want: 30},
+		{name: "access_numeric_string", input: "40", want: 40},
+		{name: "access_guest", input: "guest", want: 10},
+		{name: "access_reporter", input: "reporter", want: 20},
+		{name: "access_developer", input: "developer", want: 30},
+		{name: "access_padded_maintainer", input: " maintainer ", want: 40},
+		{name: "access_owner", input: "owner", want: 50},
 	}
-	for input, want := range accessCases {
-		got, ok := actioncompat.GitLabAccessLevelValue(input)
-		if !ok || got != want {
-			t.Fatalf("gitlabAccessLevelValue(%v) = %d, %t; want %d, true", input, got, ok, want)
-		}
+	for _, tc := range accessCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := actioncompat.GitLabAccessLevelValue(tc.input)
+			if !ok || got != tc.want {
+				t.Fatalf("gitlabAccessLevelValue(%v) = %d, %t; want %d, true", tc.input, got, ok, tc.want)
+			}
+		})
 	}
-	for _, input := range []any{float64(30.5), 70, int64(70), "70", "admin", true} {
-		if got, ok := actioncompat.GitLabAccessLevelValue(input); ok {
-			t.Fatalf("gitlabAccessLevelValue(%v) = %d, true; want false", input, got)
-		}
+	rejectedAccess := []struct {
+		name  string
+		input any
+	}{
+		{name: "access_rejects_fractional_float", input: float64(30.5)},
+		{name: "access_rejects_unknown_int", input: 70},
+		{name: "access_rejects_unknown_int64", input: int64(70)},
+		{name: "access_rejects_unknown_numeric_string", input: "70"},
+		{name: "access_rejects_admin", input: "admin"},
+		{name: "access_rejects_bool", input: true},
+	}
+	for _, tc := range rejectedAccess {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := actioncompat.GitLabAccessLevelValue(tc.input); ok {
+				t.Fatalf("gitlabAccessLevelValue(%v) = %d, true; want false", tc.input, got)
+			}
+		})
 	}
 
 	if value, ok := actioncompat.BoolStringValue(" true "); !ok || !value {
 		t.Fatalf("boolStringValue(true) = %t, %t; want true, true", value, ok)
 	}
-	for _, input := range []any{true, "not-bool"} {
-		if _, ok := actioncompat.BoolStringValue(input); ok {
-			t.Fatalf("boolStringValue(%v) converted unexpectedly", input)
-		}
+	rejectedBools := []struct {
+		name  string
+		input any
+	}{
+		{name: "bool_rejects_true_not_string", input: true},
+		{name: "bool_rejects_unrecognized_string", input: "not-bool"},
+	}
+	for _, tc := range rejectedBools {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := actioncompat.BoolStringValue(tc.input); ok {
+				t.Fatalf("boolStringValue(%v) converted unexpectedly", tc.input)
+			}
+		})
 	}
 }
 
@@ -4877,24 +4914,27 @@ func TestNormalization_FormattingBranches(t *testing.T) {
 
 	t.Run("explicit confirm parses supported values", func(t *testing.T) {
 		cases := []struct {
+			name   string
 			params map[string]any
 			want   bool
 		}{
-			{params: nil, want: false},
-			{params: map[string]any{"confirm": false}, want: false},
-			{params: map[string]any{"confirm": true}, want: true},
-			{params: map[string]any{"confirm": " true "}, want: true},
-			{params: map[string]any{"confirm": "yes"}, want: false},
-			{params: map[string]any{"confirm": "no"}, want: false},
-			{params: map[string]any{"confirm": 1}, want: false},
-			{params: map[string]any{"confirm": int64(1)}, want: false},
-			{params: map[string]any{"confirm": 1.0}, want: false},
-			{params: map[string]any{"confirm": 2}, want: false},
+			{name: "nil_params", params: nil, want: false},
+			{name: "bool_false", params: map[string]any{"confirm": false}, want: false},
+			{name: "bool_true", params: map[string]any{"confirm": true}, want: true},
+			{name: "padded_true_string", params: map[string]any{"confirm": " true "}, want: true},
+			{name: "yes_string", params: map[string]any{"confirm": "yes"}, want: false},
+			{name: "no_string", params: map[string]any{"confirm": "no"}, want: false},
+			{name: "int_one", params: map[string]any{"confirm": 1}, want: false},
+			{name: "int64_one", params: map[string]any{"confirm": int64(1)}, want: false},
+			{name: "float_one", params: map[string]any{"confirm": 1.0}, want: false},
+			{name: "int_two", params: map[string]any{"confirm": 2}, want: false},
 		}
 		for _, tt := range cases {
-			if got := hasExplicitConfirm(tt.params); got != tt.want {
-				t.Fatalf("hasExplicitConfirm(%v) = %v, want %v", tt.params, got, tt.want)
-			}
+			t.Run(tt.name, func(t *testing.T) {
+				if got := hasExplicitConfirm(tt.params); got != tt.want {
+					t.Fatalf("hasExplicitConfirm(%v) = %v, want %v", tt.params, got, tt.want)
+				}
+			})
 		}
 	})
 

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -4183,25 +4183,10 @@ func assertExecuteInitializesNilParams(t *testing.T, registry *Registry) {
 // search ranking, examples, confirmations, and Markdown formatting. The cases
 // target defensive branches that are easy to regress while refactoring the low
 // token dynamic action surface.
-func TestRegistry_HelperCoverage(t *testing.T) {
-	t.Run("annotations with nil base", func(t *testing.T) {
-		got := copyAnnotations(nil)
-		if got == nil {
-			t.Fatal("copyAnnotations(nil) = nil, want zero-value annotations")
-		}
-		if got.Title != "" {
-			t.Fatalf("copyAnnotations(nil).Title = %q, want empty", got.Title)
-		}
-	})
-
-	t.Run("dedupe strings trims empty and duplicates", func(t *testing.T) {
-		got := dedupeStrings([]string{" Project ", "", "project", "Issue"})
-		want := []string{"project", "issue"}
-		if strings.Join(got, ",") != strings.Join(want, ",") {
-			t.Fatalf("dedupeStrings() = %v, want %v", got, want)
-		}
-	})
-
+// TestRegistry_ActionTagHints verifies the tag derivation helpers: schema
+// property names contribute their hint words, and protected-environment
+// and member-role actions carry their domain phrases.
+func TestRegistry_ActionTagHints(t *testing.T) {
 	t.Run("action tags include schema property hints", func(t *testing.T) {
 		schema := map[string]any{"properties": map[string]any{
 			"state_event": map[string]any{},
@@ -4227,6 +4212,26 @@ func TestRegistry_HelperCoverage(t *testing.T) {
 		memberRole := actionTags("member_role.create", "member_role", "create", nil)
 		if !stringInSlice(memberRole, "member role") {
 			t.Fatalf("actionTags(member role) = %v, want member role", memberRole)
+		}
+	})
+}
+
+func TestRegistry_HelperCoverage(t *testing.T) {
+	t.Run("annotations with nil base", func(t *testing.T) {
+		got := copyAnnotations(nil)
+		if got == nil {
+			t.Fatal("copyAnnotations(nil) = nil, want zero-value annotations")
+		}
+		if got.Title != "" {
+			t.Fatalf("copyAnnotations(nil).Title = %q, want empty", got.Title)
+		}
+	})
+
+	t.Run("dedupe strings trims empty and duplicates", func(t *testing.T) {
+		got := dedupeStrings([]string{" Project ", "", "project", "Issue"})
+		want := []string{"project", "issue"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("dedupeStrings() = %v, want %v", got, want)
 		}
 	})
 
@@ -6098,28 +6103,33 @@ func TestRegistrySearch_ProjectListSearchQuery_RanksSearchProjectsFirst(t *testi
 // credential is narrow and reauthorizing would fix it. The two causes carry
 // different remedies, so they get different sentences, and the control case
 // keeps the old message where it is still correct.
-func TestExecute_WithheldActionNamesTheCauseInsteadOfCallingItUnknown(t *testing.T) {
-	narrowedCatalog := func(t *testing.T) *actioncatalog.Catalog {
-		t.Helper()
-		routes := testRoutes(t)
-		delete(routes["gitlab_project"], "hook_add")
-		return actioncatalog.FromActionMaps(routes)
-	}
-	executeText := func(t *testing.T, registry *Registry, action string) string {
-		t.Helper()
-		result, output, err := registry.Execute(t.Context(), nil, ExecuteInput{Action: action})
-		if err != nil {
-			t.Fatalf("Execute() error = %v", err)
-		}
-		if result == nil || !result.IsError {
-			t.Fatalf("Execute() result = %+v, want tool error", result)
-		}
-		if output != nil {
-			t.Fatalf("Execute() output = %+v, want nil", output)
-		}
-		return textContent(result)
-	}
+// narrowedCatalog is the standard test catalog with project.hook_add removed,
+// the shape a withheld action leaves behind.
+func narrowedCatalog(t *testing.T) *actioncatalog.Catalog {
+	t.Helper()
+	routes := testRoutes(t)
+	delete(routes["gitlab_project"], "hook_add")
+	return actioncatalog.FromActionMaps(routes)
+}
 
+// executeText runs an action that must fail as a tool error and returns the
+// error text the client would read.
+func executeText(t *testing.T, registry *Registry, action string) string {
+	t.Helper()
+	result, output, err := registry.Execute(t.Context(), nil, ExecuteInput{Action: action})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("Execute() result = %+v, want tool error", result)
+	}
+	if output != nil {
+		t.Fatalf("Execute() output = %+v, want nil", output)
+	}
+	return textContent(result)
+}
+
+func TestExecute_WithheldActionNamesTheCauseInsteadOfCallingItUnknown(t *testing.T) {
 	t.Run("token scope says reauthorize", func(t *testing.T) {
 		registry := newCatalogRegistry(narrowedCatalog(t),
 			WithWithheldActions([]string{"project.hook_add"}, nil))

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -592,12 +592,14 @@ func TestAddStandaloneCatalog_MatchesRouteCompatibilityWrapper(t *testing.T) {
 	fromCatalog := NewRegistryFromCatalog(standaloneCatalog)
 
 	for _, actionID := range []string{"project.list", "discover_project.resolve", "interactive.issue_create"} {
-		if _, ok := fromRoutes.resolveAction(actionID); !ok {
-			t.Fatalf("route wrapper registry missing %s", actionID)
-		}
-		if _, ok := fromCatalog.resolveAction(actionID); !ok {
-			t.Fatalf("catalog registry missing %s", actionID)
-		}
+		t.Run(actionID, func(t *testing.T) {
+			if _, ok := fromRoutes.resolveAction(actionID); !ok {
+				t.Fatalf("route wrapper registry missing %s", actionID)
+			}
+			if _, ok := fromCatalog.resolveAction(actionID); !ok {
+				t.Fatalf("catalog registry missing %s", actionID)
+			}
+		})
 	}
 }
 
@@ -913,9 +915,11 @@ func TestDescribe_MetaCatalogSchemas(t *testing.T) {
 	}
 	markdown := textContent(result)
 	for _, notWant := range []string{"input_schema", "output_schema"} {
-		if strings.Contains(markdown, notWant) {
-			t.Fatalf("Describe() markdown contains %q: %s", notWant, markdown)
-		}
+		t.Run(notWant, func(t *testing.T) {
+			if strings.Contains(markdown, notWant) {
+				t.Fatalf("Describe() markdown contains %q: %s", notWant, markdown)
+			}
+		})
 	}
 	if !strings.Contains(markdown, "**Input schema**") || !strings.Contains(markdown, "```json") || !strings.Contains(markdown, "properties") {
 		t.Fatalf("Describe() markdown missing compact input schema: %s", markdown)
@@ -993,19 +997,21 @@ func TestDynamicCatalog_DelegatedSpecBackedDomainsPreserveIDsAndSchemas(t *testi
 	}
 
 	for _, actionID := range actionIDs {
-		description := actionDescriptionByID(t, output, actionID)
-		catalogAction, ok := catalog.Action(actioncatalog.ActionID(actionID))
-		if !ok {
-			t.Fatalf("catalog missing %s", actionID)
-		}
-		if !catalogAction.SpecBacked {
-			t.Fatalf("%s SpecBacked = false, want true", actionID)
-		}
-		assertSchemaPropertyNamesEqual(t, actionID, description.InputSchema, catalogAction.Route.InputSchema)
-		if !slices.Equal(description.RequiredParams, requiredParams(catalogAction.Route.InputSchema)) {
-			t.Fatalf("%s RequiredParams = %v, want %v", actionID, description.RequiredParams, requiredParams(catalogAction.Route.InputSchema))
-		}
-		assertSchemaPropertyNamesEqual(t, actionID+" output", description.OutputSchema, catalogAction.Route.OutputSchema)
+		t.Run(actionID, func(t *testing.T) {
+			description := actionDescriptionByID(t, output, actionID)
+			catalogAction, ok := catalog.Action(actioncatalog.ActionID(actionID))
+			if !ok {
+				t.Fatalf("catalog missing %s", actionID)
+			}
+			if !catalogAction.SpecBacked {
+				t.Fatalf("%s SpecBacked = false, want true", actionID)
+			}
+			assertSchemaPropertyNamesEqual(t, actionID, description.InputSchema, catalogAction.Route.InputSchema)
+			if !slices.Equal(description.RequiredParams, requiredParams(catalogAction.Route.InputSchema)) {
+				t.Fatalf("%s RequiredParams = %v, want %v", actionID, description.RequiredParams, requiredParams(catalogAction.Route.InputSchema))
+			}
+			assertSchemaPropertyNamesEqual(t, actionID+" output", description.OutputSchema, catalogAction.Route.OutputSchema)
+		})
 	}
 
 	searchCode := actionDescriptionByID(t, output, "search.code")
@@ -1125,9 +1131,11 @@ func TestFind_MarkdownGuidesImmediateExecuteAndConfirm(t *testing.T) {
 		"before starting another catalog operation",
 		"top-level `confirm:true`",
 	} {
-		if !strings.Contains(markdown, want) {
-			t.Fatalf("Find() markdown = %q, want %q", markdown, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(markdown, want) {
+				t.Fatalf("Find() markdown = %q, want %q", markdown, want)
+			}
+		})
 	}
 }
 
@@ -1616,9 +1624,11 @@ func TestDescribe_JobSingleArtifactRequiresArtifactPath(t *testing.T) {
 	}
 	description := actionDescriptionByID(t, output, "job.download_single_artifact")
 	for _, required := range []string{"artifact_path", "job_id", "project_id"} {
-		if !slices.Contains(description.RequiredParams, required) {
-			t.Fatalf("required params = %v, want %s", description.RequiredParams, required)
-		}
+		t.Run(required, func(t *testing.T) {
+			if !slices.Contains(description.RequiredParams, required) {
+				t.Fatalf("required params = %v, want %s", description.RequiredParams, required)
+			}
+		})
 	}
 	if params, ok := description.Example.Arguments["params"].(map[string]any); !ok || params["artifact_path"] == nil {
 		t.Fatalf("example arguments = %#v, want artifact_path in params", description.Example.Arguments)
@@ -2148,9 +2158,11 @@ func TestActionScopedParamAliases_CoversDocumentedActions(t *testing.T) {
 		"snippet.project_create",
 	}
 	for _, actionID := range wantActions {
-		if !slices.ContainsFunc(aliases, func(alias actioncompat.ParameterAlias) bool { return alias.ActionID == actionID }) {
-			t.Fatalf("ParameterAliases() = %+v, want action %s", aliases, actionID)
-		}
+		t.Run(actionID, func(t *testing.T) {
+			if !slices.ContainsFunc(aliases, func(alias actioncompat.ParameterAlias) bool { return alias.ActionID == actionID }) {
+				t.Fatalf("ParameterAliases() = %+v, want action %s", aliases, actionID)
+			}
+		})
 	}
 }
 
@@ -2168,9 +2180,11 @@ func TestDynamicRegister_DoesNotOwnCompatibilityPolicyTables(t *testing.T) {
 		"func gitlabAccessLevelValue(",
 		"func boolStringValue(",
 	} {
-		if strings.Contains(string(source), forbidden) {
-			t.Fatalf("register.go still owns compatibility policy table/helper %q; move policy to actioncompat", forbidden)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if strings.Contains(string(source), forbidden) {
+				t.Fatalf("register.go still owns compatibility policy table/helper %q; move policy to actioncompat", forbidden)
+			}
+		})
 	}
 }
 
@@ -2192,9 +2206,11 @@ func TestExecute_ReportsUnknownAndMissingParamsBeforeDispatch(t *testing.T) {
 	}
 	text := textContent(result)
 	for _, want := range []string{"Unknown params: reff", "Did you mean reff -> ref", "Missing required params: ref", "Valid params: file_path, project_id, ref"} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("Execute() error text = %q, want %q", text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Fatalf("Execute() error text = %q, want %q", text, want)
+			}
+		})
 	}
 }
 
@@ -2222,9 +2238,11 @@ func TestExecute_RejectsUnsupportedPipelineScheduleVariableSecurityFields(t *tes
 	}
 	text := textContent(result)
 	for _, want := range []string{"Unknown params: masked, protected", "Valid params: key, project_id, schedule_id, value, variable_type"} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("Execute() error text = %q, want %q", text, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Fatalf("Execute() error text = %q, want %q", text, want)
+			}
+		})
 	}
 }
 
@@ -2779,9 +2797,11 @@ func TestSearch_MultiIntentLongQuery_ReturnsSegmentMatches(t *testing.T) {
 		t.Fatalf("Search() result = %+v, want non-error", result)
 	}
 	for _, want := range []string{"discover_project.resolve", "merge_request.list"} {
-		if !slices.ContainsFunc(output.Results, func(r SearchResult) bool { return r.ID == want }) {
-			t.Fatalf("Search() results = %+v, want %s", output.Results, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !slices.ContainsFunc(output.Results, func(r SearchResult) bool { return r.ID == want }) {
+				t.Fatalf("Search() results = %+v, want %s", output.Results, want)
+			}
+		})
 	}
 }
 
@@ -4191,9 +4211,11 @@ func TestRegistry_HelperCoverage(t *testing.T) {
 		}}
 		got := actionTags("repository.file_create", "repository", "file_create", schema)
 		for _, want := range []string{"repository file", "branch", "url", "close"} {
-			if !stringInSlice(got, want) {
-				t.Fatalf("actionTags() = %v, want %q", got, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !stringInSlice(got, want) {
+					t.Fatalf("actionTags() = %v, want %q", got, want)
+				}
+			})
 		}
 	})
 
@@ -4621,9 +4643,11 @@ func TestCompatibilityAliasAndDescriptionBranches(t *testing.T) {
 		t.Fatalf("NormalizeCompatibilityActionAlias() = %q, %t; want feature_flags.ff_user_list_create, true", got, ok)
 	}
 	for _, actionID := range []string{"", "project.get", "project.unknown"} {
-		if got, ok := NormalizeCompatibilityActionAlias(actionID); ok || got != strings.ToLower(strings.TrimSpace(actionID)) {
-			t.Fatalf("NormalizeCompatibilityActionAlias(%q) = %q, %t; want unchanged false", actionID, got, ok)
-		}
+		t.Run(actionID, func(t *testing.T) {
+			if got, ok := NormalizeCompatibilityActionAlias(actionID); ok || got != strings.ToLower(strings.TrimSpace(actionID)) {
+				t.Fatalf("NormalizeCompatibilityActionAlias(%q) = %q, %t; want unchanged false", actionID, got, ok)
+			}
+		})
 	}
 
 	aliases := dedupeActionAliases([]actionAlias{{Alias: "", Canonical: "project.get"}, {Alias: "project.lookup", Canonical: "project.get"}, {Alias: "project.lookup", Canonical: "project.get"}})
@@ -4691,9 +4715,11 @@ func TestSchemaSearchTermHelpers_Branches(t *testing.T) {
 	}
 	enums := strings.Join(schemaPropertyEnumValues(schema), ",")
 	for _, want := range []string{"opened", "closed", "30", "true", "bug", "feature"} {
-		if !strings.Contains(enums, want) {
-			t.Fatalf("schemaPropertyEnumValues() = %q, missing %q", enums, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(enums, want) {
+				t.Fatalf("schemaPropertyEnumValues() = %q, missing %q", enums, want)
+			}
+		})
 	}
 }
 
@@ -4893,9 +4919,11 @@ func TestNormalization_FormattingBranches(t *testing.T) {
 			}},
 		})
 		for _, want := range []string{"top-level `action`", "one `params` object", "Required Params key below belongs inside `params`"} {
-			if !strings.Contains(findText, want) {
-				t.Fatalf("formatFindOutput() = %q, want %q", findText, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(findText, want) {
+					t.Fatalf("formatFindOutput() = %q, want %q", findText, want)
+				}
+			})
 		}
 	})
 }
@@ -5791,9 +5819,11 @@ func TestScoreProjectGetIntent_PositiveCase(t *testing.T) {
 
 	// "find", "path", "id" alternatives all return the boost.
 	for _, q := range []string{"project find", "project path", "project id"} {
-		if v := scoreProjectGetIntentValue(entry, normalizeSearchTerms(q)); v != scoreProjectGetIntentBoost {
-			t.Fatalf("scoreProjectGetIntentValue(%q) = %d, want %d", q, v, scoreProjectGetIntentBoost)
-		}
+		t.Run(q, func(t *testing.T) {
+			if v := scoreProjectGetIntentValue(entry, normalizeSearchTerms(q)); v != scoreProjectGetIntentBoost {
+				t.Fatalf("scoreProjectGetIntentValue(%q) = %d, want %d", q, v, scoreProjectGetIntentBoost)
+			}
+		})
 	}
 }
 
@@ -6055,14 +6085,18 @@ func TestExecute_WithheldActionNamesTheCauseInsteadOfCallingItUnknown(t *testing
 			WithWithheldActions([]string{"project.hook_add"}, nil))
 		text := executeText(t, registry, "project.hook_add")
 		for _, want := range []string{"exists but is not available", "credential in use", "api scope"} {
-			if !strings.Contains(text, want) {
-				t.Errorf("Execute() error text = %q, want it to contain %q", text, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(text, want) {
+					t.Errorf("Execute() error text = %q, want it to contain %q", text, want)
+				}
+			})
 		}
 		for _, unwanted := range []string{"unknown action", "Did you mean"} {
-			if strings.Contains(text, unwanted) {
-				t.Errorf("Execute() error text = %q, must not contain %q: the action is not unknown", text, unwanted)
-			}
+			t.Run(unwanted, func(t *testing.T) {
+				if strings.Contains(text, unwanted) {
+					t.Errorf("Execute() error text = %q, must not contain %q: the action is not unknown", text, unwanted)
+				}
+			})
 		}
 	})
 

--- a/internal/tools/elicitationtools/elicitationtools_test.go
+++ b/internal/tools/elicitationtools/elicitationtools_test.go
@@ -614,9 +614,11 @@ func TestBuildMRSummary_Full(t *testing.T) {
 		{"squash", "Squash commits"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(s, c.want) {
-			t.Errorf("buildMRSummary missing %s: want %q", c.name, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(s, c.want) {
+				t.Errorf("buildMRSummary missing %s: want %q", c.name, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/enterpriseusers/enterprise_users_test.go
+++ b/internal/tools/enterpriseusers/enterprise_users_test.go
@@ -375,9 +375,11 @@ func TestToOutput_FullUser(t *testing.T) {
 		{"namespace_id", out.NamespaceID, int64(7)},
 	}
 	for _, c := range checks {
-		if c.got != c.want {
-			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+			}
+		})
 	}
 
 	if len(out.Identities) != 1 || out.Identities[0].Provider != "ldap" || out.Identities[0].ExternUID != "ext-1" {

--- a/internal/tools/environments/environments_test.go
+++ b/internal/tools/environments/environments_test.go
@@ -801,9 +801,11 @@ func TestToOutput_AllTimestampFields(t *testing.T) {
 		"| Updated | 15 Jun 2026 12:00 UTC |",
 		"| Auto-Stop At | 31 Dec 2026 23:59 UTC |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -859,9 +861,11 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		"| Updated |",
 		"| Auto-Stop At |",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -896,9 +900,11 @@ func TestFormatListMarkdown_WithEnvironments(t *testing.T) {
 		"available",
 		"stopped",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1362,9 +1368,11 @@ func TestEnvironmentList_OrderBySortKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=name", "sort=desc", "pagination=keyset", "page_token=tok42"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -1397,9 +1405,11 @@ func TestEnvironmentCreate_NewOptionFields(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{`"cluster_agent_id":11`, `"kubernetes_namespace":"prod-ns"`, `"flux_resource_path":"flux/prod"`, `"auto_stop_setting":"with_action"`} {
-		if !strings.Contains(body, want) {
-			t.Errorf("request body %q missing %q", body, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("request body %q missing %q", body, want)
+			}
+		})
 	}
 	if out.ClusterAgent == nil || out.ClusterAgent.ID != 11 {
 		t.Errorf("ClusterAgent = %#v", out.ClusterAgent)
@@ -1435,9 +1445,11 @@ func TestEnvironmentUpdate_NewOptionFields(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{`"cluster_agent_id":11`, `"kubernetes_namespace":"prod-ns"`, `"flux_resource_path":"flux/prod"`, `"auto_stop_setting":"with_action"`} {
-		if !strings.Contains(body, want) {
-			t.Errorf("request body %q missing %q", body, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("request body %q missing %q", body, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/environments/environments_test.go
+++ b/internal/tools/environments/environments_test.go
@@ -1462,32 +1462,35 @@ func TestActionSpecs_UpdateDeleteMetadata(t *testing.T) {
 	byTool := environmentSpecsByTool(t, ActionSpecs(client))
 
 	for _, tt := range []struct {
+		name        string
 		tool        string
 		wantInUsage string
 		wantInDesc  []string
 	}{
-		{"gitlab_environment_update", "Update an existing environment", []string{"Returns:", "See also:", "gitlab_environment_get"}},
-		{"gitlab_environment_delete", "Delete an environment", []string{"Returns:", "See also:", "gitlab_environment_stop"}},
+		{"update", "gitlab_environment_update", "Update an existing environment", []string{"Returns:", "See also:", "gitlab_environment_get"}},
+		{"delete", "gitlab_environment_delete", "Delete an environment", []string{"Returns:", "See also:", "gitlab_environment_stop"}},
 	} {
-		spec := byTool[tt.tool]
-		if !strings.Contains(spec.Usage, tt.wantInUsage) {
-			t.Errorf("%s usage = %q, want substring %q", tt.tool, spec.Usage, tt.wantInUsage)
-		}
-		if strings.Contains(spec.Usage, "Use to execute") {
-			t.Errorf("%s usage still generic: %q", tt.tool, spec.Usage)
-		}
-		for _, a := range spec.Aliases {
-			if a == tt.tool {
-				t.Errorf("%s aliases still contain only the tool name: %v", tt.tool, spec.Aliases)
+		t.Run(tt.name, func(t *testing.T) {
+			spec := byTool[tt.tool]
+			if !strings.Contains(spec.Usage, tt.wantInUsage) {
+				t.Errorf("%s usage = %q, want substring %q", tt.tool, spec.Usage, tt.wantInUsage)
 			}
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s has empty RelatedActions", tt.tool)
-		}
-		for _, w := range tt.wantInDesc {
-			if !strings.Contains(spec.IndividualTool.Description, w) {
-				t.Errorf("%s description = %q, want substring %q", tt.tool, spec.IndividualTool.Description, w)
+			if strings.Contains(spec.Usage, "Use to execute") {
+				t.Errorf("%s usage still generic: %q", tt.tool, spec.Usage)
 			}
-		}
+			for _, a := range spec.Aliases {
+				if a == tt.tool {
+					t.Errorf("%s aliases still contain only the tool name: %v", tt.tool, spec.Aliases)
+				}
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s has empty RelatedActions", tt.tool)
+			}
+			for _, w := range tt.wantInDesc {
+				if !strings.Contains(spec.IndividualTool.Description, w) {
+					t.Errorf("%s description = %q, want substring %q", tt.tool, spec.IndividualTool.Description, w)
+				}
+			}
+		})
 	}
 }

--- a/internal/tools/epics/epics_test.go
+++ b/internal/tools/epics/epics_test.go
@@ -176,9 +176,11 @@ func TestList_RESTFilterOptions(t *testing.T) {
 			"include_ancestor_groups", "include_descendant_groups", "per_page",
 			"pagination", "page_token",
 		} {
-			if query.Get(key) == "" {
-				t.Errorf("query missing %q in %s", key, r.URL.RawQuery)
-			}
+			t.Run(key, func(t *testing.T) {
+				if query.Get(key) == "" {
+					t.Errorf("query missing %q in %s", key, r.URL.RawQuery)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[]`)
 	}))
@@ -889,9 +891,11 @@ func TestList_WithAllFilters(t *testing.T) {
 			return
 		}
 		for _, key := range []string{"fullPath", "state", "search", "authorUsername", "labelName", "confidential", "sort", "first", "after", "includeAncestors", "includeDescendants"} {
-			if _, ok := vars[key]; !ok {
-				t.Errorf("GraphQL variables missing %q", key)
-			}
+			t.Run(key, func(t *testing.T) {
+				if _, ok := vars[key]; !ok {
+					t.Errorf("GraphQL variables missing %q", key)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, listResponseJSON)
 	}))
@@ -932,9 +936,11 @@ func TestList_WorkItems_RequestsEEFields(t *testing.T) {
 		}
 		query := string(body)
 		for _, field := range []string{"weight", "healthStatus", "color", "status"} {
-			if !strings.Contains(query, field) {
-				t.Errorf("GraphQL query missing EE field %q; ReturnedFields opt-in not applied\nquery: %s", field, query)
-			}
+			t.Run(field, func(t *testing.T) {
+				if !strings.Contains(query, field) {
+					t.Errorf("GraphQL query missing EE field %q; ReturnedFields opt-in not applied\nquery: %s", field, query)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, listResponseJSON)
 	}))
@@ -982,9 +988,11 @@ func TestCreate_WithAllOptions(t *testing.T) {
 			return
 		}
 		for _, key := range []string{"title", "confidential", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "assigneesWidget", "labelsWidget", "weightWidget", "healthStatusWidget"} {
-			if _, exists := input[key]; !exists {
-				t.Errorf("GraphQL input missing %q", key)
-			}
+			t.Run(key, func(t *testing.T) {
+				if _, exists := input[key]; !exists {
+					t.Errorf("GraphQL input missing %q", key)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, createResponseJSON)
 	}))
@@ -1049,9 +1057,11 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 				return
 			}
 			for _, key := range []string{"title", "stateEvent", "descriptionWidget", "colorWidget", "startAndDueDateWidget", "labelsWidget", "assigneesWidget", "weightWidget", "healthStatusWidget", "statusWidget"} {
-				if _, exists := input[key]; !exists {
-					t.Errorf("GraphQL input missing %q", key)
-				}
+				t.Run(key, func(t *testing.T) {
+					if _, exists := input[key]; !exists {
+						t.Errorf("GraphQL input missing %q", key)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusOK, updateResponseJSON)
 		}
@@ -1186,9 +1196,11 @@ func TestFormatOutputMarkdown_FullFields(t *testing.T) {
 		"Closed", "gitlab.example.com", "Linked Items", "blocks", "g/sub",
 		"Epic description body",
 	} {
-		if !strings.Contains(result, want) {
-			t.Errorf("expected markdown to contain %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(result, want) {
+				t.Errorf("expected markdown to contain %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/errortracking/errortracking_test.go
+++ b/internal/tools/errortracking/errortracking_test.go
@@ -342,9 +342,11 @@ func TestFormatKeyMarkdown(t *testing.T) {
 		"**Public Key**: pk-123",
 		"**Sentry DSN**: https://dsn.example.com",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/externalstatuschecks/action_specs_test.go
+++ b/internal/tools/externalstatuschecks/action_specs_test.go
@@ -39,9 +39,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := externalStatusCheckSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_list_project_status_checks", "gitlab_list_project_mr_external_status_checks", "gitlab_list_project_external_status_checks"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	spec := byTool["gitlab_delete_project_external_status_check"]
 	if !spec.Destructive || !spec.Route.Destructive {

--- a/internal/tools/externalstatuschecks/external_status_checks_test.go
+++ b/internal/tools/externalstatuschecks/external_status_checks_test.go
@@ -349,9 +349,11 @@ func TestUpdateProjectExternalStatusCheck_WithAllFields(t *testing.T) {
 		t.Errorf("expected name 'Security Scan', got %q", out.Name)
 	}
 	for _, want := range []string{"name", "external_url", "shared_secret", "protected_branch_ids"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/featureflags/featureflags_test.go
+++ b/internal/tools/featureflags/featureflags_test.go
@@ -717,9 +717,11 @@ func TestFormatParameters_AllFields(t *testing.T) {
 	}
 	result := formatParameters(p)
 	for _, want := range []string{"percentage=50", "groupId=g1", "userIds=1,2,3", "rollout=random", "stickiness=default"} {
-		if !strings.Contains(result, want) {
-			t.Errorf("formatParameters missing %q in %q", want, result)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(result, want) {
+				t.Errorf("formatParameters missing %q in %q", want, result)
+			}
+		})
 	}
 }
 
@@ -957,29 +959,31 @@ func TestFeatureFlagActionSpecs_Metadata(t *testing.T) {
 		"gitlab_feature_flag_delete",
 	}
 	for _, tool := range wantTools {
-		spec, ok := byTool[tool]
-		if !ok {
-			t.Fatalf("missing spec for %s", tool)
-		}
-		if spec.Usage == "" || strings.Contains(spec.Usage, "Use to execute featureflags domain action") {
-			t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
-		}
-		nlAliases := 0
-		for _, a := range spec.Aliases {
-			if a != tool {
-				nlAliases++
+		t.Run(tool, func(t *testing.T) {
+			spec, ok := byTool[tool]
+			if !ok {
+				t.Fatalf("missing spec for %s", tool)
 			}
-		}
-		if nlAliases < 2 {
-			t.Errorf("%s: expected >=2 natural-language aliases, got %v", tool, spec.Aliases)
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: missing RelatedActions", tool)
-		}
-		desc := spec.IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: description missing Returns:/See also:: %q", tool, desc)
-		}
+			if spec.Usage == "" || strings.Contains(spec.Usage, "Use to execute featureflags domain action") {
+				t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
+			}
+			nlAliases := 0
+			for _, a := range spec.Aliases {
+				if a != tool {
+					nlAliases++
+				}
+			}
+			if nlAliases < 2 {
+				t.Errorf("%s: expected >=2 natural-language aliases, got %v", tool, spec.Aliases)
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s: missing RelatedActions", tool)
+			}
+			desc := spec.IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s: description missing Returns:/See also:: %q", tool, desc)
+			}
+		})
 	}
 }
 

--- a/internal/tools/ffuserlists/action_specs_test.go
+++ b/internal/tools/ffuserlists/action_specs_test.go
@@ -67,17 +67,19 @@ func TestActionSpecs_UserListIIDGuidance(t *testing.T) {
 	byTool := userListSpecsByTool(t, ActionSpecs(testutil.NewTestClient(t, http.NewServeMux())))
 
 	for _, toolName := range []string{"gitlab_ff_user_list_get", "gitlab_ff_user_list_update", "gitlab_ff_user_list_delete"} {
-		guidance := byTool[toolName].ParameterGuidance["user_list_iid"]
-		if guidance.SemanticRole != "feature_flag_user_list_iid" {
-			t.Fatalf("%s user_list_iid SemanticRole = %q, want feature_flag_user_list_iid", toolName, guidance.SemanticRole)
-		}
-		if !containsText(guidance.CommonConfusions, "user list name") {
-			t.Fatalf("%s user_list_iid CommonConfusions = %v, want name warning", toolName, guidance.CommonConfusions)
-		}
-		description := schemaPropertyDescription(t, byTool[toolName].Route.InputSchema, "user_list_iid")
-		if !strings.Contains(description, "Do not use the user list name") {
-			t.Fatalf("%s user_list_iid schema description = %q, want name warning", toolName, description)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			guidance := byTool[toolName].ParameterGuidance["user_list_iid"]
+			if guidance.SemanticRole != "feature_flag_user_list_iid" {
+				t.Fatalf("%s user_list_iid SemanticRole = %q, want feature_flag_user_list_iid", toolName, guidance.SemanticRole)
+			}
+			if !containsText(guidance.CommonConfusions, "user list name") {
+				t.Fatalf("%s user_list_iid CommonConfusions = %v, want name warning", toolName, guidance.CommonConfusions)
+			}
+			description := schemaPropertyDescription(t, byTool[toolName].Route.InputSchema, "user_list_iid")
+			if !strings.Contains(description, "Do not use the user list name") {
+				t.Fatalf("%s user_list_iid schema description = %q, want name warning", toolName, description)
+			}
+		})
 	}
 }
 
@@ -198,10 +200,12 @@ func TestActionSpecs_Descriptions(t *testing.T) {
 		"gitlab_ff_user_list_update",
 		"gitlab_ff_user_list_delete",
 	} {
-		desc := byTool[toolName].IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s description = %q, want Returns/See also form", toolName, desc)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			desc := byTool[toolName].IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s description = %q, want Returns/See also form", toolName, desc)
+			}
+		})
 	}
 	if got := userListDescription("unknown_action"); got != "" {
 		t.Errorf("userListDescription(unknown) = %q, want empty", got)
@@ -221,7 +225,9 @@ func TestActionSpecs_MetadataHelpers(t *testing.T) {
 		"ff_user_list_update",
 		"ff_user_list_delete",
 	} {
-		assertUserListMetadata(t, action)
+		t.Run(action, func(t *testing.T) {
+			assertUserListMetadata(t, action)
+		})
 	}
 
 	if got := userListUsage("unknown_action"); got != "" {

--- a/internal/tools/ffuserlists/ffuserlists_test.go
+++ b/internal/tools/ffuserlists/ffuserlists_test.go
@@ -397,9 +397,11 @@ func TestListUserLists_KeysetAndOrdering(t *testing.T) {
 			"page_token": "cursor-7",
 			"per_page":   "50",
 		} {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[`+covUserListJSON+`]`)
 	})

--- a/internal/tools/files/files_test.go
+++ b/internal/tools/files/files_test.go
@@ -1640,23 +1640,25 @@ func TestFormatRawMarkdown(t *testing.T) {
 // minLen helper
 // ---------------------------------------------------------------------------.
 
-// TestMinLen verifies the MinLen handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
+// TestMinLen verifies minLen returns the smaller of its two arguments,
+// including when they are equal or one of them is zero.
 func TestMinLen(t *testing.T) {
 	tests := []struct {
+		name       string
 		a, b, want int
 	}{
-		{3, 8, 3},
-		{8, 3, 3},
-		{5, 5, 5},
-		{0, 1, 0},
+		{"first_smaller", 3, 8, 3},
+		{"second_smaller", 8, 3, 3},
+		{"equal", 5, 5, 5},
+		{"zero", 0, 1, 0},
 	}
 	for _, tt := range tests {
-		got := minLen(tt.a, tt.b)
-		if got != tt.want {
-			t.Errorf("minLen(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := minLen(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("minLen(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/files/files_test.go
+++ b/internal/tools/files/files_test.go
@@ -1156,9 +1156,11 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 	}
 	// Verify optional fields were sent in the request body
 	for _, want := range []string{"start_branch", "encoding", "author_email", "author_name", "execute_filemode"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -1202,9 +1204,11 @@ func TestUpdate_WithAllOptionalFields(t *testing.T) {
 		t.Errorf("FilePath = %q, want %q", out.FilePath, "script.sh")
 	}
 	for _, want := range []string{"start_branch", "encoding", "author_email", "author_name", "last_commit_id", "execute_filemode"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -1448,9 +1452,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 			"**Encoding**: base64",
 			"**Blob ID**: blob123",
 		} {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
+				}
+			})
 		}
 	})
 }
@@ -1469,9 +1475,11 @@ func TestFormatFileInfoMarkdown(t *testing.T) {
 			"**File**: new_file.txt",
 			"**Branch**: feature",
 		} {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
+				}
+			})
 		}
 		if strings.Contains(got, "Commit ID") {
 			t.Errorf("FormatFileInfoMarkdown should omit empty commit IDs:\n%s", got)
@@ -1486,9 +1494,11 @@ func TestFormatFileInfoMarkdown(t *testing.T) {
 			LastCommitID: "last456",
 		})
 		for _, want := range []string{"**Commit ID**: commit123", "**Last commit ID**: last456"} {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
+				}
+			})
 		}
 	})
 }
@@ -1530,9 +1540,11 @@ func TestFormatBlameMarkdown(t *testing.T) {
 			"package main",
 			"func main() {}",
 		} {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatBlameMarkdown missing %q in:\n%s", want, got)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatBlameMarkdown missing %q in:\n%s", want, got)
+				}
+			})
 		}
 	})
 
@@ -1578,9 +1590,11 @@ func TestFormatMetaDataMarkdown(t *testing.T) {
 			"**Size**: 512 bytes",
 			"**SHA-256**: sha256val",
 		} {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatMetaDataMarkdown missing %q in:\n%s", want, got)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatMetaDataMarkdown missing %q in:\n%s", want, got)
+				}
+			})
 		}
 		if strings.Contains(got, "Executable") {
 			t.Error("should not contain 'Executable' when ExecuteFilemode is false")
@@ -1614,9 +1628,11 @@ func TestFormatRawMarkdown(t *testing.T) {
 		"# Hello World",
 		"```",
 	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("FormatRawMarkdown missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("FormatRawMarkdown missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/geo/geo_test.go
+++ b/internal/tools/geo/geo_test.go
@@ -765,9 +765,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"| Web Edit URL | [Edit](https://primary.example.com/admin/geo/sites/1/edit) |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -823,9 +825,11 @@ func TestFormatListMarkdown_WithItems(t *testing.T) {
 		"| 2 | secondary | https://secondary.example.com | false | false |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -906,9 +910,11 @@ func TestFormatStatusMarkdown_AllFields(t *testing.T) {
 		"| Updated At |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -960,9 +966,11 @@ func TestFormatListStatusMarkdown_WithItems(t *testing.T) {
 		"| 2 | false | Unhealthy | 120 | 30 | 16.4.0 |",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("expected markdown to contain %q:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("expected markdown to contain %q:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -1132,9 +1140,11 @@ func TestGetStatus_MirrorsFullStruct(t *testing.T) {
 		"cursor_last_event_id":                             {out.CursorLastEventID, 998},
 	}
 	for name, c := range intChecks {
-		if c.got != c.want {
-			t.Errorf("%s = %d, want %d", name, c.got, c.want)
-		}
+		t.Run(name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s = %d, want %d", name, c.got, c.want)
+			}
+		})
 	}
 	strChecks := map[string]struct{ got, want string }{
 		"ci_secure_files_synced_in_percentage":   {out.CISecureFilesSyncedInPercentage, "85.71%"},
@@ -1142,9 +1152,11 @@ func TestGetStatus_MirrorsFullStruct(t *testing.T) {
 		"selective_sync_type":                    {out.SelectiveSyncType, "namespaces"},
 	}
 	for name, c := range strChecks {
-		if c.got != c.want {
-			t.Errorf("%s = %q, want %q", name, c.got, c.want)
-		}
+		t.Run(name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf("%s = %q, want %q", name, c.got, c.want)
+			}
+		})
 	}
 	if !out.ContainerRepositoriesReplicationEnabled {
 		t.Error("ContainerRepositoriesReplicationEnabled not mirrored")

--- a/internal/tools/gitignoretemplates/gitignoretemplates_test.go
+++ b/internal/tools/gitignoretemplates/gitignoretemplates_test.go
@@ -244,10 +244,12 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		t.Fatal("gitlab_get_gitignore_template should define key parameter guidance")
 	}
 	for _, tool := range []string{"gitlab_list_gitignore_templates", "gitlab_get_gitignore_template"} {
-		desc := specByTool[tool].IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s description missing Returns:/See also: form: %q", tool, desc)
-		}
+		t.Run(tool, func(t *testing.T) {
+			desc := specByTool[tool].IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s description missing Returns:/See also: form: %q", tool, desc)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupboards/groupboards_test.go
+++ b/internal/tools/groupboards/groupboards_test.go
@@ -894,9 +894,11 @@ func TestFormatGroupBoardMarkdown_Minimal(t *testing.T) {
 		t.Error("markdown missing board name")
 	}
 	for _, absent := range []string{"**Group**", "**Milestone**", "**Labels**", "### Lists"} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal board", absent)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal board", absent)
+			}
+		})
 	}
 }
 
@@ -930,9 +932,11 @@ func TestFormatBoardListMarkdown_Minimal(t *testing.T) {
 		t.Error("markdown missing position")
 	}
 	for _, absent := range []string{"**Label**", "**Max Issue Count**", "**Max Issue Weight**", "**Assignee**", "**Milestone**"} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal board list", absent)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal board list", absent)
+			}
+		})
 	}
 }
 
@@ -953,9 +957,11 @@ func TestFormatListBoardListsMarkdown_WithData(t *testing.T) {
 	}
 	md := FormatListBoardListsMarkdown(out)
 	for _, want := range []string{"## Board Lists", "To Do", "Doing", "| 10 |", "| 11 |"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -993,9 +999,11 @@ func TestListGroupBoards_OrderBySortKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "pagination=keyset", "page_token=100"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -1019,9 +1027,11 @@ func TestListGroupBoardLists_OrderBySortKeyset(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=position", "sort=asc", "pagination=keyset", "page_token=5"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupepicboards/group_epic_boards_test.go
+++ b/internal/tools/groupepicboards/group_epic_boards_test.go
@@ -217,9 +217,11 @@ func TestList_NotFoundIncludesActionableHint(t *testing.T) {
 		t.Fatal("List() expected error, got nil")
 	}
 	for _, want := range []string{"Premium/Ultimate", "can be empty", "configured for the group"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("List() error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("List() error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 
@@ -422,9 +424,11 @@ func TestGet_NotFoundIncludesActionableHint(t *testing.T) {
 		t.Fatal("Get() expected error, got nil")
 	}
 	for _, want := range []string{"epic_board_list", "gitlab_group", "configure an epic board"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("Get() error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("Get() error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupimportexport/groupimportexport_test.go
+++ b/internal/tools/groupimportexport/groupimportexport_test.go
@@ -465,9 +465,11 @@ func TestFormatExportDownloadMarkdown_ContentCheck(t *testing.T) {
 func TestValidActions(t *testing.T) {
 	actions := ValidActions()
 	for _, expected := range []string{"schedule_export", "export_download", "import_file"} {
-		if !strings.Contains(actions, expected) {
-			t.Errorf("ValidActions() missing %q, got %q", expected, actions)
-		}
+		t.Run(expected, func(t *testing.T) {
+			if !strings.Contains(actions, expected) {
+				t.Errorf("ValidActions() missing %q, got %q", expected, actions)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupiterations/group_iterations_test.go
+++ b/internal/tools/groupiterations/group_iterations_test.go
@@ -543,9 +543,11 @@ func TestList_MultipleIterations(t *testing.T) {
 		t.Fatalf("got %d iterations, want 3", len(out.Iterations))
 	}
 	for i, want := range []string{"Sprint 1", "Sprint 2", "Sprint 3"} {
-		if out.Iterations[i].Title != want {
-			t.Errorf("iteration[%d].Title = %q, want %q", i, out.Iterations[i].Title, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if out.Iterations[i].Title != want {
+				t.Errorf("iteration[%d].Title = %q, want %q", i, out.Iterations[i].Title, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/grouplabels/grouplabels_test.go
+++ b/internal/tools/grouplabels/grouplabels_test.go
@@ -849,9 +849,11 @@ func TestFormatMarkdown_AllFields(t *testing.T) {
 		"- **Issues**: 5 open, 3 closed",
 		"- **Open MRs**: 1",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -877,9 +879,11 @@ func TestFormatMarkdown_MinimalFields(t *testing.T) {
 		"**Issues**",
 		"**Open MRs**",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -922,9 +926,11 @@ func TestFormatListMarkdownString_WithData(t *testing.T) {
 		"| #d9534f |",
 		"| #428bca |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupldap/action_specs_test.go
+++ b/internal/tools/groupldap/action_specs_test.go
@@ -58,17 +58,19 @@ func TestLDAPMetadata_IndividualToolDescriptions(t *testing.T) {
 		"gitlab_group_ldap_link_delete",
 		"gitlab_group_ldap_link_delete_for_provider",
 	} {
-		desc := byTool[name].IndividualTool.Description
-		if desc == "" {
-			t.Errorf("%s: IndividualTool.Description is empty", name)
-			continue
-		}
-		if !strings.Contains(desc, "Returns:") {
-			t.Errorf("%s: description missing 'Returns:': %q", name, desc)
-		}
-		if !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: description missing 'See also:': %q", name, desc)
-		}
+		t.Run(name, func(t *testing.T) {
+			desc := byTool[name].IndividualTool.Description
+			if desc == "" {
+				t.Errorf("%s: IndividualTool.Description is empty", name)
+				return
+			}
+			if !strings.Contains(desc, "Returns:") {
+				t.Errorf("%s: description missing 'Returns:': %q", name, desc)
+			}
+			if !strings.Contains(desc, "See also:") {
+				t.Errorf("%s: description missing 'See also:': %q", name, desc)
+			}
+		})
 	}
 }
 
@@ -107,13 +109,15 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		t.Error("list action should be read-only")
 	}
 	for _, name := range []string{"gitlab_group_ldap_link_delete", "gitlab_group_ldap_link_delete_for_provider"} {
-		spec := byTool[name]
-		if !spec.Destructive || !spec.Route.Destructive {
-			t.Errorf("%s should be destructive", name)
-		}
-		if !spec.Idempotent {
-			t.Errorf("%s should be idempotent", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			spec := byTool[name]
+			if !spec.Destructive || !spec.Route.Destructive {
+				t.Errorf("%s should be destructive", name)
+			}
+			if !spec.Idempotent {
+				t.Errorf("%s should be idempotent", name)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupldap/groupldap_test.go
+++ b/internal/tools/groupldap/groupldap_test.go
@@ -153,9 +153,11 @@ func TestAPIErrorIncludesActionableHint(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	for _, want := range []string{"LDAP provider name", "cn or filter", "Premium/Ultimate", "Owner access"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q does not contain %q", err.Error(), want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
+++ b/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
@@ -469,9 +469,11 @@ func TestFormatList_MultipleRows(t *testing.T) {
 	}
 	md := FormatList(out)
 	for _, want := range []string{"a.txt", "b.txt", "c.txt", "| 1 |", "| 2 |", "| 3 |"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -549,9 +551,11 @@ func TestList_KeysetAndOrdering(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "pagination=keyset", "page_token=tok123"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -569,9 +573,11 @@ func TestFormatListMarkdownString_UploadedBy(t *testing.T) {
 	}
 	md := FormatListMarkdownString(out)
 	for _, want := range []string{"Group Markdown Uploads (1)", "Uploaded By", "Bob (@bob)", "image.png"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -597,8 +603,10 @@ func TestUploadedByLabel(t *testing.T) {
 		{"empty", &UploadedByOutput{}, ""},
 	}
 	for _, tc := range cases {
-		if got := uploadedByLabel(tc.in); got != tc.want {
-			t.Errorf("%s: uploadedByLabel = %q, want %q", tc.name, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uploadedByLabel(tc.in); got != tc.want {
+				t.Errorf("%s: uploadedByLabel = %q, want %q", tc.name, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
+++ b/internal/tools/groupmarkdownuploads/groupmarkdownuploads_test.go
@@ -85,19 +85,28 @@ func TestDeleteByID_Error(t *testing.T) {
 	}
 }
 
-// TestDeleteByID_ValidationUploadID verifies the DeleteByID_ValidationUploadID handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
+// TestDeleteByID_ValidationUploadID verifies that DeleteByID rejects a
+// non-positive upload_id before reaching the API, naming the field in the
+// error.
 func TestDeleteByID_ValidationUploadID(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, id := range []int64{0, -1} {
-		err := DeleteByID(t.Context(), client, DeleteByIDInput{GroupID: "5", UploadID: id})
-		if err == nil {
-			t.Fatalf("expected error for upload_id=%d, got nil", id)
-		}
-		if !strings.Contains(err.Error(), "upload_id") {
-			t.Errorf("error %q does not mention upload_id", err.Error())
-		}
+	cases := []struct {
+		name string
+		id   int64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := DeleteByID(t.Context(), client, DeleteByIDInput{GroupID: "5", UploadID: tc.id})
+			if err == nil {
+				t.Fatalf("expected error for upload_id=%d, got nil", tc.id)
+			}
+			if !strings.Contains(err.Error(), "upload_id") {
+				t.Errorf("error %q does not mention upload_id", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupmembers/groupmembers_test.go
+++ b/internal/tools/groupmembers/groupmembers_test.go
@@ -1058,9 +1058,11 @@ func TestFormatMemberMarkdown_WithAllFields(t *testing.T) {
 		"| Expires | 31 Dec 2026 |",
 		"| URL | [dev](https://gl/dev) |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1127,9 +1129,11 @@ func TestFormatShareMarkdown_WithAllFields(t *testing.T) {
 		"| Path | shared-group |",
 		"| URL | [Shared Group](https://gl/groups/shared-group) |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupmembers/markdown_test.go
+++ b/internal/tools/groupmembers/markdown_test.go
@@ -24,9 +24,11 @@ func TestFormatBillableMembersMarkdown(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"Billable Group Members", "[dev](https://gl/dev)", "group_member"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -51,8 +53,10 @@ func TestFormatBillableMembershipsMarkdown(t *testing.T) {
 		"Developer",
 		"30",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }

--- a/internal/tools/groupmilestones/groupmilestones_test.go
+++ b/internal/tools/groupmilestones/groupmilestones_test.go
@@ -1328,9 +1328,11 @@ func TestFormatMarkdown_WithAllFields(t *testing.T) {
 		"**Created**: 1 Jan 2026 00:00 UTC",
 		"**Updated**: 15 Jan 2026 00:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtMarkdownMissing, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtMarkdownMissing, want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "Group ID") {
 		t.Errorf("should not contain legacy 'Group ID' label:\n%s", md)
@@ -1366,9 +1368,11 @@ func TestFormatMarkdown_MinimalFields(t *testing.T) {
 		"**Created**",
 		"**Updated**",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1400,9 +1404,11 @@ func TestFormatListMarkdown_WithMilestones(t *testing.T) {
 		"active",
 		"closed",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtMarkdownMissing, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtMarkdownMissing, want, md)
+			}
+		})
 	}
 }
 
@@ -1446,9 +1452,11 @@ func TestFormatIssuesMarkdown_WithData(t *testing.T) {
 		"Fix bug",
 		"Add feature",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtMarkdownMissing, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtMarkdownMissing, want, md)
+			}
+		})
 	}
 }
 
@@ -1489,9 +1497,11 @@ func TestFormatMergeRequestsMarkdown_WithData(t *testing.T) {
 		"feat",
 		"main",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtMarkdownMissing, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtMarkdownMissing, want, md)
+			}
+		})
 	}
 }
 
@@ -1533,9 +1543,11 @@ func TestFormatBurndownChartEventsMarkdown_WithData(t *testing.T) {
 		"add",
 		"remove",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf(fmtMarkdownMissing, want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf(fmtMarkdownMissing, want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupprotectedbranches/action_specs_test.go
+++ b/internal/tools/groupprotectedbranches/action_specs_test.go
@@ -41,9 +41,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := groupProtectedBranchSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_group_protected_branch_list", "gitlab_group_protected_branch_get"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	spec := byTool["gitlab_group_protected_branch_unprotect"]
 	if !spec.Destructive || !spec.Route.Destructive {

--- a/internal/tools/groupprotectedbranches/groupprotectedbranches_test.go
+++ b/internal/tools/groupprotectedbranches/groupprotectedbranches_test.go
@@ -742,9 +742,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 			"gitlab_group_protected_branch_unprotect",
 		}
 		for _, want := range checks {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatOutputMarkdown missing %q", want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("FormatOutputMarkdown missing %q", want)
+				}
+			})
 		}
 		if strings.Contains(md, "### Unprotect Access Levels") {
 			t.Error("FormatOutputMarkdown should not render empty Unprotect Access Levels section")
@@ -770,9 +772,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 			t.Error("missing force push")
 		}
 		for _, heading := range []string{"### Push Access Levels", "### Merge Access Levels", "### Unprotect Access Levels"} {
-			if strings.Contains(md, heading) {
-				t.Errorf("should not render empty section %q", heading)
-			}
+			t.Run(heading, func(t *testing.T) {
+				if strings.Contains(md, heading) {
+					t.Errorf("should not render empty section %q", heading)
+				}
+			})
 		}
 	})
 }
@@ -799,9 +803,11 @@ func TestFormatListMarkdown(t *testing.T) {
 			"gitlab_group_protected_branch_protect",
 		}
 		for _, want := range checks {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatListMarkdown missing %q", want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("FormatListMarkdown missing %q", want)
+				}
+			})
 		}
 	})
 

--- a/internal/tools/groupprotectedenvs/action_specs_test.go
+++ b/internal/tools/groupprotectedenvs/action_specs_test.go
@@ -39,9 +39,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := groupProtectedEnvSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_group_protected_environment_list", "gitlab_group_protected_environment_get"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	spec := byTool["gitlab_group_protected_environment_unprotect"]
 	if !spec.Destructive || !spec.Route.Destructive {
@@ -125,10 +127,12 @@ func TestGroupProtectedEnvDescription(t *testing.T) {
 		"gitlab_group_protected_environment_unprotect",
 	}
 	for _, name := range tools {
-		desc := groupProtectedEnvDescription(name)
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("description for %s = %q, want Returns:/See also: form", name, desc)
-		}
+		t.Run(name, func(t *testing.T) {
+			desc := groupProtectedEnvDescription(name)
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("description for %s = %q, want Returns:/See also: form", name, desc)
+			}
+		})
 	}
 	if got := groupProtectedEnvDescription("gitlab_unknown_tool"); got != "" {
 		t.Errorf("description for unknown tool = %q, want empty", got)

--- a/internal/tools/groupprotectedenvs/groupprotectedenvs_test.go
+++ b/internal/tools/groupprotectedenvs/groupprotectedenvs_test.go
@@ -363,9 +363,11 @@ func TestProtect_InvalidTierIncludesActionableHint(t *testing.T) {
 	}
 	got := err.Error()
 	for _, want := range []string{"valid group protected environment tiers", "production", "staging", "testing", "development", "other"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("Protect() error = %q, want substring %q", got, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("Protect() error = %q, want substring %q", got, want)
+			}
+		})
 	}
 }
 
@@ -486,9 +488,11 @@ func TestUpdate_NotFoundIncludesActionableHint(t *testing.T) {
 		t.Fatal("Update() error = nil, want not found error")
 	}
 	for _, want := range []string{"protected_env_list", "valid tiers", "partial updates merge"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("Update() error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("Update() error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/grouprelationsexport/grouprelationsexport_test.go
+++ b/internal/tools/grouprelationsexport/grouprelationsexport_test.go
@@ -283,9 +283,11 @@ func TestListExportStatus_KeysetAndOrdering(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=id", "sort=desc", "pagination=keyset", "page_token=abc", "relation=project"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 	if len(out.Statuses) != 1 || len(out.Statuses[0].Batches) != 1 {
 		t.Fatalf("expected 1 status with 1 batch, got %+v", out.Statuses)
@@ -374,9 +376,11 @@ func TestFormatListExportStatus_MultipleItems(t *testing.T) {
 		"true",
 		"false",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupreleases/groupreleases_test.go
+++ b/internal/tools/groupreleases/groupreleases_test.go
@@ -296,9 +296,11 @@ func TestList_MultipleReleases(t *testing.T) {
 	}
 	wantTags := []string{"v2.0.0", "v1.1.0", "v1.0.0"}
 	for i, wt := range wantTags {
-		if out.Releases[i].TagName != wt {
-			t.Errorf("Releases[%d].TagName = %q, want %q", i, out.Releases[i].TagName, wt)
-		}
+		t.Run(wt, func(t *testing.T) {
+			if out.Releases[i].TagName != wt {
+				t.Errorf("Releases[%d].TagName = %q, want %q", i, out.Releases[i].TagName, wt)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groups/groups_test.go
+++ b/internal/tools/groups/groups_test.go
@@ -2068,9 +2068,11 @@ func TestFormatOutputMarkdown_WithData(t *testing.T) {
 		"Marked for deletion",
 		"2026-06-01",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2096,9 +2098,11 @@ func TestFormatOutputMarkdown_Minimal(t *testing.T) {
 		"**Created**",
 		"Marked for deletion",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -2130,9 +2134,11 @@ func TestFormatListMarkdown_WithData(t *testing.T) {
 		"public",
 		"private",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2175,9 +2181,11 @@ func TestFormatMemberListMarkdown_WithData(t *testing.T) {
 		"Maintainer",
 		"Developer",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2221,9 +2229,11 @@ func TestFormatListProjectsMarkdown_WithData(t *testing.T) {
 		"No",
 		"Yes",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2287,9 +2297,11 @@ func TestFormatHookMarkdown_WithNameAndAllEvents(t *testing.T) {
 		"**Alert Status**: executable",
 		"**Created**:",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2361,9 +2373,11 @@ func TestFormatHookListMarkdown_WithData(t *testing.T) {
 		"push",
 		"pipeline",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2405,9 +2419,11 @@ func TestEnabledEvents_All(t *testing.T) {
 	result := enabledEvents(h)
 
 	for _, want := range []string{"push", "tag_push", "merge_request", "issues", "note", "job", "pipeline", "wiki", "deployment", "releases", "subgroup", "member"} {
-		if !strings.Contains(result, want) {
-			t.Errorf("enabledEvents missing %q: %s", want, result)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(result, want) {
+				t.Errorf("enabledEvents missing %q: %s", want, result)
+			}
+		})
 	}
 }
 
@@ -3063,9 +3079,11 @@ func TestCreate_AuditFields(t *testing.T) {
 		`"two_factor_grace_period":48`, `"wiki_access_level":"enabled"`,
 		`"default_branch_protection_defaults"`, `"allow_force_push":true`,
 	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("create request body missing %q:\n%s", want, body)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("create request body missing %q:\n%s", want, body)
+			}
+		})
 	}
 }
 
@@ -3145,9 +3163,11 @@ func TestUpdate_AuditFields(t *testing.T) {
 		`"unique_project_download_limit_allowlist":["safe"]`, `"unique_project_download_limit_alertlist":[1]`,
 		`"wiki_access_level":"private"`, `"code_owner_approval_required":true`,
 	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("update request body missing %q:\n%s", want, body)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("update request body missing %q:\n%s", want, body)
+			}
+		})
 	}
 }
 
@@ -3170,9 +3190,11 @@ func TestList_AuditFiltersAndKeyset(t *testing.T) {
 			"page_token":             "abc",
 		}
 		for k, want := range checks {
-			if got := q.Get(k); got != want {
-				t.Errorf("query %s = %q, want %q", k, got, want)
-			}
+			t.Run(k, func(t *testing.T) {
+				if got := q.Get(k); got != want {
+					t.Errorf("query %s = %q, want %q", k, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, groupListJSON)
 	}))
@@ -3229,9 +3251,11 @@ func TestSubgroupsList_AuditFilters(t *testing.T) {
 			"pagination":             "keyset",
 		}
 		for k, want := range checks {
-			if got := q.Get(k); got != want {
-				t.Errorf("query %s = %q, want %q", k, got, want)
-			}
+			t.Run(k, func(t *testing.T) {
+				if got := q.Get(k); got != want {
+					t.Errorf("query %s = %q, want %q", k, got, want)
+				}
+			})
 		}
 		if !strings.Contains(r.URL.RawQuery, "skip_groups") {
 			t.Error("skip_groups missing")
@@ -3294,9 +3318,11 @@ func TestListProjects_AuditFilters(t *testing.T) {
 			"pagination":                  "keyset",
 		}
 		for k, want := range checks {
-			if got := q.Get(k); got != want {
-				t.Errorf("query %s = %q, want %q", k, got, want)
-			}
+			t.Run(k, func(t *testing.T) {
+				if got := q.Get(k); got != want {
+					t.Errorf("query %s = %q, want %q", k, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[{"id":1,"name":"p","path_with_namespace":"org/p","visibility":"private","web_url":"https://gitlab.example.com/org/p"}]`)
 	}))
@@ -3473,9 +3499,11 @@ func TestSharedWithList_AllFilters(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, want := range []string{"search=team", "min_access_level=30", "visibility=private", "order_by=name", "sort=desc", "skip_groups=", "with_custom_attributes=true", "page=2", "per_page=10"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -3569,9 +3597,11 @@ func TestInvitedList_AllFilters(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, want := range []string{"search=guests", "min_access_level=20", "relation=", "with_custom_attributes=true", "page=3", "per_page=5"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -3662,9 +3692,11 @@ func TestTransferLocationsList_AllFilters(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, want := range []string{"search=org", "page=2", "per_page=15"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 }
 
@@ -3748,9 +3780,11 @@ func TestCreate_NewOptions(t *testing.T) {
 		"unique_project_download_limit_allowlist", "unique_project_download_limit_alertlist",
 		"auto_ban_user_on_excessive_projects_download",
 	} {
-		if !strings.Contains(body, field) {
-			t.Errorf("expected %s in request body, got: %s", field, body)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !strings.Contains(body, field) {
+				t.Errorf("expected %s in request body, got: %s", field, body)
+			}
+		})
 	}
 }
 
@@ -3779,8 +3813,10 @@ func TestUpdate_NewOptions(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, field := range []string{"math_rendering_limits_enabled", "web_based_commit_signing_enabled", "allow_personal_snippets"} {
-		if !strings.Contains(body, field) {
-			t.Errorf("expected %s in request body, got: %s", field, body)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !strings.Contains(body, field) {
+				t.Errorf("expected %s in request body, got: %s", field, body)
+			}
+		})
 	}
 }

--- a/internal/tools/groups/hooks_test.go
+++ b/internal/tools/groups/hooks_test.go
@@ -518,11 +518,20 @@ func TestSetHookCustomHeader_Success(t *testing.T) {
 // TestSetHookCustomHeader_Guards verifies required-input guards.
 func TestSetHookCustomHeader_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []SetHookCustomHeaderInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := SetHookCustomHeader(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   SetHookCustomHeaderInput
+	}{
+		{"missing_group_id", SetHookCustomHeaderInput{}},
+		{"missing_hook_id", SetHookCustomHeaderInput{GroupID: "99"}},
+		{"missing_key", SetHookCustomHeaderInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SetHookCustomHeader(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -562,11 +571,20 @@ func TestDeleteHookCustomHeader_Success(t *testing.T) {
 // TestDeleteHookCustomHeader_Guards verifies required-input guards.
 func TestDeleteHookCustomHeader_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []DeleteHookCustomHeaderInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := DeleteHookCustomHeader(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   DeleteHookCustomHeaderInput
+	}{
+		{"missing_group_id", DeleteHookCustomHeaderInput{}},
+		{"missing_hook_id", DeleteHookCustomHeaderInput{GroupID: "99"}},
+		{"missing_key", DeleteHookCustomHeaderInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := DeleteHookCustomHeader(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -609,11 +627,20 @@ func TestSetHookURLVariable_IllegalKey422_HintsKeyFormat(t *testing.T) {
 // TestSetHookURLVariable_Guards verifies required-input guards.
 func TestSetHookURLVariable_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []SetHookURLVariableInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := SetHookURLVariable(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   SetHookURLVariableInput
+	}{
+		{"missing_group_id", SetHookURLVariableInput{}},
+		{"missing_hook_id", SetHookURLVariableInput{GroupID: "99"}},
+		{"missing_key", SetHookURLVariableInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SetHookURLVariable(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -653,11 +680,20 @@ func TestDeleteHookURLVariable_Success(t *testing.T) {
 // TestDeleteHookURLVariable_Guards verifies required-input guards.
 func TestDeleteHookURLVariable_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []DeleteHookURLVariableInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := DeleteHookURLVariable(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   DeleteHookURLVariableInput
+	}{
+		{"missing_group_id", DeleteHookURLVariableInput{}},
+		{"missing_hook_id", DeleteHookURLVariableInput{GroupID: "99"}},
+		{"missing_key", DeleteHookURLVariableInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := DeleteHookURLVariable(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -683,11 +719,20 @@ func TestTestHook_Success(t *testing.T) {
 // TestTestHook_Guards verifies required-input guards.
 func TestTestHook_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []TestHookInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := TestHook(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   TestHookInput
+	}{
+		{"missing_group_id", TestHookInput{}},
+		{"missing_hook_id", TestHookInput{GroupID: "99"}},
+		{"missing_trigger", TestHookInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := TestHook(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 
@@ -727,11 +772,20 @@ func TestResendHookEvent_Success(t *testing.T) {
 // TestResendHookEvent_Guards verifies required-input guards.
 func TestResendHookEvent_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []ResendHookEventInput{{}, {GroupID: "99"}, {GroupID: "99", HookID: 10}}
-	for i, in := range cases {
-		if err := ResendHookEvent(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error", i)
-		}
+	cases := []struct {
+		name string
+		in   ResendHookEventInput
+	}{
+		{"missing_group_id", ResendHookEventInput{}},
+		{"missing_hook_id", ResendHookEventInput{GroupID: "99"}},
+		{"missing_event_id", ResendHookEventInput{GroupID: "99", HookID: 10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ResendHookEvent(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error")
+			}
+		})
 	}
 }
 

--- a/internal/tools/groups/hooks_test.go
+++ b/internal/tools/groups/hooks_test.go
@@ -212,9 +212,11 @@ func TestAddHook_Success(t *testing.T) {
 		"emoji_events", "resource_access_token_events", "project_events",
 		"push_events_branch_filter", "branch_filter_strategy",
 	} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing %q: %s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing %q: %s", want, capturedBody)
+			}
+		})
 	}
 }
 
@@ -276,9 +278,11 @@ func TestEditHook_Success(t *testing.T) {
 		t.Errorf("out.ID = %d, want 10", out.ID)
 	}
 	for _, want := range []string{"signing_token", "milestone_events", "feature_flag_events", "vulnerability_events"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing %q: %s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing %q: %s", want, capturedBody)
+			}
+		})
 	}
 }
 
@@ -445,9 +449,11 @@ func TestFormatHookMarkdown_URLVariablesRedacted(t *testing.T) {
 	})
 
 	for _, want := range []string{"Deploy hook", "Deploy events", "Alert Status", "Disabled Until", "Created", "URL Variables", "token", "REDACTED"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("FormatHookMarkdown missing %q: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("FormatHookMarkdown missing %q: %s", want, text)
+			}
+		})
 	}
 }
 
@@ -477,9 +483,11 @@ func TestEnabledEvents_AllEvents(t *testing.T) {
 	})
 
 	for _, want := range []string{"push", "tag_push", "merge_request", "issues", "note", "job", "pipeline", "wiki", "deployment", "releases", "milestone", "feature_flag", "subgroup", "member", "vulnerability"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("enabledEvents missing %q: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("enabledEvents missing %q: %s", want, text)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groups/provisioned_users_test.go
+++ b/internal/tools/groups/provisioned_users_test.go
@@ -61,9 +61,11 @@ func TestListProvisionedUsers_FiltersAndOutput(t *testing.T) {
 		"order_by":       "created_at",
 		"sort":           "desc",
 	} {
-		if got := query.Get(k); got != want {
-			t.Errorf("query %s = %q, want %q", k, got, want)
-		}
+		t.Run(k, func(t *testing.T) {
+			if got := query.Get(k); got != want {
+				t.Errorf("query %s = %q, want %q", k, got, want)
+			}
+		})
 	}
 
 	if len(out.Users) != 1 {

--- a/internal/tools/groups/push_rules_test.go
+++ b/internal/tools/groups/push_rules_test.go
@@ -288,9 +288,11 @@ func TestFormatPushRuleMarkdown(t *testing.T) {
 	}
 	md := FormatPushRuleMarkdown(r)
 	for _, want := range []string{"Group Push Rules", "Commit Message Regex", "^JIRA-", "Prevent Secrets", "Max File Size"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -325,9 +327,11 @@ func TestAddPushRule_AllFields(t *testing.T) {
 		t.Fatalf("AddPushRule() error: %v", err)
 	}
 	for _, want := range []string{"author_email_regex", "branch_name_regex", "commit_committer_check", "file_name_regex", "max_file_size", "member_check", "reject_unsigned_commits"} {
-		if !strings.Contains(gotBody, want) {
-			t.Errorf("body missing %q: %s", want, gotBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotBody, want) {
+				t.Errorf("body missing %q: %s", want, gotBody)
+			}
+		})
 	}
 }
 
@@ -363,9 +367,11 @@ func TestEditPushRule_AllFields(t *testing.T) {
 		t.Fatalf("EditPushRule() error: %v", err)
 	}
 	for _, want := range []string{"author_email_regex", "branch_name_regex", "commit_committer_check", "file_name_regex", "max_file_size", "member_check", "reject_unsigned_commits"} {
-		if !strings.Contains(gotBody, want) {
-			t.Errorf("body missing %q: %s", want, gotBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotBody, want) {
+				t.Errorf("body missing %q: %s", want, gotBody)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groups/sharing_test.go
+++ b/internal/tools/groups/sharing_test.go
@@ -51,18 +51,24 @@ func TestShareGroupWithGroup_Success(t *testing.T) {
 	}
 }
 
-// TestShareGroupWithGroup_Guards verifies the required-input guards.
+// TestShareGroupWithGroup_Guards verifies the required-input guards: each case
+// omits one required field, in the order the handler checks them.
 func TestShareGroupWithGroup_Guards(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
-	cases := []ShareGroupInput{
-		{},
-		{GroupID: "99"},
-		{GroupID: "99", SharedGroupID: 1},
+	cases := []struct {
+		name string
+		in   ShareGroupInput
+	}{
+		{name: "missing_group_id", in: ShareGroupInput{}},
+		{name: "missing_shared_group_id", in: ShareGroupInput{GroupID: "99"}},
+		{name: "missing_group_access", in: ShareGroupInput{GroupID: "99", SharedGroupID: 1}},
 	}
-	for i, in := range cases {
-		if _, err := ShareGroupWithGroup(context.Background(), client, in); err == nil {
-			t.Errorf("case %d: expected error, got nil", i)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ShareGroupWithGroup(context.Background(), client, tc.in); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
 	}
 }
 

--- a/internal/tools/groups/sharing_test.go
+++ b/internal/tools/groups/sharing_test.go
@@ -317,9 +317,11 @@ func TestListSharedProjects_AllFilters(t *testing.T) {
 		t.Fatalf("ListSharedProjects() error: %v", err)
 	}
 	for _, want := range []string{"order_by=name", "simple=true", "sort=asc", "starred=true", "visibility=private", "with_custom_attributes=true", "with_issues_enabled=true", "with_merge_requests_enabled=true"} {
-		if !strings.Contains(q, want) {
-			t.Errorf("query missing %q: %s", want, q)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(q, want) {
+				t.Errorf("query missing %q: %s", want, q)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupsaml/action_specs_test.go
+++ b/internal/tools/groupsaml/action_specs_test.go
@@ -120,9 +120,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := groupSAMLSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_group_saml_link_list", "gitlab_group_saml_link_get", "gitlab_group_saml_users_list"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	spec := byTool["gitlab_group_saml_link_delete"]
 	if !spec.Destructive || !spec.Route.Destructive {

--- a/internal/tools/groupsaml/groupsaml_test.go
+++ b/internal/tools/groupsaml/groupsaml_test.go
@@ -184,9 +184,11 @@ func TestSAMLUsersList_AllFilters(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, want := range []string{"search=jane", "username=jdoe", "active=true", "blocked=false", "created_after=", "created_before=", "page=2", "per_page=5", "order_by=created_at", "sort=desc", "pagination=keyset", "page_token=tok-123"} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(query, want) {
+				t.Errorf("query %q missing %q", query, want)
+			}
+		})
 	}
 	if out.Users[0].CreatedAt == "" {
 		t.Error("expected created_at to be formatted on the output")

--- a/internal/tools/groupscim/markdown_test.go
+++ b/internal/tools/groupscim/markdown_test.go
@@ -168,9 +168,11 @@ func TestFormatOutputMarkdown_EmptyAndPopulated(t *testing.T) {
 	}
 	got := FormatOutputMarkdown(Output{ExternalUID: "uid-1", UserID: 7, Active: true})
 	for _, want := range []string{"## SCIM Identity", "`uid-1`", "**User ID**: 7", "**Active**: true"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }
 
@@ -186,9 +188,11 @@ func TestFormatListMarkdown_EmptyAndRows(t *testing.T) {
 		{ExternalUID: "b", UserID: 2},
 	}})
 	for _, want := range []string{"## SCIM Identities (2)", "| `a` | 1 | true |", "| `b` | 2 | false |"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("FormatListMarkdown missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("FormatListMarkdown missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }
 
@@ -197,8 +201,10 @@ func TestFormatListMarkdown_EmptyAndRows(t *testing.T) {
 func TestFormatUpdateMarkdown_RendersConfirmation(t *testing.T) {
 	got := FormatUpdateMarkdown(UpdateOutput{Updated: true, Message: "ok"})
 	for _, want := range []string{"## SCIM Identity Updated", "**Updated**: true", "**Message**: ok"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("FormatUpdateMarkdown missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("FormatUpdateMarkdown missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }

--- a/internal/tools/groupserviceaccounts/action_specs_test.go
+++ b/internal/tools/groupserviceaccounts/action_specs_test.go
@@ -40,18 +40,22 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := groupServiceAccountSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_group_service_account_list", "gitlab_group_service_account_pat_list"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	for _, name := range []string{"gitlab_group_service_account_delete", "gitlab_group_service_account_pat_revoke"} {
-		spec := byTool[name]
-		if !spec.Destructive || !spec.Route.Destructive {
-			t.Errorf("%s should be destructive", name)
-		}
-		if !spec.Idempotent {
-			t.Errorf("%s should be idempotent", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			spec := byTool[name]
+			if !spec.Destructive || !spec.Route.Destructive {
+				t.Errorf("%s should be destructive", name)
+			}
+			if !spec.Idempotent {
+				t.Errorf("%s should be idempotent", name)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupserviceaccounts/groupserviceaccounts_test.go
+++ b/internal/tools/groupserviceaccounts/groupserviceaccounts_test.go
@@ -756,9 +756,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 	out := Output{ID: 42, Name: "svc-bot", Username: "svc-bot", Email: "svc@test.com"}
 	md := FormatOutputMarkdown(out)
 	for _, want := range []string{"svc-bot", "42", "svc@test.com", "gitlab_group_service_account_update"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -806,9 +808,11 @@ func TestFormatPATOutputMarkdown(t *testing.T) {
 		}
 		md := FormatPATOutputMarkdown(out)
 		for _, want := range []string{"deploy", "api", "glpat-secret", "2026-01-15", "gitlab_group_service_account_pat_revoke"} {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatPATOutputMarkdown missing %q:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("FormatPATOutputMarkdown missing %q:\n%s", want, md)
+				}
+			})
 		}
 	})
 	t.Run("without optional fields", func(t *testing.T) {
@@ -858,9 +862,11 @@ func TestFormatMarkdownString(t *testing.T) {
 	out := Output{ID: 10, Name: "svc", Username: "svc-user", Email: "svc@e.com"}
 	md := FormatMarkdownString(out)
 	for _, want := range []string{"svc-user", "10", "svc@e.com"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdownString missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdownString missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -899,9 +905,11 @@ func TestFormatPATMarkdownString(t *testing.T) {
 		}
 		md := FormatPATMarkdownString(out)
 		for _, want := range []string{"tok", "api", "secret", "2026-12-31", "2026-01-01", "2026-06-20", "Last Used"} {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatPATMarkdownString missing %q:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("FormatPATMarkdownString missing %q:\n%s", want, md)
+				}
+			})
 		}
 	})
 	t.Run("minimal fields", func(t *testing.T) {

--- a/internal/tools/groupsshcerts/group_ssh_certs_test.go
+++ b/internal/tools/groupsshcerts/group_ssh_certs_test.go
@@ -119,9 +119,11 @@ func TestList_PaginationParameters(t *testing.T) {
 			"pagination": "keyset",
 			"page_token": "tok-123",
 		} {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[{"id":7,"title":"cert-7","key":"ssh-rsa AAAA7","created_at":"2026-03-01T00:00:00Z"}]`)
 	}))

--- a/internal/tools/groupstoragemoves/group_storage_moves_test.go
+++ b/internal/tools/groupstoragemoves/group_storage_moves_test.go
@@ -759,9 +759,11 @@ func TestFormatScheduleAllMarkdown(t *testing.T) {
 		"All group repository storage moves have been scheduled",
 	}
 	for _, want := range wantAll {
-		if !strings.Contains(got, want) {
-			t.Errorf("output missing %q\ngot:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q\ngot:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupvariables/groupvariables_test.go
+++ b/internal/tools/groupvariables/groupvariables_test.go
@@ -797,9 +797,11 @@ func TestFormatOutputMarkdown_FullUnmasked(t *testing.T) {
 		"| Description | Database host |",
 		"| Value | localhost |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "| Hidden | ✅ |") {
 		t.Error("should not contain Hidden line when hidden=false")
@@ -888,9 +890,11 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		"env_var",
 		"production",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/groupwikis/action_specs_test.go
+++ b/internal/tools/groupwikis/action_specs_test.go
@@ -40,9 +40,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 
 	byTool := groupWikiSpecsByTool(t, specs)
 	for _, name := range []string{"gitlab_group_wiki_list", "gitlab_group_wiki_get"} {
-		if !byTool[name].ReadOnly {
-			t.Errorf("%s should be read-only", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly {
+				t.Errorf("%s should be read-only", name)
+			}
+		})
 	}
 	spec := byTool["gitlab_group_wiki_delete"]
 	if !spec.Destructive || !spec.Route.Destructive {
@@ -142,28 +144,30 @@ func TestActionSpecs_RichMetadata(t *testing.T) {
 		"gitlab_group_wiki_delete",
 	}
 	for _, name := range wantTools {
-		spec, ok := byTool[name]
-		if !ok {
-			t.Fatalf("missing spec for %s", name)
-		}
-		if spec.Usage == "" || spec.Usage == "Use to execute groupwikis domain action." {
-			t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
-		}
-		if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
-			t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
-		}
-		for _, alias := range spec.Aliases {
-			if !containsSubstr(alias, "group") {
-				t.Errorf("%s: alias %q is not group-wiki-specific", name, alias)
+		t.Run(name, func(t *testing.T) {
+			spec, ok := byTool[name]
+			if !ok {
+				t.Fatalf("missing spec for %s", name)
 			}
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: empty RelatedActions", name)
-		}
-		desc := spec.IndividualTool.Description
-		if !containsSubstr(desc, "Returns:") || !containsSubstr(desc, "See also:") {
-			t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
-		}
+			if spec.Usage == "" || spec.Usage == "Use to execute groupwikis domain action." {
+				t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
+			}
+			if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
+				t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
+			}
+			for _, alias := range spec.Aliases {
+				if !containsSubstr(alias, "group") {
+					t.Errorf("%s: alias %q is not group-wiki-specific", name, alias)
+				}
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s: empty RelatedActions", name)
+			}
+			desc := spec.IndividualTool.Description
+			if !containsSubstr(desc, "Returns:") || !containsSubstr(desc, "See also:") {
+				t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
+			}
+		})
 	}
 
 	// decorateGroupWikiMeta must be a no-op for a tool with no metadata entry.

--- a/internal/tools/groupwikis/action_specs_test.go
+++ b/internal/tools/groupwikis/action_specs_test.go
@@ -132,6 +132,31 @@ func TestActionSpecs_CallRouteError(t *testing.T) {
 // the natural-language aliases are group-wiki-specific (distinct from the
 // project wikis package), and that decorateGroupWikiMeta is a no-op for an
 // unknown tool.
+// assertGroupWikiSpecMetadata checks one spec for the rich metadata every
+// group wiki tool must carry: a specific Usage, group-specific natural
+// language aliases, related actions, and the Returns/See also description.
+func assertGroupWikiSpecMetadata(t *testing.T, name string, spec toolutil.ActionSpec) {
+	t.Helper()
+	if spec.Usage == "" || spec.Usage == "Use to execute groupwikis domain action." {
+		t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
+	}
+	if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
+		t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
+	}
+	for _, alias := range spec.Aliases {
+		if !containsSubstr(alias, "group") {
+			t.Errorf("%s: alias %q is not group-wiki-specific", name, alias)
+		}
+	}
+	if len(spec.RelatedActions) == 0 {
+		t.Errorf("%s: empty RelatedActions", name)
+	}
+	desc := spec.IndividualTool.Description
+	if !containsSubstr(desc, "Returns:") || !containsSubstr(desc, "See also:") {
+		t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
+	}
+}
+
 func TestActionSpecs_RichMetadata(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
 	byTool := groupWikiSpecsByTool(t, ActionSpecs(client))
@@ -149,24 +174,7 @@ func TestActionSpecs_RichMetadata(t *testing.T) {
 			if !ok {
 				t.Fatalf("missing spec for %s", name)
 			}
-			if spec.Usage == "" || spec.Usage == "Use to execute groupwikis domain action." {
-				t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
-			}
-			if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
-				t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
-			}
-			for _, alias := range spec.Aliases {
-				if !containsSubstr(alias, "group") {
-					t.Errorf("%s: alias %q is not group-wiki-specific", name, alias)
-				}
-			}
-			if len(spec.RelatedActions) == 0 {
-				t.Errorf("%s: empty RelatedActions", name)
-			}
-			desc := spec.IndividualTool.Description
-			if !containsSubstr(desc, "Returns:") || !containsSubstr(desc, "See also:") {
-				t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
-			}
+			assertGroupWikiSpecMetadata(t, name, spec)
 		})
 	}
 

--- a/internal/tools/health/health_test.go
+++ b/internal/tools/health/health_test.go
@@ -281,9 +281,11 @@ func TestFormatMarkdownString_Healthy(t *testing.T) {
 		{"response time", "15 ms"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("FormatMarkdownString healthy missing %s: want substring %q", c.name, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("FormatMarkdownString healthy missing %s: want substring %q", c.name, c.want)
+			}
+		})
 	}
 	if strings.Contains(md, "Error") {
 		t.Error("healthy status should not contain Error section")
@@ -310,9 +312,11 @@ func TestFormatMarkdownString_WithMetadata(t *testing.T) {
 		"**Department**: Test Department",
 		"**Repository**: https://github.com/jmrplens/gitlab-mcp-server",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown", want)
+			}
+		})
 	}
 }
 
@@ -332,9 +336,11 @@ func TestFormatMarkdownString_WithoutMetadata(t *testing.T) {
 		"**Department**",
 		"**Repository**",
 	} {
-		if strings.Contains(md, unwanted) {
-			t.Errorf("should not contain %q when field is empty", unwanted)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(md, unwanted) {
+				t.Errorf("should not contain %q when field is empty", unwanted)
+			}
+		})
 	}
 }
 

--- a/internal/tools/impersonationtokens/impersonationtokens_test.go
+++ b/internal/tools/impersonationtokens/impersonationtokens_test.go
@@ -647,9 +647,11 @@ func TestFormatListMarkdownString_WithTokens(t *testing.T) {
 		"| 2 | token-b | false | read_api | - |",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -672,9 +674,11 @@ func TestFormatMarkdownString_AllOptionalFields(t *testing.T) {
 		"**Token**: `glpat-secret`",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -714,9 +718,11 @@ func TestFormatPATMarkdownString_AllOptionalFields(t *testing.T) {
 		"**Token**: `glpat-fullpat`",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -751,9 +757,11 @@ func TestFormatRevokeMarkdownString(t *testing.T) {
 		"**Token ID**: 7",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 	if md == "" {
 		t.Fatal("expected non-empty markdown")

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -777,15 +777,20 @@ func importServiceSpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[str
 // the shared Markdown registry (covering the registration lambdas that adapt
 // the pointer-returning handlers to value-type registry keys).
 func TestMarkdownRegistry_PointerOutputFormatters(t *testing.T) {
-	outputs := []any{
-		GitHubImportOutput{},
-		CancelledImportOutput{},
-		BitbucketCloudImportOutput{},
-		BitbucketServerImportOutput{},
+	outputs := []struct {
+		name string
+		out  any
+	}{
+		{"github", GitHubImportOutput{}},
+		{"cancelled", CancelledImportOutput{}},
+		{"bitbucket_cloud", BitbucketCloudImportOutput{}},
+		{"bitbucket_server", BitbucketServerImportOutput{}},
 	}
-	for _, out := range outputs {
-		if result := toolutil.MarkdownForResult(out); result == nil || len(result.Content) == 0 {
-			t.Errorf("MarkdownForResult(%T) returned empty result", out)
-		}
+	for _, tc := range outputs {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := toolutil.MarkdownForResult(tc.out); result == nil || len(result.Content) == 0 {
+				t.Errorf("MarkdownForResult(%T) returned empty result", tc.out)
+			}
+		})
 	}
 }

--- a/internal/tools/importservice/importservice_test.go
+++ b/internal/tools/importservice/importservice_test.go
@@ -215,9 +215,11 @@ func TestImportFromBitbucketCloud_APIToken(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, field := range []string{"bitbucket_api_token", "bitbucket_email"} {
-		if !strings.Contains(body, field) {
-			t.Errorf("expected %s in request body, got: %s", field, body)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !strings.Contains(body, field) {
+				t.Errorf("expected %s in request body, got: %s", field, body)
+			}
+		})
 	}
 	if strings.Contains(body, "bitbucket_app_password") {
 		t.Errorf("did not expect bitbucket_app_password when using API token, got: %s", body)
@@ -380,9 +382,11 @@ func TestImportFromGitHub_WithAllOptionalFields(t *testing.T) {
 		t.Errorf("expected name 'imported', got %q", out.Name)
 	}
 	for _, want := range []string{"personal_access_token", "repo_id", "target_namespace", "new_name", "github_hostname", "timeout_strategy"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -538,9 +542,11 @@ func TestImportFromGitHub_WithOptionalStages(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"optional_stages", "single_endpoint_notes_import", "attachments_import", "collaborators_import"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q; body=%s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q; body=%s", want, capturedBody)
+			}
+		})
 	}
 	if out.RefsURL != "https://gitlab.example.com/ns/my-repo/refs" {
 		t.Errorf("expected refs_url to be mapped, got %q", out.RefsURL)

--- a/internal/tools/instancevariables/instancevariables_test.go
+++ b/internal/tools/instancevariables/instancevariables_test.go
@@ -712,9 +712,11 @@ func TestFormatOutputMarkdown_FullUnmasked(t *testing.T) {
 		"**Description**: Database host",
 		"**Value**: localhost",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -761,9 +763,11 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		"| API_KEY |",
 		"env_var",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/integrations/group_datadog_test.go
+++ b/internal/tools/integrations/group_datadog_test.go
@@ -536,9 +536,11 @@ func TestFormatGetGroupDatadogMarkdown_Full(t *testing.T) {
 		"Updated",               // i.UpdatedAt != "" branch
 	}
 	for _, want := range wantSubs {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown should contain %q, got: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown should contain %q, got: %s", want, text)
+			}
+		})
 	}
 }
 
@@ -599,9 +601,11 @@ func TestFormatSetGroupDatadogMarkdown_Full(t *testing.T) {
 		"Archive Trace Events",  // i.ArchiveTraceEvents != nil branch
 	}
 	for _, want := range wantSubs {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown should contain %q, got: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown should contain %q, got: %s", want, text)
+			}
+		})
 	}
 }
 
@@ -676,9 +680,11 @@ func TestActionSpecs_GroupDatadogPresent(t *testing.T) {
 		}
 	}
 	for name := range want {
-		if !seen[name] {
-			t.Errorf("ActionSpecs missing %q", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !seen[name] {
+				t.Errorf("ActionSpecs missing %q", name)
+			}
+		})
 	}
 }
 

--- a/internal/tools/integrations/integrations_test.go
+++ b/internal/tools/integrations/integrations_test.go
@@ -714,9 +714,11 @@ func TestSetJira_WithAllOptionalFields(t *testing.T) {
 		"jira_check_enabled", "jira_exists_check_enabled", "jira_assignee_check_enabled", "jira_status_check_enabled",
 		"jira_allowed_statuses_as_string",
 	} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -912,9 +914,11 @@ func TestIntegrationFromService_Branches(t *testing.T) {
 func TestFormatSetJiraMarkdown_RendersUpdateAndHints(t *testing.T) {
 	md := formatSetJiraMarkdownString(SetJiraOutput{Integration: IntegrationItem{Slug: "jira", Active: true}})
 	for _, want := range []string{"Jira Integration Updated", "write-only"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("formatSetJiraMarkdownString missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("formatSetJiraMarkdownString missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/integrations/set_integration_test.go
+++ b/internal/tools/integrations/set_integration_test.go
@@ -391,9 +391,11 @@ func TestFormatSetIntegrationMarkdown(t *testing.T) {
 	})
 	text := firstMarkdownText(t, result)
 	for _, want := range []string{"Integration Updated", "Slack", "Slug", "Created", "Updated"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown should contain %q, got: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown should contain %q, got: %s", want, text)
+			}
+		})
 	}
 }
 
@@ -477,8 +479,10 @@ func TestActionSpecs_GenericIntegrationsPresent(t *testing.T) {
 		}
 	}
 	for name := range want {
-		if !seen[name] {
-			t.Errorf("ActionSpecs missing %q", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !seen[name] {
+				t.Errorf("ActionSpecs missing %q", name)
+			}
+		})
 	}
 }

--- a/internal/tools/invites/invites_test.go
+++ b/internal/tools/invites/invites_test.go
@@ -765,9 +765,11 @@ func TestListPendingProjectInvitations_KeysetAndSort(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=desc", "pagination=keyset", "page_token=cursor-7", "per_page=50"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -793,9 +795,11 @@ func TestListPendingGroupInvitations_KeysetAndSort(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=id", "sort=asc", "pagination=keyset", "page_token=cursor-3"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/issuediscussions/issuediscussions_test.go
+++ b/internal/tools/issuediscussions/issuediscussions_test.go
@@ -199,9 +199,11 @@ func TestList_AppliesListAndKeysetOptions(t *testing.T) {
 		"page_token": "cursor-99",
 	}
 	for key, want := range wants {
-		if got := gotQuery.Get(key); got != want {
-			t.Errorf("query %q = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := gotQuery.Get(key); got != want {
+				t.Errorf("query %q = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 
@@ -464,9 +466,11 @@ func TestFormatListMarkdownString_Populated(t *testing.T) {
 		"First note", "Second note", "Solo note",
 		"1 Jan 2026 00:00 UTC", "2 Jan 2026 00:00 UTC", "3 Jan 2026 00:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdownString missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdownString missing %q", want)
+			}
+		})
 	}
 }
 
@@ -489,9 +493,11 @@ func TestFormatMarkdownString_Populated(t *testing.T) {
 		"Hello world", "Reply here",
 		"1 Jan 2026 00:00 UTC", "2 Jan 2026 00:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdownString missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdownString missing %q", want)
+			}
+		})
 	}
 }
 
@@ -523,9 +529,11 @@ func TestFormatNoteMarkdownString_Populated(t *testing.T) {
 		"Great work!",
 		"1 Mar 2026 10:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatNoteMarkdownString missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatNoteMarkdownString missing %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/issuelinks/action_specs_test.go
+++ b/internal/tools/issuelinks/action_specs_test.go
@@ -152,33 +152,35 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		"gitlab_issue_link_list", "gitlab_issue_link_get",
 		"gitlab_issue_link_create", "gitlab_issue_link_delete",
 	} {
-		spec := byTool[tool]
-		if spec.Usage == "" || strings.Contains(spec.Usage, "domain action") {
-			t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
-		}
-		// Must have at least one natural-language alias beyond the canonical name.
-		if len(spec.Aliases) < 2 {
-			t.Errorf("%s: missing natural-language aliases: %v", tool, spec.Aliases)
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: missing RelatedActions", tool)
-		}
-		hasIssueGet := false
-		for _, ra := range spec.RelatedActions {
-			if ra == actionIssueGet {
-				hasIssueGet = true
+		t.Run(tool, func(t *testing.T) {
+			spec := byTool[tool]
+			if spec.Usage == "" || strings.Contains(spec.Usage, "domain action") {
+				t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
 			}
-		}
-		if !hasIssueGet {
-			t.Errorf("%s: RelatedActions should cross-link %q: %v", tool, actionIssueGet, spec.RelatedActions)
-		}
-		if len(spec.ParameterGuidance) == 0 {
-			t.Errorf("%s: missing ParameterGuidance", tool)
-		}
-		desc := spec.IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: IndividualTool.Description missing Returns/See also: %q", tool, desc)
-		}
+			// Must have at least one natural-language alias beyond the canonical name.
+			if len(spec.Aliases) < 2 {
+				t.Errorf("%s: missing natural-language aliases: %v", tool, spec.Aliases)
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s: missing RelatedActions", tool)
+			}
+			hasIssueGet := false
+			for _, ra := range spec.RelatedActions {
+				if ra == actionIssueGet {
+					hasIssueGet = true
+				}
+			}
+			if !hasIssueGet {
+				t.Errorf("%s: RelatedActions should cross-link %q: %v", tool, actionIssueGet, spec.RelatedActions)
+			}
+			if len(spec.ParameterGuidance) == 0 {
+				t.Errorf("%s: missing ParameterGuidance", tool)
+			}
+			desc := spec.IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s: IndividualTool.Description missing Returns/See also: %q", tool, desc)
+			}
+		})
 	}
 }
 

--- a/internal/tools/issuelinks/action_specs_test.go
+++ b/internal/tools/issuelinks/action_specs_test.go
@@ -4,6 +4,7 @@ package issuelinks
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -145,6 +146,34 @@ func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
 // Usage (no generic placeholder), natural-language aliases, canonical
 // RelatedActions cross-links, ParameterGuidance, and IndividualTool.Description
 // with "Returns:" / "See also:" guidance for every issue link tool.
+// assertIssueLinkSpecMetadata checks one spec for the metadata every issue
+// link tool must carry: a specific Usage, natural-language aliases, a
+// RelatedActions cross-link to issue.get, parameter guidance, and the
+// Returns/See also description.
+func assertIssueLinkSpecMetadata(t *testing.T, tool string, spec toolutil.ActionSpec) {
+	t.Helper()
+	if spec.Usage == "" || strings.Contains(spec.Usage, "domain action") {
+		t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
+	}
+	// Must have at least one natural-language alias beyond the canonical name.
+	if len(spec.Aliases) < 2 {
+		t.Errorf("%s: missing natural-language aliases: %v", tool, spec.Aliases)
+	}
+	if len(spec.RelatedActions) == 0 {
+		t.Errorf("%s: missing RelatedActions", tool)
+	}
+	if !slices.Contains(spec.RelatedActions, actionIssueGet) {
+		t.Errorf("%s: RelatedActions should cross-link %q: %v", tool, actionIssueGet, spec.RelatedActions)
+	}
+	if len(spec.ParameterGuidance) == 0 {
+		t.Errorf("%s: missing ParameterGuidance", tool)
+	}
+	desc := spec.IndividualTool.Description
+	if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+		t.Errorf("%s: IndividualTool.Description missing Returns/See also: %q", tool, desc)
+	}
+}
+
 func TestActionSpecs_Metadata(t *testing.T) {
 	byTool := issueLinkSpecsByTool(t, ActionSpecs(testutil.NewTestClient(t, issueLinksActionHandler())))
 
@@ -153,33 +182,7 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		"gitlab_issue_link_create", "gitlab_issue_link_delete",
 	} {
 		t.Run(tool, func(t *testing.T) {
-			spec := byTool[tool]
-			if spec.Usage == "" || strings.Contains(spec.Usage, "domain action") {
-				t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
-			}
-			// Must have at least one natural-language alias beyond the canonical name.
-			if len(spec.Aliases) < 2 {
-				t.Errorf("%s: missing natural-language aliases: %v", tool, spec.Aliases)
-			}
-			if len(spec.RelatedActions) == 0 {
-				t.Errorf("%s: missing RelatedActions", tool)
-			}
-			hasIssueGet := false
-			for _, ra := range spec.RelatedActions {
-				if ra == actionIssueGet {
-					hasIssueGet = true
-				}
-			}
-			if !hasIssueGet {
-				t.Errorf("%s: RelatedActions should cross-link %q: %v", tool, actionIssueGet, spec.RelatedActions)
-			}
-			if len(spec.ParameterGuidance) == 0 {
-				t.Errorf("%s: missing ParameterGuidance", tool)
-			}
-			desc := spec.IndividualTool.Description
-			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-				t.Errorf("%s: IndividualTool.Description missing Returns/See also: %q", tool, desc)
-			}
+			assertIssueLinkSpecMetadata(t, tool, byTool[tool])
 		})
 	}
 }

--- a/internal/tools/issuelinks/issuelinks_test.go
+++ b/internal/tools/issuelinks/issuelinks_test.go
@@ -520,9 +520,11 @@ func TestFormatOutputMarkdown_Populated(t *testing.T) {
 		{"target", "**Target Issue**: IID 8 (project 20)"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 
@@ -571,9 +573,11 @@ func TestFormatListMarkdown_Populated(t *testing.T) {
 		{"row2 link type", "blocks"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/issuenotes/issue_notes_test.go
+++ b/internal/tools/issuenotes/issue_notes_test.go
@@ -480,9 +480,11 @@ func TestFormatOutputMarkdown_Populated(t *testing.T) {
 		{"body", "Full note body"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 
@@ -551,9 +553,11 @@ func TestFormatListMarkdown_Populated(t *testing.T) {
 		{"bob row", "| 2 | bob |"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/issues/issues_test.go
+++ b/internal/tools/issues/issues_test.go
@@ -1456,12 +1456,14 @@ func TestIssueInputSchemas_DoNotRequireOptionalMilestone(t *testing.T) {
 		"create": toolutil.RouteAction[CreateInput, Output]((*gitlabclient.Client)(nil), Create),
 		"update": toolutil.RouteAction[UpdateInput, Output]((*gitlabclient.Client)(nil), Update),
 	} {
-		schema := route.InputSchema
-		for _, field := range schemaRequiredFields(schema) {
-			if field == "milestone_id" {
-				t.Fatalf("%s schema required fields = %v, want milestone_id optional", name, schema["required"])
+		t.Run(name, func(t *testing.T) {
+			schema := route.InputSchema
+			for _, field := range schemaRequiredFields(schema) {
+				if field == "milestone_id" {
+					t.Fatalf("%s schema required fields = %v, want milestone_id optional", name, schema["required"])
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -1543,9 +1545,11 @@ func TestFormatMarkdown_Populated(t *testing.T) {
 		"Details here", "https://gitlab.example.com/issue/10",
 		"Tasks", "3/5", "Comments", "7",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1575,9 +1579,11 @@ func TestFormatListMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
 	for _, want := range []string{"Issue1", "Issue2", "alice", "bob", "#1", "#2"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1615,9 +1621,11 @@ func TestFormatListGroupMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"GroupIssue", "carol", "#5", "feat", "Group Issues"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListGroupMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListGroupMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1655,9 +1663,11 @@ func TestFormatListAllMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"AllIssue", "dave", "#100", "doc", "All Issues"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListAllMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListAllMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1694,9 +1704,11 @@ func TestFormatTodoMarkdown_Populated(t *testing.T) {
 		State: "pending", CreatedAt: testCreatedAtCov,
 	})
 	for _, want := range []string{"Todo #1", "marked", "Issue", "Bug fix", "pending", "1 Jan 2026", "https://gitlab.example.com/todo/1"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatTodoMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatTodoMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1717,9 +1729,11 @@ func TestFormatTimeStatsMarkdown_Populated(t *testing.T) {
 		TotalTimeSpent:      3600,
 	})
 	for _, want := range []string{"Time Tracking", "3h", "1h", "10800", "3600"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatTimeStatsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatTimeStatsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1740,9 +1754,11 @@ func TestFormatParticipantsMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{"Participants (2)", "alice", "bob", "Alice A", "Bob B"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatParticipantsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatParticipantsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1763,9 +1779,11 @@ func TestFormatRelatedMRsMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	}, "Related MRs")
 	for _, want := range []string{"Related MRs", "Fix MR", "merged", "@carol", "fix", "main", "!3"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatRelatedMRsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatRelatedMRsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2155,9 +2173,11 @@ func TestFormatMarkdown_ObjectDerivedFields(t *testing.T) {
 		WebURL:    "https://example.com/7",
 	})
 	for _, want := range []string{"obj-author", "@obj-assignee", "@obj-closer"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -3219,9 +3239,11 @@ func TestListMRsClosing_KeysetOrderSort(t *testing.T) {
 		t.Fatalf("ListMRsClosing keyset: %v", err)
 	}
 	for _, want := range []string{"order_by=created_at", "sort=asc", "pagination=keyset", "page_token=42"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -3247,9 +3269,11 @@ func TestListMRsRelated_KeysetOrderSort(t *testing.T) {
 		t.Fatalf("ListMRsRelated keyset: %v", err)
 	}
 	for _, want := range []string{"order_by=updated_at", "sort=desc", "pagination=keyset", "page_token=7"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -3960,9 +3984,11 @@ func TestList_AdvancedFilters(t *testing.T) {
 				"page_token":             "tok123",
 			}
 			for k, want := range checks {
-				if got := q.Get(k); got != want {
-					t.Errorf("query %q = %q, want %q", k, got, want)
-				}
+				t.Run(k, func(t *testing.T) {
+					if got := q.Get(k); got != want {
+						t.Errorf("query %q = %q, want %q", k, got, want)
+					}
+				})
 			}
 			if got := q["iids[]"]; len(got) != 2 || got[0] != "10" || got[1] != "11" {
 				t.Errorf("iids[] = %v, want [10 11]", got)

--- a/internal/tools/issuestatistics/issuestatistics_test.go
+++ b/internal/tools/issuestatistics/issuestatistics_test.go
@@ -156,9 +156,11 @@ func TestFormatMarkdown_Populated(t *testing.T) {
 		{"table header status", "| Status | Count |"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 
@@ -175,9 +177,11 @@ func TestFormatMarkdown_Empty(t *testing.T) {
 		{"closed zero", "| Closed | 0 |"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.want) {
-			t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.want) {
+				t.Errorf("%s: missing %q in:\n%s", c.label, c.want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/iterationdata/iterationdata_test.go
+++ b/internal/tools/iterationdata/iterationdata_test.go
@@ -71,21 +71,24 @@ func TestFormatOutputMarkdown_WithHint(t *testing.T) {
 // TestStateName_AllStates verifies StateName maps all GitLab iteration states.
 func TestStateName_AllStates(t *testing.T) {
 	tests := []struct {
+		name     string
 		state    int64
 		expected string
 	}{
-		{1, "opened"},
-		{2, "upcoming"},
-		{3, "current"},
-		{4, "closed"},
-		{0, "unknown(0)"},
-		{99, "unknown(99)"},
+		{"opened", 1, "opened"},
+		{"upcoming", 2, "upcoming"},
+		{"current", 3, "current"},
+		{"closed", 4, "closed"},
+		{"zero_unknown", 0, "unknown(0)"},
+		{"out_of_range_unknown", 99, "unknown(99)"},
 	}
 	for _, tt := range tests {
-		got := StateName(tt.state)
-		if got != tt.expected {
-			t.Errorf("StateName(%d) = %q, want %q", tt.state, got, tt.expected)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := StateName(tt.state)
+			if got != tt.expected {
+				t.Errorf("StateName(%d) = %q, want %q", tt.state, got, tt.expected)
+			}
+		})
 	}
 }
 

--- a/internal/tools/jobs/action_specs_test.go
+++ b/internal/tools/jobs/action_specs_test.go
@@ -290,9 +290,11 @@ func TestFormatOutputMarkdown_OptionalBranches(t *testing.T) {
 		"admin",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -1737,9 +1737,11 @@ func TestPlay_WithJobInputs_ForwardsInRequestBody(t *testing.T) {
 	}
 	body, _ := gotBody.Load().(string)
 	for _, want := range []string{`"job_inputs"`, `"environment":"staging"`, `"replicas":3`, `"debug":true`, `"regions":["eu","us"]`} {
-		if !strings.Contains(body, want) {
-			t.Errorf("request body = %s, want it to contain %s", body, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("request body = %s, want it to contain %s", body, want)
+			}
+		})
 	}
 }
 
@@ -1847,9 +1849,11 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		"**Created**:",
 		"https://gitlab.example.com/-/jobs/100",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1890,9 +1894,11 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		"**Coverage**",
 		"**User**",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1924,9 +1930,11 @@ func TestFormatListMarkdown_WithJobs(t *testing.T) {
 		"45.5s",
 		"12.3s",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1976,9 +1984,11 @@ func TestFormatTraceMarkdown_WithData(t *testing.T) {
 		"Running with gitlab-runner 15.0.0",
 		"Job succeeded",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "Truncated") {
 		t.Error("should not contain truncation warning")
@@ -2036,9 +2046,11 @@ func TestFormatBridgeListMarkdown_WithData(t *testing.T) {
 		"failed",
 		"#50",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2069,9 +2081,11 @@ func TestFormatArtifactsMarkdown_WithJobID(t *testing.T) {
 		"**Size**: 2048 bytes",
 		"base64-encoded",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "Truncated") {
 		t.Error("should not contain truncation warning")
@@ -2121,9 +2135,11 @@ func TestFormatSingleArtifactMarkdown_WithJobID(t *testing.T) {
 		"test report content",
 		"```",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/jobtokenscope/jobtokenscope_test.go
+++ b/internal/tools/jobtokenscope/jobtokenscope_test.go
@@ -645,9 +645,11 @@ func TestFormatListInboundAllowlistMarkdown_WithData(t *testing.T) {
 		"proj-b",
 		"grp/proj-a",
 	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown missing %q:\n%s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown missing %q:\n%s", want, text)
+			}
+		})
 	}
 }
 
@@ -695,9 +697,11 @@ func TestFormatListGroupAllowlistMarkdown_WithData(t *testing.T) {
 		"group-b",
 		"org/group-b",
 	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown missing %q:\n%s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown missing %q:\n%s", want, text)
+			}
+		})
 	}
 }
 

--- a/internal/tools/labels/labels_test.go
+++ b/internal/tools/labels/labels_test.go
@@ -898,9 +898,11 @@ func TestFormatMarkdown_AllFields(t *testing.T) {
 	}
 	md := FormatMarkdown(o)
 	for _, want := range []string{"bug", "#d9534f", "Bug report", "Priority", "3", "Issues", "5 open", "2 closed", "Open MRs", "1"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/license/license_test.go
+++ b/internal/tools/license/license_test.go
@@ -195,9 +195,11 @@ func TestFormatLicenseMarkdown_WithDates(t *testing.T) {
 	result := FormatLicenseMarkdown(item)
 	text := result.Content[0].(*mcp.TextContent).Text
 	for _, want := range []string{"ultimate", "1 Jan 2026", "31 Dec 2026", "Jane", "Corp", "true"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("missing %q in markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("missing %q in markdown", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/license/license_test.go
+++ b/internal/tools/license/license_test.go
@@ -116,11 +116,20 @@ func TestDelete_InvalidID(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
-	for _, id := range []int64{0, -1} {
-		err := Delete(t.Context(), client, DeleteInput{ID: id})
-		if err == nil {
-			t.Errorf("expected error for ID %d", id)
-		}
+	cases := []struct {
+		name string
+		id   int64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Delete(t.Context(), client, DeleteInput{ID: tc.id})
+			if err == nil {
+				t.Errorf("expected error for ID %d", tc.id)
+			}
+		})
 	}
 }
 

--- a/internal/tools/licensetemplates/licensetemplates_test.go
+++ b/internal/tools/licensetemplates/licensetemplates_test.go
@@ -133,9 +133,11 @@ func TestFormatGetMarkdown_AllFields(t *testing.T) {
 		Content:     "Apache License text here",
 	})
 	for _, want := range []string{"Apache 2.0", "A permissive license", "commercial-use", "include-copyright", "no-liability", "Apache License text here"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown output", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown output", want)
+			}
+		})
 	}
 	if strings.Contains(md, "- **Permissions**") {
 		t.Error("license details should use unbulleted field labels")

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -103,9 +103,11 @@ func TestFormatProject_Markdown(t *testing.T) {
 		"**Description**: A test project", "**URL**: [https://gitlab.example.com/group/my-project](https://gitlab.example.com/group/my-project)",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("missing %q in:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("missing %q in:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -285,9 +287,11 @@ func TestFormatMR_Markdown(t *testing.T) {
 		"@dev1", "enhancement", "@dev2", "@dev3",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf(fmtMissing, c)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf(fmtMissing, c)
+			}
+		})
 	}
 }
 
@@ -513,9 +517,11 @@ func TestFormatGroup_Markdown(t *testing.T) {
 		"**Parent ID**: 5",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf(fmtMissing, c)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf(fmtMissing, c)
+			}
+		})
 	}
 }
 
@@ -563,9 +569,11 @@ func TestFormatIssue_Markdown(t *testing.T) {
 		mdDescriptionHdr, "Something is broken",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf(fmtMissing, c)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf(fmtMissing, c)
+			}
+		})
 	}
 }
 
@@ -753,9 +761,11 @@ func TestFormatPipeline_DetailMarkdown(t *testing.T) {
 	md := pipelines.FormatDetailMarkdown(p)
 	checks := []string{"Pipeline #100", "success", "**Duration**: 120s", "**Coverage**: 85.5%", "**User**: admin"}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf(fmtMissing, c)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf(fmtMissing, c)
+			}
+		})
 	}
 }
 
@@ -862,9 +872,11 @@ func TestFormatCommit_DetailMarkdown(t *testing.T) {
 	md := commits.FormatDetailMarkdown(c)
 	checks := []string{"## Commit abc1234", "+10 -3", "parent1, parent2", "### Message"}
 	for _, ch := range checks {
-		if !strings.Contains(md, ch) {
-			t.Errorf(fmtMissing, ch)
-		}
+		t.Run(ch, func(t *testing.T) {
+			if !strings.Contains(md, ch) {
+				t.Errorf(fmtMissing, ch)
+			}
+		})
 	}
 }
 
@@ -1109,9 +1121,11 @@ func TestFormatJob_Markdown(t *testing.T) {
 	md := jobs.FormatOutputMarkdown(j)
 	checks := []string{"Job #200", "build", "**Stage**: build", "**Failure Reason**: script_failure", "45.5s"}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf(fmtMissing, c)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf(fmtMissing, c)
+			}
+		})
 	}
 }
 

--- a/internal/tools/memberroles/member_roles_test.go
+++ b/internal/tools/memberroles/member_roles_test.go
@@ -687,14 +687,18 @@ func TestCreateInstance_WithAllPermissions(t *testing.T) {
 		t.Error("expected RemoveProject to be true")
 	}
 	for _, want := range []string{"name", "base_access_level", "description", "admin_cicd_variables", "admin_merge_request", "read_code", "remove_project", "manage_deploy_tokens", "admin_vulnerability"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 	for _, want := range []string{`"name":"full-perms"`, `"base_access_level":30`, `"description":"All permissions"`} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing %s; got %s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing %s; got %s", want, capturedBody)
+			}
+		})
 	}
 }
 

--- a/internal/tools/members/members_test.go
+++ b/internal/tools/members/members_test.go
@@ -238,9 +238,11 @@ func TestProjectMembersList_AllListOptions(t *testing.T) {
 			"page_token":     "tok42",
 		}
 		for key, want := range checks {
-			if got := q.Get(key); got != want {
-				t.Errorf("query %s = %q, want %q", key, got, want)
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := q.Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			})
 		}
 		if got := q["user_ids[]"]; len(got) != 2 || got[0] != "10" || got[1] != "20" {
 			t.Errorf("query user_ids[] = %v, want [10 20]", got)

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -766,10 +766,12 @@ func TestPrefixAt(t *testing.T) {
 	if len(got) != len(want) {
 		t.Fatalf("prefixAt length = %d, want %d", len(got), len(want))
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("prefixAt[%d] = %q, want %q", i, got[i], want[i])
-		}
+	for i, w := range want {
+		t.Run(w, func(t *testing.T) {
+			if got[i] != w {
+				t.Errorf("prefixAt[%d] = %q, want %q", i, got[i], w)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mergerequests/mergerequests_test.go
+++ b/internal/tools/mergerequests/mergerequests_test.go
@@ -1803,9 +1803,11 @@ func TestFormatMarkdown_Populated(t *testing.T) {
 		testLabelBug, "enhancement", "1 Jan 2026", "Comments", "5",
 		"Full description here", testMRWebURL,
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1827,9 +1829,11 @@ func TestFormatListMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
 	for _, want := range []string{"MR1", "MR2", testAuthorAlice, testAuthorBob, "📝"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1845,9 +1849,11 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 func TestFormatApproveMarkdown_Populated(t *testing.T) {
 	md := FormatApproveMarkdown(ApproveOutput{Approved: true, ApprovalsRequired: 2, ApprovedBy: 1})
 	for _, want := range []string{"Approved", "true", "2", "1"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatApproveMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatApproveMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1868,9 +1874,11 @@ func TestFormatCommitsMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"abc1234", "feat: add login", "Alice", "1 Jan 2026"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatCommitsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatCommitsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1890,9 +1898,11 @@ func TestFormatPipelinesMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{"10", "success", "push", testBranchMain} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatPipelinesMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatPipelinesMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1929,9 +1939,11 @@ func TestFormatParticipantsMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{testAuthorAlice, testAuthorBob, "Alice A", "Bob B", testStateActive, "Participants (2)"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatParticipantsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatParticipantsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1951,9 +1963,11 @@ func TestFormatReviewersMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{testAuthorCarol, "Carol C", "reviewed", "1 Mar 2026", "Reviewers (1)"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatReviewersMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatReviewersMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1974,9 +1988,11 @@ func TestFormatIssuesClosedMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"Bug fix", testStateOpened, testAuthorAlice, testLabelBug, "#5"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatIssuesClosedMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatIssuesClosedMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -1995,9 +2011,11 @@ func TestFormatCreatePipelineMarkdown(t *testing.T) {
 		SHA: testSHAAbc, WebURL: "https://gitlab.example.com/pipelines/500",
 	})
 	for _, want := range []string{"500", testStatePending, "merge_request_event", testFeatureBranch, testSHAAbc, "https://gitlab.example.com/pipelines/500"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatCreatePipelineMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatCreatePipelineMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2019,9 +2037,11 @@ func TestFormatTimeStatsMarkdown_Populated(t *testing.T) {
 		TimeEstimate: 10800, TotalTimeSpent: 5400,
 	})
 	for _, want := range []string{"3h", "10800", "1h30m", "5400"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatTimeStatsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatTimeStatsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2045,9 +2065,11 @@ func TestFormatRelatedIssuesMarkdown_Populated(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
 	for _, want := range []string{"Related bug", testStateOpened, testAuthorAlice, testLabelBug, "critical", "#10"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatRelatedIssuesMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatRelatedIssuesMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2067,9 +2089,11 @@ func TestFormatCreateTodoMarkdown_Populated(t *testing.T) {
 		State: testStatePending,
 	})
 	for _, want := range []string{"42", testActionMarked, testTargetTypeMR, testMRTitle, testMRWebURL, testStatePending} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatCreateTodoMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatCreateTodoMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2145,9 +2169,11 @@ func TestFormatDependencyMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{testBlockerTitle, "!10", testStateOpened, testBranchFeatA, testBranchMain} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatDependencyMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatDependencyMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2168,9 +2194,11 @@ func TestFormatDependenciesMarkdown_Populated(t *testing.T) {
 		},
 	})
 	for _, want := range []string{testDepTitleA, "Dep B", "!10", "!20", testStateOpened, testStateMerged, "Dependencies (2)"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatDependenciesMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatDependenciesMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -4180,9 +4208,11 @@ func TestFormatMarkdown_MergedState(t *testing.T) {
 		ChangesCount:        "3", MergeUser: &toolutil.BasicUserOutput{Username: "alice"}, MergedAt: testCreatedAt,
 	})
 	for _, want := range []string{"group/project", "v1.0", "[#42](https://pipeline)", "3 files", "@alice"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in merged MR markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in merged MR markdown", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mergetrains/merge_trains_test.go
+++ b/internal/tools/mergetrains/merge_trains_test.go
@@ -441,7 +441,9 @@ func respondMergeTrainList(w http.ResponseWriter, body string) {
 func TestListProjectMergeTrains_KeysetAndOrdering(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for k, v := range map[string]string{"order_by": "id", "sort": "desc", "pagination": "keyset", "page_token": "tok"} {
-			testutil.AssertQueryParam(t, r, k, v)
+			t.Run(k, func(t *testing.T) {
+				testutil.AssertQueryParam(t, r, k, v)
+			})
 		}
 		testutil.RespondJSONWithPagination(w, http.StatusOK, `[]`,
 			testutil.PaginationHeaders{Page: "1", PerPage: "20", Total: "0", TotalPages: "0"})
@@ -462,7 +464,9 @@ func TestListProjectMergeTrains_KeysetAndOrdering(t *testing.T) {
 func TestListMergeRequestInMergeTrain_KeysetAndOrdering(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for k, v := range map[string]string{"order_by": "id", "pagination": "keyset", "page_token": "tok"} {
-			testutil.AssertQueryParam(t, r, k, v)
+			t.Run(k, func(t *testing.T) {
+				testutil.AssertQueryParam(t, r, k, v)
+			})
 		}
 		testutil.RespondJSONWithPagination(w, http.StatusOK, `[]`,
 			testutil.PaginationHeaders{Page: "1", PerPage: "20", Total: "0", TotalPages: "0"})

--- a/internal/tools/milestones/milestones_test.go
+++ b/internal/tools/milestones/milestones_test.go
@@ -1044,9 +1044,11 @@ func TestFormatMarkdown_AllFields(t *testing.T) {
 	}
 	md := FormatMarkdown(o)
 	for _, want := range []string{"v1.0", "active", "First release", "Start Date", "Due Date", "Created", "Updated", "URL"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mrapprovals/mrapprovals_test.go
+++ b/internal/tools/mrapprovals/mrapprovals_test.go
@@ -888,9 +888,11 @@ func TestReset_NotFoundMentionsAccessTokenRequirement(t *testing.T) {
 		t.Fatal("expected error for 404 response")
 	}
 	for _, want := range []string{"bot user", "project/group access token", "PATs from human users"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mrchanges/mrchanges_test.go
+++ b/internal/tools/mrchanges/mrchanges_test.go
@@ -340,14 +340,18 @@ func TestFormatOutputMarkdown_WithChanges(t *testing.T) {
 		"| new_name.go | renamed from old_name.go |",
 		"diff_versions_list",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	for _, absent := range []string{"raw_diffs", "truncation"} {
-		if strings.Contains(md, absent) {
-			t.Errorf("markdown should not contain %q when no files are truncated:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("markdown should not contain %q when no files are truncated:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -372,9 +376,11 @@ func TestFormatOutputMarkdown_TruncatedFiles(t *testing.T) {
 		"huge_test.c",
 		"truncation",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "removed.go") && strings.Contains(md, "truncation") {
 		// Deleted files with empty diff should NOT be in truncation warning
@@ -420,9 +426,11 @@ func TestFormatDiffVersionsListMarkdown_WithVersions(t *testing.T) {
 		"abcdef12", // truncated to 8
 		"12345678", // truncated to 8
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	// Full SHA should not appear (truncated to 8)
 	if strings.Contains(md, "abcdef1234567890") {
@@ -485,9 +493,11 @@ func TestFormatDiffVersionGetMarkdown_Full(t *testing.T) {
 		"| renamed.go | renamed from original.go |",
 		"diff_versions_list",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "raw_diffs") {
 		t.Errorf("should not reference non-existent raw_diffs action:\n%s", md)
@@ -601,9 +611,11 @@ func TestFormatRawDiffsMarkdown_WithDiff(t *testing.T) {
 		"diff --git",
 		"```",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -779,9 +791,11 @@ func TestMRChangesGet_PaginationAndOptions(t *testing.T) {
 		t.Fatalf("Get() unexpected error: %v", err)
 	}
 	for _, want := range []string{"unidiff=true", "order_by=id", "sort=desc", "page=2", "per_page=50", "pagination=keyset", "page_token=tok123"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 	if len(out.Changes) != 1 {
 		t.Fatalf("len(Changes) = %d, want 1", len(out.Changes))
@@ -816,9 +830,11 @@ func TestListDiffVersions_PaginationAndOptions(t *testing.T) {
 		t.Fatalf("ListDiffVersions() unexpected error: %v", err)
 	}
 	for _, want := range []string{"order_by=id", "sort=asc", "page=3", "per_page=25", "pagination=keyset", "page_token=cur9"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mrcontextcommits/mrcontextcommits_test.go
+++ b/internal/tools/mrcontextcommits/mrcontextcommits_test.go
@@ -382,9 +382,11 @@ func TestFormatListMarkdown_ContentValidation(t *testing.T) {
 		"| def4 |",
 		"Dev2",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	// Pipe in title should be escaped

--- a/internal/tools/mrdiscussions/mr_discussions_test.go
+++ b/internal/tools/mrdiscussions/mr_discussions_test.go
@@ -781,9 +781,11 @@ func TestFormatNoteMarkdown_Full(t *testing.T) {
 		"**Resolved**: true",
 		"Looks good!",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -824,9 +826,11 @@ func TestFormatOutputMarkdown_Full(t *testing.T) {
 		"### Note 2 (by bob)",
 		"Reply",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -869,9 +873,11 @@ func TestFormatListMarkdown_WithDiscussions(t *testing.T) {
 		"false",
 		"true",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mrdraftnotes/mr_draft_notes_test.go
+++ b/internal/tools/mrdraftnotes/mr_draft_notes_test.go
@@ -782,9 +782,11 @@ func TestFormatOutputMarkdown_Full(t *testing.T) {
 		"### Body",
 		"Draft review comment",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -838,9 +840,11 @@ func TestFormatListMarkdown_WithDraftNotes(t *testing.T) {
 		"abcdef12", // commit truncated to 8 chars
 		"Short note",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	// Full 16-char commit should not appear (truncated to 8)
 	if strings.Contains(md, "abcdef1234567890") {
@@ -1291,9 +1295,11 @@ func TestFormatOutputMarkdown_PositionAndLineCode(t *testing.T) {
 		"**Line Code**: `code_3_4`",
 		"**Position**: `main.go` line 7",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/mrnotes/mr_notes_test.go
+++ b/internal/tools/mrnotes/mr_notes_test.go
@@ -629,9 +629,11 @@ func TestFormatOutputMarkdown_Full(t *testing.T) {
 		"@author",
 		"Looks good!",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -692,9 +694,11 @@ func TestFormatListMarkdown_WithNotes(t *testing.T) {
 	}
 	md := FormatListMarkdown(out)
 	for _, want := range []string{"## MR Notes (2)", "| 1 |", "| 2 |", "| ID |"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/orbit/action_specs_test.go
+++ b/internal/tools/orbit/action_specs_test.go
@@ -35,25 +35,27 @@ func TestActionSpecs_OrderAndCount(t *testing.T) {
 	}
 	wantNames := []string{"status", "schema", "tools", "dsl", "query", "graph_status"}
 	for i, want := range wantNames {
-		if specs[i].Name != want {
-			t.Fatalf("ActionSpecs()[%d].Name = %q, want %q", i, specs[i].Name, want)
-		}
-		if len(specs[i].Aliases) == 0 {
-			t.Fatalf("ActionSpecs()[%d].Aliases = %v, want first alias gitlab_orbit_%s", i, specs[i].Aliases, want)
-		}
-		if specs[i].Aliases[0] != "gitlab_orbit_"+want {
-			t.Fatalf("ActionSpecs()[%d].Aliases[0] = %q, want gitlab_orbit_%s (full list: %v)",
-				i, specs[i].Aliases[0], want, specs[i].Aliases)
-		}
-		if specs[i].OwnerPackage != "orbit" {
-			t.Fatalf("ActionSpecs()[%d].OwnerPackage = %q, want orbit", i, specs[i].OwnerPackage)
-		}
-		if !specs[i].GitLabDotComOnly || specs[i].Edition != "premium" {
-			t.Fatalf("ActionSpecs()[%d] gating = dotcom:%t edition:%q, want GitLab.com premium", i, specs[i].GitLabDotComOnly, specs[i].Edition)
-		}
-		if !specs[i].OpenWorld {
-			t.Fatalf("ActionSpecs()[%d].OpenWorld = false, want true", i)
-		}
+		t.Run(want, func(t *testing.T) {
+			if specs[i].Name != want {
+				t.Fatalf("ActionSpecs()[%d].Name = %q, want %q", i, specs[i].Name, want)
+			}
+			if len(specs[i].Aliases) == 0 {
+				t.Fatalf("ActionSpecs()[%d].Aliases = %v, want first alias gitlab_orbit_%s", i, specs[i].Aliases, want)
+			}
+			if specs[i].Aliases[0] != "gitlab_orbit_"+want {
+				t.Fatalf("ActionSpecs()[%d].Aliases[0] = %q, want gitlab_orbit_%s (full list: %v)",
+					i, specs[i].Aliases[0], want, specs[i].Aliases)
+			}
+			if specs[i].OwnerPackage != "orbit" {
+				t.Fatalf("ActionSpecs()[%d].OwnerPackage = %q, want orbit", i, specs[i].OwnerPackage)
+			}
+			if !specs[i].GitLabDotComOnly || specs[i].Edition != "premium" {
+				t.Fatalf("ActionSpecs()[%d] gating = dotcom:%t edition:%q, want GitLab.com premium", i, specs[i].GitLabDotComOnly, specs[i].Edition)
+			}
+			if !specs[i].OpenWorld {
+				t.Fatalf("ActionSpecs()[%d].OpenWorld = false, want true", i)
+			}
+		})
 	}
 }
 
@@ -136,9 +138,11 @@ func TestOrbit_ActionSpecs_Metadata(t *testing.T) {
 		names = append(names, spec.IndividualTool.Name)
 	}
 	for _, want := range []string{"gitlab_orbit_status", "gitlab_orbit_schema", "gitlab_orbit_tools", "gitlab_orbit_dsl", "gitlab_orbit_query", "gitlab_orbit_graph_status"} {
-		if !containsTool(names, want) {
-			t.Fatalf("ActionSpecs() missing %s in %v", want, names)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !containsTool(names, want) {
+				t.Fatalf("ActionSpecs() missing %s in %v", want, names)
+			}
+		})
 	}
 }
 

--- a/internal/tools/packages/markdown_test.go
+++ b/internal/tools/packages/markdown_test.go
@@ -39,9 +39,11 @@ func TestFormatPublishMarkdown_WithChecksumAndURL(t *testing.T) {
 		"**URL**: [https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz](https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz)",
 		"publish_and_link",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("FormatPublishMarkdown() = %q, want %q", got, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("FormatPublishMarkdown() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -58,9 +60,11 @@ func TestFormatDownloadMarkdown_WithChecksum(t *testing.T) {
 		"**SHA256**: abcdef",
 		"file_list",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("FormatDownloadMarkdown() = %q, want %q", got, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("FormatDownloadMarkdown() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -89,9 +93,11 @@ func TestFormatPublishAndLinkMarkdown_RendersBothSections(t *testing.T) {
 		"**Name**: app.tar.gz",
 		"**URL**: [https://gitlab.example.com/release/app.tar.gz](https://gitlab.example.com/release/app.tar.gz)",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("FormatPublishAndLinkMarkdown() = %q, want %q", got, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("FormatPublishAndLinkMarkdown() = %q, want %q", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/packages/packages_composite_test.go
+++ b/internal/tools/packages/packages_composite_test.go
@@ -250,9 +250,11 @@ func TestPackagePublishAndLink_ContextCancelled(t *testing.T) {
 func TestPackagePublishDirectory_Success(t *testing.T) {
 	dir := t.TempDir()
 	for _, name := range []string{"a.tar.gz", "b.tar.gz", "readme.md"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("content-"+name), 0o600); err != nil {
-			t.Fatalf("write file: %v", err)
-		}
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("content-"+name), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		})
 	}
 
 	publishCount := 0
@@ -298,9 +300,11 @@ func TestPackagePublishDirectory_Success(t *testing.T) {
 func TestPackagePublishDirectory_WithPattern(t *testing.T) {
 	dir := t.TempDir()
 	for _, name := range []string{"a.tar.gz", "b.tar.gz", "readme.md", "notes.txt"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o600); err != nil {
-			t.Fatalf("write file: %v", err)
-		}
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		})
 	}
 
 	publishCount := 0
@@ -584,9 +588,11 @@ func TestPackagePublishDirectory_ContextCancelled(t *testing.T) {
 func TestPackagePublishDirectory_CancelledDuringLoop(t *testing.T) {
 	dir := t.TempDir()
 	for _, name := range []string{"a.bin", "b.bin"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o600); err != nil {
-			t.Fatalf("write file: %v", err)
-		}
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		})
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -775,9 +781,11 @@ func TestPublishDirectory_ProgressSequenceOnlyIncreases(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]int{"a.bin": 200 * 1024, "b.bin": 320 * 1024}
 	for name, size := range files {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(strings.Repeat("x", size)), 0o600); err != nil {
-			t.Fatalf("writing %s: %v", name, err)
-		}
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(strings.Repeat("x", size)), 0o600); err != nil {
+				t.Fatalf("writing %s: %v", name, err)
+			}
+		})
 	}
 
 	var wantTotal float64

--- a/internal/tools/pipelines/pipelines_test.go
+++ b/internal/tools/pipelines/pipelines_test.go
@@ -1342,9 +1342,11 @@ func TestFormatListMarkdown_WithPipelines(t *testing.T) {
 		"abc123de", // SHA truncated to 8 chars
 		"short",    // SHA shorter than 8 kept as-is
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1431,9 +1433,11 @@ func TestFormatDetailMarkdown_Full(t *testing.T) {
 		"**User**: testuser",
 		"**URL**:",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1461,9 +1465,11 @@ func TestFormatDetailMarkdown_Minimal(t *testing.T) {
 		"**YAML Errors**",
 		"**User**",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1489,9 +1495,11 @@ func TestFormatVariablesMarkdown_WithData(t *testing.T) {
 		"env_var",
 		"file",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1546,9 +1554,11 @@ func TestFormatTestReportMarkdown_WithSuites(t *testing.T) {
 		"60.00s",
 		"60.50s",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1596,9 +1606,11 @@ func TestFormatTestReportSummaryMarkdown_WithSuites(t *testing.T) {
 		"Unit",
 		"100.00s",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -2076,9 +2088,11 @@ func TestCreate_WithInputs(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/v4/projects/42/pipeline" {
 			body, _ := io.ReadAll(r.Body)
 			for _, want := range []string{`"environment":"production"`, `"replicas":3`, `"debug":false`, `"regions":["us","eu"]`} {
-				if !strings.Contains(string(body), want) {
-					t.Errorf("request body missing %q:\n%s", want, body)
-				}
+				t.Run(want, func(t *testing.T) {
+					if !strings.Contains(string(body), want) {
+						t.Errorf("request body missing %q:\n%s", want, body)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusCreated, pipelineDetailJSON)
 			return

--- a/internal/tools/pipelineschedules/action_specs_test.go
+++ b/internal/tools/pipelineschedules/action_specs_test.go
@@ -59,17 +59,19 @@ func TestActionSpecs_VariableValueGuidance(t *testing.T) {
 	byTool := pipelineScheduleSpecsByTool(t, ActionSpecs(testutil.NewTestClient(t, pipelineScheduleActionHandler())))
 
 	for _, toolName := range []string{"gitlab_pipeline_schedule_create_variable", "gitlab_pipeline_schedule_edit_variable"} {
-		guidance := byTool[toolName].ParameterGuidance["value"]
-		if guidance.SemanticRole != "pipeline_schedule_variable_value" {
-			t.Fatalf("%s value SemanticRole = %q, want pipeline_schedule_variable_value", toolName, guidance.SemanticRole)
-		}
-		if !strings.Contains(guidance.ValueSource, "Supply an explicit value") {
-			t.Fatalf("%s value ValueSource = %q, want explicit value guidance", toolName, guidance.ValueSource)
-		}
-		description := schemaPropertyDescription(t, byTool[toolName].Route.InputSchema, "value")
-		if !strings.Contains(description, "Required") {
-			t.Fatalf("%s value schema description = %q, want required guidance", toolName, description)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			guidance := byTool[toolName].ParameterGuidance["value"]
+			if guidance.SemanticRole != "pipeline_schedule_variable_value" {
+				t.Fatalf("%s value SemanticRole = %q, want pipeline_schedule_variable_value", toolName, guidance.SemanticRole)
+			}
+			if !strings.Contains(guidance.ValueSource, "Supply an explicit value") {
+				t.Fatalf("%s value ValueSource = %q, want explicit value guidance", toolName, guidance.ValueSource)
+			}
+			description := schemaPropertyDescription(t, byTool[toolName].Route.InputSchema, "value")
+			if !strings.Contains(description, "Required") {
+				t.Fatalf("%s value schema description = %q, want required guidance", toolName, description)
+			}
+		})
 	}
 }
 

--- a/internal/tools/pipelineschedules/pipelineschedules_test.go
+++ b/internal/tools/pipelineschedules/pipelineschedules_test.go
@@ -1539,9 +1539,11 @@ func TestToOutput_AllOptionalFields(t *testing.T) {
 		"| Created | 1 Jan 2026 00:00 UTC |",
 		"| Updated | 7 Mar 2026 12:00 UTC |",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("markdown missing %q:\n%s", want, out)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("markdown missing %q:\n%s", want, out)
+			}
+		})
 	}
 }
 
@@ -1577,9 +1579,11 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		"| Created |",
 		"| Updated |",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1609,9 +1613,11 @@ func TestFormatListMarkdown_WithSchedules(t *testing.T) {
 		"admin",
 		"user1",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1640,9 +1646,11 @@ func TestFormatVariableMarkdown_WithType(t *testing.T) {
 		"**Value**: hello",
 		"**Type**: env_var",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1682,9 +1690,11 @@ func TestFormatTriggeredPipelinesMarkdown_WithData(t *testing.T) {
 		"failed",
 		"schedule",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/pipelinetriggers/pipelinetriggers_test.go
+++ b/internal/tools/pipelinetriggers/pipelinetriggers_test.go
@@ -368,9 +368,11 @@ func TestListTriggers_OrderBySort(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=id", "sort=desc", "pagination=keyset", "page_token=5"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query = %q, want to contain %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query = %q, want to contain %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -825,9 +827,11 @@ func TestFormatTriggerMarkdown_AllFields(t *testing.T) {
 		"1 Jan 2026 00:00 UTC",
 		"1 Dec 2026 00:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -846,9 +850,11 @@ func TestFormatTriggerMarkdown_MinimalFields(t *testing.T) {
 		"| Created |",
 		"| Last Used |",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -879,9 +885,11 @@ func TestFormatListTriggersMarkdown_DetailedContent(t *testing.T) {
 		"admin",
 		"user1",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -904,9 +912,11 @@ func TestFormatRunOutputMarkdown_WithoutWebURL(t *testing.T) {
 		"| Ref | develop |",
 		"| Status | pending |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "| URL |") {
 		t.Errorf("should not contain URL row when WebURL is empty:\n%s", md)
@@ -928,9 +938,11 @@ func TestFormatRunOutputMarkdown_AllFields(t *testing.T) {
 		"| Pipeline ID | 99 |",
 		"| URL | [Pipeline #99](https://gl/p/1/-/pipelines/99) |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/planlimits/planlimits_test.go
+++ b/internal/tools/planlimits/planlimits_test.go
@@ -171,9 +171,11 @@ func TestFormatGetMarkdown_AllFields(t *testing.T) {
 	}
 	md := FormatGetMarkdown(out)
 	for _, want := range []string{"100", "200", "300", "400", "500", "600", "700", "800", "Plan Limits"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown", want)
+			}
+		})
 	}
 }
 
@@ -198,9 +200,11 @@ func TestFormatChangeMarkdown_AllFields(t *testing.T) {
 		t.Error("missing title")
 	}
 	for _, want := range []string{"Conan", "Generic", "Helm", "Maven", "NPM", "NuGet", "PyPI", "Terraform"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projectaliases/project_aliases_test.go
+++ b/internal/tools/projectaliases/project_aliases_test.go
@@ -317,9 +317,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 		"gitlab_list_project_aliases",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -341,9 +343,11 @@ func TestFormatListMarkdown_WithAliases(t *testing.T) {
 		"| 2 | `beta` | 200 |",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdown missing %q in:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "No project aliases found") {
 		t.Error("non-empty list should not contain empty message")

--- a/internal/tools/projectdiscovery/projectdiscovery_test.go
+++ b/internal/tools/projectdiscovery/projectdiscovery_test.go
@@ -310,9 +310,11 @@ func TestFormatMarkdown_OutputContainsProjectInfo(t *testing.T) {
 		"private",
 	}
 	for _, want := range checks {
-		if !contains(md, want) {
-			t.Errorf("FormatMarkdown() output missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !contains(md, want) {
+				t.Errorf("FormatMarkdown() output missing %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projectdiscovery/projectdiscovery_test.go
+++ b/internal/tools/projectdiscovery/projectdiscovery_test.go
@@ -462,9 +462,11 @@ func TestResolve_AllOutputFields(t *testing.T) {
 		{"ExtractedPath", out.ExtractedPath, "group/subgroup/my-project"},
 	}
 	for _, c := range checks {
-		if c.got != c.want {
-			t.Errorf(fmtWantField, c.field, c.got, c.want)
-		}
+		t.Run(c.field, func(t *testing.T) {
+			if c.got != c.want {
+				t.Errorf(fmtWantField, c.field, c.got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projectimportexport/projectimportexport_test.go
+++ b/internal/tools/projectimportexport/projectimportexport_test.go
@@ -572,9 +572,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		"gitlab_download_project_export",
 		"gitlab_get_project_import_status",
 	} {
-		if !byTool[name].ReadOnly || !byTool[name].Idempotent {
-			t.Errorf("%s should be read-only and idempotent", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly || !byTool[name].Idempotent {
+				t.Errorf("%s should be read-only and idempotent", name)
+			}
+		})
 	}
 }
 
@@ -812,9 +814,11 @@ func TestImportFromFile_OverrideParams(t *testing.T) {
 				return
 			}
 			for key, want := range wantParams {
-				if got := r.FormValue(key); got != want {
-					t.Errorf("%s = %q, want %q", key, got, want)
-				}
+				t.Run(key, func(t *testing.T) {
+					if got := r.FormValue(key); got != want {
+						t.Errorf("%s = %q, want %q", key, got, want)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusCreated,
 				`{"id":99,"name":"p","path":"p","path_with_namespace":"g/p","import_status":"scheduled"}`)

--- a/internal/tools/projectmirrors/project_mirrors_test.go
+++ b/internal/tools/projectmirrors/project_mirrors_test.go
@@ -177,9 +177,11 @@ func TestList_KeysetAndOrdering(t *testing.T) {
 		"pagination": "keyset",
 		"page_token": "abc",
 	} {
-		if got.Get(key) != want {
-			t.Errorf("query %q = %q, want %q", key, got.Get(key), want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got.Get(key) != want {
+				t.Errorf("query %q = %q, want %q", key, got.Get(key), want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projects/action_specs_test.go
+++ b/internal/tools/projects/action_specs_test.go
@@ -259,9 +259,11 @@ func TestLegacyOutputWrappers_ReturnMessages(t *testing.T) {
 func TestProjectOptions_PushRuleAddGuidance(t *testing.T) {
 	options := projectOptions("gitlab_project_add_push_rule", "push_rule")
 	for _, want := range []string{"at least one rule-setting parameter", "commit_message_regex", "project_id alone"} {
-		if !strings.Contains(options.Usage, want) {
-			t.Fatalf("Usage = %q, want %q", options.Usage, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(options.Usage, want) {
+				t.Fatalf("Usage = %q, want %q", options.Usage, want)
+			}
+		})
 	}
 	if _, ok := options.ParameterGuidance["commit_message_regex"]; !ok {
 		t.Fatalf("ParameterGuidance = %#v, want commit_message_regex guidance", options.ParameterGuidance)
@@ -278,9 +280,11 @@ func TestActionSpecs_ProjectGetAndListGuidance(t *testing.T) {
 
 	getSpec := projectActionSpecByTool(t, specs, "gitlab_project_get")
 	for _, want := range []string{"exact project", "group/project", "Do not use search.projects"} {
-		if !strings.Contains(getSpec.Usage, want) {
-			t.Fatalf("get Usage = %q, want %q", getSpec.Usage, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(getSpec.Usage, want) {
+				t.Fatalf("get Usage = %q, want %q", getSpec.Usage, want)
+			}
+		})
 	}
 	if guidance := getSpec.ParameterGuidance["project_id"]; guidance.SemanticRole != "scope_project" || !strings.Contains(guidance.ValueSource, "full namespace path") {
 		t.Fatalf("project_id guidance = %+v, want namespace path guidance", guidance)

--- a/internal/tools/projects/mirroring_test.go
+++ b/internal/tools/projects/mirroring_test.go
@@ -85,9 +85,11 @@ func TestGetPullMirror_NotMirroredHint(t *testing.T) {
 		t.Fatal(errExpectedAPI)
 	}
 	for _, want := range []string{"not mirrored", "pull_mirror_configure", "pull_mirror_get"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -2614,9 +2614,11 @@ func TestAddPushRule_RequiresRuleSetting(t *testing.T) {
 	}
 	message := err.Error()
 	for _, want := range []string{"at least one push rule setting", "params.commit_message_regex", "reject_unsigned_commits"} {
-		if !strings.Contains(message, want) {
-			t.Fatalf("error = %q, want %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Fatalf("error = %q, want %q", message, want)
+			}
+		})
 	}
 }
 
@@ -2868,9 +2870,11 @@ func TestFormatMarkdown(t *testing.T) {
 	}
 	md := FormatMarkdown(out)
 	for _, want := range []string{"test-project", "group/test-project", testPrivate, "main", testDescProject, "group", "Forked From", "upstream/proj", "Archived", "Forks", "Stars", mdOpenIssues, "go, mcp", "1 Jan 2026", mdHTTPClone, mdSSHClone, "MR Title Regex", "Conventional MR titles", "Protected MR Pipelines"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2885,9 +2889,11 @@ func TestFormatProjectNotFound(t *testing.T) {
 	}
 	content := result.Content[0].(*mcp.TextContent).Text
 	for _, want := range []string{"Project", "Not Found", "group%2Fmissing", "gitlab_project_list"} {
-		if !strings.Contains(content, want) {
-			t.Errorf("not-found markdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Errorf("not-found markdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -2950,9 +2956,11 @@ func TestFormatListMarkdown(t *testing.T) {
 		}
 		md := FormatListMarkdown(out)
 		for _, w := range []string{"Projects (2)", testProjA, testProjB, testPublic, testPrivate} {
-			if !strings.Contains(md, w) {
-				t.Errorf("FormatListMarkdown missing %q", w)
-			}
+			t.Run(w, func(t *testing.T) {
+				if !strings.Contains(md, w) {
+					t.Errorf("FormatListMarkdown missing %q", w)
+				}
+			})
 		}
 	})
 	t.Run("empty", func(t *testing.T) {
@@ -3041,9 +3049,11 @@ func TestFormatHookMarkdown(t *testing.T) {
 	}
 	md := FormatHookMarkdown(out)
 	for _, w := range []string{"test-hook", "example.com/hook", "Push", "Issues", "Merge Requests"} {
-		if !strings.Contains(md, w) {
-			t.Errorf("FormatHookMarkdown missing %q", w)
-		}
+		t.Run(w, func(t *testing.T) {
+			if !strings.Contains(md, w) {
+				t.Errorf("FormatHookMarkdown missing %q", w)
+			}
+		})
 	}
 }
 
@@ -3153,9 +3163,11 @@ func TestFork_WithAllOptions(t *testing.T) {
 		t.Errorf(fmtNameWantQ, out.Name, testMyFork)
 	}
 	for _, want := range []string{"name", "path", "namespace_id", "namespace_path", "description", "visibility", "branches", "mr_default_target_self"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -3369,9 +3381,11 @@ func TestFormatMarkdown_FullFields(t *testing.T) {
 		mdHTTPClone,
 		mdSSHClone,
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3391,9 +3405,11 @@ func TestFormatMarkdown_MinimalFields(t *testing.T) {
 	}
 	// Optional fields should NOT appear
 	for _, absent := range []string{"Namespace", "Archived", "Forks", "Stars", mdOpenIssues, "Topics", mdHTTPClone, mdSSHClone} {
-		if strings.Contains(md, absent) {
-			t.Errorf("FormatMarkdown should not contain %q for minimal output", absent)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("FormatMarkdown should not contain %q for minimal output", absent)
+			}
+		})
 	}
 }
 
@@ -3410,9 +3426,11 @@ func TestFormatDeleteMarkdown_PermanentlyRemoved(t *testing.T) {
 	}
 	md := FormatDeleteMarkdown(out)
 	for _, want := range []string{"Project Deletion", testSuccess, "Project deleted", testPermRemoved} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatDeleteMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatDeleteMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3447,9 +3465,11 @@ func TestFormatListMarkdown_WithProjects(t *testing.T) {
 	}
 	md := FormatListMarkdown(out)
 	for _, want := range []string{"Projects (2)", testProjA, testProjB, testPublic, testPrivate} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3497,9 +3517,11 @@ func TestFormatListForksMarkdown_WithForks(t *testing.T) {
 	}
 	md := FormatListForksMarkdown(out)
 	for _, want := range []string{"Project Forks (1)", testForkA, "user/fork-a", testPublic} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListForksMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListForksMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3529,9 +3551,11 @@ func TestFormatLanguagesMarkdown_WithLanguages(t *testing.T) {
 	}
 	md := FormatLanguagesMarkdown(out)
 	for _, want := range []string{"Project Languages", "Go", "72.5%", "Shell", "27.5%"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatLanguagesMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatLanguagesMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3559,9 +3583,11 @@ func TestFormatListHooksMarkdown_WithHooks(t *testing.T) {
 	}
 	md := FormatListHooksMarkdown(out)
 	for _, want := range []string{"Project Webhooks (2)", "my-hook", testHookURL, testHookURL2} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListHooksMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListHooksMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3612,9 +3638,11 @@ func TestFormatHookMarkdown_WithName(t *testing.T) {
 	}
 	md := FormatHookMarkdown(out)
 	for _, want := range []string{"Webhook #1", "deploy-hook", testHookURL, "SSL Verification", "Event Triggers", "Push", "Issues", "Merge Requests", "Resource Deploy Token", "REDACTED"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatHookMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatHookMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3647,9 +3675,11 @@ func TestFormatListProjectUsersMarkdown_WithUsers(t *testing.T) {
 	}
 	md := FormatListProjectUsersMarkdown(out)
 	for _, want := range []string{"Project Users (2)", testAlice, "@alice", "active", testBob, "@bob", "blocked"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListProjectUsersMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListProjectUsersMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3676,9 +3706,11 @@ func TestFormatListProjectGroupsMarkdown_WithGroups(t *testing.T) {
 	}
 	md := FormatListProjectGroupsMarkdown(out)
 	for _, want := range []string{"Project Groups (2)", "group-a", "org/group-a", "group-b", "org/group-b"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListProjectGroupsMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListProjectGroupsMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -3705,9 +3737,11 @@ func TestFormatListStarrersMarkdown_WithStarrers(t *testing.T) {
 	}
 	md := FormatListStarrersMarkdown(out)
 	for _, want := range []string{"Project Starrers (2)", testAlice, "@alice", "1 Jan 2026", testBob, "@bob", "1 Feb 2026"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListStarrersMarkdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListStarrersMarkdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -4739,9 +4773,11 @@ func TestListUserProjects_FilterQueryParams(t *testing.T) {
 		"pagination":       "keyset",
 		"page_token":       "tok-1",
 	} {
-		if got := gotQuery.Get(tag); got != want {
-			t.Errorf("query param %s = %q, want %q", tag, got, want)
-		}
+		t.Run(tag, func(t *testing.T) {
+			if got := gotQuery.Get(tag); got != want {
+				t.Errorf("query param %s = %q, want %q", tag, got, want)
+			}
+		})
 	}
 }
 
@@ -6637,9 +6673,11 @@ func TestCreateForUser_AllOptionalFields(t *testing.T) {
 				`"description":"desc"`,
 				`"default_branch":"develop"`,
 			} {
-				if !strings.Contains(s, want) {
-					t.Errorf("request body missing %s, got %s", want, s)
-				}
+				t.Run(want, func(t *testing.T) {
+					if !strings.Contains(s, want) {
+						t.Errorf("request body missing %s, got %s", want, s)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusCreated, extProjectJSON)
 			return
@@ -7130,9 +7168,11 @@ func TestFormatApprovalRuleMarkdown_AllFields(t *testing.T) {
 		EligibleApprovers:             []*toolutil.BasicUserOutput{{Username: "alice"}, {Username: "bob"}, {Username: "charlie"}},
 	})
 	for _, want := range []string{"regular", "code_coverage", "alice, bob", "security-team", "alice, bob, charlie"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -7190,9 +7230,11 @@ func TestFormatPullMirrorMarkdown_AllFields(t *testing.T) {
 		MirrorBranchRegex:                "^main$",
 	})
 	for _, want := range []string{"mirror.example.com", "finished", "timeout", "15 Jan 2024", "^main$"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q", want)
+			}
+		})
 	}
 }
 
@@ -7612,9 +7654,11 @@ func TestBuildCreateOpts_AccessLevels_AllMapped(t *testing.T) {
 		"ModelRegistryAccessLevel":         opts.ModelRegistryAccessLevel,
 	}
 	for name, got := range levels {
-		if got == nil || *got == "" {
-			t.Errorf("%s not set", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got == nil || *got == "" {
+				t.Errorf("%s not set", name)
+			}
+		})
 	}
 	// Explicit access level wins over the deprecated bool toggle.
 	in2 := CreateInput{Name: "p", IssuesEnabled: new(false), IssuesAccessLevel: "enabled"}
@@ -7927,9 +7971,11 @@ func TestBuildUpdateOpts_AccessLevels_AllMapped(t *testing.T) {
 		"ModelRegistryAccessLevel":         opts.ModelRegistryAccessLevel,
 	}
 	for name, got := range levels {
-		if got == nil || *got == "" {
-			t.Errorf("%s not set", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got == nil || *got == "" {
+				t.Errorf("%s not set", name)
+			}
+		})
 	}
 	// Bool toggle still bridges when access-level string is absent.
 	bridged := buildUpdateOpts(UpdateInput{ProjectID: "1", IssuesEnabled: new(false)})

--- a/internal/tools/projects/target_branch_rules_test.go
+++ b/internal/tools/projects/target_branch_rules_test.go
@@ -254,9 +254,11 @@ func TestFormatListTargetBranchRulesMarkdown_WithRules(t *testing.T) {
 	}
 	md := FormatListTargetBranchRulesMarkdown(out)
 	for _, want := range []string{"Target Branch Rules (2)", "release/*", "production", "hotfix/*", "target_branch_rule_create"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -273,9 +275,11 @@ func TestFormatListTargetBranchRulesMarkdown_Empty(t *testing.T) {
 func TestFormatTargetBranchRuleMarkdown(t *testing.T) {
 	md := FormatTargetBranchRuleMarkdown(TargetBranchRuleOutput{ID: 7, Name: "release/*", TargetBranch: "production", CreatedAt: "2026-02-01T09:30:00Z"})
 	for _, want := range []string{"Target Branch Rule: release/*", "production", "target_branch_rule_list"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	// A rule without CreatedAt should still render.
 	mdNoCreated := FormatTargetBranchRuleMarkdown(TargetBranchRuleOutput{ID: 8, Name: "x", TargetBranch: "main"})
@@ -298,26 +302,30 @@ func TestActionSpecs_TargetBranchRulesGated(t *testing.T) {
 
 	ce := ActionSpecs(client, false)
 	for _, tool := range tools {
-		if findProjectSpec(ce, tool) != nil {
-			t.Errorf("%s should be gated out of the CE catalog", tool)
-		}
+		t.Run(tool, func(t *testing.T) {
+			if findProjectSpec(ce, tool) != nil {
+				t.Errorf("%s should be gated out of the CE catalog", tool)
+			}
+		})
 	}
 
 	ee := ActionSpecs(client, true)
 	for _, tool := range tools {
-		spec := findProjectSpec(ee, tool)
-		if spec == nil {
-			t.Fatalf("%s missing from enterprise catalog", tool)
-		}
-		if spec.Edition != "premium" {
-			t.Errorf("%s Edition = %q, want premium", tool, spec.Edition)
-		}
-		if !strings.Contains(spec.IndividualTool.Description, "Returns:") || !strings.Contains(spec.IndividualTool.Description, "See also:") {
-			t.Errorf("%s missing Returns/See also description: %q", tool, spec.IndividualTool.Description)
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s has empty RelatedActions", tool)
-		}
+		t.Run(tool, func(t *testing.T) {
+			spec := findProjectSpec(ee, tool)
+			if spec == nil {
+				t.Fatalf("%s missing from enterprise catalog", tool)
+			}
+			if spec.Edition != "premium" {
+				t.Errorf("%s Edition = %q, want premium", tool, spec.Edition)
+			}
+			if !strings.Contains(spec.IndividualTool.Description, "Returns:") || !strings.Contains(spec.IndividualTool.Description, "See also:") {
+				t.Errorf("%s missing Returns/See also description: %q", tool, spec.IndividualTool.Description)
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s has empty RelatedActions", tool)
+			}
+		})
 	}
 
 	if listSpec := findProjectSpec(ee, "gitlab_project_list_target_branch_rules"); listSpec == nil || !listSpec.ReadOnly {

--- a/internal/tools/projectserviceaccounts/projectserviceaccounts_test.go
+++ b/internal/tools/projectserviceaccounts/projectserviceaccounts_test.go
@@ -463,16 +463,20 @@ func TestActionSpecs(t *testing.T) {
 		t.Fatal("gitlab_project_service_account_list should be read-only")
 	}
 	for _, toolName := range []string{"gitlab_project_service_account_delete", "gitlab_project_service_account_pat_revoke"} {
-		if !byTool[toolName].Destructive || !byTool[toolName].Route.Destructive {
-			t.Fatalf("%s should be destructive", toolName)
-		}
+		t.Run(toolName, func(t *testing.T) {
+			if !byTool[toolName].Destructive || !byTool[toolName].Route.Destructive {
+				t.Fatalf("%s should be destructive", toolName)
+			}
+		})
 	}
 	for _, spec := range specs {
 		description := spec.IndividualTool.Description
 		for _, want := range []string{"Returns:", "See also:"} {
-			if !strings.Contains(description, want) {
-				t.Fatalf("%s description = %q, want %q", spec.IndividualTool.Name, description, want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(description, want) {
+					t.Fatalf("%s description = %q, want %q", spec.IndividualTool.Name, description, want)
+				}
+			})
 		}
 	}
 

--- a/internal/tools/projectstoragemoves/project_storage_moves_test.go
+++ b/internal/tools/projectstoragemoves/project_storage_moves_test.go
@@ -876,9 +876,11 @@ func TestFormatScheduleAllMarkdown(t *testing.T) {
 		"gitlab_retrieve_all_project_storage_moves",
 	}
 	for _, want := range wantAll {
-		if !strings.Contains(got, want) {
-			t.Errorf("output missing %q\ngot:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("output missing %q\ngot:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/projecttemplates/projecttemplates_test.go
+++ b/internal/tools/projecttemplates/projecttemplates_test.go
@@ -144,9 +144,11 @@ func TestFormatGetMarkdown_AllFields(t *testing.T) {
 		Content:     "MIT License text",
 	})
 	for _, want := range []string{"MIT License", "MIT", "Popular", "A permissive license", "commercial-use", "include-copyright", "no-liability", "MIT License text"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown output", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown output", want)
+			}
+		})
 	}
 }
 
@@ -261,9 +263,11 @@ func TestList_WithFiltersAndKeyset(t *testing.T) {
 			"pagination": "keyset",
 			"page_token": "tok123",
 		} {
-			if q.Get(key) != want {
-				t.Errorf("query %s = %q, want %q (raw=%s)", key, q.Get(key), want, r.URL.RawQuery)
-			}
+			t.Run(key, func(t *testing.T) {
+				if q.Get(key) != want {
+					t.Errorf("query %s = %q, want %q (raw=%s)", key, q.Get(key), want, r.URL.RawQuery)
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `[{"key":"mit","name":"MIT License"}]`)
 	}))

--- a/internal/tools/protectedenvs/action_specs_test.go
+++ b/internal/tools/protectedenvs/action_specs_test.go
@@ -201,10 +201,12 @@ func TestProtectedEnvironmentDescription_AllActions(t *testing.T) {
 		"gitlab_protected_environment_unprotect",
 	}
 	for _, name := range tools {
-		desc := protectedEnvironmentDescription(name)
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s description missing Returns/See also: %q", name, desc)
-		}
+		t.Run(name, func(t *testing.T) {
+			desc := protectedEnvironmentDescription(name)
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s description missing Returns/See also: %q", name, desc)
+			}
+		})
 	}
 	if got := protectedEnvironmentDescription("gitlab_unknown"); got != "" {
 		t.Errorf("unknown tool description = %q, want empty", got)
@@ -227,24 +229,26 @@ func TestProtectedEnvironmentMeta_PerToolDiscovery(t *testing.T) {
 		"gitlab_protected_environment_unprotect",
 	}
 	for _, name := range tools {
-		opts := protectedEnvironmentOptions(name)
-		if strings.HasPrefix(opts.Usage, sharedUsagePrefix) {
-			t.Errorf("%s still uses generic shared Usage: %q", name, opts.Usage)
-		}
-		if len(opts.Aliases) < 2 {
-			t.Errorf("%s has %d aliases, want >= 2", name, len(opts.Aliases))
-		}
-		for _, alias := range opts.Aliases {
-			if alias == name {
-				t.Errorf("%s alias list still contains the bare tool name", name)
+		t.Run(name, func(t *testing.T) {
+			opts := protectedEnvironmentOptions(name)
+			if strings.HasPrefix(opts.Usage, sharedUsagePrefix) {
+				t.Errorf("%s still uses generic shared Usage: %q", name, opts.Usage)
 			}
-			if strings.Contains(alias, "group") {
-				t.Errorf("%s alias %q overlaps group-level wording", name, alias)
+			if len(opts.Aliases) < 2 {
+				t.Errorf("%s has %d aliases, want >= 2", name, len(opts.Aliases))
 			}
-		}
-		if len(opts.RelatedActions) == 0 {
-			t.Errorf("%s has empty RelatedActions", name)
-		}
+			for _, alias := range opts.Aliases {
+				if alias == name {
+					t.Errorf("%s alias list still contains the bare tool name", name)
+				}
+				if strings.Contains(alias, "group") {
+					t.Errorf("%s alias %q overlaps group-level wording", name, alias)
+				}
+			}
+			if len(opts.RelatedActions) == 0 {
+				t.Errorf("%s has empty RelatedActions", name)
+			}
+		})
 	}
 
 	// Unknown tool: decorator is a no-op, so the shared defaults remain.

--- a/internal/tools/protectedenvs/protectedenvs_test.go
+++ b/internal/tools/protectedenvs/protectedenvs_test.go
@@ -84,9 +84,11 @@ func TestList_OrderBySortKeyset(t *testing.T) {
 		t.Fatalf("List() unexpected error: %v", err)
 	}
 	for _, want := range []string{"order_by=name", "sort=desc", "pagination=keyset", "page_token=tok123"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -248,9 +250,11 @@ func TestProtect_WithAllOptionalFields(t *testing.T) {
 		t.Fatalf("Protect() unexpected error: %v", err)
 	}
 	for _, want := range []string{"deploy_access_levels", "user_id", "group_id", "group_inheritance_type", "approval_rules", "required_approvals"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -527,9 +531,11 @@ func TestUpdate_WithAllFields(t *testing.T) {
 		t.Errorf("Name = %q, want %q", out.Name, "production")
 	}
 	for _, want := range []string{"deploy_access_levels", "user_id", "group_id", "group_inheritance_type", "approval_rules", "required_approvals", "_destroy"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/register_test.go
+++ b/internal/tools/register_test.go
@@ -624,7 +624,9 @@ func TestRegisterAllMeta_ToolNames(t *testing.T) {
 		delete(expectedNames, tool.Name)
 	}
 	for name := range expectedNames {
-		t.Errorf("expected meta-tool not found: %s", name)
+		t.Run(name, func(t *testing.T) {
+			t.Errorf("expected meta-tool not found: %s", name)
+		})
 	}
 }
 
@@ -714,9 +716,11 @@ func TestRegisterAllDoesNotUseDomainRegisterTools(t *testing.T) {
 		t.Fatalf("ReadFile register.go: %v", err)
 	}
 	for _, forbidden := range []string{".RegisterTools(", "registerAllLegacy", "legacyIndividualToolDescriptions", "listToolsForDescriptionCapture"} {
-		if strings.Contains(string(src), forbidden) {
-			t.Fatalf("register.go contains %q; RegisterAll must remain catalog-backed", forbidden)
-		}
+		t.Run(forbidden, func(t *testing.T) {
+			if strings.Contains(string(src), forbidden) {
+				t.Fatalf("register.go contains %q; RegisterAll must remain catalog-backed", forbidden)
+			}
+		})
 	}
 }
 

--- a/internal/tools/releaselinks/release_links_test.go
+++ b/internal/tools/releaselinks/release_links_test.go
@@ -791,9 +791,11 @@ func TestFormatOutputMarkdown_WithData(t *testing.T) {
 		"- **Type**: package",
 		"- **External**: true",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -847,9 +849,11 @@ func TestFormatListMarkdown_WithLinks(t *testing.T) {
 		"Binary arm64",
 		"package",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -893,9 +897,11 @@ func TestFormatListMarkdown_ContainsHints(t *testing.T) {
 		"link_create'",
 		"link_create_batch'",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown missing hint containing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatListMarkdown missing hint containing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -923,9 +929,11 @@ func TestFormatBatchMarkdown_WithCreatedAndFailed(t *testing.T) {
 		"checksum.txt: 409 Conflict",
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("missing %q in:\n%s", c, md)
-		}
+		t.Run(c, func(t *testing.T) {
+			if !strings.Contains(md, c) {
+				t.Errorf("missing %q in:\n%s", c, md)
+			}
+		})
 	}
 }
 
@@ -1179,9 +1187,11 @@ func TestReleaseLinkDescriptions_RMeta(t *testing.T) {
 		"gitlab_release_link_update",
 		"gitlab_release_link_delete",
 	} {
-		desc := byTool[name].IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s description = %q, want Returns:/See also: form", name, desc)
-		}
+		t.Run(name, func(t *testing.T) {
+			desc := byTool[name].IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s description = %q, want Returns:/See also: form", name, desc)
+			}
+		})
 	}
 }

--- a/internal/tools/releases/releases_test.go
+++ b/internal/tools/releases/releases_test.go
@@ -671,9 +671,11 @@ func TestFormatMarkdown_AllFields(t *testing.T) {
 		"### Description",
 		"Feature X",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -709,9 +711,11 @@ func TestFormatMarkdown_MinimalFields(t *testing.T) {
 		"### Description",
 		"**Released**",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -752,9 +756,11 @@ func TestFormatListMarkdown_WithData(t *testing.T) {
 		"First",
 		"dev",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -916,9 +922,11 @@ func TestFormatMarkdown_ContainsHints(t *testing.T) {
 		"link_create_batch'",
 		"publish_and_link'",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatMarkdown missing hint containing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("FormatMarkdown missing hint containing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1351,9 +1359,11 @@ func TestReleaseList_IncludeHTMLDescriptionAndKeyset(t *testing.T) {
 				"order_by":                 "created_at",
 				"sort":                     "asc",
 			} {
-				if got := q.Get(k); got != want {
-					t.Errorf("query param %s = %q, want %q", k, got, want)
-				}
+				t.Run(k, func(t *testing.T) {
+					if got := q.Get(k); got != want {
+						t.Errorf("query param %s = %q, want %q", k, got, want)
+					}
+				})
 			}
 			testutil.RespondJSON(w, http.StatusOK, `[]`)
 			return
@@ -1492,14 +1502,18 @@ func TestToOutput_DocumentedSubset_OmitsUndocumentedCommitAndAuthorFields(t *tes
 	}
 	commitJSON := string(commitData)
 	for _, undocumented := range []string{`"stats"`, `"status"`, `"project_id"`, `"web_url"`} {
-		if strings.Contains(commitJSON, undocumented) {
-			t.Errorf("serialized commit must omit undocumented field %s; got %s", undocumented, commitJSON)
-		}
+		t.Run(undocumented, func(t *testing.T) {
+			if strings.Contains(commitJSON, undocumented) {
+				t.Errorf("serialized commit must omit undocumented field %s; got %s", undocumented, commitJSON)
+			}
+		})
 	}
 	for _, documented := range []string{`"id"`, `"short_id"`, `"title"`} {
-		if !strings.Contains(commitJSON, documented) {
-			t.Errorf("serialized commit must keep documented field %s; got %s", documented, commitJSON)
-		}
+		t.Run(documented, func(t *testing.T) {
+			if !strings.Contains(commitJSON, documented) {
+				t.Errorf("serialized commit must keep documented field %s; got %s", documented, commitJSON)
+			}
+		})
 	}
 
 	// The author created_at is not part of the documented author subset.
@@ -1512,8 +1526,10 @@ func TestToOutput_DocumentedSubset_OmitsUndocumentedCommitAndAuthorFields(t *tes
 		t.Errorf("serialized author must omit undocumented created_at; got %s", authorJSON)
 	}
 	for _, documented := range []string{`"avatar_url"`, `"web_url"`, `"state"`} {
-		if !strings.Contains(authorJSON, documented) {
-			t.Errorf("serialized author must keep documented field %s; got %s", documented, authorJSON)
-		}
+		t.Run(documented, func(t *testing.T) {
+			if !strings.Contains(authorJSON, documented) {
+				t.Errorf("serialized author must keep documented field %s; got %s", documented, authorJSON)
+			}
+		})
 	}
 }

--- a/internal/tools/repositorysubmodules/list_test.go
+++ b/internal/tools/repositorysubmodules/list_test.go
@@ -52,19 +52,21 @@ func TestParseGitmodules_Success(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		e := entries[i]
-		if e.Name != tt.name {
-			t.Errorf("entry[%d] name: got %q, want %q", i, e.Name, tt.name)
-		}
-		if e.Path != tt.path {
-			t.Errorf("entry[%d] path: got %q, want %q", i, e.Path, tt.path)
-		}
-		if e.URL != tt.url {
-			t.Errorf("entry[%d] url: got %q, want %q", i, e.URL, tt.url)
-		}
-		if e.ResolvedProject != tt.resolvedProject {
-			t.Errorf("entry[%d] resolved: got %q, want %q", i, e.ResolvedProject, tt.resolvedProject)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			e := entries[i]
+			if e.Name != tt.name {
+				t.Errorf("entry[%d] name: got %q, want %q", i, e.Name, tt.name)
+			}
+			if e.Path != tt.path {
+				t.Errorf("entry[%d] path: got %q, want %q", i, e.Path, tt.path)
+			}
+			if e.URL != tt.url {
+				t.Errorf("entry[%d] url: got %q, want %q", i, e.URL, tt.url)
+			}
+			if e.ResolvedProject != tt.resolvedProject {
+				t.Errorf("entry[%d] resolved: got %q, want %q", i, e.ResolvedProject, tt.resolvedProject)
+			}
+		})
 	}
 }
 
@@ -322,9 +324,11 @@ func TestActionSpecs_IncludesTools(t *testing.T) {
 		"gitlab_read_repository_submodule_file",
 		"gitlab_update_repository_submodule",
 	} {
-		if _, ok := byTool[name]; !ok {
-			t.Errorf("expected tool %q in ActionSpecs", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if _, ok := byTool[name]; !ok {
+				t.Errorf("expected tool %q in ActionSpecs", name)
+			}
+		})
 	}
 }
 

--- a/internal/tools/repositorysubmodules/list_test.go
+++ b/internal/tools/repositorysubmodules/list_test.go
@@ -479,9 +479,11 @@ func TestEnrichSubmoduleCommitSHAs_CancelledContext(t *testing.T) {
 	enrichSubmoduleCommitSHAs(ctx, client, "42", "main", entries)
 
 	for _, e := range entries {
-		if e.CommitSHA != "" {
-			t.Errorf("expected empty CommitSHA for entry %q after cancelled context, got %q", e.Name, e.CommitSHA)
-		}
+		t.Run(e.Name, func(t *testing.T) {
+			if e.CommitSHA != "" {
+				t.Errorf("expected empty CommitSHA for entry %q after cancelled context, got %q", e.Name, e.CommitSHA)
+			}
+		})
 	}
 }
 

--- a/internal/tools/repositorysubmodules/repositorysubmodules_test.go
+++ b/internal/tools/repositorysubmodules/repositorysubmodules_test.go
@@ -206,25 +206,27 @@ func TestActionSpecs_NonGenericMetadata(t *testing.T) {
 		"gitlab_read_repository_submodule_file",
 		"gitlab_update_repository_submodule",
 	} {
-		spec := byTool[tool]
-		if strings.Contains(spec.Usage, "Use to execute") || spec.Usage == "" {
-			t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
-		}
-		if len(spec.Aliases) < 2 {
-			t.Errorf("%s: expected distinctive aliases, got %v", tool, spec.Aliases)
-		}
-		for _, a := range spec.Aliases {
-			if a == tool {
-				t.Errorf("%s: alias must not equal the tool name", tool)
+		t.Run(tool, func(t *testing.T) {
+			spec := byTool[tool]
+			if strings.Contains(spec.Usage, "Use to execute") || spec.Usage == "" {
+				t.Errorf("%s: generic or empty Usage: %q", tool, spec.Usage)
 			}
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: expected related actions", tool)
-		}
-		desc := spec.IndividualTool.Description
-		if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
-			t.Errorf("%s: description must use Returns/See also form, got %q", tool, desc)
-		}
+			if len(spec.Aliases) < 2 {
+				t.Errorf("%s: expected distinctive aliases, got %v", tool, spec.Aliases)
+			}
+			for _, a := range spec.Aliases {
+				if a == tool {
+					t.Errorf("%s: alias must not equal the tool name", tool)
+				}
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s: expected related actions", tool)
+			}
+			desc := spec.IndividualTool.Description
+			if !strings.Contains(desc, "Returns:") || !strings.Contains(desc, "See also:") {
+				t.Errorf("%s: description must use Returns/See also form, got %q", tool, desc)
+			}
+		})
 	}
 }
 
@@ -267,9 +269,11 @@ func TestActionSpecs_Metadata(t *testing.T) {
 		}
 	}
 	for _, name := range []string{"gitlab_list_repository_submodules", "gitlab_read_repository_submodule_file"} {
-		if !byTool[name].ReadOnly || !byTool[name].Idempotent {
-			t.Errorf("%s should be read-only and idempotent", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if !byTool[name].ReadOnly || !byTool[name].Idempotent {
+				t.Errorf("%s should be read-only and idempotent", name)
+			}
+		})
 	}
 	if byTool["gitlab_update_repository_submodule"].ReadOnly || !byTool["gitlab_update_repository_submodule"].Idempotent {
 		t.Error("update submodule action should be mutating and idempotent")

--- a/internal/tools/resourceevents/resourceevents_test.go
+++ b/internal/tools/resourceevents/resourceevents_test.go
@@ -1296,15 +1296,20 @@ func TestListGroupEpicLabelEvents_Success(t *testing.T) {
 // input missing any required field without reaching the API.
 func TestGetGroupEpicLabelEvent_Validation(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	cases := []GetGroupEpicLabelEventInput{
-		{},
-		{GroupID: covGID()},
-		{GroupID: covGID(), EpicIID: 7},
+	cases := []struct {
+		name string
+		in   GetGroupEpicLabelEventInput
+	}{
+		{"empty_input", GetGroupEpicLabelEventInput{}},
+		{"missing_epic_iid", GetGroupEpicLabelEventInput{GroupID: covGID()}},
+		{"missing_label_event_id", GetGroupEpicLabelEventInput{GroupID: covGID(), EpicIID: 7}},
 	}
-	for _, in := range cases {
-		if _, err := GetGroupEpicLabelEvent(t.Context(), client, in); err == nil {
-			t.Fatalf("expected validation error for %+v", in)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := GetGroupEpicLabelEvent(t.Context(), client, tc.in); err == nil {
+				t.Fatalf("expected validation error for %+v", tc.in)
+			}
+		})
 	}
 }
 

--- a/internal/tools/resourcegroups/resourcegroups_test.go
+++ b/internal/tools/resourcegroups/resourcegroups_test.go
@@ -172,9 +172,11 @@ func TestFormatGroupMarkdown(t *testing.T) {
 		"**Key**: staging",
 		"**Process Mode**: oldest_first",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -200,9 +202,11 @@ func TestFormatJobsMarkdown_WithData(t *testing.T) {
 		"pending",
 		"created",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/runnercontrollers/runnercontrollers_test.go
+++ b/internal/tools/runnercontrollers/runnercontrollers_test.go
@@ -418,9 +418,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 
 	md := FormatOutputMarkdown(out)
 	for _, want := range []string{"ctrl-1", "enabled", "Created At", "Updated At"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Without timestamps
@@ -441,9 +443,11 @@ func TestFormatDetailsMarkdown(t *testing.T) {
 
 	md := FormatDetailsMarkdown(out)
 	for _, want := range []string{"ctrl-1", "Details", "true", "Created At"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Without timestamps
@@ -467,9 +471,11 @@ func TestFormatListMarkdown(t *testing.T) {
 
 	md := FormatListMarkdown(out)
 	for _, want := range []string{"ctrl-1", "ctrl-2", "enabled", "disabled"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Empty

--- a/internal/tools/runnercontrollerscopes/runnercontrollerscopes_test.go
+++ b/internal/tools/runnercontrollerscopes/runnercontrollerscopes_test.go
@@ -377,9 +377,11 @@ func TestFormatScopesMarkdown(t *testing.T) {
 
 	md := FormatScopesMarkdown(out)
 	for _, want := range []string{"Instance-Level", "Runner-Level", "42"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Empty instance scopes

--- a/internal/tools/runnercontrollertokens/runnercontrollertokens_test.go
+++ b/internal/tools/runnercontrollertokens/runnercontrollertokens_test.go
@@ -491,9 +491,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 
 	md := FormatOutputMarkdown(out)
 	for _, want := range []string{"my-token", "glrt-abc123", "Last Used At", "Created At"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Without token and timestamps
@@ -521,9 +523,11 @@ func TestFormatListMarkdown(t *testing.T) {
 
 	md := FormatListMarkdown(out)
 	for _, want := range []string{"tok-1", "tok-2"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q: %s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q: %s", want, md)
+			}
+		})
 	}
 
 	// Empty

--- a/internal/tools/runners/runners_test.go
+++ b/internal/tools/runners/runners_test.go
@@ -1702,9 +1702,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 		"| Shared | ✅ |",
 		"| Online | ✅ |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1753,9 +1755,11 @@ func TestFormatDetailsMarkdown_Full(t *testing.T) {
 		"| Projects | 2 |",
 		"| Groups | 1 |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1775,9 +1779,11 @@ func TestFormatDetailsMarkdown_Minimal(t *testing.T) {
 		"| Maintenance Note |",
 		"| Last Contact |",
 	} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1806,9 +1812,11 @@ func TestFormatListMarkdown_WithData(t *testing.T) {
 		"instance_type",
 		"project_type",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1849,9 +1857,11 @@ func TestFormatJobListMarkdown_WithData(t *testing.T) {
 		"running",
 		"12.5s",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1882,9 +1892,11 @@ func TestFormatAuthTokenMarkdown_Full(t *testing.T) {
 		"**Token**: glrt-abc123",
 		"**Expires At**: 31 Dec 2026 23:59 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1912,9 +1924,11 @@ func TestFormatRegTokenMarkdown_Full(t *testing.T) {
 		"**Token**: reg-tok-123",
 		"**Expires At**: 1 Jun 2026 00:00 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securefiles/securefiles_test.go
+++ b/internal/tools/securefiles/securefiles_test.go
@@ -312,9 +312,11 @@ func TestFormatListMarkdown_WithPagination(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 5, Page: 1, PerPage: 2, TotalPages: 3},
 	})
 	for _, want := range []string{"| ID |", "| 1 |", "| 2 |", "key.pem", "cert.pem"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -396,9 +398,11 @@ func TestList_KeysetPagination(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, want := range []string{"order_by=id", "sort=desc", "pagination=keyset", "page_token=42"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query %q missing %q", gotQuery, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(gotQuery, want) {
+				t.Errorf("query %q missing %q", gotQuery, want)
+			}
+		})
 	}
 }
 
@@ -426,9 +430,11 @@ func TestFormatShowMarkdown_FullMetadata(t *testing.T) {
 		"2024-01-02T03:04:05Z", "2025-01-02T03:04:05Z", "Certificate Metadata",
 		"00:11:22", "Acme Root CA", "service.example.com", "2026-06-01T00:00:00Z",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securityattributes/security_attributes_test.go
+++ b/internal/tools/securityattributes/security_attributes_test.go
@@ -841,9 +841,11 @@ func TestMarkdown_EscapesTableCells_PreservesLinkHint(t *testing.T) {
 
 	outputMarkdown := FormatOutputMarkdown(attribute)
 	for _, want := range []string{"#FF&#124;0000", "Needs &#124; review", "| Editable state | `EDITABLE` |"} {
-		if !strings.Contains(outputMarkdown, want) {
-			t.Fatalf("FormatOutputMarkdown() missing %q:\n%s", want, outputMarkdown)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(outputMarkdown, want) {
+				t.Fatalf("FormatOutputMarkdown() missing %q:\n%s", want, outputMarkdown)
+			}
+		})
 	}
 }
 
@@ -878,9 +880,11 @@ func TestMarkdownFormatsProjectAndBulkUpdates(t *testing.T) {
 		AttributeIDs: []int64{9, 10},
 	})
 	for _, want := range []string{"| Mode | `REPLACE` |", "| Attributes | `[9 10]` |", "| Groups | `[5]` |", "| Projects | `[42]` |"} {
-		if !strings.Contains(bulkMarkdown, want) {
-			t.Fatalf("FormatBulkUpdateMarkdown() missing %q:\n%s", want, bulkMarkdown)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(bulkMarkdown, want) {
+				t.Fatalf("FormatBulkUpdateMarkdown() missing %q:\n%s", want, bulkMarkdown)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securitycategories/security_categories_test.go
+++ b/internal/tools/securitycategories/security_categories_test.go
@@ -608,9 +608,11 @@ func TestFormatOutputMarkdown_WithAttributes_RendersTable(t *testing.T) {
 		}},
 	})
 	for _, want := range []string{"Business &#124; impact", "Business &#124; labels", "| Multiple selection | true |", "| Template type | `CUSTOM` |", "High &#124; Risk"} {
-		if !strings.Contains(md, want) {
-			t.Fatalf("FormatOutputMarkdown() missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Fatalf("FormatOutputMarkdown() missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securityfindings/securityfindings_test.go
+++ b/internal/tools/securityfindings/securityfindings_test.go
@@ -168,9 +168,11 @@ func TestList_WithFilters(t *testing.T) {
 				t.Errorf("pipelineIID = %v, want 456", vars["pipelineIID"])
 			}
 			for _, key := range []string{"severity", "confidence", "scanner", "reportType"} {
-				if _, ok := vars[key]; !ok {
-					t.Errorf("GraphQL variables missing %q", key)
-				}
+				t.Run(key, func(t *testing.T) {
+					if _, ok := vars[key]; !ok {
+						t.Errorf("GraphQL variables missing %q", key)
+					}
+				})
 			}
 			testutil.RespondGraphQL(w, http.StatusOK, `{
 				"project": {
@@ -303,9 +305,11 @@ func TestList_PipelineNotFound(t *testing.T) {
 	}
 	errText := err.Error()
 	for _, want := range []string{"pipeline_iid", "gitlab_pipeline", "security scan report artifacts"} {
-		if !strings.Contains(errText, want) {
-			t.Fatalf("error missing %q: %v", want, err)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errText, want) {
+				t.Fatalf("error missing %q: %v", want, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securityscanprofiles/security_scan_profiles_test.go
+++ b/internal/tools/securityscanprofiles/security_scan_profiles_test.go
@@ -325,9 +325,11 @@ func TestFormatMutationMarkdown(t *testing.T) {
 		ProjectIDs:            []int64{7, 8}, GroupIDs: []int64{3},
 	})
 	for _, want := range []string{"Security Scan Profile", "dependency_scanning", "7, 8", "3"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -344,9 +346,11 @@ func TestFormatListProjectStatusesMarkdown(t *testing.T) {
 		}},
 	})
 	for _, want := range []string{"Scan Profile Statuses: g/p", "ACTIVE", "Default", "sast"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/securitysettings/markdown_test.go
+++ b/internal/tools/securitysettings/markdown_test.go
@@ -38,9 +38,11 @@ func TestFormatProjectMarkdown_AllFields(t *testing.T) {
 		"**Updated**: 2026-01-02T00:00:00Z",
 	}
 	for _, exp := range expectations {
-		if !strings.Contains(md, exp) {
-			t.Errorf("expected markdown to contain %q, got:\n%s", exp, md)
-		}
+		t.Run(exp, func(t *testing.T) {
+			if !strings.Contains(md, exp) {
+				t.Errorf("expected markdown to contain %q, got:\n%s", exp, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/snippets/project_snippets_test.go
+++ b/internal/tools/snippets/project_snippets_test.go
@@ -493,9 +493,11 @@ func TestCreate_WithAllOptions(t *testing.T) {
 		t.Errorf(fmtIDEquals, out.ID)
 	}
 	for _, want := range []string{"title", "description", "visibility", "files"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -528,9 +530,11 @@ func TestUpdate_WithAllOptions(t *testing.T) {
 		t.Errorf(fmtIDEquals, out.ID)
 	}
 	for _, want := range []string{"title", "description", "visibility", "files"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/snippets/snippets_test.go
+++ b/internal/tools/snippets/snippets_test.go
@@ -656,9 +656,11 @@ func TestList_KeysetAndOrdering(t *testing.T) {
 	for key, want := range map[string]string{
 		"order_by": "created_at", "sort": "desc", "pagination": "keyset", "page_token": "tok", "per_page": "50",
 	} {
-		if got.Get(key) != want {
-			t.Errorf("query %s = %q, want %q", key, got.Get(key), want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got.Get(key) != want {
+				t.Errorf("query %s = %q, want %q", key, got.Get(key), want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/snippetstoragemoves/snippet_storage_moves_test.go
+++ b/internal/tools/snippetstoragemoves/snippet_storage_moves_test.go
@@ -618,9 +618,11 @@ func TestFormatOutputMarkdown_WithSnippet(t *testing.T) {
 		"[my-snippet](https://gitlab.example.com/snippets/55)",
 		"(ID: 55)",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("output missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("output missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -692,9 +694,11 @@ func TestFormatListMarkdown_WithMoves(t *testing.T) {
 		"| 2 | started | default | storage3 |",
 		"_Page 1, 2 moves shown._",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("output missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("output missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -830,8 +834,10 @@ func TestFormatScheduleAllMarkdown(t *testing.T) {
 		"All snippet repository storage moves have been scheduled",
 		"gitlab_retrieve_all_snippet_storage_moves",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("output missing %q\ngot:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("output missing %q\ngot:\n%s", want, md)
+			}
+		})
 	}
 }

--- a/internal/tools/systemhooks/systemhooks_test.go
+++ b/internal/tools/systemhooks/systemhooks_test.go
@@ -180,9 +180,11 @@ func TestEdit_Success(t *testing.T) {
 		t.Errorf("expected ID 1, got %d", out.Hook.ID)
 	}
 	for _, want := range []string{"url", "signing_token", "push_events"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing %q: %s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing %q: %s", want, capturedBody)
+			}
+		})
 	}
 }
 
@@ -227,9 +229,11 @@ func TestEdit_AllOptionalFields(t *testing.T) {
 		t.Errorf("expected ID 2, got %d", out.Hook.ID)
 	}
 	for _, want := range []string{"url", "name", "description", "token", "signing_token", "push_events_branch_filter", "branch_filter_strategy", "tag_push_events", "merge_requests_events", "repository_update_events", "enable_ssl_verification"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing %q: %s", want, capturedBody)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing %q: %s", want, capturedBody)
+			}
+		})
 	}
 }
 
@@ -472,9 +476,11 @@ func TestFormatHookMarkdown_URLVariablesRedacted(t *testing.T) {
 	text := result.Content[0].(*mcp.TextContent).Text
 
 	for _, want := range []string{"URL Variables", "token", "REDACTED"} {
-		if !strings.Contains(text, want) {
-			t.Errorf("FormatHookMarkdown missing %q: %s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("FormatHookMarkdown missing %q: %s", want, text)
+			}
+		})
 	}
 }
 
@@ -618,8 +624,10 @@ func TestFormatDelegatorMarkdown_GetAddEdit(t *testing.T) {
 		"add":  FormatAddMarkdown(AddOutput{Hook: hook}),
 		"edit": FormatEditMarkdown(EditOutput{Hook: hook}),
 	} {
-		if result == nil || len(result.Content) == 0 {
-			t.Errorf("%s delegator returned empty result", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if result == nil || len(result.Content) == 0 {
+				t.Errorf("%s delegator returned empty result", name)
+			}
+		})
 	}
 }

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -283,9 +283,11 @@ func TestTagGet_SuccessEnrichedFields(t *testing.T) {
 		"Release.Desc":          {out.Release.Description, "Second major release"},
 	}
 	for field, pair := range stringChecks {
-		if pair[0] != pair[1] {
-			t.Errorf("%s = %q, want %q", field, pair[0], pair[1])
-		}
+		t.Run(field, func(t *testing.T) {
+			if pair[0] != pair[1] {
+				t.Errorf("%s = %q, want %q", field, pair[0], pair[1])
+			}
+		})
 	}
 	for field, ts := range map[string]string{
 		"AuthoredDate":  out.Commit.AuthoredDate,
@@ -293,9 +295,11 @@ func TestTagGet_SuccessEnrichedFields(t *testing.T) {
 		"CommitCreated": out.Commit.CreatedAt,
 		"CreatedAt":     out.CreatedAt,
 	} {
-		if ts == "" {
-			t.Errorf("%s is empty, want timestamp", field)
-		}
+		t.Run(field, func(t *testing.T) {
+			if ts == "" {
+				t.Errorf("%s is empty, want timestamp", field)
+			}
+		})
 	}
 	if len(out.Commit.ParentIDs) != 1 || out.Commit.ParentIDs[0] != "zzz000" {
 		t.Errorf("out.Commit.ParentIDs = %v, want [zzz000]", out.Commit.ParentIDs)
@@ -900,9 +904,11 @@ func TestTagProtect_WithAllowedToCreate(t *testing.T) {
 		t.Errorf(fmtNameWant, out.Name, "v*")
 	}
 	for _, want := range []string{"allowed_to_create", "user_id", "group_id", "deploy_key_id"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/terraformstates/terraformstates_test.go
+++ b/internal/tools/terraformstates/terraformstates_test.go
@@ -224,9 +224,11 @@ func TestDeleteVersion_Error(t *testing.T) {
 func TestFormatStateMarkdown_Coverage(t *testing.T) {
 	md := FormatStateMarkdown(StateItem{Name: "prod-state", LatestSerial: 42, DownloadPath: "/dl/path"})
 	for _, want := range []string{"prod-state", "42", "/dl/path"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("missing %q in markdown", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("missing %q in markdown", want)
+			}
+		})
 	}
 }
 

--- a/internal/tools/topics/topics_test.go
+++ b/internal/tools/topics/topics_test.go
@@ -120,9 +120,11 @@ func TestList_KeysetPagination(t *testing.T) {
 		"per_page":   "50",
 	}
 	for key, want := range checks {
-		if got := q.Get(key); got != want {
-			t.Errorf("query %q = %q, want %q", key, got, want)
-		}
+		t.Run(key, func(t *testing.T) {
+			if got := q.Get(key); got != want {
+				t.Errorf("query %q = %q, want %q", key, got, want)
+			}
+		})
 	}
 }
 
@@ -391,9 +393,11 @@ func TestCreate_WithAllOptionalFields(t *testing.T) {
 		t.Errorf("expected name 'go', got %q", out.Topic.Name)
 	}
 	for _, want := range []string{"title", "description"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -439,9 +443,11 @@ func TestUpdate_WithAllOptionalFields(t *testing.T) {
 		t.Errorf("expected topic ID 1, got %d", out.Topic.ID)
 	}
 	for _, want := range []string{"title", "description"} {
-		if !strings.Contains(capturedBody, want) {
-			t.Errorf("request body missing field %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(capturedBody, want) {
+				t.Errorf("request body missing field %q", want)
+			}
+		})
 	}
 }
 
@@ -492,8 +498,10 @@ func TestFormatDelegatorMarkdown_GetCreateUpdate(t *testing.T) {
 		"create": FormatCreateMarkdown(CreateOutput{Topic: topic}),
 		"update": FormatUpdateMarkdown(UpdateOutput{Topic: topic}),
 	} {
-		if result == nil || len(result.Content) == 0 {
-			t.Errorf("%s delegator returned empty result", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if result == nil || len(result.Content) == 0 {
+				t.Errorf("%s delegator returned empty result", name)
+			}
+		})
 	}
 }

--- a/internal/tools/uploads/uploads_test.go
+++ b/internal/tools/uploads/uploads_test.go
@@ -916,9 +916,11 @@ func TestList_KeysetPaginationParams(t *testing.T) {
 			"page":       "2",
 		}
 		for k, want := range checks {
-			if got := q.Get(k); got != want {
-				t.Errorf("query %q = %q, want %q", k, got, want)
-			}
+			t.Run(k, func(t *testing.T) {
+				if got := q.Get(k); got != want {
+					t.Errorf("query %q = %q, want %q", k, got, want)
+				}
+			})
 		}
 		w.Header().Set("X-Next-Page", "3")
 		w.Header().Set("X-Page", "2")

--- a/internal/tools/useremails/useremails_test.go
+++ b/internal/tools/useremails/useremails_test.go
@@ -548,9 +548,11 @@ func TestFormatListMarkdownString_WithEmails(t *testing.T) {
 		{"unconfirmed email dash", "| 2 | unconfirmed@example.com | - |"},
 	}
 	for _, c := range checks {
-		if !strings.Contains(md, c.contains) {
-			t.Errorf("%s: markdown missing %q\ngot:\n%s", c.label, c.contains, md)
-		}
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(md, c.contains) {
+				t.Errorf("%s: markdown missing %q\ngot:\n%s", c.label, c.contains, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/users/user_admin_test.go
+++ b/internal/tools/users/user_admin_test.go
@@ -200,7 +200,9 @@ func TestAdminActions_TableDriven(t *testing.T) {
 	}
 
 	for _, action := range actions {
-		runAdminActionCases(t, action)
+		t.Run(action.name, func(t *testing.T) {
+			runAdminActionCases(t, action)
+		})
 	}
 }
 
@@ -316,8 +318,10 @@ func TestFormatAdminActionMarkdownString_Fields(t *testing.T) {
 		UserID: 99, Action: "banned", Success: true,
 	})
 	for _, want := range []string{"99", "banned", "true"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }

--- a/internal/tools/users/user_crud_test.go
+++ b/internal/tools/users/user_crud_test.go
@@ -380,9 +380,11 @@ func TestCreate_AllOptionalFields(t *testing.T) {
 		"skype", "discord", "github", "provider", "extern_uid", "group_id_for_saml",
 		"theme_id", "color_scheme_id", "shared_runners_minutes_limit", "extra_shared_runners_minutes_limit",
 	} {
-		if _, ok := body[key]; !ok {
-			t.Errorf("create body missing %q: %v", key, body)
-		}
+		t.Run(key, func(t *testing.T) {
+			if _, ok := body[key]; !ok {
+				t.Errorf("create body missing %q: %v", key, body)
+			}
+		})
 	}
 }
 
@@ -413,8 +415,10 @@ func TestModify_AllOptionalFields(t *testing.T) {
 		"auditor", "view_diffs_file_by_file", "commit_email", "public_email", "website_url",
 		"linkedin", "twitter", "skype", "provider", "extern_uid", "theme_id",
 	} {
-		if _, ok := body[key]; !ok {
-			t.Errorf("modify body missing %q: %v", key, body)
-		}
+		t.Run(key, func(t *testing.T) {
+			if _, ok := body[key]; !ok {
+				t.Errorf("modify body missing %q: %v", key, body)
+			}
+		})
 	}
 }

--- a/internal/tools/users/user_misc_test.go
+++ b/internal/tools/users/user_misc_test.go
@@ -588,9 +588,11 @@ func TestFormatUserActivitiesMarkdownString_WithData(t *testing.T) {
 		"| alice | 2026-06-15 |",
 		"| bob | 2026-06-14 |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -620,9 +622,11 @@ func TestFormatUserMembershipsMarkdownString_WithData(t *testing.T) {
 		"| 1 | my-project | Project | 30 |",
 		"| 2 | my-group | Namespace | 50 |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -647,9 +651,11 @@ func TestFormatUserRunnerMarkdownString(t *testing.T) {
 		"glrt-abc123",
 		"Token Expires At",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -667,9 +673,11 @@ func TestFormatDeleteUserIdentityMarkdownString(t *testing.T) {
 		UserID: 42, Provider: "saml", Deleted: true,
 	})
 	for _, want := range []string{"42", "saml", "true"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/users/user_service_accounts_test.go
+++ b/internal/tools/users/user_service_accounts_test.go
@@ -256,9 +256,11 @@ func TestFormatServiceAccountListMarkdownString_WithData(t *testing.T) {
 		"| 1 | svc-1 | Service 1 |",
 		"| 2 | svc-2 | Service 2 |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -285,9 +287,11 @@ func TestFormatCurrentUserPATMarkdownString_WithAllFields(t *testing.T) {
 		"**Expires At**: 2026-01-15",
 		"`glpat-secret`",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -437,9 +441,11 @@ func TestFormatServiceAccountMarkdownString_WithEmail(t *testing.T) {
 		"**Email**: svc7@example.com",
 		"**Unconfirmed Email**: pending@example.com",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/users/user_ssh_keys_test.go
+++ b/internal/tools/users/user_ssh_keys_test.go
@@ -540,9 +540,11 @@ func TestFormatSSHKeyMarkdownString_WithData(t *testing.T) {
 		"**Usage Type**: auth",
 		"**Expires At**",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 

--- a/internal/tools/users/users_test.go
+++ b/internal/tools/users/users_test.go
@@ -1176,9 +1176,11 @@ func TestFormatMarkdownString_WithData(t *testing.T) {
 		"### SCIM Identities",
 		"| scim-alice | 9 | true |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1228,9 +1230,11 @@ func TestFormatListMarkdownString_WithData(t *testing.T) {
 		"| 1 | [@alice](https://gitlab.example.com/alice) | Alice | alice@example.com | active |",
 		"| 2 | [@bob](https://gitlab.example.com/bob) | Bob | bob@example.com | blocked |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1277,9 +1281,11 @@ func TestFormatStatusMarkdownString_WithData(t *testing.T) {
 		"**Availability**: busy",
 		"**Clear At**: 31 Dec 2026 23:59 UTC",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1290,9 +1296,11 @@ func TestFormatStatusMarkdownString_Empty(t *testing.T) {
 		t.Errorf("expected header:\n%s", md)
 	}
 	for _, absent := range []string{"**Emoji**", "**Message**", "**Availability**", "**Clear At**"} {
-		if strings.Contains(md, absent) {
-			t.Errorf("should not contain %q when empty:\n%s", absent, md)
-		}
+		t.Run(absent, func(t *testing.T) {
+			if strings.Contains(md, absent) {
+				t.Errorf("should not contain %q when empty:\n%s", absent, md)
+			}
+		})
 	}
 }
 
@@ -1337,9 +1345,11 @@ func TestFormatSSHKeyListMarkdownString_WithData(t *testing.T) {
 		"| 2 | Personal |",
 		"auth_and_signing",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1382,9 +1392,11 @@ func TestFormatEmailListMarkdownString_WithData(t *testing.T) {
 		"| 1 | primary@example.com |",
 		"| 2 | alias@example.com |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1428,9 +1440,11 @@ func TestFormatContributionEventsMarkdownString_WithData(t *testing.T) {
 		"| 100 | pushed | Project | main |",
 		"| 101 | commented | Issue | Fix bug |",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1476,9 +1490,11 @@ func TestFormatAssociationsCountMarkdownString_WithData(t *testing.T) {
 		"**Issues**: 45",
 		"**Merge Requests**: 30",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1718,9 +1734,11 @@ func TestList_AllFilters(t *testing.T) {
 		"two_factor", "extern_uid", "provider", "public_email", "created_after", "created_before",
 		"pagination", "page_token",
 	} {
-		if query.Get(key) == "" {
-			t.Errorf("query missing %q: %v", key, query.Encode())
-		}
+		t.Run(key, func(t *testing.T) {
+			if query.Get(key) == "" {
+				t.Errorf("query missing %q: %v", key, query.Encode())
+			}
+		})
 	}
 }
 

--- a/internal/tools/wikis/action_specs_test.go
+++ b/internal/tools/wikis/action_specs_test.go
@@ -156,23 +156,25 @@ func TestActionSpecs_RichMetadata(t *testing.T) {
 		"gitlab_wiki_upload_attachment",
 	}
 	for _, name := range wantTools {
-		spec, ok := byTool[name]
-		if !ok {
-			t.Fatalf("missing spec for %s", name)
-		}
-		if spec.Usage == "" || spec.Usage == "Use to execute wikis domain action." {
-			t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
-		}
-		if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
-			t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
-		}
-		if len(spec.RelatedActions) == 0 {
-			t.Errorf("%s: empty RelatedActions", name)
-		}
-		desc := spec.IndividualTool.Description
-		if !contains(desc, "Returns:") || !contains(desc, "See also:") {
-			t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
-		}
+		t.Run(name, func(t *testing.T) {
+			spec, ok := byTool[name]
+			if !ok {
+				t.Fatalf("missing spec for %s", name)
+			}
+			if spec.Usage == "" || spec.Usage == "Use to execute wikis domain action." {
+				t.Errorf("%s: generic or empty Usage: %q", name, spec.Usage)
+			}
+			if len(spec.Aliases) == 0 || spec.Aliases[0] == name {
+				t.Errorf("%s: aliases not replaced with natural-language phrases: %v", name, spec.Aliases)
+			}
+			if len(spec.RelatedActions) == 0 {
+				t.Errorf("%s: empty RelatedActions", name)
+			}
+			desc := spec.IndividualTool.Description
+			if !contains(desc, "Returns:") || !contains(desc, "See also:") {
+				t.Errorf("%s: description missing Returns:/See also: form: %q", name, desc)
+			}
+		})
 	}
 
 	// decorateWikiMeta must be a no-op for a tool with no metadata entry.

--- a/internal/tools/workitems/workitems_test.go
+++ b/internal/tools/workitems/workitems_test.go
@@ -19,6 +19,17 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// invalidIIDCases lists the work item IIDs every handler must reject before
+// reaching the API: Get, Delete and Update share the same guard.
+var invalidIIDCases = []struct {
+	name string
+	iid  int64
+}{
+	{"zero", 0},
+	{"negative", -1},
+	{"large_negative", -100},
+}
+
 // TestGet_Success verifies Get when success.
 func TestGet_Success(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,14 +51,16 @@ func TestGet_Success(t *testing.T) {
 // TestGet_InvalidIID verifies Get when invalid IID.
 func TestGet_InvalidIID(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, iid := range []int64{0, -1, -100} {
-		_, err := Get(t.Context(), client, GetInput{FullPath: testFullPath, IID: iid})
-		if err == nil {
-			t.Fatalf("expected error for IID=%d, got nil", iid)
-		}
-		if !strings.Contains(err.Error(), "work_item_iid") {
-			t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", iid, err)
-		}
+	for _, tc := range invalidIIDCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Get(t.Context(), client, GetInput{FullPath: testFullPath, IID: tc.iid})
+			if err == nil {
+				t.Fatalf("expected error for IID=%d, got nil", tc.iid)
+			}
+			if !strings.Contains(err.Error(), "work_item_iid") {
+				t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", tc.iid, err)
+			}
+		})
 	}
 }
 
@@ -391,14 +404,16 @@ func TestDelete_Success(t *testing.T) {
 // TestDelete_InvalidIID verifies that Delete rejects invalid IIDs.
 func TestDelete_InvalidIID(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, iid := range []int64{0, -1, -100} {
-		err := Delete(t.Context(), client, DeleteInput{FullPath: testFullPath, IID: iid})
-		if err == nil {
-			t.Fatalf("expected error for IID=%d, got nil", iid)
-		}
-		if !strings.Contains(err.Error(), "work_item_iid") {
-			t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", iid, err)
-		}
+	for _, tc := range invalidIIDCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Delete(t.Context(), client, DeleteInput{FullPath: testFullPath, IID: tc.iid})
+			if err == nil {
+				t.Fatalf("expected error for IID=%d, got nil", tc.iid)
+			}
+			if !strings.Contains(err.Error(), "work_item_iid") {
+				t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", tc.iid, err)
+			}
+		})
 	}
 }
 
@@ -1343,14 +1358,16 @@ func TestUpdate_AllOptions(t *testing.T) {
 // with an error mentioning "iid".
 func TestUpdate_InvalidIID(t *testing.T) {
 	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
-	for _, iid := range []int64{0, -1, -100} {
-		_, err := Update(t.Context(), client, UpdateInput{FullPath: testFullPath, IID: iid, Title: "x"})
-		if err == nil {
-			t.Fatalf("expected error for IID=%d, got nil", iid)
-		}
-		if !strings.Contains(err.Error(), "work_item_iid") {
-			t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", iid, err)
-		}
+	for _, tc := range invalidIIDCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Update(t.Context(), client, UpdateInput{FullPath: testFullPath, IID: tc.iid, Title: "x"})
+			if err == nil {
+				t.Fatalf("expected error for IID=%d, got nil", tc.iid)
+			}
+			if !strings.Contains(err.Error(), "work_item_iid") {
+				t.Errorf("expected error to mention 'iid' for IID=%d, got: %v", tc.iid, err)
+			}
+		})
 	}
 }
 

--- a/internal/tools/workitems/workitems_test.go
+++ b/internal/tools/workitems/workitems_test.go
@@ -132,11 +132,13 @@ func TestList_Filters(t *testing.T) {
 			"includeDescendants": false,
 		}
 		for key, want := range expected {
-			if got := request.Variables[key]; got != want {
-				t.Errorf("variable %s = %#v, want %#v", key, got, want)
-				http.Error(w, "variable, want", http.StatusInternalServerError)
-				return
-			}
+			t.Run(key, func(t *testing.T) {
+				if got := request.Variables[key]; got != want {
+					t.Errorf("variable %s = %#v, want %#v", key, got, want)
+					http.Error(w, "variable, want", http.StatusInternalServerError)
+					return
+				}
+			})
 		}
 		testutil.RespondJSON(w, http.StatusOK, `{"data":{"namespace":{"workItems":{"nodes":[]}}}}`)
 	})
@@ -182,9 +184,11 @@ func TestList_Children(t *testing.T) {
 		t.Fatalf(fmtUnexpErr, err)
 	}
 	for _, field := range []string{"hierarchy", "hasChildren", "children"} {
-		if !strings.Contains(capturedQuery, field) {
-			t.Errorf("list query missing %q field:\n%s", field, capturedQuery)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !strings.Contains(capturedQuery, field) {
+				t.Errorf("list query missing %q field:\n%s", field, capturedQuery)
+			}
+		})
 	}
 	if len(out.WorkItems) != 1 {
 		t.Fatalf("expected 1 work item, got %d", len(out.WorkItems))
@@ -729,9 +733,11 @@ func TestFormatGetMarkdown_FullPopulated(t *testing.T) {
 		"A very detailed description.",
 	}
 	for _, s := range expects {
-		if !strings.Contains(text, s) {
-			t.Errorf("missing %q in output:\n%s", s, text)
-		}
+		t.Run(s, func(t *testing.T) {
+			if !strings.Contains(text, s) {
+				t.Errorf("missing %q in output:\n%s", s, text)
+			}
+		})
 	}
 }
 
@@ -754,9 +760,11 @@ func TestFormatGetMarkdown_Children(t *testing.T) {
 	}
 	text := extractText(t, result)
 	for _, s := range []string{"### Children", "| 20 | my-group/child-a |", "| 21 | my-group/child-b |"} {
-		if !strings.Contains(text, s) {
-			t.Errorf("missing %q in output:\n%s", s, text)
-		}
+		t.Run(s, func(t *testing.T) {
+			if !strings.Contains(text, s) {
+				t.Errorf("missing %q in output:\n%s", s, text)
+			}
+		})
 	}
 }
 
@@ -2057,9 +2065,11 @@ func TestFormatWorkItemTypeListMarkdown_WithTypes(t *testing.T) {
 		"Issue",
 		"Task",
 	} {
-		if !strings.Contains(text, want) {
-			t.Errorf("markdown missing %q:\n%s", want, text)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown missing %q:\n%s", want, text)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/action_spec_individual_test.go
+++ b/internal/toolutil/action_spec_individual_test.go
@@ -216,9 +216,11 @@ func TestIndividualToolFromActionSpec_PreservesIndividualRequiredFields(t *testi
 		t.Fatalf("schema required = %T, want []any", schema["required"])
 	}
 	for _, field := range []string{"project_id", "environment_scope"} {
-		if !slices.ContainsFunc(required, func(value any) bool { return value == field }) {
-			t.Fatalf("required fields = %#v, want %q", required, field)
-		}
+		t.Run(field, func(t *testing.T) {
+			if !slices.ContainsFunc(required, func(value any) bool { return value == field }) {
+				t.Fatalf("required fields = %#v, want %q", required, field)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/errors_test.go
+++ b/internal/toolutil/errors_test.go
@@ -1312,10 +1312,12 @@ func TestGitLabRoleAccessLevelStringAliases(t *testing.T) {
 		{"MAINTAINER", 40},
 	}
 	for _, tc := range cases {
-		got, ok := gitLabRoleAccessLevel(tc.role)
-		if !ok || got != tc.want {
-			t.Errorf("gitLabRoleAccessLevel(%q) = %d/%v, want %d/true", tc.role, got, ok, tc.want)
-		}
+		t.Run(tc.role, func(t *testing.T) {
+			got, ok := gitLabRoleAccessLevel(tc.role)
+			if !ok || got != tc.want {
+				t.Errorf("gitLabRoleAccessLevel(%q) = %d/%v, want %d/true", tc.role, got, ok, tc.want)
+			}
+		})
 	}
 
 	// unknown role → rejected

--- a/internal/toolutil/errors_test.go
+++ b/internal/toolutil/errors_test.go
@@ -236,9 +236,11 @@ func TestDetailedError_Markdown(t *testing.T) {
 		"**Request ID**: `req-abc-123`",
 	}
 	for _, want := range checks {
-		if !strings.Contains(md, want) {
-			t.Errorf("Markdown() missing %q in:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("Markdown() missing %q in:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -1223,9 +1225,11 @@ func TestCloneAccessLevelAliasesDirect(t *testing.T) {
 // detector accepts both the canonical field and the alias family.
 func TestHasStructuredApprovalCountDirect(t *testing.T) {
 	for _, key := range []string{"required_approvals", "required_approval_count", "approval_count", "approvals_required"} {
-		if !hasStructuredApprovalCount(map[string]any{key: 2}) {
-			t.Errorf("hasStructuredApprovalCount(%s) = false, want true", key)
-		}
+		t.Run(key, func(t *testing.T) {
+			if !hasStructuredApprovalCount(map[string]any{key: 2}) {
+				t.Errorf("hasStructuredApprovalCount(%s) = false, want true", key)
+			}
+		})
 	}
 	if hasStructuredApprovalCount(map[string]any{"other": 1}) {
 		t.Error("hasStructuredApprovalCount(other) = true, want false")

--- a/internal/toolutil/icons_test.go
+++ b/internal/toolutil/icons_test.go
@@ -170,17 +170,22 @@ func TestAllIcons_SizesAny(t *testing.T) {
 func TestAllIcons_WebPFallbackTheme(t *testing.T) {
 	for name, icons := range allIcons() {
 		t.Run(name, func(t *testing.T) {
-			light, dark := icons[1], icons[2]
-			if light.Theme != mcp.IconThemeLight {
-				t.Errorf("light entry Theme = %q, want %q", light.Theme, mcp.IconThemeLight)
-			}
-			if dark.Theme != mcp.IconThemeDark {
-				t.Errorf("dark entry Theme = %q, want %q", dark.Theme, mcp.IconThemeDark)
-			}
-			for i, ic := range []mcp.Icon{light, dark} {
-				if len(ic.Sizes) != 1 || ic.Sizes[0] != "16x16" {
-					t.Errorf("WebP entry %d Sizes = %v, want [\"16x16\"]", i+1, ic.Sizes)
-				}
+			for i, entry := range []struct {
+				name  string
+				icon  mcp.Icon
+				theme mcp.IconTheme
+			}{
+				{"light", icons[1], mcp.IconThemeLight},
+				{"dark", icons[2], mcp.IconThemeDark},
+			} {
+				t.Run(entry.name, func(t *testing.T) {
+					if entry.icon.Theme != entry.theme {
+						t.Errorf("%s entry Theme = %q, want %q", entry.name, entry.icon.Theme, entry.theme)
+					}
+					if len(entry.icon.Sizes) != 1 || entry.icon.Sizes[0] != "16x16" {
+						t.Errorf("WebP entry %d Sizes = %v, want [\"16x16\"]", i+1, entry.icon.Sizes)
+					}
+				})
 			}
 		})
 	}
@@ -210,22 +215,30 @@ func TestAllIcons_WebPFallbackDecodes(t *testing.T) {
 	const prefix = "data:image/webp;base64,"
 	for name, icons := range allIcons() {
 		t.Run(name, func(t *testing.T) {
-			for i, ic := range []mcp.Icon{icons[1], icons[2]} {
-				payload := strings.TrimPrefix(ic.Source, prefix)
-				decoded, err := base64.StdEncoding.DecodeString(payload)
-				if err != nil {
-					t.Fatalf("entry %d: base64 decode failed: %v", i+1, err)
-				}
-				cfg, format, err := image.DecodeConfig(strings.NewReader(string(decoded)))
-				if err != nil {
-					t.Fatalf("entry %d: image.DecodeConfig failed: %v", i+1, err)
-				}
-				if format != "webp" {
-					t.Errorf("entry %d: decoded format = %q, want %q", i+1, format, "webp")
-				}
-				if cfg.Width != 16 || cfg.Height != 16 {
-					t.Errorf("entry %d: decoded dimensions = %dx%d, want 16x16", i+1, cfg.Width, cfg.Height)
-				}
+			for i, entry := range []struct {
+				name string
+				icon mcp.Icon
+			}{
+				{"light", icons[1]},
+				{"dark", icons[2]},
+			} {
+				t.Run(entry.name, func(t *testing.T) {
+					payload := strings.TrimPrefix(entry.icon.Source, prefix)
+					decoded, err := base64.StdEncoding.DecodeString(payload)
+					if err != nil {
+						t.Fatalf("entry %d: base64 decode failed: %v", i+1, err)
+					}
+					cfg, format, err := image.DecodeConfig(strings.NewReader(string(decoded)))
+					if err != nil {
+						t.Fatalf("entry %d: image.DecodeConfig failed: %v", i+1, err)
+					}
+					if format != "webp" {
+						t.Errorf("entry %d: decoded format = %q, want %q", i+1, format, "webp")
+					}
+					if cfg.Width != 16 || cfg.Height != 16 {
+						t.Errorf("entry %d: decoded dimensions = %dx%d, want 16x16", i+1, cfg.Width, cfg.Height)
+					}
+				})
 			}
 		})
 	}

--- a/internal/toolutil/label_markdown_test.go
+++ b/internal/toolutil/label_markdown_test.go
@@ -38,9 +38,11 @@ func TestFormatLabelMarkdown_AllBranches(t *testing.T) {
 		"- **Open MRs**: 1",
 		"Use action 'label_update'",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("FormatLabelMarkdown() missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("FormatLabelMarkdown() missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }
 
@@ -64,9 +66,11 @@ func TestFormatLabelMarkdown_MinimalUnescaped(t *testing.T) {
 	}, LabelMarkdownOptions{DetailTitle: "Group Label"})
 
 	for _, unwanted := range []string{"- **Priority**", "- **Issues**", "- **Open MRs**", "&#124;"} {
-		if strings.Contains(got, unwanted) {
-			t.Fatalf("FormatLabelMarkdown() unexpectedly contains %q in:\n%s", unwanted, got)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(got, unwanted) {
+				t.Fatalf("FormatLabelMarkdown() unexpectedly contains %q in:\n%s", unwanted, got)
+			}
+		})
 	}
 	if !strings.Contains(got, "- **Description**: plain|pipe") {
 		t.Fatalf("FormatLabelMarkdown() did not preserve unescaped description:\n%s", got)
@@ -103,9 +107,11 @@ func TestFormatLabelListMarkdownFunc_WithLabels(t *testing.T) {
 		"Page 1 of 1",
 		"Use action 'label_get'",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("FormatLabelListMarkdown() missing %q in:\n%s", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("FormatLabelListMarkdown() missing %q in:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/logging_test.go
+++ b/internal/toolutil/logging_test.go
@@ -223,26 +223,36 @@ func TestCancellation_IsNotReportedAsAFailure(t *testing.T) {
 // TestWasCancelled_SeparatesCallerDepartureFromFailure checks the predicate the
 // log level turns on.
 func TestWasCancelled_SeparatesCallerDepartureFromFailure(t *testing.T) {
-	canceled := []error{
-		context.Canceled,
-		context.DeadlineExceeded,
-		fmt.Errorf("listing issues: %w", context.Canceled),
+	canceled := []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "deadline_exceeded", err: context.DeadlineExceeded},
+		{name: "wrapped_canceled", err: fmt.Errorf("listing issues: %w", context.Canceled)},
 	}
-	for _, err := range canceled {
-		if !wasCancelled(err) {
-			t.Errorf("wasCancelled(%v) = false, want true", err)
-		}
+	for _, tc := range canceled {
+		t.Run(tc.name, func(t *testing.T) {
+			if !wasCancelled(tc.err) {
+				t.Errorf("wasCancelled(%v) = false, want true", tc.err)
+			}
+		})
 	}
 
-	failures := []error{
-		nil,
-		errors.New("boom"),
-		fmt.Errorf("listing issues: %w", errors.New("500 from GitLab")),
+	failures := []struct {
+		name string
+		err  error
+	}{
+		{name: "nil_error", err: nil},
+		{name: "plain_failure", err: errors.New("boom")},
+		{name: "wrapped_failure", err: fmt.Errorf("listing issues: %w", errors.New("500 from GitLab"))},
 	}
-	for _, err := range failures {
-		if wasCancelled(err) {
-			t.Errorf("wasCancelled(%v) = true; a real failure would be logged at INFO and lost", err)
-		}
+	for _, tc := range failures {
+		t.Run(tc.name, func(t *testing.T) {
+			if wasCancelled(tc.err) {
+				t.Errorf("wasCancelled(%v) = true; a real failure would be logged at INFO and lost", tc.err)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/markdown_test.go
+++ b/internal/toolutil/markdown_test.go
@@ -159,9 +159,11 @@ func TestFormatStorageMoveDetailMarkdown(t *testing.T) {
 		"| **Group** | [team&#124;ops](https://gitlab.example.com/groups/team-ops) (ID: 42) |",
 		"Use action 'retrieve_all' to monitor progress",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -179,9 +181,11 @@ func TestFormatStorageMoveListMarkdown(t *testing.T) {
 			"No snippet storage moves found.",
 			HintPreserveLinks,
 		} {
-			if !strings.Contains(md, want) {
-				t.Errorf("empty markdown missing %q:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("empty markdown missing %q:\n%s", want, md)
+				}
+			})
 		}
 		if strings.Contains(md, "| ID | State |") {
 			t.Errorf("empty markdown should not include table:\n%s", md)
@@ -218,9 +222,11 @@ func TestFormatStorageMoveListMarkdown(t *testing.T) {
 			"| 2 | started |",
 			"_Page 2, 2 moves shown._",
 		} {
-			if !strings.Contains(md, want) {
-				t.Errorf("list markdown missing %q:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("list markdown missing %q:\n%s", want, md)
+				}
+			})
 		}
 	})
 }
@@ -332,9 +338,11 @@ func TestFormatStorageMoveCollectionMarkdown(t *testing.T) {
 			"| 1 | finished | default | storage2 | [alpha](https://example.com/p/alpha) | 2026-06-01 12:00:00 |",
 			"_Page 1, 2 moves shown._",
 		} {
-			if !strings.Contains(md, want) {
-				t.Errorf("missing %q in:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("missing %q in:\n%s", want, md)
+				}
+			})
 		}
 	})
 
@@ -351,9 +359,11 @@ func TestFormatStorageMoveCollectionMarkdown(t *testing.T) {
 			"## Project Storage Moves",
 			"No project storage moves found.",
 		} {
-			if !strings.Contains(md, want) {
-				t.Errorf("missing %q in:\n%s", want, md)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(md, want) {
+					t.Errorf("missing %q in:\n%s", want, md)
+				}
+			})
 		}
 	})
 }
@@ -394,9 +404,11 @@ func TestFormatCICDVariableMarkdown(t *testing.T) {
 		"| Value | [masked] |",
 		"Use action 'update' to change this variable",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "hidden-value") {
 		t.Errorf("masked variable value leaked in markdown:\n%s", md)
@@ -414,16 +426,20 @@ func TestCICDVariableMarkdownHelpers(t *testing.T) {
 
 	detail := FormatCICDVariableDetailMarkdown(variable, "Variable", true)
 	for _, want := range []string{"## Variable: TOKEN", "| Value | secret |", "Use action 'delete' to remove this variable"} {
-		if !strings.Contains(detail, want) {
-			t.Errorf("detail markdown missing %q:\n%s", want, detail)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(detail, want) {
+				t.Errorf("detail markdown missing %q:\n%s", want, detail)
+			}
+		})
 	}
 
 	list := FormatCICDVariableCollectionMarkdown(variables, PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1}, func(v CICDVariableMarkdown) CICDVariableMarkdown { return v }, "Variables", "No variables found.\n", false, "Read a variable")
 	for _, want := range []string{"## Variables (1)", "| Key | Type | Protected | Masked |", "| TOKEN | file | " + BoolEmoji(true), "Read a variable"} {
-		if !strings.Contains(list, want) {
-			t.Errorf("list markdown missing %q:\n%s", want, list)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(list, want) {
+				t.Errorf("list markdown missing %q:\n%s", want, list)
+			}
+		})
 	}
 }
 
@@ -445,9 +461,11 @@ func TestFormatCICDVariableListMarkdown(t *testing.T) {
 		"| MY&#124;VAR | env_var | " + BoolEmoji(true) + " | " + BoolEmoji(false) + " | prod&#124;blue |",
 		"Use action 'get' with a key to see variable details",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	empty := FormatCICDVariableListMarkdown(nil, pagination, CICDVariableListMarkdownOptions{EmptyMessage: "No variables found.\n"})
@@ -477,9 +495,11 @@ func TestFormatDiscussionListMarkdown(t *testing.T) {
 		"Page 1 of 3 | 42 items total | 20 per page",
 		"Use `gitlab_get_commit_discussion` to view full discussion details",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	empty := FormatDiscussionListMarkdown(nil, DiscussionListMarkdownOptions{EmptyMessage: "No discussions found.\n"})
@@ -501,16 +521,20 @@ func TestDiscussionMarkdownHelpers(t *testing.T) {
 
 	restList := renderer.FormatRESTList(DiscussionOutputMarkdowns([]DiscussionOutput{restDiscussion}), PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1})
 	for _, want := range []string{"## REST Discussions (1)", "### Discussion rest-1", "Open a discussion"} {
-		if !strings.Contains(restList, want) {
-			t.Errorf("REST list markdown missing %q:\n%s", want, restList)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(restList, want) {
+				t.Errorf("REST list markdown missing %q:\n%s", want, restList)
+			}
+		})
 	}
 
 	rendererGraphQLList := renderer.FormatGraphQLList([]DiscussionMarkdown{restDiscussion.MarkdownDiscussion()}, GraphQLPaginationOutput{HasPreviousPage: true, StartCursor: "before"})
 	for _, want := range []string{"## REST Discussions (1)", "prev page cursor: `before`", "Open a discussion"} {
-		if !strings.Contains(rendererGraphQLList, want) {
-			t.Errorf("renderer GraphQL list markdown missing %q:\n%s", want, rendererGraphQLList)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(rendererGraphQLList, want) {
+				t.Errorf("renderer GraphQL list markdown missing %q:\n%s", want, rendererGraphQLList)
+			}
+		})
 	}
 
 	discussion := restDiscussion.MarkdownDiscussion()
@@ -523,9 +547,11 @@ func TestDiscussionMarkdownHelpers(t *testing.T) {
 
 	graphqlList := FormatGraphQLDiscussionListMarkdown([]DiscussionMarkdown{discussion}, GraphQLPaginationOutput{HasNextPage: true, EndCursor: "cursor"}, func(v DiscussionMarkdown) DiscussionMarkdown { return v }, "GraphQL Discussions", "No discussions found.\n", "Fetch next page")
 	for _, want := range []string{"## GraphQL Discussions (1)", "next page cursor: `cursor`", "Fetch next page"} {
-		if !strings.Contains(graphqlList, want) {
-			t.Errorf("GraphQL list markdown missing %q:\n%s", want, graphqlList)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(graphqlList, want) {
+				t.Errorf("GraphQL list markdown missing %q:\n%s", want, graphqlList)
+			}
+		})
 	}
 
 	restWrapper := FormatRESTDiscussionListMarkdown([]DiscussionOutput{restDiscussion}, PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1}, DiscussionOutput.MarkdownDiscussion, "Wrapped Discussions", "No discussions found.\n", "Wrapped hint")
@@ -545,9 +571,11 @@ func TestFormatDiscussionMarkdown(t *testing.T) {
 		"- **@alice** (17 May 2026 12:00 UTC): hello\nworld",
 		"Use action 'discussion_add_note' to reply to this discussion",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -569,9 +597,11 @@ func TestFormatDiscussionNoteMarkdown(t *testing.T) {
 		"- **Created**: 17 May 2026 12:00 UTC",
 		"Use action 'discussion_update_note' with note_id to edit this note",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -597,9 +627,11 @@ func TestFormatTemplateListMarkdown(t *testing.T) {
 		"Use `gitlab_get_ci_yaml_template` to view a specific template",
 		"Use the key to fetch full template content",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	empty := FormatTemplateListMarkdown(nil, pagination, TemplateListMarkdownOptions{Title: "CI YAML Templates", EmptyMessage: "No templates found.\n"})
@@ -617,16 +649,20 @@ func TestTemplateMarkdownHelpers(t *testing.T) {
 
 	list := renderer.FormatList(templates, PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1})
 	for _, want := range []string{"## Templates", "| Go | Go template |", "Open a template"} {
-		if !strings.Contains(list, want) {
-			t.Errorf("template list markdown missing %q:\n%s", want, list)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(list, want) {
+				t.Errorf("template list markdown missing %q:\n%s", want, list)
+			}
+		})
 	}
 
 	content := renderer.FormatContent("Go", "stages:\n  - test")
 	for _, want := range []string{"## Template: Go", "```yaml", "Copy it"} {
-		if !strings.Contains(content, want) {
-			t.Errorf("template content markdown missing %q:\n%s", want, content)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(content, want) {
+				t.Errorf("template content markdown missing %q:\n%s", want, content)
+			}
+		})
 	}
 
 	collection := FormatTemplateCollectionMarkdown(templates, PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1}, func(v TemplateMarkdown) TemplateMarkdown { return v }, "Collection", "No templates found.\n", "Collection hint")
@@ -644,9 +680,11 @@ func TestFormatTemplateContentMarkdown(t *testing.T) {
 		"```dockerfile\nFROM golang:latest\n```",
 		"Copy this template to your Dockerfile and customize it",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	withFence := FormatTemplateContentMarkdown(
@@ -664,9 +702,11 @@ func TestFormatTemplateContentMarkdown(t *testing.T) {
 		"first hint",
 		"second hint",
 	} {
-		if !strings.Contains(withFence, want) {
-			t.Errorf("markdown with embedded fence missing %q:\n%s", want, withFence)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(withFence, want) {
+				t.Errorf("markdown with embedded fence missing %q:\n%s", want, withFence)
+			}
+		})
 	}
 
 	withLongFence := FormatTemplateContentMarkdown(
@@ -680,9 +720,11 @@ func TestFormatTemplateContentMarkdown(t *testing.T) {
 		"````\nembedded\n````",
 		"\n`````\n",
 	} {
-		if !strings.Contains(withLongFence, want) {
-			t.Errorf("markdown with four-backtick fence missing %q:\n%s", want, withLongFence)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(withLongFence, want) {
+				t.Errorf("markdown with four-backtick fence missing %q:\n%s", want, withLongFence)
+			}
+		})
 	}
 }
 
@@ -709,9 +751,11 @@ func TestFormatNoteMarkdown(t *testing.T) {
 		"note body",
 		"Use note update to edit this note",
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 }
 
@@ -726,9 +770,11 @@ func TestNoteMarkdownHelpers(t *testing.T) {
 
 	detail := FormatNoteMarkdown(note, NoteMarkdownOptions{Title: "Issue Note", IncludeResolvable: true})
 	for _, want := range []string{"## Issue Note #8", "- **Resolvable**: unresolved", "plain body"} {
-		if !strings.Contains(detail, want) {
-			t.Errorf("note detail markdown missing %q:\n%s", want, detail)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(detail, want) {
+				t.Errorf("note detail markdown missing %q:\n%s", want, detail)
+			}
+		})
 	}
 
 	list := FormatNoteListMarkdown(notes, PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1}, NoteListMarkdownOptions{Title: "Notes", EmptyMessage: "No notes found.\n"})
@@ -755,9 +801,11 @@ func TestFormatNoteListMarkdown(t *testing.T) {
 		"| 7 | alice&#124;dev | 17 May 2026 12:00 UTC | " + BoolEmoji(true) + " | " + BoolEmoji(true) + " |",
 		HintPreserveLinks,
 	} {
-		if !strings.Contains(md, want) {
-			t.Errorf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	empty := FormatNoteListMarkdown(nil, pagination, NoteListMarkdownOptions{Title: "Issue Notes", EmptyMessage: "No issue notes found.\n"})

--- a/internal/toolutil/meta_schema_test.go
+++ b/internal/toolutil/meta_schema_test.go
@@ -113,9 +113,11 @@ func TestBuildMetaSchemaIndex_SortsToolsAndActions(t *testing.T) {
 	}
 	wantActions := []string{"delete", "get"}
 	for i, want := range wantActions {
-		if index.Tools[0].Actions[i] != want {
-			t.Fatalf("issue action %d = %q, want %q", i, index.Tools[0].Actions[i], want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if index.Tools[0].Actions[i] != want {
+				t.Fatalf("issue action %d = %q, want %q", i, index.Tools[0].Actions[i], want)
+			}
+		})
 	}
 }
 
@@ -327,9 +329,11 @@ func TestParseMetaSchemaURI_ValidAndMalformedURIs_ReturnsParsedParts(t *testing.
 		"gitlab://schema/meta//delete",
 		"gitlab://schema/meta/gitlab_project/",
 	} {
-		if gotTool, gotAction := ParseMetaSchemaURI(uri); gotTool != "" || gotAction != "" {
-			t.Fatalf("ParseMetaSchemaURI(%q) = %q/%q, want empty", uri, gotTool, gotAction)
-		}
+		t.Run(uri, func(t *testing.T) {
+			if gotTool, gotAction := ParseMetaSchemaURI(uri); gotTool != "" || gotAction != "" {
+				t.Fatalf("ParseMetaSchemaURI(%q) = %q/%q, want empty", uri, gotTool, gotAction)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/metatool.go
+++ b/internal/toolutil/metatool.go
@@ -2524,7 +2524,7 @@ var (
 // Callers that memoize a registered surface must key on it, because the
 // same registration produces different input schemas under each mode.
 func MetaParamSchemaMode() string {
-	return metaParamSchemaMode
+	return currentMetaParamSchemaMode()
 }
 
 func SetMetaParamSchemaMode(mode string) {

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -407,14 +407,18 @@ func TestJSONFieldReflectionHelpers(t *testing.T) {
 
 	fields := jsonFieldNames(reflect.TypeFor[namedInput]())
 	for _, want := range []string{"embedded_name", "Plain", "tagged", "Anonymous", "string_list"} {
-		if _, ok := fields[want]; !ok {
-			t.Fatalf("jsonFieldNames() missing %q in %#v", want, fields)
-		}
+		t.Run(want, func(t *testing.T) {
+			if _, ok := fields[want]; !ok {
+				t.Fatalf("jsonFieldNames() missing %q in %#v", want, fields)
+			}
+		})
 	}
 	for _, unwanted := range []string{"-", "_"} {
-		if _, ok := fields[unwanted]; ok {
-			t.Fatalf("jsonFieldNames() contains %q in %#v", unwanted, fields)
-		}
+		t.Run(unwanted, func(t *testing.T) {
+			if _, ok := fields[unwanted]; ok {
+				t.Fatalf("jsonFieldNames() contains %q in %#v", unwanted, fields)
+			}
+		})
 	}
 	if got := jsonFieldNames(reflect.TypeFor[string]()); got != nil {
 		t.Fatalf("jsonFieldNames(non-struct) = %#v, want nil", got)
@@ -575,9 +579,11 @@ func TestNormalizeParamAliasesForSchema_NormalizesAndCoerces(t *testing.T) {
 		t.Fatalf("note/storage shard values = %#v", got)
 	}
 	for _, alias := range []string{"search", "mr_iid", "project_path", "link", "from", "to", "environment", "merge_when_pipeline_succeeds", "active", "file_path", "body", "shard"} {
-		if _, exists := got[alias]; exists {
-			t.Fatalf("alias %q still present in %#v", alias, got)
-		}
+		t.Run(alias, func(t *testing.T) {
+			if _, exists := got[alias]; exists {
+				t.Fatalf("alias %q still present in %#v", alias, got)
+			}
+		})
 	}
 }
 
@@ -1769,9 +1775,11 @@ func TestMetaToolDescriptionPrefix_IncludesParameterGuidance(t *testing.T) {
 		"Source: Owning project whose allowlist is being changed.",
 		"Avoid: Do not use the project being removed as project_id.",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("prefix missing %q: %q", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("prefix missing %q: %q", want, got)
+			}
+		})
 	}
 
 	description := got + "Manage GitLab CI job token scope."
@@ -1794,9 +1802,11 @@ func TestMetaToolDescriptionPrefix_IncludesActionGuidance(t *testing.T) {
 		"metadata_get: Read GitLab instance metadata such as version and revision.",
 		"settings_get: Read current GitLab application settings.",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("prefix missing %q: %q", want, got)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("prefix missing %q: %q", want, got)
+			}
+		})
 	}
 
 	description := got + "Manage GitLab instance administration."
@@ -3254,10 +3264,12 @@ func TestInputSchemaForType_SecretFieldsWriteOnly(t *testing.T) {
 	schema := inputSchemaForType(reflect.TypeFor[secretInput]())
 	properties := schema["properties"].(map[string]any)
 	for _, key := range []string{"token", "signing_token"} {
-		property := properties[key].(map[string]any)
-		if property["writeOnly"] != true {
-			t.Fatalf("%s writeOnly = %v, want true", key, property["writeOnly"])
-		}
+		t.Run(key, func(t *testing.T) {
+			property := properties[key].(map[string]any)
+			if property["writeOnly"] != true {
+				t.Fatalf("%s writeOnly = %v, want true", key, property["writeOnly"])
+			}
+		})
 	}
 	name := properties["name"].(map[string]any)
 	if _, ok := name["writeOnly"]; ok {
@@ -3326,9 +3338,11 @@ func TestFieldTiers_ReadsTierTag(t *testing.T) {
 		t.Fatalf("FieldTiers = %v, want %v", got, want)
 	}
 	for name, tier := range want {
-		if got[name] != tier {
-			t.Errorf("FieldTiers[%q] = %q, want %q", name, got[name], tier)
-		}
+		t.Run(name, func(t *testing.T) {
+			if got[name] != tier {
+				t.Errorf("FieldTiers[%q] = %q, want %q", name, got[name], tier)
+			}
+		})
 	}
 	if _, ok := got["title"]; ok {
 		t.Error("untagged field title must not appear")
@@ -4604,10 +4618,12 @@ func TestCoercePaginationBooleanDirect(t *testing.T) {
 
 	// name in {first,last,per_page} → 100
 	for _, name := range []string{"first", "last", "per_page"} {
-		got, ok = coercePaginationBoolean(name, true, intType)
-		if !ok || got != 100 {
-			t.Errorf("coercePaginationBoolean(%s, true) = %v/%v, want 100/true", name, got, ok)
-		}
+		t.Run(name, func(t *testing.T) {
+			got, ok = coercePaginationBoolean(name, true, intType)
+			if !ok || got != 100 {
+				t.Errorf("coercePaginationBoolean(%s, true) = %v/%v, want 100/true", name, got, ok)
+			}
+		})
 	}
 
 	// bool false → unchanged
@@ -4690,12 +4706,14 @@ func TestIsStringSliceTypeAndIsStringTypeDirect(t *testing.T) {
 		{"bool", reflect.TypeFor[bool](), false, false},
 	}
 	for _, tc := range cases {
-		if got := isStringType(tc.typ); got != tc.isString {
-			t.Errorf("%s: isStringType = %v, want %v", tc.name, got, tc.isString)
-		}
-		if got := isStringSliceType(tc.typ); got != tc.isSlice {
-			t.Errorf("%s: isStringSliceType = %v, want %v", tc.name, got, tc.isSlice)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStringType(tc.typ); got != tc.isString {
+				t.Errorf("%s: isStringType = %v, want %v", tc.name, got, tc.isString)
+			}
+			if got := isStringSliceType(tc.typ); got != tc.isSlice {
+				t.Errorf("%s: isStringSliceType = %v, want %v", tc.name, got, tc.isSlice)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/metatool_test.go
+++ b/internal/toolutil/metatool_test.go
@@ -299,10 +299,20 @@ func TestUnmarshalParams_CoercesStructuredAccessLevelShapes(t *testing.T) {
 // rejects values that overflow the valid access-level range (oversized strings, ints,
 // and floats) while still accepting an in-range numeric string.
 func TestGitLabRoleAccessLevel_RejectsOutOfRangeIntegers(t *testing.T) {
-	for _, value := range []any{"9223372036854775807", int64(1 << 62), float64(1e20)} {
-		if got, ok := gitLabRoleAccessLevel(value); ok {
-			t.Fatalf("gitLabRoleAccessLevel(%v) = %d, true; want rejected", value, got)
-		}
+	oversized := []struct {
+		name  string
+		value any
+	}{
+		{"max_int64_string", "9223372036854775807"},
+		{"int64_two_pow_62", int64(1 << 62)},
+		{"float64_1e20", float64(1e20)},
+	}
+	for _, tc := range oversized {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := gitLabRoleAccessLevel(tc.value); ok {
+				t.Fatalf("gitLabRoleAccessLevel(%v) = %d, true; want rejected", tc.value, got)
+			}
+		})
 	}
 
 	if got, ok := gitLabRoleAccessLevel("60"); !ok || got != 60 {
@@ -4490,63 +4500,117 @@ func TestStructHasJSONField(t *testing.T) {
 // integer, including negative and out-of-range values.
 func TestValidGitLabRoleAccessLevelDirect(t *testing.T) {
 	cases := []struct {
+		name   string
 		value  int
 		wantOK bool
 	}{
-		{0, true},
-		{10, true},
-		{20, true},
-		{30, true},
-		{40, true},
-		{50, true},
-		{60, true},
-		{1, false},
-		{5, false},
-		{15, false},
-		{25, false},
-		{70, false},
-		{100, false},
-		{-1, false},
-		{-10, false},
+		{"no_access", 0, true},
+		{"guest", 10, true},
+		{"reporter", 20, true},
+		{"developer", 30, true},
+		{"maintainer", 40, true},
+		{"owner", 50, true},
+		{"admin", 60, true},
+		{"one", 1, false},
+		{"minimal_access_5", 5, false},
+		{"planner_15", 15, false},
+		{"between_roles_25", 25, false},
+		{"above_admin_70", 70, false},
+		{"hundred", 100, false},
+		{"negative_one", -1, false},
+		{"negative_ten", -10, false},
 	}
 	for _, tc := range cases {
-		got, ok := validGitLabRoleAccessLevel(tc.value)
-		if ok != tc.wantOK {
-			t.Errorf("validGitLabRoleAccessLevel(%d) ok = %v, want %v", tc.value, ok, tc.wantOK)
-		}
-		if ok && got != tc.value {
-			t.Errorf("validGitLabRoleAccessLevel(%d) = %d, want %d", tc.value, got, tc.value)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := validGitLabRoleAccessLevel(tc.value)
+			if ok != tc.wantOK {
+				t.Errorf("validGitLabRoleAccessLevel(%d) ok = %v, want %v", tc.value, ok, tc.wantOK)
+			}
+			if ok && got != tc.value {
+				t.Errorf("validGitLabRoleAccessLevel(%d) = %d, want %d", tc.value, got, tc.value)
+			}
+		})
 	}
 }
 
 // TestValidGitLabRoleAccessLevelInt64Direct verifies the int64 variant
 // rejects out-of-int-range and negative values before narrowing.
 func TestValidGitLabRoleAccessLevelInt64Direct(t *testing.T) {
-	for _, value := range []int64{0, 10, 20, 30, 40, 50, 60} {
-		if got, ok := validGitLabRoleAccessLevelInt64(value); !ok || got != int(value) {
-			t.Errorf("validGitLabRoleAccessLevelInt64(%d) = %d/%v, want %d/true", value, got, ok, value)
-		}
+	accepted := []struct {
+		name  string
+		value int64
+	}{
+		{"no_access", 0},
+		{"guest", 10},
+		{"reporter", 20},
+		{"developer", 30},
+		{"maintainer", 40},
+		{"owner", 50},
+		{"admin", 60},
 	}
-	for _, value := range []int64{-1, 5, 70, 1 << 40, 1 << 60} {
-		if _, ok := validGitLabRoleAccessLevelInt64(value); ok {
-			t.Errorf("validGitLabRoleAccessLevelInt64(%d) ok = true, want false", value)
-		}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := validGitLabRoleAccessLevelInt64(tc.value); !ok || got != int(tc.value) {
+				t.Errorf("validGitLabRoleAccessLevelInt64(%d) = %d/%v, want %d/true", tc.value, got, ok, tc.value)
+			}
+		})
+	}
+	rejected := []struct {
+		name  string
+		value int64
+	}{
+		{"negative", -1},
+		{"minimal_access_5", 5},
+		{"above_admin_70", 70},
+		{"two_pow_40", 1 << 40},
+		{"two_pow_60", 1 << 60},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := validGitLabRoleAccessLevelInt64(tc.value); ok {
+				t.Errorf("validGitLabRoleAccessLevelInt64(%d) ok = true, want false", tc.value)
+			}
+		})
 	}
 }
 
 // TestValidGitLabRoleAccessLevelFloat64Direct verifies the float64 variant
 // only accepts whole-number values in the canonical set.
 func TestValidGitLabRoleAccessLevelFloat64Direct(t *testing.T) {
-	for _, value := range []float64{0, 10, 20, 30, 40, 50, 60} {
-		if got, ok := validGitLabRoleAccessLevelFloat64(value); !ok || got != int(value) {
-			t.Errorf("validGitLabRoleAccessLevelFloat64(%v) = %d/%v, want %d/true", value, got, ok, int(value))
-		}
+	accepted := []struct {
+		name  string
+		value float64
+	}{
+		{"no_access", 0},
+		{"guest", 10},
+		{"reporter", 20},
+		{"developer", 30},
+		{"maintainer", 40},
+		{"owner", 50},
+		{"admin", 60},
 	}
-	for _, value := range []float64{1.5, 5, 70, -10} {
-		if _, ok := validGitLabRoleAccessLevelFloat64(value); ok {
-			t.Errorf("validGitLabRoleAccessLevelFloat64(%v) ok = true, want false", value)
-		}
+	for _, tc := range accepted {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := validGitLabRoleAccessLevelFloat64(tc.value); !ok || got != int(tc.value) {
+				t.Errorf("validGitLabRoleAccessLevelFloat64(%v) = %d/%v, want %d/true", tc.value, got, ok, int(tc.value))
+			}
+		})
+	}
+	rejected := []struct {
+		name  string
+		value float64
+	}{
+		{"fractional", 1.5},
+		{"minimal_access_5", 5},
+		{"above_admin_70", 70},
+		{"negative", -10},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := validGitLabRoleAccessLevelFloat64(tc.value); ok {
+				t.Errorf("validGitLabRoleAccessLevelFloat64(%v) ok = true, want false", tc.value)
+			}
+		})
 	}
 }
 
@@ -4576,10 +4640,20 @@ func TestNumericRoleAccessLevel(t *testing.T) {
 	if _, ok := numericRoleAccessLevel(float64(70)); ok {
 		t.Error("numericRoleAccessLevel(float64 70) ok = true, want false")
 	}
-	for _, value := range []any{"30", true, nil} {
-		if _, ok := numericRoleAccessLevel(value); ok {
-			t.Errorf("numericRoleAccessLevel(%T %v) ok = true, want false", value, value)
-		}
+	nonNumeric := []struct {
+		name  string
+		value any
+	}{
+		{"numeric_string", "30"},
+		{"bool", true},
+		{"nil", nil},
+	}
+	for _, tc := range nonNumeric {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := numericRoleAccessLevel(tc.value); ok {
+				t.Errorf("numericRoleAccessLevel(%T %v) ok = true, want false", tc.value, tc.value)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/noteshapes_test.go
+++ b/internal/toolutil/noteshapes_test.go
@@ -295,14 +295,18 @@ func TestNoteShapeJSONTags(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	for _, key := range []string{`"id":1`, `"username":"u"`, `"name":"n"`, `"web_url":"w"`} {
-		if !strings.Contains(string(raw), key) {
-			t.Errorf("NoteUserOutput JSON missing %q: %s", key, raw)
-		}
+		t.Run(key, func(t *testing.T) {
+			if !strings.Contains(string(raw), key) {
+				t.Errorf("NoteUserOutput JSON missing %q: %s", key, raw)
+			}
+		})
 	}
 	for _, key := range []string{`"email"`, `"state"`, `"avatar_url"`} {
-		if strings.Contains(string(raw), key) {
-			t.Errorf("NoteUserOutput JSON should omit empty %q: %s", key, raw)
-		}
+		t.Run(key, func(t *testing.T) {
+			if strings.Contains(string(raw), key) {
+				t.Errorf("NoteUserOutput JSON should omit empty %q: %s", key, raw)
+			}
+		})
 	}
 	raw, err = json.Marshal(&LinePositionOutput{LineCode: "x"})
 	if err != nil {

--- a/internal/toolutil/pipelineshapes_test.go
+++ b/internal/toolutil/pipelineshapes_test.go
@@ -152,15 +152,19 @@ func TestPipelineOutputJSONTags(t *testing.T) {
 		`"tag":false`, `"duration":0`, `"queued_duration":0`,
 		`"coverage":""`, `"yaml_errors":""`,
 	} {
-		if !strings.Contains(string(raw), key) {
-			t.Errorf("PipelineOutput JSON missing %q: %s", key, raw)
-		}
+		t.Run(key, func(t *testing.T) {
+			if !strings.Contains(string(raw), key) {
+				t.Errorf("PipelineOutput JSON missing %q: %s", key, raw)
+			}
+		})
 	}
 	// Pointer + time fields use omitempty and must NOT appear when empty.
 	for _, key := range []string{`"user"`, `"updated_at"`, `"created_at"`, `"started_at"`, `"finished_at"`, `"committed_at"`, `"detailed_status"`} {
-		if strings.Contains(string(raw), key) {
-			t.Errorf("PipelineOutput JSON should omit empty %q: %s", key, raw)
-		}
+		t.Run(key, func(t *testing.T) {
+			if strings.Contains(string(raw), key) {
+				t.Errorf("PipelineOutput JSON should omit empty %q: %s", key, raw)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/ratelimit_test.go
+++ b/internal/toolutil/ratelimit_test.go
@@ -22,10 +22,20 @@ import (
 // limiter (returns nil, treated as no-op by AttachRateLimit).
 func TestNewRateLimiter_Disabled(t *testing.T) {
 	t.Parallel()
-	for _, rps := range []float64{0, -1, -100} {
-		if l := NewRateLimiter(rps, 10); l != nil {
-			t.Errorf("NewRateLimiter(%g, 10) = %v, want nil", rps, l)
-		}
+	for _, tc := range []struct {
+		name string
+		rps  float64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"large_negative", -100},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if l := NewRateLimiter(tc.rps, 10); l != nil {
+				t.Errorf("NewRateLimiter(%g, 10) = %v, want nil", tc.rps, l)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/template_markdown_test.go
+++ b/internal/toolutil/template_markdown_test.go
@@ -16,9 +16,11 @@ func TestFormatTemplateAttributeListMarkdown(t *testing.T) {
 	})
 
 	for _, want := range []string{"## Templates", "mit", "MIT &#124; License", "Yes", "Use a get action"} {
-		if !strings.Contains(md, want) {
-			t.Fatalf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Fatalf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	empty := FormatTemplateAttributeListMarkdown(nil, TemplateAttributeListMarkdownOptions{Title: "Templates", EmptyMessage: "No templates found.", AttributeHeader: "Popular"})
@@ -45,9 +47,11 @@ func TestFormatTemplateDetailMarkdown(t *testing.T) {
 	})
 
 	for _, want := range []string{"Project Template: MIT", "mit", "Nickname", "Popular", "A permissive license", "commercial-use", "include-copyright", "no-liability", "```\nlicense text\n```", "Use this template"} {
-		if !strings.Contains(md, want) {
-			t.Fatalf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Fatalf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 
 	minimal := FormatTemplateDetailMarkdown(TemplateDetailMarkdown{Title: "License: Minimal"})
@@ -70,9 +74,11 @@ func TestFormatTemplateDetailMarkdown_PlainFields(t *testing.T) {
 	})
 
 	for _, want := range []string{"**Description**: A permissive license", "**Permissions**: commercial-use", "**Conditions**: include-copyright", "**Limitations**: no-liability"} {
-		if !strings.Contains(md, want) {
-			t.Fatalf("markdown missing %q:\n%s", want, md)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Fatalf("markdown missing %q:\n%s", want, md)
+			}
+		})
 	}
 	if strings.Contains(md, "- **Permissions**") {
 		t.Fatalf("plain markdown should not render bulleted detail fields:\n%s", md)

--- a/site/identity/person.snapshot.json
+++ b/site/identity/person.snapshot.json
@@ -39,7 +39,19 @@
   "publishingPrinciples": "https://jmrp.io/about/#editorial",
   "potentialAction": {
     "@type": "DonateAction",
-    "name": "Sponsor this work on GitHub",
+    "name": [
+      {
+        "@value": "Sponsor this work on GitHub",
+        "@language": "en"
+      },
+      {
+        "@value": "Patrocina este trabajo en GitHub",
+        "@language": "es"
+      }
+    ],
+    "recipient": {
+      "@id": "https://jmrp.io/#person"
+    },
     "target": {
       "@type": "EntryPoint",
       "urlTemplate": "https://github.com/sponsors/jmrplens"

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   yaml-language-server@1.20.0>yaml: 2.9.0
   brace-expansion@<1.1.18: 1.1.18
   brace-expansion@>=3.0.0 <5.0.9: 5.0.9
-  fast-uri@<3.1.5: 3.1.5
+  fast-uri@<3.1.6: 3.1.6
   ip-address@<10.3.1: 10.3.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
 
@@ -2052,8 +2052,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5062,7 +5062,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5967,7 +5967,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -15,11 +15,13 @@ overrides:
   "brace-expansion@<1.1.18": 1.1.18
   "brace-expansion@>=3.0.0 <5.0.9": 5.0.9
   # fast-uri host confusion via failed IDN / backslash authority
-  # (GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-6q2v-7v5f-6qmw);
-  # dev/build deps only (html-validate > @sidvind/better-ajv-errors > ajv).
+  # (GHSA-4c8g-83qw-93j6, GHSA-v2hh-gcrm-f6hx, GHSA-6q2v-7v5f-6qmw), and via
+  # percent-encoded scheme normalization (GHSA-jqff-g426-hqxp, which the 3.1.5
+  # this line used to pin does not carry a fix for). Dev/build deps only, now
+  # reached through @astrojs/check's language server as well as html-validate.
   # Pinned exactly rather than ">=": an open range now resolves to 4.x, and a
   # major bump of ajv's URI parser is not what an advisory fix should drag in.
-  "fast-uri@<3.1.5": 3.1.5
+  "fast-uri@<3.1.6": 3.1.6
   # ip-address Address4 decodes leading-zero octets as decimal (GHSA-8gjw-6f7c-jmc4);
   # dev/build deps only (pa11y-ci > puppeteer > socks-proxy-agent > socks).
   "ip-address@<10.3.1": 10.3.1

--- a/test/e2e/collector/configurations_test.go
+++ b/test/e2e/collector/configurations_test.go
@@ -56,9 +56,11 @@ func TestRealCollector_ToolNamePolicyOff(t *testing.T) {
 
 	t.Run("the span keeps both", func(t *testing.T) {
 		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
-			if _, present := attr(span.Attributes, key); !present {
-				t.Errorf("%s is absent from the span; the policy is about metric series, not about hiding the value", key)
-			}
+			t.Run(key, func(t *testing.T) {
+				if _, present := attr(span.Attributes, key); !present {
+					t.Errorf("%s is absent from the span; the policy is about metric series, not about hiding the value", key)
+				}
+			})
 		}
 	})
 
@@ -67,9 +69,11 @@ func TestRealCollector_ToolNamePolicyOff(t *testing.T) {
 			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
 		}
 		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
-			if instrument := metricDimensionExists(t, c, key); instrument != "" {
-				t.Errorf("%s is still a dimension of %s under the off policy", key, instrument)
-			}
+			t.Run(key, func(t *testing.T) {
+				if instrument := metricDimensionExists(t, c, key); instrument != "" {
+					t.Errorf("%s is still a dimension of %s under the off policy", key, instrument)
+				}
+			})
 		}
 	})
 }
@@ -106,9 +110,11 @@ func TestRealCollector_IdentityFullExportsTheReadableUser(t *testing.T) {
 			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
 		}
 		for _, key := range []string{"user.id", "user.name", "user.hash"} {
-			if instrument := metricDimensionExists(t, c, key); instrument != "" {
-				t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
-			}
+			t.Run(key, func(t *testing.T) {
+				if instrument := metricDimensionExists(t, c, key); instrument != "" {
+					t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
+				}
+			})
 		}
 	})
 }

--- a/test/e2e/collector/inventory_test.go
+++ b/test/e2e/collector/inventory_test.go
@@ -311,9 +311,11 @@ func TestRealCollector_IdentityReachesSpansAndNeverMetrics(t *testing.T) {
 			t.Error("user.hash is present but empty, which correlates nothing while still claiming to")
 		}
 		for _, readable := range []string{"user.id", "user.name"} {
-			if value, leaked := attr(span.Attributes, readable); leaked {
-				t.Errorf("%s = %q under the pseudonymous policy; the whole point of the policy is that this key is not exported", readable, value)
-			}
+			t.Run(readable, func(t *testing.T) {
+				if value, leaked := attr(span.Attributes, readable); leaked {
+					t.Errorf("%s = %q under the pseudonymous policy; the whole point of the policy is that this key is not exported", readable, value)
+				}
+			})
 		}
 	})
 
@@ -325,9 +327,11 @@ func TestRealCollector_IdentityReachesSpansAndNeverMetrics(t *testing.T) {
 			t.Fatalf("the collector parsed no %s metric, so this assertion would pass vacuously", durationMetric)
 		}
 		for _, key := range []string{"user.hash", "user.id", "user.name"} {
-			if instrument := metricDimensionExists(t, c, key); instrument != "" {
-				t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
-			}
+			t.Run(key, func(t *testing.T) {
+				if instrument := metricDimensionExists(t, c, key); instrument != "" {
+					t.Errorf("%q is a dimension of %s; identity must never reach a metric under any policy", key, instrument)
+				}
+			})
 		}
 	})
 }

--- a/test/e2e/collector/protective_test.go
+++ b/test/e2e/collector/protective_test.go
@@ -139,9 +139,11 @@ func TestRealCollector_ReadOnlyRemovesTheToolRatherThanRefusingIt(t *testing.T) 
 	// deployment working.
 	if errorType, present := attr(span.Attributes, "error.type"); present {
 		for _, serverFault := range []string{"-32603", "_OTHER"} {
-			if errorType == serverFault {
-				t.Errorf("error.type = %q under read-only; refusing a mutating call is not this server failing", errorType)
-			}
+			t.Run(serverFault, func(t *testing.T) {
+				if errorType == serverFault {
+					t.Errorf("error.type = %q under read-only; refusing a mutating call is not this server failing", errorType)
+				}
+			})
 		}
 	}
 }

--- a/test/e2e/collector/surfaces_test.go
+++ b/test/e2e/collector/surfaces_test.go
@@ -133,9 +133,11 @@ func TestRealCollector_IndividualSurfaceDropsTheNameFromMetricsByDefault(t *test
 
 	t.Run("the span still says what was called", func(t *testing.T) {
 		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
-			if _, present := attr(span.Attributes, key); !present {
-				t.Errorf("%s is absent from the span; the policy bounds series and does not hide values", key)
-			}
+			t.Run(key, func(t *testing.T) {
+				if _, present := attr(span.Attributes, key); !present {
+					t.Errorf("%s is absent from the span; the policy bounds series and does not hide values", key)
+				}
+			})
 		}
 	})
 
@@ -144,10 +146,12 @@ func TestRealCollector_IndividualSurfaceDropsTheNameFromMetricsByDefault(t *test
 			t.Fatalf("no %s metric, so this would pass vacuously", durationMetric)
 		}
 		for _, key := range []string{"gen_ai.tool.name", "gitlab_mcp.action"} {
-			if instrument := metricDimensionExists(t, c, key); instrument != "" {
-				t.Errorf("%s is a dimension of %s on the individual surface; about a thousand values against a 2000-series budget",
-					key, instrument)
-			}
+			t.Run(key, func(t *testing.T) {
+				if instrument := metricDimensionExists(t, c, key); instrument != "" {
+					t.Errorf("%s is a dimension of %s on the individual surface; about a thousand values against a 2000-series budget",
+						key, instrument)
+				}
+			})
 		}
 	})
 }

--- a/test/e2e/http/clientcompat_test.go
+++ b/test/e2e/http/clientcompat_test.go
@@ -256,14 +256,16 @@ func TestClient_DesktopOriginBehaviour(t *testing.T) {
 	t.Run("fetch metadata that says it is not cross-site is honored", func(t *testing.T) {
 		srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
 		for _, meta := range []string{"same-origin", "none"} {
-			got := srv.do(t, mcpPOST(map[string]string{
-				"PRIVATE-TOKEN":  "glpat-whatever",
-				"Origin":         desktopOrigin,
-				"Sec-Fetch-Site": meta,
-			}))
-			if got.status == http.StatusForbidden {
-				t.Errorf("Sec-Fetch-Site: %s was refused as cross-site", meta)
-			}
+			t.Run(meta, func(t *testing.T) {
+				got := srv.do(t, mcpPOST(map[string]string{
+					"PRIVATE-TOKEN":  "glpat-whatever",
+					"Origin":         desktopOrigin,
+					"Sec-Fetch-Site": meta,
+				}))
+				if got.status == http.StatusForbidden {
+					t.Errorf("Sec-Fetch-Site: %s was refused as cross-site", meta)
+				}
+			})
 		}
 	})
 }

--- a/test/e2e/http/collector_auth_test.go
+++ b/test/e2e/http/collector_auth_test.go
@@ -96,9 +96,11 @@ func TestCollectorAuth_EveryOption(t *testing.T) {
 					"X-Tenant":      "acme",
 					"X-Env":         "prod",
 				} {
-					if value := got.Get(header); value != want {
-						t.Errorf("%s = %q, want %q", header, value, want)
-					}
+					t.Run(header, func(t *testing.T) {
+						if value := got.Get(header); value != want {
+							t.Errorf("%s = %q, want %q", header, value, want)
+						}
+					})
 				}
 			},
 		},

--- a/test/e2e/http/collector_privacy_test.go
+++ b/test/e2e/http/collector_privacy_test.go
@@ -76,14 +76,19 @@ func TestCollectorPrivacy_NothingPrivateReachesTheCollector(t *testing.T) {
 	// Calls carrying every category. Whether each succeeds is beside the point:
 	// a failing call is exactly where a server is most tempted to record what it
 	// was given.
-	calls := []request{
-		authorizedCall(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{`+protocolMeta+`,"name":"gitlab_execute_action","arguments":{"action":"issue.list","project_id":"`+projectPath+`"}}}`, withAction("issue.list")),
-		authorizedCall(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{`+protocolMeta+`,"name":"gitlab_execute_action","arguments":{"action":"search.code","search":"`+searchQuery+`"}}}`, withAction("search.code")),
-		authorizedCall(`{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{`+protocolMeta+`,"uri":"gitlab://projects/`+projectPath+`/issues"}}`, nil),
-		{body: `{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{` + protocolMeta + `}}`, headers: map[string]string{"PRIVATE-TOKEN": clientToken}},
+	calls := []struct {
+		name string
+		call request
+	}{
+		{"project_path_in_tool_arguments", authorizedCall(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{`+protocolMeta+`,"name":"gitlab_execute_action","arguments":{"action":"issue.list","project_id":"`+projectPath+`"}}}`, withAction("issue.list"))},
+		{"search_query_in_tool_arguments", authorizedCall(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{`+protocolMeta+`,"name":"gitlab_execute_action","arguments":{"action":"search.code","search":"`+searchQuery+`"}}}`, withAction("search.code"))},
+		{"project_path_in_resource_uri", authorizedCall(`{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{`+protocolMeta+`,"uri":"gitlab://projects/`+projectPath+`/issues"}}`, nil)},
+		{"client_token_in_header", request{body: `{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{` + protocolMeta + `}}`, headers: map[string]string{"PRIVATE-TOKEN": clientToken}}},
 	}
-	for _, call := range calls {
-		srv.do(t, call)
+	for _, tc := range calls {
+		t.Run(tc.name, func(t *testing.T) {
+			srv.do(t, tc.call)
+		})
 	}
 
 	c.awaitExport(t, 20*time.Second)

--- a/test/e2e/http/crossorigin_test.go
+++ b/test/e2e/http/crossorigin_test.go
@@ -100,25 +100,31 @@ func TestCrossOrigin_ExactlyOneAllowOriginHeader(t *testing.T) {
 		"--trusted-origins="+trustedOrigin,
 	)
 
-	for _, r := range []request{
-		mcpPOST(map[string]string{
+	cases := []struct {
+		name string
+		req  request
+	}{
+		{"actual_request", mcpPOST(map[string]string{
 			"PRIVATE-TOKEN":  "glpat-whatever",
 			"Origin":         trustedOrigin,
 			"Sec-Fetch-Site": "cross-site",
-		}),
-		{
+		})},
+		{"preflight", request{
 			method: http.MethodOptions, path: "/mcp",
 			headers: map[string]string{
 				"Origin":                         trustedOrigin,
 				"Access-Control-Request-Method":  http.MethodPost,
 				"Access-Control-Request-Headers": "content-type",
 			},
-		},
-	} {
-		got := srv.do(t, r)
-		if n := len(got.header.Values("Access-Control-Allow-Origin")); n > 1 {
-			t.Errorf("%s: %d Access-Control-Allow-Origin headers, want at most 1 — a browser rejects the response outright", r.method, n)
-		}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := srv.do(t, tc.req)
+			if n := len(got.header.Values("Access-Control-Allow-Origin")); n > 1 {
+				t.Errorf("%s: %d Access-Control-Allow-Origin headers, want at most 1 — a browser rejects the response outright", tc.req.method, n)
+			}
+		})
 	}
 }
 

--- a/test/e2e/http/crossorigin_test.go
+++ b/test/e2e/http/crossorigin_test.go
@@ -173,14 +173,18 @@ func TestCrossOrigin_PreflightIsAnswered(t *testing.T) {
 		"Access-Control-Allow-Origin": trustedOrigin,
 		"Access-Control-Max-Age":      "86400",
 	} {
-		if got := got.header.Get(header); got != want {
-			t.Errorf("%s = %q, want %q", header, got, want)
-		}
+		t.Run(header, func(t *testing.T) {
+			if got := got.header.Get(header); got != want {
+				t.Errorf("%s = %q, want %q", header, got, want)
+			}
+		})
 	}
 	for _, name := range []string{"Content-Type", "PRIVATE-TOKEN", "Mcp-Session-Id"} {
-		if allowed := got.header.Get("Access-Control-Allow-Headers"); !strings.Contains(allowed, name) {
-			t.Errorf("Access-Control-Allow-Headers = %q, want it to name %s", allowed, name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if allowed := got.header.Get("Access-Control-Allow-Headers"); !strings.Contains(allowed, name) {
+				t.Errorf("Access-Control-Allow-Headers = %q, want it to name %s", allowed, name)
+			}
+		})
 	}
 	if !strings.Contains(strings.Join(got.header.Values("Vary"), ","), "Origin") {
 		t.Error("a response that varies by Origin must say so, or a cache serves one origin's permission to another")
@@ -215,14 +219,16 @@ func TestCrossOrigin_SafeMethodsStayReachable(t *testing.T) {
 	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
 
 	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
-		got := srv.do(t, request{
-			method:  http.MethodGet,
-			path:    path,
-			headers: map[string]string{"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+		t.Run(path, func(t *testing.T) {
+			got := srv.do(t, request{
+				method:  http.MethodGet,
+				path:    path,
+				headers: map[string]string{"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+			})
+			if got.status == http.StatusForbidden {
+				t.Errorf("GET %s was refused as cross-origin; safe methods are exempt", path)
+			}
 		})
-		if got.status == http.StatusForbidden {
-			t.Errorf("GET %s was refused as cross-origin; safe methods are exempt", path)
-		}
 	}
 }
 

--- a/test/e2e/http/discovery_test.go
+++ b/test/e2e/http/discovery_test.go
@@ -67,9 +67,11 @@ func TestProtectedResourceMetadata_BehavesLikeAnHTTPDocument(t *testing.T) {
 			t.Fatal("the 405 carries no Allow header, so a client cannot learn what to send instead")
 		}
 		for _, method := range []string{"GET", "HEAD"} {
-			if !strings.Contains(allow, method) {
-				t.Errorf("Allow = %q, want it to list %s", allow, method)
-			}
+			t.Run(method, func(t *testing.T) {
+				if !strings.Contains(allow, method) {
+					t.Errorf("Allow = %q, want it to list %s", allow, method)
+				}
+			})
 		}
 	})
 

--- a/test/e2e/http/gate_test.go
+++ b/test/e2e/http/gate_test.go
@@ -198,14 +198,16 @@ func TestGate_NonPostMethodsReachTheSDK(t *testing.T) {
 	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
 
 	for _, method := range []string{http.MethodGet, http.MethodDelete} {
-		got := srv.do(t, request{
-			method:  method,
-			path:    "/mcp",
-			headers: map[string]string{"PRIVATE-TOKEN": "glpat-whatever", "MCP-Protocol-Version": protocolVersion},
+		t.Run(method, func(t *testing.T) {
+			got := srv.do(t, request{
+				method:  method,
+				path:    "/mcp",
+				headers: map[string]string{"PRIVATE-TOKEN": "glpat-whatever", "MCP-Protocol-Version": protocolVersion},
+			})
+			if got.status != http.StatusMethodNotAllowed {
+				t.Errorf("%s /mcp = %d, want %d", method, got.status, http.StatusMethodNotAllowed)
+			}
 		})
-		if got.status != http.StatusMethodNotAllowed {
-			t.Errorf("%s /mcp = %d, want %d", method, got.status, http.StatusMethodNotAllowed)
-		}
 	}
 }
 
@@ -215,10 +217,12 @@ func TestGate_HealthAndCardNeedNoCredential(t *testing.T) {
 	srv := startServer(t, nil, "--gitlab-url=https://gitlab.example.com")
 
 	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
-		got := srv.do(t, request{method: http.MethodGet, path: path})
-		if got.status != http.StatusOK {
-			t.Errorf("GET %s = %d, want %d", path, got.status, http.StatusOK)
-		}
+		t.Run(path, func(t *testing.T) {
+			got := srv.do(t, request{method: http.MethodGet, path: path})
+			if got.status != http.StatusOK {
+				t.Errorf("GET %s = %d, want %d", path, got.status, http.StatusOK)
+			}
+		})
 	}
 }
 

--- a/test/e2e/http/limits_test.go
+++ b/test/e2e/http/limits_test.go
@@ -128,9 +128,11 @@ func TestLimit_ReadOnlyRemovesMutations(t *testing.T) {
 			countTools(readOnly), countTools(full))
 	}
 	for _, mutating := range []string{`"name":"gitlab_create_`, `"name":"gitlab_delete_`, `"name":"gitlab_update_`} {
-		if strings.Contains(readOnly, mutating) {
-			t.Errorf("a mutating tool matching %s survived --read-only", mutating)
-		}
+		t.Run(mutating, func(t *testing.T) {
+			if strings.Contains(readOnly, mutating) {
+				t.Errorf("a mutating tool matching %s survived --read-only", mutating)
+			}
+		})
 	}
 }
 

--- a/test/e2e/http/oauth_test.go
+++ b/test/e2e/http/oauth_test.go
@@ -261,9 +261,11 @@ func TestOAuth_RejectedTokenSaysInvalidToken(t *testing.T) {
 	}
 	challenge := got.header.Get("WWW-Authenticate")
 	for _, want := range []string{`error="invalid_token"`, "error_description=", "resource_metadata="} {
-		if !strings.Contains(challenge, want) {
-			t.Errorf("challenge %q is missing %s", challenge, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(challenge, want) {
+				t.Errorf("challenge %q is missing %s", challenge, want)
+			}
+		})
 	}
 }
 

--- a/test/e2e/http/proxy_test.go
+++ b/test/e2e/http/proxy_test.go
@@ -248,12 +248,14 @@ func TestProxy_HealthAndCardSurviveTheProxy(t *testing.T) {
 	plain := &server{baseURL: base + "/plain"}
 
 	for _, path := range []string{"/health", "/.well-known/mcp/server-card.json"} {
-		got := plain.do(t, request{method: http.MethodGet, path: path})
-		if got.status != http.StatusOK {
-			t.Errorf("GET %s through the proxy = %d, want %d", path, got.status, http.StatusOK)
-		}
-		if strings.Contains(path, "server-card") && !strings.Contains(got.body, "\"name\"") {
-			t.Errorf("the server card came back without a name: %s", got.body)
-		}
+		t.Run(path, func(t *testing.T) {
+			got := plain.do(t, request{method: http.MethodGet, path: path})
+			if got.status != http.StatusOK {
+				t.Errorf("GET %s through the proxy = %d, want %d", path, got.status, http.StatusOK)
+			}
+			if strings.Contains(path, "server-card") && !strings.Contains(got.body, "\"name\"") {
+				t.Errorf("the server card came back without a name: %s", got.body)
+			}
+		})
 	}
 }

--- a/test/e2e/http/telemetry_test.go
+++ b/test/e2e/http/telemetry_test.go
@@ -63,9 +63,11 @@ func TestTelemetry_ServerCardAnnouncesItWithoutNamingTheCollector(t *testing.T) 
 		t.Error("the telemetry block does not report itself enabled")
 	}
 	for _, key := range []string{"signals", "recorded", "not_recorded"} {
-		if _, present := block[key]; !present {
-			t.Errorf("the telemetry block has no %q; announcing without saying what is captured is not announcing", key)
-		}
+		t.Run(key, func(t *testing.T) {
+			if _, present := block[key]; !present {
+				t.Errorf("the telemetry block has no %q; announcing without saying what is captured is not announcing", key)
+			}
+		})
 	}
 }
 

--- a/test/e2e/http/telemetry_test.go
+++ b/test/e2e/http/telemetry_test.go
@@ -156,12 +156,16 @@ func TestTelemetry_AnUnreachableCollectorChangesNoResponse(t *testing.T) {
 
 	// Nothing about the collector may reach a client, whatever the outcome was.
 	for _, tc := range cases {
-		body := strings.ToLower(instrumented.do(t, tc.call).body)
-		for _, leak := range []string{"127.0.0.1:1", "otlp", "collector", "telemetry"} {
-			if strings.Contains(body, leak) {
-				t.Errorf("%q reached a client response: %s", leak, body)
+		t.Run(subtestName(tc.call)+" leaks nothing", func(t *testing.T) {
+			body := strings.ToLower(instrumented.do(t, tc.call).body)
+			for _, leak := range []string{"127.0.0.1:1", "otlp", "collector", "telemetry"} {
+				t.Run(leak, func(t *testing.T) {
+					if strings.Contains(body, leak) {
+						t.Errorf("%q reached a client response: %s", leak, body)
+					}
+				})
 			}
-		}
+		})
 	}
 }
 

--- a/test/e2e/stdio/transport_test.go
+++ b/test/e2e/stdio/transport_test.go
@@ -36,15 +36,17 @@ func TestStdout_CarriesNothingButJSONRPC(t *testing.T) {
 		request(2, "tools/list", ""),
 		request(3, "tools/call", `{"name":"gitlab_execute_action","arguments":{"action":"user.get_current"}}`),
 	} {
-		got := s.call(t, msg)
-		// readMessage already fails on anything that is not JSON. What is left
-		// to check is that it is JSON-RPC, and that it answers what was asked.
-		if got["jsonrpc"] != "2.0" {
-			t.Errorf("message %d is not JSON-RPC 2.0: %v", i+1, got)
-		}
-		if got["id"] == nil {
-			t.Errorf("message %d carries no id, so a client cannot match it to a request: %v", i+1, got)
-		}
+		t.Run(msg, func(t *testing.T) {
+			got := s.call(t, msg)
+			// readMessage already fails on anything that is not JSON. What is left
+			// to check is that it is JSON-RPC, and that it answers what was asked.
+			if got["jsonrpc"] != "2.0" {
+				t.Errorf("message %d is not JSON-RPC 2.0: %v", i+1, got)
+			}
+			if got["id"] == nil {
+				t.Errorf("message %d carries no id, so a client cannot match it to a request: %v", i+1, got)
+			}
+		})
 	}
 
 	if logs := s.stderrText(); logs == "" {
@@ -105,9 +107,11 @@ func TestStderr_DefaultLevelIsNotAllSessionChatter(t *testing.T) {
 		"client log level set",
 		"server connecting",
 	} {
-		if strings.Contains(logs, chatter) {
-			t.Errorf("%q is on the default log stream; it is per-session and carries nothing:\n%s", chatter, logs)
-		}
+		t.Run(chatter, func(t *testing.T) {
+			if strings.Contains(logs, chatter) {
+				t.Errorf("%q is on the default log stream; it is per-session and carries nothing:\n%s", chatter, logs)
+			}
+		})
 	}
 
 	// The other half of the claim: this is a demotion, not a silencing. The
@@ -175,9 +179,11 @@ func TestHandshake_AnswersTheLegacyInitialize(t *testing.T) {
 	// capability that is advertised and not served is worse than one that is
 	// missing. These three are registered on the default surface.
 	for _, want := range []string{"tools", "resources", "prompts"} {
-		if _, present := caps[want]; !present {
-			t.Errorf("the handshake does not declare %q, which this surface registers", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if _, present := caps[want]; !present {
+				t.Errorf("the handshake does not declare %q, which this surface registers", want)
+			}
+		})
 	}
 	if _, present := caps["logging"]; present {
 		t.Error("the handshake declares logging, which this server does not implement")

--- a/test/e2e/suite/accessextras2_ce_test.go
+++ b/test/e2e/suite/accessextras2_ce_test.go
@@ -116,11 +116,13 @@ func TestIndividual_AccessRequests(t *testing.T) {
 				{"approvee", sessionApprove},
 				{"denyee", sessionDeny},
 			} {
-				out, err := callToolOn[accessrequests.Output](ctx, requester.session, "gitlab_access_request_request_project", accessrequests.RequestProjectInput{
-					ProjectID: proj.pidOf(),
+				t.Run(requester.name, func(t *testing.T) {
+					out, err := callToolOn[accessrequests.Output](ctx, requester.session, "gitlab_access_request_request_project", accessrequests.RequestProjectInput{
+						ProjectID: proj.pidOf(),
+					})
+					requireNoError(t, err, "request project access ("+requester.name+")")
+					requireTruef(t, out.ID > 0, "expected requester user ID in access request")
 				})
-				requireNoError(t, err, "request project access ("+requester.name+")")
-				requireTruef(t, out.ID > 0, "expected requester user ID in access request")
 			}
 			t.Log("Both users requested project access")
 		})
@@ -133,11 +135,13 @@ func TestIndividual_AccessRequests(t *testing.T) {
 				{"approvee", sessionApprove},
 				{"denyee", sessionDeny},
 			} {
-				out, err := callToolOn[accessrequests.Output](ctx, requester.session, "gitlab_access_request_request_group", accessrequests.RequestGroupInput{
-					GroupID: groupID,
+				t.Run(requester.name, func(t *testing.T) {
+					out, err := callToolOn[accessrequests.Output](ctx, requester.session, "gitlab_access_request_request_group", accessrequests.RequestGroupInput{
+						GroupID: groupID,
+					})
+					requireNoError(t, err, "request group access ("+requester.name+")")
+					requireTruef(t, out.ID > 0, "expected requester user ID in access request")
 				})
-				requireNoError(t, err, "request group access ("+requester.name+")")
-				requireTruef(t, out.ID > 0, "expected requester user ID in access request")
 			}
 			t.Log("Both users requested group access")
 		})

--- a/test/e2e/suite/dynamic_ce_test.go
+++ b/test/e2e/suite/dynamic_ce_test.go
@@ -52,9 +52,11 @@ func TestDynamicToolSurface_ExposesFindExecuteOnly(t *testing.T) {
 		t.Fatalf("dynamic tool names = %v, want %v", names, want)
 	}
 	for _, catalogTool := range []string{"gitlab_project", "gitlab_repository"} {
-		if slices.Contains(names, catalogTool) {
-			t.Fatalf("dynamic surface exposed catalog tool %q in %v", catalogTool, names)
-		}
+		t.Run(catalogTool, func(t *testing.T) {
+			if slices.Contains(names, catalogTool) {
+				t.Fatalf("dynamic surface exposed catalog tool %q in %v", catalogTool, names)
+			}
+		})
 	}
 }
 

--- a/test/e2e/suite/enterprise_ee_test.go
+++ b/test/e2e/suite/enterprise_ee_test.go
@@ -1717,9 +1717,11 @@ func TestEnterpriseOrbit_NotRegisteredOnSelfManaged(t *testing.T) {
 		orbitGraphTool,
 	}
 	for _, expected := range expectedOrbitIndividualTools {
-		if registeredOrbit[expected] {
-			t.Fatalf("individual tool %q should not be registered on self-managed Enterprise", expected)
-		}
+		t.Run(expected, func(t *testing.T) {
+			if registeredOrbit[expected] {
+				t.Fatalf("individual tool %q should not be registered on self-managed Enterprise", expected)
+			}
+		})
 	}
 	t.Logf("Confirmed none of the 6 expected gitlab_orbit_* individual tools are registered on self-managed Enterprise")
 

--- a/test/e2e/suite/meta_schema_resource_ce_test.go
+++ b/test/e2e/suite/meta_schema_resource_ce_test.go
@@ -137,9 +137,11 @@ func TestToolManifestResource_ReadMergeRequestCreate(t *testing.T) {
 	}
 	body := result.Contents[0].Text
 	for _, want := range []string{"project_id", "source_branch", "target_branch", "title"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("schema missing %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("schema missing %q", want)
+			}
+		})
 	}
 
 	var schema map[string]any
@@ -185,8 +187,10 @@ func TestToolManifestResource_IndexEnumeratesMetaTools(t *testing.T) {
 	}
 	body := result.Contents[0].Text
 	for _, want := range []string{"gitlab_project.get", "gitlab_merge_request.create", "gitlab_issue.get"} {
-		if !strings.Contains(body, want) {
-			t.Errorf("manifest missing meta-tool action %q", want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(body, want) {
+				t.Errorf("manifest missing meta-tool action %q", want)
+			}
+		})
 	}
 }

--- a/test/e2e/suite/packageextras_ce_test.go
+++ b/test/e2e/suite/packageextras_ce_test.go
@@ -205,7 +205,9 @@ func TestIndividual_PackagePublishComposite(t *testing.T) {
 	t.Run("PublishDirectory", func(t *testing.T) {
 		dir := t.TempDir()
 		for _, name := range []string{"first.txt", "second.txt"} {
-			requireNoError(t, os.WriteFile(filepath.Join(dir, name), []byte("directory payload "+name), 0o600), "write temp file "+name)
+			t.Run(name, func(t *testing.T) {
+				requireNoError(t, os.WriteFile(filepath.Join(dir, name), []byte("directory payload "+name), 0o600), "write temp file "+name)
+			})
 		}
 
 		out, pErr := callToolOn[packages.PublishDirOutput](ctx, sess.individual, "gitlab_package_publish_directory", packages.PublishDirInput{

--- a/test/e2e/suite/projectextras_ee_test.go
+++ b/test/e2e/suite/projectextras_ee_test.go
@@ -156,6 +156,7 @@ func TestMeta_IssueWeightEvents(t *testing.T) {
 
 	// Two weight changes guarantee at least two weight events regardless of
 	// whether GitLab records an event for the initial weight assignment.
+	// sequential: ordered setup steps on one issue, the last of which is the weight asserted below; a failed step must abort the test, not a subtest
 	for _, weight := range []int64{3, 5} {
 		_, updErr := callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "update",

--- a/test/e2e/suite/scope_filter_ce_test.go
+++ b/test/e2e/suite/scope_filter_ce_test.go
@@ -178,9 +178,11 @@ func TestScopeFilter_NonAdminToken(t *testing.T) {
 		"gitlab_user",
 	}
 	for _, name := range regularTools {
-		if _, ok := toolSet[name]; !ok {
-			t.Errorf("regular tool %s should still be registered for non-admin token", name)
-		}
+		t.Run(name, func(t *testing.T) {
+			if _, ok := toolSet[name]; !ok {
+				t.Errorf("regular tool %s should still be registered for non-admin token", name)
+			}
+		})
 	}
 
 	t.Logf("Scope filter test passed: %d tools registered, %d removed", len(result.Tools), removed)


### PR DESCRIPTION
Every case table in the test suite now runs its cases as `t.Run` subtests, and a new auditor keeps it that way. This is the general form of the CodeRabbit note on the previous test layer (three pairwise comparisons written inline instead of as a table), applied to the whole tree.

## What changed

- **`cmd/audit_test_subtests`**, a go/ast auditor in the style of `audit_test_goroutines`: it reports every range over a table literal (inline or bound to a local) inside a `Test*` function whose body asserts without a `t.Run` inside, gates with `-check`, writes a JSON work list with `-json`, and rewrites the unambiguous sites with `-fix` (a `[]string` table is named after its element, a struct table after a name-like string field, a `map[string]` table after its key; a bare `continue` becomes `return`). A `// sequential: <reason>` comment above a loop declares dependent steps rather than cases, and loops inside a `synctest.Test` bubble are skipped because the testing package panics on `t.Run` there. Both exceptions are counted in the report.
- **The sweep**: 911 case loops across 285 files asserted without a subtest. `-fix` rewrote 827 of them mechanically; the remaining 84 (tables with no name-like field, blank loop variables) got a hand rewrite with a `name` field and descriptive case names, two fixture-setup loops were unrolled instead of wrapped, and two loops were declared sequential with the reason in the comment (a listen teardown that joins the watcher the previous step created, and an ordered e2e setup on one issue). Assertions and messages are unchanged.
- **Gate wiring**: `make check-test-subtests` runs in CI next to the goroutine gate and as step 7 of `make analyze`; CLAUDE.md, the Go guideline, `cmd-utilities.md` and `static-analysis.md` describe the rule, the rewrite and the escape hatches.
- **Lint follow-through**: subtests created under parents that call `t.Parallel()` call it too (eight sites, all read-only loops whose parents own no deferred resources), and the four tests that crossed the cognitive-complexity limit when their loops were wrapped hand their per-case assertions to helpers.
- The `MetaParamSchemaMode` getter added in the previous layer now reads through the synchronized accessor, as the review there asked.

## Verification

`go run ./cmd/audit_test_subtests/ -check` passes on the whole tree (0 sites, 2 declared sequential, 2 inside synctest bubbles, 2,014 compliant loops). Full unit suite green with `-shuffle=on`, the stdio transport module green, `audit_test_goroutines -check` and `audit_test_names -check-files` green, golangci-lint clean with every build tag. The HTTP transport module passed three times in isolation during the work; a fourth run hit the package's 15-minute limit on a machine that was also running eight other test suites, which is load, not the change, and CI runs it on its own.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Part of the coverage work in https://github.com/jmrplens/gitlab-mcp-server/issues/359: the auditor and the sweep are what let cmd/ be held to a coverage number at all.
