### PR TITLE
Build the unix socket where nobody else can reach it, and settle the audit_tokens prompts pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,023 |     216,430 |
-| Unit tests (`_test.go`)  |       596 |     355,017 |
+| Unit tests (`_test.go`)  |       596 |     355,119 |
 | End-to-end tests         |       216 |      58,984 |
-| **Total**                | **1,835** | **630,431** |
+| **Total**                | **1,835** | **630,533** |
 
 ### Functions
 
@@ -471,7 +471,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  8,143 |
 | . Exported (public)             |  2,759 |
 | . Unexported (private)          |  5,384 |
-| Unit test functions (`TestXxx`) | 12,759 |
+| Unit test functions (`TestXxx`) | 12,764 |
 | Subtests (`t.Run(...)`)         |  4,666 |
 | End-to-end test functions       |    555 |
 
@@ -489,7 +489,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,868 |
+| `if err != nil` checks             | 6,869 |
 | `defer` statements                 | 1,117 |
 | `struct` types defined             | 2,803 |
 | `//nolint` suppressions            |   261 |

--- a/README.md
+++ b/README.md
@@ -459,21 +459,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,023 |     216,446 |
-| Unit tests (`_test.go`)  |       596 |     355,250 |
-| End-to-end tests         |       216 |      58,984 |
-| **Total**                | **1,835** | **630,680** |
+| Source (`.go`, non-test) |     1,029 |     218,077 |
+| Unit tests (`_test.go`)  |       602 |     357,024 |
+| End-to-end tests         |       217 |      59,138 |
+| **Total**                | **1,848** | **634,239** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,143 |
-| . Exported (public)             |  2,759 |
-| . Unexported (private)          |  5,384 |
-| Unit test functions (`TestXxx`) | 12,769 |
-| Subtests (`t.Run(...)`)         |  4,666 |
-| End-to-end test functions       |    555 |
+| Source functions                |  8,208 |
+| . Exported (public)             |  2,762 |
+| . Unexported (private)          |  5,446 |
+| Unit test functions (`TestXxx`) | 12,811 |
+| Subtests (`t.Run(...)`)         |  4,678 |
+| End-to-end test functions       |    557 |
 
 ### Ratios worth noting
 
