### PR TITLE
Keep milestone and version label in step, and retire needs-triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -32,11 +32,13 @@ jobs:
     steps:
       - name: Remove the label
         env:
+          # GH_REPO rather than --repo: this job checks nothing out, so gh has
+          # no repository to infer from the working directory.
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
           REASON: ${{ github.event.action }}
         run: |
           set -euo pipefail
           echo "issue $ISSUE was $REASON, so it has been triaged"
-          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "needs-triage"
+          gh issue edit "$ISSUE" --remove-label "needs-triage"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,42 @@
+name: Triage
+
+# Retires needs-triage once an issue has been triaged.
+#
+# Every issue template applies needs-triage on open, and nothing has ever
+# removed it: the only two issues that arrived through a template still carry it
+# while closed. A label that is applied automatically and retired by nobody
+# stops meaning anything, and the list it is supposed to produce, "what have I
+# not looked at yet", silently becomes the list of everything.
+#
+# Two events say the looking has happened. A milestone means the issue has been
+# placed in a release, which is this project's triage decision. Closing means it
+# needs no decision at all.
+on:
+  issues:
+    types: [milestoned, closed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  retire:
+    name: Retire needs-triage
+    runs-on: ubuntu-latest
+    # Cheap guard so the job does not start for the majority of events, which
+    # are about issues that never carried the label.
+    if: contains(github.event.issue.labels.*.name, 'needs-triage')
+    steps:
+      - name: Remove the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          REASON: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          echo "issue $ISSUE was $REASON, so it has been triaged"
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "needs-triage"

--- a/.github/workflows/version-labels.yml
+++ b/.github/workflows/version-labels.yml
@@ -24,6 +24,11 @@ permissions:
 # One run at a time per issue. Two rapid edits to the same issue would
 # otherwise race and could leave the pair disagreeing, which is the single
 # thing this workflow exists to prevent.
+#
+# A concurrency group holds one pending run, so a burst of edits can discard the
+# intermediate ones. That is why the step below reads the issue's CURRENT state
+# rather than acting on the event payload: a discarded event must not be able to
+# leave a stale decision behind.
 concurrency:
   group: version-labels-${{ github.event.issue.number }}
   cancel-in-progress: false
@@ -35,50 +40,80 @@ jobs:
     steps:
       - name: Apply the pairing
         env:
+          # GH_REPO rather than --repo on each call: this job checks nothing
+          # out, so gh has no repository to infer from the working directory
+          # and every write would fail during resolution.
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
           ACTION: ${{ github.event.action }}
-          MILESTONE: ${{ github.event.issue.milestone.title }}
-          # On demilestoned the issue no longer carries the milestone, so the
-          # title has to come from the event's own payload.
+          # The milestone the event carries. On demilestoned the issue no longer
+          # holds it, so the payload is the only place it exists.
           EVENT_MILESTONE: ${{ github.event.milestone.title }}
           LABEL: ${{ github.event.label.name }}
         run: |
           set -euo pipefail
 
           # Every milestone title, which is also the set of version labels this
-          # workflow is allowed to touch. Anything else on the issue is somebody
-          # else's label and is left alone.
-          gh api "repos/$REPO/milestones?state=all&per_page=100" \
+          # workflow may touch. Anything else on the issue belongs to somebody
+          # else and is left alone. Paginated because a repository may hold more
+          # than one page of them, and a milestone missing from this list would
+          # be silently treated as "not a version".
+          gh api --paginate "repos/$GH_REPO/milestones?state=all&per_page=100" \
             --jq '.[].title' > /tmp/milestones.txt
 
           known_milestone() {
             grep -qxF "$1" /tmp/milestones.txt
           }
 
+          # The issue as it is NOW, not as the event described it. Events are
+          # delivered per change and the concurrency group drops intermediate
+          # pending runs, so acting on a snapshot can apply a decision that has
+          # already been undone.
+          gh issue view "$ISSUE" --json milestone,labels > /tmp/issue.json
+          CURRENT_MILESTONE="$(jq -r '.milestone.title // ""' /tmp/issue.json)"
+          has_label() {
+            jq -e --arg l "$1" 'any(.labels[]; .name == $l)' /tmp/issue.json >/dev/null
+          }
+
           case "$ACTION" in
             milestoned)
