### PR TITLE
fix(eval): give the thirteen colliding evaluator cases their own identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,034 |     219,327 |
-| Unit tests (`_test.go`)  |       606 |     358,865 |
+| Source (`.go`, non-test) |     1,034 |     219,363 |
+| Unit tests (`_test.go`)  |       606 |     358,950 |
 | End-to-end tests         |       218 |      59,303 |
-| **Total**                | **1,858** | **637,495** |
+| **Total**                | **1,858** | **637,616** |
 
 ### Functions
 
@@ -471,8 +471,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  8,252 |
 | . Exported (public)             |  2,773 |
 | . Unexported (private)          |  5,479 |
-| Unit test functions (`TestXxx`) | 12,867 |
-| Subtests (`t.Run(...)`)         |  4,724 |
+| Unit test functions (`TestXxx`) | 12,870 |
+| Subtests (`t.Run(...)`)         |  4,726 |
 | End-to-end test functions       |    558 |
 
 ### Ratios worth noting
@@ -482,7 +482,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~592 lines |
-| Comment lines in source            |  32,178 (~14.7% of source) |
+| Comment lines in source            |  32,214 (~14.7% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,987 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,173 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,988 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,176 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_registry.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_registry.go
@@ -37,6 +37,14 @@ func CasesByPreset(preset string) []EvalCase {
 }
 
 // ValidateEvalCaseRegistry validates the migrated typed evaluation registry.
+//
+// Case IDs are unique across the whole catalog, with no exception for cases
+// that live in different partitions or different case sets. Nothing downstream
+// carries a partition alongside the ID that would let it tell two same-named
+// cases apart: [CaseByID] returns the first match and hides the rest, the
+// --task flag selects every case with a matching ID, and report rows are
+// labeled by ID alone. A duplicate is therefore reported unconditionally,
+// never downgraded to a warning for a known pair.
 func ValidateEvalCaseRegistry(routes map[string]toolutil.ActionMap) []string {
 	return validateEvalCaseRegistry(AllEvalCases(), routes)
 }

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_registry_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_registry_test.go
@@ -361,21 +361,106 @@ func TestDestructiveEvalCases_DestructiveStepsRequireConfirm(t *testing.T) {
 	}
 }
 
