### PR TITLE
Go 1.27.1 everywhere the version is pinned

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -86,7 +86,7 @@ body:
     id: go-version
     attributes:
       label: Go version (only if building from source)
-      placeholder: "e.g., 1.27.0"
+      placeholder: "e.g., 1.27.1"
 
   - type: dropdown
     id: mcp-client

--- a/.github/agents/go-mcp-expert.agent.md
+++ b/.github/agents/go-mcp-expert.agent.md
@@ -177,7 +177,7 @@ Always write idiomatic Go code that follows the official SDK patterns and Go com
 ## MCP Go SDK v1.7.0 Key Knowledge
 
 - **Protocol version**: 2026-07-28 (default; served over HTTP only in stateless mode, the server default). Legacy stateful HTTP (`--stateless=false`) negotiates 2025-11-25 or older
-- **Project Go requirement**: 1.27.0
+- **Project Go requirement**: 1.27.1
 - **OAuth**: Stabilized — no build tag needed, `auth/` and `auth/extauth/` packages
 - **DNS rebinding protection**: Built-in for HTTP transport (localhost binding)
 - **Cross-origin protection**: `http.CrossOriginProtection` middleware applied automatically

--- a/.github/agents/plan-expert.agent.md
+++ b/.github/agents/plan-expert.agent.md
@@ -35,7 +35,7 @@ This project is a **Model Context Protocol (MCP) server** in Go exposing GitLab 
 
 | Component          | Technology                                              |
 | ------------------ | ------------------------------------------------------- |
-| Language           | Go 1.27.0                                               |
+| Language           | Go 1.27.1                                               |
 | MCP SDK            | `github.com/modelcontextprotocol/go-sdk/mcp` v1.7.0    |
 | GitLab Client      | `gitlab.com/gitlab-org/api/client-go/v2` v2.42.0        |
 | Self-Update        | `github.com/creativeprojects/go-selfupdate` v1.5.2     |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This project implements a **Model Context Protocol (MCP) server** that exposes G
 
 ## Architecture
 
-- **Language**: Go 1.27.0
+- **Language**: Go 1.27.1
 - **MCP SDK**: `github.com/modelcontextprotocol/go-sdk/mcp` v1.7.0
 - **GitLab Client**: `gitlab.com/gitlab-org/api/client-go/v2` v2.42.0 (official client, migrated from deprecated `xanzy/go-gitlab`)
 - **Transport**: stdio (primary), HTTP (optional)

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -408,7 +408,7 @@ func TestCovListMetricImagesWithPagination(t *testing.T) { ... }
 
 ## Go 1.27 Project Modern Features
 
-This project declares `1.27.0`; prefer these modern patterns when they simplify code without reducing clarity:
+This project declares `1.27.1`; prefer these modern patterns when they simplify code without reducing clarity:
 
 ### Promoted Fields in Composite Literals (Go 1.27+)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.27.0"
+  GO_VERSION: "1.27.1"
   COVERAGE_MIN: "90"
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.27.0"
+  GO_VERSION: "1.27.1"
 
 jobs:
   analyze:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.27.0"
+  GO_VERSION: "1.27.1"
   GITLAB_IMAGE: ${{ inputs.gitlab_image || 'gitlab/gitlab-ce:latest' }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ concurrency:
 permissions: {}
 
 env:
-  GO_VERSION: "1.27.0"
+  GO_VERSION: "1.27.1"
   REGISTRY: ghcr.io
   IMAGE_NAME: jmrplens/gitlab-mcp-server
   DOCKERHUB_IMAGE: jmrplens/gitlab-mcp-server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 | Attribute     | Value                                               |
 | ------------- | --------------------------------------------------- |
-| Language      | Go 1.27.0                                           |
+| Language      | Go 1.27.1                                           |
 | MCP SDK       | `github.com/modelcontextprotocol/go-sdk/mcp` v1.7.0 |
 | GitLab Client | `gitlab.com/gitlab-org/api/client-go/v2` v2.59.0       |
 | Transport     | stdio (primary), HTTP (optional)                    |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
 # --- Build stage ---
-FROM --platform=$BUILDPLATFORM golang:1.27.0-alpine3.24@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27.1-alpine3.24@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache git ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jmrplens/gitlab-mcp-server/v2
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/go-logr/logr v1.4.4


### PR DESCRIPTION
Supersedes the Dockerfile-only bump in https://github.com/jmrplens/gitlab-mcp-server/pull/417. That change is correct and incomplete: this project pins the exact patch in twelve places, and moving only the builder image would leave the container building against a runtime the module does not declare while CI and the local toolchain stayed on 1.27.0.

## What is pinned, and where

| File | What it pins |
| --- | --- |
| `go.mod` | The `go` directive. The Makefile derives `GOTOOLCHAIN` by parsing that line, so the patch belongs there rather than split into a separate `toolchain` directive, whatever the bots suggest |
| `.github/workflows/ci.yml`, `codeql.yml`, `e2e.yml`, `release.yml` | `GO_VERSION` |
| `Dockerfile` | The builder image tag and its digest |
| `CLAUDE.md` | The language row of the project table |
| `.github/ISSUE_TEMPLATE/bug-report.yml` | The version example a reporter fills in |
| `.github/copilot-instructions.md`, `instructions/go.instructions.md`, `agents/plan-expert.agent.md`, `agents/go-mcp-expert.agent.md` | Hardcoded in the assistant context files |

Four workflows carry `GO_VERSION`, not three: `codeql.yml` gained one after the note I was working from was written, which is why I grepped for the version rather than following the list.

## What I deliberately did not change

The `1.27.0` in a comment at the top of `codeql.yml`. It records when CodeQL first lagged behind a Go release ("first hit: Go 1.27.0, 2026-08"), so it is a date-stamped observation, not a declaration. Rewriting it would make the note claim something that did not happen.

## Verification

Both artifacts were checked against their source rather than taken on trust.

The toolchain tarball, against the checksum published at `go.dev/dl`:

```
downloaded: 63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445
published:  63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445
```

The builder image digest, resolved from the registry rather than copied from the bot's diff:

```
docker-content-digest: sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125
```

It matches what dependabot proposed.

The tree builds and tests under 1.27.1, `make check-supply-chain` passes, and `@action-validator/cli` accepts `ci.yml`, `codeql.yml` and `e2e.yml`. It reports 39 errors on `release.yml`, and reports the same 39 on the unmodified file from `main`: its schema does not know the `attestations` permission. Pre-existing and unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Update every active Go version pin to 1.27.1 to keep local development, automation, documentation, and container builds aligned.

Enhancements:
- Synchronize the project’s pinned Go version to 1.27.1 across module metadata, development tooling, CI, Docker builds, and assistant guidance.

Build:
- Update the Docker builder image to the verified Go 1.27.1 image and digest.

Documentation:
- Update user-facing and contributor-facing Go version references and examples to 1.27.1.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Upgraded project Go version from 1.27.0 to 1.27.1 across all configuration files, documentation, and CI/CD workflows.</li>
<li>Updated Dockerfile to use the official golang:1.27.1-alpine3.24 image for the build stage.</li>
</ul></div>