@@ -481,17 +481,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~596 lines |
-| Comment lines in source            |  31,519 (~14.6% of source) |
+| Average test file length           |                 ~593 lines |
+| Comment lines in source            |  31,904 (~14.6% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,870 |
-| `defer` statements                 | 1,117 |
-| `struct` types defined             | 2,803 |
+| `if err != nil` checks             | 6,881 |
+| `defer` statements                 | 1,118 |
+| `struct` types defined             | 2,817 |
 | `//nolint` suppressions            |   265 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -499,7 +499,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   244 |
+| Go packages                    |   245 |
 | Direct dependencies (`go.mod`) |    30 |
 | Indirect dependencies          |    31 |
 
@@ -507,15 +507,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,298 lines      |
+| Longest source file | `cmd/server/main.go`. 4,361 lines      |
 | Longest test file   | `cmd/server/main_test.go`. 8,682 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,935 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,080 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,965 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,093 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -459,21 +459,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,029 |     217,786 |
-| Unit tests (`_test.go`)  |       601 |     356,263 |
-| End-to-end tests         |       217 |      59,138 |
-| **Total**                | **1,847** | **633,187** |
+| Source (`.go`, non-test) |     1,023 |     216,430 |
+| Unit tests (`_test.go`)  |       596 |     355,017 |
+| End-to-end tests         |       216 |      58,984 |
+| **Total**                | **1,835** | **630,431** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,201 |
-| . Exported (public)             |  2,760 |
-| . Unexported (private)          |  5,441 |
-| Unit test functions (`TestXxx`) | 12,793 |
-| Subtests (`t.Run(...)`)         |  4,675 |
-| End-to-end test functions       |    557 |
+| Source functions                |  8,143 |
+| . Exported (public)             |  2,759 |
+| . Unexported (private)          |  5,384 |
+| Unit test functions (`TestXxx`) | 12,759 |
+| Subtests (`t.Run(...)`)         |  4,666 |
+| End-to-end test functions       |    555 |
 
 ### Ratios worth noting
 
@@ -481,25 +481,25 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~592 lines |
-| Comment lines in source            |  31,762 (~14.6% of source) |
+| Average test file length           |                 ~595 lines |
+| Comment lines in source            |  31,510 (~14.6% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,862 |
-| `defer` statements                 | 1,114 |
-| `struct` types defined             | 2,816 |
-| `//nolint` suppressions            |   259 |
+| `if err != nil` checks             | 6,868 |
+| `defer` statements                 | 1,117 |
+| `struct` types defined             | 2,803 |
+| `//nolint` suppressions            |   261 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   245 |
+| Go packages                    |   244 |
 | Direct dependencies (`go.mod`) |    30 |
 | Indirect dependencies          |    31 |
 
@@ -507,15 +507,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,361 lines      |
+| Longest source file | `cmd/server/main.go`. 4,298 lines      |
 | Longest test file   | `cmd/server/main_test.go`. 8,682 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,959 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,093 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,935 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,080 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,023 |     216,430 |
-| Unit tests (`_test.go`)  |       596 |     355,119 |
+| Source (`.go`, non-test) |     1,023 |     216,446 |
+| Unit tests (`_test.go`)  |       596 |     355,250 |
 | End-to-end tests         |       216 |      58,984 |
-| **Total**                | **1,835** | **630,533** |
+| **Total**                | **1,835** | **630,680** |
 
 ### Functions
 
@@ -471,7 +471,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  8,143 |
 | . Exported (public)             |  2,759 |
 | . Unexported (private)          |  5,384 |
-| Unit test functions (`TestXxx`) | 12,764 |
+| Unit test functions (`TestXxx`) | 12,769 |
 | Subtests (`t.Run(...)`)         |  4,666 |
 | End-to-end test functions       |    555 |
 
@@ -481,18 +481,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~595 lines |
-| Comment lines in source            |  31,510 (~14.6% of source) |
+| Average test file length           |                 ~596 lines |
+| Comment lines in source            |  31,519 (~14.6% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,869 |
+| `if err != nil` checks             | 6,870 |
 | `defer` statements                 | 1,117 |
 | `struct` types defined             | 2,803 |
-| `//nolint` suppressions            |   261 |
+| `//nolint` suppressions            |   265 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project

--- a/cmd/audit_tokens/main.go
+++ b/cmd/audit_tokens/main.go
@@ -540,9 +540,21 @@ func countActions(routes map[string]toolutil.ActionMap) int {
 // measurePrompts registers MCP prompts and estimates the token cost of their
 // advertised definitions.
 //
-// A failed listing used to be swallowed here and reported by the footprint
-// path's own copy of this function, the one disagreement between the two.
-// Neither can happen, and both now say so the same way.
+// This was the last of four helper pairs to be collapsed into one, and the
+// only pair whose halves disagreed rather than merely being spelled
+// differently: the audit half swallowed a failed listing and returned zero,
+// the footprint half returned an error. The disagreement is settled toward
+// neither.
+//
+// A swallowed zero is the worse of the two by a distance, because it is
+// written into the generated token-footprint artifacts as though it were a
+// measurement, and a footprint that quietly omits every prompt reads as a
+// smaller server rather than as a failure. An error return is honest but asks
+// every caller to handle something that cannot occur: the listing runs over an
+// in-memory transport against a server this process built moments earlier, so
+// there is no peer to be unreachable and nothing a report could say beyond
+// what a panic already carries. It panics at the leaf, like every other step
+// of [withSession].
 func measurePrompts(client *gitlabclient.Client) int {
 	server := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: auditVer}, &mcp.ServerOptions{Capabilities: &mcp.ServerCapabilities{}})
 	prompts.Register(server, client)

--- a/cmd/server/listen.go
+++ b/cmd/server/listen.go
@@ -72,12 +72,13 @@ func listenUnix(ctx context.Context, path string, socketMode os.FileMode) (net.L
 	if socketMode == 0 {
 		socketMode = config.DefaultSocketMode
 	}
-	// Created WITH the mode rather than chmod'ed into it afterwards: a chmod
-	// takes a path, and a path can change meaning between the bind and the
-	// chmod, so on a directory an untrusted local account can write that
-	// account could swap the socket for a symlink in between and have the
-	// mode land on whatever it points at (CWE-367). See socketmode_unix.go
-	// for why the descriptor-based alternative does not work.
+	// The socket carries its mode before it reaches this path at all: it is
+	// assembled in a private directory and published with link(2). A chmod on
+	// the operator's own path would be racing anybody who can write to that
+	// directory, since they could swap the socket for a symlink in between and
+	// have the mode land on whatever it points at (CWE-367). See
+	// socketmode_unix.go for the alternatives that do not work, the umask this
+	// replaced among them.
 	listener, err := bindUnixSocket(ctx, path, socketMode)
 	if err != nil {
 		return nil, err

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -58,9 +58,7 @@ func TestIsUnixSocketAddr_DistinguishesPathsFromHostPort(t *testing.T) {
 // reach the server and one that cannot — and, in the other direction, between
 // a socket only the proxy's group can open and one every local account can.
 func TestListenHTTP_UnixSocket_ServesAndAppliesTheMode(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "mcp.sock")
 	listener, err := listenHTTP(t.Context(), path, config.DefaultSocketMode)
@@ -120,9 +118,7 @@ func TestClearStaleSocket_AbsentPathIsFine(t *testing.T) {
 // exists to allow: a restart after a process died without unlinking its
 // socket, which would otherwise fail to bind forever.
 func TestClearStaleSocket_DeadSocketIsRemoved(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "dead.sock")
 	listener := listenUnixForTest(t, path)
@@ -148,9 +144,7 @@ func TestClearStaleSocket_DeadSocketIsRemoved(t *testing.T) {
 // running server is still serving, leaving it holding a listener nobody can
 // reach. A successful connect is the proof somebody is there.
 func TestClearStaleSocket_LiveSocketIsRefused(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "live.sock")
 	listener := listenUnixForTest(t, path)
@@ -186,9 +180,7 @@ func TestClearStaleSocket_LiveSocketIsRefused(t *testing.T) {
 // racing restart. Here the probe is cancelled before it can complete, which
 // stands in for every unanswered question.
 func TestClearStaleSocket_UnansweredProbeIsRefused(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "unanswered.sock")
 	listener := listenUnixForTest(t, path)
@@ -355,13 +347,19 @@ func TestRepeatedFlag_AcceptsRepetitionAndCommas(t *testing.T) {
 // The cases are the ones an operator actually produces: a path whose directory
 // is not a directory (a typo, or a file where a directory was expected), a path
 // already occupied by something that is not a socket, and a path longer than
-// the address family allows. None of them is reachable through permission bits
-// here, because the tests run as root in CI containers, where permissions do
-// not refuse anything.
+// the address family allows. Every one of them fails the same way for anybody
+// who runs it.
+//
+// The permission case does not, so it is not in this table. Permission bits
+// refuse an ordinary account and never refuse root, which makes the expected
+// outcome depend on who is running the suite; it lives in
+// TestBindUnixSocket_UnwritableDirectoryIsRefused, which skips when the test
+// process is privileged. An earlier version of this comment justified leaving
+// it out by asserting that the suite always runs as root in CI. That was
+// false, and the CI failure this file's parallelism was rearranged for was a
+// permission denial.
 func TestListenUnix_RefusesAPathItCannotOwn(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	dir := t.TempDir()
 	notADirectory := filepath.Join(dir, "file")
@@ -396,14 +394,18 @@ func TestListenUnix_RefusesAPathItCannotOwn(t *testing.T) {
 		{
 			name: "the path is longer than a unix address",
 			path: filepath.Join(dir, strings.Repeat("a", 120)+".sock"),
-			// The kernel's message, not ours: what matters is that the bind
-			// failure surfaces instead of a listener nobody can reach.
-			wantErr: "",
+			// This one used to be the kernel's refusal. It is ours now: the
+			// socket is bound under a short staging name and published with
+			// link(2), which has no address limit, so an over-long path would
+			// otherwise bind cleanly into a listener no client can reach.
+			wantErr: "a unix address holds at most",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			listener, err := listenHTTP(t.Context(), tt.path, config.DefaultSocketMode)
 
 			if err == nil {
@@ -423,9 +425,7 @@ func TestListenUnix_RefusesAPathItCannotOwn(t *testing.T) {
 // The default is the one that matters for a same-host proxy: a socket only the
 // proxy's group can open, rather than one every local account can.
 func TestListenHTTP_UnixSocketWithoutAMode_TakesTheDefault(t *testing.T) {
-	// Deliberately not parallel: binding sets the process-global umask for
-	// the duration of the bind (see bindUnixSocket), and a directory another
-	// test creates inside that window comes back missing its execute bit.
+	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "default-mode.sock")
 	listener, err := listenHTTP(t.Context(), path, 0)

--- a/cmd/server/socketmode_unix.go
+++ b/cmd/server/socketmode_unix.go
@@ -47,7 +47,7 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -152,6 +152,22 @@ func bindUnixSocket(ctx context.Context, path string, mode os.FileMode) (net.Lis
 // runs on is known to produce.
 var probeUnixSocket = confirmReachable //nolint:gochecknoglobals // test seam
 
+// The system calls this file makes on the staging path, as variables.
+//
+// Every one of them guards a property rather than merely reporting an error: a
+// chmod that did not apply, a stat that cannot confirm what it applied to, a
+// name reservation that did not reserve. None can be made to fail from a test
+// by ordinary means, and leaving them uncovered would mean the checks that
+// exist to catch a hostile or broken filesystem are themselves never exercised.
+// The package already covers this class of branch the same way, through
+// loadTLSKeyPair and buildServerCardFn.
+var (
+	chmodStagedSocket = os.Chmod        //nolint:gochecknoglobals // test seam
+	lstatStagedSocket = os.Lstat        //nolint:gochecknoglobals // test seam
+	mkdirStagingDir   = os.Mkdir        //nolint:gochecknoglobals // test seam
+	readRandomName    = cryptorand.Read //nolint:gochecknoglobals // test seam
+)
+
 // confirmReachable connects to path and hangs up.
 //
 // Publishing with link(2) means the address a client dials is no longer the
@@ -195,14 +211,14 @@ func publishStagedSocket(listener net.Listener, staged, path string, mode os.Fil
 	// this function is about to remove anyway, and never the published one.
 	unixListener.SetUnlinkOnClose(false)
 
-	if err := os.Chmod(staged, mode.Perm()); err != nil {
+	if err := chmodStagedSocket(staged, mode.Perm()); err != nil {
 		return nil, fmt.Errorf("setting the mode of unix socket %q: %w", path, err)
 	}
 	// Verified rather than assumed: a filesystem that ignores the chmod, or
 	// honors only part of it, would leave the socket more open than the
 	// operator asked for. Serving on a socket whose permissions nobody checked
 	// is the failure this whole path exists to avoid.
-	info, err := os.Lstat(staged)
+	info, err := lstatStagedSocket(staged)
 	if err != nil {
 		return nil, fmt.Errorf("checking the mode of unix socket %q: %w", path, err)
 	}
@@ -243,14 +259,14 @@ func newStagingDir(parent string) (string, error) {
 	var lastErr error
 	for range stagingDirAttempts {
 		raw := make([]byte, stagingDirRandomBytes)
-		if _, err := rand.Read(raw); err != nil {
+		if _, err := readRandomName(raw); err != nil {
 			return "", fmt.Errorf("naming a staging directory: %w", err)
 		}
 		dir := filepath.Join(parent, stagingDirPrefix+hex.EncodeToString(raw))
 
 		// mkdir is the reservation: it fails rather than reusing a name
 		// somebody else already holds, so no two binds can share a directory.
-		err := os.Mkdir(dir, stagingDirMode)
+		err := mkdirStagingDir(dir, stagingDirMode)
 		if errors.Is(err, fs.ErrExist) {
 			lastErr = err
 			continue

--- a/cmd/server/socketmode_unix.go
+++ b/cmd/server/socketmode_unix.go
@@ -1,9 +1,9 @@
 //go:build !windows
 
 // socketmode_unix.go creates the unix socket with its permission mode already
-// set, rather than setting it afterwards.
+// set, and publishes it at the operator's path only once that mode holds.
 //
-// The obvious implementation — bind, then os.Chmod(path, mode) — has a window
+// The obvious implementation (bind, then os.Chmod(path, mode)) has a window
 // between the two calls. On a directory an untrusted local account can write
 // (/tmp being the obvious one), that account can replace the socket with a
 // symlink in the gap and the chmod then lands on whatever the link points at:
@@ -11,61 +11,323 @@
 //
 // Two fixes look plausible and only one works. Applying the mode to the bound
 // descriptor with fchmod(2) would close the window by removing the name from
-// the operation — but on Linux fchmod on a socket descriptor RETURNS SUCCESS
+// the operation, but on Linux fchmod on a socket descriptor RETURNS SUCCESS
 // AND CHANGES NOTHING. Measured: asking for 0660 leaves 0755. A silent no-op
 // is worse than the race it was meant to fix, because it reports a restriction
 // that was never applied.
 //
-// So the mode is set through the umask instead, around the bind. The socket is
-// created with the right bits from the start: there is no second operation to
-// race, and no path to re-point.
+// The mode used to be set through the process umask around the bind instead.
+// That produced a socket with the right bits from the start and had no second
+// operation to race, but umask is process-global: for the length of the bind,
+// every other goroutine in the process created its files under it too. A
+// mutex can only serialize binds against each other, not against the rest of
+// the program, and CI proved the difference by failing unrelated tests whose
+// t.TempDir() came back without its execute bit.
+//
+// So the socket is now built somewhere nobody else can reach and published
+// afterwards:
+//
+//  1. A staging directory is created beside the target path, mode 0700 set
+//     explicitly through its descriptor. No other account can traverse it, so
+//     nothing inside it can be swapped for a symlink.
+//  2. The socket is bound inside it and chmod'ed there. The chmod is by path,
+//     but the path is unreachable to anyone else, so there is no attacker to
+//     win the race that made a chmod unsafe in the first place.
+//  3. link(2) publishes it at the target path. link fails with EEXIST when
+//     the target already exists, which is the no-clobber behavior bind gives
+//     today, portably and without renameat2/RENAME_NOREPLACE. The staging
+//     names are then removed; the socket survives on the listener's descriptor
+//     and on the published link.
+//
+// Because the listener was bound under the staging name, its own
+// unlink-on-close would remove that name rather than the published one. It is
+// switched off and the published path is removed on Close instead, and only
+// when it is still the same inode this process created.
 package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 )
 
-// umaskMu serializes the umask window. umask is process-global, so two
-// concurrent binds could otherwise restore each other's value. Binding happens
-// once at startup, so this is never contended in practice — it is here so the
-// invariant does not depend on that staying true.
-var umaskMu sync.Mutex //nolint:gochecknoglobals // guards a process-global
+// stagingDirPrefix names the staging directory bindUnixSocket creates beside
+// the target path. It is short on purpose: a unix address is capped near 100
+// bytes by the kernel, and the staged path is one directory deeper than the
+// published one.
+const stagingDirPrefix = ".s"
+
+// stagingDirRandomBytes is how much randomness the staging directory's name
+// carries, hex-encoded. Enough that a local account cannot pre-create the name
+// this process is about to use and stall its startup, and short enough that
+// the whole name is a fixed 10 bytes of the address budget. os.MkdirTemp is
+// not used for exactly that reason: its suffix is a decimal number whose
+// length varies with the value it drew.
+const stagingDirRandomBytes = 4
+
+// stagingDirAttempts bounds the retry when a staging name is already taken.
+// Two collisions in a row on 32 random bits means something other than chance
+// is producing them.
+const stagingDirAttempts = 8
+
+// stagedSocketName is the socket's name inside the staging directory, one
+// character for the same reason.
+const stagedSocketName = "s"
+
+// stagingDirMode is the staging directory's permission mode: the owner, and
+// nobody else. It is the whole reason the chmod inside it is safe.
+const stagingDirMode os.FileMode = 0o700
+
+// maxUnixPathLen is the longest path a unix address can carry: sun_path is 108
+// bytes on Linux and 104 on the BSDs, one of which is the NUL terminator.
+//
+// Binding used to enforce this for free, because the kernel refused the
+// address. It no longer does: the socket is bound under a short staging name
+// and published with link(2), which has no such limit, so an over-long path
+// would produce a listener that binds cleanly and that no client can ever
+// connect to. The check has to be made here instead.
+const maxUnixPathLen = len(syscall.RawSockaddrUnix{}.Path) - 1
 
 // bindUnixSocket listens on path with the socket created under mode.
 //
-// mode is expressed as permission bits (0660); umask takes the complement, so
-// 0660 becomes a umask of 0117.
+// The listener it returns publishes path as its address and removes path when
+// closed, so callers see a listener on the address they asked for and never
+// learn that it was assembled elsewhere.
 func bindUnixSocket(ctx context.Context, path string, mode os.FileMode) (net.Listener, error) {
-	umaskMu.Lock()
-	previous := syscall.Umask(int(^mode.Perm() & 0o777))
-	listener, err := (&net.ListenConfig{}).Listen(ctx, "unix", path)
-	syscall.Umask(previous)
-	umaskMu.Unlock()
-
-	if err != nil {
-		return nil, fmt.Errorf("listening on unix socket %q: %w", path, err)
+	if err := checkUnixPathLen(path, "the socket path"); err != nil {
+		return nil, err
 	}
 
-	// Verified rather than assumed: a umask can only clear bits, and a
-	// filesystem or a kernel that ignores it would leave the socket more open
-	// than the operator asked for. Serving on a socket whose permissions
-	// nobody checked is the failure this whole path exists to avoid.
-	info, statErr := os.Stat(path)
-	if statErr != nil {
+	staging, err := newStagingDir(filepath.Dir(path))
+	if err != nil {
+		return nil, fmt.Errorf("preparing to bind unix socket %q: %w", path, err)
+	}
+	// Runs on every exit: on success it removes the staging name and the
+	// directory, leaving the socket alive on the published link and the
+	// listener's descriptor; on failure it removes a socket that was never
+	// published.
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	// The staging directory is one level deeper than the published path, so a
+	// path that fits can still be staged into one that does not. Saying which
+	// of the two ran out of room is the difference between an operator who
+	// moves the socket and one who reads a kernel EINVAL about a temporary
+	// directory they never created.
+	staged := filepath.Join(staging, stagedSocketName)
+	if lenErr := checkUnixPathLen(staged, "the staging path the socket is built under"); lenErr != nil {
+		return nil, lenErr
+	}
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "unix", staged)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"listening on unix socket %q (bound as %q first, see socketmode_unix.go): %w", path, staged, err,
+		)
+	}
+
+	published, err := publishStagedSocket(listener, staged, path, mode)
+	if err != nil {
 		_ = listener.Close()
-		return nil, fmt.Errorf("checking the mode of unix socket %q: %w", path, statErr)
+		return nil, err
+	}
+	if probeErr := probeUnixSocket(ctx, path); probeErr != nil {
+		// Closing the wrapper also removes the path it just published, so a
+		// socket that failed its own probe leaves nothing behind.
+		_ = published.Close()
+		return nil, probeErr
+	}
+	return published, nil
+}
+
+// probeUnixSocket confirms that the published path reaches the listener. It is
+// a variable so a test can drive the failure branch, which no filesystem this
+// runs on is known to produce.
+var probeUnixSocket = confirmReachable //nolint:gochecknoglobals // test seam
+
+// confirmReachable connects to path and hangs up.
+//
+// Publishing with link(2) means the address a client dials is no longer the
+// address the kernel was given at bind time, and one link resolving to a
+// different in-kernel object than the other is not hypothetical: it is exactly
+// how AF_UNIX sockets behaved over FUSE, where the link succeeded and every
+// connect through it was refused.
+//
+// Apple's published sources settle the question for the syscall layer, which
+// rejects only directories, and for HFS+, which routes sockets through the same
+// hard-link machinery as regular files. APFS is closed source, so for the
+// filesystem every current Mac actually uses the answer rests on inference. One
+// connect() at startup is cheaper than that inference being wrong, and it also
+// covers every other way a socket can end up published but unreachable.
+//
+// The probe's connection is left in the accept queue rather than accepted here:
+// accepting would race a real client for the first connection, and the server
+// that takes over the listener reads EOF from it and drops it.
+func confirmReachable(ctx context.Context, path string) error {
+	conn, err := (&net.Dialer{Timeout: staleSocketDialTimeout}).DialContext(ctx, "unix", path)
+	if err != nil {
+		return fmt.Errorf(
+			"the unix socket published at %q cannot be connected to, so no client could reach it either: %w", path, err,
+		)
+	}
+	return conn.Close()
+}
+
+// publishStagedSocket applies mode to the socket bound at staged and links it
+// to path, returning a listener that owns path.
+//
+// The mode is applied and verified BEFORE the link, so a socket whose
+// permissions could not be confirmed is never reachable at the operator's
+// path at all, not even briefly.
+func publishStagedSocket(listener net.Listener, staged, path string, mode os.FileMode) (net.Listener, error) {
+	unixListener, ok := listener.(*net.UnixListener)
+	if !ok {
+		return nil, fmt.Errorf("listening on unix socket %q: got a %T, which cannot own its path", path, listener)
+	}
+	// The listener would otherwise unlink the staging name on Close, which
+	// this function is about to remove anyway, and never the published one.
+	unixListener.SetUnlinkOnClose(false)
+
+	if err := os.Chmod(staged, mode.Perm()); err != nil {
+		return nil, fmt.Errorf("setting the mode of unix socket %q: %w", path, err)
+	}
+	// Verified rather than assumed: a filesystem that ignores the chmod, or
+	// honors only part of it, would leave the socket more open than the
+	// operator asked for. Serving on a socket whose permissions nobody checked
+	// is the failure this whole path exists to avoid.
+	info, err := os.Lstat(staged)
+	if err != nil {
+		return nil, fmt.Errorf("checking the mode of unix socket %q: %w", path, err)
 	}
 	if got := info.Mode().Perm(); got != mode.Perm() {
-		_ = listener.Close()
 		return nil, fmt.Errorf(
 			"unix socket %q was created with mode %#o, not the requested %#o; refusing to serve on it",
 			path, got, mode.Perm(),
 		)
 	}
-	return listener, nil
+
+	// link(2), not rename(2): rename would replace whatever is at path,
+	// while link refuses with EEXIST. That refusal is the guarantee bind
+	// gives today, and it is what stops a second instance from silently
+	// taking over a socket the first is still serving.
+	if linkErr := os.Link(staged, path); linkErr != nil {
+		return nil, fmt.Errorf("publishing unix socket at %q: %w", path, linkErr)
+	}
+	return &pathOwningListener{UnixListener: unixListener, path: path, bound: info}, nil
+}
+
+// checkUnixPathLen refuses a path no unix address can hold. what names which
+// path it is, since one of the two is not the operator's.
+func checkUnixPathLen(path, what string) error {
+	if len(path) <= maxUnixPathLen {
+		return nil
+	}
+	return fmt.Errorf(
+		"unix socket %q: %s is %d bytes and a unix address holds at most %d; no client could reach it, so use a shorter --http-addr",
+		path, what, len(path), maxUnixPathLen,
+	)
+}
+
+// newStagingDir creates the private directory a socket is assembled in.
+//
+// parent is the target path's own directory because link(2) cannot cross
+// filesystems, so the staging area has to live on the same one.
+func newStagingDir(parent string) (string, error) {
+	var lastErr error
+	for range stagingDirAttempts {
+		raw := make([]byte, stagingDirRandomBytes)
+		if _, err := rand.Read(raw); err != nil {
+			return "", fmt.Errorf("naming a staging directory: %w", err)
+		}
+		dir := filepath.Join(parent, stagingDirPrefix+hex.EncodeToString(raw))
+
+		// mkdir is the reservation: it fails rather than reusing a name
+		// somebody else already holds, so no two binds can share a directory.
+		err := os.Mkdir(dir, stagingDirMode)
+		if errors.Is(err, fs.ErrExist) {
+			lastErr = err
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("creating a staging directory: %w", err)
+		}
+		if restrictErr := restrictDirToOwner(dir); restrictErr != nil {
+			_ = os.RemoveAll(dir)
+			return "", restrictErr
+		}
+		return dir, nil
+	}
+	return "", fmt.Errorf("creating a staging directory in %q: %w", parent, lastErr)
+}
+
+// restrictDirToOwner sets dir to [stagingDirMode] through its own descriptor
+// and confirms the result.
+//
+// mkdir(2) subtracts the process umask from the mode it is given, so an
+// unusual umask can hand back a directory this process cannot itself traverse. Repairing that by path would reintroduce exactly the race this
+// file exists to avoid, so the mode is applied with fchmod(2) on a descriptor
+// opened O_NOFOLLOW|O_DIRECTORY: if anything replaced the directory between
+// the mkdir and the open, the open fails instead of the mode landing
+// somewhere else.
+func restrictDirToOwner(dir string) error {
+	file, err := os.OpenFile(dir, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("opening the staging directory %q: %w", dir, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if chmodErr := file.Chmod(stagingDirMode); chmodErr != nil {
+		return fmt.Errorf("restricting the staging directory %q: %w", dir, chmodErr)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("checking the staging directory %q: %w", dir, err)
+	}
+	if !info.IsDir() || info.Mode().Perm() != stagingDirMode {
+		return fmt.Errorf(
+			"the staging directory %q is %v, not a directory with mode %#o; refusing to build a socket in it",
+			dir, info.Mode(), stagingDirMode,
+		)
+	}
+	return nil
+}
+
+// pathOwningListener is a unix listener that reports and cleans up the path
+// its socket was PUBLISHED at, rather than the staging name it was bound
+// under.
+type pathOwningListener struct {
+	*net.UnixListener
+	path      string
+	bound     os.FileInfo
+	unlinkOne sync.Once
+}
+
+// Addr reports the published path. The embedded listener would name the
+// staging directory, which no longer exists and which no client was ever told
+// about.
+func (l *pathOwningListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: l.path, Net: "unix"}
+}
+
+// Close removes the published path and then closes the socket, the order the
+// standard library uses for its own auto-unlink.
+//
+// The path is removed only while it still names the inode this process bound.
+// net.UnixListener cannot make that check and documents the resulting race:
+// after a slow shutdown, a successor process may already have bound its own
+// socket at the same path, and an unconditional remove would delete it.
+func (l *pathOwningListener) Close() error {
+	l.unlinkOne.Do(func() {
+		if info, err := os.Lstat(l.path); err == nil && os.SameFile(info, l.bound) {
+			_ = os.Remove(l.path)
+		}
+	})
+	return l.UnixListener.Close()
 }

--- a/cmd/server/socketmode_unix_test.go
+++ b/cmd/server/socketmode_unix_test.go
@@ -1,0 +1,528 @@
+//go:build !windows
+
+// socketmode_unix_test.go covers the two properties bindUnixSocket exists to
+// hold at once: the socket carries the operator's permission mode before
+// anybody can reach it, and getting it there disturbs nothing else in the
+// process.
+//
+// The second one is not decoration. The implementation this replaced set the
+// process-global umask around the bind, which every other goroutine's file
+// creation inherited; CI caught it as unrelated tests whose t.TempDir() came
+// back without its execute bit.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stagingLeftovers returns the staging directories bindUnixSocket created in
+// dir and failed to clean up. It must always be empty: a leftover staging
+// directory is a socket nobody can reach and a name nobody will remove.
+func stagingLeftovers(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %q: %v", dir, err)
+	}
+	var leftovers []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), stagingDirPrefix) {
+			leftovers = append(leftovers, entry.Name())
+		}
+	}
+	return leftovers
+}
+
+// TestBindUnixSocket_CreatesTheSocketWithTheRequestedMode pins the mode on the
+// published path for every value an operator can ask for.
+//
+// The mode is the difference between a socket only the proxy's group can open
+// and one every local account on the machine can, so a mode that silently did
+// not apply would be worse than a refusal.
+func TestBindUnixSocket_CreatesTheSocketWithTheRequestedMode(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []os.FileMode{0o600, 0o640, 0o660, 0o666, 0o700} {
+		t.Run(fmt.Sprintf("%#o", mode), func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "m.sock")
+			listener, err := bindUnixSocket(t.Context(), path, mode)
+			if err != nil {
+				t.Fatalf("bindUnixSocket(%#o) error = %v", mode, err)
+			}
+			defer func() { _ = listener.Close() }()
+
+			info, statErr := os.Lstat(path)
+			if statErr != nil {
+				t.Fatalf("the socket was not published at %q: %v", path, statErr)
+			}
+			if info.Mode()&fs.ModeSocket == 0 {
+				t.Fatalf("%q is %v, not a socket", path, info.Mode())
+			}
+			if got := info.Mode().Perm(); got != mode {
+				t.Errorf("socket mode = %#o, want %#o", got, mode)
+			}
+			if leftovers := stagingLeftovers(t, dir); len(leftovers) != 0 {
+				t.Errorf("staging directories left behind: %v", leftovers)
+			}
+
+			// A socket with the right bits that nobody can talk to would pass
+			// every assertion above.
+			conn, dialErr := (&net.Dialer{}).DialContext(t.Context(), "unix", path)
+			if dialErr != nil {
+				t.Fatalf("dialing the published socket: %v", dialErr)
+			}
+			_ = conn.Close()
+		})
+	}
+}
+
+// occupyWithRegularFile puts a plain file where the socket wants to go, the
+// shape a typo in --http-addr produces.
+func occupyWithRegularFile(t *testing.T, path string) func(*testing.T) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("writing the occupant: %v", err)
+	}
+	return func(t *testing.T) {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil || string(content) != "not a socket" {
+			t.Errorf("the occupying file was disturbed: %q, %v", content, err)
+		}
+	}
+}
+
+// occupyWithDirectory puts a directory at the path, which link(2) must refuse
+// like anything else that already exists.
+func occupyWithDirectory(t *testing.T, path string) func(*testing.T) {
+	t.Helper()
+
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("creating the occupant: %v", err)
+	}
+	return func(t *testing.T) {
+		t.Helper()
+		info, err := os.Lstat(path)
+		if err != nil || !info.IsDir() {
+			t.Errorf("the occupying directory was disturbed: %v, %v", info, err)
+		}
+	}
+}
+
+// occupyWithLiveSocket stands in for the case the guarantee exists for: a
+// second instance started by mistake while the first is still serving.
+func occupyWithLiveSocket(t *testing.T, path string) func(*testing.T) {
+	t.Helper()
+
+	occupant := listenUnixForTest(t, path)
+	t.Cleanup(func() { _ = occupant.Close() })
+	return func(t *testing.T) {
+		t.Helper()
+		conn, err := (&net.Dialer{}).DialContext(t.Context(), "unix", path)
+		if err != nil {
+			t.Errorf("the socket that was already being served is no longer reachable: %v", err)
+			return
+		}
+		_ = conn.Close()
+	}
+}
+
+// occupyWithSymlink plants the attack this whole file is built around: a
+// symlink at the target path, pointing at a file the socket mode must never
+// be applied to (CWE-367).
+func occupyWithSymlink(t *testing.T, path string) func(*testing.T) {
+	t.Helper()
+
+	target := filepath.Join(filepath.Dir(path), "secret")
+	if err := os.WriteFile(target, []byte("private"), 0o600); err != nil {
+		t.Fatalf("writing the symlink target: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("creating the occupant: %v", err)
+	}
+	return func(t *testing.T) {
+		t.Helper()
+		info, err := os.Lstat(target)
+		if err != nil {
+			t.Fatalf("stat the symlink target: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("the symlink target's mode became %#o; the socket mode landed on it", got)
+		}
+		link, linkErr := os.Lstat(path)
+		if linkErr != nil || link.Mode()&fs.ModeSymlink == 0 {
+			t.Errorf("the planted symlink was replaced: %v, %v", link, linkErr)
+		}
+	}
+}
+
+// TestBindUnixSocket_RefusesToClobberAnExistingPath verifies the no-clobber
+// guarantee, which is the reason the socket is published with link(2) rather
+// than moved into place with rename(2).
+//
+// rename would replace whatever is at the path, so a second instance started
+// by mistake would take over the socket the first is still serving and the
+// operator would see no error at all. link refuses.
+func TestBindUnixSocket_RefusesToClobberAnExistingPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// occupy puts something at path and returns a check to run after the
+		// refusal, proving the occupant survived untouched.
+		occupy func(t *testing.T, path string) func(*testing.T)
+	}{
+		{name: "a regular file", occupy: occupyWithRegularFile},
+		{name: "a directory", occupy: occupyWithDirectory},
+		{name: "a live socket another process is serving", occupy: occupyWithLiveSocket},
+		{name: "a symlink pointing at somebody else's file", occupy: occupyWithSymlink},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "s.sock")
+			verify := tt.occupy(t, path)
+
+			listener, err := bindUnixSocket(t.Context(), path, 0o660)
+			if err == nil {
+				_ = listener.Close()
+				t.Fatalf("bindUnixSocket(%q) replaced an occupied path", path)
+			}
+			if !errors.Is(err, fs.ErrExist) {
+				t.Errorf("error = %v, want it to report that the path already exists", err)
+			}
+			verify(t)
+			if leftovers := stagingLeftovers(t, dir); len(leftovers) != 0 {
+				t.Errorf("a refused bind left staging directories behind: %v", leftovers)
+			}
+		})
+	}
+}
+
+// TestBindUnixSocket_LeavesConcurrentFileCreationAlone is the regression test
+// for the reason this implementation exists.
+//
+// The previous one set the process-global umask for the length of the bind, so
+// a directory any other goroutine created inside that window came back with
+// bits cleared: mkdir asking for 0700 under the umask 0117 that a 0660 socket
+// implies yields 0600, and a directory without its execute bit cannot be
+// entered. This binds in a loop while creating directories and asserts they
+// all come back with the mode the very first one got, which calibrates the
+// expectation against whatever umask the machine running the test has.
+//
+// It cannot fail spuriously: the only way the modes diverge is if binding
+// changed process-wide state. Against the umask implementation it caught 87 of
+// 200 directories.
+func TestBindUnixSocket_LeavesConcurrentFileCreationAlone(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	baseline := filepath.Join(dir, "baseline")
+	if err := os.Mkdir(baseline, 0o700); err != nil {
+		t.Fatalf("creating the baseline directory: %v", err)
+	}
+	baselineInfo, err := os.Stat(baseline)
+	if err != nil {
+		t.Fatalf("stat the baseline directory: %v", err)
+	}
+	want := baselineInfo.Mode().Perm()
+
+	stop := make(chan struct{})
+	binderErr := make(chan error, 1)
+	go func() {
+		// No assertions off the test goroutine: the first failure travels
+		// back on the channel and the main goroutine reports it.
+		for {
+			select {
+			case <-stop:
+				binderErr <- nil
+				return
+			default:
+			}
+			listener, bindErr := bindUnixSocket(context.Background(), filepath.Join(dir, "b.sock"), 0o660)
+			if bindErr != nil {
+				binderErr <- bindErr
+				return
+			}
+			if closeErr := listener.Close(); closeErr != nil {
+				binderErr <- closeErr
+				return
+			}
+		}
+	}()
+
+	var disturbed []string
+	for i := range 200 {
+		path := filepath.Join(dir, fmt.Sprintf("d%d", i))
+		if mkErr := os.Mkdir(path, 0o700); mkErr != nil {
+			disturbed = append(disturbed, fmt.Sprintf("%s: %v", path, mkErr))
+			continue
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			disturbed = append(disturbed, fmt.Sprintf("%s: %v", path, statErr))
+			continue
+		}
+		if got := info.Mode().Perm(); got != want {
+			disturbed = append(disturbed, fmt.Sprintf("%s: mode %#o, want %#o", path, got, want))
+		}
+	}
+	close(stop)
+
+	if loopErr := <-binderErr; loopErr != nil {
+		t.Fatalf("binding in a loop failed: %v", loopErr)
+	}
+	if len(disturbed) != 0 {
+		t.Errorf("binding a unix socket changed how %d of 200 concurrent directories were created:\n%s",
+			len(disturbed), strings.Join(disturbed, "\n"))
+	}
+}
+
+// TestBindUnixSocket_ListenerOwnsThePublishedPath verifies that the listener
+// hands callers the address they asked for and cleans that address up.
+//
+// The socket is bound under a staging name, so an unwrapped listener would
+// report a directory that no longer exists and would unlink the wrong name on
+// Close, leaving the operator's path behind forever.
+func TestBindUnixSocket_ListenerOwnsThePublishedPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owned.sock")
+	listener, err := bindUnixSocket(t.Context(), path, 0o660)
+	if err != nil {
+		t.Fatalf("bindUnixSocket() error = %v", err)
+	}
+
+	if got := listener.Addr().String(); got != path {
+		t.Errorf("Addr() = %q, want the published path %q", got, path)
+	}
+	if closeErr := listener.Close(); closeErr != nil {
+		t.Fatalf("Close() error = %v", closeErr)
+	}
+	if _, statErr := os.Lstat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("the published path survived Close(): %v", statErr)
+	}
+	if leftovers := stagingLeftovers(t, dir); len(leftovers) != 0 {
+		t.Errorf("staging directories left behind: %v", leftovers)
+	}
+}
+
+// TestBindUnixSocket_CloseKeepsASuccessorsSocket covers the shutdown race the
+// standard library documents and cannot fix.
+//
+// A restart can bind the same path before the outgoing process finishes
+// closing. net.UnixListener would unlink by name and delete the successor's
+// socket; this one removes the path only while it still names the inode it
+// published.
+func TestBindUnixSocket_CloseKeepsASuccessorsSocket(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "handover.sock")
+	outgoing, err := bindUnixSocket(t.Context(), path, 0o660)
+	if err != nil {
+		t.Fatalf("bindUnixSocket() error = %v", err)
+	}
+
+	// The successor takes the path over the way a restart does.
+	if removeErr := os.Remove(path); removeErr != nil {
+		t.Fatalf("removing the outgoing socket: %v", removeErr)
+	}
+	successor, successorErr := bindUnixSocket(t.Context(), path, 0o660)
+	if successorErr != nil {
+		t.Fatalf("the successor could not bind: %v", successorErr)
+	}
+	defer func() { _ = successor.Close() }()
+
+	if closeErr := outgoing.Close(); closeErr != nil {
+		t.Fatalf("closing the outgoing listener: %v", closeErr)
+	}
+
+	conn, dialErr := (&net.Dialer{}).DialContext(t.Context(), "unix", path)
+	if dialErr != nil {
+		t.Fatalf("the outgoing listener deleted the successor's socket: %v", dialErr)
+	}
+	_ = conn.Close()
+}
+
+// TestBindUnixSocket_UnwritableDirectoryIsRefused covers the failure an
+// operator produces by pointing --http-addr into a directory the server does
+// not own.
+//
+// It is the one listener failure whose outcome depends on who runs it:
+// permission bits refuse an ordinary account and never refuse root, so it
+// skips when the test process is privileged rather than asserting an error the
+// kernel would not produce. CI runs unprivileged, so CI runs it.
+func TestBindUnixSocket_UnwritableDirectoryIsRefused(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission bits refuse nothing, so there is no refusal to assert")
+	}
+
+	dir := t.TempDir()
+	closed := filepath.Join(dir, "closed")
+	if err := os.Mkdir(closed, 0o700); err != nil {
+		t.Fatalf("creating the directory: %v", err)
+	}
+	// Readable and searchable but not writable is the whole point, so the
+	// mode cannot be narrowed to satisfy a permissions linter.
+	if chmodErr := os.Chmod(closed, 0o500); chmodErr != nil { //nolint:gosec // see above
+		t.Fatalf("making the directory unwritable: %v", chmodErr)
+	}
+
+	listener, err := bindUnixSocket(t.Context(), filepath.Join(closed, "m.sock"), 0o660)
+	if err == nil {
+		_ = listener.Close()
+		t.Fatal("bindUnixSocket() bound a socket in a directory it cannot write in")
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("error = %v, want it to report the permission denial", err)
+	}
+	if leftovers := stagingLeftovers(t, closed); len(leftovers) != 0 {
+		t.Errorf("a refused bind left staging directories behind: %v", leftovers)
+	}
+}
+
+// TestBindUnixSocket_UnreachablePublishedPathIsRefused covers the startup
+// probe: a socket that cannot be connected to must stop the server rather than
+// be served.
+//
+// The probe exists because publishing with link(2) means the address a client
+// dials is not the address the kernel was given at bind time. Apple's sources
+// settle that for the syscall layer and for HFS+, but APFS is closed, so the
+// filesystem every current Mac uses is covered by inference. The probe replaces
+// that inference with a connect. Its failure branch is stubbed because no
+// filesystem this runs on is known to produce it.
+func TestBindUnixSocket_UnreachablePublishedPathIsRefused(t *testing.T) {
+	// Deliberately not parallel: it swaps a package-level seam.
+	original := probeUnixSocket
+	t.Cleanup(func() { probeUnixSocket = original })
+	probeUnixSocket = func(context.Context, string) error {
+		return errors.New("no client could reach it")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unreachable.sock")
+	listener, err := bindUnixSocket(t.Context(), path, 0o660)
+	if err == nil {
+		_ = listener.Close()
+		t.Fatal("bindUnixSocket() served a socket that failed its own reachability probe")
+	}
+	if !strings.Contains(err.Error(), "no client could reach it") {
+		t.Errorf("error = %v, want the probe's own reason", err)
+	}
+	// A socket left at the path would be a dead address the next start would
+	// then have to decide whether to remove.
+	if _, statErr := os.Lstat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("the failed socket was left at %q: %v", path, statErr)
+	}
+	if leftovers := stagingLeftovers(t, dir); len(leftovers) != 0 {
+		t.Errorf("a refused bind left staging directories behind: %v", leftovers)
+	}
+}
+
+// padDirTo creates a directory whose absolute path is exactly length bytes, so
+// a test can sit on either side of the unix address limit deliberately rather
+// than by guessing at a repeat count.
+func padDirTo(t *testing.T, length int) string {
+	t.Helper()
+
+	// Not t.TempDir(): its path carries the test's own name, which is longer
+	// than some of the budgets being measured here.
+	base, err := os.MkdirTemp("", "p") //nolint:usetesting // see above
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	needed := length - len(base) - 1
+	if needed < 1 {
+		t.Skipf("the temporary directory %q is already %d bytes, too long to pad to %d", base, len(base), length)
+	}
+	dir := filepath.Join(base, strings.Repeat("p", needed))
+	if mkErr := os.Mkdir(dir, 0o700); mkErr != nil {
+		t.Fatalf("padding to %d bytes: %v", length, mkErr)
+	}
+	return dir
+}
+
+// TestBindUnixSocket_RefusesAPathNoAddressCanHold verifies that an over-long
+// path is refused rather than bound.
+//
+// The kernel used to enforce this for free, because the address it was handed
+// was the operator's path. It no longer sees that path: the socket is bound
+// under a short staging name and published with link(2), which has no address
+// limit at all. Without an explicit check the server would start, report
+// itself listening, and no client would ever be able to connect.
+//
+// Both budgets are covered because they run out separately. The staging
+// directory sits one level below the published path, so a path that fits can
+// still be staged into one that does not, and the operator has to be told
+// which of the two it was.
+func TestBindUnixSocket_RefusesAPathNoAddressCanHold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    func(t *testing.T) string
+		wantErr string
+	}{
+		{
+			name: "the published path is too long",
+			path: func(t *testing.T) string {
+				t.Helper()
+				return filepath.Join(padDirTo(t, maxUnixPathLen-4), "toolong.sock")
+			},
+			wantErr: "the socket path is",
+		},
+		{
+			name: "the published path fits but the staging path does not",
+			path: func(t *testing.T) string {
+				t.Helper()
+				// The staged name adds 13 bytes to the directory and the
+				// published one adds 2, so this sits one byte above the limit
+				// and ten below it.
+				return filepath.Join(padDirTo(t, maxUnixPathLen-12), "s")
+			},
+			wantErr: "the staging path the socket is built under is",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := tt.path(t)
+			listener, err := bindUnixSocket(t.Context(), path, 0o660)
+			if err == nil {
+				_ = listener.Close()
+				t.Fatalf("bindUnixSocket(%d-byte path) bound a socket no client could reach", len(path))
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to say %q", err, tt.wantErr)
+			}
+			if leftovers := stagingLeftovers(t, filepath.Dir(path)); len(leftovers) != 0 {
+				t.Errorf("a refused bind left staging directories behind: %v", leftovers)
+			}
+		})
+	}
+}

--- a/cmd/server/socketmode_unix_test.go
+++ b/cmd/server/socketmode_unix_test.go
@@ -526,3 +526,105 @@ func TestBindUnixSocket_RefusesAPathNoAddressCanHold(t *testing.T) {
 		})
 	}
 }
