### PR TITLE
Enumerate SDK services from client-go, not from our call sites

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ This project implements a **Model Context Protocol (MCP) server** that exposes G
 gitlab-mcp-server/
 ├── cmd/                    # 20 dev utility binaries — see docs/development/cmd-utilities.md for the full reference
 │   ├── server/             # MCP server entry point (+ --shutdown flag)
-│   ├── audit_1to1/         # 1:1 SDK↔API parity audit (-scope structs|actions|metadata; -validate-docs)
+│   ├── audit_1to1/         # 1:1 SDK↔API parity audit (-scope structs|actions|metadata|sdk; -validate-docs)
 │   ├── audit_catalog_first/        # Catalog-first registration invariants (ADR-0004)
 │   ├── audit_discovery_completeness/ # Discovery-metadata quality audit (META-001)
 │   ├── audit_doc_coverage/ # docs/tools/*.md vs catalog coverage gaps (DOC-002)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The six read-only `gitlab_orbit_*` tools (`status`, `schema`, `tools`, `dsl`, `q
 gitlab-mcp-server/
 ├── cmd/
 │   ├── server/                  # MCP server entry point and --shutdown support
-│   ├── audit_1to1/              # Consolidated 1:1 SDK↔API parity audit (R-INPUT/R-OUTPUT/R-ACTION/R-META + merge)
+│   ├── audit_1to1/              # Consolidated 1:1 SDK↔API parity audit (R-INPUT/R-OUTPUT/R-ACTION/R-META + merge; -scope=sdk gates the service universe and the raw-GraphQL exemptions)
 │   ├── audit_catalog_first/     # Enforces catalog-first registration invariants (ADR-0004)
 │   ├── audit_discovery_completeness/ # Audits discovery metadata (aliases/usage/related/param-guidance/sibling-cluster; input-enum candidates) — META-001
 │   ├── audit_doc_coverage/      # Audits docs/tools/*.md vs canonical action catalog (DOC-002); reads doc-ownership.json

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	mdlint mdlint-fix audit-docs check-doc-links \
 	analyze analyze-fix analyze-report install-tools \
 	audit-output audit-tokens audit-tools audit-surface-quality audit-metrics audit-dynamic-aliases audit-test-names audit-godocs audit-godocs-check fix-godocs \
-	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-validate-docs audit-edition-tier \
+	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-sdk audit-1to1-validate-docs audit-edition-tier \
 	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names audit-test-subtests check-test-subtests check-supply-chain \
 	check-readonly-graphql audit-readonly-graphql \
 	audit-doc-coverage audit-doc-coverage-check \
@@ -970,12 +970,23 @@ audit-catalog-first:
 audit-action-spec-coverage:
 	go run ./cmd/audit_catalog_first/
 
-## audit-1to1: run all three 1:1-audit gap streams (struct/action/metadata) and merge into plan/1to1-backlog.json.
+## audit-1to1: run all three 1:1-audit gap streams (struct/action/metadata), merge into
+## plan/1to1-backlog.json, then gate on SDK parity (audit-1to1-sdk).
 ## Single binary cmd/audit_1to1 consolidates the former audit_struct_completeness,
 ## audit_action_coverage, audit_metadata_completeness, and gen_1to1_backlog.
+## The backlog is written first so a gate failure still leaves the artifact behind.
 audit-1to1:
 	go run ./cmd/audit_1to1/ -gaps-only -output plan/1to1-backlog.json
 	@echo "1:1 audit backlog written to plan/1to1-backlog.json"
+	$(MAKE) audit-1to1-sdk
+
+## audit-1to1-sdk: gate every client-go service and every raw-GraphQL operation on a
+## decision (R-SERVICE/R-GRAPHQL). Unlike the three candidate streams this one FAILS on
+## a finding: a new SDK service that is neither called nor declared, a raw-GraphQL
+## operation whose wrapper now exists and is not adjudicated, or a declaration that has
+## gone stale.
+audit-1to1-sdk:
+	go run ./cmd/audit_1to1/ -scope=sdk -gaps-only
 
 ## audit-1to1-validate-docs: verify every doc/api citation behind the 1:1 adjudication tables is still fetchable.
 audit-1to1-validate-docs:

--- a/README.md
+++ b/README.md
@@ -459,20 +459,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,034 |     219,363 |
-| Unit tests (`_test.go`)  |       606 |     358,950 |
+| Source (`.go`, non-test) |     1,039 |     220,171 |
+| Unit tests (`_test.go`)  |       611 |     360,053 |
 | End-to-end tests         |       218 |      59,303 |
-| **Total**                | **1,858** | **637,616** |
+| **Total**                | **1,868** | **639,527** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,252 |
-| . Exported (public)             |  2,773 |
-| . Unexported (private)          |  5,479 |
-| Unit test functions (`TestXxx`) | 12,870 |
-| Subtests (`t.Run(...)`)         |  4,726 |
+| Source functions                |  8,281 |
+| . Exported (public)             |  2,786 |
+| . Unexported (private)          |  5,495 |
+| Unit test functions (`TestXxx`) | 12,897 |
+| Subtests (`t.Run(...)`)         |  4,743 |
 | End-to-end test functions       |    558 |
 
 ### Ratios worth noting
