### PR TITLE
Gate that no read-only action can reach a GraphQL mutation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,7 @@ gitlab-mcp-server/
 │   ├── audit_surface_quality/ # MCP surface metadata + output quality (-view; was audit_tools + audit_output)
 │   ├── audit_tokens/       # Token overhead; -footprint, --compare-schemas (was audit_meta_schema); cl100k_base tokenizer (tokens.go)
 │   ├── audit_metrics/      # MCP tool/resource/prompt metrics
+│   ├── audit_readonly_graphql/ # No ReadOnly action may reach a GraphQL mutation (make check-readonly-graphql)
 │   ├── audit_test_goroutines/ # Off-goroutine testing.T abort audit (--check gate)
 │   ├── audit_test_names/   # Test naming convention (+ -apply/-dry-run)
 │   ├── audit_string_dupes/ # Duplicated string literals missing constants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: make check-lhm-manifest
       - name: Check documented tool names exist
         run: make check-doc-tool-names
+      - name: Check no read-only action reaches a GraphQL mutation
+        run: make check-readonly-graphql
       - name: Check the one-click install buttons
         run: make check-install-buttons
       - name: Check MCP Registry manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ gitlab-mcp-server/
 │   ├── audit_install_buttons/  # Decodes every one-click install payload (base64 or percent-encoded JSON) and holds the buttons to one configuration per command (make check-install-buttons)
 │   ├── godoc_tool/              # Consolidated Go doc auditor + fixer (was audit_godocs + add_docs)
 │   ├── audit_metrics/           # Audits MCP tool/resource/prompt metrics
+│   ├── audit_readonly_graphql/  # Fails when an action classified ReadOnly can reach a GraphQL mutation, which `--read-only` and a read_api token's narrowed surface would both keep (make check-readonly-graphql)
 │   ├── audit_supply_chain/      # Audits five release-configuration invariants: SHA-pinned uses:, credentialed jobs that run no run-time-resolved code, stated Dependabot cooldowns, a current SECURITY.md, signature-verifying installers (make check-supply-chain)
 │   ├── audit_surface_quality/   # Consolidated surface audit: metadata violations + output quality (was audit_tools + audit_output)
 │   ├── audit_test_goroutines/   # Audits testing.T aborts made off the test goroutine (A/B categories, --check gate)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 	audit-output audit-tokens audit-tools audit-surface-quality audit-metrics audit-dynamic-aliases audit-test-names audit-godocs audit-godocs-check fix-godocs \
 	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-validate-docs audit-edition-tier \
 	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names audit-test-subtests check-test-subtests check-supply-chain \
+	check-readonly-graphql audit-readonly-graphql \
 	audit-doc-coverage audit-doc-coverage-check \
 	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest gen-icon-webp check-icon-webp check-server-json check-server-json-packages check-openplugin audit-doc-tool-names check-doc-tool-names check-install-buttons check-mcpb mcpb gen-npm sync-npm-version validate-npm validate-npm-local publish-npm-dry publish-npm gen-pypi validate-pypi validate-pypi-local publish-pypi-dry publish-pypi publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
 	docs-local-go \
@@ -1063,6 +1064,19 @@ audit-gateway-chars:
 ## character, so a rejection at a gateway's door cannot ship silently.
 check-gateway-chars:
 	go run ./cmd/audit_gateway_chars/ -check
+
+## check-readonly-graphql: fail when an action classified ReadOnly can reach a
+## GraphQL mutation. --read-only and the surface served to a read_api token
+## both keep such an action, so it would write exactly where a write is
+## supposed to be impossible. The HTTP method cannot see this: client-go POSTs
+## every GraphQL request, reads included.
+check-readonly-graphql:
+	go run ./cmd/audit_readonly_graphql/
+
+## audit-readonly-graphql: same gate, listing the read-only actions that touch
+## GraphQL at all rather than only what failed.
+audit-readonly-graphql:
+	go run ./cmd/audit_readonly_graphql/ -v
 
 ## audit-test-names: audit test function naming convention compliance.
 audit-test-names:

--- a/README.md
+++ b/README.md
@@ -459,20 +459,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,023 |     216,155 |
-| Unit tests (`_test.go`)  |       595 |     354,489 |
+| Source (`.go`, non-test) |     1,029 |     217,618 |
+| Unit tests (`_test.go`)  |       601 |     356,068 |
 | End-to-end tests         |       216 |      58,984 |
-| **Total**                | **1,834** | **629,628** |
+| **Total**                | **1,846** | **632,670** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,136 |
-| . Exported (public)             |  2,757 |
-| . Unexported (private)          |  5,379 |
-| Unit test functions (`TestXxx`) | 12,751 |
-| Subtests (`t.Run(...)`)         |  4,663 |
+| Source functions                |  8,196 |
+| . Exported (public)             |  2,758 |
+| . Unexported (private)          |  5,438 |
+| Unit test functions (`TestXxx`) | 12,788 |
+| Subtests (`t.Run(...)`)         |  4,673 |
 | End-to-end test functions       |    555 |
 
 ### Ratios worth noting
@@ -481,17 +481,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~595 lines |
-| Comment lines in source            |  31,377 (~14.5% of source) |
+| Average test file length           |                 ~592 lines |
+| Comment lines in source            |  31,679 (~14.6% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,851 |
+| `if err != nil` checks             | 6,858 |
 | `defer` statements                 | 1,113 |
-| `struct` types defined             | 2,802 |
+| `struct` types defined             | 2,816 |
 | `//nolint` suppressions            |   259 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -499,7 +499,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   244 |
+| Go packages                    |   245 |
 | Direct dependencies (`go.mod`) |    30 |
 | Indirect dependencies          |    31 |
 
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,930 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,080 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,956 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,091 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_readonly_graphql/audit.go
+++ b/cmd/audit_readonly_graphql/audit.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// exceptionDirective is how a deliberate exception is declared: in the source
+// next to the action it excuses, never in this audit.
+//
+//	//gitlab:allow-readonly-graphql-mutation <action_name>: <reason>
+//
+// The directive has to sit in the package that owns the action and name that
+// action, so a reader of the handler sees the exception beside the handler and
+// a reader of this file sees no list of blessed actions at all. An exception
+// that stops matching anything is reported, so one left behind by a later
+// change does not quietly widen the gate.
+const exceptionDirective = "//gitlab:allow-readonly-graphql-mutation"
+
+// action is one catalog action the audit has to answer for.
+type action struct {
+	ID       string
+	Name     string
+	Owner    string
+	ReadOnly bool
+}
+
+// exception is one declared exception, kept with where it was declared.
+type exception struct {
+	pkgName string
+	action  string
+	reason  string
+	pos     token.Pos
+}
+
+// finding is one reason the audit fails.
+type finding struct {
+	// action is the catalog action ID the finding is about.
+	action string
+	// message is the whole explanation, already formatted.
+	message string
+}
+
+// auditResult is everything one run learned, so a caller can report it.
+type auditResult struct {
+	findings []finding
+	// checked is how many read-only actions were resolved and classified.
+	checked int
+	// graphQL is the read-only actions that reach the GraphQL transport at
+	// all, by catalog ID. They are the ones this gate is really about, and
+	// the verbose report lists them so the set is reviewable rather than a
+	// number.
+	graphQL []string
+	// exceptions is how many declared exceptions were used.
+	exceptions int
+}
+
+// audit resolves every read-only action to its handler, classifies the GraphQL
+// documents that handler can send, and reports the ones that are mutations.
+func audit(prog *program, actions []action, root string) auditResult {
+	res := &resolver{prog: prog}
+	sites := res.collectSites()
+	exceptions := collectExceptions(prog)
+	used := make(map[string]bool, len(exceptions))
+	result := auditResult{}
+
+	for _, act := range actions {
+		if !act.ReadOnly {
+			continue
+		}
+		matched := matchSites(sites, act)
+		if len(matched) == 0 {
+			result.findings = append(result.findings, unresolvedFinding(act,
+				"no ActionSpec construction resolves to this action"))
+			continue
+		}
+		roots := handlerFuncs(prog, matched)
+		// A spec whose route resolves to no handler at all is the dangerous
+		// shape, not a harmless one: the reachable set is empty, so every
+		// classification below would come back clean whatever the handler
+		// actually does. Report it for the same reason an unplaceable action
+		// is reported.
+		if len(roots) == 0 {
+			result.findings = append(result.findings, unresolvedFinding(act,
+				"the action's route resolves to no handler"))
+			continue
+		}
+		result.checked++
+		reached := prog.reachable(roots)
+		sends, mutations := classifyReached(prog, reached)
+		if sends {
+			result.graphQL = append(result.graphQL, act.ID)
+		}
+		// Naming a mutation document is the finding, whether or not the send
+		// was recognized. Requiring both would make every failure depend on
+		// recognizing the transport too, and a chain this audit could not
+		// follow to GraphQL.Do would then excuse the mutation rather than
+		// report it, which is the one outcome a gate must not have.
+		if len(mutations) == 0 {
+			continue
+		}
+		if key, ok := exceptionFor(exceptions, act); ok {
+			used[key] = true
+			result.exceptions++
+			continue
+		}
+		result.findings = append(result.findings, mutationFinding(prog, act, matched, mutations, root))
+	}
+
+	result.findings = append(result.findings, staleExceptions(prog, exceptions, used, root)...)
+	sort.Slice(result.findings, func(i, j int) bool {
+		if result.findings[i].action != result.findings[j].action {
+			return result.findings[i].action < result.findings[j].action
+		}
+		return result.findings[i].message < result.findings[j].message
+	})
+	return result
+}
+
+// unresolvedFinding reports a read-only action this audit cannot answer for.
+// It is a failure rather than a skip because a gate that passes what it cannot
+// classify stops holding the moment a domain is written in a shape the
+// resolver does not follow, and says nothing while it does.
+func unresolvedFinding(act action, reason string) finding {
+	return finding{
+		action: act.ID,
+		message: fmt.Sprintf("%s: %s, so its handler cannot be classified.\n"+
+			"    Declare the action through a toolutil action-spec constructor in package %q, or the gate cannot vouch for it.",
+			act.ID, reason, act.Owner),
+	}
+}
+
+// matchSites picks the construction sites that declare one catalog action.
+// The owning package decides when several packages declare the same action
+// name; when none of them is the owner, every site with that name is taken,
+// because a wrong guess must not be the quiet one.
+func matchSites(sites map[string][]site, act action) []site {
+	candidates := sites[act.Name]
+	if len(candidates) == 0 {
+		return nil
+	}
+	owned := make([]site, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.pkgName == act.Owner {
+			owned = append(owned, candidate)
+		}
+	}
+	if len(owned) > 0 {
+		return owned
+	}
+	return candidates
+}
+
+// handlerFuncs turns resolved handler references into call-graph roots. A
+// handler written as a literal has no declared function, so its body is
+// indexed on the spot and its callees become the roots instead.
+func handlerFuncs(prog *program, matched []site) []*types.Func {
+	var roots []*types.Func
+	for _, matchedSite := range matched {
+		for _, handler := range matchedSite.handlers {
+			if handler.fn != nil {
+				roots = append(roots, handler.fn)
+				continue
+			}
+			roots = append(roots, prog.indexLiteral(handler.pkg, handler.lit)...)
+		}
+	}
+	return roots
+}
+
+// classifyReached reports whether the reachable set sends GraphQL at all, and
+// which mutation documents it names.
+func classifyReached(prog *program, reached map[*types.Func]bool) (bool, []mutationSite) {
+	sends := false
+	var mutations []mutationSite
+	for fnObj := range reached {
+		fn, ok := prog.funcs[fnObj]
+		if !ok {
+			continue
+		}
+		if fn.sendsGraphQL {
+			sends = true
+		}
+		for _, doc := range fn.docs {
+			if doc.kind == writeDocument {
+				mutations = append(mutations, mutationSite{fn: fnObj, doc: doc})
+			}
+		}
+	}
+	sort.Slice(mutations, func(i, j int) bool { return mutations[i].doc.pos < mutations[j].doc.pos })
+	return sends, mutations
+}
+
+// mutationSite is one mutation document named by one reachable function.
+type mutationSite struct {
+	fn  *types.Func
+	doc docRef
+}
+
+// mutationFinding formats the failure this audit exists for.
+func mutationFinding(prog *program, act action, matched []site, mutations []mutationSite, root string) finding {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s is classified ReadOnly but its handler sends a GraphQL mutation.\n", act.ID)
+	for _, matchedSite := range matched {
+		fmt.Fprintf(&builder, "    action declared at %s\n", relative(prog.position(matchedSite.pos), root))
+	}
+	for _, mutation := range mutations {
+		fmt.Fprintf(&builder, "    %s sends %s at %s\n",
+			mutation.fn.Name(), documentName(mutation.doc), relative(prog.position(mutation.doc.pos), root))
+	}
+	builder.WriteString("    A read-only action must not reach a mutation: --read-only and the surface served to a\n")
+	builder.WriteString("    read_api token both keep it, so the write would run where a write is supposed to be impossible.\n")
+	builder.WriteString("    Reclassify the action as mutating, or declare the exception with " + exceptionDirective + ".")
+	return finding{action: act.ID, message: builder.String()}
+}
+
+// documentName names the document a finding points at.
+func documentName(doc docRef) string {
+	if doc.name == "" {
+		return "an inline mutation document"
+	}
+	return doc.name
+}
+
+// collectExceptions reads every exception directive in the loaded source.
+func collectExceptions(prog *program) map[string]exception {
+	found := make(map[string]exception)
+	for _, pkg := range prog.order {
+		for _, file := range pkg.Syntax {
+			for _, group := range file.Comments {
+				for _, comment := range group.List {
+					parsed, ok := parseException(pkg.Name, comment.Text, comment.Pos())
+					if !ok {
+						continue
+					}
+					found[exceptionKey(parsed.pkgName, parsed.action)] = parsed
+				}
+			}
+		}
+	}
+	return found
+}
+
+// parseException reads one directive comment.
+func parseException(pkgName, text string, pos token.Pos) (exception, bool) {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(text), exceptionDirective)
+	if !ok {
+		return exception{}, false
+	}
+	name, reason, hasReason := strings.Cut(strings.TrimSpace(rest), ":")
+	name = strings.TrimSpace(name)
+	reason = strings.TrimSpace(reason)
+	if name == "" || !hasReason || reason == "" {
+		return exception{}, false
+	}
+	return exception{pkgName: pkgName, action: name, reason: reason, pos: pos}, true
+}
+
+// exceptionKey identifies one exception by the package and action it names.
+func exceptionKey(pkgName, actionName string) string {
+	return pkgName + "." + actionName
+}
+
+// exceptionFor finds the exception excusing one action, if it was declared in
+// the package that owns the action.
+func exceptionFor(exceptions map[string]exception, act action) (string, bool) {
+	key := exceptionKey(act.Owner, act.Name)
+	_, ok := exceptions[key]
+	return key, ok
+}
+
+// staleExceptions reports directives that no longer excuse anything, so an
+// exception cannot outlive the reason it was written for.
+func staleExceptions(prog *program, exceptions map[string]exception, used map[string]bool, root string) []finding {
+	var findings []finding
+	for key, declared := range exceptions {
+		if used[key] {
+			continue
+		}
+		findings = append(findings, finding{
+			action: key,
+			message: fmt.Sprintf("%s at %s excuses a read-only action that no longer sends a mutation. Remove it.",
+				exceptionDirective, relative(prog.position(declared.pos), root)),
+		})
+	}
+	return findings
+}
+
+// indexLiteral indexes a handler written as a function literal and returns the
+// functions its body names, which stand in for it as call-graph roots.
+func (p *program) indexLiteral(pkg *packages.Package, lit *ast.FuncLit) []*types.Func {
+	fn := p.indexBody(pkg, nil, &ast.FuncDecl{Body: lit.Body})
+	roots := make([]*types.Func, 0, len(fn.calls))
+	for callee := range fn.calls {
+		roots = append(roots, callee)
+	}
+	sort.Slice(roots, func(i, j int) bool { return roots[i].Pos() < roots[j].Pos() })
+	return roots
+}
+
+// relative trims a position to the repository root so a finding reads as a
+// path a person can open.
+func relative(pos token.Position, root string) string {
+	path := pos.Filename
+	if root != "" {
+		if rel, err := filepath.Rel(root, path); err == nil && !strings.HasPrefix(rel, "..") {
+			path = filepath.ToSlash(rel)
+		}
+	}
+	return fmt.Sprintf("%s:%d", path, pos.Line)
+}