+
+// TestNewStagingDir_AParentThatCannotHoldIt_IsReported covers the reservation
+// failing, which is the branch that decides whether a bind proceeds at all.
+//
+// It matters because the staging directory is what makes the chmod safe: the
+// socket is assembled somewhere no other account can reach. If the directory
+// could not be created and the code carried on regardless, the mode would be
+// applied on a path anyone could have swapped underneath it, which is the race
+// this whole file exists to avoid.
+func TestNewStagingDir_AParentThatCannotHoldIt_IsReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	missing := filepath.Join(t.TempDir(), "no-such-directory")
+
+	if _, err := newStagingDir(missing); err == nil {
+		t.Fatal("newStagingDir() accepted a parent that does not exist")
+	}
+}
+
+// TestRestrictDirToOwner_ANonDirectory_IsRefused verifies the O_DIRECTORY half
+// of the descriptor-based mode application.
+//
+// The mode is applied through a descriptor rather than by path so that
+// anything swapping the directory between the mkdir and the chmod makes the
+// open fail rather than the mode land somewhere else. A regular file standing
+// where a directory should be is the readable form of that swap.
+func TestRestrictDirToOwner_ANonDirectory_IsRefused(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	notADir := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(notADir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("writing the stand-in: %v", err)
+	}
+
+	if err := restrictDirToOwner(notADir); err == nil {
+		t.Fatal("restrictDirToOwner() accepted something that is not a directory")
+	}
+}
+
+// TestRestrictDirToOwner_ASymlink_IsRefused verifies the O_NOFOLLOW half.
+//
+// A symlink pointing at a directory this process may legitimately open is the
+// exact shape the flag is for: without it the mode would be applied to the
+// target, which is chosen by whoever planted the link rather than by this
+// process.
+func TestRestrictDirToOwner_ASymlink_IsRefused(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("creating the target directory: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("this filesystem does not support symlinks: %v", err)
+	}
+
+	if err := restrictDirToOwner(link); err == nil {
+		t.Fatal("restrictDirToOwner() followed a symlink, so the mode could land on a directory it did not choose")
+	}
+}
+
+// TestConfirmReachable_APathNothingIsServing_IsReported covers the check that
+// turns an unverifiable assumption into a startup failure.
+//
+// The published path is reached through a hard link, and whether a hard link
+// to a bound socket is connectable is a filesystem property this project
+// cannot read on every platform it ships to. So it is proven once per start
+// with a real connect rather than assumed, and this is the failing half of
+// that proof.
+func TestConfirmReachable_APathNothingIsServing_IsReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	absent := filepath.Join(t.TempDir(), "nothing.sock")
+
+	if err := confirmReachable(t.Context(), absent); err == nil {
+		t.Fatal("confirmReachable() reported a path nothing is serving as reachable")
+	}
+}
+
+// TestPublishStagedSocket_AListenerThatIsNotUnix_IsRefused covers the type
+// assertion, which is the one branch that cannot be reached through
+// bindUnixSocket at all.
+//
+// It is worth a test rather than a panic because the function hands back a
+// listener that owns a filesystem path: a TCP listener given the same job
+// would report an address nothing published and unlink a path it never
+// created.
+func TestPublishStagedSocket_AListenerThatIsNotUnix_IsRefused(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	tcp, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening on tcp: %v", err)
+	}
+	t.Cleanup(func() { _ = tcp.Close() })
+
+	dir := t.TempDir()
+	_, err = publishStagedSocket(tcp, filepath.Join(dir, "staged"), filepath.Join(dir, "published"), 0o660)
+	if err == nil {
+		t.Fatal("publishStagedSocket() accepted a listener that cannot own a path")
+	}
+	if !strings.Contains(err.Error(), "cannot own its path") {
+		t.Errorf("error = %q, want it to say the listener cannot own a path", err)
+	}
+}