@@ -480,18 +480,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
-| Average source file length         |                 ~212 lines |
-| Average test file length           |                 ~592 lines |
-| Comment lines in source            |  32,214 (~14.7% of source) |
+| Average source file length         |                 ~211 lines |
+| Average test file length           |                 ~589 lines |
+| Comment lines in source            |  32,439 (~14.7% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,918 |
+| `if err != nil` checks             | 6,946 |
 | `defer` statements                 | 1,119 |
-| `struct` types defined             | 2,835 |
+| `struct` types defined             | 2,842 |
 | `//nolint` suppressions            |   267 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -499,7 +499,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   246 |
+| Go packages                    |   247 |
 | Direct dependencies (`go.mod`) |    30 |
 | Indirect dependencies          |    31 |
 
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,988 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,176 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,003 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,199 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_1to1/internal/actions/analyze.go
+++ b/cmd/audit_1to1/internal/actions/analyze.go
@@ -10,24 +10,22 @@
 // The output is a candidate backlog, not a hard gate: a method may be
 // intentionally unexposed, or owned by a sibling package. A human adjudicates
 // each entry.
+//
+// Its universe is this repository's call sites, which bounds what it can see: a
+// service no handler references never enters the map, so it cannot report one.
+// The sibling sdk package enumerates the services from client-go's Client
+// struct and covers exactly that blind spot.
 package actions
 
 import (
 	"encoding/json"
 	"fmt"
-	"go/ast"
-	"go/types"
 	"sort"
-	"strings"
-
-	"golang.org/x/tools/go/packages"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
 )
 
 const (
-	requestOptionMarker = "RequestOptionFunc"
-
 	coveredRawGeneric     = "COVERED_RAW. Generic slug-dispatched integration action (gitlab_set_integration / gitlab_*_group_integration)"
 	coveredGenericSearch  = "COVERED_GENERIC. Method-value scoped search"
 	coveredGraphQLEpicDsc = "COVERED_GRAPHQL. Epicdiscussions pkg"
@@ -64,14 +62,6 @@ type reportSummary struct {
 	MissingMethods   int `json:"missing_methods"`
 }
 
-// serviceUsage accumulates, for one client-go service interface, the set of
-// methods called and the internal/tools packages that reference it.
-type serviceUsage struct {
-	named  *types.Named
-	called map[string]struct{}
-	pkgs   map[string]struct{}
-}
-
 // Run builds the report for the given repository root and returns it as
 // indented JSON (with a trailing newline). gapsOnly filters to entries with at
 // least one finding, matching the original -gaps-only flag.
@@ -92,10 +82,7 @@ func buildReport(root string, gapsOnly bool) (report, error) {
 	if err != nil {
 		return report{}, err
 	}
-	usage := map[string]*serviceUsage{}
-	for _, pkg := range pkgs {
-		collectServiceUsage(pkg, usage)
-	}
+	usage := shared.CollectServiceUsage(pkgs)
 	services := make([]serviceCoverage, 0, len(usage))
 	for _, use := range usage {
 		cov := coverageForService(use)
@@ -108,8 +95,8 @@ func buildReport(root string, gapsOnly bool) (report, error) {
 
 	var staleAcceptances []string
 	for _, use := range usage {
-		service := strings.TrimSuffix(use.named.Obj().Name(), "ServiceInterface")
-		for method := range use.called {
+		service := use.Service()
+		for method := range use.Called {
 			key := service + "." + method
 			if _, ok := acceptedMissingMethods[key]; ok {
 				staleAcceptances = append(staleAcceptances, key)
@@ -125,42 +112,6 @@ func buildReport(root string, gapsOnly bool) (report, error) {
 		Services:         services,
 		StaleAcceptances: staleAcceptances,
 	}, nil
-}
-
-// collectServiceUsage walks every call expression in pkg and records calls whose
-// receiver type is a client-go service interface.
-func collectServiceUsage(pkg *packages.Package, usage map[string]*serviceUsage) {
-	pkgName := shortPackage(pkg.PkgPath)
-	for _, file := range pkg.Syntax {
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			named, ok := clientGoServiceInterface(pkg.TypesInfo.TypeOf(sel.X))
-			if !ok {
-				return true
-			}
-			use := usageFor(usage, named)
-			use.called[sel.Sel.Name] = struct{}{}
-			use.pkgs[pkgName] = struct{}{}
-			return true
-		})
-	}
-}
-
-func usageFor(usage map[string]*serviceUsage, named *types.Named) *serviceUsage {
-	key := named.Obj().Name()
-	use, ok := usage[key]
-	if !ok {
-		use = &serviceUsage{named: named, called: map[string]struct{}{}, pkgs: map[string]struct{}{}}
-		usage[key] = use
-	}
-	return use
 }
 
 // acceptedMissingMethods adjudicates SDK service methods that the call-expression
@@ -355,13 +306,13 @@ func isAcceptedMissingMethod(service, method string) bool {
 	return ok
 }
 
-func coverageForService(use *serviceUsage) serviceCoverage {
-	apiMethods := apiMethodNames(use.named)
-	service := strings.TrimSuffix(use.named.Obj().Name(), "ServiceInterface")
+func coverageForService(use *shared.ServiceUsage) serviceCoverage {
+	apiMethods := shared.APIMethodNames(use.Named)
+	service := use.Service()
 	covered := 0
 	var missing []string
 	for _, method := range apiMethods {
-		if _, ok := use.called[method]; ok {
+		if _, ok := use.Called[method]; ok {
 			covered++
 			continue
 		}
@@ -374,74 +325,12 @@ func coverageForService(use *serviceUsage) serviceCoverage {
 	}
 	sort.Strings(missing)
 	return serviceCoverage{
-		Service:        use.named.Obj().Name(),
-		Packages:       sortedSet(use.pkgs),
+		Service:        use.Named.Obj().Name(),
+		Packages:       shared.SortedSet(use.Packages),
 		APIMethods:     len(apiMethods),
 		CoveredMethods: covered,
 		MissingMethods: missing,
 	}
-}
-
-// apiMethodNames returns the exported methods of a client-go service interface
-// whose signature ends in a variadic ...RequestOptionFunc (the REST endpoint
-// marker).
-func apiMethodNames(named *types.Named) []string {
-	iface, ok := named.Underlying().(*types.Interface)
-	if !ok {
-		return nil
-	}
-	var names []string
-	for method := range iface.Methods() {
-		if !method.Exported() {
-			continue
-		}
-		if sig, isSig := method.Type().(*types.Signature); isSig && signatureIsAPICall(sig) {
-			names = append(names, method.Name())
-		}
-	}
-	sort.Strings(names)
-	return names
-}
-
-func signatureIsAPICall(sig *types.Signature) bool {
-	if !sig.Variadic() || sig.Params().Len() == 0 {
-		return false
-	}
-	last := sig.Params().At(sig.Params().Len() - 1)
-	slice, ok := last.Type().(*types.Slice)
-	if !ok {
-		return false
-	}
-	named, ok := slice.Elem().(*types.Named)
-	if !ok {
-		return false
-	}
-	if named.Obj().Pkg() == nil || !strings.Contains(named.Obj().Pkg().Path(), shared.ClientGoPkgPath) {
-		return false
-	}
-	return strings.Contains(named.Obj().Name(), requestOptionMarker)
-}
-
-// clientGoServiceInterface returns the named interface if t is a client-go
-// service interface (e.g. BranchesServiceInterface).
-func clientGoServiceInterface(t types.Type) (*types.Named, bool) {
-	if t == nil {
-		return nil, false
-	}
-	if ptr, ok := t.(*types.Pointer); ok {
-		t = ptr.Elem()
-	}
-	named, ok := t.(*types.Named)
-	if !ok {
-		return nil, false
-	}
-	if _, isIface := named.Underlying().(*types.Interface); !isIface {
-		return nil, false
-	}
-	if named.Obj().Pkg() == nil || !strings.Contains(named.Obj().Pkg().Path(), shared.ClientGoPkgPath) {
-		return nil, false
-	}
-	return named, true
 }
 
 func summarize(services []serviceCoverage) reportSummary {
@@ -455,24 +344,4 @@ func summarize(services []serviceCoverage) reportSummary {
 		s.MissingMethods += len(svc.MissingMethods)
 	}
 	return s
-}
-
-func sortedSet(set map[string]struct{}) []string {
-	out := make([]string, 0, len(set))
-	for value := range set {
-		out = append(out, value)
-	}
-	sort.Strings(out)
-	return out
-}
-
-func shortPackage(pkgPath string) string {
-	_, after, ok := strings.Cut(pkgPath, shared.ToolsPkgInfix)
-	if !ok {
-		if last := strings.LastIndex(pkgPath, "/"); last >= 0 {
-			return pkgPath[last+1:]
-		}
-		return pkgPath
-	}
-	return after
 }

--- a/cmd/audit_1to1/internal/actions/analyze_test.go
+++ b/cmd/audit_1to1/internal/actions/analyze_test.go
@@ -13,36 +13,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 )
 
-// TestShortPackage_ExtractsDomain verifies the internal/tools domain extraction
-// and its fallbacks for paths outside the tools tree.
-func TestShortPackage_ExtractsDomain(t *testing.T) {
-	cases := map[string]string{
-		"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/branches": "branches",
-		"github.com/x/internal/tools/group/sub":                            "group/sub",
-		"flat":                                                             "flat",
-		"a/b/c":                                                            "c",
-	}
-	for input, want := range cases {
-		t.Run(input, func(t *testing.T) {
-			if got := shortPackage(input); got != want {
-				t.Errorf("shortPackage(%q) = %q, want %q", input, got, want)
-			}
-		})
-	}
-}
-
-// TestSortedSet_SortsAndDedups verifies set→sorted-slice conversion.
-func TestSortedSet_SortsAndDedups(t *testing.T) {
-	got := sortedSet(map[string]struct{}{"b": {}, "a": {}, "c": {}})
-	want := []string{"a", "b", "c"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("sortedSet = %v, want %v", got, want)
-	}
-	if sortedSet(map[string]struct{}{}) == nil {
-		t.Error("sortedSet of empty map should be non-nil empty slice")
-	}
-}
-
 // TestSummarize_AggregatesServiceCounts verifies summary aggregation including
 // the services-with-gaps tally.
 func TestSummarize_AggregatesServiceCounts(t *testing.T) {
@@ -112,129 +82,24 @@ func TestBuildReport_Deterministic(t *testing.T) {
 	}
 }
 
-// clientGoPkg is a synthetic package whose path passes the client-go check
-// the resolver applies to receiver and option types.
-var clientGoPkg = types.NewPackage(shared.ClientGoPkgPath+"/v2", "gitlab")
-
-// namedIn declares a named type in pkg over underlying.
-func namedIn(pkg *types.Package, name string, underlying types.Type) *types.Named {
-	return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), underlying, nil)
-}
-
-// requestOptionSlice is the ...RequestOptionFunc variadic tail of a client-go
-// API method.
-func requestOptionSlice() *types.Slice {
-	return types.NewSlice(namedIn(clientGoPkg, "RequestOptionFunc", types.NewSignatureType(nil, nil, nil, nil, nil, false)))
-}
-
-// method builds an interface method with the given parameters.
-func method(pkg *types.Package, name string, variadic bool, params ...*types.Var) *types.Func {
-	sig := types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), nil, variadic)
-	return types.NewFunc(token.NoPos, pkg, name, sig)
-}
-
-// param builds one unnamed parameter of type typ.
-func param(typ types.Type) *types.Var {
-	return types.NewParam(token.NoPos, clientGoPkg, "", typ)
-}
-
-// serviceInterface declares a client-go service interface with methods.
-func serviceInterface(pkg *types.Package, name string, methods ...*types.Func) *types.Named {
-	iface := types.NewInterfaceType(methods, nil)
-	iface.Complete()
-	return namedIn(pkg, name, iface)
-}
-
-// TestSignatureIsAPICall_Shapes_RecognizesOnlyRequestOptionTails verifies
-// the REST endpoint marker: only a variadic signature whose tail is a slice
-// of a client-go type named after RequestOptionFunc counts, so plain
-// variadics, named slice types, unnamed or foreign element types and other
-// client-go types are all rejected.
-func TestSignatureIsAPICall_Shapes_RecognizesOnlyRequestOptionTails(t *testing.T) {
-	otherPkg := types.NewPackage("example.com/other", "other")
-	cases := []struct {
-		name string
-		sig  *types.Signature
-		want bool
-	}{
-		{name: "no_params", sig: method(clientGoPkg, "M", false).Signature(), want: false},
-		{name: "not_variadic", sig: method(clientGoPkg, "M", false, param(requestOptionSlice())).Signature(), want: false},
-		{
-			name: "named_slice_type_is_not_a_bare_slice",
-			sig:  method(clientGoPkg, "M", true, param(namedIn(clientGoPkg, "Options", requestOptionSlice()))).Signature(),
-			want: false,
-		},
-		{name: "unnamed_element", sig: method(clientGoPkg, "M", true, param(types.NewSlice(types.Typ[types.String]))).Signature(), want: false},
-		{name: "universe_element_has_no_package", sig: method(clientGoPkg, "M", true, param(types.NewSlice(types.Universe.Lookup("error").Type()))).Signature(), want: false},
-		{
-			name: "foreign_package_element",
-			sig:  method(clientGoPkg, "M", true, param(types.NewSlice(namedIn(otherPkg, "RequestOptionFunc", types.Typ[types.Int])))).Signature(),
-			want: false,
-		},
-		{
-			name: "client_go_element_without_marker",
-			sig:  method(clientGoPkg, "M", true, param(types.NewSlice(namedIn(clientGoPkg, "Client", types.Typ[types.Int])))).Signature(),
-			want: false,
-		},
-		{name: "request_option_tail", sig: method(clientGoPkg, "M", true, param(types.Typ[types.Int]), param(requestOptionSlice())).Signature(), want: true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := signatureIsAPICall(tc.sig); got != tc.want {
-				t.Errorf("signatureIsAPICall = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-// TestAPIMethodNames_Interface_ListsExportedEndpointsSorted verifies the
-// endpoint listing keeps only the exported methods with the REST marker, in
-// sorted order, and yields nothing for a named type that is not an interface.
-func TestAPIMethodNames_Interface_ListsExportedEndpointsSorted(t *testing.T) {
-	iface := serviceInterface(clientGoPkg, "BranchesServiceInterface",
-		method(clientGoPkg, "ListBranches", true, param(requestOptionSlice())),
-		method(clientGoPkg, "CreateBranch", true, param(requestOptionSlice())),
-		method(clientGoPkg, "helper", true, param(requestOptionSlice())),
-		method(clientGoPkg, "String", false),
+// endpointInterface declares a client-go service interface named name whose
+// methods all carry the variadic ...RequestOptionFunc endpoint marker, which
+// is all the coverage adjudication needs to resolve them as API methods.
+func endpointInterface(name string, methods ...string) *types.Named {
+	pkg := types.NewPackage(shared.ClientGoPkgPath+"/v2", "gitlab")
+	optionFunc := types.NewNamed(
+		types.NewTypeName(token.NoPos, pkg, "RequestOptionFunc", nil),
+		types.NewSignatureType(nil, nil, nil, nil, nil, false), nil,
 	)
-	if got := apiMethodNames(iface); !reflect.DeepEqual(got, []string{"CreateBranch", "ListBranches"}) {
-		t.Errorf("apiMethodNames = %v, want the two exported endpoints sorted", got)
+	tail := types.NewParam(token.NoPos, pkg, "", types.NewSlice(optionFunc))
+	funcs := make([]*types.Func, 0, len(methods))
+	for _, method := range methods {
+		sig := types.NewSignatureType(nil, nil, nil, types.NewTuple(tail), nil, true)
+		funcs = append(funcs, types.NewFunc(token.NoPos, pkg, method, sig))
 	}
-	if got := apiMethodNames(namedIn(clientGoPkg, "Client", types.NewStruct(nil, nil))); got != nil {
-		t.Errorf("apiMethodNames of a struct = %v, want nil", got)
-	}
-}
-
-// TestClientGoServiceInterface_Types_AcceptsOnlyClientGoInterfaces verifies
-// the receiver test behind every recorded call: a client-go interface,
-// reached directly or through a pointer, is a service; nil, basic, struct,
-// universe and foreign-package types are not.
-func TestClientGoServiceInterface_Types_AcceptsOnlyClientGoInterfaces(t *testing.T) {
-	service := serviceInterface(clientGoPkg, "TagsServiceInterface", method(clientGoPkg, "ListTags", true, param(requestOptionSlice())))
-	cases := []struct {
-		name string
-		typ  types.Type
-		want bool
-	}{
-		{name: "nil", typ: nil, want: false},
-		{name: "basic", typ: types.Typ[types.Int], want: false},
-		{name: "client_go_struct", typ: namedIn(clientGoPkg, "Tag", types.NewStruct(nil, nil)), want: false},
-		{name: "universe_error_interface", typ: types.Universe.Lookup("error").Type(), want: false},
-		{name: "foreign_interface", typ: serviceInterface(types.NewPackage("example.com/x", "x"), "Svc"), want: false},
-		{name: "service_interface", typ: service, want: true},
-		{name: "pointer_to_service_interface", typ: types.NewPointer(service), want: true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			named, ok := clientGoServiceInterface(tc.typ)
-			if ok != tc.want {
-				t.Fatalf("clientGoServiceInterface = %v, want %v", ok, tc.want)
-			}
-			if ok && named != service {
-				t.Errorf("returned %v, want the service interface", named)
-			}
-		})
-	}
+	iface := types.NewInterfaceType(funcs, nil)
+	iface.Complete()
+	return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), iface, nil)
 }
 
 // TestCoverageForService_Usage_AdjudicatesAcceptedMethods verifies the
@@ -242,16 +107,11 @@ func TestClientGoServiceInterface_Types_AcceptsOnlyClientGoInterfaces(t *testing
 // both count as covered, the rest are the sorted missing list, and the
 // referencing packages are listed sorted.
 func TestCoverageForService_Usage_AdjudicatesAcceptedMethods(t *testing.T) {
-	service := serviceInterface(clientGoPkg, "SearchServiceInterface",
-		method(clientGoPkg, "Commits", true, param(requestOptionSlice())),
-		method(clientGoPkg, "Milestones", true, param(requestOptionSlice())),
-		method(clientGoPkg, "Blobs", true, param(requestOptionSlice())),
-		method(clientGoPkg, "Users", true, param(requestOptionSlice())),
-	)
-	use := &serviceUsage{
-		named:  service,
-		called: map[string]struct{}{"Commits": {}},
-		pkgs:   map[string]struct{}{"search": {}, "groups": {}},
+	service := endpointInterface("SearchServiceInterface", "Commits", "Milestones", "Blobs", "Users")
+	use := &shared.ServiceUsage{
+		Named:    service,
+		Called:   map[string]struct{}{"Commits": {}},
+		Packages: map[string]struct{}{"search": {}, "groups": {}},
 	}
 	got := coverageForService(use)
 	want := serviceCoverage{

--- a/cmd/audit_1to1/internal/sdk/analyze.go
+++ b/cmd/audit_1to1/internal/sdk/analyze.go
@@ -1,0 +1,175 @@
+// Package sdk holds the two 1:1 audit rules whose universe comes from the SDK
+// rather than from this repository's own call sites (R-SERVICE, R-GRAPHQL).
+//
+// The action-coverage scope answers "which methods of a service we call are
+// uncovered". It cannot answer "is there a service we call nothing on", because
+// its universe is built by walking our call expressions: a service nothing
+// references never enters the map, so an entire upstream service can be added
+// and the audit still report zero gaps. That is exactly what happened when
+// WorkItemSavedViewsService arrived with seven methods.
+//
+// So this scope enumerates the services from the client-go Client struct and
+// holds each one to a decision: covered by a call, or declared an exception
+// with a category and a reason. A service that is neither is a finding.
+//
+// It carries a second rule for the same reason. ADR-0006 admits raw
+// GraphQL.Do() for domains WITHOUT a client-go service wrapper. The wrapper
+// appearing later is what retires that exemption, and nothing was checking, so
+// the exemption was permanent in practice. Every raw GraphQL operation whose
+// package maps to a client-go service is therefore held to a decision too,
+// per operation rather than per package: packages that use GraphQL for one
+// operation and the SDK for the rest are the norm, so a package-level verdict
+// would be mostly noise.
+//
+// Unlike the three candidate-backlog scopes, this one is a gate: Run reports
+// whether the tree is clean, and the command exits non-zero when it is not.
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+)
+
+// Service and operation statuses.
+const (
+	statusCovered       = "covered"
+	statusDeclared      = "declared"
+	statusUndeclared    = "undeclared"
+	statusAdjudicated   = "adjudicated"
+	statusUnadjudicated = "unadjudicated"
+)
+
+type report struct {
+	SchemaVersion     int                `json:"schema_version"`
+	ClientGoPath      string             `json:"client_go_path"`
+	Summary           reportSummary      `json:"summary"`
+	Services          []sdkService       `json:"services"`
+	GraphQLOperations []graphqlOperation `json:"graphql_operations"`
+	StaleDeclarations []string           `json:"stale_declarations,omitempty"`
+}
+
+type reportSummary struct {
+	SDKServices          int `json:"sdk_services"`
+	ServicesCovered      int `json:"services_covered"`
+	ServicesDeclared     int `json:"services_declared"`
+	ServicesUndeclared   int `json:"services_undeclared"`
+	GraphQLOperations    int `json:"graphql_operations"`
+	GraphQLAdjudicated   int `json:"graphql_adjudicated"`
+	GraphQLUnadjudicated int `json:"graphql_unadjudicated"`
+	StaleDeclarations    int `json:"stale_declarations"`
+}
+
+// clean reports whether the audited tree has no finding, i.e. whether the gate
+// passes.
+func (s reportSummary) clean() bool {
+	return s.ServicesUndeclared == 0 && s.GraphQLUnadjudicated == 0 && s.StaleDeclarations == 0
+}
+
+// Run builds the report for the given repository root and returns it as
+// indented JSON (with a trailing newline) together with the gate outcome.
+// gapsOnly keeps only the findings, matching the other scopes' flag.
+func Run(root string, gapsOnly bool) (content []byte, clean bool, err error) {
+	rep, err := buildReport(root, gapsOnly)
+	if err != nil {
+		return nil, false, err
+	}
+	content, err = json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal report: %w", err)
+	}
+	return append(content, '\n'), rep.Summary.clean(), nil
+}
+
+func buildReport(root string, gapsOnly bool) (report, error) {
+	pkgs, err := shared.LoadToolPackages(root)
+	if err != nil {
+		return report{}, err
+	}
+	clientGo, err := shared.ClientGoTypes(pkgs)
+	if err != nil {
+		return report{}, err
+	}
+	declared, err := collectSDKServices(clientGo)
+	if err != nil {
+		return report{}, err
+	}
+	services := adjudicateServices(declared, shared.CollectServiceUsage(pkgs), declaredServices)
+
+	graphQL, err := shared.GraphQLInterface(clientGo)
+	if err != nil {
+		return report{}, err
+	}
+	operations := buildGraphQLOperations(collectGraphQLSites(pkgs, graphQL), serviceIndex(services), graphqlServiceAliases, graphqlDecisions)
+
+	stale := mergeStale(staleServiceDeclarations(services, declaredServices), staleGraphQLDecisions(operations, graphqlDecisions))
+	summary := summarize(services, operations, stale)
+
+	if gapsOnly {
+		services = keepUndeclaredServices(services)
+		operations = keepUnadjudicatedOperations(operations)
+	}
+	return report{
+		SchemaVersion:     shared.SchemaVersion,
+		ClientGoPath:      shared.ClientGoPkgPath,
+		Summary:           summary,
+		Services:          services,
+		GraphQLOperations: operations,
+		StaleDeclarations: stale,
+	}, nil
+}
+
+// mergeStale joins the two stale lists into one sorted list, so the report
+// reads as a single roll of claims that no longer hold rather than two.
+func mergeStale(services, operations []string) []string {
+	stale := make([]string, 0, len(services)+len(operations))
+	stale = append(stale, services...)
+	stale = append(stale, operations...)
+	sort.Strings(stale)
+	return stale
+}
+
+func keepUndeclaredServices(services []sdkService) []sdkService {
+	out := make([]sdkService, 0)
+	for _, service := range services {
+		if service.Status == statusUndeclared {
+			out = append(out, service)
+		}
+	}
+	return out
+}
+
+func keepUnadjudicatedOperations(operations []graphqlOperation) []graphqlOperation {
+	out := make([]graphqlOperation, 0)
+	for _, op := range operations {
+		if op.Status == statusUnadjudicated {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+func summarize(services []sdkService, operations []graphqlOperation, stale []string) reportSummary {
+	s := reportSummary{SDKServices: len(services), StaleDeclarations: len(stale)}
+	for _, service := range services {
+		switch service.Status {
+		case statusCovered:
+			s.ServicesCovered++
+		case statusDeclared:
+			s.ServicesDeclared++
+		default:
+			s.ServicesUndeclared++
+		}
+	}
+	s.GraphQLOperations = len(operations)
+	for _, op := range operations {
+		if op.Status == statusAdjudicated {
+			s.GraphQLAdjudicated++
+			continue
+		}
+		s.GraphQLUnadjudicated++
+	}
+	return s
+}

--- a/cmd/audit_1to1/internal/sdk/analyze_test.go
+++ b/cmd/audit_1to1/internal/sdk/analyze_test.go
@@ -1,0 +1,424 @@
+// Package sdk tests the two SDK-sourced audit rules: that every client-go
+// service is either called or declared, and that every raw-GraphQL operation
+// whose wrapper exists carries a decision. The end-to-end cases run against a
+// throwaway module carrying a stand-in client-go, so a case can state the whole
+// universe it asserts about instead of depending on the repository's shape.
+package sdk
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
+)
+
+// fixtureSDK is a stand-in for the client-go root package. Its import path
+// carries the client-go path as an infix, which is what the resolver matches
+// on, so the analyzers treat it exactly as they treat the real SDK.
+const fixtureSDK = `package gitlab
+
+// RequestOptionFunc is the variadic tail that marks a REST endpoint.
+type RequestOptionFunc func()
+
+type BranchesServiceInterface interface {
+	ListBranches(options ...RequestOptionFunc) error
+	CreateBranch(options ...RequestOptionFunc) error
+	helper() error
+}
+
+type WidgetsServiceInterface interface {
+	ListWidgets(options ...RequestOptionFunc) error
+}
+
+type GadgetsServiceInterface interface {
+	ListGadgets(options ...RequestOptionFunc) error
+}
+
+type GraphQLQuery struct{ Query string }
+
+type GraphQLInterface interface {
+	Do(query GraphQLQuery, target any, options ...RequestOptionFunc) error
+}
+
+type Client struct {
+	UserAgent string
+	notAField int
+	GraphQL   GraphQLInterface
+	Branches  BranchesServiceInterface
+	Widgets   WidgetsServiceInterface
+	Gadgets   GadgetsServiceInterface
+}
+`
+
+// fixtureModule writes a module whose internal/tools tree calls the stand-in
+// SDK, and returns its root. Extra files are merged in, overriding the
+// defaults, so a case can add or replace a tool package.
+func fixtureModule(t *testing.T, extra map[string]string) string {
+	t.Helper()
+	const sdkDir = "gitlab.com/gitlab-org/api/client-go/v2/sdk.go"
+	files := map[string]string{
+		"go.mod": "module example.com/fixture\n\ngo 1.27\n",
+		sdkDir:   fixtureSDK,
+		"internal/tools/branches/branches.go": `package branches
+
+import gl "example.com/fixture/gitlab.com/gitlab-org/api/client-go/v2"
+
+// List calls the SDK wrapper, so Branches is covered.
+func List(c *gl.Client) error { return c.Branches.ListBranches() }
+`,
+		"internal/tools/widgets/widgets.go": `package widgets
+
+import gl "example.com/fixture/gitlab.com/gitlab-org/api/client-go/v2"
+
+// List reaches GitLab over raw GraphQL even though Widgets is a wrapper.
+func List(c *gl.Client) error {
+	return c.GraphQL.Do(gl.GraphQLQuery{Query: "{ widgets }"}, nil)
+}
+
+// Mutate hands the GraphQL interface to a helper rather than calling Do on it,
+// the form a .Do-only scanner misses.
+func Mutate(c *gl.Client) error { return exec(c.GraphQL) }
+
+func exec(g gl.GraphQLInterface) error {
+	return g.Do(gl.GraphQLQuery{Query: "mutation {}"}, nil)
+}
+`,
+	}
+	maps.Copy(files, extra)
+	root := t.TempDir()
+	writeFiles(t, root, files)
+	return root
+}
+
+// writeFiles writes each slash-separated relative path under root, creating
+// parents as needed.
+func writeFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+}
+
+// fixtureReport builds the report for a fixture module with the given tables.
+func fixtureReport(t *testing.T, root string, declaredBy map[string]declaration, aliases map[string]string, decisions map[string]decision) report {
+	t.Helper()
+	pkgs, err := shared.LoadToolPackages(root)
+	if err != nil {
+		t.Fatalf("load fixture packages: %v", err)
+	}
+	clientGo, err := shared.ClientGoTypes(pkgs)
+	if err != nil {
+		t.Fatalf("client-go types: %v", err)
+	}
+	declared, err := collectSDKServices(clientGo)
+	if err != nil {
+		t.Fatalf("collectSDKServices: %v", err)
+	}
+	services := adjudicateServices(declared, shared.CollectServiceUsage(pkgs), declaredBy)
+	graphQL, err := shared.GraphQLInterface(clientGo)
+	if err != nil {
+		t.Fatalf("GraphQLInterface: %v", err)
+	}
+	operations := buildGraphQLOperations(collectGraphQLSites(pkgs, graphQL), serviceIndex(services), aliases, decisions)
+	stale := mergeStale(staleServiceDeclarations(services, declaredBy), staleGraphQLDecisions(operations, decisions))
+	return report{Summary: summarize(services, operations, stale), Services: services, GraphQLOperations: operations, StaleDeclarations: stale}
+}
+
+// statusOf indexes a report's services by name for assertions.
+func statusOf(services []sdkService) map[string]string {
+	out := map[string]string{}
+	for _, service := range services {
+		out[service.Service] = service.Status
+	}
+	return out
+}
+
+// TestFixture_EveryServiceGetsADecision verifies the whole rule on a module
+// whose universe is known: a called service is covered, an uncalled one that
+// the table names is declared, and an uncalled one nothing names is the
+// finding this scope exists to raise. The GraphQL interface itself counts as a
+// service and is covered by the handler that uses it.
+func TestFixture_EveryServiceGetsADecision(t *testing.T) {
+	root := fixtureModule(t, nil)
+	rep := fixtureReport(t, root,
+		map[string]declaration{"Widgets": {coveredGraphQL, "reached over GraphQL"}},
+		nil, nil)
+
+	want := map[string]string{
+		"Branches":         statusCovered,
+		"GraphQLInterface": statusCovered,
+		"Widgets":          statusDeclared,
+		"Gadgets":          statusUndeclared,
+	}
+	if got := statusOf(rep.Services); !reflect.DeepEqual(got, want) {
+		t.Errorf("service statuses = %v, want %v", got, want)
+	}
+	if rep.Summary.SDKServices != 4 || rep.Summary.ServicesCovered != 2 ||
+		rep.Summary.ServicesDeclared != 1 || rep.Summary.ServicesUndeclared != 1 {
+		t.Errorf("summary = %+v, want 4 services split 2 covered / 1 declared / 1 undeclared", rep.Summary)
+	}
+	if rep.Summary.clean() {
+		t.Error("a report with an undeclared service reported a clean gate")
+	}
+	for _, service := range rep.Services {
+		if service.Service != "Branches" {
+			continue
+		}
+		if service.Field != "Branches" || service.Interface != "BranchesServiceInterface" {
+			t.Errorf("Branches field/interface = %q/%q", service.Field, service.Interface)
+		}
+		if service.APIMethods != 2 {
+			t.Errorf("Branches api_methods = %d, want the 2 exported endpoint methods", service.APIMethods)
+		}
+		if !reflect.DeepEqual(service.Packages, []string{"branches"}) {
+			t.Errorf("Branches packages = %v, want [branches]", service.Packages)
+		}
+	}
+}
+
+// TestFixture_GraphQLOperationsAreReportedPerFunction verifies the second rule:
+// both raw-GraphQL forms are found (a direct Do and an interface handed to a
+// helper), each is reported under its enclosing function rather than as one
+// package verdict, and the table's decision rides along.
+func TestFixture_GraphQLOperationsAreReportedPerFunction(t *testing.T) {
+	root := fixtureModule(t, nil)
+	rep := fixtureReport(t, root,
+		map[string]declaration{"Widgets": {coveredGraphQL, "reached over GraphQL"}, "Gadgets": {unwrappedTracked, "not exposed"}},
+		nil,
+		map[string]decision{"widgets.List": {decisionKeep, "the wrapper returns a different shape"}})
+
+	if len(rep.GraphQLOperations) != 3 {
+		t.Fatalf("operations = %+v, want List, Mutate and the helper", rep.GraphQLOperations)
+	}
+	byName := map[string]graphqlOperation{}
+	for _, op := range rep.GraphQLOperations {
+		byName[op.operationKey()] = op
+	}
+	for _, key := range []string{"widgets.List", "widgets.Mutate", "widgets.exec"} {
+		t.Run(key, func(t *testing.T) {
+			op, ok := byName[key]
+			if !ok {
+				t.Fatalf("%s not reported (got %v)", key, rep.GraphQLOperations)
+			}
+			if op.Service != "Widgets" || op.ServiceMethods != 1 {
+				t.Errorf("%s resolved %s/%d, want Widgets/1", key, op.Service, op.ServiceMethods)
+			}
+			if len(op.Sites) == 0 || !strings.HasPrefix(op.Sites[0], "internal/tools/widgets/widgets.go:") {
+				t.Errorf("%s sites = %v, want a repository-relative file:line", key, op.Sites)
+			}
+		})
+	}
+	if op := byName["widgets.List"]; op.Status != statusAdjudicated || op.Decision != decisionKeep {
+		t.Errorf("widgets.List = %s/%s, want adjudicated/KEEP", op.Status, op.Decision)
+	}
+	if op := byName["widgets.Mutate"]; op.Status != statusUnadjudicated || op.Decision != "" {
+		t.Errorf("widgets.Mutate = %s/%s, want unadjudicated with no decision", op.Status, op.Decision)
+	}
+	if rep.Summary.GraphQLAdjudicated != 1 || rep.Summary.GraphQLUnadjudicated != 2 {
+		t.Errorf("graphql summary = %+v, want 1 adjudicated / 2 unadjudicated", rep.Summary)
+	}
+}
+
+// TestFixture_NewUpstreamServiceIsAFinding is the regression this scope was
+// built for: adding a service to the Client struct that nothing calls turns the
+// gate red, where the call-site-derived action scope would have gone on
+// reporting zero gaps.
+func TestFixture_NewUpstreamServiceIsAFinding(t *testing.T) {
+	withNewService := strings.Replace(fixtureSDK,
+		"	Gadgets   GadgetsServiceInterface\n",
+		"	Gadgets   GadgetsServiceInterface\n	Sprockets SprocketsServiceInterface\n", 1)
+	withNewService += `
+type SprocketsServiceInterface interface {
+	ListSprockets(options ...RequestOptionFunc) error
+}
+`
+	root := fixtureModule(t, map[string]string{
+		"gitlab.com/gitlab-org/api/client-go/v2/sdk.go": withNewService,
+	})
+	declaredBy := map[string]declaration{
+		"Widgets": {coveredGraphQL, "reached over GraphQL"},
+		"Gadgets": {unwrappedTracked, "not exposed"},
+	}
+	decisions := map[string]decision{
+		"widgets.List":   {decisionKeep, "kept"},
+		"widgets.Mutate": {decisionKeep, "kept"},
+		"widgets.exec":   {decisionKeep, "kept"},
+	}
+	rep := fixtureReport(t, root, declaredBy, nil, decisions)
+	if statusOf(rep.Services)["Sprockets"] != statusUndeclared {
+		t.Fatalf("new service status = %q, want undeclared", statusOf(rep.Services)["Sprockets"])
+	}
+	if rep.Summary.clean() {
+		t.Error("gate passed with an undeclared upstream service")
+	}
+
+	declaredBy["Sprockets"] = declaration{unwrappedTracked, "tracked elsewhere"}
+	if !fixtureReport(t, root, declaredBy, nil, decisions).Summary.clean() {
+		t.Error("gate still failed after the new service was declared")
+	}
+}
+
+// TestFixture_StaleDeclarationsFailTheGate verifies both stale forms: a
+// declaration for a service the tree now calls, and a decision for an operation
+// that no longer exists. Either one is a claim about code that has moved on.
+func TestFixture_StaleDeclarationsFailTheGate(t *testing.T) {
+	root := fixtureModule(t, nil)
+	rep := fixtureReport(t, root,
+		map[string]declaration{
+			"Branches": {coveredRaw, "stale: branches is called directly"},
+			"Removed":  {coveredRaw, "stale: no such service upstream"},
+			"Widgets":  {coveredGraphQL, "reached over GraphQL"},
+			"Gadgets":  {unwrappedTracked, "not exposed"},
+		},
+		nil,
+		map[string]decision{"widgets.Gone": {decisionKeep, "stale: no such operation"}})
+
+	want := []string{
+		"graphql widgets.Gone",
+		"service Branches (now called directly)",
+		"service Removed (no longer declared by client-go)",
+	}
+	if !reflect.DeepEqual(rep.StaleDeclarations, want) {
+		t.Errorf("stale = %v, want %v", rep.StaleDeclarations, want)
+	}
+	if rep.Summary.StaleDeclarations != 3 || rep.Summary.clean() {
+		t.Errorf("summary = %+v, want 3 stale declarations and a failing gate", rep.Summary)
+	}
+}
+
+// TestFixture_MissingClientGoPieces_AbortTheRun verifies the two structural
+// preconditions fail loudly rather than reporting an empty, passing audit: a
+// module with no client-go in its import graph, and one whose SDK declares no
+// GraphQL interface.
+func TestFixture_MissingClientGoPieces_AbortTheRun(t *testing.T) {
+	t.Run("no_client_go_in_the_import_graph", func(t *testing.T) {
+		root := t.TempDir()
+		writeFiles(t, root, map[string]string{
+			"go.mod":                        "module example.com/plain\n\ngo 1.27\n",
+			"internal/tools/alpha/alpha.go": "package alpha\n\nfunc A() int { return 1 }\n",
+		})
+		if _, _, err := Run(root, true); err == nil || !strings.Contains(err.Error(), "client-go root package not found") {
+			t.Fatalf("Run = %v, want a missing client-go error", err)
+		}
+	})
+
+	t.Run("sdk_without_a_graphql_interface", func(t *testing.T) {
+		root := fixtureModule(t, map[string]string{
+			"gitlab.com/gitlab-org/api/client-go/v2/sdk.go": strings.NewReplacer(
+				"GraphQLInterface", "QueryRunner",
+				"GraphQL   QueryRunner", "Runner    QueryRunner",
+			).Replace(fixtureSDK),
+			"internal/tools/widgets/widgets.go": "package widgets\n\nfunc Nothing() {}\n",
+		})
+		if _, _, err := Run(root, true); err == nil || !strings.Contains(err.Error(), "GraphQLInterface not found") {
+			t.Fatalf("Run = %v, want a missing GraphQLInterface error", err)
+		}
+	})
+}
+
+// TestRun_Repository_GateIsGreenAndShapeIsStable runs the real repository
+// through the command-facing entry point: the gate passes with the committed
+// tables, the JSON carries the shared header and a trailing newline, and
+// -gaps-only leaves the finding lists empty because there are none.
+func TestRun_Repository_GateIsGreenAndShapeIsStable(t *testing.T) {
+	root, err := cmdutil.RepositoryRoot(".")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	content, clean, err := Run(root, true)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !clean {
+		t.Errorf("SDK parity gate is red; run `make audit-1to1-sdk`:\n%s", content)
+	}
+	if !strings.HasSuffix(string(content), "}\n") {
+		t.Error("report lacks the trailing newline")
+	}
+	var rep report
+	if unmarshalErr := json.Unmarshal(content, &rep); unmarshalErr != nil {
+		t.Fatalf("report is not JSON: %v", unmarshalErr)
+	}
+	if rep.SchemaVersion != shared.SchemaVersion || rep.ClientGoPath != shared.ClientGoPkgPath {
+		t.Errorf("report header = %d/%q, want %d/%q", rep.SchemaVersion, rep.ClientGoPath, shared.SchemaVersion, shared.ClientGoPkgPath)
+	}
+	if len(rep.Services) != 0 || len(rep.GraphQLOperations) != 0 {
+		t.Errorf("gaps-only report kept %d services and %d operations, want none", len(rep.Services), len(rep.GraphQLOperations))
+	}
+	if rep.Summary.SDKServices != rep.Summary.ServicesCovered+rep.Summary.ServicesDeclared+rep.Summary.ServicesUndeclared {
+		t.Errorf("service statuses do not add up: %+v", rep.Summary)
+	}
+	if rep.Summary.SDKServices < 100 {
+		t.Errorf("sdk_services = %d, want the SDK's full service surface", rep.Summary.SDKServices)
+	}
+}
+
+// TestBuildReport_Repository_ListsEveryServiceAndIsDeterministic verifies the
+// full (non gaps-only) report against the repository: every service carries a
+// status, a declared one carries its category and reason, and two runs agree.
+func TestBuildReport_Repository_ListsEveryServiceAndIsDeterministic(t *testing.T) {
+	root, err := cmdutil.RepositoryRoot(".")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	first, err := buildReport(root, false)
+	if err != nil {
+		t.Fatalf("buildReport: %v", err)
+	}
+	if len(first.Services) != first.Summary.SDKServices {
+		t.Fatalf("listed %d services, summary says %d", len(first.Services), first.Summary.SDKServices)
+	}
+	var prev string
+	for _, service := range first.Services {
+		if service.Service < prev {
+			t.Errorf("services not sorted: %q before %q", prev, service.Service)
+		}
+		prev = service.Service
+		if service.Status == statusDeclared && (service.Category == "" || service.Reason == "") {
+			t.Errorf("declared service %s has no category or reason", service.Service)
+		}
+		if service.Status == statusCovered && len(service.Packages) == 0 {
+			t.Errorf("covered service %s names no referencing package", service.Service)
+		}
+	}
+	for _, op := range first.GraphQLOperations {
+		if op.Status != statusAdjudicated {
+			t.Errorf("operation %s is not adjudicated", op.operationKey())
+		}
+		if op.Decision == "" || op.Reason == "" {
+			t.Errorf("operation %s carries no decision or reason", op.operationKey())
+		}
+	}
+
+	second, err := buildReport(root, false)
+	if err != nil {
+		t.Fatalf("second buildReport: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Error("buildReport is not deterministic across runs")
+	}
+}
+
+// TestRun_MissingRoot_Fails verifies a root the loader cannot enter aborts the
+// run and reports the gate as failed rather than clean.
+func TestRun_MissingRoot_Fails(t *testing.T) {
+	content, clean, err := Run(filepath.Join(t.TempDir(), "absent"), true)
+	if err == nil || !strings.Contains(err.Error(), "load packages") {
+		t.Fatalf("Run on a missing root = %v, want a load error", err)
+	}
+	if clean || content != nil {
+		t.Errorf("failed run returned clean=%v content=%d bytes, want false and nil", clean, len(content))
+	}
+}

--- a/cmd/audit_1to1/internal/sdk/decisions.go
+++ b/cmd/audit_1to1/internal/sdk/decisions.go
@@ -1,0 +1,140 @@
+package sdk
+
+// Service declaration categories. The first four mirror the vocabulary
+// acceptedMissingMethods already uses one level up, so a reader who knows the
+// method table can read this one; the last two are service-level only.
+const (
+	// coveredRaw: reached through client.GL().NewRequest + Do rather than the
+	// wrapper, for a reason the handler documents.
+	coveredRaw = "COVERED_RAW"
+	// coveredGeneric: the wrapper's methods are passed as VALUES into a generic
+	// helper, so they are calls the call-expression scanner cannot see.
+	coveredGeneric = "COVERED_GENERIC"
+	// coveredGraphQL: the domain is reached over GraphQL (ADR-0006). The
+	// decision about whether that is still right lives in graphqlDecisions,
+	// per operation.
+	coveredGraphQL = "COVERED_GRAPHQL"
+	// supersededUpstream: the service wraps an API GitLab has replaced, and we
+	// call the replacement's service instead.
+	supersededUpstream = "SUPERSEDED_UPSTREAM"
+	// unwrappedTracked: genuinely not exposed, with an issue that says so.
+	unwrappedTracked = "UNWRAPPED_TRACKED"
+)
+
+// certificateClusters is the shared reason behind the three cluster services.
+// GitLab removed the certificate-based Kubernetes integration outright, so the
+// group, instance and project wrappers over it are all superseded by the same
+// replacement and carry the same evidence.
+const certificateClusters = "certificate-based cluster integration, marked upstream 'Deprecated: in GitLab 14.5, to be removed in 19.0' and removed by GitLab; internal/tools/clusteragents calls ClusterAgents instead"
+
+// declaration adjudicates one client-go service no handler calls.
+type declaration struct {
+	Category string
+	Reason   string
+}
+
+// declaredServices adjudicates the client-go services no handler calls. Every
+// service on the Client struct is either called or listed here; anything else
+// is a finding, which is the check that would have caught WorkItemSavedViews on
+// the version bump instead of after it.
+//
+// Keys are bare service names (the interface name without its ServiceInterface
+// suffix), NOT Client struct field names. The two differ often enough that
+// writing the table against fields invents services: Boards and Avatar are
+// fields over IssueBoards and AvatarRequests, both of which handlers call
+// directly, so listing them here as exceptions would describe a gap that does
+// not exist.
+var declaredServices = map[string]declaration{
+	// COVERED_RAW
+	"ApplicationStatistics": {coveredRaw, "internal/tools/appstatistics.Get issues a raw GET application/statistics: client-go's ApplicationStatistics declares int64 fields and some GitLab versions answer with string-encoded numbers, so the wrapper cannot decode a successful response. Recorded in docs/development/upstream-bugs.md"},
+	"GroupEpicBoards":       {coveredRaw, "internal/tools/groupepicboards issues raw GETs for groups/:id/epic_boards and .../:board_id: the wrapper's GroupEpicBoard type omits documented response fields (hide_backlog_list, hide_closed_list, labels, lists), and the raw request decodes the full documented shape"},
+
+	// COVERED_GENERIC
+	"Invites": {coveredGeneric, "internal/tools/invites passes all four methods as method VALUES into generic list/invite helpers (ListPendingProjectInvitations, ListPendingGroupInvitations, ProjectInvites, GroupInvites), which is a call the call-expression scanner cannot see"},
+
+	// COVERED_GRAPHQL — see graphqlDecisions for the per-operation decision.
+	"EpicIssues":             {coveredGraphQL, "internal/tools/epicissues drives the work-item hierarchy widget over GraphQL. The interface itself is documented upstream as 'Will be removed in v5 of the API, use Work Items API instead'"},
+	"ProjectVulnerabilities": {coveredGraphQL, "internal/tools/vulnerabilities queries and mutates vulnerabilities over GraphQL, which is what the interface's own upstream doc comment directs to: 'Deprecated: use GraphQL Query.vulnerabilities instead'"},
+	"SecurityAttributes":     {coveredGraphQL, "internal/tools/securityattributes issues the securityAttribute* mutations directly; the wrapper is itself a GraphQL wrapper over the same mutations, so this is a migration rather than a gap (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"SecurityCategories":     {coveredGraphQL, "internal/tools/securitycategories issues the securityCategory* mutations directly; the wrapper is itself a GraphQL wrapper over the same mutations, so this is a migration rather than a gap (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+
+	// SUPERSEDED_UPSTREAM
+	"GeoNodes":         {supersededUpstream, "upstream marks it 'Deprecated: will be removed in v5 of the API, use Geo Sites API instead'; internal/tools/geo calls GeoSites for all eight operations"},
+	"GroupClusters":    {supersededUpstream, certificateClusters},
+	"InstanceClusters": {supersededUpstream, certificateClusters},
+	"ProjectClusters":  {supersededUpstream, certificateClusters},
+
+	// UNWRAPPED_TRACKED
+	"SecurityDependencyFirewall": {unwrappedTracked, "EvaluatePackage is genuinely unexposed; tracked in https://github.com/jmrplens/gitlab-mcp-server/issues/429"},
+}
+
+// GraphQL operation decisions.
+const (
+	// decisionKeep: raw GraphQL stays, and the reason says why the wrapper's
+	// existence does not retire the exemption.
+	decisionKeep = "KEEP"
+	// decisionMigrate: the wrapper covers the call and the operation should
+	// move to it; the reason names where that is tracked.
+	decisionMigrate = "MIGRATE"
+)
+
+// decision adjudicates one raw-GraphQL operation whose domain now has a
+// client-go service wrapper.
+type decision struct {
+	Decision string
+	Reason   string
+}
+
+// graphqlServiceAliases maps a tool package to the client-go service covering
+// its domain where the two spellings differ. Without it the rule only sees the
+// cases whose package name happens to equal the service name, which is how a
+// domain as central as vulnerabilities would go unexamined.
+//
+// Deliberately absent: epicnotes, epicdiscussions and epicworkitems. Their
+// GraphQL handlers do have SDK counterparts on Notes and Discussions, but
+// those are per-METHOD gaps on services other packages call, and they are
+// already adjudicated as COVERED_GRAPHQL in acceptedMissingMethods one level
+// up. Aliasing them here would restate an existing decision in a second table,
+// and two tables that can disagree about the same fact are worse than one.
+var graphqlServiceAliases = map[string]string{
+	"vulnerabilities": "ProjectVulnerabilities",
+}
+
+// graphqlDecisions adjudicates the raw-GraphQL operations whose domain has a
+// client-go service, keyed "<package>.<function>". ADR-0006 admits raw
+// GraphQL.Do() for domains WITHOUT a wrapper, so the wrapper appearing later is
+// what retires the exemption. Nothing checked for that, which made the
+// exemption permanent in practice; this table is where it stops being.
+//
+// The unit is the operation, not the package: several packages use GraphQL for
+// one operation and the SDK for the rest, and a package-level verdict would be
+// mostly noise.
+var graphqlDecisions = map[string]decision{
+	// KEEP — the wrapper exists but wraps an API upstream has deprecated in
+	// favor of the very GraphQL these handlers call, so migrating would move
+	// us onto the path GitLab is removing.
+	"epicissues.List":        {decisionKeep, "EpicIssues is documented upstream as 'Will be removed in v5 of the API, use Work Items API instead'; the handler reads the work-item hierarchy widget, which is that replacement"},
+	"epicissues.Assign":      {decisionKeep, "EpicIssues.AssignEpicIssue drives the epic REST API being removed; the handler uses the workItemUpdate hierarchy mutation instead"},
+	"epicissues.Remove":      {decisionKeep, "EpicIssues.RemoveEpicIssue drives the epic REST API being removed; the handler uses the workItemUpdate hierarchy mutation instead"},
+	"epicissues.UpdateOrder": {decisionKeep, "EpicIssues.UpdateEpicIssueAssignment drives the epic REST API being removed; child ordering is a work-item hierarchy mutation"},
+
+	"vulnerabilities.List":                     {decisionKeep, "ProjectVulnerabilities is documented upstream as 'Deprecated: use GraphQL Query.vulnerabilities instead', which is precisely what this handler does"},
+	"vulnerabilities.Get":                      {decisionKeep, "same deprecation; the wrapper has no single-vulnerability read at all, only ListProjectVulnerabilities and CreateVulnerability"},
+	"vulnerabilities.SeverityCount":            {decisionKeep, "severity counts are a GraphQL aggregate (vulnerabilitySeveritiesCount) with no REST or wrapper equivalent"},
+	"vulnerabilities.PipelineSecuritySummary":  {decisionKeep, "the pipeline security report summary is GraphQL-only; the wrapper exposes nothing pipeline-scoped"},
+	"vulnerabilities.runVulnerabilityMutation": {decisionKeep, "dismiss/confirm/resolve/revert are GraphQL mutations; the wrapper exposes only CreateVulnerability"},
+
+	// MIGRATE — the wrapper covers the same call, so ADR-0006's exemption is
+	// spent. Tracked in https://github.com/jmrplens/gitlab-mcp-server/issues/430.
+	"workitems.List": {decisionMigrate, "WorkItems.ListWorkItems issues the same namespace workItems query, accepts a superset of the handler's filters and returns the same cursor pagination through Response.PageInfo; internal/tools/epics already calls it (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+
+	"securityattributes.createSecurityAttributes":       {decisionMigrate, "SecurityAttributes.CreateSecurityAttributes wraps the same securityAttributeCreate mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securityattributes.updateSecurityAttribute":        {decisionMigrate, "SecurityAttributes.UpdateSecurityAttribute wraps the same securityAttributeUpdate mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securityattributes.destroySecurityAttribute":       {decisionMigrate, "SecurityAttributes.DestroySecurityAttribute wraps the same securityAttributeDestroy mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securityattributes.projectUpdateSecurityAttribute": {decisionMigrate, "SecurityAttributes.ProjectUpdateSecurityAttribute wraps the same securityAttributeProjectUpdate mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securityattributes.bulkUpdateSecurityAttributes":   {decisionMigrate, "SecurityAttributes.BulkUpdateSecurityAttributes wraps the same bulkUpdateSecurityAttributes mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+
+	"securitycategories.createSecurityCategory":  {decisionMigrate, "SecurityCategories.CreateSecurityCategory wraps the same securityCategoryCreate mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securitycategories.updateSecurityCategory":  {decisionMigrate, "SecurityCategories.UpdateSecurityCategory wraps the same securityCategoryUpdate mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+	"securitycategories.destroySecurityCategory": {decisionMigrate, "SecurityCategories.DestroySecurityCategory wraps the same securityCategoryDestroy mutation (https://github.com/jmrplens/gitlab-mcp-server/issues/430)"},
+}

--- a/cmd/audit_1to1/internal/sdk/decisions_test.go
+++ b/cmd/audit_1to1/internal/sdk/decisions_test.go
@@ -1,0 +1,119 @@
+// Tests for the two human-maintained adjudication tables. They check the shape
+// an entry must have, not the judgement it records: a category from the agreed
+// vocabulary, a reason long enough to be evidence rather than a shrug, and keys
+// that name something real. A table nobody can check is how an audit turns into
+// a list of assertions.
+
+package sdk
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
+)
+
+// minReasonLength is the shortest a reason can be and still say why. It is a
+// smell test, not a measurement: "n/a" and "see above" fall under it, every
+// real entry clears it comfortably.
+const minReasonLength = 40
+
+// TestDeclaredServices_Entries_CarryAKnownCategoryAndEvidence verifies every
+// service declaration is well formed: a category from the agreed set, a
+// substantial reason, and a key that is a bare service name rather than a
+// Client struct field or an interface name.
+func TestDeclaredServices_Entries_CarryAKnownCategoryAndEvidence(t *testing.T) {
+	known := map[string]bool{
+		coveredRaw: true, coveredGeneric: true, coveredGraphQL: true,
+		supersededUpstream: true, unwrappedTracked: true,
+	}
+	for service, declared := range declaredServices {
+		t.Run(service, func(t *testing.T) {
+			if !known[declared.Category] {
+				t.Errorf("category %q is not one of the declared categories", declared.Category)
+			}
+			if len(declared.Reason) < minReasonLength {
+				t.Errorf("reason %q is too short to be evidence", declared.Reason)
+			}
+			if strings.HasSuffix(service, "ServiceInterface") {
+				t.Error("key is an interface name; the table is keyed on bare service names")
+			}
+			if strings.TrimSpace(service) != service || service == "" {
+				t.Errorf("key %q is not a bare service name", service)
+			}
+		})
+	}
+}
+
+// TestGraphQLDecisions_Entries_CarryAKnownVerdictAndEvidence verifies every
+// GraphQL decision is well formed and keyed "<package>.<function>".
+func TestGraphQLDecisions_Entries_CarryAKnownVerdictAndEvidence(t *testing.T) {
+	for key, adjudged := range graphqlDecisions {
+		t.Run(key, func(t *testing.T) {
+			if adjudged.Decision != decisionKeep && adjudged.Decision != decisionMigrate {
+				t.Errorf("decision %q is neither %s nor %s", adjudged.Decision, decisionKeep, decisionMigrate)
+			}
+			if len(adjudged.Reason) < minReasonLength {
+				t.Errorf("reason %q is too short to be evidence", adjudged.Reason)
+			}
+			pkg, function, ok := strings.Cut(key, ".")
+			if !ok || pkg == "" || function == "" {
+				t.Errorf("key %q is not <package>.<function>", key)
+			}
+			if strings.ToLower(pkg) != pkg {
+				t.Errorf("key %q does not start with a package name", key)
+			}
+		})
+	}
+}
+
+// TestGraphQLDecisions_Migrations_NameWhereTheyAreTracked verifies a MIGRATE
+// verdict points somewhere, so the audit cannot be left green by writing
+// "should move" and never moving it.
+func TestGraphQLDecisions_Migrations_NameWhereTheyAreTracked(t *testing.T) {
+	for key, adjudged := range graphqlDecisions {
+		if adjudged.Decision != decisionMigrate {
+			continue
+		}
+		t.Run(key, func(t *testing.T) {
+			if !strings.Contains(adjudged.Reason, "://") {
+				t.Errorf("MIGRATE reason %q names no tracking link", adjudged.Reason)
+			}
+		})
+	}
+}
+
+// TestGraphQLServiceAliases_Targets_NameARealSDKService verifies every alias
+// resolves against the SDK this project compiles with. An alias whose target
+// does not exist silently disables the rule for that package, which is exactly
+// the class of blind spot this scope was added to remove.
+func TestGraphQLServiceAliases_Targets_NameARealSDKService(t *testing.T) {
+	root, err := cmdutil.RepositoryRoot(".")
+	if err != nil {
+		t.Fatalf("repository root: %v", err)
+	}
+	pkgs, err := shared.LoadToolPackages(root)
+	if err != nil {
+		t.Fatalf("load packages: %v", err)
+	}
+	clientGo, err := shared.ClientGoTypes(pkgs)
+	if err != nil {
+		t.Fatalf("client-go types: %v", err)
+	}
+	services, err := collectSDKServices(clientGo)
+	if err != nil {
+		t.Fatalf("collectSDKServices: %v", err)
+	}
+	index := serviceIndex(services)
+	for pkg, target := range graphqlServiceAliases {
+		t.Run(pkg+"_to_"+target, func(t *testing.T) {
+			if _, ok := index[target]; !ok {
+				t.Errorf("alias target %q is not a client-go service", target)
+			}
+			if _, sameName := index[strings.ToUpper(pkg[:1])+pkg[1:]]; sameName {
+				t.Errorf("package %q already matches a service by name; the alias is redundant", pkg)
+			}
+		})
+	}
+}

--- a/cmd/audit_1to1/internal/sdk/graphql.go
+++ b/cmd/audit_1to1/internal/sdk/graphql.go
@@ -1,0 +1,215 @@
+package sdk
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+)
+
+// graphqlOperation is one handler (or helper) function that reaches GitLab
+// through the raw GraphQL interface instead of an SDK service wrapper.
+type graphqlOperation struct {
+	// Package is the short internal/tools package name.
+	Package string `json:"package"`
+	// Operation is the enclosing function, the unit ADR-0006 is adjudicated
+	// in: a package that uses GraphQL for one operation and the SDK for the
+	// rest has one entry here, not a whole-package finding.
+	Operation string `json:"operation"`
+	// Service is the client-go service that now covers the same domain, and
+	// whose existence retires the ADR-0006 exemption.
+	Service string `json:"service"`
+	// ServiceMethods is how many endpoint methods that service declares.
+	ServiceMethods int `json:"service_methods"`
+	// Status is adjudicated or unadjudicated.
+	Status string `json:"status"`
+	// Decision and Reason are set for an adjudicated operation.
+	Decision string `json:"decision,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+	// Sites lists the file:line of each raw GraphQL reference in the function.
+	Sites []string `json:"sites"`
+}
+
+// operationKey identifies one adjudicated operation, "<package>.<function>".
+func (o graphqlOperation) operationKey() string { return o.Package + "." + o.Operation }
+
+// graphqlSite is one raw GraphQL reference found in the tree.
+type graphqlSite struct {
+	pkg      string
+	function string
+	position string
+}
+
+// collectGraphQLSites records every place a tool package takes hold of the
+// client-go GraphQL interface: a value of that type, wherever it appears.
+// Matching the VALUE rather than the .Do call is what catches the delegating
+// form, client.GL().GraphQL handed to a helper. internal/toolutil is outside
+// the audited tree, so a handler that delegates its mutation there would
+// otherwise look REST-only.
+func collectGraphQLSites(pkgs []*packages.Package, graphQL *types.Named) []graphqlSite {
+	var sites []graphqlSite
+	for _, pkg := range pkgs {
+		pkgName := shared.ShortPackage(pkg.PkgPath)
+		for _, file := range pkg.Syntax {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				name := functionName(fn)
+				ast.Inspect(fn.Body, func(node ast.Node) bool {
+					expr, isExpr := node.(ast.Expr)
+					if !isExpr || !isGraphQLInterface(pkg.TypesInfo.TypeOf(expr), graphQL) {
+						return true
+					}
+					sites = append(sites, graphqlSite{
+						pkg:      pkgName,
+						function: name,
+						position: relativePosition(pkg, expr.Pos()),
+					})
+					// Stop here: descending into a matched client.GL().GraphQL
+					// would match its own GraphQL identifier again and record
+					// the same reference twice.
+					return false
+				})
+			}
+		}
+	}
+	sort.Slice(sites, func(i, j int) bool {
+		if sites[i].pkg != sites[j].pkg {
+			return sites[i].pkg < sites[j].pkg
+		}
+		if sites[i].function != sites[j].function {
+			return sites[i].function < sites[j].function
+		}
+		return sites[i].position < sites[j].position
+	})
+	return sites
+}
+
+// functionName renders a declaration as it should read in the adjudication
+// table: bare for a function, Receiver.Method for a method.
+func functionName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	return receiverName(fn.Recv.List[0].Type) + "." + fn.Name.Name
+}
+
+func receiverName(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.StarExpr:
+		return receiverName(typed.X)
+	case *ast.IndexExpr:
+		return receiverName(typed.X)
+	case *ast.IndexListExpr:
+		return receiverName(typed.X)
+	case *ast.Ident:
+		return typed.Name
+	default:
+		return "?"
+	}
+}
+
+// isGraphQLInterface reports whether t is the client-go GraphQL interface,
+// through a pointer or directly.
+func isGraphQLInterface(t types.Type, graphQL *types.Named) bool {
+	if t == nil {
+		return false
+	}
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	return ok && named.Obj() == graphQL.Obj()
+}
+
+// relativePosition renders a position as a repository-relative file:line.
+func relativePosition(pkg *packages.Package, pos token.Pos) string {
+	position := pkg.Fset.Position(pos)
+	file := position.Filename
+	if idx := strings.LastIndex(file, "/internal/"); idx >= 0 {
+		file = file[idx+1:]
+	}
+	return fmt.Sprintf("%s:%d", file, position.Line)
+}
+
+// buildGraphQLOperations groups the raw GraphQL sites by enclosing function and
+// keeps those whose package maps to a client-go service, adjudicating each
+// against graphqlDecisions.
+func buildGraphQLOperations(sites []graphqlSite, services map[string]sdkService, aliases map[string]string, decisions map[string]decision) []graphqlOperation {
+	byOperation := map[string]*graphqlOperation{}
+	var order []string
+	for _, site := range sites {
+		service, ok := serviceForPackage(site.pkg, services, aliases)
+		if !ok {
+			continue
+		}
+		key := site.pkg + "." + site.function
+		op, seen := byOperation[key]
+		if !seen {
+			op = &graphqlOperation{
+				Package:        site.pkg,
+				Operation:      site.function,
+				Service:        service.Service,
+				ServiceMethods: service.APIMethods,
+			}
+			byOperation[key] = op
+			order = append(order, key)
+		}
+		op.Sites = append(op.Sites, site.position)
+	}
+	sort.Strings(order)
+	operations := make([]graphqlOperation, 0, len(order))
+	for _, key := range order {
+		op := byOperation[key]
+		if adjudged, ok := decisions[key]; ok {
+			op.Status = statusAdjudicated
+			op.Decision = adjudged.Decision
+			op.Reason = adjudged.Reason
+		} else {
+			op.Status = statusUnadjudicated
+		}
+		operations = append(operations, *op)
+	}
+	return operations
+}
+
+// serviceForPackage resolves the client-go service a tool package corresponds
+// to: the service whose lower-cased name equals the package name, or the one an
+// explicit alias names when the two spellings differ.
+func serviceForPackage(pkgName string, services map[string]sdkService, aliases map[string]string) (sdkService, bool) {
+	if alias, ok := aliases[pkgName]; ok {
+		service, exists := services[alias]
+		return service, exists
+	}
+	for name, service := range services {
+		if strings.EqualFold(name, pkgName) {
+			return service, true
+		}
+	}
+	return sdkService{}, false
+}
+
+// staleGraphQLDecisions lists adjudicated operations that no longer exist, so a
+// decision cannot outlive the code it was written about.
+func staleGraphQLDecisions(operations []graphqlOperation, decisions map[string]decision) []string {
+	live := map[string]struct{}{}
+	for _, op := range operations {
+		live[op.operationKey()] = struct{}{}
+	}
+	var stale []string
+	for key := range decisions {
+		if _, ok := live[key]; !ok {
+			stale = append(stale, "graphql "+key)
+		}
+	}
+	sort.Strings(stale)
+	return stale
+}

--- a/cmd/audit_1to1/internal/sdk/graphql_test.go
+++ b/cmd/audit_1to1/internal/sdk/graphql_test.go
@@ -1,0 +1,185 @@
+// Unit tests for the raw-GraphQL rule: how a declaration is named, how a
+// package resolves to a service, and how sites become adjudicated operations.
+
+package sdk
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+)
+
+// declFrom parses a snippet and returns its last function declaration, so the
+// naming cases read as the Go they are about even when a receiver type has to
+// be declared first.
+func declFrom(t *testing.T, src string) *ast.FuncDecl {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package p\n\n"+src, 0)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	for _, decl := range slices.Backward(file.Decls) {
+		if fn, ok := decl.(*ast.FuncDecl); ok {
+			return fn
+		}
+	}
+	t.Fatalf("%q declares no function", src)
+	return nil
+}
+
+// TestFunctionName_Declarations_NameFunctionsAndMethods verifies the operation
+// key each declaration form produces, including the generic receivers whose
+// type expression is an index rather than a name.
+func TestFunctionName_Declarations_NameFunctionsAndMethods(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{name: "function", src: "func List() {}", want: "List"},
+		{name: "value_receiver", src: "type S struct{}\n\nfunc (s S) List() {}", want: "S.List"},
+		{name: "pointer_receiver", src: "func (s *Service) List() {}", want: "Service.List"},
+		{name: "generic_receiver", src: "func (s *Store[T]) List() {}", want: "Store.List"},
+		{name: "generic_receiver_two_params", src: "func (s Store[K, V]) List() {}", want: "Store.List"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := functionName(declFrom(t, tc.src)); got != tc.want {
+				t.Errorf("functionName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReceiverName_Unexpected_FallsBackRatherThanPanics verifies an unforeseen
+// receiver expression yields a placeholder, so a future Go form cannot crash
+// the audit.
+func TestReceiverName_Unexpected_FallsBackRatherThanPanics(t *testing.T) {
+	if got := receiverName(&ast.BasicLit{Kind: token.INT, Value: "1"}); got != "?" {
+		t.Errorf("receiverName of an unexpected expression = %q, want ?", got)
+	}
+}
+
+// TestIsGraphQLInterface_Types_MatchOnlyThatInterface verifies the type test
+// behind every recorded site: the interface itself, through a pointer, and
+// nothing else.
+func TestIsGraphQLInterface_Types_MatchOnlyThatInterface(t *testing.T) {
+	pkg := types.NewPackage(shared.ClientGoPkgPath+"/v2", "gitlab")
+	named := func(name string) *types.Named {
+		iface := types.NewInterfaceType(nil, nil)
+		iface.Complete()
+		return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), iface, nil)
+	}
+	graphQL := named("GraphQLInterface")
+	cases := []struct {
+		name string
+		typ  types.Type
+		want bool
+	}{
+		{name: "nil", typ: nil, want: false},
+		{name: "basic", typ: types.Typ[types.String], want: false},
+		{name: "other_interface", typ: named("BranchesServiceInterface"), want: false},
+		{name: "the_interface", typ: graphQL, want: true},
+		{name: "pointer_to_it", typ: types.NewPointer(graphQL), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGraphQLInterface(tc.typ, graphQL); got != tc.want {
+				t.Errorf("isGraphQLInterface = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestServiceForPackage_Names_MatchCaseInsensitivelyOrByAlias verifies the
+// package-to-service resolution: a case-insensitive name match, an explicit
+// alias for the spellings that differ, an alias naming a service the SDK does
+// not declare (which resolves to nothing rather than inventing one), and a
+// package with no counterpart.
+func TestServiceForPackage_Names_MatchCaseInsensitivelyOrByAlias(t *testing.T) {
+	services := map[string]sdkService{
+		"WorkItems":              {Service: "WorkItems", APIMethods: 6},
+		"ProjectVulnerabilities": {Service: "ProjectVulnerabilities", APIMethods: 2},
+	}
+	aliases := map[string]string{
+		"vulnerabilities": "ProjectVulnerabilities",
+		"phantom":         "NoSuchService",
+	}
+	cases := []struct {
+		name    string
+		pkg     string
+		want    string
+		wantOK  bool
+		methods int
+	}{
+		{name: "case_insensitive_name_match", pkg: "workitems", want: "WorkItems", wantOK: true, methods: 6},
+		{name: "alias", pkg: "vulnerabilities", want: "ProjectVulnerabilities", wantOK: true, methods: 2},
+		{name: "alias_to_an_absent_service", pkg: "phantom", wantOK: false},
+		{name: "no_counterpart", pkg: "cicatalog", wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, ok := serviceForPackage(tc.pkg, services, aliases)
+			if ok != tc.wantOK {
+				t.Fatalf("serviceForPackage(%q) ok = %v, want %v", tc.pkg, ok, tc.wantOK)
+			}
+			if ok && (service.Service != tc.want || service.APIMethods != tc.methods) {
+				t.Errorf("serviceForPackage(%q) = %+v, want %s/%d", tc.pkg, service, tc.want, tc.methods)
+			}
+		})
+	}
+}
+
+// TestBuildGraphQLOperations_Sites_GroupPerFunctionAndAdjudicate verifies the
+// grouping and the verdict: sites in the same function collapse into one
+// operation carrying every position, a package with no client-go counterpart
+// is dropped rather than reported, and the table's decision decides the status.
+func TestBuildGraphQLOperations_Sites_GroupPerFunctionAndAdjudicate(t *testing.T) {
+	sites := []graphqlSite{
+		{pkg: "workitems", function: "List", position: "internal/tools/workitems/workitems.go:10"},
+		{pkg: "workitems", function: "List", position: "internal/tools/workitems/workitems.go:20"},
+		{pkg: "workitems", function: "Get", position: "internal/tools/workitems/workitems.go:40"},
+		{pkg: "cicatalog", function: "List", position: "internal/tools/cicatalog/cicatalog.go:10"},
+	}
+	services := map[string]sdkService{"WorkItems": {Service: "WorkItems", APIMethods: 6}}
+	decisions := map[string]decision{"workitems.List": {decisionMigrate, "the wrapper covers it"}}
+
+	got := buildGraphQLOperations(sites, services, nil, decisions)
+	want := []graphqlOperation{
+		{
+			Package: "workitems", Operation: "Get", Service: "WorkItems", ServiceMethods: 6,
+			Status: statusUnadjudicated,
+			Sites:  []string{"internal/tools/workitems/workitems.go:40"},
+		},
+		{
+			Package: "workitems", Operation: "List", Service: "WorkItems", ServiceMethods: 6,
+			Status: statusAdjudicated, Decision: decisionMigrate, Reason: "the wrapper covers it",
+			Sites: []string{"internal/tools/workitems/workitems.go:10", "internal/tools/workitems/workitems.go:20"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildGraphQLOperations = %+v, want %+v", got, want)
+	}
+}
+
+// TestStaleGraphQLDecisions_Keys_ReportDecisionsWithoutAnOperation verifies a
+// decision whose operation is gone is reported, and one still matching an
+// operation is not.
+func TestStaleGraphQLDecisions_Keys_ReportDecisionsWithoutAnOperation(t *testing.T) {
+	operations := []graphqlOperation{{Package: "workitems", Operation: "List"}}
+	decisions := map[string]decision{
+		"workitems.List":   {decisionMigrate, "still there"},
+		"workitems.Gone":   {decisionKeep, "the function was removed"},
+		"removed.Anything": {decisionKeep, "the package was removed"},
+	}
+	want := []string{"graphql removed.Anything", "graphql workitems.Gone"}
+	if got := staleGraphQLDecisions(operations, decisions); !reflect.DeepEqual(got, want) {
+		t.Errorf("staleGraphQLDecisions = %v, want %v", got, want)
+	}
+}

--- a/cmd/audit_1to1/internal/sdk/services.go
+++ b/cmd/audit_1to1/internal/sdk/services.go
@@ -1,0 +1,120 @@
+package sdk
+
+import (
+	"go/types"
+	"sort"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+)
+
+// sdkService is one service the client-go Client struct declares, held against
+// the decision every service owes: covered by a call, or declared an exception.
+type sdkService struct {
+	// Service is the bare service name, e.g. Branches.
+	Service string `json:"service"`
+	// Field is the Client struct field that publishes it. It differs from the
+	// service name often enough (Boards is IssueBoards, GroupCluster is
+	// GroupClusters) that reading the exception table against field names
+	// invents services that do not exist.
+	Field string `json:"field"`
+	// Interface is the declared interface type name.
+	Interface string `json:"interface"`
+	// APIMethods is how many endpoint methods it declares.
+	APIMethods int `json:"api_methods"`
+	// Status is covered, declared or undeclared.
+	Status string `json:"status"`
+	// Category and Reason are set for a declared exception.
+	Category string `json:"category,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+	// Packages lists the internal/tools packages that call it, when covered.
+	Packages []string `json:"packages,omitempty"`
+}
+
+// collectSDKServices enumerates every service the client-go Client struct
+// declares. Reading the universe from the struct rather than from our own call
+// sites is the whole point of this scope: a service nothing references never
+// entered the call-site map, so an entire new upstream service could be added
+// and audited as zero gaps.
+func collectSDKServices(clientGo *types.Package) ([]sdkService, error) {
+	st, err := shared.ClientStruct(clientGo)
+	if err != nil {
+		return nil, err
+	}
+	var services []sdkService
+	for field := range st.Fields() {
+		if !field.Exported() {
+			continue
+		}
+		named, ok := shared.ClientGoServiceInterface(field.Type())
+		if !ok {
+			continue
+		}
+		services = append(services, sdkService{
+			Service:    shared.ServiceName(named),
+			Field:      field.Name(),
+			Interface:  named.Obj().Name(),
+			APIMethods: len(shared.APIMethodNames(named)),
+		})
+	}
+	sort.Slice(services, func(i, j int) bool { return services[i].Service < services[j].Service })
+	return services, nil
+}
+
+// adjudicateServices assigns every enumerated service its status from the
+// call-site universe and the declared-exception table. The table is a
+// parameter rather than the package global so a test can state the whole
+// universe it is asserting about.
+func adjudicateServices(services []sdkService, usage map[string]*shared.ServiceUsage, declaredBy map[string]declaration) []sdkService {
+	out := make([]sdkService, 0, len(services))
+	for _, service := range services {
+		if use, called := usage[service.Interface]; called {
+			service.Status = statusCovered
+			service.Packages = shared.SortedSet(use.Packages)
+			out = append(out, service)
+			continue
+		}
+		if declared, ok := declaredBy[service.Service]; ok {
+			service.Status = statusDeclared
+			service.Category = declared.Category
+			service.Reason = declared.Reason
+			out = append(out, service)
+			continue
+		}
+		service.Status = statusUndeclared
+		out = append(out, service)
+	}
+	return out
+}
+
+// staleServiceDeclarations lists declared exceptions that no longer apply: a
+// service our code now calls, or one upstream has removed. Either way the
+// declaration is a claim about code that has moved on, and leaving it in place
+// is how a table stops describing reality.
+func staleServiceDeclarations(services []sdkService, declaredBy map[string]declaration) []string {
+	byName := map[string]sdkService{}
+	for _, service := range services {
+		byName[service.Service] = service
+	}
+	var stale []string
+	for name := range declaredBy {
+		service, exists := byName[name]
+		switch {
+		case !exists:
+			stale = append(stale, "service "+name+" (no longer declared by client-go)")
+		case service.Status == statusCovered:
+			stale = append(stale, "service "+name+" (now called directly)")
+		}
+	}
+	sort.Strings(stale)
+	return stale
+}
+
+// serviceIndex keys the enumerated services by bare name, for the GraphQL rule's
+// package-to-service lookup.
+func serviceIndex(services []sdkService) map[string]sdkService {
+	index := make(map[string]sdkService, len(services))
+	for _, service := range services {
+		index[service.Service] = service
+	}
+	return index
+}

--- a/cmd/audit_1to1/internal/sdk/services_test.go
+++ b/cmd/audit_1to1/internal/sdk/services_test.go
@@ -1,0 +1,90 @@
+// Unit tests for the service universe: how a Client struct field becomes a
+// service entry, how a status is assigned, and when a declaration goes stale.
+
+package sdk
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/shared"
+)
+
+// TestAdjudicateServices_Statuses_PreferCallsOverDeclarations verifies the
+// order the three statuses are decided in: a call wins over a declaration
+// (which is what makes such a declaration stale rather than authoritative), a
+// declaration carries its category and reason through, and anything else is
+// the finding.
+func TestAdjudicateServices_Statuses_PreferCallsOverDeclarations(t *testing.T) {
+	services := []sdkService{
+		{Service: "Branches", Interface: "BranchesServiceInterface"},
+		{Service: "Widgets", Interface: "WidgetsServiceInterface"},
+		{Service: "Gadgets", Interface: "GadgetsServiceInterface"},
+		{Service: "Sprockets", Interface: "SprocketsServiceInterface"},
+	}
+	usage := map[string]*shared.ServiceUsage{
+		"BranchesServiceInterface": {Packages: map[string]struct{}{"tags": {}, "branches": {}}},
+		"WidgetsServiceInterface":  {Packages: map[string]struct{}{"widgets": {}}},
+	}
+	declaredBy := map[string]declaration{
+		"Widgets": {coveredRaw, "declared even though it is called"},
+		"Gadgets": {unwrappedTracked, "tracked in an issue"},
+	}
+
+	got := adjudicateServices(services, usage, declaredBy)
+	want := []sdkService{
+		{Service: "Branches", Interface: "BranchesServiceInterface", Status: statusCovered, Packages: []string{"branches", "tags"}},
+		{Service: "Widgets", Interface: "WidgetsServiceInterface", Status: statusCovered, Packages: []string{"widgets"}},
+		{Service: "Gadgets", Interface: "GadgetsServiceInterface", Status: statusDeclared, Category: unwrappedTracked, Reason: "tracked in an issue"},
+		{Service: "Sprockets", Interface: "SprocketsServiceInterface", Status: statusUndeclared},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("adjudicateServices = %+v, want %+v", got, want)
+	}
+}
+
+// TestStaleServiceDeclarations_Cases_NameBothWaysADeclarationExpires verifies
+// the two ways a declaration stops describing reality, and that a declaration
+// still doing its job is not reported.
+func TestStaleServiceDeclarations_Cases_NameBothWaysADeclarationExpires(t *testing.T) {
+	services := []sdkService{
+		{Service: "Branches", Status: statusCovered},
+		{Service: "Gadgets", Status: statusDeclared},
+		{Service: "Sprockets", Status: statusUndeclared},
+	}
+	declaredBy := map[string]declaration{
+		"Branches": {coveredRaw, "now called directly"},
+		"Gadgets":  {unwrappedTracked, "still not exposed"},
+		"Removed":  {coveredRaw, "upstream dropped the service"},
+	}
+	want := []string{
+		"service Branches (now called directly)",
+		"service Removed (no longer declared by client-go)",
+	}
+	if got := staleServiceDeclarations(services, declaredBy); !reflect.DeepEqual(got, want) {
+		t.Errorf("staleServiceDeclarations = %v, want %v", got, want)
+	}
+	if got := staleServiceDeclarations(services, nil); got != nil {
+		t.Errorf("staleServiceDeclarations with no table = %v, want nil", got)
+	}
+}
+
+// TestServiceIndex_Names_KeysByBareServiceName verifies the lookup the GraphQL
+// rule resolves a package against is keyed on the bare service name, not the
+// interface or the struct field.
+func TestServiceIndex_Names_KeysByBareServiceName(t *testing.T) {
+	index := serviceIndex([]sdkService{
+		{Service: "IssueBoards", Field: "Boards", Interface: "IssueBoardsServiceInterface", APIMethods: 7},
+	})
+	service, ok := index["IssueBoards"]
+	if !ok || service.APIMethods != 7 {
+		t.Fatalf("index[IssueBoards] = %+v, %v", service, ok)
+	}
+	for _, absent := range []string{"Boards", "IssueBoardsServiceInterface"} {
+		t.Run(absent, func(t *testing.T) {
+			if _, found := index[absent]; found {
+				t.Errorf("index is keyed on %q, want the bare service name only", absent)
+			}
+		})
+	}
+}

--- a/cmd/audit_1to1/internal/shared/clientgo.go
+++ b/cmd/audit_1to1/internal/shared/clientgo.go
@@ -1,0 +1,253 @@
+package shared
+
+import (
+	"errors"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	// requestOptionMarker is the variadic tail every client-go REST endpoint
+	// carries, and the only reliable way to tell an endpoint method apart from
+	// a helper on the same interface.
+	requestOptionMarker = "RequestOptionFunc"
+
+	// serviceInterfaceSuffix is stripped from an interface name to get the bare
+	// service key both the method adjudication table and the SDK service
+	// universe are written in.
+	serviceInterfaceSuffix = "ServiceInterface"
+
+	// clientStructName is the client-go entry point whose fields declare the
+	// complete service surface.
+	clientStructName = "Client"
+
+	// graphQLInterfaceName is the client-go interface a raw GraphQL call goes
+	// through. Its absence means the SDK renamed it and the GraphQL rule would
+	// otherwise silently find nothing.
+	graphQLInterfaceName = "GraphQLInterface"
+
+	// sdkPrefix opens every structural-lookup failure, so the reader knows the
+	// missing declaration is upstream's rather than this repository's.
+	sdkPrefix = "client-go "
+)
+
+// ServiceUsage accumulates, for one client-go service interface, the set of
+// methods called and the internal/tools packages that reference it.
+type ServiceUsage struct {
+	// Named is the client-go service interface itself.
+	Named *types.Named
+	// Called holds the method names our handlers invoke on it.
+	Called map[string]struct{}
+	// Packages holds the short internal/tools package names that reference it.
+	Packages map[string]struct{}
+}
+
+// Service returns the bare service name for this usage entry.
+func (u *ServiceUsage) Service() string { return ServiceName(u.Named) }
+
+// ServiceName returns the bare service name of a client-go service interface:
+// the interface name without its ServiceInterface suffix (so
+// BranchesServiceInterface is Branches). Interfaces that do not carry the
+// suffix, such as GraphQLInterface, keep their name.
+func ServiceName(named *types.Named) string {
+	return strings.TrimSuffix(named.Obj().Name(), serviceInterfaceSuffix)
+}
+
+// CollectServiceUsage walks every call expression in pkgs and records calls
+// whose receiver type is a client-go service interface, keyed by interface
+// name. It is the call-site universe shared by the action-coverage scope
+// (which methods of a used service are uncovered) and the SDK scope (which of
+// the SDK's declared services are referenced at all), so the two cannot
+// disagree about what "we call this" means.
+func CollectServiceUsage(pkgs []*packages.Package) map[string]*ServiceUsage {
+	usage := map[string]*ServiceUsage{}
+	for _, pkg := range pkgs {
+		collectPackageUsage(pkg, usage)
+	}
+	return usage
+}
+
+func collectPackageUsage(pkg *packages.Package, usage map[string]*ServiceUsage) {
+	pkgName := ShortPackage(pkg.PkgPath)
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			named, ok := ClientGoServiceInterface(pkg.TypesInfo.TypeOf(sel.X))
+			if !ok {
+				return true
+			}
+			use := usageFor(usage, named)
+			use.Called[sel.Sel.Name] = struct{}{}
+			use.Packages[pkgName] = struct{}{}
+			return true
+		})
+	}
+}
+
+func usageFor(usage map[string]*ServiceUsage, named *types.Named) *ServiceUsage {
+	key := named.Obj().Name()
+	use, ok := usage[key]
+	if !ok {
+		use = &ServiceUsage{Named: named, Called: map[string]struct{}{}, Packages: map[string]struct{}{}}
+		usage[key] = use
+	}
+	return use
+}
+
+// ClientGoServiceInterface returns the named interface if t is a client-go
+// service interface (e.g. BranchesServiceInterface).
+func ClientGoServiceInterface(t types.Type) (*types.Named, bool) {
+	if t == nil {
+		return nil, false
+	}
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return nil, false
+	}
+	if _, isIface := named.Underlying().(*types.Interface); !isIface {
+		return nil, false
+	}
+	return named, IsClientGoObject(named.Obj())
+}
+
+// IsClientGoObject reports whether obj is declared in the client-go module.
+func IsClientGoObject(obj *types.TypeName) bool {
+	return obj != nil && obj.Pkg() != nil && strings.Contains(obj.Pkg().Path(), ClientGoPkgPath)
+}
+
+// APIMethodNames returns the exported methods of a client-go service interface
+// whose signature ends in a variadic ...RequestOptionFunc (the REST endpoint
+// marker).
+func APIMethodNames(named *types.Named) []string {
+	iface, ok := named.Underlying().(*types.Interface)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for method := range iface.Methods() {
+		if !method.Exported() {
+			continue
+		}
+		if sig, isSig := method.Type().(*types.Signature); isSig && SignatureIsAPICall(sig) {
+			names = append(names, method.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SignatureIsAPICall reports whether sig is a client-go endpoint call, i.e. a
+// variadic signature whose tail is a slice of a client-go RequestOptionFunc.
+func SignatureIsAPICall(sig *types.Signature) bool {
+	if !sig.Variadic() || sig.Params().Len() == 0 {
+		return false
+	}
+	last := sig.Params().At(sig.Params().Len() - 1)
+	slice, ok := last.Type().(*types.Slice)
+	if !ok {
+		return false
+	}
+	named, ok := slice.Elem().(*types.Named)
+	if !ok {
+		return false
+	}
+	if !IsClientGoObject(named.Obj()) {
+		return false
+	}
+	return strings.Contains(named.Obj().Name(), requestOptionMarker)
+}
+
+// ClientGoTypes returns the type information for the client-go root package,
+// found through the import graph of the already-loaded tool packages. Reading
+// it from that graph rather than loading it again guarantees the SDK surface
+// audited is the one the handlers actually compile against.
+func ClientGoTypes(pkgs []*packages.Package) (*types.Package, error) {
+	for _, pkg := range pkgs {
+		for path, imported := range pkg.Imports {
+			if !strings.Contains(path, ClientGoPkgPath) || imported.Types == nil {
+				continue
+			}
+			if clientStructType(imported.Types) != nil {
+				return imported.Types, nil
+			}
+		}
+	}
+	return nil, errors.New(sdkPrefix + "root package not found in the tool packages' import graph")
+}
+
+// ClientStruct returns the fields of the client-go Client struct, which declare
+// the SDK's complete service surface.
+func ClientStruct(clientGo *types.Package) (*types.Struct, error) {
+	st := clientStructType(clientGo)
+	if st == nil {
+		return nil, errors.New(sdkPrefix + clientStructName + " struct not found")
+	}
+	return st, nil
+}
+
+func clientStructType(pkg *types.Package) *types.Struct {
+	obj := pkg.Scope().Lookup(clientStructName)
+	if obj == nil {
+		return nil
+	}
+	st, ok := obj.Type().Underlying().(*types.Struct)
+	if !ok {
+		return nil
+	}
+	return st
+}
+
+// GraphQLInterface returns the client-go interface every raw GraphQL call goes
+// through. It is an error for it to be absent: without it the GraphQL rule
+// would report nothing and read as passing.
+func GraphQLInterface(clientGo *types.Package) (*types.Named, error) {
+	obj := clientGo.Scope().Lookup(graphQLInterfaceName)
+	if obj == nil {
+		return nil, errors.New(sdkPrefix + graphQLInterfaceName + " not found")
+	}
+	named, ok := obj.Type().(*types.Named)
+	if !ok {
+		return nil, errors.New(sdkPrefix + graphQLInterfaceName + " is not a named type")
+	}
+	if _, isIface := named.Underlying().(*types.Interface); !isIface {
+		return nil, errors.New(sdkPrefix + graphQLInterfaceName + " is not an interface")
+	}
+	return named, nil
+}
+
+// ShortPackage reduces a package path to the internal/tools domain name it
+// carries, falling back to the last path element outside that tree.
+func ShortPackage(pkgPath string) string {
+	_, after, ok := strings.Cut(pkgPath, ToolsPkgInfix)
+	if !ok {
+		if last := strings.LastIndex(pkgPath, "/"); last >= 0 {
+			return pkgPath[last+1:]
+		}
+		return pkgPath
+	}
+	return after
+}
+
+// SortedSet converts a set to a sorted slice, never nil.
+func SortedSet(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/audit_1to1/internal/shared/clientgo_test.go
+++ b/cmd/audit_1to1/internal/shared/clientgo_test.go
@@ -1,0 +1,393 @@
+// Tests for the client-go type resolution the audit scopes share: which
+// receiver is a service interface, which method is a REST endpoint, and how a
+// package path reduces to a domain name.
+
+package shared
+
+import (
+	"go/token"
+	"go/types"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestShortPackage_ExtractsDomain verifies the internal/tools domain extraction
+// and its fallbacks for paths outside the tools tree.
+func TestShortPackage_ExtractsDomain(t *testing.T) {
+	cases := map[string]string{
+		"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/branches": "branches",
+		"github.com/x/internal/tools/group/sub":                            "group/sub",
+		"flat":                                                             "flat",
+		"a/b/c":                                                            "c",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := ShortPackage(input); got != want {
+				t.Errorf("ShortPackage(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+// TestSortedSet_SortsAndDedups verifies set→sorted-slice conversion.
+func TestSortedSet_SortsAndDedups(t *testing.T) {
+	got := SortedSet(map[string]struct{}{"b": {}, "a": {}, "c": {}})
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedSet = %v, want %v", got, want)
+	}
+	if SortedSet(map[string]struct{}{}) == nil {
+		t.Error("sortedSet of empty map should be non-nil empty slice")
+	}
+}
+
+// clientGoPkg is a synthetic package whose path passes the client-go check
+// the resolver applies to receiver and option types.
+var clientGoPkg = types.NewPackage(ClientGoPkgPath+"/v2", "gitlab")
+
+// namedIn declares a named type in pkg over underlying.
+func namedIn(pkg *types.Package, name string, underlying types.Type) *types.Named {
+	return types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), underlying, nil)
+}
+
+// requestOptionSlice is the ...RequestOptionFunc variadic tail of a client-go
+// API method.
+func requestOptionSlice() *types.Slice {
+	return types.NewSlice(namedIn(clientGoPkg, "RequestOptionFunc", types.NewSignatureType(nil, nil, nil, nil, nil, false)))
+}
+
+// method builds an interface method with the given parameters.
+func method(pkg *types.Package, name string, variadic bool, params ...*types.Var) *types.Func {
+	sig := types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), nil, variadic)
+	return types.NewFunc(token.NoPos, pkg, name, sig)
+}
+
+// param builds one unnamed parameter of type typ.
+func param(typ types.Type) *types.Var {
+	return types.NewParam(token.NoPos, clientGoPkg, "", typ)
+}
+
+// serviceInterface declares a client-go service interface with methods.
+func serviceInterface(pkg *types.Package, name string, methods ...*types.Func) *types.Named {
+	iface := types.NewInterfaceType(methods, nil)
+	iface.Complete()
+	return namedIn(pkg, name, iface)
+}
+
+// TestSignatureIsAPICall_Shapes_RecognizesOnlyRequestOptionTails verifies
+// the REST endpoint marker: only a variadic signature whose tail is a slice
+// of a client-go type named after RequestOptionFunc counts, so plain
+// variadics, named slice types, unnamed or foreign element types and other
+// client-go types are all rejected.
+func TestSignatureIsAPICall_Shapes_RecognizesOnlyRequestOptionTails(t *testing.T) {
+	otherPkg := types.NewPackage("example.com/other", "other")
+	cases := []struct {
+		name string
+		sig  *types.Signature
+		want bool
+	}{
+		{name: "no_params", sig: method(clientGoPkg, "M", false).Signature(), want: false},
+		{name: "not_variadic", sig: method(clientGoPkg, "M", false, param(requestOptionSlice())).Signature(), want: false},
+		{
+			name: "named_slice_type_is_not_a_bare_slice",
+			sig:  method(clientGoPkg, "M", true, param(namedIn(clientGoPkg, "Options", requestOptionSlice()))).Signature(),
+			want: false,
+		},
+		{name: "unnamed_element", sig: method(clientGoPkg, "M", true, param(types.NewSlice(types.Typ[types.String]))).Signature(), want: false},
+		{name: "universe_element_has_no_package", sig: method(clientGoPkg, "M", true, param(types.NewSlice(types.Universe.Lookup("error").Type()))).Signature(), want: false},
+		{
+			name: "foreign_package_element",
+			sig:  method(clientGoPkg, "M", true, param(types.NewSlice(namedIn(otherPkg, "RequestOptionFunc", types.Typ[types.Int])))).Signature(),
+			want: false,
+		},
+		{
+			name: "client_go_element_without_marker",
+			sig:  method(clientGoPkg, "M", true, param(types.NewSlice(namedIn(clientGoPkg, "Client", types.Typ[types.Int])))).Signature(),
+			want: false,
+		},
+		{name: "request_option_tail", sig: method(clientGoPkg, "M", true, param(types.Typ[types.Int]), param(requestOptionSlice())).Signature(), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SignatureIsAPICall(tc.sig); got != tc.want {
+				t.Errorf("signatureIsAPICall = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAPIMethodNames_Interface_ListsExportedEndpointsSorted verifies the
+// endpoint listing keeps only the exported methods with the REST marker, in
+// sorted order, and yields nothing for a named type that is not an interface.
+func TestAPIMethodNames_Interface_ListsExportedEndpointsSorted(t *testing.T) {
+	iface := serviceInterface(clientGoPkg, "BranchesServiceInterface",
+		method(clientGoPkg, "ListBranches", true, param(requestOptionSlice())),
+		method(clientGoPkg, "CreateBranch", true, param(requestOptionSlice())),
+		method(clientGoPkg, "helper", true, param(requestOptionSlice())),
+		method(clientGoPkg, "String", false),
+	)
+	if got := APIMethodNames(iface); !reflect.DeepEqual(got, []string{"CreateBranch", "ListBranches"}) {
+		t.Errorf("apiMethodNames = %v, want the two exported endpoints sorted", got)
+	}
+	if got := APIMethodNames(namedIn(clientGoPkg, "Client", types.NewStruct(nil, nil))); got != nil {
+		t.Errorf("apiMethodNames of a struct = %v, want nil", got)
+	}
+}
+
+// TestClientGoServiceInterface_Types_AcceptsOnlyClientGoInterfaces verifies
+// the receiver test behind every recorded call: a client-go interface,
+// reached directly or through a pointer, is a service; nil, basic, struct,
+// universe and foreign-package types are not.
+func TestClientGoServiceInterface_Types_AcceptsOnlyClientGoInterfaces(t *testing.T) {
+	service := serviceInterface(clientGoPkg, "TagsServiceInterface", method(clientGoPkg, "ListTags", true, param(requestOptionSlice())))
+	cases := []struct {
+		name string
+		typ  types.Type
+		want bool
+	}{
+		{name: "nil", typ: nil, want: false},
+		{name: "basic", typ: types.Typ[types.Int], want: false},
+		{name: "client_go_struct", typ: namedIn(clientGoPkg, "Tag", types.NewStruct(nil, nil)), want: false},
+		{name: "universe_error_interface", typ: types.Universe.Lookup("error").Type(), want: false},
+		{name: "foreign_interface", typ: serviceInterface(types.NewPackage("example.com/x", "x"), "Svc"), want: false},
+		{name: "service_interface", typ: service, want: true},
+		{name: "pointer_to_service_interface", typ: types.NewPointer(service), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			named, ok := ClientGoServiceInterface(tc.typ)
+			if ok != tc.want {
+				t.Fatalf("clientGoServiceInterface = %v, want %v", ok, tc.want)
+			}
+			if ok && named != service {
+				t.Errorf("returned %v, want the service interface", named)
+			}
+		})
+	}
+}
+
+// TestServiceName_Interfaces_StripOnlyTheSuffix verifies the bare service name
+// both adjudication tables are keyed on: the ServiceInterface suffix goes, and
+// an interface without it (GraphQLInterface) keeps its whole name.
+func TestServiceName_Interfaces_StripOnlyTheSuffix(t *testing.T) {
+	cases := map[string]string{
+		"BranchesServiceInterface": "Branches",
+		"GraphQLInterface":         "GraphQLInterface",
+		"ServiceInterface":         "",
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := ServiceName(serviceInterface(clientGoPkg, name)); got != want {
+				t.Errorf("ServiceName(%q) = %q, want %q", name, got, want)
+			}
+		})
+	}
+}
+
+// fixtureSDKSource is the stand-in client-go the loader-backed cases resolve.
+// Its import path carries the client-go path as an infix, which is what the
+// resolver matches on.
+const fixtureSDKSource = `package gitlab
+
+type RequestOptionFunc func()
+
+type BranchesServiceInterface interface {
+	ListBranches(options ...RequestOptionFunc) error
+	CreateBranch(options ...RequestOptionFunc) error
+}
+
+type GraphQLInterface interface {
+	Do(query string, target any, options ...RequestOptionFunc) error
+}
+
+type Client struct {
+	GraphQL  GraphQLInterface
+	Branches BranchesServiceInterface
+}
+`
+
+// sdkPath is where a fixture module keeps its stand-in client-go.
+const sdkPath = "gitlab.com/gitlab-org/api/client-go/v2/sdk.go"
+
+// sdkImport is the import line a fixture tool package uses to reach it.
+const sdkImport = "example.com/fixture/gitlab.com/gitlab-org/api/client-go/v2"
+
+// sdkModule writes a throwaway module whose internal/tools tree calls the
+// stand-in client-go, and returns its root.
+func sdkModule(t *testing.T, sdk string) string {
+	t.Helper()
+	return writeModule(t, map[string]string{
+		sdkPath: sdk,
+		"internal/tools/branches/branches.go": "package branches\n\nimport gl \"" + sdkImport + "\"\n\n" +
+			"// List calls one endpoint and leaves the other uncalled.\nfunc List(c *gl.Client) error { return c.Branches.ListBranches() }\n",
+	})
+}
+
+// TestClientGoTypes_ImportGraph_FindsTheRootPackage verifies the SDK types are
+// read out of the loaded tool packages' import graph, so the surface audited is
+// the one the handlers compile against, and that a tree importing no client-go
+// fails rather than reporting an empty universe.
+func TestClientGoTypes_ImportGraph_FindsTheRootPackage(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		pkgs, err := LoadToolPackages(sdkModule(t, fixtureSDKSource))
+		if err != nil {
+			t.Fatalf("LoadToolPackages: %v", err)
+		}
+		clientGo, err := ClientGoTypes(pkgs)
+		if err != nil {
+			t.Fatalf("ClientGoTypes: %v", err)
+		}
+		if clientGo.Scope().Lookup("Client") == nil {
+			t.Error("resolved a package without a Client struct")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		pkgs, err := LoadToolPackages(writeModule(t, map[string]string{
+			"internal/tools/alpha/alpha.go": "package alpha\n\nfunc A() int { return 1 }\n",
+		}))
+		if err != nil {
+			t.Fatalf("LoadToolPackages: %v", err)
+		}
+		if _, typesErr := ClientGoTypes(pkgs); typesErr == nil || !strings.Contains(typesErr.Error(), "client-go root package not found") {
+			t.Fatalf("ClientGoTypes = %v, want a not-found error", typesErr)
+		}
+	})
+}
+
+// TestClientStructAndGraphQLInterface_Shapes_RequireTheRealDeclarations
+// verifies both structural lookups resolve the real declarations, and refuse a
+// package that renames or reshapes them rather than returning an empty result
+// that would read as a passing audit.
+func TestClientStructAndGraphQLInterface_Shapes_RequireTheRealDeclarations(t *testing.T) {
+	pkgs, err := LoadToolPackages(sdkModule(t, fixtureSDKSource))
+	if err != nil {
+		t.Fatalf("LoadToolPackages: %v", err)
+	}
+	clientGo, err := ClientGoTypes(pkgs)
+	if err != nil {
+		t.Fatalf("ClientGoTypes: %v", err)
+	}
+	st, err := ClientStruct(clientGo)
+	if err != nil {
+		t.Fatalf("ClientStruct: %v", err)
+	}
+	if st.NumFields() != 2 {
+		t.Errorf("Client has %d fields, want the 2 declared", st.NumFields())
+	}
+	graphQL, err := GraphQLInterface(clientGo)
+	if err != nil {
+		t.Fatalf("GraphQLInterface: %v", err)
+	}
+	if graphQL.Obj().Name() != "GraphQLInterface" {
+		t.Errorf("GraphQLInterface resolved %q", graphQL.Obj().Name())
+	}
+
+	// Each stand-in below keeps a Client struct so the root package still
+	// resolves, and breaks exactly one of the two lookups.
+	cases := []struct {
+		name    string
+		sdk     string
+		wantErr string
+	}{
+		{
+			name:    "graphql_renamed_away",
+			sdk:     "package gitlab\n\ntype Client struct{}\n",
+			wantErr: "GraphQLInterface not found",
+		},
+		{
+			name:    "graphql_is_not_a_named_type",
+			sdk:     "package gitlab\n\ntype Client struct{}\n\nfunc GraphQLInterface() {}\n",
+			wantErr: "GraphQLInterface is not a named type",
+		},
+		{
+			name:    "graphql_names_a_struct",
+			sdk:     "package gitlab\n\ntype Client struct{}\n\ntype GraphQLInterface struct{}\n",
+			wantErr: "GraphQLInterface is not an interface",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeModule(t, map[string]string{
+				sdkPath: tc.sdk,
+				"internal/tools/alpha/alpha.go": "package alpha\n\nimport gl \"" + sdkImport + "\"\n\n" +
+					"// Use keeps the SDK in the import graph.\nfunc Use(c *gl.Client) *gl.Client { return c }\n",
+			})
+			loaded, loadErr := LoadToolPackages(root)
+			if loadErr != nil {
+				t.Fatalf("LoadToolPackages: %v", loadErr)
+			}
+			pkg, typesErr := ClientGoTypes(loaded)
+			if typesErr != nil {
+				t.Fatalf("ClientGoTypes: %v", typesErr)
+			}
+			if _, gqlErr := GraphQLInterface(pkg); gqlErr == nil || !strings.Contains(gqlErr.Error(), tc.wantErr) {
+				t.Errorf("GraphQLInterface error = %v, want it to contain %q", gqlErr, tc.wantErr)
+			}
+		})
+	}
+
+	t.Run("client_is_not_a_struct", func(t *testing.T) {
+		// A Client that is not a struct makes the whole root package
+		// unresolvable, which is how a renamed entry point surfaces.
+		root := writeModule(t, map[string]string{
+			sdkPath: "package gitlab\n\ntype Client interface{}\n",
+			"internal/tools/alpha/alpha.go": "package alpha\n\nimport gl \"" + sdkImport + "\"\n\n" +
+				"// Use keeps the SDK in the import graph.\nfunc Use(c gl.Client) gl.Client { return c }\n",
+		})
+		loaded, loadErr := LoadToolPackages(root)
+		if loadErr != nil {
+			t.Fatalf("LoadToolPackages: %v", loadErr)
+		}
+		if _, typesErr := ClientGoTypes(loaded); typesErr == nil || !strings.Contains(typesErr.Error(), "client-go root package not found") {
+			t.Fatalf("ClientGoTypes = %v, want a not-found error", typesErr)
+		}
+	})
+}
+
+// TestCollectServiceUsage_CallSites_RecordMethodsAndPackages verifies the
+// call-site universe both scopes read: the interface a call goes through is
+// keyed by its own name, only the methods actually called are recorded, and the
+// referencing package is named by its internal/tools domain.
+func TestCollectServiceUsage_CallSites_RecordMethodsAndPackages(t *testing.T) {
+	pkgs, err := LoadToolPackages(sdkModule(t, fixtureSDKSource))
+	if err != nil {
+		t.Fatalf("LoadToolPackages: %v", err)
+	}
+	usage := CollectServiceUsage(pkgs)
+	use, ok := usage["BranchesServiceInterface"]
+	if !ok {
+		t.Fatalf("Branches not recorded (got %v)", usage)
+	}
+	if use.Service() != "Branches" {
+		t.Errorf("Service() = %q, want Branches", use.Service())
+	}
+	if _, called := use.Called["ListBranches"]; !called {
+		t.Errorf("called = %v, want ListBranches", use.Called)
+	}
+	if _, called := use.Called["CreateBranch"]; called {
+		t.Error("CreateBranch recorded as called, but nothing calls it")
+	}
+	if !reflect.DeepEqual(SortedSet(use.Packages), []string{"branches"}) {
+		t.Errorf("packages = %v, want [branches]", SortedSet(use.Packages))
+	}
+	if _, recorded := usage["GraphQLInterface"]; recorded {
+		t.Error("GraphQLInterface recorded although no handler calls it")
+	}
+}
+
+// TestClientStruct_Package_RefusesANonStructClient verifies the struct lookup
+// itself, given a package whose Client is not a struct. The loader-backed cases
+// above cannot reach this branch, because such a package never resolves as the
+// client-go root in the first place.
+func TestClientStruct_Package_RefusesANonStructClient(t *testing.T) {
+	pkg := types.NewPackage(ClientGoPkgPath+"/v2", "gitlab")
+	iface := types.NewInterfaceType(nil, nil)
+	iface.Complete()
+	named := namedIn(pkg, "Client", iface)
+	pkg.Scope().Insert(named.Obj())
+	if _, err := ClientStruct(pkg); err == nil || !strings.Contains(err.Error(), "Client struct not found") {
+		t.Fatalf("ClientStruct = %v, want a not-found error", err)
+	}
+}

--- a/cmd/audit_1to1/main.go
+++ b/cmd/audit_1to1/main.go
@@ -9,6 +9,12 @@
 // backlog that gen_1to1_backlog previously generated from three separate files,
 // via the same merge pipeline (byte-identical by construction).
 //
+// The sdk scope is a fourth, separate one, deliberately outside the merged
+// backlog: the three streams above are candidate lists a human adjudicates,
+// while sdk is a gate that exits non-zero on a finding. Keeping it out of the
+// merge also leaves plan/1to1-backlog.json's shape untouched for the tooling
+// that reads it.
+//
 // Usage:
 //
 //	go run ./cmd/audit_1to1/                                  # merged backlog to stdout
@@ -16,6 +22,7 @@
 //	go run ./cmd/audit_1to1/ -scope=structs                   # struct report only
 //	go run ./cmd/audit_1to1/ -scope=actions -gaps-only
 //	go run ./cmd/audit_1to1/ -scope=metadata
+//	go run ./cmd/audit_1to1/ -scope=sdk -gaps-only            # SDK parity gate
 package main
 
 import (
@@ -26,6 +33,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -33,6 +41,7 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/actions"
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/merge"
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/metadata"
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/sdk"
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_1to1/internal/structs"
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/apidocs"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
@@ -41,7 +50,7 @@ import (
 func main() {
 	outputPath := flag.String("output", "-", "path to write JSON report, or '-' for stdout")
 	gapsOnly := flag.Bool("gaps-only", false, "only include entries with at least one finding")
-	scope := flag.String("scope", "structs,actions,metadata", "one of {structs,actions,metadata} for a single-scope report, or all three (default) for the merged backlog; two-scope combinations are not supported")
+	scope := flag.String("scope", "structs,actions,metadata", "one of {structs,actions,metadata,sdk} for a single-scope report, or the first three (default) for the merged backlog; two-scope combinations are not supported")
 	validateDocs := flag.Bool("validate-docs", false, "instead of the audit, verify every doc/api citation in the adjudication tables is still fetchable (exits non-zero on a stale citation)")
 	refresh := flag.Bool("refresh", false, "with -validate-docs, force re-fetch of cited docs even when cached and fresh")
 	offline := flag.Bool("offline", false, "with -validate-docs, use only cached docs; do not fetch")
@@ -68,20 +77,26 @@ func run(scope string, gapsOnly bool, outputPath string) error {
 	}
 
 	var content []byte
+	clean := true
 	switch {
-	case len(scopes) == 3:
+	case isMergedScope(scopes):
 		content, err = runMerged(gapsOnly)
 	case len(scopes) == 1:
-		content, err = runSingle(scopes[0], gapsOnly)
+		content, clean, err = runSingle(scopes[0], gapsOnly)
 	default:
-		return fmt.Errorf("scope must be a single value or all three (got %d: %s); partial two-scope combinations are not supported",
-			len(scopes), strings.Join(scopes, ","))
+		return fmt.Errorf("scope must be a single value or the merged trio %s (got %d: %s); other combinations are not supported",
+			strings.Join(mergedScopes, ","), len(scopes), strings.Join(scopes, ","))
 	}
 	if err != nil {
 		return err
 	}
 	if writeErr := writeOutput(outputPath, content); writeErr != nil {
 		return fmt.Errorf("write output: %w", writeErr)
+	}
+	// The report is written before the gate fails, so whoever reads the failure
+	// has the same artifact a passing run would have produced.
+	if !clean {
+		return errors.New("audit_1to1: SDK parity findings (see report)")
 	}
 	return nil
 }
@@ -146,46 +161,67 @@ func runMerged(gapsOnly bool) ([]byte, error) {
 	return merge.BuildBacklogFromBytes(structBytes, actionBytes, metadataBytes)
 }
 
-// runSingle runs one analyzer and returns its native JSON shape.
-func runSingle(scope string, gapsOnly bool) ([]byte, error) {
+// runSingle runs one analyzer and returns its native JSON shape plus whether
+// that scope's gate passes. Only sdk gates; the three candidate streams always
+// report clean, because a listed candidate is a backlog entry rather than a
+// defect.
+func runSingle(scope string, gapsOnly bool) (content []byte, clean bool, err error) {
 	switch scope {
-	case "structs", "actions":
-		root, err := cmdutil.RepositoryRoot(".")
-		if err != nil {
-			return nil, fmt.Errorf("find repository root: %w", err)
+	case "structs", "actions", "sdk":
+		root, rootErr := cmdutil.RepositoryRoot(".")
+		if rootErr != nil {
+			return nil, false, fmt.Errorf("find repository root: %w", rootErr)
 		}
-		if scope == "structs" {
-			return structs.Run(root, gapsOnly)
+		switch scope {
+		case "structs":
+			content, err = structs.Run(root, gapsOnly)
+			return content, true, err
+		case "actions":
+			content, err = actions.Run(root, gapsOnly)
+			return content, true, err
+		default:
+			return sdk.Run(root, gapsOnly)
 		}
-		return actions.Run(root, gapsOnly)
 	case "metadata":
 		// The metadata analyzer reads the in-memory catalog, not the tree, so
 		// unlike the two filesystem scanners it has nothing to fail at.
-		return metadata.Run(gapsOnly), nil
+		return metadata.Run(gapsOnly), true, nil
 	default:
-		return nil, fmt.Errorf("unknown scope %q (valid: structs, actions, metadata)", scope)
+		return nil, false, fmt.Errorf("unknown scope %q (valid: structs, actions, metadata, sdk)", scope)
 	}
 }
 
+// mergedScopes is the trio the merged backlog is built from, sorted. The sdk
+// scope is deliberately not one of them: it gates rather than accumulating
+// candidates, and adding it would change the shape of plan/1to1-backlog.json.
+var mergedScopes = []string{"actions", "metadata", "structs"}
+
+// isMergedScope reports whether scopes is exactly the merged trio, so a
+// three-value selection that merely happens to have three entries (say
+// structs,actions,sdk) is rejected instead of silently merging.
+func isMergedScope(scopes []string) bool {
+	return slices.Equal(scopes, mergedScopes)
+}
+
 // parseScope validates and normalizes the -scope flag. Returns the deduplicated,
-// sorted list of scopes. An empty value or "all" expands to all three.
+// sorted list of scopes. An empty value or "all" expands to the merged trio.
 func parseScope(s string) ([]string, error) {
 	s = strings.TrimSpace(s)
 	if s == "" || s == "all" {
-		return []string{"actions", "metadata", "structs"}, nil
+		return slices.Clone(mergedScopes), nil
 	}
 	seen := map[string]bool{}
 	var scopes []string
 	for raw := range strings.SplitSeq(s, ",") {
 		v := strings.TrimSpace(raw)
 		switch v {
-		case "structs", "actions", "metadata":
+		case "structs", "actions", "metadata", "sdk":
 			if !seen[v] {
 				seen[v] = true
 				scopes = append(scopes, v)
 			}
 		default:
-			return nil, fmt.Errorf("invalid scope %q (valid: structs, actions, metadata, all)", v)
+			return nil, fmt.Errorf("invalid scope %q (valid: structs, actions, metadata, sdk, all)", v)
 		}
 	}
 	sort.Strings(scopes)

--- a/cmd/audit_1to1/main_test.go
+++ b/cmd/audit_1to1/main_test.go
@@ -29,6 +29,7 @@ func TestParseScope(t *testing.T) {
 		{name: "keyword all expands", input: "all", wantCount: 3},
 		{name: "empty expands to all", input: "", wantCount: 3},
 		{name: "single scope", input: "structs", wantCount: 1, wantFirst: "structs"},
+		{name: "sdk scope", input: "sdk", wantCount: 1, wantFirst: "sdk"},
 		{name: "deduplicates repeats", input: "structs,structs,actions,actions", wantCount: 2},
 		{name: "trims whitespace", input: " structs , actions , metadata ", wantCount: 3},
 		{name: "rejects unknown token", input: "structs,unknown", wantErr: true, errSubstr: "unknown"},
@@ -62,14 +63,43 @@ func TestParseScope(t *testing.T) {
 }
 
 // TestRunSingle_UnknownScope verifies the single-scope dispatcher refuses a
-// scope name it does not know instead of running nothing silently.
+// scope name it does not know instead of running nothing silently, and that a
+// refusal reports the gate as failed rather than clean.
 func TestRunSingle_UnknownScope(t *testing.T) {
-	_, err := runSingle("bogus", false)
+	_, clean, err := runSingle("bogus", false)
 	if err == nil {
 		t.Fatal("expected error for unknown scope")
 	}
 	if !strings.Contains(err.Error(), "unknown scope") {
 		t.Errorf("error should mention 'unknown scope', got: %v", err)
+	}
+	if clean {
+		t.Error("an unknown scope reported a clean gate")
+	}
+}
+
+// TestIsMergedScope_Combinations_MatchOnlyTheTrio verifies the merged backlog
+// runs for exactly the three candidate streams. Adding the sdk scope made the
+// old "three entries means all of them" test wrong: structs,actions,sdk also
+// has three entries and must not be merged.
+func TestIsMergedScope_Combinations_MatchOnlyTheTrio(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []string
+		want   bool
+	}{
+		{name: "the_trio", scopes: []string{"actions", "metadata", "structs"}, want: true},
+		{name: "trio_with_sdk_substituted", scopes: []string{"actions", "sdk", "structs"}, want: false},
+		{name: "all_four", scopes: []string{"actions", "metadata", "sdk", "structs"}, want: false},
+		{name: "single", scopes: []string{"sdk"}, want: false},
+		{name: "empty", scopes: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMergedScope(tc.scopes); got != tc.want {
+				t.Errorf("isMergedScope(%v) = %v, want %v", tc.scopes, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -170,7 +200,8 @@ func TestRun_ScopeSelection_RejectsUnsupportedScopes(t *testing.T) {
 		wantErr string
 	}{
 		{name: "unknown_scope", scope: "bogus", wantErr: `invalid scope "bogus"`},
-		{name: "two_scopes", scope: "structs,actions", wantErr: "partial two-scope combinations are not supported"},
+		{name: "two_scopes", scope: "structs,actions", wantErr: "other combinations are not supported"},
+		{name: "three_scopes_that_are_not_the_trio", scope: "structs,actions,sdk", wantErr: "other combinations are not supported"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -198,6 +229,7 @@ func TestRun_EachScope_WritesItsReportShape(t *testing.T) {
 		{name: "metadata", scope: "metadata", wantKeys: []string{"schema_version", "summary", "packages"}},
 		{name: "structs", scope: "structs", wantKeys: []string{"schema_version", "client_go_path", "summary", "packages"}},
 		{name: "actions", scope: "actions", wantKeys: []string{"schema_version", "client_go_path", "summary", "services"}},
+		{name: "sdk", scope: "sdk", wantKeys: []string{"schema_version", "client_go_path", "summary", "services", "graphql_operations"}},
 		{name: "merged", scope: "all", wantKeys: []string{"schema_version", "note", "summary", "packages"}},
 	}
 	for _, tc := range cases {

--- a/docs/development/adr/adr-0006-raw-graphql-for-uncovered-domains.md
+++ b/docs/development/adr/adr-0006-raw-graphql-for-uncovered-domains.md
@@ -136,6 +136,14 @@ If `client-go` adds typed wrappers for any of these 5 domains in the future, mig
 3. Keep the same input/output types and tool handler signatures
 4. No changes to tool registration, meta-tools, or tests (only mock handlers switch from `/api/graphql` to REST endpoints)
 
+### The exemption is checked, not permanent
+
+This decision admits raw GraphQL **for a domain without a wrapper**, so the wrapper arriving is what retires the exemption. Nothing enforced that for a long time, which made the exemption permanent in practice: wrappers appeared upstream and the handlers stayed as they were, because no gate could see the difference.
+
+`go run ./cmd/audit_1to1/ -scope=sdk` now holds every raw-GraphQL operation whose package maps to a client-go service to a recorded decision, `KEEP` or `MIGRATE`, in `cmd/audit_1to1/internal/sdk/decisions.go`. An operation with no decision fails the build, and so does a decision left behind for an operation that no longer exists. The unit is the operation rather than the package, because several packages use GraphQL for one operation and the SDK for the rest.
+
+`KEEP` is a real answer, not a way of avoiding the migration. The wrapper existing does not always mean it should be used: `EpicIssues` and `ProjectVulnerabilities` are both wrappers over REST APIs whose own upstream doc comments direct callers to the very GraphQL these handlers already call, so moving onto them would be moving onto the path GitLab is removing. What the rule forbids is leaving that judgement unwritten.
+
 ## References
 
 - [ADR-0004: Modular tools sub-packages](adr-0004-modular-tools-subpackages.md)

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -10,7 +10,7 @@ Every utility can be run directly with `go run ./cmd/<name>/ [flags]`, or throug
 
 | Utility                        | Category                      | Purpose                                                                                                                                                                                             | Make target                               |
 | ------------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `audit_1to1`                   | SDK/API parity audits         | Consolidated SDK↔API parity audit (struct/action/metadata gap streams)                                                                                                                              | `make audit-1to1`                         |
+| `audit_1to1`                   | SDK/API parity audits         | Consolidated SDK↔API parity audit (struct/action/metadata gap streams, plus the `sdk` service and raw-GraphQL gate)                                                                                 | `make audit-1to1`                         |
 | `audit_catalog_first`          | Catalog & metadata audits     | Source-discovered ActionSpec catalog-first coverage inventory                                                                                                                                       | `make audit-catalog-first`                |
 | `audit_discovery_completeness` | Catalog & metadata audits     | Extended META-001 model-discovery metadata quality auditor                                                                                                                                          | `make audit-discovery`                    |
 | `audit_doc_coverage`           | Catalog & metadata audits     | Per-doc-file gaps vs the action catalog (DOC-002)                                                                                                                                                   | `make audit-doc-coverage`                 |
@@ -40,6 +40,8 @@ Every utility can be run directly with `go run ./cmd/<name>/ [flags]`, or throug
 
 Consolidated 1:1 SDK↔API parity audit. It combines three gap streams behind a single `-scope` flag: struct field mapping (R-INPUT/R-OUTPUT), action coverage (R-ACTION), and discovery metadata (R-META). When all three scopes run (the default), it produces a merged per-package backlog. It replaces the former `audit_struct_completeness`, `audit_action_coverage`, `audit_metadata_completeness`, and `gen_1to1_backlog` binaries.
 
+A fourth scope, `sdk`, differs from those three in both its universe and its severity, and is described under [SDK parity gate](#sdk-parity-gate) below.
+
 #### Usage
 
 ```bash
@@ -48,6 +50,9 @@ go run ./cmd/audit_1to1/
 
 # Single-scope run, gaps only, to stdout
 go run ./cmd/audit_1to1/ -scope=structs -gaps-only -output=-
+
+# SDK parity gate: exits non-zero on a finding
+go run ./cmd/audit_1to1/ -scope=sdk -gaps-only
 
 # Validate that every doc/api citation behind the adjudication tables is still
 # fetchable (the official API doc is the 1:1 ground truth)
@@ -60,7 +65,7 @@ go run ./cmd/audit_1to1/ -validate-docs
 | ---------------- | ---------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-gaps-only`     | `bool`     | `false`                    | Only include entries with at least one finding                                                                                                     |
 | `-output`        | `string`   | `-`                        | Path to write the JSON report, or `-` for stdout                                                                                                   |
-| `-scope`         | `string`   | `structs,actions,metadata` | A single `{structs,actions,metadata}` scope, or all three (default, merged backlog); two-scope combinations are rejected                           |
+| `-scope`         | `string`   | `structs,actions,metadata` | A single `{structs,actions,metadata,sdk}` scope, or exactly the first three (default, merged backlog); any other combination is rejected           |
 | `-validate-docs` | `bool`     | `false`                    | Instead of the audit, verify every `doc/api/<area>.md` citation in the adjudication tables is still fetchable (exits non-zero on a stale citation) |
 | `-refresh`       | `bool`     | `false`                    | With `-validate-docs`, force re-fetch of cited docs even when cached and fresh                                                                     |
 | `-offline`       | `bool`     | `false`                    | With `-validate-docs`, use only cached docs; do not fetch                                                                                          |
@@ -70,9 +75,28 @@ go run ./cmd/audit_1to1/ -validate-docs
 
 JSON. A single-scope run produces that auditor's native shape. An all-scopes run produces a merged backlog containing `schema_version`, a `summary` block (9 counters), and a `packages[]` array. `-validate-docs` emits `{schema_version, checked, ok, stale[]}`.
 
+#### SDK parity gate
+
+`-scope=sdk`. The three candidate streams derive their universe from this repository: they walk our call expressions and report what those calls miss. That cannot answer "is there a service we call nothing on", because a service nothing references never enters the map. `WorkItemSavedViewsService` arrived upstream with seven methods, sat entirely unexposed, and the audit went on reporting zero gaps.
+
+The `sdk` scope enumerates the services from client-go's `Client` struct instead, and holds each one to a decision:
+
+- **covered** — a handler calls it;
+- **declared** — `declaredServices` in `cmd/audit_1to1/internal/sdk/decisions.go` names it, with a category (`COVERED_RAW`, `COVERED_GENERIC`, `COVERED_GRAPHQL`, `SUPERSEDED_UPSTREAM`, `UNWRAPPED_TRACKED`) and the evidence behind it;
+- **undeclared** — a finding.
+
+It carries a second rule for the same reason. [ADR-0006](adr/adr-0006-raw-graphql-for-uncovered-domains.md) admits raw `GraphQL.Do()` for domains **without** a client-go service wrapper; the wrapper appearing later is what retires that exemption, and nothing was checking. Every raw-GraphQL operation whose package maps to a client-go service is therefore held to a decision too, `KEEP` or `MIGRATE`, in `graphqlDecisions`. The unit is the **operation**, not the package: several packages use GraphQL for one operation and the SDK for the rest, so a package-level verdict would be mostly noise.
+
+Both tables are checked for staleness in the same run: a declaration for a service the tree now calls, a declaration for a service upstream removed, or a decision for an operation that no longer exists is itself a finding.
+
+Unlike the other scopes this one **exits non-zero** on a finding, and is deliberately kept out of the merged backlog so `plan/1to1-backlog.json` keeps its shape for the tooling that reads it.
+
+Report keys: `schema_version`, `client_go_path`, a `summary` block (8 counters), `services[]`, `graphql_operations[]`, and `stale_declarations[]`. With `-gaps-only` the two arrays hold only findings.
+
 #### Make targets
 
-- `make audit-1to1` — writes `plan/1to1-backlog.json`.
+- `make audit-1to1` — writes `plan/1to1-backlog.json`, then runs `audit-1to1-sdk`.
+- `make audit-1to1-sdk` — the SDK parity gate; fails the build on a finding.
 - `make audit-1to1-validate-docs` — validates the doc/api citations (CI gate).
 - `make audit-struct-completeness` — legacy wrapper running `-scope=structs`.
 - `make audit-action-coverage` — legacy wrapper running `-scope=actions`.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -24,7 +24,7 @@ gitlab-mcp-server/
 │   ├── server/                  # MCP server entry point
 │   │   ├── main.go              # Signal handling, transport selection
 │   │   └── main_test.go         # Server startup and HTTP handler tests
-│   ├── audit_1to1/              # Consolidated 1:1 SDK↔API parity audit (-scope structs|actions|metadata)
+│   ├── audit_1to1/              # Consolidated 1:1 SDK↔API parity audit (-scope structs|actions|metadata|sdk)
 │   ├── audit_catalog_first/ # ActionSpec catalog coverage inventory
 │   ├── audit_discovery_completeness/ # Discovery metadata audit with cluster-aware severity (META-001)
 │   ├── audit_doc_coverage/      # docs/reference/tools/*.md vs catalog coverage gaps (DOC-002)

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -109,7 +109,8 @@ gotestsum --version
 | `make audit-surface-quality` | Consolidated MCP surface audit (metadata + output quality)                                                                                                                     |
 | `make audit-tokens`          | Measure exposed tool token overhead (`--compare-schemas` for meta-tool sizing spike)                                                                                           |
 | `make audit-metrics`         | Report MCP tool/resource/prompt counts                                                                                                                                         |
-| `make audit-1to1`            | Consolidated 1:1 SDK↔API parity audit (struct/action/metadata + merged backlog)                                                                                                |
+| `make audit-1to1`            | Consolidated 1:1 SDK↔API parity audit (struct/action/metadata + merged backlog), then the SDK parity gate                                                                      |
+| `make audit-1to1-sdk`        | Gate every client-go service and raw-GraphQL operation on a decision; fails on a finding                                                                                       |
 | `make audit-catalog-first`   | Generate ActionSpec surface coverage inventory in `dist/action-spec-coverage.json`                                                                                             |
 | `make audit-dynamic-aliases` | Audit Dynamic search aliases and canonical action reachability                                                                                                                 |
 | `make audit-test-names`      | Audit test function naming convention compliance                                                                                                                               |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,356 |
-| Unit test functions                                   | 12,800 |
-| E2E test functions                                    |    556 |
-| cmd test functions                                    |  1,929 |
+| Total test functions                                  | 13,447 |
+| Unit test functions                                   | 12,889 |
+| E2E test functions                                    |    558 |
+| cmd test functions                                    |  2,016 |
 | Test files (internal/)                                |    494 |
-| Test files (cmd/)                                     |    105 |
-| Test files (test/e2e/)                                |    215 |
+| Test files (cmd/)                                     |    117 |
+| Test files (test/e2e/)                                |    216 |
 | Tool sub-packages tested                              |    174 |
 | Core packages tested                                  |     21 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.9% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.8% |
 | Overall coverage (`go test ./internal/...`)           |  98.3% |
-| Average package coverage                              |  98.5% |
+| Average package coverage                              |  98.4% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,183 | 83.7% |
+| `TestFunc_Scenario` (2-part)           | 11,206 | 83.3% |
 | `TestFunc` (no underscore)             |    965 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,208 |  9.0% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,276 |  9.5% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,159 |        130 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,161 |        130 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (174) |          8,411 |        351 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            556 |        215 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,929 |        105 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,356** |    **814** |                                                                                                 |
+| E2E integration         |            558 |        216 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          2,016 |        117 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,447** |    **827** |                                                                                                 |
 
 ### Core Packages
 
@@ -72,12 +72,12 @@
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       272 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
-| serverpool    |        82 |    99.1% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
+| serverpool    |        84 |    98.5% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        35 |    89.8% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       787 |    98.4% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,159** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,161** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -300,10 +300,11 @@
 
 | Package                                        | Coverage |
 | ---------------------------------------------- | -------: |
-| cmd/audit_1to1                                 |    70.4% |
-| cmd/audit_1to1/internal/actions                |    99.2% |
+| cmd/audit_1to1                                 |    71.1% |
+| cmd/audit_1to1/internal/actions                |    98.1% |
 | cmd/audit_1to1/internal/merge                  |    98.9% |
 | cmd/audit_1to1/internal/metadata               |   100.0% |
+| cmd/audit_1to1/internal/sdk                    |    97.0% |
 | cmd/audit_1to1/internal/shared                 |    96.0% |
 | cmd/audit_1to1/internal/structs                |    99.0% |
 | cmd/audit_catalog_first                        |    93.3% |
@@ -316,6 +317,7 @@
 | cmd/audit_gateway_chars                        |    88.2% |
 | cmd/audit_install_buttons                      |    84.2% |
 | cmd/audit_metrics                              |    97.8% |
+| cmd/audit_readonly_graphql                     |    90.2% |
 | cmd/audit_string_dupes                         |    92.1% |
 | cmd/audit_supply_chain                         |    98.0% |
 | cmd/audit_surface_quality                      |    93.0% |
@@ -333,7 +335,7 @@
 | cmd/gen_docker_tools                           |    95.9% |
 | cmd/gen_icon_webp                              |    92.3% |
 | cmd/gen_lhm_manifest                           |    89.4% |
-| cmd/gen_llms                                   |    99.0% |
+| cmd/gen_llms                                   |    98.9% |
 | cmd/gen_stats                                  |    98.6% |
 | cmd/gen_testing_docs                           |    97.7% |
 | cmd/godoc_tool                                 |    93.7% |
@@ -341,7 +343,7 @@
 | cmd/internal/auditshared                       |   100.0% |
 | cmd/internal/docgen                            |    99.6% |
 | cmd/internal/mcpsurface                        |   100.0% |
-| cmd/server                                     |    95.9% |
+| cmd/server                                     |    95.7% |
 
 ### Core Packages
 
@@ -363,7 +365,7 @@
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.4% |
-| serverpool    |    99.1% |
+| serverpool    |    98.5% |
 | subscriptions |    98.5% |
 | telemetry     |    93.1% |
 | testutil      |    89.8% |
@@ -552,7 +554,7 @@
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
 - **cmd/gen_action_catalog_manifest** (66.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_1to1** (70.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_1to1** (71.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (77.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **progress** (83.8%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_install_buttons** (84.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.


### PR DESCRIPTION
`make audit-1to1` reported zero gaps while an entire new SDK service sat unexposed. Both blind spots behind that come from the same decision: the universe it audits is derived from what this code already calls.

`collectServiceUsage` walks our call expressions and records services whose receiver is a client-go service interface, so a service nothing references never enters the map. client-go v2.62.0 declares **167** services on its `Client` struct; the audit saw **156**. `WorkItemSavedViewsService` arrived upstream with seven methods, sat entirely unexposed, and the audit went on reporting zero gaps. The one case the 1:1 rule exists for is the one case the audit could not see.

## The service universe now comes from the SDK

A new `-scope=sdk` reads the services off the `Client` struct through `go/types` and holds each one to a decision: **covered** by a call, **declared** an exception with a category and a reason, or **undeclared**, which is a finding. The declaration table sits in `cmd/audit_1to1/internal/sdk/decisions.go`, in the same shape `acceptedMissingMethods` already uses for methods.

Twelve services are declared. I checked each rather than transcribing the list in the issue, and two of the entries I had written there turned out not to be exceptions at all:

- **`Avatar` and `Boards` are not gaps.** They are `Client` struct *fields* over `AvatarRequestsServiceInterface` and `IssueBoardsServiceInterface`, and handlers call both directly (`internal/tools/avatar`, `internal/tools/boards`, `internal/resources`). Reading the universe against field names invents services that do not exist, so the table is keyed on bare service names and a test asserts that.
- **Four I had not listed are real**: `EpicIssues`, `ProjectVulnerabilities`, `SecurityAttributes`, `SecurityCategories`, all reached over GraphQL.

The rest hold up. `Invites` is called, but only as method *values* passed into generic helpers, which the call-expression scanner cannot see. `ApplicationStatistics` and `GroupEpicBoards` go through raw REST for reasons their handlers document. `GeoNodes` and the three cluster services are marked deprecated upstream and we call the replacements (`GeoSites`, `ClusterAgents`). `SecurityDependencyFirewall` is genuinely unwrapped and points at https://github.com/jmrplens/gitlab-mcp-server/issues/429.

## Raw GraphQL that outlived its reason

[ADR-0006](https://github.com/jmrplens/gitlab-mcp-server/blob/audit-1to1-services/docs/development/adr/adr-0006-raw-graphql-for-uncovered-domains.md) admits raw `GraphQL.Do()` **for domains without a client-go service wrapper**, so the wrapper appearing later is what retires the exemption. Nothing checked, which made the exemption permanent in practice.

The scope now finds every place a tool package takes hold of the client-go GraphQL interface and, where the package maps to a client-go service, holds the operation to a `KEEP` or `MIGRATE` decision. Detection matches the interface **value**, not the `.Do` call, so a handler that hands `client.GL().GraphQL` to a helper in `internal/toolutil` (outside the audited tree) does not read as REST-only.

The unit is the operation rather than the package, since packages that use GraphQL for one operation and the SDK for the rest are the norm. Eighteen operations are adjudicated:

- **Nine `KEEP`.** `EpicIssues` and `ProjectVulnerabilities` are wrappers over REST APIs whose own upstream doc comments direct callers to the very GraphQL these handlers already call ("use Work Items API instead", "use GraphQL Query.vulnerabilities instead"), so migrating would move onto the path GitLab is removing. Three `vulnerabilities` operations have no wrapper equivalent at all.
- **Nine `MIGRATE`**, tracked in https://github.com/jmrplens/gitlab-mcp-server/issues/430: `workitems.List`, whose wrapper issues the same namespace query with a superset of the filters and the same cursor pagination, and the eight `securityattributes` / `securitycategories` mutations, whose wrappers are themselves GraphQL wrappers over the identical mutations.

The list in the issue was a dozen packages, derived by grepping for the string `GraphQL`. That over-counts: `terraformstates`, `groupwikis`, `runnercontrollers*` and `projects` only carry stale doc-comment mentions of GraphQL and call REST, and `securityscanprofiles` mentions it in a field description. Matching actual call sites through `go/types` is what makes the rule reportable.

## How the gate was introduced without leaving it red

Making a finding fail immediately would have turned `make audit-1to1` red on a dozen pre-existing cases, which is how a gate gets disabled. Three things keep it useful and green:

1. **The tables are seeded with today's tree**, each entry carrying evidence rather than a placeholder. A test rejects a reason too short to be evidence, and a `MIGRATE` verdict that names nowhere to track it.
2. **Both tables are checked for staleness in the same run.** A declaration for a service we now call, a declaration for a service upstream removed, or a decision for an operation that no longer exists is itself a finding, so the tables cannot quietly stop describing reality.
3. **The scope stays out of the merged backlog and gates on its own.** The three candidate streams are lists a human adjudicates and keep their exit code; `sdk` exits non-zero. `plan/1to1-backlog.json` is byte-identical, and I verified the `-scope=actions` report is byte-for-byte unchanged after the refactor below.

`make audit-1to1` now runs the backlog first and the gate second, so a failure still leaves the artifact behind. `make audit-1to1-sdk` runs the gate alone.

## Shared type resolution

The client-go type resolution both scopes need (which receiver is a service interface, which method is a REST endpoint, how a package path reduces to a domain) moves from `internal/actions` to `internal/shared`, along with `CollectServiceUsage`. The call-site universe and the service universe now come from one function, so they cannot drift into disagreeing about what "we call this" means. The tests moved with the code.

## Verification

`go build ./...`, `go test ./cmd/... ./internal/...` (240 packages, clean), `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `make audit-1to1`, `make check-test-file-names`, `audit_test_subtests -check`, `audit_test_goroutines --check`, `markdownlint-cli2` and `format_md_tables --check` on the changed docs. Each run unpiped.

Coverage of the audit tree is 94.5% overall, 97.0% for the new `sdk` package and 95.2% for `shared`. The end-to-end cases build a throwaway module carrying a stand-in client-go, so a case can state the whole universe it asserts about instead of depending on the repository's shape; one of them adds a service to that stand-in `Client` struct and asserts the gate goes red, which is the regression this whole scope exists for.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/427