-              want="v$MILESTONE"
-              echo "milestone $MILESTONE set, pairing label $want"
+              # Confirm the milestone is still there. A milestoned event whose
+              # milestone has since been removed must not re-apply its label.
+              if [ -z "$CURRENT_MILESTONE" ]; then
+                echo "the milestone was removed again before this ran, nothing to do"
+                exit 0
+              fi
+              want="v$CURRENT_MILESTONE"
+              echo "milestone $CURRENT_MILESTONE set, pairing label $want"
               # Create the label rather than letting the API invent it. A label
               # added by addLabels arrives default grey with no description,
               # which is indistinguishable from a typo in the milestone title.
               gh label create "$want" --color "1D76DB" \
-                --description "Targeted at the $MILESTONE release" 2>/dev/null || true
-              gh issue edit "$ISSUE" --add-label "$want"
+                --description "Targeted at the $CURRENT_MILESTONE release" 2>/dev/null || true
+              has_label "$want" || gh issue edit "$ISSUE" --add-label "$want"
               # An issue belongs to one release. Drop the label of every other
               # milestone so a retarget does not leave both showing.
               while read -r other; do
                 [ -n "$other" ] || continue
-                [ "$other" = "$MILESTONE" ] && continue
-                gh issue edit "$ISSUE" --remove-label "v$other" 2>/dev/null || true
+                [ "$other" = "$CURRENT_MILESTONE" ] && continue
+                if has_label "v$other"; then
+                  gh issue edit "$ISSUE" --remove-label "v$other"
+                fi
               done < /tmp/milestones.txt
               ;;
 
             demilestoned)
+              # Only if it is still absent: a rapid remove-then-set would
+              # otherwise strip the label of the milestone now in place.
+              if [ -n "$CURRENT_MILESTONE" ]; then
+                echo "a milestone is set again ($CURRENT_MILESTONE), leaving its label alone"
+                exit 0
+              fi
               echo "milestone $EVENT_MILESTONE removed, dropping label v$EVENT_MILESTONE"
-              gh issue edit "$ISSUE" --remove-label "v$EVENT_MILESTONE" 2>/dev/null || true
+              if has_label "v$EVENT_MILESTONE"; then
+                gh issue edit "$ISSUE" --remove-label "v$EVENT_MILESTONE"
+              fi
               ;;
 
             labeled)
@@ -89,11 +124,16 @@ jobs:
                 echo "label $LABEL names no milestone, nothing to do"
                 exit 0
               fi
-              if [ "$MILESTONE" = "$candidate" ]; then
+              # The label may have been removed again since the event.
+              if ! has_label "$LABEL"; then
+                echo "label $LABEL is no longer on the issue, nothing to do"
+                exit 0
+              fi
+              if [ "$CURRENT_MILESTONE" = "$candidate" ]; then
                 echo "already on milestone $candidate"
                 exit 0
               fi
-              echo "label $LABEL added, setting milestone $candidate"
+              echo "label $LABEL present, setting milestone $candidate"
               gh issue edit "$ISSUE" --milestone "$candidate"
               ;;
 
@@ -103,11 +143,16 @@ jobs:
                 echo "label $LABEL names no milestone, nothing to do"
                 exit 0
               fi
+              # The label may have been added back since the event.
+              if has_label "$LABEL"; then
+                echo "label $LABEL is on the issue again, leaving the milestone"
+                exit 0
+              fi
               # Only clear the milestone the removed label was pairing with.
               # Removing a stale label from an issue that has since been
               # retargeted must not unset the milestone it now belongs to.