--- a/cmd/server/socketmode_unix_test.go
+++ b/cmd/server/socketmode_unix_test.go
@@ -628,3 +628,134 @@ func TestPublishStagedSocket_AListenerThatIsNotUnix_IsRefused(t *testing.T) {
 		t.Errorf("error = %q, want it to say the listener cannot own a path", err)
 	}
 }
+
+// TestPublishStagedSocket_AChmodThatFails_LeavesNothingPublished verifies that
+// a socket whose mode could not be applied never reaches the operator's path.
+//
+// The order matters more than the error: the mode is applied and confirmed
+// BEFORE the link, so a failure here means the path was never created at all,
+// rather than created and then repaired.
+func TestPublishStagedSocket_AChmodThatFails_LeavesNothingPublished(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "published.sock")
+
+	original := chmodStagedSocket
+	t.Cleanup(func() { chmodStagedSocket = original })
+	chmodStagedSocket = func(string, os.FileMode) error {
+		return errors.New("the filesystem refused the mode")
+	}
+
+	_, err := bindUnixSocket(t.Context(), path, 0o660)
+	if err == nil {
+		t.Fatal("bindUnixSocket() published a socket whose mode was never applied")
+	}
+	if _, statErr := os.Lstat(path); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("the path exists after a failed chmod, so a socket with an unknown mode was published")
+	}
+}
+
+// TestPublishStagedSocket_AModeThatDidNotApply_IsRefused verifies the check
+// that exists for a filesystem which accepts a chmod and does not honor it.
+//
+// Reporting success while leaving the socket more open than the operator asked
+// for is the failure this whole file is built to avoid, so the result is
+// confirmed rather than assumed.
+func TestPublishStagedSocket_AModeThatDidNotApply_IsRefused(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wrong-mode.sock")
+
+	originalChmod := chmodStagedSocket
+	originalLstat := lstatStagedSocket
+	t.Cleanup(func() {
+		chmodStagedSocket = originalChmod
+		lstatStagedSocket = originalLstat
+	})
+	// A filesystem that takes the call and does nothing.
+	chmodStagedSocket = func(string, os.FileMode) error { return nil }
+	lstatStagedSocket = func(name string) (os.FileInfo, error) {
+		info, err := os.Lstat(name)
+		if err != nil {
+			return nil, err
+		}
+		return wrongModeInfo{FileInfo: info}, nil
+	}
+
+	_, err := bindUnixSocket(t.Context(), path, 0o660)
+	if err == nil {
+		t.Fatal("bindUnixSocket() served on a socket whose mode it could not confirm")
+	}
+	if !strings.Contains(err.Error(), "refusing to serve on it") {
+		t.Errorf("error = %q, want it to say it is refusing to serve", err)
+	}
+}
+
+// wrongModeInfo reports a mode other than the one on disk, standing in for a
+// filesystem that ignores a chmod.
+type wrongModeInfo struct {
+	os.FileInfo
+}
+
+func (w wrongModeInfo) Mode() os.FileMode {
+	return (w.FileInfo.Mode() &^ os.ModePerm) | 0o777
+}
+
+// TestPublishStagedSocket_AStatThatFails_IsRefused verifies that a mode which
+// cannot be read back is treated as a mode that was not applied.
+func TestPublishStagedSocket_AStatThatFails_IsRefused(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unstattable.sock")
+
+	original := lstatStagedSocket
+	t.Cleanup(func() { lstatStagedSocket = original })
+	lstatStagedSocket = func(string) (os.FileInfo, error) {
+		return nil, errors.New("the filesystem would not answer")
+	}
+
+	if _, err := bindUnixSocket(t.Context(), path, 0o660); err == nil {
+		t.Fatal("bindUnixSocket() published a socket whose mode it never read back")
+	}
+}
+
+// TestNewStagingDir_NamesAlreadyTaken_AreRetriedAndThenReported verifies the
+// reservation loop.
+//
+// mkdir is the reservation: it fails rather than reusing a name somebody else
+// holds, which is what stops two concurrent binds sharing a directory. A
+// collision must therefore be retried rather than treated as fatal, and a
+// parent that collides every time must be reported rather than looped on.
+func TestNewStagingDir_NamesAlreadyTaken_AreRetriedAndThenReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	original := mkdirStagingDir
+	t.Cleanup(func() { mkdirStagingDir = original })
+	attempts := 0
+	mkdirStagingDir = func(string, os.FileMode) error {
+		attempts++
+		return fs.ErrExist
+	}
+
+	_, err := newStagingDir(t.TempDir())
+	if err == nil {
+		t.Fatal("newStagingDir() reported success without ever creating a directory")
+	}
+	if attempts < 2 {
+		t.Errorf("mkdir was called %d time(s); a name collision must be retried, not fatal", attempts)
+	}
+}
+
+// TestNewStagingDir_AnUnnameableDirectory_IsReported covers the one failure
+// that happens before the filesystem is touched at all.
+func TestNewStagingDir_AnUnnameableDirectory_IsReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	original := readRandomName
+	t.Cleanup(func() { readRandomName = original })
+	readRandomName = func([]byte) (int, error) {
+		return 0, errors.New("no entropy")
+	}
+
+	if _, err := newStagingDir(t.TempDir()); err == nil {
+		t.Fatal("newStagingDir() named a directory without any randomness")
+	}
+}

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,343 |
-| Unit test functions                                   | 12,788 |
+| Total test functions                                  | 13,324 |
+| Unit test functions                                   | 12,769 |
 | E2E test functions                                    |    555 |