-// TestValidateEvalCaseRegistry_BuiltInCatalog_ReportsOnlyDuplicateIDs
-// verifies the exported validator runs over the shipped catalog and that the
-// only structural complaint it has is a set of case IDs reused across
-// partitions (for example MT-110, which names both a read case and a
-// destructive one). Every other class of defect — empty prompts, missing
-// steps, unknown presets or partitions, destructive steps without confirm,
-// misplaced optional steps — must stay absent, so a new one fails here.
-func TestValidateEvalCaseRegistry_BuiltInCatalog_ReportsOnlyDuplicateIDs(t *testing.T) {
-	problems := ValidateEvalCaseRegistry(nil)
-	for _, problem := range problems {
+// TestValidateEvalCaseRegistry_BuiltInCatalog_ReportsNoProblems verifies the
+// exported validator runs over the shipped catalog and finds nothing to
+// complain about at all: no duplicate IDs, and no empty prompts, missing
+// steps, unknown presets or partitions, destructive steps without confirm or
+// misplaced optional steps either.
+//
+// This assertion used to accept duplicate-ID problems and reject every other
+// kind, which let thirteen known collisions
+// (https://github.com/jmrplens/gitlab-mcp-server/issues/361) sit in the
+// catalog while still failing the build on any other defect. The exemption is
+// gone, so a reused ID now fails here like anything else.
+func TestValidateEvalCaseRegistry_BuiltInCatalog_ReportsNoProblems(t *testing.T) {
+	for _, problem := range ValidateEvalCaseRegistry(nil) {
 		t.Run(problem, func(t *testing.T) {
-			if !strings.HasSuffix(problem, " has duplicate ID") {
-				t.Fatalf("ValidateEvalCaseRegistry(nil) reported %q, want only duplicate-ID problems", problem)
+			t.Errorf("ValidateEvalCaseRegistry(nil) reported %q, want no problems", problem)
+		})
+	}
+}
+
+// TestAllEvalCases_BuiltInCatalog_HasNoDuplicateIDs verifies no two shipped
+// cases share an ID, asserted directly against the catalog rather than through
+// the validator, so weakening the validator cannot hide a collision here.
+//
+// Partitions and case sets are not namespaces: [All] concatenates them into
+// one slice and every consumer keys on the bare ID. The failure names each
+// colliding case with its partition and prompt, because the useful question
+// when this breaks is which two cases claimed the number.
+func TestAllEvalCases_BuiltInCatalog_HasNoDuplicateIDs(t *testing.T) {
+	casesByID := map[EvalCaseID][]EvalCase{}
+	var collidingIDs []EvalCaseID
+	for _, evalCase := range AllEvalCases() {
+		if len(casesByID[evalCase.ID]) == 1 {
+			collidingIDs = append(collidingIDs, evalCase.ID)
+		}
+		casesByID[evalCase.ID] = append(casesByID[evalCase.ID], evalCase)
+	}
+	for _, id := range collidingIDs {
+		t.Run(string(id), func(t *testing.T) {
+			for _, evalCase := range casesByID[id] {
+				t.Logf("partition %q: %s", evalCase.Partition, casePrompt(evalCase))
+			}
+			t.Errorf("case ID %s names %d cases, want 1", id, len(casesByID[id]))
+		})
+	}
+}
+
+// TestCaseByID_BuiltInCatalog_ResolvesEveryCase verifies every shipped case is
+// reachable by its own ID.
+//
+// CaseByID returns the first match, so a duplicate does not fail the lookup,
+// it hides the later case behind the earlier one. This test fails on the
+// hidden case rather than on the duplication itself, which is the symptom a
+// caller of CaseByID or --task actually experiences: MT-110 used to resolve to
+// a merge-request listing while an award-emoji deletion sharing the number was
+// unreachable.
+func TestCaseByID_BuiltInCatalog_ResolvesEveryCase(t *testing.T) {
+	for _, evalCase := range AllEvalCases() {
+		t.Run(string(evalCase.ID), func(t *testing.T) {
+			resolved, ok := CaseByID(string(evalCase.ID))
+			if !ok {
+				t.Fatalf("CaseByID(%q) ok = false, want true", evalCase.ID)
+			}
+			if got, want := casePrompt(resolved), casePrompt(evalCase); got != want {
+				t.Errorf("CaseByID(%q) resolved to %q, want %q; the case is shadowed by another with the same ID", evalCase.ID, got, want)
 			}
 		})
+	}
+}
+
+// TestValidateEvalCaseRegistry_DuplicateIDAcrossPartitions_ReportsProblem
+// verifies a reused ID is reported even when the two cases sit in different
+// partitions and target different editions.
+//
+// That is the exact shape of the thirteen collisions the catalog used to
+// carry: a CE read case and a destructive or Enterprise case sharing one
+// number. A differing partition does not make the reuse safe, because no
+// consumer of a case ID carries the partition alongside it, so the validator
+// must not treat this pair as a special case.
+func TestValidateEvalCaseRegistry_DuplicateIDAcrossPartitions_ReportsProblem(t *testing.T) {
+	routes := map[string]toolutil.ActionMap{"gitlab_project": {"get": {}}}
+	step := []ExpectedStep{{ExpectedTool: "gitlab_project", ExpectedAction: "get"}}
+	cases := []EvalCase{
+		{
+			ID:        "MT-110",
+			Prompt:    "List merged merge requests.",
+			Steps:     step,
+			Edition:   EvalCaseEdition(editionCE),
+			Partition: EvalPartition(partitionBaseRead),
+		},
+		{
+			ID:        "MT-110",
+			Prompt:    "Force-push remote mirror ID 9.",
+			Steps:     step,
+			Edition:   EvalCaseEdition(editionEnterprise),
+			Partition: EvalPartition(partitionEnterpriseDestructive),
+		},
+	}
+	problems := validateEvalCaseRegistry(cases, routes)
+	if !slices.Contains(problems, "MT-110 has duplicate ID") {
+		t.Fatalf("problems = %v, want to contain %q", problems, "MT-110 has duplicate ID")
 	}
 }
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/cases/doc.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/cases/doc.go
@@ -10,4 +10,26 @@
 // through the helper they expose (for example [mutatingEvalCases]). The
 // registry helper [All] merges every partition into a single slice that
 // callers clone before mutating.
+//
+// # Case identifiers
+//
+// A case ID is unique across the whole catalog, not per partition or per case
+// set. Partitions are not namespaces: [All] concatenates them into one slice,
+// and everything downstream keys on the bare ID. The --task flag selects by
+// ID, [github.com/jmrplens/gitlab-mcp-server/v2/cmd/eval_mcp_surfaces/internal/evaluator.CaseByID]
+// resolves by ID, and report rows are labeled by ID. A reused ID therefore
+// does not merely look untidy: --task runs both cases, the lookup can only
+// ever return the first, and a report cannot tell the two results apart.
+//
+// Allocate a new ID above the highest number already present, and never reuse
+// a retired one. Retired numbers stay retired because raw run reports outlive
+// the catalog: reusing MT-039 or MT-093..MT-098 would make an old report and a
+// new one disagree about what that identifier means.
+//
+// This rule was written after thirteen collisions were found in the shipped
+// catalog (https://github.com/jmrplens/gitlab-mcp-server/issues/361). Read
+// cases added on 2026-05-29 were numbered MT-110..MT-122, a range the
+// destructive and Enterprise partitions had already occupied since 2026-05-06,
+// while the catalog's high-water mark was MT-179. The read cases were renumbered
+// to MT-199..MT-211; the older identifiers kept their meaning.
 package cases

--- a/cmd/eval_mcp_surfaces/internal/evaluator/cases/read.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/cases/read.go
@@ -33,31 +33,37 @@ func readEvalCases() []Case {
 		baseReadEvalCase("MT-090", "List available Dockerfile templates.", readStep("gitlab_template", "dockerfile_list", nil, nil)),
 		baseReadEvalCase("MT-092", "List wiki pages in project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_wiki", "list", params("project_id"), params("with_content"))),
 		baseReadEvalCase("MT-179", "Inspect merge request `7` changes in project `my-org/tools/gitlab-mcp-server` without running an LLM analyzer.", readStep("gitlab_mr_review", "changes_get", params("project_id", "merge_request_iid"), nil)),
-		baseReadEvalCase("MT-110", "List merged merge requests in project `my-org/tools/gitlab-mcp-server` ordered by updated date, with 5 results per page.", readStep("gitlab_merge_request", "list", params("project_id"), params("state", "order_by", "sort", "per_page"))),
-		baseReadEvalCase("MT-111", "Get all pending to-do items for the current user.", readStep("gitlab_todo", "list", nil, params("state", "per_page"))),
-		baseReadEvalCase("MT-112", "List all available MCP resources exposed by the server.", readStep("gitlab_list_resources", "", nil, nil)),
-		baseReadEvalCase("MT-121", "List all MCP capabilities exposed by the server.", readStep("gitlab_list_capabilities", "", nil, nil)),
-		baseReadEvalCase("MT-122", "Read MCP resource `gitlab://tools` to inspect the tool catalog manifest.", readStep("gitlab_read_resource", "", params("uri"), nil)),
+		// MT-199..MT-211 were MT-110..MT-122 until the collisions in
+		// https://github.com/jmrplens/gitlab-mcp-server/issues/361 were
+		// resolved. Those numbers already named destructive and Enterprise
+		// cases, so these read cases moved above the high-water mark and the
+		// older cases kept their identifiers. See the package doc comment for
+		// the allocation rule.
+		baseReadEvalCase("MT-199", "List merged merge requests in project `my-org/tools/gitlab-mcp-server` ordered by updated date, with 5 results per page.", readStep("gitlab_merge_request", "list", params("project_id"), params("state", "order_by", "sort", "per_page"))),
+		baseReadEvalCase("MT-200", "Get all pending to-do items for the current user.", readStep("gitlab_todo", "list", nil, params("state", "per_page"))),
+		baseReadEvalCase("MT-201", "List all available MCP resources exposed by the server.", readStep("gitlab_list_resources", "", nil, nil)),
+		baseReadEvalCase("MT-210", "List all MCP capabilities exposed by the server.", readStep("gitlab_list_capabilities", "", nil, nil)),
+		baseReadEvalCase("MT-211", "Read MCP resource `gitlab://tools` to inspect the tool catalog manifest.", readStep("gitlab_read_resource", "", params("uri"), nil)),
 		baseReadEvalCase(
-			"MT-113", "List available MCP prompts, then get prompt details for `my_open_mrs` using that exact prompt name.",
+			"MT-202", "List available MCP prompts, then get prompt details for `my_open_mrs` using that exact prompt name.",
 			readStep("gitlab_list_prompts", "", nil, nil),
 			readStep("gitlab_get_prompt", "", params("name"), nil),
 		),
 		baseReadEvalCase(
-			"MT-114", "Retrieve the current user info, then call parameter completion for prompt `my_issues` and argument `state` (use `ref_type` = `ref/prompt`, plus `name` and `argument_name`).",
+			"MT-203", "Retrieve the current user info, then call parameter completion for prompt `my_issues` and argument `state` (use `ref_type` = `ref/prompt`, plus `name` and `argument_name`).",
 			readStep("gitlab_user", "current", nil, nil),
 			readStep("gitlab_complete", "", params("ref_type", "name", "argument_name"), params("argument_value")),
 		),
-		baseReadEvalCase("MT-115", "List issues with status `closed` created in the last 60 days in project `my-org/tools/gitlab-mcp-server`, ordered by creation date.", readStep("gitlab_issue", "list", params("project_id"), params("state", "order_by", "sort", "created_after", "per_page"))),
+		baseReadEvalCase("MT-204", "List issues with status `closed` created in the last 60 days in project `my-org/tools/gitlab-mcp-server`, ordered by creation date.", readStep("gitlab_issue", "list", params("project_id"), params("state", "order_by", "sort", "created_after", "per_page"))),
 		baseReadEvalCase(
-			"MT-116", "For project `my-org/tools/gitlab-mcp-server`, first discover and execute `pipeline.list` for ref `main`, then discover and execute `job.list` for the returned pipeline ID and list job statuses.",
+			"MT-205", "For project `my-org/tools/gitlab-mcp-server`, first discover and execute `pipeline.list` for ref `main`, then discover and execute `job.list` for the returned pipeline ID and list job statuses.",
 			readStep("gitlab_pipeline", "list", params("project_id"), params("ref", "per_page")),
 			readStep("gitlab_job", "list", params("project_id", "pipeline_id"), params("scope", "per_page")),
 		),
-		baseReadEvalCase("MT-117", "Find issues labeled `bug` and in milestone `v2.0` for project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_issue", "list", params("project_id"), params("labels", "milestone", "per_page"))),
-		baseReadEvalCase("MT-118", "Get the second page of releases (100 per page) for project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_release", "list", params("project_id"), params("page", "per_page"))),
-		baseReadEvalCase("MT-119", "Search for branches starting with `feat` in project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_branch", "list", params("project_id"), params("search", "per_page"))),
-		baseReadEvalCase("MT-120", "List members with their roles in project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_project", "members", params("project_id"), params("per_page", "query"))),
+		baseReadEvalCase("MT-206", "Find issues labeled `bug` and in milestone `v2.0` for project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_issue", "list", params("project_id"), params("labels", "milestone", "per_page"))),
+		baseReadEvalCase("MT-207", "Get the second page of releases (100 per page) for project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_release", "list", params("project_id"), params("page", "per_page"))),
+		baseReadEvalCase("MT-208", "Search for branches starting with `feat` in project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_branch", "list", params("project_id"), params("search", "per_page"))),
+		baseReadEvalCase("MT-209", "List members with their roles in project `my-org/tools/gitlab-mcp-server`.", readStep("gitlab_project", "members", params("project_id"), params("per_page", "query"))),
 		baseReadEvalCase(
 			"MS-001", "Resolve remote URL `https://gitlab.example.com/my-org/tools/gitlab-mcp-server.git` for project `my-org/tools/gitlab-mcp-server`, verify the project metadata, then read `README.md` from `main`.",
 			readStep("gitlab_discover_project", "", params("remote_url"), nil),
@@ -167,23 +173,23 @@ func baseReadPromptTemplateAndFixtures(id string) (template string, fixtures []s
 		return "Get raw content of personal snippet ID `{{ .Values.snippet_id }}`.", []string{fixtureSnippet}
 	case "MT-179":
 		return "Inspect merge request `{{ .MergeRequest.IID }}` changes in project `{{ .Project.Path }}` without running an LLM analyzer.", []string{fixtureMergeRequest}
-	case "MT-110":
+	case "MT-199":
 		return "List merged merge requests in project `{{ .Project.Path }}` ordered by updated date, with 5 results per page.", []string{fixtureMergeRequest}
-	case "MT-113":
+	case "MT-202":
 		return "List available MCP prompts, then get prompt details for `my_open_mrs` using that exact prompt name.", nil
-	case "MT-114":
+	case "MT-203":
 		return "Retrieve the current user info, then call parameter completion for prompt `my_issues` and argument `state` (use `ref_type` = `ref/prompt`, plus `name` and `argument_name`).", nil
-	case "MT-115":
+	case "MT-204":
 		return "List issues with status closed created in the last 60 days in project `{{ .Project.Path }}`, ordered by creation date.", []string{fixtureIssue}
-	case "MT-116":
+	case "MT-205":
 		return "For project `{{ .Project.Path }}`, first discover and execute `pipeline.list` for ref `main`, then discover and execute `job.list` for pipeline `{{ .Pipeline.ID }}` and list job statuses.", []string{fixturePipelineJob}
-	case "MT-117":
+	case "MT-206":
 		return "Find issues labeled bug and in milestone v2.0 for project `{{ .Project.Path }}`.", []string{fixtureIssue}
-	case "MT-118":
+	case "MT-207":
 		return "Get the second page of releases (100 per page) for project `{{ .Project.Path }}`.", []string{fixtureRelease}
-	case "MT-119":
+	case "MT-208":
 		return "Search for branches starting with feat in project `{{ .Project.Path }}`.", []string{fixtureBranch}
-	case "MT-120":
+	case "MT-209":
 		return "List members with their roles in project `{{ .Project.Path }}`.", []string{fixtureMember}
 	case "MS-002":
 		return "Investigate failed pipeline `{{ .Pipeline.ID }}` for project `{{ .Project.Path }}` and remote URL `{{ .Values.remote_url }}`: first resolve that exact remote URL to the project, inspect the pipeline, list failed jobs, fetch job `{{ .Job.ID }}` trace.", []string{fixtureFailedJobArtifact}

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -5342,7 +5342,7 @@ func TestIntentBoost_SearchCodeSurfacesForCodeQueries(t *testing.T) {
 }
 
 // TestIntentBoost_CurrentUserSurfacesForIdentityQueries verifies user.current
-// ranks first for current-user phrasings (surface-eval task MT-114). The
+// ranks first for current-user phrasings (surface-eval task MT-203). The
 // canonical alias "current user" is multi-word and never reaches the
 // exact-alias score on word-tokenized queries, so user.get and member-get
 // actions previously outranked it.


### PR DESCRIPTION
Closes https://github.com/jmrplens/gitlab-mcp-server/issues/361

`ValidateEvalCaseRegistry` reported 13 duplicate case identifiers over the shipped evaluator catalog. Nothing had ever run the validator against the real catalog, so this stayed invisible until coverage work reached that function.

## The 13 collisions

All of them sit in `MT-110`..`MT-122`, and every pair is a CE read case against a destructive or Enterprise one:

| ID | CE read case (`base-read`) | Colliding case | Its partition |
| --- | --- | --- | --- |
| `MT-110` | List merged merge requests, ordered by updated date | Remove award emoji ID 12 from issue 42 | `base-destructive` |
| `MT-111` | Get all pending to-do items | Delete deploy key ID 88 | `base-destructive` |
| `MT-112` | List all available MCP resources | Delete project deploy token ID 66 | `base-destructive` |
| `MT-113` | List MCP prompts, then get prompt details | Delete commit discussion note 999 | `base-destructive` |
| `MT-114` | Current user, then prompt argument completion | Unlock Terraform state `production` | `base-destructive` |
| `MT-115` | List closed issues from the last 60 days | Mark database migration version as applied | `base-destructive` |
| `MT-116` | `pipeline.list` then `job.list` through discovery | Force-push remote mirror ID 9 | `enterprise-destructive` |
| `MT-117` | Find issues labeled `bug` in milestone `v2.0` | Download attestation IID 5 | `enterprise-read` |
| `MT-118` | Second page of releases | Get instance audit event ID 77 | `enterprise-read` |
| `MT-119` | Search branches starting with `feat` | List project audit events for January 2026 | `enterprise-read` |
| `MT-120` | List members with their roles | Update admin compliance policy settings | `enterprise-mutating` |
| `MT-121` | List all MCP capabilities | Create a dependency list export | `enterprise-mutating` |
| `MT-122` | Read resource `gitlab://tools` | Download dependency list export ID 987 | `enterprise-read` |

## Why this is not cosmetic

Partitions are not namespaces. `All()` concatenates them into one slice and every consumer keys on the bare ID, so I could reproduce three concrete defects against the catalog as it stood:

- `--task MT-110` selected **two** unrelated tasks, one of them destructive when I had asked for a read. Same for all 13.
- `CaseByID` returns the first match, so it could only ever resolve the read case. The destructive and Enterprise twins were unreachable by their own identifiers.
- Report rows are labeled by ID alone, and the aggregation maps key on it, so a report cannot tell the two results apart.

There is also an ID-keyed safety decision in `taskUnavailableInLiveEvaluator` that says `MT-115` is unsafe to run live. That is true of the destructive `MT-115` and false of the read one. It is currently guarded by a `task.Case != nil` check so it does not misfire today, but it is the same hazard one refactor away.

## The decision, and the evidence behind it

The issue framed this as a decision because a case identifier is what a published evaluation report refers to, so renaming one would change the meaning of every historical report that cites it. I went looking for such a report before choosing, and the premise does not hold here:

- `docs/development/testing/model-results.md` aggregates by preset and model. It contains no case identifier at all, and `git log -S'MT-' --follow` over that path returns **no commit in its entire history**, back through the docs reorganisation rename.
- The same search over `README.md` returns nothing.
- Per-case identifiers reach only the raw per-attempt Markdown reports, and the published page states outright that raw reports and traces are not committed.
- The only tracked files that ever carried an `| MT-110 |` row were the two generated case-catalog listings under `testdata/`, both since deleted. They listed the catalog, they were not run reports.

So the renaming cost that would have justified namespacing or narrowing the contract is not real: no published report changes meaning.

That leaves renaming as clearly the cheapest option. Namespacing identifiers per case set would rewrite all 272 of them and break every `--task` string in the docs, to solve a problem 13 cases have. Accepting the collision and narrowing the validator would leave `--task` ambiguous and `CaseByID` lossy, which is a live defect rather than a naming preference.

**Which side gets renamed is not a coin flip either.** The read cases are the newer half of all 13 pairs. The destructive and Enterprise cases have held `MT-110`..`MT-129` since 2026-05-06 (`99ad62e46`, when the catalog was still Markdown), and the read cases were added on 2026-05-29 (`0b4192fa5`) into that already-occupied range, at a point when the catalog's high-water mark was already `MT-179`. So the 13 read cases move to `MT-199`..`MT-211` and the older identifiers keep the meaning they have had all along.

I deliberately did not recycle the retired numbers (`MT-039`, `MT-093`..`MT-098`) that are sitting free lower down. Raw run reports outlive the catalog, and reusing a retired number would make an old report and a new one disagree about what it means, which is the same class of problem in slower motion.

Nothing but the identifiers changed: prompts, steps, parameters, fixtures, presets and partitions are byte-identical.

## What the validator now refuses

Before, `ValidateEvalCaseRegistry` did detect all 13, but the test over the shipped catalog accepted any problem ending in `has duplicate ID` and rejected every other kind. So a new empty prompt or an unknown preset failed the build while 13 known duplicates did not. That exemption is gone, and the contract is now recorded on the validator itself and in the `cases` package doc comment, alongside the rule for allocating a new identifier.

The placeholder test is replaced by three that pin the real contract:

- `TestValidateEvalCaseRegistry_BuiltInCatalog_ReportsNoProblems` requires the shipped catalog to report **nothing at all**, duplicates included.
- `TestAllEvalCases_BuiltInCatalog_HasNoDuplicateIDs` asserts uniqueness directly against the catalog rather than through the validator, so weakening the validator cannot hide a collision. It names both colliding cases with their partitions and prompts.
- `TestCaseByID_BuiltInCatalog_ResolvesEveryCase` checks every case resolves to itself, which fails on the *shadowed* case rather than on the duplication, matching what a caller of `--task` actually experiences.

I checked these are not vacuous by reintroducing one collision on a scratch copy: all three fail, and the diagnostics name both cases and their partitions.

## Verification

`go build ./...`, `go test ./cmd/... -count=1`, `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `make check-test-file-names`, `go run ./cmd/audit_test_subtests/ -check`, `go run ./cmd/audit_test_goroutines/ --check`, plus `go test ./internal/tools/dynamic/ -count=1` for the one comment reference I retargeted. `make check-stats` passes with the README statistics regenerated.

## One thing I left alone

`docs/development/testing/testing.md` is a generated file and it is stale, but not because of this branch: it records 1,929 `cmd` test functions across 105 files where the tree actually has 1,992 across 112, and the E2E counts are off too. Refreshing it needs a full coverage run over `./internal/... ./cmd/...`, and that run currently dies because `cmd/audit_metrics` `TestRun_SiteStats_WritesAndThenVerifies` takes longer than the 10 minute per-package `go test` default once coverage instrumentation is on (`gen_testing_docs` does not pass `-timeout` through to the coverage command). Running it with `-skip-coverage` instead blanks every coverage column to `n/a`. Both the staleness and the generator's timeout are worth their own issue rather than 700 lines of unrelated churn in this one.