--- a/cmd/audit_readonly_graphql/audit_test.go
+++ b/cmd/audit_readonly_graphql/audit_test.go
@@ -1,0 +1,445 @@
+package main
+
+import (
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// excusedFixture is a read-only action that really does reach a mutation and
+// says so in the source, beside the action, with the directive that excuses it.
+const excusedFixture = `package excused
+
+import (
+	"context"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+const writeMutation = @@
+mutation($id: ID!) {
+  thingTouch(input: {id: $id}) { errors }
+}
+@@
+
+// Input is the fixture handler input.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the fixture handler output.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+// Risky reads, and reaches a mutation on the way.
+func Risky(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	var response struct {
+		Data map[string]any ` + "`json:\"data\"`" + `
+	}
+	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
+		Query:     writeMutation,
+		Variables: map[string]any{"id": input.ID},
+	}, &response, gl.WithContext(ctx))
+	return Output{OK: err == nil}, err
+}
+
+// ActionSpecs declares the excused action.
+func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
+	return []toolutil.ActionSpec{
+		//gitlab:allow-readonly-graphql-mutation risky_read: the fixture that proves an exception is declared beside the action.
+		toolutil.NewReadActionSpec("risky_read", toolutil.RouteAction(client, Risky), toolutil.ActionSpecOptions{}),
+	}
+}
+`
+
+// staleFixture declares an exception for an action that reaches no mutation,
+// which is the shape an exception left behind by a later fix takes.
+const staleFixture = `package stale
+
+import (
+	"context"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// Input is the fixture handler input.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the fixture handler output.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+// Quiet touches nothing.
+func Quiet(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	_ = ctx
+	_ = client
+	return Output{OK: input.ID != ""}, nil
+}
+
+// ActionSpecs declares an action whose exception no longer excuses anything.
+func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
+	return []toolutil.ActionSpec{
+		//gitlab:allow-readonly-graphql-mutation quiet_read: left behind after the mutation was removed.
+		toolutil.NewReadActionSpec("quiet_read", toolutil.RouteAction(client, Quiet), toolutil.ActionSpecOptions{}),
+	}
+}
+`
+
+// exceptionSources is the fixture set for the exception tests, kept apart from
+// the detection fixtures because a directive is global to the loaded program:
+// an unused one is a finding, so it would show up in every other test.
+func exceptionSources() map[string]string {
+	return map[string]string{"excused": excusedFixture, "stale": staleFixture}
+}
+
+// exceptionActions is the catalog for the exception fixtures.
+func exceptionActions() []action {
+	return []action{
+		{ID: "excused.risky_read", Name: "risky_read", Owner: "excused", ReadOnly: true},
+		{ID: "stale.quiet_read", Name: "quiet_read", Owner: "stale", ReadOnly: true},
+	}
+}
+
+// findingActions returns the action ID of every finding, sorted.
+func findingActions(result auditResult) []string {
+	ids := make([]string, 0, len(result.findings))
+	for _, item := range result.findings {
+		ids = append(ids, item.action)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// messageFor returns the finding reported for one action, or "".
+func messageFor(result auditResult, actionID string) string {
+	for _, item := range result.findings {
+		if item.action == actionID {
+			return item.message
+		}
+	}
+	return ""
+}
+
+// TestAudit_ReadOnlyActionReachingMutation_IsReported is the case this audit
+// exists for: an action classified ReadOnly whose handler sends a mutation,
+// whether the handler sends it directly, reaches it through a callee, writes
+// the document inline, or runs it from a function-literal route. The actions
+// that only query, and the action classified as mutating, must stay clean.
+func TestAudit_ReadOnlyActionReachingMutation_IsReported(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := append(vulnActions(), shapesActions()...)
+
+	result := audit(prog, actions, repoRoot(t))
+
+	want := []string{
+		"shapes.closure",
+		"vuln.read_dismiss",
+		"vuln.read_dismiss_indirect",
+		"vuln.read_inline",
+	}
+	if got := findingActions(result); !equalStrings(got, want) {
+		t.Errorf("findings for %v, want %v", got, want)
+	}
+}
+
+// TestAudit_ReadOnlyActionSendingOnlyQueries_IsClean verifies a read-only
+// action whose handler sends GraphQL queries is not a finding, which is the
+// whole reason the HTTP method cannot be the test: these actions POST.
+func TestAudit_ReadOnlyActionSendingOnlyQueries_IsClean(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{
+		{ID: "vuln.list", Name: "list", Owner: "vuln", ReadOnly: true},
+		{ID: "shapes.direct", Name: "direct", Owner: "shapes", ReadOnly: true},
+	}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 0 {
+		t.Errorf("query-only read actions produced findings: %v", findingActions(result))
+	}
+	if result.checked != 2 {
+		t.Errorf("checked %d actions, want 2", result.checked)
+	}
+	if !equalStrings(result.graphQL, []string{"vuln.list", "shapes.direct"}) {
+		t.Errorf("actions reported as sending GraphQL = %v, want both fixtures", result.graphQL)
+	}
+}
+
+// TestAudit_MutatingActionReachingMutation_IsNotAFinding verifies the rule the
+// issue states directly: a mutation reached from an action already classified
+// as mutating is not a finding, because nothing claims that action is safe.
+func TestAudit_MutatingActionReachingMutation_IsNotAFinding(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{{ID: "vuln.dismiss", Name: "dismiss", Owner: "vuln", ReadOnly: false}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 0 {
+		t.Errorf("a mutating action was reported: %v", findingActions(result))
+	}
+	if result.checked != 0 {
+		t.Errorf("checked %d actions, want 0: a mutating action is not classified at all", result.checked)
+	}
+}
+
+// TestAudit_ActionSendingNoGraphQL_IsNotAFinding verifies the other rule the
+// issue states: an action that sends no GraphQL is not a finding, and is not
+// counted among the actions that touch GraphQL either.
+func TestAudit_ActionSendingNoGraphQL_IsNotAFinding(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{{ID: "shapes.quiet", Name: "quiet", Owner: "shapes", ReadOnly: true}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 0 {
+		t.Errorf("a REST-only action was reported: %v", findingActions(result))
+	}
+	if len(result.graphQL) != 0 {
+		t.Errorf("a REST-only action was counted as sending GraphQL: %v", result.graphQL)
+	}
+}
+
+// TestAudit_FindingNamesTheActionAndTheFile verifies a failure says which
+// action and which file, which is what the issue asks a failure to name.
+func TestAudit_FindingNamesTheActionAndTheFile(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	result := audit(prog, vulnActions(), repoRoot(t))
+
+	message := messageFor(result, "vuln.read_dismiss")
+	if message == "" {
+		t.Fatal("the constructed violation produced no finding")
+	}
+	for _, want := range []string{"vuln.read_dismiss", "dismissMutation", fixtureDir + "/vuln/vuln.go:"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(message, want) {
+				t.Errorf("finding does not mention %q:\n%s", want, message)
+			}
+		})
+	}
+}
+
+// TestAudit_InlineDocument_IsNamedAsInline verifies a mutation written at the
+// point of use is reported as such, since there is no constant name to print.
+func TestAudit_InlineDocument_IsNamedAsInline(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	result := audit(prog, vulnActions(), repoRoot(t))
+
+	message := messageFor(result, "vuln.read_inline")
+	if !strings.Contains(message, "an inline mutation document") {
+		t.Errorf("finding does not describe the inline document:\n%s", message)
+	}
+}
+
+// TestAudit_UnresolvedAction_IsReported verifies an action the audit cannot
+// place is a failure rather than a silent pass. A gate that skips what it
+// cannot resolve is a gate that stops holding the moment a domain is written
+// in a shape the resolver does not follow.
+func TestAudit_UnresolvedAction_IsReported(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{{ID: "vuln.never_declared", Name: "never_declared", Owner: "vuln", ReadOnly: true}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 1 {
+		t.Fatalf("an unresolvable action produced %d findings, want 1", len(result.findings))
+	}
+	if !strings.Contains(result.findings[0].message, "no ActionSpec construction resolves") {
+		t.Errorf("finding does not say the action could not be resolved:\n%s", result.findings[0].message)
+	}
+	if result.checked != 0 {
+		t.Errorf("checked %d actions, want 0: an unresolved action was not classified", result.checked)
+	}
+}
+
+// TestAudit_RouteWithNoResolvableHandler_IsReported verifies the quiet failure
+// mode is loud: an action whose route the resolver cannot follow to a handler
+// has an empty reachable set, so every classification would come back clean
+// whatever the handler does. It is reported instead.
+func TestAudit_RouteWithNoResolvableHandler_IsReported(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{{ID: "shapes.shared_route", Name: "shared_route", Owner: "shapes", ReadOnly: true}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 1 {
+		t.Fatalf("an unfollowable route produced %d findings, want 1", len(result.findings))
+	}
+	if !strings.Contains(result.findings[0].message, "resolves to no handler") {
+		t.Errorf("finding does not say the route had no handler:\n%s", result.findings[0].message)
+	}
+}
+
+// TestAudit_OwnerPackageMismatch_FallsBackToEverySiteWithThatName verifies the
+// resolution fallback errs towards reporting: when no site in the owning
+// package declares the action, every site with that name is taken, so a
+// mismatch cannot be the quiet outcome.
+func TestAudit_OwnerPackageMismatch_FallsBackToEverySiteWithThatName(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	actions := []action{{ID: "elsewhere.read_dismiss", Name: "read_dismiss", Owner: "elsewhere", ReadOnly: true}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if len(result.findings) != 1 {
+		t.Fatalf("the fallback produced %d findings, want 1", len(result.findings))
+	}
+	if !strings.Contains(result.findings[0].message, "GraphQL mutation") {
+		t.Errorf("finding is not the mutation report:\n%s", result.findings[0].message)
+	}
+}
+
+// TestAudit_ExceptionBesideTheAction_SuppressesTheFinding verifies a deliberate
+// exception declared in the source next to the action excuses it, and that an
+// exception nothing uses is reported so it cannot outlive its reason.
+func TestAudit_ExceptionBesideTheAction_SuppressesTheFinding(t *testing.T) {
+	prog := loadFixture(t, exceptionSources())
+
+	result := audit(prog, exceptionActions(), repoRoot(t))
+
+	if messageFor(result, "excused.risky_read") != "" {
+		t.Error("the excused action was reported despite its directive")
+	}
+	if result.exceptions != 1 {
+		t.Errorf("%d exceptions used, want 1", result.exceptions)
+	}
+	stale := messageFor(result, "stale.quiet_read")
+	if stale == "" {
+		t.Fatal("the unused directive was not reported")
+	}
+	if !strings.Contains(stale, "no longer sends a mutation") {
+		t.Errorf("stale finding does not explain itself:\n%s", stale)
+	}
+}
+
+// TestAudit_ExceptionInAnotherPackage_DoesNotApply verifies an exception only
+// excuses the action it was declared beside: the same action name attributed to
+// a different owning package is reported, and the now-unused directive is
+// reported too.
+func TestAudit_ExceptionInAnotherPackage_DoesNotApply(t *testing.T) {
+	prog := loadFixture(t, exceptionSources())
+	actions := []action{{ID: "stale.risky_read", Name: "risky_read", Owner: "stale", ReadOnly: true}}
+
+	result := audit(prog, actions, repoRoot(t))
+
+	if messageFor(result, "stale.risky_read") == "" {
+		t.Error("an action excused only in another package was not reported")
+	}
+	if result.exceptions != 0 {
+		t.Errorf("%d exceptions used, want 0", result.exceptions)
+	}
+}
+
+// TestParseException_DirectiveForms verifies what counts as a declared
+// exception: the directive, an action name, and a reason. A directive without
+// a reason is not an exception, because an exception with no stated reason is
+// the thing this design is trying to prevent.
+func TestParseException_DirectiveForms(t *testing.T) {
+	cases := []struct {
+		name       string
+		comment    string
+		wantOK     bool
+		wantAction string
+		wantReason string
+	}{
+		{
+			name:       "action and reason",
+			comment:    "//gitlab:allow-readonly-graphql-mutation epic_note_list: GitLab has no read equivalent.",
+			wantOK:     true,
+			wantAction: "epic_note_list",
+			wantReason: "GitLab has no read equivalent.",
+		},
+		{
+			name:       "indented inside a doc comment",
+			comment:    "  //gitlab:allow-readonly-graphql-mutation  spaced_action :  reason with spaces  ",
+			wantOK:     true,
+			wantAction: "spaced_action",
+			wantReason: "reason with spaces",
+		},
+		{name: "no reason", comment: "//gitlab:allow-readonly-graphql-mutation epic_note_list", wantOK: false},
+		{name: "empty reason", comment: "//gitlab:allow-readonly-graphql-mutation epic_note_list:", wantOK: false},
+		{name: "no action", comment: "//gitlab:allow-readonly-graphql-mutation : a reason", wantOK: false},
+		{name: "ordinary comment", comment: "// this is not a directive", wantOK: false},
+		{name: "similar prefix", comment: "//gitlab:allow-something-else foo: bar", wantOK: false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, ok := parseException("pkg", testCase.comment, 0)
+			if ok != testCase.wantOK {
+				t.Fatalf("parseException(%q) ok = %t, want %t", testCase.comment, ok, testCase.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.action != testCase.wantAction {
+				t.Errorf("action = %q, want %q", got.action, testCase.wantAction)
+			}
+			if got.reason != testCase.wantReason {
+				t.Errorf("reason = %q, want %q", got.reason, testCase.wantReason)
+			}
+			if got.pkgName != "pkg" {
+				t.Errorf("package = %q, want %q", got.pkgName, "pkg")
+			}
+		})
+	}
+}
+
+// TestRelative_PathsOutsideTheRoot_StayAbsolute verifies a position the
+// repository root does not contain is printed as it is, rather than as a
+// nonsense path full of parent directories.
+func TestRelative_PathsOutsideTheRoot_StayAbsolute(t *testing.T) {
+	cases := []struct {
+		name string
+		root string
+		file string
+		want string
+	}{
+		{name: "inside the root", root: "/repo", file: "/repo/internal/tools/x.go", want: "internal/tools/x.go:7"},
+		{name: "outside the root", root: "/repo", file: "/elsewhere/x.go", want: "/elsewhere/x.go:7"},
+		{name: "no root given", root: "", file: "/repo/internal/x.go", want: "/repo/internal/x.go:7"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := relative(token.Position{Filename: testCase.file, Line: 7}, testCase.root)
+			if got != testCase.want {
+				t.Errorf("relative(%q, %q) = %q, want %q", testCase.file, testCase.root, got, testCase.want)
+			}
+		})
+	}
+}
+
+// shapesActions is the catalog for the shapes fixture: every construction
+// shape declared read-only, which is honest for all of them but the closure.
+func shapesActions() []action {
+	names := []string{"direct", "helper", "decorated", "literal", "variable", "constant", "appended", "closure", "quiet"}
+	actions := make([]action, 0, len(names))
+	for _, name := range names {
+		actions = append(actions, action{ID: "shapes." + name, Name: name, Owner: "shapes", ReadOnly: true})
+	}
+	return actions
+}
+
+// equalStrings compares two string slices element by element.
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	gotCopy := append([]string(nil), got...)
+	wantCopy := append([]string(nil), want...)
+	sort.Strings(gotCopy)
+	sort.Strings(wantCopy)
+	for i := range gotCopy {
+		if gotCopy[i] != wantCopy[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/audit_readonly_graphql/catalog.go
+++ b/cmd/audit_readonly_graphql/catalog.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
+)
+
+// catalogActions returns every action in the canonical catalog at the widest
+// tier, which is the surface this audit has to answer for: a tier below
+// Ultimate only removes actions, so auditing Ultimate audits all of them.
+//
+// The client is nil on purpose. Building the catalog registers routes and
+// schemas from the specs compiled into this binary and never calls GitLab, so
+// the audit needs no instance, no token, and no network.
+func catalogActions() ([]action, error) {
+	catalog, err := tools.BuildActionCatalog(nil, tools.ActionCatalogOptions{
+		Tier:       edition.Ultimate,
+		IncludeMCP: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build action catalog: %w", err)
+	}
+	var actions []action
+	for _, group := range catalog.Groups() {
+		for _, catalogAction := range group.ActionsInOrder() {
+			actions = append(actions, action{
+				ID:       string(catalogAction.ID),
+				Name:     catalogAction.Name,
+				Owner:    catalogAction.OwnerPackage,
+				ReadOnly: catalogAction.ReadOnly,
+			})
+		}
+	}
+	return actions, nil
+}

--- a/cmd/audit_readonly_graphql/catalog_test.go
+++ b/cmd/audit_readonly_graphql/catalog_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+// TestCatalogActions_ReturnsTheWholeSurface verifies the audit reads the real
+// canonical catalog offline: every action arrives with the identity the
+// findings quote, and both classifications are present, which is what makes
+// the read-only subset meaningful.
+func TestCatalogActions_ReturnsTheWholeSurface(t *testing.T) {
+	actions, err := catalogActions()
+	if err != nil {
+		t.Fatalf("catalogActions: %v", err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("the canonical catalog produced no actions")
+	}
+
+	readOnly, mutating := 0, 0
+	for _, item := range actions {
+		if item.ID == "" || item.Name == "" || item.Owner == "" {
+			t.Fatalf("action %+v is missing the identity a finding has to name", item)
+		}
+		if item.ReadOnly {
+			readOnly++
+			continue
+		}
+		mutating++
+	}
+	if readOnly == 0 {
+		t.Error("no read-only actions, so this audit would check nothing")
+	}
+	if mutating == 0 {
+		t.Error("no mutating actions, which means the classification was not read")
+	}
+}
+
+// TestCatalogActions_IncludesKnownReadAndWriteActions verifies the two
+// classifications land on actions whose nature is not in doubt, so a catalog
+// change that inverted the flag would not pass this file.
+func TestCatalogActions_IncludesKnownReadAndWriteActions(t *testing.T) {
+	actions, err := catalogActions()
+	if err != nil {
+		t.Fatalf("catalogActions: %v", err)
+	}
+	byID := make(map[string]action, len(actions))
+	for _, item := range actions {
+		byID[item.ID] = item
+	}
+
+	cases := []struct {
+		id           string
+		wantReadOnly bool
+	}{
+		{id: "issue.list", wantReadOnly: true},
+		{id: "project.get", wantReadOnly: true},
+		{id: "vulnerability.list", wantReadOnly: true},
+		{id: "vulnerability.dismiss", wantReadOnly: false},
+		{id: "issue.create", wantReadOnly: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.id, func(t *testing.T) {
+			item, ok := byID[testCase.id]
+			if !ok {
+				t.Fatalf("action %q is not in the catalog", testCase.id)
+			}
+			if item.ReadOnly != testCase.wantReadOnly {
+				t.Errorf("action %q ReadOnly = %t, want %t", testCase.id, item.ReadOnly, testCase.wantReadOnly)
+			}
+		})
+	}
+}

--- a/cmd/audit_readonly_graphql/document.go
+++ b/cmd/audit_readonly_graphql/document.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// documentKind is what one GraphQL document asks the server to do.
+type documentKind int
+
+const (
+	// notADocument is a string that carries no GraphQL operation.
+	notADocument documentKind = iota
+	// readDocument is a query, a subscription, a bare selection set, or a
+	// fragment: nothing in it changes server state.
+	readDocument
+	// writeDocument is a document carrying at least one mutation operation.
+	writeDocument
+)
+
+// String names the kind for a report line.
+func (k documentKind) String() string {
+	switch k {
+	case writeDocument:
+		return "mutation"
+	case readDocument:
+		return "query"
+	default:
+		return "not-a-document"
+	}
+}
+
+// mutationOperation matches a GraphQL mutation operation definition at the
+// start of a line: "mutation(", "mutation {", "mutationName(", or
+// "mutation Name {". The trailing punctuation is what separates an operation
+// definition from English prose, which is why an error string such as
+// "mutation errors: %s" does not match.
+//
+// The match is anchored per line rather than at the start of the string
+// because documents in this repository are raw literals that open with a
+// newline, are indented inside the literal, and are sometimes assembled from
+// a shared fragment constant, so the operation keyword can sit on any line.
+var mutationOperation = regexp.MustCompile(`(?m)^[ \t]*mutation[ \t]*(?:\(|\{|[A-Za-z_][A-Za-z0-9_]*[ \t]*[({])`)
+
+// readOperation matches the read-side operation definitions in the same shape.
+// A document is only classified at all if it looks like GraphQL, and this is
+// what says so for the reads.
+var readOperation = regexp.MustCompile(`(?m)^[ \t]*(?:query|subscription|fragment)[ \t]*(?:\(|\{|[A-Za-z_][A-Za-z0-9_]*\b)`)
+
+// classifyDocument reports what a string literal or string constant asks the
+// GitLab GraphQL API to do.
+//
+// The HTTP method cannot answer this: client-go sends every GraphQL request as
+// a POST, so around twenty read-only actions legitimately POST and the verb
+// separates nothing. The operation type in the document is the whole of the
+// distinction, and it is visible in the source.
+//
+// A string has to look like a GraphQL document to be classified as one: it
+// needs braces, and it needs an operation definition or a bare selection set.
+// Everything else, including ordinary prose that happens to contain the word
+// mutation, is notADocument.
+func classifyDocument(s string) documentKind {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" || !strings.Contains(trimmed, "{") || !strings.Contains(trimmed, "}") {
+		return notADocument
+	}
+	if mutationOperation.MatchString(trimmed) {
+		return writeDocument
+	}
+	if readOperation.MatchString(trimmed) {
+		return readDocument
+	}
+	// A bare selection set is an anonymous query. GitLab accepts one, and this
+	// project sends a few. It cannot express a mutation: the mutation keyword
+	// is mandatory for the write operation type, so a document that omits the
+	// keyword entirely is a read by construction.
+	if strings.HasPrefix(trimmed, "{") {
+		return readDocument
+	}
+	return notADocument
+}

--- a/cmd/audit_readonly_graphql/document_test.go
+++ b/cmd/audit_readonly_graphql/document_test.go
@@ -1,0 +1,133 @@
+package main
+
+import "testing"
+
+// TestClassifyDocument_OperationTypes verifies the whole of the distinction
+// this audit rests on: what a string asks GitLab to do is decided by the
+// operation type written in it, and nothing else. The cases cover the shapes
+// this repository actually writes (raw literals opening with a newline,
+// indented documents, named and anonymous operations, documents assembled from
+// a fragment constant) and the prose that must not be mistaken for one.
+func TestClassifyDocument_OperationTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		want documentKind
+	}{
+		{
+			name: "anonymous mutation",
+			doc:  "\nmutation($id: VulnerabilityID!) {\n  vulnerabilityDismiss(input: {id: $id}) {\n    errors\n  }\n}\n",
+			want: writeDocument,
+		},
+		{
+			name: "named mutation",
+			doc:  "mutation CreateSecurityCategory($input: SecurityCategoryCreateInput!) {\n  securityCategoryCreate(input: $input) { errors }\n}",
+			want: writeDocument,
+		},
+		{
+			name: "mutation with a space before the brace",
+			doc:  "mutation {\n  destroyNote(input: {id: \"x\"}) { errors }\n}",
+			want: writeDocument,
+		},
+		{
+			name: "indented mutation inside a raw literal",
+			doc:  "\n\t\tmutation UpdateThing($input: ThingInput!) {\n\t\t\tthingUpdate(input: $input) { errors }\n\t\t}\n",
+			want: writeDocument,
+		},
+		{
+			name: "anonymous query",
+			doc:  "\nquery($fullPath: ID!) {\n  group(fullPath: $fullPath) { id }\n}\n",
+			want: readDocument,
+		},
+		{
+			name: "named query",
+			doc:  "query GetEpic($fullPath: ID!, $iid: String!) {\n  group(fullPath: $fullPath) { epic(iid: $iid) { id } }\n}",
+			want: readDocument,
+		},
+		{
+			name: "bare selection set is an anonymous query",
+			doc:  "{\n  currentUser { id username }\n}",
+			want: readDocument,
+		},
+		{
+			name: "subscription is a read",
+			doc:  "subscription OnThing($id: ID!) {\n  thing(id: $id) { state }\n}",
+			want: readDocument,
+		},
+		{
+			name: "fragment alone declares no operation",
+			doc:  "fragment vulnFields on Vulnerability {\n  id\n  title\n}",
+			want: readDocument,
+		},
+		{
+			name: "prose containing the word mutation",
+			doc:  "%s mutation errors: %s",
+			want: notADocument,
+		},
+		{
+			name: "hint mentioning a mutation by name",
+			doc:  "body is rendered as Markdown; the createNote mutation may fail if the work item is locked",
+			want: notADocument,
+		},
+		{
+			name: "error format string that starts with the word",
+			doc:  "mutation failed",
+			want: notADocument,
+		},
+		{
+			name: "empty string",
+			doc:  "",
+			want: notADocument,
+		},
+		{
+			name: "whitespace only",
+			doc:  "   \n\t ",
+			want: notADocument,
+		},
+		{
+			name: "braces without an operation",
+			doc:  "{\"error\": \"not graphql\"",
+			want: notADocument,
+		},
+		{
+			name: "json object is a selection set as far as this audit cares",
+			doc:  "{\"a\": 1}",
+			want: readDocument,
+		},
+		{
+			name: "a fragment spliced into a mutation is still a mutation",
+			doc:  "\nmutation($id: VulnerabilityID!) {\n  vulnerabilityConfirm(input: {id: $id}) {\n    vulnerability {\n      id\n      title\n    }\n    errors\n  }\n}\n",
+			want: writeDocument,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := classifyDocument(testCase.doc); got != testCase.want {
+				t.Errorf("classifyDocument(%q) = %v, want %v", testCase.doc, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestDocumentKind_String_NamesEveryKind verifies the report wording for each
+// classification, including the zero value a caller sees for a string that
+// carries no GraphQL at all.
+func TestDocumentKind_String_NamesEveryKind(t *testing.T) {
+	cases := []struct {
+		name string
+		kind documentKind
+		want string
+	}{
+		{name: "write", kind: writeDocument, want: "mutation"},
+		{name: "read", kind: readDocument, want: "query"},
+		{name: "neither", kind: notADocument, want: "not-a-document"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.kind.String(); got != testCase.want {
+				t.Errorf("documentKind(%d).String() = %q, want %q", testCase.kind, got, testCase.want)
+			}
+		})
+	}
+}

--- a/cmd/audit_readonly_graphql/main.go
+++ b/cmd/audit_readonly_graphql/main.go
@@ -1,0 +1,117 @@
+// Command audit_readonly_graphql fails when an action the canonical catalog
+// classifies ReadOnly can reach a GraphQL mutation.
+//
+// --read-only removes actions through FilterReadOnlyActions, and the surface
+// served to a read_api OAuth token is narrowed the same way. Both key on the
+// action's catalog classification, not on what its handler does. An action
+// classified ReadOnly whose handler issues a GraphQL mutation therefore
+// survives both filters and executes a write precisely where a write is
+// supposed to be impossible, with nothing anywhere reporting it: GitLab
+// performs the write, because the credential's scope is whatever the caller's
+// token actually carries.
+//
+// The HTTP method cannot be the test. client-go sends every GraphQL request as
+// a POST, so around twenty read-only actions legitimately POST and the verb
+// separates nothing. The operation type in the document is the whole of the
+// distinction, and it is in the source: a mutation is "mutation ..." in the
+// document handed to GraphQL.Do, against "query ..." or a bare selection set
+// for a read.
+//
+// So the audit resolves every read-only catalog action to the function its
+// route runs, walks what that function can call, and classifies every GraphQL
+// document those bodies name. An action that sends no GraphQL is not a
+// finding, and neither is a mutation reached from an action already classified
+// as mutating.
+//
+// Usage:
+//
+//	go run ./cmd/audit_readonly_graphql/
+//	go run ./cmd/audit_readonly_graphql/ -v
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// auditPatterns are the packages the audit loads. Every catalog handler and
+// every GraphQL document in this project lives under them.
+var auditPatterns = []string{"./internal/..."}
+
+// actionSource supplies the catalog actions to audit. It is a parameter so the
+// exit paths and the classification are reachable from a test without the
+// compiled-in catalog deciding what the test gets to see.
+type actionSource func() ([]action, error)
+
+// auditRun is one configured run: where to look, what to look at, and where
+// the actions being audited come from.
+type auditRun struct {
+	dir      string
+	verbose  bool
+	patterns []string
+	// overlay supplies source that is not on disk, which is how a test hands
+	// the audit a fixture package instead of the repository.
+	overlay map[string][]byte
+	actions actionSource
+}
+
+func main() {
+	dir := flag.String("dir", ".", "repository root to audit")
+	verbose := flag.Bool("v", false, "report what was checked, not only what failed")
+	flag.Parse()
+
+	os.Exit(run(auditRun{
+		dir:      *dir,
+		verbose:  *verbose,
+		patterns: auditPatterns,
+		actions:  catalogActions,
+	}, os.Stdout, os.Stderr))
+}
+
+// run is main with its streams, its catalog, and its exit status handed to it,
+// so the ways this audit ends are reachable from a test instead of only from a
+// process. It returns the exit status rather than calling os.Exit.
+func run(cfg auditRun, out, errOut io.Writer) int {
+	actions, err := cfg.actions()
+	if err != nil {
+		fmt.Fprintln(errOut, "audit_readonly_graphql:", err)
+		return 1
+	}
+	if len(actions) == 0 {
+		fmt.Fprintln(errOut, "audit_readonly_graphql: the catalog is empty, which means this audit is looking at the wrong thing")
+		return 1
+	}
+
+	prog, err := loadProgram(cfg.dir, cfg.patterns, cfg.overlay)
+	if err != nil {
+		fmt.Fprintln(errOut, "audit_readonly_graphql:", err)
+		return 1
+	}
+
+	result := audit(prog, actions, cfg.dir)
+	if cfg.verbose {
+		reportChecked(out, result)
+	}
+	if len(result.findings) > 0 {
+		for _, item := range result.findings {
+			fmt.Fprintln(errOut, item.message)
+		}
+		fmt.Fprintf(errOut, "\naudit_readonly_graphql: %d problem(s) across %d read-only action(s)\n", len(result.findings), result.checked)
+		return 1
+	}
+	fmt.Fprintf(out, "audit_readonly_graphql: %d read-only actions reach no GraphQL mutation (%d of them send GraphQL)\n",
+		result.checked, len(result.graphQL))
+	return 0
+}
+
+// reportChecked lists what the run resolved, so the set of read-only actions
+// that touch GraphQL at all is reviewable rather than a number.
+func reportChecked(out io.Writer, result auditResult) {
+	fmt.Fprintf(out, "audit_readonly_graphql: %d declared exception(s) in use\n", result.exceptions)
+	fmt.Fprintf(out, "audit_readonly_graphql: %d read-only action(s) send GraphQL:\n", len(result.graphQL))
+	for _, id := range result.graphQL {
+		fmt.Fprintf(out, "    %s\n", id)
+	}
+}

--- a/cmd/audit_readonly_graphql/main_test.go
+++ b/cmd/audit_readonly_graphql/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// runFixture runs the audit over a fixture package set and returns the exit
+// status with both streams.
+func runFixture(t *testing.T, sources map[string]string, actions []action, verbose bool) (int, string, string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	status := run(auditRun{
+		dir:      repoRoot(t),
+		verbose:  verbose,
+		patterns: []string{fixturePattern},
+		overlay:  fixtureOverlay(t, sources),
+		actions:  func() ([]action, error) { return actions, nil },
+	}, &out, &errOut)
+	return status, out.String(), errOut.String()
+}
+
+// TestRun_CleanCatalog_Succeeds verifies the passing path: read-only actions
+// that reach no mutation exit zero and say what was checked.
+func TestRun_CleanCatalog_Succeeds(t *testing.T) {
+	actions := []action{
+		{ID: "vuln.list", Name: "list", Owner: "vuln", ReadOnly: true},
+		{ID: "vuln.dismiss", Name: "dismiss", Owner: "vuln", ReadOnly: false},
+	}
+
+	status, out, errOut := runFixture(t, vulnSources(), actions, false)
+
+	if status != 0 {
+		t.Fatalf("exit status %d, want 0. stderr:\n%s", status, errOut)
+	}
+	if !strings.Contains(out, "reach no GraphQL mutation") {
+		t.Errorf("stdout does not report the clean result:\n%s", out)
+	}
+	if errOut != "" {
+		t.Errorf("a clean run wrote to stderr:\n%s", errOut)
+	}
+}
+
+// TestRun_VerboseCleanCatalog_ListsTheGraphQLActions verifies the verbose
+// report names the read-only actions that touch GraphQL, so the set a reviewer
+// has to care about is visible rather than a count.
+func TestRun_VerboseCleanCatalog_ListsTheGraphQLActions(t *testing.T) {
+	actions := []action{{ID: "vuln.list", Name: "list", Owner: "vuln", ReadOnly: true}}
+
+	status, out, _ := runFixture(t, vulnSources(), actions, true)
+
+	if status != 0 {
+		t.Fatalf("exit status %d, want 0", status)
+	}
+	for _, want := range []string{"declared exception(s) in use", "read-only action(s) send GraphQL", "vuln.list"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(out, want) {
+				t.Errorf("verbose output does not contain %q:\n%s", want, out)
+			}
+		})
+	}
+}
+
+// TestRun_ReadOnlyActionReachingMutation_Fails verifies the failing path: a
+// non-zero exit, the finding on stderr, and a count.
+func TestRun_ReadOnlyActionReachingMutation_Fails(t *testing.T) {
+	actions := []action{{ID: "vuln.read_dismiss", Name: "read_dismiss", Owner: "vuln", ReadOnly: true}}
+
+	status, _, errOut := runFixture(t, vulnSources(), actions, false)
+
+	if status != 1 {
+		t.Fatalf("exit status %d, want 1", status)
+	}
+	for _, want := range []string{"vuln.read_dismiss", "GraphQL mutation", "1 problem(s)"} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(errOut, want) {
+				t.Errorf("stderr does not contain %q:\n%s", want, errOut)
+			}
+		})
+	}
+}
+
+// TestRun_CatalogSourceFails_Reports verifies a catalog that cannot be built
+// is reported rather than treated as a catalog with nothing in it.
+func TestRun_CatalogSourceFails_Reports(t *testing.T) {
+	var out, errOut bytes.Buffer
+
+	status := run(auditRun{
+		dir:      repoRoot(t),
+		patterns: []string{fixturePattern},
+		actions:  func() ([]action, error) { return nil, errFixture },
+	}, &out, &errOut)
+
+	if status != 1 {
+		t.Fatalf("exit status %d, want 1", status)
+	}
+	if !strings.Contains(errOut.String(), errFixture.Error()) {
+		t.Errorf("stderr does not carry the catalog error:\n%s", errOut.String())
+	}
+}
+
+// TestRun_EmptyCatalog_Fails verifies an empty catalog fails rather than
+// passing, since an audit with nothing to audit is not a passing audit.
+func TestRun_EmptyCatalog_Fails(t *testing.T) {
+	var out, errOut bytes.Buffer
+
+	status := run(auditRun{
+		dir:      repoRoot(t),
+		patterns: []string{fixturePattern},
+		actions:  func() ([]action, error) { return nil, nil },
+	}, &out, &errOut)
+
+	if status != 1 {
+		t.Fatalf("exit status %d, want 1", status)
+	}
+	if !strings.Contains(errOut.String(), "the catalog is empty") {
+		t.Errorf("stderr does not say the catalog was empty:\n%s", errOut.String())
+	}
+}
+
+// TestRun_UnloadablePackages_Fails verifies a source tree that will not load
+// fails the run instead of yielding an audit with no handlers to classify.
+func TestRun_UnloadablePackages_Fails(t *testing.T) {
+	var out, errOut bytes.Buffer
+
+	status := run(auditRun{
+		dir:      repoRoot(t),
+		patterns: []string{"./internal/tools/testdata/..."},
+		actions:  func() ([]action, error) { return vulnActions(), nil },
+	}, &out, &errOut)
+
+	if status != 1 {
+		t.Fatalf("exit status %d, want 1", status)
+	}
+	if !strings.Contains(errOut.String(), "no packages matched") {
+		t.Errorf("stderr does not report the load failure:\n%s", errOut.String())
+	}
+}
+
+// TestAuditPatterns_CoverTheHandlers verifies the production patterns still
+// name the tree the catalog handlers live in. A pattern that stopped matching
+// them would leave every action unresolvable, which the audit reports, but
+// naming the expectation here says why the pattern is what it is.
+func TestAuditPatterns_CoverTheHandlers(t *testing.T) {
+	if len(auditPatterns) != 1 || auditPatterns[0] != "./internal/..." {
+		t.Errorf("auditPatterns = %v, want [./internal/...]", auditPatterns)
+	}
+}

--- a/cmd/audit_readonly_graphql/program.go
+++ b/cmd/audit_readonly_graphql/program.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// loadMode is everything the audit needs from the loader: syntax to walk and
+// types to resolve an identifier to the object it names.
+//
+// NeedDeps is deliberately absent. Every function this audit follows lives in
+// the patterns it loads, so type-checking the whole dependency tree from
+// source would buy nothing and cost minutes; dependencies come in through
+// export data, which still gives each of their objects one identity shared
+// with the packages that use them.
+const loadMode = packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+	packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+
+// toolutilPath is the import path of the package that owns ActionSpec, the
+// route constructors, and the shared GraphQL executors. Resolution keys on the
+// path rather than on the package name so an import alias cannot fool it.
+const toolutilPath = "github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+
+// program is the loaded, indexed source the audit reasons over.
+type program struct {
+	fset *token.FileSet
+	// pkgs is every loaded package keyed by import path.
+	pkgs map[string]*packages.Package
+	// funcs maps a declared function to its indexed body.
+	funcs map[*types.Func]*function
+	// documents maps a string constant or package-level string variable to
+	// what its value asks GitLab to do.
+	documents map[types.Object]documentKind
+	// order is the loaded packages in the loader's order.
+	order []*packages.Package
+}
+
+// docRef is one GraphQL document named inside a function body.
+type docRef struct {
+	kind documentKind
+	// name is the constant this document was declared as, or "" when the
+	// document is written inline at the point of use.
+	name string
+	// pos is where the body names it, which is the line a finding points at.
+	pos token.Pos
+	// declared is where the document itself is written.
+	declared token.Pos
+}
+
+// function is one declared function with everything the audit reads from it.
+type function struct {
+	obj  *types.Func
+	pkg  *packages.Package
+	decl *ast.FuncDecl
+	// calls is every function this body names. A reference counts as a call:
+	// a function value handed to a helper is called by that helper, and the
+	// audit would rather over-approximate the reachable set than miss a
+	// mutation reached through a callback.
+	calls map[*types.Func]bool
+	// docs is every GraphQL document this body names.
+	docs []docRef
+	// sendsGraphQL reports whether this body reaches the GraphQL transport,
+	// which is what makes a document it names a request rather than a string.
+	sendsGraphQL bool
+}
+
+// graphQLSenders are the entry points that put a GraphQL document on the wire:
+// the client-go GraphQL service method every call here ultimately reaches, and
+// the shared toolutil executors that call it with a document their caller
+// supplied.
+var graphQLSenders = map[string]bool{
+	"Do":                      true,
+	"ExecGraphQLNoteMutation": true,
+	"ExecGraphQLDestroyNote":  true,
+}
+
+// loadProgram loads and indexes the packages named by patterns, rooted at dir.
+//
+// The overlay is how a test supplies source that is not on disk: a fixture
+// package written in the test file itself loads and type-checks against the
+// real toolutil, so the resolver is exercised on the shapes it has to handle
+// rather than on a mock of them. Production passes nil.
+func loadProgram(dir string, patterns []string, overlay map[string][]byte) (*program, error) {
+	cfg := &packages.Config{Mode: loadMode, Dir: dir, Tests: false, Overlay: overlay}
+	loaded, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("load packages: %w", err)
+	}
+	if len(loaded) == 0 {
+		return nil, fmt.Errorf("no packages matched %s in %s", strings.Join(patterns, " "), dir)
+	}
+	prog := &program{
+		fset:      loaded[0].Fset,
+		pkgs:      make(map[string]*packages.Package, len(loaded)),
+		funcs:     make(map[*types.Func]*function),
+		documents: make(map[types.Object]documentKind),
+	}
+	for _, pkg := range loaded {
+		if loadErr := packageLoadError(pkg); loadErr != nil {
+			return nil, loadErr
+		}
+		prog.pkgs[pkg.PkgPath] = pkg
+		prog.order = append(prog.order, pkg)
+	}
+	for _, pkg := range prog.order {
+		prog.indexDocuments(pkg)
+	}
+	for _, pkg := range prog.order {
+		prog.indexFunctions(pkg)
+	}
+	return prog, nil
+}
+
+// packageLoadError turns a package's load errors into one reportable error. A
+// partially typed package would make every resolution below silently
+// unresolvable, which is exactly the failure mode this audit must not have.
+func packageLoadError(pkg *packages.Package) error {
+	if len(pkg.Errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("load %s: %w", pkg.PkgPath, pkg.Errors[0])
+}
+
+// indexDocuments records every string constant and package-level string
+// variable whose value is a GraphQL document.
+//
+// Constants are folded by the type checker, so a document assembled from a
+// shared fragment constant is indexed with the fragment already spliced in,
+// which is how the vulnerability state mutations are written.
+func (p *program) indexDocuments(pkg *packages.Package) {
+	if pkg.TypesInfo == nil || pkg.Types == nil {
+		return
+	}
+	for ident, obj := range pkg.TypesInfo.Defs {
+		if obj == nil {
+			continue
+		}
+		value, ok := definedStringValue(pkg, obj, ident)
+		if !ok {
+			continue
+		}
+		if kind := classifyDocument(value); kind != notADocument {
+			p.documents[obj] = kind
+		}
+	}
+}
+
+// definedStringValue returns the constant string an object was defined with,
+// for the two shapes a GraphQL document is written in: a string constant, and
+// a package-level variable initialized from a constant string expression.
+func definedStringValue(pkg *packages.Package, obj types.Object, ident *ast.Ident) (string, bool) {
+	if con, ok := obj.(*types.Const); ok {
+		return constantString(con.Val())
+	}
+	variable, ok := obj.(*types.Var)
+	if !ok || variable.Parent() != pkg.Types.Scope() {
+		return "", false
+	}
+	init := variableInitializer(pkg, ident)
+	if init == nil {
+		return "", false
+	}
+	tv, ok := pkg.TypesInfo.Types[init]
+	if !ok || tv.Value == nil {
+		return "", false
+	}
+	return constantString(tv.Value)
+}
+
+// variableInitializer finds the expression a package-level variable is
+// declared with. A variable declared without one, or declared in a grouped
+// spec that assigns fewer values than names, has none.
+func variableInitializer(pkg *packages.Package, ident *ast.Ident) ast.Expr {
+	var found ast.Expr
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(node ast.Node) bool {
+			spec, ok := node.(*ast.ValueSpec)
+			if !ok || len(spec.Names) != len(spec.Values) {
+				return true
+			}
+			for i, name := range spec.Names {
+				if name == ident {
+					found = spec.Values[i]
+					return false
+				}
+			}
+			return true
+		})
+		if found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// constantString unwraps a string constant value.
+func constantString(value constant.Value) (string, bool) {
+	if value == nil || value.Kind() != constant.String {
+		return "", false
+	}
+	return constant.StringVal(value), true
+}
+
+// indexFunctions records every declared function's body.
+func (p *program) indexFunctions(pkg *packages.Package) {
+	if pkg.TypesInfo == nil {
+		return
+	}
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Body == nil {
+				continue
+			}
+			obj, ok := pkg.TypesInfo.Defs[funcDecl.Name].(*types.Func)
+			if !ok {
+				continue
+			}
+			p.funcs[obj] = p.indexBody(pkg, obj, funcDecl)
+		}
+	}
+}
+
+// indexBody walks one function body. Function literals inside it are walked as
+// part of it: a closure a handler defines runs when that handler runs, so
+// folding it into the enclosing function keeps the reachable set honest
+// without a separate node per literal.
+func (p *program) indexBody(pkg *packages.Package, obj *types.Func, decl *ast.FuncDecl) *function {
+	fn := &function{obj: obj, pkg: pkg, decl: decl, calls: make(map[*types.Func]bool)}
+	seen := make(map[token.Pos]bool)
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.Ident:
+			p.recordUse(fn, pkg, typed, seen)
+		case *ast.BasicLit:
+			if typed.Kind == token.STRING {
+				p.recordLiteral(fn, pkg, typed, seen)
+			}
+		}
+		return true
+	})
+	return fn
+}
+
+// recordUse records what one identifier in a body names.
+func (p *program) recordUse(fn *function, pkg *packages.Package, ident *ast.Ident, seen map[token.Pos]bool) {
+	obj := pkg.TypesInfo.Uses[ident]
+	if obj == nil {
+		return
+	}
+	if callee, ok := obj.(*types.Func); ok {
+		fn.calls[callee] = true
+		if graphQLSenders[callee.Name()] && isGraphQLSender(callee) {
+			fn.sendsGraphQL = true
+		}
+		return
+	}
+	kind, ok := p.documents[obj]
+	if !ok || seen[ident.Pos()] {
+		return
+	}
+	seen[ident.Pos()] = true
+	fn.docs = append(fn.docs, docRef{kind: kind, name: obj.Name(), pos: ident.Pos(), declared: obj.Pos()})
+}
+
+// recordLiteral records a GraphQL document written inline rather than as a
+// named constant.
+func (p *program) recordLiteral(fn *function, pkg *packages.Package, lit *ast.BasicLit, seen map[token.Pos]bool) {
+	tv, ok := pkg.TypesInfo.Types[lit]
+	if !ok || tv.Value == nil || seen[lit.Pos()] {
+		return
+	}
+	value, ok := constantString(tv.Value)
+	if !ok {
+		return
+	}
+	kind := classifyDocument(value)
+	if kind == notADocument {
+		return
+	}
+	seen[lit.Pos()] = true
+	fn.docs = append(fn.docs, docRef{kind: kind, pos: lit.Pos(), declared: lit.Pos()})
+}
+
+// isGraphQLSender reports whether a method named Do (or one of the shared
+// executors) belongs to the GraphQL transport rather than to some unrelated
+// type that happens to have a method with the same name.
+func isGraphQLSender(callee *types.Func) bool {
+	if callee.Pkg() != nil && callee.Pkg().Path() == toolutilPath {
+		return true
+	}
+	sig, ok := callee.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return false
+	}
+	return strings.Contains(sig.Recv().Type().String(), "GraphQL")
+}
+
+// reachable returns the transitive closure of functions a handler can run,
+// including the handlers themselves.
+func (p *program) reachable(roots []*types.Func) map[*types.Func]bool {
+	seen := make(map[*types.Func]bool, len(roots))
+	queue := append([]*types.Func(nil), roots...)
+	for len(queue) > 0 {
+		current := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if seen[current] {
+			continue
+		}
+		seen[current] = true
+		fn, ok := p.funcs[current]
+		if !ok {
+			continue
+		}
+		for callee := range fn.calls {
+			if !seen[callee] {
+				queue = append(queue, callee)
+			}
+		}
+	}
+	return seen
+}
+
+// position renders a source position.
+func (p *program) position(pos token.Pos) token.Position {
+	return p.fset.Position(pos)
+}