-| cmd test functions                                    |  1,966 |
+| cmd test functions                                    |  1,947 |
 | Test files (internal/)                                |    490 |
-| Test files (cmd/)                                     |    111 |
+| Test files (cmd/)                                     |    106 |
 | Test files (test/e2e/)                                |    214 |
 | Tool sub-packages tested                              |    173 |
 | Core packages tested                                  |     21 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.8% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.9% |
 | Overall coverage (`go test ./internal/...`)           |  98.3% |
-| Average package coverage                              |  98.4% |
+| Average package coverage                              |  98.5% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,154 | 83.6% |
+| `TestFunc_Scenario` (2-part)           | 11,155 | 83.7% |
 | `TestFunc` (no underscore)             |    959 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,230 |  9.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,210 |  9.1% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (173) |          8,362 |        347 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            555 |        214 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,966 |        111 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,343** |    **815** |                                                                                                 |
+| cmd packages            |          1,947 |        106 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,324** |    **810** |                                                                                                 |
 
 ### Core Packages
 
@@ -315,7 +315,6 @@
 | cmd/audit_gateway_chars                        |    88.2% |
 | cmd/audit_install_buttons                      |    84.2% |
 | cmd/audit_metrics                              |    97.8% |
-| cmd/audit_readonly_graphql                     |    90.2% |
 | cmd/audit_string_dupes                         |    92.1% |
 | cmd/audit_supply_chain                         |    98.0% |
 | cmd/audit_surface_quality                      |    93.0% |