-              if [ "$MILESTONE" != "$candidate" ]; then
-                echo "issue is on milestone ${MILESTONE:-none}, not $candidate; leaving it"
+              if [ "$CURRENT_MILESTONE" != "$candidate" ]; then
+                echo "issue is on milestone ${CURRENT_MILESTONE:-none}, not $candidate; leaving it"
                 exit 0
               fi
               echo "label $LABEL removed, clearing milestone $candidate"

--- a/.github/workflows/version-labels.yml
+++ b/.github/workflows/version-labels.yml
@@ -1,0 +1,116 @@
+name: Version labels
+
+# Keeps a milestone and its version label saying the same thing, in both
+# directions, so neither view of "which release is this for" can drift from the
+# other. The convention is one character wide: milestone "2.8.0" pairs with
+# label "v2.8.0".
+#
+# This cannot loop. GitHub does not start a workflow run from an event caused by
+# the repository's own GITHUB_TOKEN, so the label this job adds does not trigger
+# the label half, and the milestone it sets does not trigger the milestone half.
+# That guarantee is the reason this is safe to write in both directions at once,
+# and it is why nothing here needs a "skip if I did it" marker. Giving this
+# workflow a personal access token instead would remove the guarantee and the
+# two halves would feed each other.
+on:
+  issues:
+    types: [milestoned, demilestoned, labeled, unlabeled]
+
+# Only what it edits. No contents access: this job reads the API and writes
+# labels and milestones, and never touches the tree.
+permissions:
+  issues: write
+
+# One run at a time per issue. Two rapid edits to the same issue would
+# otherwise race and could leave the pair disagreeing, which is the single
+# thing this workflow exists to prevent.
+concurrency:
+  group: version-labels-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Keep milestone and label in step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply the pairing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          ACTION: ${{ github.event.action }}
+          MILESTONE: ${{ github.event.issue.milestone.title }}
+          # On demilestoned the issue no longer carries the milestone, so the
+          # title has to come from the event's own payload.
+          EVENT_MILESTONE: ${{ github.event.milestone.title }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          # Every milestone title, which is also the set of version labels this
+          # workflow is allowed to touch. Anything else on the issue is somebody
+          # else's label and is left alone.
+          gh api "repos/$REPO/milestones?state=all&per_page=100" \
+            --jq '.[].title' > /tmp/milestones.txt
+
+          known_milestone() {
+            grep -qxF "$1" /tmp/milestones.txt
+          }
+
+          case "$ACTION" in
+            milestoned)
+              want="v$MILESTONE"
+              echo "milestone $MILESTONE set, pairing label $want"
+              # Create the label rather than letting the API invent it. A label
+              # added by addLabels arrives default grey with no description,
+              # which is indistinguishable from a typo in the milestone title.
+              gh label create "$want" --color "1D76DB" \
+                --description "Targeted at the $MILESTONE release" 2>/dev/null || true
+              gh issue edit "$ISSUE" --add-label "$want"
+              # An issue belongs to one release. Drop the label of every other
+              # milestone so a retarget does not leave both showing.
+              while read -r other; do
+                [ -n "$other" ] || continue
+                [ "$other" = "$MILESTONE" ] && continue
+                gh issue edit "$ISSUE" --remove-label "v$other" 2>/dev/null || true
+              done < /tmp/milestones.txt
+              ;;
+
+            demilestoned)
+              echo "milestone $EVENT_MILESTONE removed, dropping label v$EVENT_MILESTONE"
+              gh issue edit "$ISSUE" --remove-label "v$EVENT_MILESTONE" 2>/dev/null || true
+              ;;
+
+            labeled)
+              # Only labels that name a milestone: "v2.8.0" pairs with "2.8.0",
+              # while "vulnerability" pairs with nothing and is ignored.
+              candidate="${LABEL#v}"
+              if [ "$candidate" = "$LABEL" ] || ! known_milestone "$candidate"; then
+                echo "label $LABEL names no milestone, nothing to do"
+                exit 0
+              fi
+              if [ "$MILESTONE" = "$candidate" ]; then
+                echo "already on milestone $candidate"
+                exit 0
+              fi
+              echo "label $LABEL added, setting milestone $candidate"
+              gh issue edit "$ISSUE" --milestone "$candidate"
+              ;;
+
+            unlabeled)
+              candidate="${LABEL#v}"
+              if [ "$candidate" = "$LABEL" ] || ! known_milestone "$candidate"; then
+                echo "label $LABEL names no milestone, nothing to do"
+                exit 0
+              fi
+              # Only clear the milestone the removed label was pairing with.
+              # Removing a stale label from an issue that has since been
+              # retargeted must not unset the milestone it now belongs to.
+              if [ "$MILESTONE" != "$candidate" ]; then
+                echo "issue is on milestone ${MILESTONE:-none}, not $candidate; leaving it"
+                exit 0
+              fi
+              echo "label $LABEL removed, clearing milestone $candidate"
+              gh issue edit "$ISSUE" --remove-milestone
+              ;;
+          esac