--- a/cmd/audit_readonly_graphql/program_test.go
+++ b/cmd/audit_readonly_graphql/program_test.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"errors"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fixtureDir is the directory the in-memory fixture packages pretend to live
+// in. Nothing is written there: the packages exist only in the loader overlay,
+// which keeps generated Go source out of the repository while still
+// type-checking it against the real toolutil.
+const fixtureDir = "cmd/audit_readonly_graphql/fixture"
+
+// fixturePattern matches every fixture package at once.
+const fixturePattern = "./" + fixtureDir + "/..."
+
+// backtickPlaceholder stands in for a backtick inside a fixture source, which
+// is itself written as a raw string literal and so cannot contain one.
+const backtickPlaceholder = "@@"
+
+// repoRoot walks up from the test's working directory to the module root, so
+// the fixture overlay can name absolute paths inside the module and the loader
+// resolves the module's own import paths.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// fixtureOverlay turns a map of package name to source into a loader overlay
+// rooted at the module. Each entry becomes one file in its own package
+// directory under [fixtureDir].
+func fixtureOverlay(t *testing.T, sources map[string]string) map[string][]byte {
+	t.Helper()
+	root := repoRoot(t)
+	overlay := make(map[string][]byte, len(sources))
+	for name, source := range sources {
+		path := filepath.Join(root, filepath.FromSlash(fixtureDir), name, name+".go")
+		overlay[path] = []byte(strings.ReplaceAll(source, backtickPlaceholder, "`"))
+	}
+	return overlay
+}
+
+// fixtureCache memoizes one loaded program per fixture source set. Loading is
+// a full type-check of the fixture against toolutil and takes seconds, the
+// result is read-only for everything the tests ask of it, and the tests run in
+// one goroutine, so paying for it once per source set keeps the package's
+// tests from spending a minute re-parsing the same few packages.
+var fixtureCache = map[string]*program{}
+
+// loadFixture loads the fixture packages described by sources.
+func loadFixture(t *testing.T, sources map[string]string) *program {
+	t.Helper()
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	key := strings.Join(names, "|")
+	if cached, ok := fixtureCache[key]; ok {
+		return cached
+	}
+	prog, err := loadProgram(repoRoot(t), []string{fixturePattern}, fixtureOverlay(t, sources))
+	if err != nil {
+		t.Fatalf("loadProgram: %v", err)
+	}
+	fixtureCache[key] = prog
+	return prog
+}
+
+// vulnFixture is the fixture the audit tests share: one package holding a read
+// document and a mutation document, handlers for each, a handler that reaches
+// the mutation only through a callee, and action specs that classify some of
+// them honestly and one of them wrongly.
+//
+// It is written the way a real domain is written, including the
+// package-local spec helper that forwards to toolutil, because the resolver's
+// whole job is to follow that forwarding.
+const vulnFixture = `package vuln
+
+import (
+	"context"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+const listQuery = @@
+query($fullPath: ID!) {
+  group(fullPath: $fullPath) {
+    vulnerabilities { nodes { id } }
+  }
+}
+@@
+
+const dismissMutation = @@
+mutation($id: VulnerabilityID!) {
+  vulnerabilityDismiss(input: {id: $id}) {
+    errors
+  }
+}
+@@
+
+// Input is the shared input for every fixture handler.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the shared output for every fixture handler.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+// List sends the read document.
+func List(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return send(ctx, client, listQuery, input)
+}
+
+// Dismiss sends the mutation document itself.
+func Dismiss(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return send(ctx, client, dismissMutation, input)
+}
+
+// DismissIndirect names no document: it reaches the mutation through a callee,
+// which is what the call graph has to see.
+func DismissIndirect(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return dismissAll(ctx, client, input)
+}
+
+func dismissAll(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return send(ctx, client, dismissMutation, input)
+}
+
+// InlineWrite writes with a document that is never given a name.
+func InlineWrite(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return send(ctx, client, @@
+mutation($id: VulnerabilityID!) {
+  vulnerabilityConfirm(input: {id: $id}) {
+    errors
+  }
+}
+@@, input)
+}
+
+func send(ctx context.Context, client *gitlabclient.Client, query string, input Input) (Output, error) {
+	var response struct {
+		Data map[string]any ` + "`json:\"data\"`" + `
+	}
+	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{
+		Query:     query,
+		Variables: map[string]any{"id": input.ID},
+	}, &response, gl.WithContext(ctx))
+	return Output{OK: err == nil}, err
+}
+
+// ActionSpecs declares the fixture's actions. "list" is honest, "dismiss" is
+// classified as a write and so is not a finding, "read_dismiss" and
+// "read_dismiss_indirect" are the constructed violations.
+func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
+	return []toolutil.ActionSpec{
+		readSpec("list", toolutil.RouteAction(client, List)),
+		toolutil.NewCreateActionSpec("dismiss", toolutil.RouteAction(client, Dismiss), toolutil.ActionSpecOptions{}),
+		readSpec("read_dismiss", toolutil.RouteAction(client, Dismiss)),
+		readSpec("read_dismiss_indirect", toolutil.RouteAction(client, DismissIndirect)),
+		readSpec("read_inline", toolutil.RouteAction(client, InlineWrite)),
+	}
+}
+
+func readSpec(name string, route toolutil.ActionRoute) toolutil.ActionSpec {
+	options := toolutil.ActionSpecOptions{Usage: "fixture"}
+	return toolutil.NewReadActionSpec(name, route, options)
+}
+`
+
+// vulnSources is the fixture package set the audit tests load.
+func vulnSources() map[string]string {
+	return map[string]string{"vuln": vulnFixture}
+}
+
+// vulnActions is the catalog the audit tests hand to [audit] for the vuln
+// fixture: the same names the fixture declares, classified the same way.
+func vulnActions() []action {
+	return []action{
+		{ID: "vuln.list", Name: "list", Owner: "vuln", ReadOnly: true},
+		{ID: "vuln.dismiss", Name: "dismiss", Owner: "vuln", ReadOnly: false},
+		{ID: "vuln.read_dismiss", Name: "read_dismiss", Owner: "vuln", ReadOnly: true},
+		{ID: "vuln.read_dismiss_indirect", Name: "read_dismiss_indirect", Owner: "vuln", ReadOnly: true},
+		{ID: "vuln.read_inline", Name: "read_inline", Owner: "vuln", ReadOnly: true},
+	}
+}
+
+// lookupFunc finds a declared function in the loaded program by package name
+// and function name.
+func lookupFunc(t *testing.T, prog *program, pkgName, funcName string) *types.Func {
+	t.Helper()
+	for fn := range prog.funcs {
+		if fn.Pkg() != nil && fn.Pkg().Name() == pkgName && fn.Name() == funcName {
+			return fn
+		}
+	}
+	t.Fatalf("function %s.%s not found in loaded program", pkgName, funcName)
+	return nil
+}
+
+// TestLoadProgram_FixturePackages_IndexesDocumentsAndFunctions verifies the
+// loader indexes an overlay-only package: its functions get bodies, its
+// GraphQL constants get classified, and the function that calls the GraphQL
+// transport is marked as sending.
+func TestLoadProgram_FixturePackages_IndexesDocumentsAndFunctions(t *testing.T) {
+	prog := loadFixture(t, vulnSources())
+
+	send := lookupFunc(t, prog, "vuln", "send")
+	if !prog.funcs[send].sendsGraphQL {
+		t.Error("send() calls GraphQL.Do but was not marked as sending GraphQL")
+	}
+
+	kinds := map[string]documentKind{}
+	for obj, kind := range prog.documents {
+		if obj.Pkg() != nil && obj.Pkg().Name() == "vuln" {
+			kinds[obj.Name()] = kind
+		}
+	}
+	if got := kinds["listQuery"]; got != readDocument {
+		t.Errorf("listQuery classified %v, want %v", got, readDocument)
+	}
+	if got := kinds["dismissMutation"]; got != writeDocument {
+		t.Errorf("dismissMutation classified %v, want %v", got, writeDocument)
+	}
+}
+
+// TestLoadProgram_NoMatchingPattern_ReturnsError verifies that a pattern
+// matching nothing is an error rather than an empty, silently passing audit.
+// A testdata directory is the pattern that matches nothing without the
+// toolchain calling it an error: the go command skips testdata, so the
+// directory exists and the pattern still resolves to no packages.
+func TestLoadProgram_NoMatchingPattern_ReturnsError(t *testing.T) {
+	_, err := loadProgram(repoRoot(t), []string{"./internal/tools/testdata/..."}, nil)
+	if err == nil {
+		t.Fatal("loading a pattern that matches nothing must fail")
+	}
+	if !strings.Contains(err.Error(), "no packages matched") {
+		t.Errorf("error %q does not say the pattern matched nothing", err)
+	}
+}
+
+// TestLoadProgram_BrokenFixture_ReturnsLoadError verifies a package that does
+// not compile is reported rather than treated as a package with no handlers,
+// which would make every action in it silently unclassifiable.
+func TestLoadProgram_BrokenFixture_ReturnsLoadError(t *testing.T) {
+	_, err := loadProgram(repoRoot(t), []string{fixturePattern}, fixtureOverlay(t, map[string]string{
+		"broken": "package broken\n\nfunc Broken() int { return \"not an int\" }\n",
+	}))
+	if err == nil {
+		t.Fatal("a fixture that does not type-check must fail the load")
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Errorf("error %q does not name the package that failed", err)
+	}
+}
+
+// TestPackageLoadError_NoErrors_ReturnsNil verifies the happy path of the
+// per-package error check, which the loader relies on to pass clean packages
+// through untouched.
+func TestPackageLoadError_NoErrors_ReturnsNil(t *testing.T) {
+	prog := loadFixture(t, vulnSources())
+	for _, pkg := range prog.order {
+		if err := packageLoadError(pkg); err != nil {
+			t.Errorf("packageLoadError(%s) = %v, want nil", pkg.PkgPath, err)
+		}
+	}
+}
+
+// TestProgram_Reachable_FollowsCallees verifies the call graph reaches a
+// function only named through an intermediate callee, and stops at functions
+// nothing names.
+func TestProgram_Reachable_FollowsCallees(t *testing.T) {
+	prog := loadFixture(t, vulnSources())
+	indirect := lookupFunc(t, prog, "vuln", "DismissIndirect")
+	dismissAll := lookupFunc(t, prog, "vuln", "dismissAll")
+	send := lookupFunc(t, prog, "vuln", "send")
+	list := lookupFunc(t, prog, "vuln", "List")
+
+	reached := prog.reachable([]*types.Func{indirect})
+	for _, want := range []*types.Func{indirect, dismissAll, send} {
+		t.Run(want.Name(), func(t *testing.T) {
+			if !reached[want] {
+				t.Errorf("reachable from DismissIndirect does not contain %s", want.Name())
+			}
+		})
+	}
+	if reached[list] {
+		t.Error("reachable from DismissIndirect wrongly contains List")
+	}
+}
+
+// TestProgram_Reachable_NoRoots_IsEmpty verifies the closure of nothing is
+// nothing, which is the shape an unresolved handler would produce.
+func TestProgram_Reachable_NoRoots_IsEmpty(t *testing.T) {
+	prog := loadFixture(t, vulnSources())
+	if reached := prog.reachable(nil); len(reached) != 0 {
+		t.Errorf("reachable(nil) returned %d functions, want 0", len(reached))
+	}
+}
+
+// TestIsGraphQLSender_Classification verifies the transport check accepts the
+// client-go GraphQL service method and the shared toolutil executors, and
+// rejects a method named Do on something else.
+func TestIsGraphQLSender_Classification(t *testing.T) {
+	prog := loadFixture(t, vulnSources())
+	send := prog.funcs[lookupFunc(t, prog, "vuln", "send")]
+
+	var graphQLDo, other *types.Func
+	for callee := range send.calls {
+		if callee.Name() == "Do" {
+			graphQLDo = callee
+		}
+	}
+	if graphQLDo == nil {
+		t.Fatal("send() does not name a Do method, so the fixture no longer exercises the transport check")
+	}
+	if !isGraphQLSender(graphQLDo) {
+		t.Error("the client-go GraphQL Do method was not recognized as a sender")
+	}
+	// A plain function with no receiver, from a package that is not toolutil,
+	// must not count as a transport.
+	other = lookupFunc(t, prog, "vuln", "List")
+	if isGraphQLSender(other) {
+		t.Error("an ordinary handler was wrongly recognized as a GraphQL sender")
+	}
+}
+
+// TestLoadProgram_PackageLevelVariables_IndexesOnlyConstantDocuments verifies
+// the two shapes a document can be written in as a variable: one initialized
+// from a constant string, which is indexed, and one initialized from a call,
+// whose value is not knowable from the source and so is not.
+func TestLoadProgram_PackageLevelVariables_IndexesOnlyConstantDocuments(t *testing.T) {
+	prog := loadFixture(t, map[string]string{"vars": varFixture})
+
+	indexed := map[string]documentKind{}
+	for obj, kind := range prog.documents {
+		if obj.Pkg() != nil && obj.Pkg().Name() == "vars" {
+			indexed[obj.Name()] = kind
+		}
+	}
+	if got, ok := indexed["declaredMutation"]; !ok || got != writeDocument {
+		t.Errorf("declaredMutation indexed as %v (present=%t), want %v", got, ok, writeDocument)
+	}
+	if _, ok := indexed["computedMutation"]; ok {
+		t.Error("a variable initialized from a call must not be indexed as a document")
+	}
+	if _, ok := indexed["undeclared"]; ok {
+		t.Error("a variable with no initializer must not be indexed as a document")
+	}
+}
+
+// varFixture declares GraphQL documents as package-level variables rather than
+// constants, plus the two variable shapes that carry no knowable value.
+const varFixture = `package vars
+
+var declaredMutation = @@
+mutation($id: ID!) {
+  thing(input: {id: $id}) { errors }
+}
+@@
+
+var computedMutation = build()
+
+var undeclared string
+
+func build() string {
+	return "mutation { thing { errors } }"
+}
+`
+
+// TestConstantString_NonString_ReturnsFalse verifies the constant unwrapper
+// refuses values that are not strings, which is what keeps numeric and boolean
+// constants out of the document index.
+func TestConstantString_NonString_ReturnsFalse(t *testing.T) {
+	if _, ok := constantString(nil); ok {
+		t.Error("a nil constant value must not unwrap to a string")
+	}
+}
+
+// errFixture is returned by the failing action source in the run tests.
+var errFixture = errors.New("fixture catalog failure")