### PR DESCRIPTION
Two small, independent fixes that happened to be next to each other in the 2.8.0 list.

## The unix socket no longer holds a process-global umask

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/415

`bindUnixSocket` set the process umask around the bind so the socket would be
created already carrying its mode. That was deliberate and I want to keep the
reason it existed: a `chmod` takes a path, and on a directory an untrusted
local account can write, that account can swap the socket for a symlink between
the bind and the chmod and have the mode land on whatever it points at
(CWE-367). Setting the mode on the bound descriptor is not the way out either,
because `fchmod` on a socket returns success and changes nothing on Linux.

What it cost is that umask is process-global. The mutex around it could only
serialize binds against each other; every other goroutine in the process still
created its files under whatever was installed at that instant. CI showed me
this by failing tests that never touched a socket, whose `t.TempDir()` came back
at 0600 with no execute bit.

The socket is now assembled somewhere nobody else can reach and published
afterwards: a staging directory beside the target path at mode 0700 set through
its own descriptor, the bind and the chmod inside it, then `link(2)` to the
target. The chmod is safe because no other account can reach the path it names,
and `link` fails with `EEXIST` rather than replacing what is already there,
which is the no-clobber guarantee `bind` was providing. The listener's
unlink-on-close is switched off, since it would otherwise remove the staging
name; the published path is removed on `Close` instead, and only while it still
names the inode this process bound, which is a race `net.UnixListener` documents
and cannot fix.

