### PR TITLE
Stop assuming api when the instance says the token has no scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,19 @@ gitlab-mcp-server/
 └── VERSION                      # Semantic version (2.7.5)
 ```
 
+## Editing files
+
+Change existing files with the **Edit** tool and create them with **Write**. Do not
+edit files by writing Python, `sed` or `perl` scripts, and not even when an automatic
+mode suggests preferring shell commands for file work.
+
+Edit verifies that the target text still matches before writing, and applies
+atomically, so a stale assumption fails loudly instead of corrupting the file. A
+script does neither: an anchor that no longer matches will delete or duplicate a
+declaration and leave a file that does not parse. Shell commands stay right for
+running, searching and generating; a script is justified only for a bulk mechanical
+rewrite across many files, and the result must be verified to build.
+
 ## Key Development Patterns
 
 ### Adding a New MCP Tool

--- a/README.md
+++ b/README.md
@@ -459,20 +459,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,034 |     219,156 |
-| Unit tests (`_test.go`)  |       606 |     358,625 |
+| Source (`.go`, non-test) |     1,034 |     219,222 |
+| Unit tests (`_test.go`)  |       606 |     358,720 |
 | End-to-end tests         |       218 |      59,303 |
-| **Total**                | **1,858** | **637,084** |
+| **Total**                | **1,858** | **637,245** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,249 |
+| Source functions                |  8,250 |
 | . Exported (public)             |  2,773 |
-| . Unexported (private)          |  5,476 |
-| Unit test functions (`TestXxx`) | 12,862 |
-| Subtests (`t.Run(...)`)         |  4,723 |
+| . Unexported (private)          |  5,477 |
+| Unit test functions (`TestXxx`) | 12,865 |
+| Subtests (`t.Run(...)`)         |  4,724 |
 | End-to-end test functions       |    558 |
 
 ### Ratios worth noting
@@ -480,9 +480,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
-| Average source file length         |                 ~211 lines |
+| Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~591 lines |
-| Comment lines in source            |  32,089 (~14.6% of source) |
+| Comment lines in source            |  32,119 (~14.7% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~3,984 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,164 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~3,985 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,169 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/bearerguard.go
+++ b/cmd/server/bearerguard.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -227,11 +228,9 @@ func (g *bearerGuard) check(r *http.Request) *gateFailure {
 		slog.InfoContext(r.Context(), "request rejected: token cannot read the API",
 			"minimum", g.minimumScope, "granted", strings.Join(info.Scopes, " "))
 		return &gateFailure{
-			status: http.StatusForbidden,
-			code:   errCodeForbidden,
-			message: "This token carries no GitLab API scope: " + g.minimumScope + " is the least this server can work with. " +
-				"Reauthorize the application requesting it, granting " + g.advertisedScope + " for the full tool surface or " +
-				g.minimumScope + " for a read-only one.",
+			status:  http.StatusForbidden,
+			code:    errCodeForbidden,
+			message: describeScopeShortfall(info.Scopes, g.minimumScope, g.advertisedScope),
 			// The scope named here is the MINIMUM that satisfies this
 			// request, not the deployment's recommended one. RFC 6750
 			// section 3.1 defines the attribute as "the scope necessary to
@@ -426,6 +425,36 @@ func (g *bearerGuard) blockedByBudget(key, source string) bool {
 // GitLab answers that with invalid_scope. The protected-resource document
 // says the same thing in scopes_supported, but a client is not obliged to
 // fetch it before it authorizes.
+// describeScopeShortfall explains why a genuine token is not enough, naming
+// what it does carry.
+//
+// What the token holds matters to the reader more than what it lacks. GitLab
+// issues an "mcp" scope for its own MCP server, and a client registering
+// dynamically against gitlab.com receives exactly that, from a consent screen
+// reading "Grants read-write access to MCP server". Somebody who authorized
+// that has every reason to believe they granted the right thing, and a message
+// naming only api and read_api leaves them to work out what went wrong.
+func describeScopeShortfall(granted []string, minimum, advertised string) string {
+	held := "no GitLab API scope"
+	switch {
+	case len(granted) == 1:
+		held = "the " + granted[0] + " scope"
+	case len(granted) > 1:
+		held = "the " + strings.Join(granted, ", ") + " scopes"
+	}
+
+	message := "This token carries " + held + ", and " + minimum +
+		" is the least this server can work with. " +
+		"Reauthorize the application requesting it, granting " + advertised +
+		" for the full tool surface or " + minimum + " for a read-only one."
+
+	if slices.Contains(granted, "mcp") || slices.Contains(granted, "mcp_orbit") {
+		message += " GitLab's mcp scope is for its own MCP server and does not grant the REST API this server calls, " +
+			"which is what a dynamically registered client receives by default."
+	}
+	return message
+}
+
 func (g *bearerGuard) challenge(params ...string) string {
 	return oauthChallenge(g.advertisedScope, g.metadataURL, params...)
 }

--- a/internal/oauth/verifier.go
+++ b/internal/oauth/verifier.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/auth"
@@ -520,7 +521,8 @@ type introspection struct {
 // date. Parsing the latter as RFC 3339 fails and silently degrades to "no
 // expiry", which is exactly the bug this exists to prevent.
 func introspectToken(ctx context.Context, client *http.Client, gitlabURL, token string) introspection {
-	if payload := fetchIntrospection(ctx, client, gitlabURL+"/api/v4/personal_access_tokens/self", token); payload != nil {
+	var refused atomic.Bool
+	if payload := fetchIntrospection(ctx, client, gitlabURL+"/api/v4/personal_access_tokens/self", token, &refused); payload != nil {
 		if scopes := stringSlice(payload["scopes"]); scopes != nil {
 			return introspection{
 				scopes:   expandImpliedScopes(scopes),
@@ -529,7 +531,7 @@ func introspectToken(ctx context.Context, client *http.Client, gitlabURL, token 
 			}
 		}
 	}
-	if payload := fetchIntrospection(ctx, client, gitlabURL+"/oauth/token/info", token); payload != nil {
+	if payload := fetchIntrospection(ctx, client, gitlabURL+"/oauth/token/info", token, &refused); payload != nil {
 		if scopes := stringSlice(payload["scope"]); scopes != nil {
 			return introspection{
 				scopes:         expandImpliedScopes(scopes),
@@ -539,6 +541,19 @@ func introspectToken(ctx context.Context, client *http.Client, gitlabURL, token 
 			}
 		}
 	}
+	if refused.Load() {
+		// Both endpoints saw the credential and declined to describe it, so
+		// this is an answer about the token rather than a gap in what we could
+		// ask. Assuming api here is what let a token that cannot read its own
+		// scopes through the door, to fail on every tool call afterwards with
+		// an error from GitLab instead of one refusal here that says what to
+		// reauthorize.
+		slog.DebugContext(ctx, "the instance refused to describe this token's scopes; treating it as carrying none")
+		return introspection{answered: true}
+	}
+	// Nothing answered at all: an older instance, an unreachable endpoint, a
+	// timeout. The question could not be put, so refusing every such token
+	// would lock out deployments that work.
 	slog.DebugContext(ctx, "token scope introspection unavailable; assuming api scope")
 	return introspection{scopes: expandImpliedScopes([]string{"api"})}
 }
@@ -619,6 +634,19 @@ func expiryFromSeconds(raw any) time.Time {
 // stringSlice reads a JSON array of strings, returning nil when the field is
 // absent, not an array, or carries no strings.
 func stringSlice(raw any) []string {
+	// A space-separated string first, because that is what the specifications
+	// say: RFC 6749 defines scope as a space-delimited list and RFC 7662
+	// repeats it for introspection. GitLab's /oauth/token/info answers with a
+	// JSON array instead, which is why the array case exists, but reading only
+	// the array means a conforming authorization server is silently understood
+	// as "no scopes" and falls through to the assumption below.
+	if text, ok := raw.(string); ok {
+		out := strings.Fields(text)
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	}
 	items, ok := raw.([]any)
 	if !ok {
 		return nil
@@ -650,7 +678,10 @@ func expandImpliedScopes(scopes []string) []string {
 // fetchScopes reads one introspection endpoint and returns the named
 // string-array field, or nil when the endpoint does not answer for this
 // token kind.
-func fetchIntrospection(ctx context.Context, client *http.Client, endpoint, token string) map[string]any {
+// refused reports that the endpoint answered about this credential rather than
+// being unavailable, which is what separates "cannot ask" from "asked and was
+// told no".
+func fetchIntrospection(ctx context.Context, client *http.Client, endpoint, token string, refused *atomic.Bool) map[string]any {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		return nil
@@ -662,6 +693,12 @@ func fetchIntrospection(ctx context.Context, client *http.Client, endpoint, toke
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		// A 401 or 403 is an answer, not a failure to ask: the instance saw
+		// this credential and declined to describe it. Recorded so the caller
+		// can tell that apart from an endpoint that could not be reached.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			refused.Store(true)
+		}
 		return nil
 	}
 	var payload map[string]any

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -815,7 +816,8 @@ func TestFetchScopes_UnusableEndpoint_ReportsNoAnswer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := fetchIntrospection(t.Context(), http.DefaultClient, tt.endpoint, "glpat-x"); got != nil {
+			var refused atomic.Bool
+			if got := fetchIntrospection(t.Context(), http.DefaultClient, tt.endpoint, "glpat-x", &refused); got != nil {
 				t.Errorf("fetchIntrospection(%s) = %v, want nil", tt.name, got)
 			}
 		})
@@ -1537,5 +1539,98 @@ func TestVerificationRedirect_MissingContext(t *testing.T) {
 				t.Errorf("verificationRedirect() error = %v, want error %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestStringSlice_AcceptsTheSpaceSeparatedFormTheSpecificationsDefine covers
+// the scope shape this code did not read.
+//
+// RFC 6749 defines scope as a space-delimited string and RFC 7662 repeats it
+// for introspection. GitLab's /oauth/token/info answers with a JSON array
+// instead, which is why the array form works and is why reading only the array
+// went unnoticed: against gitlab.com it is right. Against a conforming
+// authorization server it silently means "no scopes", and the caller then
+// assumes api and admits a token it should have refused.
+func TestStringSlice_AcceptsTheSpaceSeparatedFormTheSpecificationsDefine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  any
+		want []string
+	}{
+		{name: "the array GitLab returns", raw: []any{"api", "read_user"}, want: []string{"api", "read_user"}},
+		{name: "the string the specifications define", raw: "api read_user", want: []string{"api", "read_user"}},
+		{name: "a single scope as a string", raw: "read_api", want: []string{"read_api"}},
+		{name: "extra whitespace is not a scope", raw: "  api   read_api  ", want: []string{"api", "read_api"}},
+		{name: "an empty string carries nothing", raw: "", want: nil},
+		{name: "only whitespace carries nothing", raw: "   ", want: nil},
+		{name: "a number is not a scope list", raw: 42, want: nil},
+		{name: "an empty array carries nothing", raw: []any{}, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stringSlice(tt.raw)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("stringSlice(%#v) = %#v, want %#v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIntrospectToken_RefusedByBothEndpoints_ReportsNoScopesRatherThanAssumingAPI
+// covers the distinction the fallback did not make.
+//
+// Assuming api when the instance cannot be asked is deliberate: an older
+// instance, an unreachable endpoint, and refusing every such token would lock
+// out deployments that work. But a 401 or 403 is an answer, not a gap. A
+// credential that cannot read its own scopes will not read anything else
+// either, and admitting it means failing on every tool call with an error from
+// GitLab instead of one refusal at the door that says what to reauthorize.
+func TestIntrospectToken_RefusedByBothEndpoints_ReportsNoScopesRatherThanAssumingAPI(t *testing.T) {
+	t.Parallel()
+
+	refusing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(refusing.Close)
+
+	got := introspectToken(t.Context(), refusing.Client(), refusing.URL, "gloas-whatever")
+
+	if len(got.scopes) != 0 {
+		t.Errorf("introspectToken() reported scopes %v for a token both endpoints refused to describe", got.scopes)
+	}
+	if !got.answered {
+		t.Error("introspectToken() did not record that the instance answered, so the refusal reads as an outage")
+	}
+	if SatisfiesMinimum(got.scopes, MinimumScope) {
+		t.Error("a token whose scopes could not be read was admitted; it would fail on every call instead")
+	}
+}
+
+// TestIntrospectToken_UnreachableInstance_StillAssumesAPI verifies the other
+// half, which is the reason the assumption exists at all.
+//
+// Nothing answered, so nothing is known. Refusing here would turn an
+// introspection endpoint being absent or slow into a server that admits
+// nobody, which is a worse failure than admitting a token that turns out to be
+// under-scoped.
+func TestIntrospectToken_UnreachableInstance_StillAssumesAPI(t *testing.T) {
+	t.Parallel()
+
+	// Closed immediately, so connections are refused rather than answered.
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := down.URL
+	down.Close()
+
+	got := introspectToken(t.Context(), http.DefaultClient, url, "glpat-whatever")
+
+	if !SatisfiesMinimum(got.scopes, MinimumScope) {
+		t.Errorf("introspectToken() reported %v for an unreachable instance; an outage must not lock every token out", got.scopes)
+	}
+	if got.answered {
+		t.Error("introspectToken() recorded an answer from an instance that never replied")
 	}
 }


### PR DESCRIPTION
Reported against the hosted endpoint: the handshake succeeds and then every tool call fails with

> GitLab rejected this token for lacking the scope this request needs. Reauthorize granting api for the full tool surface, or read_api for a read-only one. The token itself is valid.

The message is accurate and arrives in the worst possible place. The client has already been told the connection is healthy, so the failure looks like a broken server rather than a credential that was never going to work.

## What produces it

A client registering dynamically against gitlab.com receives a token carrying GitLab's `mcp` scope, from a consent screen reading "Grants read-write access to MCP server". That scope is for GitLab's own MCP endpoint and grants no general REST API, which is the API every action here calls.

Such a token should be refused at the door. It was admitted instead, because of two defects in introspection.

## `stringSlice` read only a JSON array

RFC 6749 defines `scope` as a space-delimited string, and RFC 7662 repeats it for introspection. `stringSlice` accepted `[]any` and nothing else, so a conforming authorization server was understood as carrying no scopes at all.

Against gitlab.com nothing changes, because `/oauth/token/info` answers with an array. That is precisely why this went unnoticed: the one instance it was tested against is the one that does not exercise it.

## The fallback could not tell an outage from a refusal

`fetchIntrospection` returned `nil` for a connection error, a timeout, a 404, a 401 and a 403 alike. `introspectToken` then assumed `api` for all of them:

```go
slog.DebugContext(ctx, "token scope introspection unavailable; assuming api scope")
return introspection{scopes: expandImpliedScopes([]string{"api"})}
```

The assumption itself is right and stays. If the instance cannot be asked, refusing every token would lock out deployments that work, which is a worse failure than admitting one that turns out to be under-scoped.

But a 401 or a 403 is an answer, not a gap. The instance saw the credential and declined to describe it, and a token that cannot read its own scopes will not read anything else either. Those two cases are now distinguished, and only the first keeps the assumption.

## The refusal now names what the token has

Telling somebody to grant `api` does not explain why the thing they just authorized failed. The message names the scopes the token actually carries, and when one of them is `mcp` it says what that scope is for, because that is the case a user is most likely to be looking at while reading it.

## Tests

Three, and each fails without the change. The one that matters most reproduces the reported behaviour exactly:

```
introspectToken() reported scopes [api read_api] for a token both endpoints refused to describe
a token whose scopes could not be read was admitted; it would fail on every call instead
```

The counterpart pins the half that must not change: an unreachable instance still assumes `api`, so an introspection endpoint being absent or slow cannot turn into a server that admits nobody.

## Not changed

The documentation, which already covers this. `docs/guides/oauth-app-setup.md` has a section titled "Scopes: pick `api`, avoid `mcp`", explains that a credential minted for `mcp` grants no general REST or GraphQL access, and warns that a client without an explicit client ID falls back to dynamic registration "which on GitLab yields a token this server cannot use". I had recorded documentation as missing in the issue and it was not; corrected there.

Also included: the editing preference in `CLAUDE.md`, after a script with a stale anchor silently corrupted a Go file during this work.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/432