--- a/cmd/audit_readonly_graphql/resolve.go
+++ b/cmd/audit_readonly_graphql/resolve.go
@@ -1,0 +1,577 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// maxResolveDepth bounds the interprocedural walk. The real chains are three
+// or four calls deep (spec helper, NewReadActionSpec, NewActionSpec, the
+// composite literal), so this is slack rather than a limit anyone reaches; it
+// exists so a cyclic helper cannot hang the audit.
+const maxResolveDepth = 32
+
+// specTypeName and routeTypeName are the toolutil types the resolver follows.
+const (
+	specTypeName  = "ActionSpec"
+	routeTypeName = "ActionRoute"
+)
+
+// handlerRef is one function an action routes to: either a declared function
+// or a literal written at the route site.
+type handlerRef struct {
+	fn  *types.Func
+	lit *ast.FuncLit
+	pkg *packages.Package
+}
+
+// site is one resolved ActionSpec construction: the action name it declares
+// and the handlers its route runs.
+type site struct {
+	pkgName  string
+	name     string
+	handlers []handlerRef
+	pos      token.Pos
+}
+
+// frame is where an expression is being resolved: the package it was written
+// in, the function body enclosing it (for local variables), and the parameter
+// bindings that got us there.
+type frame struct {
+	pkg  *packages.Package
+	decl *ast.FuncDecl
+	env  map[*types.Var]binding
+}
+
+// binding is one parameter bound to the argument expression a caller passed,
+// together with the frame that argument has to be resolved in.
+type binding struct {
+	expr  ast.Expr
+	frame frame
+}
+
+// resolver resolves ActionSpec construction sites to (action name, handlers).
+//
+// It is a small interprocedural constant propagation rather than a pattern
+// match on one spelling, because the specs are not written in one spelling:
+// most domains call a package-local helper that adds shared options and
+// forwards to toolutil, so the action name and the handler arrive at the
+// toolutil constructor as parameters. Following the parameters is what makes
+// the audit hold for a domain written in a shape nobody anticipated, and an
+// action it cannot follow is reported rather than skipped.
+type resolver struct {
+	prog *program
+}
+
+// collectSites resolves every ActionSpec construction the loaded packages
+// contain, keyed by the action name it declares.
+func (r *resolver) collectSites() map[string][]site {
+	sites := make(map[string][]site)
+	for _, pkg := range r.prog.order {
+		if pkg.TypesInfo == nil {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			r.collectFileSites(pkg, file, sites)
+		}
+	}
+	return sites
+}
+
+// collectFileSites resolves the spec expressions in one file: the elements of
+// every []ActionSpec literal and the elements appended to one.
+func (r *resolver) collectFileSites(pkg *packages.Package, file *ast.File, sites map[string][]site) {
+	var enclosing *ast.FuncDecl
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.FuncDecl:
+			enclosing = typed
+		case *ast.CompositeLit:
+			if isSpecSliceType(pkg.TypesInfo.TypeOf(typed)) {
+				r.resolveElements(pkg, enclosing, typed.Elts, sites)
+			}
+		case *ast.CallExpr:
+			if isAppendCall(pkg, typed) {
+				r.resolveElements(pkg, enclosing, typed.Args[1:], sites)
+			}
+		}
+		return true
+	})
+}
+
+// resolveElements resolves each expression that evaluates to one ActionSpec.
+func (r *resolver) resolveElements(pkg *packages.Package, enclosing *ast.FuncDecl, elements []ast.Expr, sites map[string][]site) {
+	for _, element := range elements {
+		if !isSpecType(pkg.TypesInfo.TypeOf(element)) {
+			continue
+		}
+		start := frame{pkg: pkg, decl: enclosing}
+		name, handlers := r.resolveSpec(element, start, 0)
+		if name == "" {
+			continue
+		}
+		sites[name] = append(sites[name], site{
+			pkgName:  pkg.Name,
+			name:     name,
+			handlers: handlers,
+			pos:      element.Pos(),
+		})
+	}
+}
+
+// resolveSpec resolves one ActionSpec expression to the action name it
+// declares and the handlers its route runs.
+func (r *resolver) resolveSpec(expr ast.Expr, at frame, depth int) (string, []handlerRef) {
+	if depth > maxResolveDepth {
+		return "", nil
+	}
+	switch typed := ast.Unparen(expr).(type) {
+	case *ast.Ident:
+		return r.resolveSpecIdent(typed, at, depth)
+	case *ast.CompositeLit:
+		return r.resolveSpecLiteral(typed, at, depth)
+	case *ast.CallExpr:
+		return r.resolveSpecCall(typed, at, depth)
+	}
+	return "", nil
+}
+
+// resolveSpecIdent follows a spec held in a parameter or a local variable.
+func (r *resolver) resolveSpecIdent(ident *ast.Ident, at frame, depth int) (string, []handlerRef) {
+	var name string
+	var handlers []handlerRef
+	for _, next := range r.follow(ident, at) {
+		nextName, nextHandlers := r.resolveSpec(next.expr, next.frame, depth+1)
+		name, handlers = merge(name, handlers, nextName, nextHandlers)
+	}
+	return name, handlers
+}
+
+// merge combines two partial resolutions of the same spec. The first name wins
+// and every handler is kept: a variable assigned in two branches routes to
+// both, and dropping either would leave a mutation unclassified.
+func merge(name string, handlers []handlerRef, nextName string, nextHandlers []handlerRef) (string, []handlerRef) {
+	if name == "" {
+		name = nextName
+	}
+	return name, append(handlers, nextHandlers...)
+}
+
+// resolveSpecLiteral reads the Name and Route fields of an ActionSpec literal.
+func (r *resolver) resolveSpecLiteral(lit *ast.CompositeLit, at frame, depth int) (string, []handlerRef) {
+	var name string
+	var handlers []handlerRef
+	for _, element := range lit.Elts {
+		kv, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Name":
+			name = r.resolveString(kv.Value, at, depth+1)
+		case "Route":
+			handlers = r.resolveRoute(kv.Value, at, depth+1)
+		}
+	}
+	return name, handlers
+}
+
+// resolveSpecCall resolves a call that produces an ActionSpec.
+//
+// A toolutil constructor taking (name string, route ActionRoute, ...) is the
+// base case: its first two arguments are the answer. Anything else with a body
+// is entered with its parameters bound to the arguments, and its return
+// expressions resolved there.
+func (r *resolver) resolveSpecCall(call *ast.CallExpr, at frame, depth int) (string, []handlerRef) {
+	callee := calleeFunc(at.pkg, call)
+	if callee == nil {
+		return "", nil
+	}
+	if nameArg, routeArg, ok := specConstructorArgs(callee, call); ok {
+		return r.resolveString(nameArg, at, depth+1), r.resolveRoute(routeArg, at, depth+1)
+	}
+	var name string
+	var handlers []handlerRef
+	for _, ret := range r.returnsOf(callee, call, at, specTypeName) {
+		retName, retHandlers := r.resolveSpec(ret.expr, ret.frame, depth+1)
+		name, handlers = merge(name, handlers, retName, retHandlers)
+	}
+	return name, handlers
+}
+
+// resolveRoute resolves an ActionRoute expression to the handlers it runs.
+func (r *resolver) resolveRoute(expr ast.Expr, at frame, depth int) []handlerRef {
+	if depth > maxResolveDepth {
+		return nil
+	}
+	switch typed := ast.Unparen(expr).(type) {
+	case *ast.Ident:
+		var found []handlerRef
+		for _, next := range r.follow(typed, at) {
+			found = append(found, r.resolveRoute(next.expr, next.frame, depth+1)...)
+		}
+		return found
+	case *ast.CompositeLit:
+		return r.resolveRouteLiteral(typed, at, depth)
+	case *ast.CallExpr:
+		return r.resolveRouteCall(typed, at, depth)
+	}
+	return nil
+}
+
+// resolveRouteLiteral reads the Handler field of an ActionRoute literal.
+func (r *resolver) resolveRouteLiteral(lit *ast.CompositeLit, at frame, depth int) []handlerRef {
+	var found []handlerRef
+	for _, element := range lit.Elts {
+		kv, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, isIdent := kv.Key.(*ast.Ident); isIdent && key.Name == "Handler" {
+			found = append(found, r.resolveHandler(kv.Value, at, depth+1)...)
+		}
+	}
+	return found
+}
+
+// resolveRouteCall resolves a call that produces an ActionRoute.
+//
+// A toolutil route constructor is the base case: its function-typed arguments
+// are the handlers. Anything else with a body is entered the same way a spec
+// constructor is, and a decorating method (route.WithTags(...)) resolves to its
+// receiver.
+func (r *resolver) resolveRouteCall(call *ast.CallExpr, at frame, depth int) []handlerRef {
+	callee := calleeFunc(at.pkg, call)
+	if callee == nil {
+		return nil
+	}
+	if isToolutilFunc(callee) {
+		var found []handlerRef
+		for _, arg := range call.Args {
+			found = append(found, r.resolveHandler(arg, at, depth+1)...)
+		}
+		if len(found) > 0 {
+			return found
+		}
+	}
+	var found []handlerRef
+	for _, ret := range r.returnsOf(callee, call, at, routeTypeName) {
+		found = append(found, r.resolveRoute(ret.expr, ret.frame, depth+1)...)
+	}
+	if len(found) > 0 {
+		return found
+	}
+	if receiver := methodReceiver(call); receiver != nil {
+		return r.resolveRoute(receiver, at, depth+1)
+	}
+	return nil
+}
+
+// resolveHandler resolves one argument to the function it names, if it names
+// one. Arguments that are not functions (the GitLab client, an options value)
+// resolve to nothing.
+func (r *resolver) resolveHandler(expr ast.Expr, at frame, depth int) []handlerRef {
+	if depth > maxResolveDepth {
+		return nil
+	}
+	unwrapped := ast.Unparen(expr)
+	switch typed := unwrapped.(type) {
+	case *ast.FuncLit:
+		return []handlerRef{{lit: typed, pkg: at.pkg}}
+	case *ast.IndexExpr:
+		return r.resolveHandler(typed.X, at, depth+1)
+	case *ast.IndexListExpr:
+		return r.resolveHandler(typed.X, at, depth+1)
+	}
+	if _, isSignature := at.pkg.TypesInfo.TypeOf(unwrapped).Underlying().(*types.Signature); !isSignature {
+		return nil
+	}
+	switch typed := unwrapped.(type) {
+	case *ast.Ident:
+		if fn, ok := at.pkg.TypesInfo.Uses[typed].(*types.Func); ok {
+			return []handlerRef{{fn: fn, pkg: at.pkg}}
+		}
+		var found []handlerRef
+		for _, next := range r.follow(typed, at) {
+			found = append(found, r.resolveHandler(next.expr, next.frame, depth+1)...)
+		}
+		return found
+	case *ast.SelectorExpr:
+		if fn, ok := at.pkg.TypesInfo.Uses[typed.Sel].(*types.Func); ok {
+			return []handlerRef{{fn: fn, pkg: at.pkg}}
+		}
+	}
+	return nil
+}
+
+// resolveString resolves an expression to the constant string it evaluates to.
+//
+// Constant folding answers most of it: literals, named constants, and
+// concatenations all carry a value in the type information. Parameters do not,
+// so they are followed to the argument the caller passed, and the one
+// pass-through the constructors apply (strings.TrimSpace) is followed through.
+func (r *resolver) resolveString(expr ast.Expr, at frame, depth int) string {
+	if depth > maxResolveDepth {
+		return ""
+	}
+	unwrapped := ast.Unparen(expr)
+	if tv, ok := at.pkg.TypesInfo.Types[unwrapped]; ok && tv.Value != nil {
+		if value, isString := constantString(tv.Value); isString {
+			return value
+		}
+	}
+	switch typed := unwrapped.(type) {
+	case *ast.Ident:
+		for _, next := range r.follow(typed, at) {
+			if value := r.resolveString(next.expr, next.frame, depth+1); value != "" {
+				return value
+			}
+		}
+	case *ast.CallExpr:
+		callee := calleeFunc(at.pkg, typed)
+		if callee == nil {
+			return ""
+		}
+		if isStringPassThrough(callee) && len(typed.Args) == 1 {
+			return strings.TrimSpace(r.resolveString(typed.Args[0], at, depth+1))
+		}
+		for _, ret := range r.returnsOf(callee, typed, at, "") {
+			if value := r.resolveString(ret.expr, ret.frame, depth+1); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+// returnsOf enters a callee's body with its parameters bound to the caller's
+// arguments and yields every returned expression of the wanted type. An empty
+// typeName wants the single result of a one-result function, which is how the
+// string pass-throughs are followed.
+func (r *resolver) returnsOf(callee *types.Func, call *ast.CallExpr, at frame, typeName string) []binding {
+	fn, ok := r.prog.funcs[callee]
+	if !ok || fn.decl.Body == nil {
+		return nil
+	}
+	inner := frame{pkg: fn.pkg, decl: fn.decl, env: bindParams(callee, call, at)}
+	index, ok := resultIndex(callee, typeName)
+	if !ok {
+		return nil
+	}
+	var found []binding
+	ast.Inspect(fn.decl.Body, func(node ast.Node) bool {
+		if lit, isLit := node.(*ast.FuncLit); isLit {
+			_ = lit
+			return false
+		}
+		ret, isReturn := node.(*ast.ReturnStmt)
+		if !isReturn || index >= len(ret.Results) {
+			return true
+		}
+		found = append(found, binding{expr: ret.Results[index], frame: inner})
+		return true
+	})
+	return found
+}
+
+// follow resolves an identifier to the expressions it can hold: the argument
+// bound to it if it is a parameter, or the right-hand sides assigned to it if
+// it is a local variable.
+func (r *resolver) follow(ident *ast.Ident, at frame) []binding {
+	variable, ok := at.pkg.TypesInfo.Uses[ident].(*types.Var)
+	if !ok {
+		return nil
+	}
+	if bound, isBound := at.env[variable]; isBound {
+		return []binding{bound}
+	}
+	if at.decl == nil {
+		return nil
+	}
+	var found []binding
+	for _, assigned := range assignmentsTo(at.pkg, at.decl, variable) {
+		found = append(found, binding{expr: assigned, frame: at})
+	}
+	return found
+}
+
+// assignmentsTo returns every right-hand side assigned to a local variable in
+// one function body.
+func assignmentsTo(pkg *packages.Package, decl *ast.FuncDecl, variable *types.Var) []ast.Expr {
+	var found []ast.Expr
+	record := func(names, values []ast.Expr) {
+		if len(names) != len(values) {
+			return
+		}
+		for i, name := range names {
+			ident, ok := name.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			if pkg.TypesInfo.Defs[ident] == variable || pkg.TypesInfo.Uses[ident] == variable {
+				found = append(found, values[i])
+			}
+		}
+	}
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.AssignStmt:
+			record(typed.Lhs, typed.Rhs)
+		case *ast.ValueSpec:
+			names := make([]ast.Expr, 0, len(typed.Names))
+			for _, name := range typed.Names {
+				names = append(names, name)
+			}
+			record(names, typed.Values)
+		}
+		return true
+	})
+	return found
+}
+
+// bindParams binds a callee's parameters to the caller's argument expressions.
+// A variadic parameter is left unbound: no spec or route travels through one.
+func bindParams(callee *types.Func, call *ast.CallExpr, at frame) map[*types.Var]binding {
+	sig, ok := callee.Type().(*types.Signature)
+	if !ok {
+		return nil
+	}
+	params := sig.Params()
+	env := make(map[*types.Var]binding, params.Len())
+	for i := 0; i < params.Len() && i < len(call.Args); i++ {
+		if sig.Variadic() && i == params.Len()-1 {
+			break
+		}
+		env[params.At(i)] = binding{expr: call.Args[i], frame: at}
+	}
+	return env
+}
+
+// resultIndex finds which result of a signature carries the wanted toolutil
+// type. An empty name wants a single result of any type.
+func resultIndex(callee *types.Func, typeName string) (int, bool) {
+	sig, ok := callee.Type().(*types.Signature)
+	if !ok {
+		return 0, false
+	}
+	results := sig.Results()
+	if typeName == "" {
+		if results.Len() != 1 {
+			return 0, false
+		}
+		return 0, true
+	}
+	for i := range results.Len() {
+		if isToolutilType(results.At(i).Type(), typeName) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// specConstructorArgs recognizes the toolutil constructor shape
+// (name string, route ActionRoute, ...) ActionSpec and returns the two arguments
+// that answer the question. Matching the shape rather than a list of names
+// means a constructor added later is covered without editing this audit.
+func specConstructorArgs(callee *types.Func, call *ast.CallExpr) (nameArg, routeArg ast.Expr, ok bool) {
+	if !isToolutilFunc(callee) {
+		return nil, nil, false
+	}
+	sig, isSignature := callee.Type().(*types.Signature)
+	if !isSignature || sig.Params().Len() < 2 || len(call.Args) < 2 {
+		return nil, nil, false
+	}
+	if sig.Params().At(0).Type() != types.Typ[types.String] {
+		return nil, nil, false
+	}
+	if !isToolutilType(sig.Params().At(1).Type(), routeTypeName) {
+		return nil, nil, false
+	}
+	if _, found := resultIndex(callee, specTypeName); !found {
+		return nil, nil, false
+	}
+	return call.Args[0], call.Args[1], true
+}
+
+// isStringPassThrough reports whether a call returns its string argument for
+// the purposes of an action name. TrimSpace is the only one the constructors
+// apply, and the resolver applies it too, because the catalog holds the
+// trimmed name.
+func isStringPassThrough(callee *types.Func) bool {
+	return callee.Pkg() != nil && callee.Pkg().Path() == "strings" && callee.Name() == "TrimSpace"
+}
+
+// calleeFunc resolves the function a call expression invokes.
+func calleeFunc(pkg *packages.Package, call *ast.CallExpr) *types.Func {
+	expr := ast.Unparen(call.Fun)
+	for {
+		switch typed := expr.(type) {
+		case *ast.IndexExpr:
+			expr = ast.Unparen(typed.X)
+			continue
+		case *ast.IndexListExpr:
+			expr = ast.Unparen(typed.X)
+			continue
+		case *ast.Ident:
+			fn, _ := pkg.TypesInfo.Uses[typed].(*types.Func)
+			return fn
+		case *ast.SelectorExpr:
+			fn, _ := pkg.TypesInfo.Uses[typed.Sel].(*types.Func)
+			return fn
+		}
+		return nil
+	}
+}
+
+// methodReceiver returns the receiver expression of a method call, or nil.
+func methodReceiver(call *ast.CallExpr) ast.Expr {
+	selector, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+	return selector.X
+}
+
+// isAppendCall reports whether a call is append(slice, elem...) with no spread.
+func isAppendCall(pkg *packages.Package, call *ast.CallExpr) bool {
+	ident, ok := ast.Unparen(call.Fun).(*ast.Ident)
+	if !ok || ident.Name != "append" || call.Ellipsis != token.NoPos || len(call.Args) < 2 {
+		return false
+	}
+	builtin, ok := pkg.TypesInfo.Uses[ident].(*types.Builtin)
+	return ok && builtin.Name() == "append"
+}
+
+// isToolutilFunc reports whether a function is declared in toolutil.
+func isToolutilFunc(callee *types.Func) bool {
+	return callee.Pkg() != nil && callee.Pkg().Path() == toolutilPath
+}
+
+// isToolutilType reports whether a type is the named toolutil type.
+func isToolutilType(typ types.Type, name string) bool {
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Name() == name && obj.Pkg() != nil && obj.Pkg().Path() == toolutilPath
+}
+
+// isSpecType reports whether a type is toolutil.ActionSpec.
+func isSpecType(typ types.Type) bool {
+	return typ != nil && isToolutilType(typ, specTypeName)
+}
+
+// isSpecSliceType reports whether a type is []toolutil.ActionSpec.
+func isSpecSliceType(typ types.Type) bool {
+	slice, ok := typ.(*types.Slice)
+	return ok && isSpecType(slice.Elem())
+}

--- a/cmd/audit_readonly_graphql/resolve_test.go
+++ b/cmd/audit_readonly_graphql/resolve_test.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// shapesFixture declares one action per spelling an ActionSpec is written in
+// across this repository, each routed to its own handler, so the resolver is
+// held to following the forwarding rather than to recognizing one shape.
+//
+// The closure action exists because a route may be built from a function
+// literal, which has no declared function to use as a call-graph root; its body
+// reaches the mutation, so a resolver that dropped literals would report
+// nothing for it.
+const shapesFixture = `package shapes
+
+import (
+	"context"
+	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_readonly_graphql/fixture/other"
+)
+
+// constantName is an action name written as a constant rather than a literal.
+const constantName = "constant"
+
+const readQuery = @@
+query {
+  currentUser { id }
+}
+@@
+
+const writeMutation = @@
+mutation($id: ID!) {
+  thingUpdate(input: {id: $id}) { errors }
+}
+@@
+
+// Input is the shared input for every fixture handler.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the shared output for every fixture handler.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+func Direct(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func ViaHelper(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func Decorated(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func Literal(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func Variable(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func Constant(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+func Appended(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+// Quiet touches no GraphQL at all, which is the ordinary case: most actions
+// are REST and this audit has nothing to say about them.
+func Quiet(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	_ = ctx
+	_ = client
+	return Output{OK: input.ID != ""}, nil
+}
+
+// closureBody is what the function-literal route runs, and it writes.
+func closureBody(ctx context.Context) error {
+	_ = ctx
+	_ = writeMutation
+	return nil
+}
+
+func read(ctx context.Context, client *gitlabclient.Client) (Output, error) {
+	var response struct {
+		Data map[string]any ` + "`json:\"data\"`" + `
+	}
+	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{Query: readQuery}, &response, gl.WithContext(ctx))
+	return Output{OK: err == nil}, err
+}
+
+// GenericHandler is a handler whose route names an explicit instantiation.
+func GenericHandler[T any](ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	return read(ctx, client)
+}
+
+// VoidHandler routes through the void constructor, whose output type is
+// synthesized rather than declared.
+func VoidHandler(ctx context.Context, client *gitlabclient.Client, input Input) error {
+	_, err := read(ctx, client)
+	return err
+}
+
+// routeLiteralHandler is wired through an ActionRoute struct literal.
+func routeLiteralHandler(ctx context.Context, params map[string]any) (any, error) {
+	_ = ctx
+	_ = params
+	return nil, nil
+}
+
+// namedByFunc supplies an action name from a function rather than a literal.
+func namedByFunc() string {
+	return "named_by_func"
+}
+
+// ActionSpecs declares one action per construction shape.
+func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
+	specs := []toolutil.ActionSpec{
+		toolutil.NewReadActionSpec("direct", toolutil.RouteAction(client, Direct), toolutil.ActionSpecOptions{}),
+		helperSpec("helper", toolutil.RouteAction(client, ViaHelper)),
+		toolutil.NewReadActionSpec("decorated", toolutil.RouteAction(client, Decorated).WithTags("fixture"), toolutil.ActionSpecOptions{}),
+		toolutil.ActionSpec{Name: "literal", Route: toolutil.RouteAction(client, Literal)},
+		variableSpec(client),
+		toolutil.NewReadActionSpec(constantName, routeFor(client), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("closure", toolutil.Route(func(ctx context.Context, params map[string]any) (any, error) {
+			_ = params
+			return nil, closureBody(ctx)
+		}), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("quiet", toolutil.RouteAction(client, Quiet), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("generic", toolutil.RouteAction[Input, Output](client, Direct), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("generic_void", toolutil.RouteVoidAction[Input](client, VoidHandler), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("instantiated", toolutil.RouteAction(client, GenericHandler[string]), toolutil.ActionSpecOptions{}),
+		toolutil.ActionSpec{Name: "route_literal", Route: toolutil.ActionRoute{Handler: routeLiteralHandler}},
+		handlerSpec("passed_handler", client, ViaHelper),
+		toolutil.NewReadActionSpec(strings.TrimSpace("  trimmed  "), toolutil.RouteAction(client, Direct), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec(namedByFunc(), toolutil.RouteAction(client, Direct), toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("shared_route", other.SharedRoute, toolutil.ActionSpecOptions{}),
+		toolutil.NewReadActionSpec("cross_package", toolutil.RouteAction(client, other.Handle), toolutil.ActionSpecOptions{}),
+	}
+	return append(specs, toolutil.NewReadActionSpec("appended", toolutil.RouteAction(client, Appended), toolutil.ActionSpecOptions{}))
+}
+
+func helperSpec(name string, route toolutil.ActionRoute) toolutil.ActionSpec {
+	options := toolutil.ActionSpecOptions{Usage: "fixture"}
+	return toolutil.NewReadActionSpec(name, route, options)
+}
+
+// handlerSpec takes the handler itself rather than a built route, so the
+// resolver has to follow a function value through a parameter.
+func handlerSpec(name string, client *gitlabclient.Client, handler func(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error)) toolutil.ActionSpec {
+	return toolutil.NewReadActionSpec(name, toolutil.RouteAction(client, handler), toolutil.ActionSpecOptions{})
+}
+
+func variableSpec(client *gitlabclient.Client) toolutil.ActionSpec {
+	var route = toolutil.RouteAction(client, Variable)
+	spec := toolutil.NewReadActionSpec("variable", route, toolutil.ActionSpecOptions{})
+	return spec
+}
+
+func routeFor(client *gitlabclient.Client) toolutil.ActionRoute {
+	return toolutil.RouteAction(client, Constant)
+}
+`
+
+// otherFixture holds the pieces a spec can reach across a package boundary: a
+// handler named through a selector, and a route held in a package-level
+// variable, which the resolver deliberately does not follow.
+const otherFixture = `package other
+
+import (
+	"context"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// Input is the fixture handler input.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the fixture handler output.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+// SharedRoute is a route built once at package level.
+var SharedRoute = toolutil.Route(shared)
+
+func shared(ctx context.Context, params map[string]any) (any, error) {
+	_ = ctx
+	_ = params
+	return nil, nil
+}
+
+// Handle is a handler another package routes to by selector.
+func Handle(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	_ = ctx
+	_ = client
+	return Output{OK: input.ID != ""}, nil
+}
+`
+
+// mainSources is the fixture set every resolution and detection test loads.
+func mainSources() map[string]string {
+	return map[string]string{
+		"vuln":   vulnFixture,
+		"shapes": shapesFixture,
+		"vars":   varFixture,
+		"other":  otherFixture,
+	}
+}
+
+// handlerNames returns the handlers resolved for one action name in one
+// package, sorted, with a function literal reported as "closure".
+func handlerNames(sites map[string][]site, pkgName, actionName string) []string {
+	var names []string
+	for _, resolved := range sites[actionName] {
+		if resolved.pkgName != pkgName {
+			continue
+		}
+		for _, handler := range resolved.handlers {
+			if handler.fn == nil {
+				names = append(names, "closure")
+				continue
+			}
+			names = append(names, handler.fn.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestResolver_CollectSites_EveryConstructionShape verifies the resolver finds
+// the action name and the handler for every spelling an ActionSpec is written
+// in: the toolutil constructor called directly, a package-local helper that
+// forwards to it, a decorated route, a struct literal, a local variable, a
+// name written as a constant, a route built by a helper, an appended element,
+// and a route whose handler is a function literal.
+func TestResolver_CollectSites_EveryConstructionShape(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	sites := (&resolver{prog: prog}).collectSites()
+
+	cases := []struct {
+		action  string
+		handler string
+	}{
+		{action: "direct", handler: "Direct"},
+		{action: "helper", handler: "ViaHelper"},
+		{action: "decorated", handler: "Decorated"},
+		{action: "literal", handler: "Literal"},
+		{action: "variable", handler: "Variable"},
+		{action: "constant", handler: "Constant"},
+		{action: "appended", handler: "Appended"},
+		{action: "closure", handler: "closure"},
+		{action: "generic", handler: "Direct"},
+		{action: "generic_void", handler: "VoidHandler"},
+		{action: "instantiated", handler: "GenericHandler"},
+		{action: "route_literal", handler: "routeLiteralHandler"},
+		{action: "passed_handler", handler: "ViaHelper"},
+		{action: "trimmed", handler: "Direct"},
+		{action: "named_by_func", handler: "Direct"},
+		{action: "cross_package", handler: "Handle"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.action, func(t *testing.T) {
+			got := handlerNames(sites, "shapes", testCase.action)
+			if len(got) != 1 || got[0] != testCase.handler {
+				t.Errorf("action %q resolved to %v, want [%s]", testCase.action, got, testCase.handler)
+			}
+		})
+	}
+}
+
+// TestResolver_CollectSites_ForwardingHelper verifies the domain shape most of
+// this repository uses: a package-local helper that takes the action name and
+// the route and forwards both to a toolutil constructor.
+func TestResolver_CollectSites_ForwardingHelper(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	sites := (&resolver{prog: prog}).collectSites()
+
+	for _, actionName := range []string{"list", "read_dismiss", "read_dismiss_indirect"} {
+		t.Run(actionName, func(t *testing.T) {
+			if got := handlerNames(sites, "vuln", actionName); len(got) != 1 {
+				t.Errorf("action %q resolved to %v, want exactly one handler", actionName, got)
+			}
+		})
+	}
+	if got := handlerNames(sites, "vuln", "read_dismiss"); got[0] != "Dismiss" {
+		t.Errorf("read_dismiss resolved to %v, want [Dismiss]", got)
+	}
+	if got := handlerNames(sites, "vuln", "read_dismiss_indirect"); got[0] != "DismissIndirect" {
+		t.Errorf("read_dismiss_indirect resolved to %v, want [DismissIndirect]", got)
+	}
+}
+
+// TestResolver_CollectSites_UnknownActionHasNoSite verifies an action name the
+// source never declares resolves to nothing, which is what turns a catalog
+// action the audit cannot place into a reported failure rather than a silent
+// pass.
+func TestResolver_CollectSites_UnknownActionHasNoSite(t *testing.T) {
+	prog := loadFixture(t, mainSources())
+	sites := (&resolver{prog: prog}).collectSites()
+	if found, ok := sites["never_declared"]; ok {
+		t.Errorf("an undeclared action resolved to %d site(s)", len(found))
+	}
+}
+
+// TestResolveString_NonConstantExpression_ResolvesToEmpty verifies that a name
+// the source does not determine resolves to the empty string, so a site whose
+// name is computed at run time is not silently attributed to some other action.
+func TestResolveString_NonConstantExpression_ResolvesToEmpty(t *testing.T) {
+	prog := loadFixture(t, loadedSourceWithComputedName())
+	sites := (&resolver{prog: prog}).collectSites()
+	for name := range sites {
+		if strings.Contains(name, "computed") {
+			t.Errorf("a computed action name resolved to %q", name)
+		}
+	}
+}
+
+// loadedSourceWithComputedName is a fixture whose action name is not knowable
+// from the source.
+func loadedSourceWithComputedName() map[string]string {
+	return map[string]string{"computed": computedFixture}
+}
+
+// computedFixture builds an action name at run time, which no static resolver
+// can attribute to a catalog action.
+const computedFixture = `package computed
+
+import (
+	"context"
+	"os"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// Input is the fixture handler input.
+type Input struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+
+// Output is the fixture handler output.
+type Output struct {
+	OK bool ` + "`json:\"ok\"`" + `
+}
+
+func Handle(ctx context.Context, client *gitlabclient.Client, input Input) (Output, error) {
+	_ = ctx
+	_ = client
+	_ = input
+	return Output{}, nil
+}
+
+func ActionSpecs(client *gitlabclient.Client) []toolutil.ActionSpec {
+	return []toolutil.ActionSpec{
+		toolutil.NewReadActionSpec(os.Getenv("COMPUTED_NAME"), toolutil.RouteAction(client, Handle), toolutil.ActionSpecOptions{}),
+	}
+}
+`

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -16,6 +16,7 @@ Every utility can be run directly with `go run ./cmd/<name>/ [flags]`, or throug
 | `audit_doc_coverage`           | Catalog & metadata audits     | Per-doc-file gaps vs the action catalog (DOC-002)                                                                                                                                                   | `make audit-doc-coverage`                 |
 | `audit_dynamic_aliases`        | Catalog & metadata audits     | Dynamic-toolset alias governance (collisions, ambiguity)                                                                                                                                            | `make audit-dynamic-aliases`              |
 | `audit_edition_tier`           | Catalog & metadata audits     | Doc-grounded licensing tier (Free/Premium/Ultimate) vs binary gating                                                                                                                                | `make audit-edition-tier`                 |
+| `audit_readonly_graphql`       | Catalog & metadata audits     | No action classified ReadOnly can reach a GraphQL mutation                                                                                                                                          | `make check-readonly-graphql`             |
 | `audit_surface_quality`        | Surface quality audits        | Consolidated MCP tool surface quality audit (metadata + output)                                                                                                                                     | `make audit-surface-quality`              |
 | `audit_tokens`                 | Surface quality audits        | LLM context-window overhead of every tool/resource/prompt definition; `-footprint` regenerates the README token-footprint section                                                                   | `make audit-tokens`, `make gen-footprint` |
 | `audit_metrics`                | Surface quality audits        | Comprehensive metrics summary (tools, resources, prompts, codebase)                                                                                                                                 | `make audit-metrics`                      |
@@ -251,6 +252,58 @@ A JSON report with per-action tier classification and doc-vs-binary discrepancie
 #### Notes
 
 Fetches the GitLab API reference docs from `gitlab.com` via the shared `cmd/internal/apidocs` fetcher. Docs are cached in `.cache/gitlab-api-docs/` (gitignored, shared with `audit_1to1 -validate-docs`) and reused while younger than the 7-day TTL; `-refresh` forces a re-download and `-offline` uses only the cache. The fetcher honors `Retry-After`, backs off with jitter, and spaces requests so a full sweep does not trip the raw rate limiter.
+
+### audit_readonly_graphql
+
+Fails when an action the canonical catalog classifies `ReadOnly` can reach a GraphQL mutation.
+
+`--read-only` removes actions through `FilterReadOnlyActions`, and the surface served to a `read_api` OAuth token is narrowed the same way. Both key on the action's catalog classification, not on what its handler does, so an action classified `ReadOnly` whose handler issues a mutation survives both filters and writes precisely where a write is supposed to be impossible.
+
+The HTTP method cannot be the test: `client-go` sends every GraphQL request as a POST, so around twenty read-only actions legitimately POST. The operation type in the document is the whole of the distinction, and it is in the source.
+
+The audit loads `./internal/...`, resolves every read-only catalog action to the function its route runs, walks what that function can call, and classifies every GraphQL document those bodies name. An action that sends no GraphQL is not a finding, and neither is a mutation reached from an action already classified as mutating.
+
+#### Usage
+
+```bash
+# CI gate
+go run ./cmd/audit_readonly_graphql/
+
+# Also list the read-only actions that touch GraphQL at all
+go run ./cmd/audit_readonly_graphql/ -v
+```
+
+#### Flags
+
+| Flag   | Type     | Default | Description                                   |
+| ------ | -------- | ------- | --------------------------------------------- |
+| `-dir` | `string` | `.`     | Repository root to audit                      |
+| `-v`   | `bool`   | `false` | Report what was checked, not only what failed |
+
+#### Output
+
+One block per finding on stderr, naming the action, the file the action is declared in, the function that sends the mutation, and the document. Exits `1` when any finding is reported and when the catalog or the source tree cannot be loaded, so a gate that cannot read its inputs never looks like a gate that passed.
+
+Three things count as findings, not only the obvious one:
+
+- a read-only action whose handler can reach a mutation document;
+- a read-only action no `ActionSpec` construction resolves to, or whose route resolves to no handler, because an action the audit cannot classify is one it cannot vouch for;
+- an exception directive that no longer excuses anything, so an exception cannot outlive its reason.
+
+#### Declaring an exception
+
+A deliberate exception is declared in the source next to the action, never in the auditor:
+
+```go
+//gitlab:allow-readonly-graphql-mutation <action_name>: <reason>
+```
+
+The directive has to sit in the package that owns the action and name that action, so the exception is visible to a reader of the handler.
+
+#### Make targets
+
+- `make check-readonly-graphql`: the CI gate.
+- `make audit-readonly-graphql`: the same gate, with the GraphQL-sending read-only actions listed.
 
 ## Surface quality audits
 
@@ -846,3 +899,4 @@ The following utilities expose a verification mode (`--check` or `-check`, or an
 | `audit-docs` → `format_md_tables -check` | `format_md_tables`             | All Markdown pipe tables are normalized                                              | Non-zero if any table needs formatting                    |
 | `audit-docs` → `gen_testing_docs -check` | `gen_testing_docs`             | The `docs/development/testing/testing.md` test-metrics block is current              | Non-zero if the generated section is stale                |
 | `check-supply-chain`                     | `audit_supply_chain`           | The five release-configuration invariants still hold                                 | Non-zero if any is broken, or if the audit cannot be run  |
+| `check-readonly-graphql`                 | `audit_readonly_graphql`       | No action classified ReadOnly can reach a GraphQL mutation                           | Non-zero on any finding, or if the audit cannot be run    |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,285 |
-| Unit test functions                                   | 12,733 |
-| E2E test functions                                    |    552 |
-| cmd test functions                                    |  1,911 |
+| Total test functions                                  | 13,343 |
+| Unit test functions                                   | 12,788 |
+| E2E test functions                                    |    555 |
+| cmd test functions                                    |  1,966 |
 | Test files (internal/)                                |    490 |
-| Test files (cmd/)                                     |    103 |
-| Test files (test/e2e/)                                |    213 |
+| Test files (cmd/)                                     |    111 |
+| Test files (test/e2e/)                                |    214 |
 | Tool sub-packages tested                              |    173 |
 | Core packages tested                                  |     21 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.9% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.8% |
 | Overall coverage (`go test ./internal/...`)           |  98.3% |
-| Average package coverage                              |  98.5% |
+| Average package coverage                              |  98.4% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,142 | 83.9% |
+| `TestFunc_Scenario` (2-part)           | 11,154 | 83.6% |
 | `TestFunc` (no underscore)             |    959 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,184 |  8.9% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,230 |  9.2% |
 
 ## Test Distribution
 
@@ -48,9 +48,9 @@
 | Core packages           |          2,159 |        130 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (173) |          8,362 |        347 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            552 |        213 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,911 |        103 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,285** |    **806** |                                                                                                 |
+| E2E integration         |            555 |        214 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          1,966 |        111 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,343** |    **815** |                                                                                                 |
 
 ### Core Packages
 
@@ -313,7 +313,9 @@
 | cmd/audit_e2e_gaps                             |    92.9% |
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    88.2% |
+| cmd/audit_install_buttons                      |    84.2% |
 | cmd/audit_metrics                              |    97.8% |
+| cmd/audit_readonly_graphql                     |    90.2% |
 | cmd/audit_string_dupes                         |    92.1% |
 | cmd/audit_supply_chain                         |    98.0% |
 | cmd/audit_surface_quality                      |    93.0% |
@@ -339,7 +341,7 @@
 | cmd/internal/auditshared                       |   100.0% |
 | cmd/internal/docgen                            |    99.6% |
 | cmd/internal/mcpsurface                        |   100.0% |
-| cmd/server                                     |    96.3% |
+| cmd/server                                     |    95.8% |
 
 ### Core Packages
 
@@ -552,6 +554,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/audit_1to1** (70.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (77.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **progress** (83.8%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
+- **cmd/audit_install_buttons** (84.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_edition_tier** (86.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **edition** (87.0%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/gen_brand** (87.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.


### PR DESCRIPTION
Closes https://github.com/jmrplens/gitlab-mcp-server/issues/408

`--read-only` removes actions through `FilterReadOnlyActions`, and the surface served to a `read_api` OAuth token is narrowed the same way. Both key on the action's catalog classification, not on what its handler does. An action classified `ReadOnly` whose handler issues a GraphQL mutation therefore survives both filters and executes a write precisely where a write is supposed to be impossible, with nothing anywhere reporting it: GitLab performs the write, because the credential's scope is whatever the caller's token actually carries.

None exists today. I checked while auditing the surface. Nothing stopped the next one, and this is the kind of thing that arrives as a one-line handler change in an unrelated pull request.

## How the audit decides

The HTTP method cannot be the test. `client-go` sends every GraphQL request as a POST, so fifteen read-only actions legitimately POST and the verb separates nothing. The operation type in the document is the whole of the distinction, and it is in the source.

`cmd/audit_readonly_graphql` loads `./internal/...` with types, and for every read-only action in the canonical catalog at the Ultimate tier:

1. resolves the action to the function its route runs;
2. walks the transitive set of functions that handler can run;
3. classifies every GraphQL document those bodies name, folding constants so a document assembled from a shared fragment is classified with the fragment spliced in.

A document is a mutation when a `mutation` operation definition appears at the start of a line: `mutation(`, `mutation {`, `mutationName(`, or `mutation Name {`. The trailing punctuation is what separates an operation definition from prose, so `"%s mutation errors: %s"` is not a document. `query`, `subscription`, `fragment` and a bare selection set are reads; a bare selection set cannot express a write, because the `mutation` keyword is mandatory for that operation type.

Attribution is per function, not per package. `vulnerabilities` holds four mutation documents and five read-only actions, and none of the reads is reported, because `List` does not name what `Dismiss` names.

## Resolving an action to its handler

This is the part that had to be real work rather than a pattern match. The specs are not written in one spelling: most domains call a package-local helper that adds shared options and forwards to `toolutil`, so the action name and the handler arrive at the constructor as parameters, and half the domains that matter are written that way. The resolver is a small interprocedural constant propagation: it enters a callee with its parameters bound to the caller's arguments and resolves the returned expression there, recognising the `toolutil` constructor by its shape (`(name string, route ActionRoute, ...) ActionSpec`) rather than by a list of names, so a constructor added later is covered without editing the audit.

It follows the direct constructor, a forwarding helper, a decorated route, an `ActionSpec` struct literal, a local variable, a name written as a constant or produced by a function, an explicit generic instantiation, an appended element, a handler passed as a parameter, a handler named by selector across packages, and a route whose handler is a function literal. Each of those is a test.

Two things are reported that could have been skipped, and skipping them is what would have made this gate hollow:

- an action no `ActionSpec` construction resolves to;
- an action whose route resolves to no handler, which is the dangerous shape rather than a harmless one: the reachable set is empty, so every classification would come back clean whatever the handler does.

All 505 read-only actions pass both today.

## Declaring an exception

Beside the action, in the package that owns it, never in the auditor:

```go
//gitlab:allow-readonly-graphql-mutation <action_name>: <reason>
```

A directive without a reason is not an exception, and one that stops excusing anything is itself a finding, so an exception cannot outlive the reason it was written for.

## What it found

Nothing, which is what I expected. 505 read-only actions resolve, 15 of them send GraphQL (`branch.rule_list`, `ci_catalog.get`, `ci_catalog.list`, `custom_emoji.list`, the epic discussion/note/issue reads, `issue.work_item_list`, `security_finding.list`, and the four `vulnerability` reads), and every one sends a query.

I checked the detector is not vacuous by inverting the classification: it then reports 24 mutating actions across all seven files in the tree that hold a mutation document, naming the action, the spec site, the function, and the document.

## Wiring

`make check-readonly-graphql` is the gate, `make audit-readonly-graphql` lists the GraphQL-sending read-only actions as well. CI runs it in the job that already runs `make check-doc-tool-names`. It takes about 17 seconds and needs no instance, no token and no network: the catalog is built from the specs compiled into the binary with a nil client.

## Tests

The fixtures are Go packages written in the test file and handed to the loader through its overlay, so they type-check against the real `toolutil` and `client-go` without a line of generated source landing in the repository. The audit fails on a constructed read-only action that sends a mutation (directly, through a callee, written inline, and from a function-literal route) and passes on read-only actions that only query. Package coverage is 90.2%.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Prevent ReadOnly actions from reaching GraphQL mutations by adding a fail-closed static audit and enforcing it in CI.

New Features:
- Add an offline audit that verifies ReadOnly catalog actions cannot reach GraphQL mutations and supports scoped, reasoned source-level exceptions.

Enhancements:
- Resolve action specifications and transitive handlers across common construction patterns, classify GraphQL documents, and fail closed when actions or routes cannot be resolved.

Build:
- Add Make targets for running the read-only GraphQL audit and its verbose report.

CI:
- Run the read-only GraphQL safety check in CI.

Documentation:
- Document the new audit utility, usage, findings, exceptions, and Make targets.

Tests:
- Add comprehensive resolver, GraphQL classification, catalog, exception, and command behavior tests using typed in-memory fixtures.

Chores:
- Refresh generated repository and testing metrics to include the new audit and tests.