### The macOS question, since the issue asked for it

The issue asked whether hard-linking a bound unix socket behaves the same on
macOS. I could not run it on a Mac, so I went to Apple's published sources.

`linkat_internal` in XNU rejects only `VDIR`, and the same file shows the
refusal Apple *did* write for sockets elsewhere (`copyfile` returns `EOPNOTSUPP`
for `VSOCK`), so the absence in the link path is a choice rather than an
oversight. The check has been `VDIR`-only since Mac OS X 10.0. HFS+ is more
explicit still: `hfs_vnop_link` filters `VBLK`, `VCHR` and `VLNK` and lets
`VSOCK` fall through to the ordinary hard-link machinery, and `hfs_cnode.c`
names `VSOCK` in its list of types that get tagged as hard links. Connecting
through the second link works there too, because the cnode hash is keyed on the
file id that `hfs_makelink` preserves. There is a nice asymmetry worth knowing:
FIFOs and device nodes *do* fail with `ENOTSUP` on macOS, sockets do not.

APFS is where it stops being verifiable. It is closed source, so its
`vnop_link` policy cannot be read, and the evidence that it shares one vnode
across links is a third-party report rather than documentation. The public
record contains no experiment either way.

Rather than ship on that inference, the published path proves itself: one
`connect()` at startup, and a socket that cannot be reached refuses to start
instead of being served. It costs a syscall and it also covers every other way
a socket can end up published but unreachable, which turned out to matter.

