### PR TITLE
Label pull requests from the paths they touch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,13 @@
 # Path-based labels applied to pull requests by .github/workflows/labeler.yml.
-# Label names must already exist in the repository; the action does not create
-# them, it skips the ones it cannot find and says nothing.
+# Every key must name a label that already exists in the repository, and the
+# consequence of getting that wrong is larger than it looks: the action sends
+# the whole label set in one PUT, so a single name the repository does not have
+# loses the entire call and the pull request gets none of its labels. It is not
+# a per-label skip, and it is not silent either. The workflow grants only
+# pull-requests: write, under which that call comes back 403; issues: write
+# would let the action create the missing label instead, which is deliberately
+# not granted, because a label created that way is default grey with no
+# description and this repository manages its labels by hand (see CONTRIBUTING).
 #
 # Five labels, chosen against the real change history rather than against the
 # tree, because a rule that fires on nearly every pull request carries no

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,124 @@
+# Path-based labels applied to pull requests by .github/workflows/labeler.yml.
+# Label names must already exist in the repository; the action does not create
+# them, it skips the ones it cannot find and says nothing.
+#
+# Five labels, chosen against the real change history rather than against the
+# tree, because a rule that fires on nearly every pull request carries no
+# information. Every candidate was measured over 43 merged and open pull
+# requests first: "touches docs/" was true of 42 of them and "touches
+# internal/tools/" of 28, so neither became a label, and no rule that survived
+# fires on more than half. GitLab API surface work is the norm here, so an
+# unlabeled pull request is the ordinary case rather than a gap in the map.
+
+# --- Kind of change -----------------------------------------------------------
+
+# Documentation *only*, hence any-glob-to-all-files against one braced pattern:
+# every changed file has to be prose. The "any file is a doc" form was true of
+# 42 of those 43 pull requests, because everything here ships with its
+# documentation; the only informative version of this label is the one that
+# says no code moved. site/src/content is the published bilingual mirror of
+# docs/ and belongs on the same side of that line.
+documentation:
+  - changed-files:
+      - any-glob-to-all-files:
+          - "{docs/**,site/src/content/**,README.md,CONTRIBUTING.md,CODE_OF_CONDUCT.md,AGENTS.md,CLAUDE.md,llms*.txt,llms-install.md,.github/copilot-instructions.md,.github/dockerhub-description.md,.github/pull_request_template.md,.github/{agents,instructions,skills,ISSUE_TEMPLATE}/**}"
+
+# Anything where a mistake is a vulnerability rather than a bug: credential
+# handling and admission (oauth, serverpool, the HTTP auth gate), the GitLab
+# client's TLS, redirect, response-limit and scope handling, the local-path
+# allow-lists a tool input is checked against, and the supply-chain controls.
+#
+# Deliberately over-eager. Whole packages are listed, tests included, so a
+# coverage pass over internal/serverpool/ picks the label up without meriting
+# it. That is the cheap direction to be wrong in: an extra label costs a glance,
+# a missed one costs a security change reviewed as though it were not.
+security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - SECURITY.md
+          - PRIVACY.md
+          - .gitguardian.yaml
+          - .github/workflows/codeql.yml
+          - .github/scripts/**
+          - .github/dependabot.yml
+          - cmd/audit_supply_chain/**
+          - cmd/server/authgate*.go
+          - cmd/server/bearerguard*.go
+          - internal/oauth/**
+          - internal/serverpool/**
+          - internal/gitlab/**
+          - internal/capguard/**
+          - internal/toolutil/fileutils*.go
+          - internal/toolutil/filesource*.go
+          - scripts/govulncheck.sh
+          - scripts/install.sh
+          - scripts/install.ps1
+
+# The pipeline itself, whose failure mode is that nobody finds out until it
+# runs. The Makefile is excluded on purpose: it is the entry point for every
+# gate in the repository and changes with almost any tooling work, which made
+# this label fire on two thirds of pull requests instead of two fifths.
+# cmd/audit_*/ is excluded for the same reason: those are Go programs with Go
+# tests, reviewed as code, and only the workflow that calls them is pipeline.
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+          - .github/labeler.yml
+          - .github/dependabot.yml
+          - .github/scripts/**
+          - .golangci.yml
+          - .markdownlint-cli2.jsonc
+          - .markdownlint-cli2.yaml
+          - .coderabbit.yaml
+          - sonar-project.properties
+
+# What users install, across six channels. This label marks the pull requests
+# whose mistakes cannot be taken back: a published npm version and a PyPI file
+# name are permanent, an OCI tag and a release asset are what an installer
+# resolves, and server.json is what the MCP Registry hands to clients.
+distribution:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .goreleaser.yml
+          - .github/workflows/release.yml
+          - Dockerfile
+          - .dockerignore
+          - docker-compose.yml
+          - docker-compose.build.yml
+          - VERSION
+          - server.json
+          - plugin.json
+          - .plugin/**
+          - lhm.plugin.json
+          - mcp.json
+          - glama.json
+          - mcpb/**
+          - npm/**
+          - pypi/**
+          - scripts/build-mcpb.sh
+          - scripts/build-npm.mjs
+          - scripts/build_pypi.py
+          - scripts/publish-*
+          - scripts/validate-npm.mjs
+          - scripts/validate_pypi.py
+          - scripts/validate-server-json-packages.sh
+          - scripts/check-openplugin.sh
+          - scripts/update-homebrew-tap.sh
+          - scripts/update-server-json-sha.sh
+          - scripts/fetch-release-assets.sh
+          - scripts/smoke-test-image.sh
+          - scripts/verify_published_packages*.py
+          - scripts/install.sh
+          - scripts/install.ps1
+
+# The same label .github/dependabot.yml asks for, so a client-go bump made by
+# hand and one opened by Dependabot land in the same filter. npm/ and pypi/ are
+# not here: those manifests are stamped by the release, not resolved.
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - go.mod
+          - go.sum
+          - site/package.json
+          - site/pnpm-lock.yaml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,34 @@
+name: Labeler
+
+# pull_request_target so that pull requests from forks also get labeled: the
+# default GITHUB_TOKEN is read-only for fork pull requests under `pull_request`.
+# The action only reads the changed file list and never checks out or runs the
+# pull request's code, so the elevated token is not exposed to it.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# Keyed on the pull request number, not github.ref: under pull_request_target
+# that ref is the base branch, so every open pull request would share one group
+# and each new one would cancel the last.
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label by changed paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
+        with:
+          # Keep labels added by hand. Only ever add, never remove.
+          sync-labels: false
+          # Stated rather than inherited: half the map's globs are dotted paths
+          # (.github/, .goreleaser.yml, .golangci.yml), and a default is a
+          # property of the action, not of this repository.
+          dot: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,22 +272,26 @@ Templates auto-apply the relevant labels listed in [Labels](#labels).
 
 ## Labels
 
-Issue templates auto-assign labels on submission. The repo uses a flat label set (no `type::`/`priority::` namespaces — those are GitLab conventions):
+Issue templates auto-assign labels on submission, and pull requests are labeled from the paths they touch by `.github/workflows/labeler.yml` against the map in `.github/labeler.yml`. The repo uses a flat label set (no `type::`/`priority::` namespaces — those are GitLab conventions):
 
-| Label              | Color     | Used by                                          |
-| ------------------ | --------- | ------------------------------------------------ |
-| `bug`              | `#d73a4a` | Bug Report template                              |
-| `feature`          | `#a2eeef` | Feature Request template                         |
-| `enhancement`      | `#a2eeef` | Enhancement template (GitHub default)            |
-| `documentation`    | `#0075ca` | Documentation template (GitHub default)          |
-| `security`         | `#d73a4a` | Manual — applied to GitHub Security Advisories   |
-| `high-priority`    | `#b60205` | Manual — critical bugs and security advisories   |
-| `needs-triage`     | `#c2e0c6` | All issue templates (auto-applied on submission) |
-| `good first issue` | `#7057ff` | Manual — newcomer-friendly issues                |
-| `help wanted`      | `#008672` | Manual — community contributions welcome         |
-| `question`         | `#d876e3` | Manual — questions / discussions                 |
-| `duplicate`        | `#cfd3d7` | Manual — duplicates of existing issues           |
-| `invalid`          | `#e4e669` | Manual — out of scope                            |
-| `wontfix`          | `#ffffff` | Manual — accepted but won't implement            |
+| Label              | Color     | Used by                                                |
+| ------------------ | --------- | ------------------------------------------------------ |
+| `bug`              | `#d73a4a` | Bug Report template                                    |
+| `feature`          | `#a2eeef` | Feature Request template                               |
+| `enhancement`      | `#a2eeef` | Enhancement template (GitHub default)                  |
+| `documentation`    | `#0075ca` | Documentation template; path labeler on docs-only PRs  |
+| `security`         | `#d73a4a` | Security Advisories; path labeler on security paths    |
+| `ci`               | `#bfdadc` | Path labeler — pipeline, workflows, lint configuration |
+| `distribution`     | `#fbca04` | Path labeler — release artifacts and install channels  |
+| `dependencies`     | `#0052cc` | Path labeler and Dependabot — dependency files         |
+| `release`          | `#0e8a16` | Manual — release tracking issues                       |
+| `high-priority`    | `#b60205` | Manual — critical bugs and security advisories         |
+| `needs-triage`     | `#c2e0c6` | All issue templates (auto-applied on submission)       |
+| `good first issue` | `#7057ff` | Manual — newcomer-friendly issues                      |
+| `help wanted`      | `#008672` | Manual — community contributions welcome               |
+| `question`         | `#d876e3` | Manual — questions / discussions                       |
+| `duplicate`        | `#cfd3d7` | Manual — duplicates of existing issues                 |
+| `invalid`          | `#e4e669` | Manual — out of scope                                  |
+| `wontfix`          | `#ffffff` | Manual — accepted but won't implement                  |
 
-Manage labels with `gh label list` / `gh label create`.
+The path labeler never removes a label (`sync-labels: false`), so anything applied by hand survives a later push. It also cannot create one: a label named in `.github/labeler.yml` that does not exist is skipped in silence. Manage labels with `gh label list` / `gh label create`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,4 +294,4 @@ Issue templates auto-assign labels on submission, and pull requests are labeled 
 | `invalid`          | `#e4e669` | Manual — out of scope                                  |
 | `wontfix`          | `#ffffff` | Manual — accepted but won't implement                  |
 
-The path labeler never removes a label (`sync-labels: false`), so anything applied by hand survives a later push. It also cannot create one: a label named in `.github/labeler.yml` that does not exist is skipped in silence. Manage labels with `gh label list` / `gh label create`.
+The path labeler never removes a label (`sync-labels: false`), so anything applied by hand survives a later push. It also cannot create one, because the workflow grants only `pull-requests: write`. A label named in `.github/labeler.yml` that does not exist in the repository is therefore not skipped: the action sends the whole set in a single request, so that one name costs the pull request every label it should have had, and the job says so rather than passing quietly. Create the label first, with `gh label list` / `gh label create`.


### PR DESCRIPTION
Pull requests get labels from the paths they touch, the way `jmrplens/phonometry` already does it: `actions/labeler` driven by a path map, on `pull_request_target` so pull requests from forks are labelled too, with `sync-labels: false` so a label added by hand is never removed.

The `pull_request_target` trigger is the part that would look alarming out of context, so the workflow says why it is safe here and only here: the action reads the changed file list and never checks out or runs the pull request's code, so the elevated token is never exposed to it. Without that comment somebody eventually "fixes" the trigger and quietly breaks labelling for forks.

The action is pinned to a commit SHA rather than a tag, which is the one place this repository differs from the original. `cmd/audit_supply_chain` fails the build over an unpinned `uses:`, and it decides on raw file text, so even a `uses:` inside a comment counts.

## The map was measured, not guessed

Rules were replayed against the changed-file lists of 43 real pull requests, the five open ones plus 38 merged, with labeler v7's four match modes reimplemented from its own source. Candidates were kept or cut on how often they actually fired.

The two rules that looked obvious both failed. **"Touches `docs/`" was true of 42 of 43 pull requests**, and **"touches `internal/tools/`" of 28 of 43**. This repository documents whatever it changes, and its subject *is* the GitLab API surface, so both rules only restate that a change happened. A label present on nearly every pull request is not a filter, it is decoration.

What shipped, with the measured rate:

| Label | Fires on | Why it earns its place |
| --- | --- | --- |
| `security` | 47% | Credential handling and admission, the client's TLS, redirect and response limits, the local-path allow-lists, the supply chain |
| `ci` | 42% | Workflows and lint configuration. Excluding the `Makefile` took this from 63%, since it is the entry point for every gate |
| `distribution` | 40% | What users install across six channels, where a mistake is permanent |
| `dependencies` | 23% | The label `dependabot.yml` already asks for |
| `documentation` | 7% | Documentation **only**, so it means "nothing else changed" rather than "docs were touched" |

`security` is deliberately over-eager, covering whole packages including their tests. An extra label costs a glance; a missed one costs a security change reviewed as though it were not. On two of the open pull requests it fires from test files under `internal/oauth` and `internal/serverpool`, which is the intended behaviour rather than a false positive: a weakened assertion in a verifier test is exactly the thing worth flagging.

Rejected with numbers rather than taste: a tools or catalog label (66% broad, 42% narrowed, and the narrow form still fired on test-only sweeps), `site` (69%, and its content half belongs to the documentation rule), `e2e` (37%), a site-app label (26%), and a tests-only label that fired on **0 of 43**, because production code and tests always move together here.

The existing `release` label was not reused for the release chain. It is in service as an issue-tracker label, and mixing pull requests into that filter would break it, hence `distribution`.

## Two traps, commented where they live

**The concurrency key.** Under `pull_request_target`, `github.ref` is the *base* branch, so the usual `${{ github.ref }}` group would put every open pull request in one group and have each new one cancel the last. It is keyed on the pull request number.

**`dot: true` is stated rather than inherited**, because half the globs are dotted paths.

## A defect found on the way

`.github/dependabot.yml` names five labels and **none of them existed**. Dependabot does not create labels, so its pull requests have been arriving bare: 273, 272, 271, 265 and 252 all carry none. The five now exist, so the configuration means what it says.

## What is still unproven

The workflow has never run, and it cannot run on this pull request. `pull_request_target` deliberately takes the workflow definition from the **base** branch rather than the head, which is the security property that makes the trigger safe at all: otherwise a fork could edit the workflow and be handed a write token. The base here does not have the file yet, so nothing fired, and I confirmed that rather than assuming the run was merely slow.

That means four things stay unverified until the first pull request opened after this lands: that `pull_request_target` fires as expected, that the `pull-requests: write` token actually applies labels, that the action parses this map without complaint, and that the braced documentation glob behaves the same inside labeler's bundled minimatch as in the version the map was measured against. The map itself is not guesswork, having been replayed against 43 real pull requests, but the plumbing around it is untested by construction.

## Summary by Sourcery

Automatically label pull requests from the files they change while preserving manual labels and aligning repository labels with Dependabot configuration.

New Features:
- Add automatic pull-request labeling based on changed paths for security, CI, distribution, dependencies, and documentation changes.
- Add the required repository labels for path-based labeling and Dependabot dependency updates.

Bug Fixes:
- Restore the missing labels referenced by Dependabot so dependency pull requests receive their configured labels.

Enhancements:
- Document the new pull-request labeling behavior and preserve manually applied labels.

CI:
- Add a pinned GitHub Actions labeler workflow for fork-safe pull-request labeling with path mappings and pull-request-specific concurrency.

Documentation:
- Update contributor documentation with the expanded label catalog and path-labeling guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull requests are now automatically labeled based on the files they change, including documentation, security, CI, distribution, and dependency-related updates.
  - Existing manually assigned labels are preserved during automatic labeling.

- **Documentation**
  - Contributing guidelines now explain the automatic labeling process, supported labels, and label management behavior.
  - Documentation and security label descriptions have been updated to reflect the automated workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->