### PR DESCRIPTION
Two facts about issues are now recorded twice, the milestone and the `vX.Y.Z` label, and a fact maintained by hand in two places drifts. These two workflows keep them in step and make an existing label mean something again.

## `version-labels.yml`

Pairs milestone and label in both directions, on a one-character convention: milestone `2.8.0` is label `v2.8.0`. Setting either applies the other, removing either removes the other, and retargeting an issue drops the label of the milestone it left.

**It cannot loop, and that is a property rather than luck.** GitHub does not start a workflow run from an event caused by the repository's own `GITHUB_TOKEN`, so the label this job adds does not trigger the label half, and the milestone it sets does not trigger the milestone half. That is what makes writing both directions safe at once, and it is why nothing here needs a "skip if it was me" marker. Handing this workflow a personal access token instead would remove the guarantee and the two halves would feed each other, so the file says so at the top.

Three details that are deliberate:

- It creates the label rather than letting the API invent one. `addLabels` on an unknown name produces a default grey label with no description, indistinguishable from a typo in a milestone title.
- On `unlabeled` it only clears the milestone the removed label was actually pairing with. Removing a stale label from an issue that has since been retargeted must not unset the milestone it now belongs to.
- The set of labels it may touch is the set of milestone titles, read from the API. `v2.8.0` pairs with a milestone; a label like `vulnerability` names nothing and is left alone.

## `triage.yml`

Retires `needs-triage` once an issue has been triaged.

Every issue template applies that label on open. Nothing has ever removed it: the only two issues that ever arrived through a template were still carrying it while closed. A label that is applied automatically and retired by nobody stops meaning anything, and the list it exists to produce, "what have I not looked at yet", quietly becomes the list of everything.

Two events say the looking has happened. A milestone means the issue has been placed in a release, which is this project's triage decision. Closing means it needed no decision. Both retire the label.

I removed the label from the two closed issues that were carrying it, so the state matches what the workflow would now maintain.

## What I did not add

A stale bot. It is the usual next suggestion and it would be wrong here: this tracker is a backlog I write for myself, not an inbound queue, so closing by inactivity would delete planned work and call it hygiene. The issues that sit longest are the large ones, which is the opposite of the signal a stale bot assumes.

Neither workflow uses an action, only `gh` inside a `run` step, so there is nothing new for the supply-chain audit to pin. `make check-supply-chain` passes and `@action-validator/cli` accepts both files.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Keep issue release metadata synchronized and retire triage labels once issues have been resolved or assigned.

Enhancements:
- Synchronize version labels and milestones in both directions so release targeting remains consistent when either is added, removed, or changed.
- Retire the `needs-triage` label when issues are assigned to a milestone or closed, restoring it as a meaningful indicator of untriaged issues.

CI:
- Add GitHub Actions workflows to maintain issue milestone and label state using scoped repository permissions and per-issue concurrency.

Chores:
- Remove `needs-triage` from the existing closed issues that still carried it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automation to remove the `needs-triage` label when an issue is assigned a milestone or closed.
  - Added two-way synchronization between issue milestones and matching version labels, keeping them aligned when either is added, removed, or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->