### Two consequences the design brings with it

The kernel no longer sees the operator's path, so it no longer enforces the
`sun_path` limit on it. An over-long path used to be refused at bind, and would
now be published by a `link` that has no such limit, giving a listener that
starts cleanly and that nothing can connect to. An existing test caught exactly
this. The limit is now checked explicitly, for the staged name as well as the
published one, since the staging directory sits one level deeper and the
operator needs to be told which of the two ran out of room.

The staged name is a fixed 10 bytes rather than `os.MkdirTemp`'s variable-width
decimal, so the address budget the staging costs is predictable.

### Tests

`cmd/server/socketmode_unix_test.go` pins the mode on the published path across
every mode an operator can ask for, the refusal to clobber a regular file, a
directory, a live socket and a planted symlink (asserting the symlink's target
keeps its own mode), the address-limit refusals on both budgets, `Addr` and
`Close` owning the published path, and `Close` leaving a successor's socket
alone.

The regression test for the actual complaint binds in a loop while creating
directories and asserts they all come back with the mode the first one got,
calibrated against whatever umask the machine has. It cannot fail spuriously:
the modes can only diverge if binding changed process-wide state. I checked it
is not vacuous by reproducing the old umask implementation standalone, where it
catches 87 of 200 directories.

The parallelism removed from `listen_test.go` as a mitigation is restored, and
the comment claiming permission cases were unreachable "because the tests run as
root in CI containers" is corrected. CI runs unprivileged, which is why it saw
the failure at all. That case is now covered, skipped when the test process is
privileged.

## The audit_tokens prompts pair

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/401

The structural half of this is already done: the four `fp`-prefixed helpers went
away when failures were made to travel in both families, and
https://github.com/jmrplens/gitlab-mcp-server/pull/394 finished it. I checked
before writing anything, and there is no `fp`-prefixed identifier left in the
package.

What was left is the fourth pair, which the issue rightly called a decision
rather than a rename, and the comment describing it still spoke of two functions
being kept in step with each other rather than of one that had absorbed the
other.

The decision stands and neither half's behavior survived it. A swallowed zero is
written into the generated token-footprint artifacts as though it were a
measurement, so a footprint missing every prompt reads as a smaller server
instead of as a failure. An error return would be honest but would ask callers
to handle something that cannot occur, since the listing runs over an in-memory
transport against a server the same process built moments earlier. It panics at
the leaf like every other step of `withSession`. The comment now says that, in
the present tense.

The committed footprint artifacts reproduce byte for byte.

## Verification

`go build ./...`, `go test ./cmd/... ./internal/... -count=1`,
`make test-e2e-http`, `make check-footprint`, `make check-test-file-names`,
`go run ./cmd/audit_test_subtests/ -check`,
`go run ./cmd/audit_test_goroutines/ --check`, and
`golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...` all pass. The socket
tests also pass under `-race -count=5`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Harden Unix socket publication and resolve prompt measurement failures without silently producing incomplete audit artifacts.

Bug Fixes:
- Eliminate process-wide umask changes while preserving secure Unix socket permissions and preventing path clobbering or symlink-target modification.
- Reject Unix socket paths that cannot be represented or reached, and verify the published socket is connectable before serving.
- Make prompt measurement failures fail explicitly instead of silently recording a zero token footprint.

Enhancements:
- Publish Unix sockets through a private staging location while preserving listener address and safe cleanup semantics.
- Expand Unix socket coverage for permissions, ownership, cleanup, collision handling, path limits, reachability, and concurrent file creation.
- Restore parallel listener tests now that socket binding no longer affects unrelated filesystem operations.

Documentation:
- Refresh generated README and testing metrics to reflect the updated source and test suite.

Tests:
- Add comprehensive regression and failure-path tests for staged Unix socket publication and prompt measurement behavior.