### PR TITLE
feat(gen_testing_docs): pass -timeout through, refresh testing.md, gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,18 @@ jobs:
       # stays maintainer tooling, run with gen-icon-webp after icon edits.
       - name: Check action catalog manifest
         run: make check-action-catalog-manifest
+      # Everything in the testing reference that the source tree determines:
+      # test counts, naming breakdown, per-layer tables, and which packages
+      # appear in the coverage tables, which is what caught one missing from
+      # them. Not the coverage percentages: those depend on the machine that
+      # measured them (tests asserting permission refusals skip for uid 0,
+      # cmd/gen_icon_webp needs rsvg-convert and cwebp, cmd/server has a
+      # load-dependent branch), so a gate on them would go red over tenths of a
+      # percent nobody can fix. Carrying them forward instead also means no
+      # coverage pass here at all, so this costs seconds on a job SonarCloud
+      # already waits on. `make gen-testing-docs` refreshes the numbers.
+      - name: Check the generated testing reference
+        run: make check-testing-docs
       - name: Run tests with coverage
         run: |
           go test -count=1 -coverpkg=./cmd/...,./internal/... -coverprofile=coverage.out ./cmd/... ./internal/...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,15 +96,18 @@ make inspector-stop
 run that target**, but every `check-*` freshness gate is now wired into CI
 individually: the `test` job runs the eight Go ones (`check-llms`,
 `check-lhm-manifest`, `check-server-json`, `check-openplugin`, `check-stats`,
-`check-footprint`, `check-site-stats`, `check-action-catalog-manifest`) and the
-`analyze-md` job runs the two that need Node (`check-doc-links`,
-`check-mcpb`). Adding a new `check-*` target means adding it to one of those
-two jobs — `check-stats` and `check-footprint` sat stale on `main` for several
-releases precisely because nothing gated them.
+`check-footprint`, `check-site-stats`, `check-action-catalog-manifest`,
+`check-testing-docs`) and the `analyze-md` job runs the two that need Node
+(`check-doc-links`, `check-mcpb`). Adding a new `check-*` target means adding
+it to one of those two jobs — `check-stats` and `check-footprint` sat stale on
+`main` for several releases precisely because nothing gated them, and
+`docs/development/testing/testing.md` drifted for the same reason.
+`check-testing-docs` gates everything in that file a checkout determines and
+not the coverage columns, which no two machines agree on; refresh those with
+`make gen-testing-docs`.
 
-The rest of `audit-docs` — markdownlint, `gen_testing_docs --check`, the godoc
-and surface-quality audits, and the site build — is still yours to run before
-pushing.
+The rest of `audit-docs` — markdownlint, the godoc and surface-quality audits,
+and the site build — is still yours to run before pushing.
 
 ## Adding a new GitLab API tool
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names audit-test-subtests check-test-subtests check-supply-chain \
 	check-readonly-graphql audit-readonly-graphql \
 	audit-doc-coverage audit-doc-coverage-check \
-	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest gen-icon-webp check-icon-webp check-server-json check-server-json-packages check-openplugin audit-doc-tool-names check-doc-tool-names check-install-buttons check-mcpb mcpb gen-npm sync-npm-version validate-npm validate-npm-local publish-npm-dry publish-npm gen-pypi validate-pypi validate-pypi-local publish-pypi-dry publish-pypi publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs update-all \
+	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest gen-icon-webp check-icon-webp check-server-json check-server-json-packages check-openplugin audit-doc-tool-names check-doc-tool-names check-install-buttons check-mcpb mcpb gen-npm sync-npm-version validate-npm validate-npm-local publish-npm-dry publish-npm gen-pypi validate-pypi validate-pypi-local publish-pypi-dry publish-pypi publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs check-testing-docs update-all \
 	docs-local-go \
        docker-build docker-push docker-run \
        inspector inspector-stop help
@@ -509,7 +509,7 @@ audit-docs:
 	go run ./cmd/format_md_tables/ --check
 	go run ./cmd/gen_llms/ --check
 	go run ./cmd/gen_lhm_manifest/ --check
-	go run ./cmd/gen_testing_docs/ --check
+	$(MAKE) check-testing-docs
 	go run ./cmd/audit_metrics/ -site-stats site/src/data/stats.json -check
 	$(MAKE) check-doc-links
 	go run ./cmd/godoc_tool/ audit
@@ -924,8 +924,19 @@ check-site-stats:
 	go run ./cmd/audit_metrics/ -site-stats site/src/data/stats.json -check
 
 ## gen-testing-docs: regenerate testing.md counts and coverage tables.
+## Runs unit-test coverage over ./cmd/... and ./internal/..., so it takes minutes.
+## Add -skip-coverage to refresh only the counts, keeping the recorded values.
 gen-testing-docs:
 	go run ./cmd/gen_testing_docs/
+
+## check-testing-docs: verify everything in testing.md that a checkout determines.
+## Seconds, not minutes: it carries the recorded coverage values forward instead of
+## recomputing them, because those depend on the machine (privilege, and whether
+## rsvg-convert is installed) while counts and package rows do not. This is the CI
+## gate. To verify the coverage values too, regenerate with gen-testing-docs and
+## look at the diff.
+check-testing-docs:
+	go run ./cmd/gen_testing_docs/ --check -skip-coverage
 
 ## gen-action-catalog-manifest: regenerate the ActionSpec group builder manifest.
 gen-action-catalog-manifest:

--- a/README.md
+++ b/README.md
@@ -459,20 +459,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,041 |     220,634 |
-| Unit tests (`_test.go`)  |       612 |     360,879 |
+| Source (`.go`, non-test) |     1,041 |     220,939 |
+| Unit tests (`_test.go`)  |       612 |     361,265 |
 | End-to-end tests         |       218 |      59,303 |
-| **Total**                | **1,871** | **640,816** |
+| **Total**                | **1,871** | **641,507** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,291 |
+| Source functions                |  8,303 |
 | . Exported (public)             |  2,787 |
-| . Unexported (private)          |  5,504 |
-| Unit test functions (`TestXxx`) | 12,916 |
-| Subtests (`t.Run(...)`)         |  4,754 |
+| . Unexported (private)          |  5,516 |
+| Unit test functions (`TestXxx`) | 12,927 |
+| Subtests (`t.Run(...)`)         |  4,760 |
 | End-to-end test functions       |    558 |
 
 ### Ratios worth noting
@@ -480,18 +480,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
-| Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~589 lines |
-| Comment lines in source            |  32,726 (~14.8% of source) |
+| Average source file length         |                 ~212 lines |
+| Average test file length           |                 ~590 lines |
+| Comment lines in source            |  32,842 (~14.9% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,953 |
+| `if err != nil` checks             | 6,962 |
 | `defer` statements                 | 1,122 |
-| `struct` types defined             | 2,842 |
+| `struct` types defined             | 2,843 |
 | `//nolint` suppressions            |   270 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -514,7 +514,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,011 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~4,017 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 13,208 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/cmd/gen_testing_docs/main.go
+++ b/cmd/gen_testing_docs/main.go
@@ -87,6 +87,48 @@ const (
 	testFilesMetricFormat = "Test files (%s)"
 )
 
+const (
+	// defaultTestTimeout is the per-package bound handed to every `go test`
+	// this generator runs. It has to clear the slowest package under coverage
+	// instrumentation, which is cmd/audit_metrics: its site-stats test builds
+	// the whole action catalog three times and takes several minutes with
+	// counters compiled in, well past the 10 minute default `go test` applies
+	// when nobody passes -timeout. That default was what made the coverage
+	// pass unrunnable, and with no way to raise it the file this generator
+	// writes could not be refreshed at all.
+	defaultTestTimeout = 30 * time.Minute
+
+	// overheadBudget is what the generation gets on top of the time its
+	// `go test` runs may consume: package listing, the coverage summary, AST
+	// parsing and the document write. It doubles as the head start the
+	// process context keeps over the bound handed to `go test`, so a package
+	// that runs long is reported by `go test` itself, which panics with the
+	// goroutine dump naming the test, rather than being killed anonymously
+	// when the context deadline cancels the command.
+	overheadBudget = 5 * time.Minute
+
+	// maxReportedDifferences caps the lines a failing check prints, so a
+	// regeneration that moves the whole block points at where to look instead
+	// of reprinting the document into a CI log.
+	maxReportedDifferences = 20
+
+	// coverageUnavailable is the cell fmtCoverage writes for a package no
+	// coverage run measured, and the cell parseCoverageCell reads back.
+	coverageUnavailable = "n/a"
+
+	// averageCoverageLabel and toolsOrchestrationKey are shared by the
+	// renderer and the reader, so the two cannot drift apart: a label edited
+	// on one side only would silently stop a -skip-coverage run from finding
+	// the value it is meant to carry forward.
+	averageCoverageLabel  = "Average package coverage"
+	toolsOrchestrationKey = "tools (orch.)"
+)
+
+var (
+	overallCoverageLabel  = fmt.Sprintf("Overall coverage (`go test %s %s`)", internalPattern, cmdPattern)
+	internalCoverageLabel = fmt.Sprintf("Overall coverage (`go test %s`)", internalPattern)
+)
+
 var (
 	coverageLineRE = regexp.MustCompile(`^ok\s+(\S+)\s+.*coverage:\s+([0-9.]+)% of statements`)
 	totalLineRE    = regexp.MustCompile(`total:\s+\(statements\)\s+([0-9.]+)%`)
@@ -99,10 +141,11 @@ var (
 // check enables non-mutating CI mode that fails when the generated block
 // would change. skipCoverage skips running `go test -cover` and only
 // updates count-only sections. topToolRows caps the high-test-count tool
-// sub-package summary table. timeout bounds the unit-test coverage run.
-// coverageDir overrides the temp profile directory; empty uses a fresh
-// temp dir. includeE2ERun additionally executes the build-tagged E2E
-// suite, which requires a real GitLab test environment.
+// sub-package summary table. timeout is handed to each `go test` run as its
+// per-package bound, and the generation as a whole gets that budget once per
+// test run plus overheadBudget. coverageDir overrides the temp profile
+// directory; empty uses a fresh temp dir. includeE2ERun additionally executes
+// the build-tagged E2E suite, which requires a real GitLab test environment.
 type options struct {
 	docPath       string
 	check         bool
@@ -163,6 +206,18 @@ type repositoryMetrics struct {
 	E2ENote                string
 }
 
+// recordedCoverageValues is the coverage a generated document already carries.
+//
+// ByKey is keyed the way the coverage tables label their rows, which is the
+// package key for every layer but the tools orchestration one. Overall,
+// Internal and AveragePackage are the three figures of the overview table.
+type recordedCoverageValues struct {
+	ByKey          map[string]coverageValue
+	Overall        coverageValue
+	Internal       coverageValue
+	AveragePackage coverageValue
+}
+
 // packageInfo identifies one Go package returned by go list.
 //
 // ImportPath is the module path. Dir is the absolute directory containing
@@ -188,7 +243,7 @@ func run(args []string, stdout io.Writer) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), runBudget(opts))
 	defer cancel()
 
 	metrics, err := collectMetrics(ctx, opts)
@@ -197,16 +252,17 @@ func run(args []string, stdout io.Writer) error {
 	}
 
 	content := renderTestingStats(metrics, opts.topToolRows)
-	changed, err := updateManagedSection(opts.docPath, content, opts.check)
+	changed, report, err := updateManagedSection(opts.docPath, content, opts.check)
 	if err != nil {
 		return err
 	}
 
 	if opts.check {
 		if changed {
-			return fmt.Errorf("%s is out of date; run go run ./cmd/gen_testing_docs/", opts.docPath)
+			return fmt.Errorf("%s is out of date; run go run ./cmd/gen_testing_docs/\n%s%s",
+				opts.docPath, report, checkScopeNote(opts.skipCoverage))
 		}
-		_, _ = fmt.Fprintf(stdout, "%s is up to date\n", opts.docPath)
+		_, _ = fmt.Fprintf(stdout, "%s is up to date%s\n", opts.docPath, checkedScopeSuffix(opts.skipCoverage))
 		return nil
 	}
 
@@ -227,7 +283,7 @@ func parseOptions(args []string) (options, error) {
 	fs.BoolVar(&opts.check, "check", false, "fail if the generated section is not current")
 	fs.BoolVar(&opts.skipCoverage, "skip-coverage", false, "skip go test coverage execution and update count-only sections")
 	fs.IntVar(&opts.topToolRows, "top-tool-rows", 25, "number of high-test-count tool sub-packages to show in the summary table")
-	fs.DurationVar(&opts.timeout, "timeout", 15*time.Minute, "timeout for Go test coverage commands")
+	fs.DurationVar(&opts.timeout, "timeout", defaultTestTimeout, "per-package timeout handed to each go test run")
 	fs.StringVar(&opts.coverageDir, "coverage-dir", "", "directory for temporary coverage profiles; defaults to a temp directory")
 	fs.BoolVar(&opts.includeE2ERun, "include-e2e-run", false, "also run the build-tagged E2E suite; requires GitLab test environment")
 	if err := fs.Parse(args); err != nil {
@@ -239,7 +295,28 @@ func parseOptions(args []string) (options, error) {
 	if opts.topToolRows < 1 {
 		return options{}, errors.New("top-tool-rows must be greater than zero")
 	}
+	if opts.timeout <= 0 {
+		return options{}, errors.New("timeout must be greater than zero")
+	}
 	return opts, nil
+}
+
+// runBudget returns the wall-clock deadline for one generation.
+//
+// Each `go test` the run may issue gets the full -timeout, so the budget
+// counts them rather than sharing one bound between them: the coverage pass
+// always, the E2E suite only when -include-e2e-run asks for it. Sharing was
+// wrong for -include-e2e-run, where a coverage pass that used its whole bound
+// left the E2E run none.
+func runBudget(opts options) time.Duration {
+	runs := 0
+	if !opts.skipCoverage {
+		runs++
+	}
+	if opts.includeE2ERun {
+		runs++
+	}
+	return time.Duration(runs)*opts.timeout + overheadBudget
 }
 
 // collectMetrics discovers packages, counts tests, and runs coverage commands.
@@ -255,17 +332,12 @@ func collectMetrics(ctx context.Context, opts options) (repositoryMetrics, error
 		E2ENote:      "E2E tests are counted statically from test/e2e because two of the four modules need something this run does not have: test/e2e/suite needs a provisioned GitLab instance and test/e2e/orbit needs a gitlab.com token for the Knowledge Graph API, while test/e2e/http and test/e2e/stdio need neither and run on every CI push. The count here is of `_test.go` files; the README's end-to-end row counts every tracked `.go` file under test/e2e, so it is higher by the non-test helpers (`doc.go`, `name_helpers.go`).",
 	}
 
-	coverageByPackage := map[string]coverageValue{}
-	if !opts.skipCoverage {
-		cmdutil.Progressf("gen_testing_docs: running unit-test coverage for ./internal/... and ./cmd/... (this can take a few minutes)...")
-		combinedCoverage, combinedTotal, internalTotal, coverageErr := runUnitCoverage(ctx, opts)
-		if coverageErr != nil {
-			return repositoryMetrics{}, coverageErr
-		}
-		coverageByPackage = combinedCoverage
-		metrics.OverallCoverage = combinedTotal
-		metrics.InternalCoverage = internalTotal
+	coverageByPackage, recorded, err := collectCoverage(ctx, opts)
+	if err != nil {
+		return repositoryMetrics{}, err
 	}
+	metrics.OverallCoverage = recorded.Overall
+	metrics.InternalCoverage = recorded.Internal
 	toolCounts := actionSpecToolCounts()
 
 	for _, info := range infos {
@@ -290,27 +362,24 @@ func collectMetrics(ctx context.Context, opts options) (repositoryMetrics, error
 		}
 
 		if pkg.Layer == layerToolSubpackage {
-			legacyToolCount, toolErr := countMCPTools(info.Dir)
-			if toolErr != nil {
-				return repositoryMetrics{}, fmt.Errorf("count MCP tools in %s: %w", pkg.RelPath, toolErr)
-			}
-			localSpecCount, specErr := countLocalActionSpecTools(info.Dir)
-			if specErr != nil {
-				return repositoryMetrics{}, fmt.Errorf("count ActionSpec tools in %s: %w", pkg.RelPath, specErr)
-			}
-			pkg.ToolCount = max(legacyToolCount, localSpecCount)
-			if catalogToolCount := toolCounts[pkg.Key]; catalogToolCount > 0 {
-				pkg.ToolCount = max(catalogToolCount, legacyToolCount)
+			if pkg.ToolCount, err = packageToolCount(info.Dir, pkg.RelPath, pkg.Key, toolCounts); err != nil {
+				return repositoryMetrics{}, err
 			}
 		}
 
 		if coverage, ok := coverageByPackage[pkg.ImportPath]; ok {
 			pkg.Coverage = coverage
 		}
+		if coverage, ok := recorded.ByKey[coverageTableKey(pkg)]; ok {
+			pkg.Coverage = coverage
+		}
 		metrics.Packages = append(metrics.Packages, pkg)
 	}
 
 	metrics.AveragePackageCoverage = averageCoverage(metrics.Packages)
+	if recorded.AveragePackage.OK {
+		metrics.AveragePackageCoverage = recorded.AveragePackage
+	}
 
 	if opts.includeE2ERun {
 		if _, e2eErr := runGo(ctx, []string{"test", "-tags", "e2e", "-timeout", opts.timeout.String(), e2eSuiteRun}); e2eErr != nil {
@@ -320,6 +389,154 @@ func collectMetrics(ctx context.Context, opts options) (repositoryMetrics, error
 	}
 
 	return metrics, nil
+}
+
+// packageToolCount returns how many MCP tools one tool sub-package owns.
+//
+// The static AddTool scan, the local ActionSpec scan and the runtime catalog
+// can each under-count a package the other two see, so the highest wins;
+// relPath names the package in an error, which is how the failures read.
+func packageToolCount(dir, relPath, key string, catalog map[string]int) (int, error) {
+	legacyCount, err := countMCPTools(dir)
+	if err != nil {
+		return 0, fmt.Errorf("count MCP tools in %s: %w", relPath, err)
+	}
+	localSpecCount, err := countLocalActionSpecTools(dir)
+	if err != nil {
+		return 0, fmt.Errorf("count ActionSpec tools in %s: %w", relPath, err)
+	}
+	if catalogCount := catalog[key]; catalogCount > 0 {
+		return max(catalogCount, legacyCount), nil
+	}
+	return max(legacyCount, localSpecCount), nil
+}
+
+// collectCoverage resolves where this run's coverage numbers come from: a
+// fresh unit-test run, or the values the document already records.
+//
+// The two are returned side by side because they are keyed differently: a
+// measured run knows import paths, a document knows the labels its tables use.
+func collectCoverage(ctx context.Context, opts options) (map[string]coverageValue, recordedCoverageValues, error) {
+	if opts.skipCoverage {
+		return map[string]coverageValue{}, recordedCoverage(opts.docPath), nil
+	}
+
+	cmdutil.Progressf("gen_testing_docs: running unit-test coverage for ./internal/... and ./cmd/... (this can take a few minutes)...")
+	measured, overall, internal, err := runUnitCoverage(ctx, opts)
+	if err != nil {
+		return nil, recordedCoverageValues{}, err
+	}
+	return measured, recordedCoverageValues{Overall: overall, Internal: internal}, nil
+}
+
+// recordedCoverage recovers the coverage the document already records, so a
+// -skip-coverage run refreshes the counts without discarding the numbers.
+//
+// It used to blank every coverage column to n/a, which made the fast path
+// useless for anything but a first draft, and made a fast freshness check
+// impossible: a check that rewrites the columns it is comparing always fails.
+// Reading them back instead makes -skip-coverage a refresh of everything a
+// checkout determines, and leaves the numbers a coverage run determines to
+// the coverage run.
+// A document that cannot be read has nothing to carry forward, so this stays
+// silent about it: updateManagedSection reads the same path a moment later and
+// reports the failure once, with the message it has always used.
+func recordedCoverage(docPath string) recordedCoverageValues {
+	if docPath == "" {
+		return recordedCoverageValues{}
+	}
+	resolved, err := resolveRepositoryPath(docPath)
+	if err != nil {
+		return recordedCoverageValues{}
+	}
+	data, err := os.ReadFile(resolved) //#nosec G304 -- path constrained to repository root by resolveRepositoryPath.
+	if err != nil {
+		return recordedCoverageValues{}
+	}
+	return parseRecordedCoverage(string(data))
+}
+
+// parseRecordedCoverage reads the coverage cells out of a generated document.
+//
+// Every package the coverage report knows about has one two-column row in it,
+// keyed exactly as coverageTableKey keys it, and the two overall figures are
+// two-column rows of the overview table. Nothing else in the document is a
+// two-column row whose second cell is a percentage, so the shape is enough to
+// find them without tracking which section is being read.
+func parseRecordedCoverage(text string) recordedCoverageValues {
+	recorded := recordedCoverageValues{ByKey: map[string]coverageValue{}}
+	for line := range strings.Lines(text) {
+		cells := splitCoverageRow(line)
+		if len(cells) != 2 {
+			continue
+		}
+		value, ok := parseCoverageCell(cells[1])
+		if !ok {
+			continue
+		}
+		switch cells[0] {
+		case overallCoverageLabel:
+			recorded.Overall = value
+		case internalCoverageLabel:
+			recorded.Internal = value
+		case averageCoverageLabel:
+			// Read back rather than recomputed: the per-package values in the
+			// document are rounded to one decimal, so averaging them again
+			// need not land on the figure the full run wrote.
+			recorded.AveragePackage = value
+		default:
+			recorded.ByKey[cells[0]] = value
+		}
+	}
+	return recorded
+}
+
+// splitCoverageRow returns the trimmed cells of a Markdown table row, or nil
+// when the line is not one, a separator included.
+func splitCoverageRow(line string) []string {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "|") || !strings.HasSuffix(trimmed, "|") {
+		return nil
+	}
+	if strings.Contains(trimmed, "---") {
+		return nil
+	}
+	parts := strings.Split(strings.Trim(trimmed, "|"), "|")
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cells = append(cells, strings.TrimSpace(part))
+	}
+	return cells
+}
+
+// parseCoverageCell reads one rendered coverage cell back into a value.
+//
+// It accepts what fmtCoverage writes and nothing else, so a count cell such as
+// "13,476" is not mistaken for a measurement.
+func parseCoverageCell(cell string) (coverageValue, bool) {
+	if cell == coverageUnavailable {
+		return coverageValue{}, true
+	}
+	digits, ok := strings.CutSuffix(cell, "%")
+	if !ok {
+		return coverageValue{}, false
+	}
+	percent, err := strconv.ParseFloat(digits, 64)
+	if err != nil {
+		return coverageValue{}, false
+	}
+	return coverageValue{Percent: percent, OK: true}, true
+}
+
+// coverageTableKey returns the label the coverage report gives one package.
+//
+// The orchestration layer is the one that is not its own key: every package in
+// it is rendered under a single fixed label.
+func coverageTableKey(pkg packageMetrics) string {
+	if pkg.Layer == layerToolsOrchestration {
+		return toolsOrchestrationKey
+	}
+	return pkg.Key
 }
 
 // listPackages returns all packages covered by the testing reference document.
@@ -355,7 +572,7 @@ func runUnitCoverage(ctx context.Context, opts options) (packageCoverages map[st
 
 	profilePath := filepath.Join(coverageDir, "cmd-internal.out")
 	patterns := []string{internalPattern, cmdPattern}
-	args := []string{"test", "-coverprofile=" + profilePath, "-covermode=count"}
+	args := []string{"test", "-coverprofile=" + profilePath, "-covermode=count", "-timeout", opts.timeout.String()}
 	args = append(args, patterns...)
 	args = append(args, "-count=1")
 
@@ -803,9 +1020,9 @@ func renderOverview(metrics repositoryMetrics) string {
 			{fmt.Sprintf(testFilesMetricFormat, e2eDisplay), fmtInt(testFilesWithPrefix(metrics.Packages, e2ePath))},
 			{"Tool sub-packages tested", fmtInt(countTestedPackages(toolPackages))},
 			{"Core packages tested", fmtInt(countTestedPackages(corePackages))},
-			{fmt.Sprintf("Overall coverage (`go test %s %s`)", internalPattern, cmdPattern), fmtCoverage(metrics.OverallCoverage)},
-			{fmt.Sprintf("Overall coverage (`go test %s`)", internalPattern), fmtCoverage(metrics.InternalCoverage)},
-			{"Average package coverage", fmtCoverage(metrics.AveragePackageCoverage)},
+			{overallCoverageLabel, fmtCoverage(metrics.OverallCoverage)},
+			{internalCoverageLabel, fmtCoverage(metrics.InternalCoverage)},
+			{averageCoverageLabel, fmtCoverage(metrics.AveragePackageCoverage)},
 		},
 	))
 	b.WriteByte('\n')
@@ -978,7 +1195,7 @@ func renderCoverageReport(metrics repositoryMetrics) string {
 	b.WriteString("### Tool Sub-Packages\n\n")
 	coverageRows := make([][]string, 0)
 	for _, pkg := range sortedCoveragePackages(packagesByLayer(metrics.Packages, layerToolsOrchestration)) {
-		coverageRows = append(coverageRows, []string{"tools (orch.)", fmtCoverage(pkg.Coverage)})
+		coverageRows = append(coverageRows, []string{toolsOrchestrationKey, fmtCoverage(pkg.Coverage)})
 	}
 	b.WriteString(renderPackageCoverageTableRows(appendPackageCoverageRows(coverageRows, sortedCoveragePackages(packagesByLayer(metrics.Packages, layerToolSubpackage)))))
 	b.WriteString("\n")
@@ -1054,32 +1271,109 @@ func firstSentence(s string) string {
 }
 
 // updateManagedSection replaces or creates the generated section in the target file.
-func updateManagedSection(path, content string, check bool) (bool, error) {
+//
+// In check mode nothing is written and the returned report names the first
+// lines on which the committed file and the freshly generated block disagree.
+// A gate that says only "out of date" leaves whoever reads the CI log with no
+// idea whether a test count moved, a coverage value moved, or a whole package
+// appeared, and the answer is several minutes of local coverage away.
+func updateManagedSection(path, content string, check bool) (changed bool, report string, err error) {
 	docPath, err := resolveRepositoryPath(path)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	data, err := os.ReadFile(docPath) //#nosec G304 -- path constrained to repository root by resolveRepositoryPath.
 	if err != nil {
-		return false, fmt.Errorf("read %s: %w", path, err)
+		return false, "", fmt.Errorf("read %s: %w", path, err)
 	}
 	text := string(data)
 
 	updated, err := replaceGeneratedBlock(text, content)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	if updated == text {
-		return false, nil
+		return false, "", nil
 	}
 	if check {
-		return true, nil
+		return true, lineDifferenceReport(text, updated, maxReportedDifferences), nil
 	}
 	if writeErr := os.WriteFile(docPath, []byte(updated), 0o644); writeErr != nil { //#nosec G306,G304,G703 -- path constrained to repository root by resolveRepositoryPath.
-		return false, fmt.Errorf("write %s: %w", path, writeErr)
+		return false, "", fmt.Errorf("write %s: %w", path, writeErr)
 	}
-	return true, nil
+	return true, "", nil
+}
+
+// checkScopeNote tells whoever reads a failing check what it compared.
+//
+// A coverage-measuring check compares numbers that are a property of the
+// machine as much as of the tree: tests asserting permission refusals skip for
+// uid 0, cmd/gen_icon_webp covers less wherever rsvg-convert and cwebp are not
+// installed, and cmd/server has a branch that depends on load. A difference
+// confined to those columns is a difference between two machines, not a stale
+// document, and saying so is what stops the obvious response, which is to
+// commit numbers the next machine will disagree with just as firmly.
+func checkScopeNote(skipCoverage bool) string {
+	if skipCoverage {
+		return "note: coverage values were carried forward from the document, not recomputed. This check holds everything\n" +
+			"the source tree determines, the set of packages in the coverage tables included; the percentages are\n" +
+			"indicative and a full run refreshes them.\n"
+	}
+	return "note: this check recomputed coverage, and those values depend on the machine as much as on the tree:\n" +
+		"tests asserting permission refusals skip for uid 0, cmd/gen_icon_webp needs rsvg-convert and cwebp installed,\n" +
+		"and cmd/server has a load-dependent branch. A difference confined to coverage columns is not a stale document,\n" +
+		"which is why the CI gate runs with -skip-coverage.\n"
+}
+
+// checkedScopeSuffix qualifies the success line of a check that carried the
+// coverage values forward, so "up to date" is never read as a statement about
+// numbers the run never measured.
+func checkedScopeSuffix(skipCoverage bool) string {
+	if !skipCoverage {
+		return ""
+	}
+	return " (counts, package rows and tables; coverage values carried forward, not recomputed)"
+}
+
+// lineDifferenceReport lists the first differing lines between two documents.
+//
+// Lines are compared by position, so an inserted or removed line reports every
+// line after it as differing. That is deliberate: this is a pointer at where to
+// look, not a minimal diff, and the limit keeps a wholesale regeneration from
+// filling a CI log with the entire file.
+func lineDifferenceReport(committed, generated string, limit int) string {
+	committedLines := strings.Split(committed, "\n")
+	generatedLines := strings.Split(generated, "\n")
+
+	var builder strings.Builder
+	builder.WriteString("first differences (- committed, + generated):\n")
+	reported := 0
+	for i := range max(len(committedLines), len(generatedLines)) {
+		if reported == limit {
+			break
+		}
+		committedLine := lineAt(committedLines, i)
+		generatedLine := lineAt(generatedLines, i)
+		if committedLine == generatedLine {
+			continue
+		}
+		_, _ = fmt.Fprintf(&builder, "  line %d:\n    -%s\n    +%s\n", i+1, committedLine, generatedLine)
+		reported++
+	}
+	if reported == limit {
+		builder.WriteString("  (further differences not shown)\n")
+	}
+	return builder.String()
+}
+
+// lineAt returns the line at index, or a placeholder when the document is
+// shorter than that, so a file that gained or lost lines still reports a pair.
+func lineAt(lines []string, index int) string {
+	if index >= len(lines) {
+		return "<no such line>"
+	}
+	return lines[index]
 }
 
 // resolveRepositoryPath returns an absolute path that stays inside the repository.
@@ -1146,7 +1440,9 @@ func replaceBetweenMarkers(text, content string) (string, error) {
 
 // runGo executes a Go command with the module toolchain version pinned.
 func runGo(ctx context.Context, args []string) ([]byte, error) {
-	// #nosec G204 -- args are built by this generator from fixed Go subcommands; no shell is involved.
+	// #nosec G204,G702 -- args are built by this generator from fixed Go subcommands plus its own
+	// flags: a duration rendered by time.Duration.String and a path it created. No shell is involved,
+	// and this is developer tooling a person runs on a checkout they already own.
 	cmd := exec.CommandContext(ctx, goExecutable(), args...)
 	cmd.Env = goEnvironment()
 	output, err := cmd.CombinedOutput()
@@ -1289,11 +1585,20 @@ func packagesByLayer(packages []packageMetrics, layer string) []packageMetrics {
 	return filtered
 }
 
-// sortedCoveragePackages returns packages with coverage, sorted by key.
+// sortedCoveragePackages returns the packages the coverage tables list, sorted
+// by key.
+//
+// A package with tests earns a row whether or not this run has a number for
+// it, so the set of rows is a fact about the tree rather than about the run.
+// Filtering on the value alone would let a package whose row was deleted, or
+// one added since the last full run, vanish from the table under
+// -skip-coverage and pass the freshness check that exists to catch exactly
+// that: cmd/audit_install_buttons went missing from these tables for months.
+// Such a row renders n/a until a full run fills it in.
 func sortedCoveragePackages(packages []packageMetrics) []packageMetrics {
 	filtered := []packageMetrics{}
 	for _, pkg := range packages {
-		if pkg.Coverage.OK {
+		if pkg.Coverage.OK || pkg.TestFiles > 0 {
 			filtered = append(filtered, pkg)
 		}
 	}
@@ -1418,7 +1723,7 @@ func fmtInt(n int) string {
 // fmtCoverage formats a coverage value for Markdown tables.
 func fmtCoverage(value coverageValue) string {
 	if !value.OK {
-		return "n/a"
+		return coverageUnavailable
 	}
 	return fmt.Sprintf("%.1f%%", value.Percent)
 }

--- a/cmd/gen_testing_docs/main_test.go
+++ b/cmd/gen_testing_docs/main_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -617,8 +618,8 @@ func TestRepositoryRoot_DeletedWorkingDirectory_FallsBackToDot(t *testing.T) {
 }
 
 // TestParseOptions_FlagShapes_ParsedOrRejected verifies the defaults, every
-// flag override, and the three rejection paths: an unknown flag, positional
-// arguments, and a non-positive table cap.
+// flag override, and the four rejection paths: an unknown flag, positional
+// arguments, a non-positive table cap, and a non-positive timeout.
 func TestParseOptions_FlagShapes_ParsedOrRejected(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -628,7 +629,7 @@ func TestParseOptions_FlagShapes_ParsedOrRejected(t *testing.T) {
 	}{
 		{
 			name: "defaults",
-			want: options{docPath: defaultDocPath, topToolRows: 25, timeout: 15 * time.Minute},
+			want: options{docPath: defaultDocPath, topToolRows: 25, timeout: defaultTestTimeout},
 		},
 		{
 			name: "all flags",
@@ -638,6 +639,8 @@ func TestParseOptions_FlagShapes_ParsedOrRejected(t *testing.T) {
 		{name: "unknown flag", args: []string{"--bogus"}, wantErr: true},
 		{name: "positional argument", args: []string{"extra"}, wantErr: true},
 		{name: "zero rows", args: []string{"--top-tool-rows", "0"}, wantErr: true},
+		{name: "zero timeout", args: []string{"--timeout", "0"}, wantErr: true},
+		{name: "negative timeout", args: []string{"--timeout", "-1m"}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -867,6 +870,70 @@ func TestRunUnitCoverage_UnwritableCoverageDir_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestRunUnitCoverage_SlowPackage_ReportsConfiguredTimeout verifies the
+// -timeout the generator was given reaches the `go test` it runs, by giving a
+// package that sleeps for three seconds a one second bound and reading the
+// bound back out of the failure. Without the pass-through the run would obey
+// the ten minute default `go test` applies when nobody passes -timeout, which
+// is what made the real coverage pass unrunnable: cmd/audit_metrics needs
+// longer than that under coverage instrumentation.
+func TestRunUnitCoverage_SlowPackage_ReportsConfiguredTimeout(t *testing.T) {
+	files := fakeModuleFiles()
+	files["internal/core/core_test.go"] = "package core\n\nimport (\n\t\"testing\"\n\t\"time\"\n)\n\n" +
+		"func TestAdd_Slow_ExceedsTheBound(t *testing.T) {\n\ttime.Sleep(3 * time.Second)\n}\n"
+	root := writeFakeModule(t, files)
+	t.Chdir(root)
+
+	_, _, _, err := runUnitCoverage(t.Context(), options{
+		timeout:     time.Second,
+		coverageDir: filepath.Join(root, "coverage"),
+	})
+	if err == nil {
+		t.Fatal("runUnitCoverage() error = nil, want a go test timeout")
+	}
+	if !strings.Contains(err.Error(), "test timed out after 1s") {
+		t.Fatalf("runUnitCoverage() error = %v, want the configured 1s bound", err)
+	}
+}
+
+// TestRunBudget_TestRunCounts_ScaleWithTheCommandsIssued verifies the process
+// deadline covers every `go test` the run issues at its full -timeout, plus
+// the overhead allowance, and that it stays ahead of that bound so `go test`
+// reports a long package itself.
+func TestRunBudget_TestRunCounts_ScaleWithTheCommandsIssued(t *testing.T) {
+	tests := []struct {
+		name string
+		opts options
+		want time.Duration
+	}{
+		{
+			name: "coverage only",
+			opts: options{timeout: 10 * time.Minute},
+			want: 10*time.Minute + overheadBudget,
+		},
+		{
+			name: "coverage and e2e",
+			opts: options{timeout: 10 * time.Minute, includeE2ERun: true},
+			want: 20*time.Minute + overheadBudget,
+		},
+		{
+			name: "no test runs at all",
+			opts: options{timeout: 10 * time.Minute, skipCoverage: true},
+			want: overheadBudget,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runBudget(tt.opts); got != tt.want {
+				t.Fatalf("runBudget() = %s, want %s", got, tt.want)
+			}
+			if got := runBudget(tt.opts); got <= tt.opts.timeout && !tt.opts.skipCoverage {
+				t.Fatalf("runBudget() = %s, want more than the per-package bound %s", got, tt.opts.timeout)
+			}
+		})
+	}
+}
+
 // TestCoverageDirectory_UnusableTempRoot_ReturnsError verifies the
 // unconfigured case reports a temporary root that does not exist instead of
 // handing back a directory nothing can write to.
@@ -942,7 +1009,11 @@ func TestRun_FakeModule_MigratesChecksAndReports(t *testing.T) {
 	}{
 		{name: "first run migrates", args: args, wantOut: "Updated docs/testing.md"},
 		{name: "second run is idle", args: args, wantOut: "docs/testing.md already up to date"},
-		{name: "check accepts current", args: append([]string{"--check"}, args...), wantOut: "docs/testing.md is up to date"},
+		{
+			name:    "check accepts current",
+			args:    append([]string{"--check"}, args...),
+			wantOut: "docs/testing.md is up to date" + checkedScopeSuffix(true),
+		},
 		{
 			name: "check rejects stale",
 			args: append([]string{"--check"}, args...),
@@ -1113,7 +1184,7 @@ func TestUpdateManagedSection_PathShapes_WriteOrRefuse(t *testing.T) {
 			if tt.text != "" {
 				writeFixture(t, root, tt.path, tt.text)
 			}
-			changed, err := updateManagedSection(tt.path, "same\n", tt.check)
+			changed, report, err := updateManagedSection(tt.path, "same\n", tt.check)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("updateManagedSection() error = %v, want %q", err, tt.wantErr)
@@ -1126,6 +1197,7 @@ func TestUpdateManagedSection_PathShapes_WriteOrRefuse(t *testing.T) {
 			if changed != tt.wantChanged {
 				t.Fatalf("updateManagedSection() changed = %v, want %v", changed, tt.wantChanged)
 			}
+			assertDifferenceReport(t, report, tt.check && tt.wantChanged)
 			data, readErr := os.ReadFile(filepath.Join(root, tt.path))
 			if readErr != nil {
 				t.Fatalf("read %s: %v", tt.path, readErr)
@@ -1134,6 +1206,15 @@ func TestUpdateManagedSection_PathShapes_WriteOrRefuse(t *testing.T) {
 				t.Fatalf("%s content = %q, want it to contain %q", tt.path, data, tt.wantWritten)
 			}
 		})
+	}
+}
+
+// assertDifferenceReport checks that a difference report was produced exactly
+// when one was expected: check mode over a document that would change.
+func assertDifferenceReport(t *testing.T, report string, want bool) {
+	t.Helper()
+	if want != (report != "") {
+		t.Fatalf("updateManagedSection() report = %q, want a report: %v", report, want)
 	}
 }
 
@@ -1152,9 +1233,314 @@ func TestUpdateManagedSection_ReadOnlyDocument_ReturnsWriteError(t *testing.T) {
 	}
 	t.Chdir(root)
 
-	_, err := updateManagedSection("readonly.md", "new\n", false)
+	_, _, err := updateManagedSection("readonly.md", "new\n", false)
 	if err == nil || !strings.Contains(err.Error(), "write readonly.md") {
 		t.Fatalf("updateManagedSection() error = %v, want write error", err)
+	}
+}
+
+// TestParseRecordedCoverage_GeneratedDocument_ReadsBackEveryValue verifies the
+// reader recovers exactly what the renderer writes: the three overview figures,
+// one value per coverage-table row, an unmeasured package, and nothing from a
+// count row that merely looks like a two-column table row.
+func TestParseRecordedCoverage_GeneratedDocument_ReadsBackEveryValue(t *testing.T) {
+	document := "| Metric | Value |\n| --- | ---: |\n" +
+		"| Total test functions | 13,476 |\n" +
+		"| " + overallCoverageLabel + " | 97.8% |\n" +
+		"| " + internalCoverageLabel + " | 98.3% |\n" +
+		"| " + averageCoverageLabel + " | 98.4% |\n\n" +
+		"| Package | Coverage |\n| --- | ---: |\n" +
+		"| cmd/server | 95.6% |\n" +
+		"| " + toolsOrchestrationKey + " | 99.1% |\n" +
+		"| e2eonly | " + coverageUnavailable + " |\n"
+
+	recorded := parseRecordedCoverage(document)
+
+	if !recorded.Overall.OK || recorded.Overall.Percent != 97.8 {
+		t.Fatalf("overall = %+v, want 97.8", recorded.Overall)
+	}
+	if !recorded.Internal.OK || recorded.Internal.Percent != 98.3 {
+		t.Fatalf("internal = %+v, want 98.3", recorded.Internal)
+	}
+	if !recorded.AveragePackage.OK || recorded.AveragePackage.Percent != 98.4 {
+		t.Fatalf("average = %+v, want 98.4", recorded.AveragePackage)
+	}
+	if got := recorded.ByKey["cmd/server"]; !got.OK || got.Percent != 95.6 {
+		t.Fatalf("cmd/server = %+v, want 95.6", got)
+	}
+	if got := recorded.ByKey[toolsOrchestrationKey]; !got.OK || got.Percent != 99.1 {
+		t.Fatalf("%s = %+v, want 99.1", toolsOrchestrationKey, got)
+	}
+	if got, ok := recorded.ByKey["e2eonly"]; !ok || got.OK {
+		t.Fatalf("e2eonly = %+v (present %v), want a recorded but unmeasured value", got, ok)
+	}
+	if _, ok := recorded.ByKey["Total test functions"]; ok {
+		t.Fatal("a count row was read as a coverage value")
+	}
+	if _, ok := recorded.ByKey[averageCoverageLabel]; ok {
+		t.Fatal("the average row was filed as a package")
+	}
+}
+
+// TestCoverageTableKey_Layers_MatchTheRenderedLabel verifies the reader looks a
+// package up under the label the coverage report actually gives it, which is
+// the package key everywhere except the orchestration layer.
+func TestCoverageTableKey_Layers_MatchTheRenderedLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  packageMetrics
+		want string
+	}{
+		{name: "cmd package", pkg: packageMetrics{Key: "cmd/server", Layer: layerCmd}, want: "cmd/server"},
+		{name: "core package", pkg: packageMetrics{Key: "toolutil", Layer: layerCore}, want: "toolutil"},
+		{name: "tool sub-package", pkg: packageMetrics{Key: "issues", Layer: layerToolSubpackage}, want: "issues"},
+		{name: "orchestration", pkg: packageMetrics{Key: "tools", Layer: layerToolsOrchestration}, want: toolsOrchestrationKey},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := coverageTableKey(tt.pkg); got != tt.want {
+				t.Fatalf("coverageTableKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseCoverageCell_CellShapes_AcceptOnlyMeasurements verifies the cell
+// reader accepts what fmtCoverage writes and refuses everything else, so a
+// count, a tool total or a package name is never read as a percentage.
+func TestParseCoverageCell_CellShapes_AcceptOnlyMeasurements(t *testing.T) {
+	tests := []struct {
+		name    string
+		cell    string
+		want    coverageValue
+		wantOK  bool
+		roundOK bool
+	}{
+		{name: "measured", cell: "95.6%", want: coverageValue{Percent: 95.6, OK: true}, wantOK: true},
+		{name: "full", cell: "100.0%", want: coverageValue{Percent: 100, OK: true}, wantOK: true},
+		{name: "unmeasured", cell: coverageUnavailable, want: coverageValue{}, wantOK: true},
+		{name: "count", cell: "13,476", wantOK: false},
+		{name: "tool total", cell: "57", wantOK: false},
+		{name: "not a number", cell: "n/a%", wantOK: false},
+		{name: "empty", cell: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseCoverageCell(tt.cell)
+			if ok != tt.wantOK {
+				t.Fatalf("parseCoverageCell(%q) ok = %v, want %v", tt.cell, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Fatalf("parseCoverageCell(%q) = %+v, want %+v", tt.cell, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSplitCoverageRow_LineShapes_ReturnCellsOrNothing verifies only real table
+// body rows are split, so a separator or a prose line never reaches the cell
+// reader.
+func TestSplitCoverageRow_LineShapes_ReturnCellsOrNothing(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{name: "body row", line: "| cmd/server |    95.6% |\n", want: []string{"cmd/server", "95.6%"}},
+		{name: "separator", line: "| ---------- | -------: |\n"},
+		{name: "prose", line: "Coverage target: **>90%** per package.\n"},
+		{name: "unterminated", line: "| cmd/server | 95.6%\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCoverageRow(tt.line)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitCoverageRow(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("splitCoverageRow(%q)[%d] = %q, want %q", tt.line, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestCollectMetrics_SkipCoverage_CarriesRecordedValuesForward verifies a
+// -skip-coverage run reports the coverage the document already records instead
+// of blanking it, which is what makes the fast freshness gate possible, and
+// that it reports the read failure when the document is not there to read.
+func TestCollectMetrics_SkipCoverage_CarriesRecordedValuesForward(t *testing.T) {
+	files := fakeModuleFiles()
+	files["docs/testing.md"] = "# T\n\n" + startMarker + "\n\n" +
+		"| Metric | Value |\n| --- | ---: |\n" +
+		"| " + overallCoverageLabel + " | 91.5% |\n" +
+		"| " + internalCoverageLabel + " | 92.5% |\n\n" +
+		"| Package | Coverage |\n| --- | ---: |\n" +
+		"| core | 88.8% |\n\n" + endMarker + "\n"
+	root := writeFakeModule(t, files)
+	t.Chdir(root)
+
+	metrics, err := collectMetrics(t.Context(), options{skipCoverage: true, docPath: "docs/testing.md", timeout: time.Minute})
+	if err != nil {
+		t.Fatalf("collectMetrics() error = %v", err)
+	}
+	if !metrics.OverallCoverage.OK || metrics.OverallCoverage.Percent != 91.5 {
+		t.Fatalf("overall coverage = %+v, want the recorded 91.5", metrics.OverallCoverage)
+	}
+	if !metrics.InternalCoverage.OK || metrics.InternalCoverage.Percent != 92.5 {
+		t.Fatalf("internal coverage = %+v, want the recorded 92.5", metrics.InternalCoverage)
+	}
+	var core packageMetrics
+	for _, pkg := range metrics.Packages {
+		if pkg.Key == "core" {
+			core = pkg
+		}
+	}
+	if !core.Coverage.OK || core.Coverage.Percent != 88.8 {
+		t.Fatalf("core coverage = %+v, want the recorded 88.8", core.Coverage)
+	}
+
+	absent, err := collectMetrics(t.Context(), options{skipCoverage: true, docPath: "docs/absent.md", timeout: time.Minute})
+	if err != nil {
+		t.Fatalf("collectMetrics() error = %v, want a document with nothing to carry forward to be silent", err)
+	}
+	if absent.OverallCoverage.OK {
+		t.Fatalf("overall coverage = %+v, want none when there is no document to read it from", absent.OverallCoverage)
+	}
+}
+
+// TestSortedCoveragePackages_RowSet_FollowsTheTreeNotTheRun verifies a package
+// with tests keeps its row even when this run has no number for it, which is
+// what makes the row set gateable: a deleted row, or a package added since the
+// last full run, has to reappear as n/a rather than quietly stay missing. A
+// package with no tests at all still earns no row.
+func TestSortedCoveragePackages_RowSet_FollowsTheTreeNotTheRun(t *testing.T) {
+	packages := []packageMetrics{
+		{Key: "measured", TestFiles: 3, Coverage: coverageValue{Percent: 91.2, OK: true}},
+		{Key: "awaiting a full run", TestFiles: 2},
+		{Key: "no tests at all"},
+	}
+
+	got := sortedCoveragePackages(packages)
+
+	keys := make([]string, 0, len(got))
+	for _, pkg := range got {
+		keys = append(keys, pkg.Key)
+	}
+	if want := []string{"awaiting a full run", "measured"}; !slices.Equal(keys, want) {
+		t.Fatalf("sortedCoveragePackages() = %v, want %v", keys, want)
+	}
+}
+
+// TestCheckScopeNote_CheckKind_SaysWhatWasCompared verifies each failing check
+// explains its own scope: that a carried-forward run still holds the package
+// rows, and that a recomputing one is comparing machine-dependent numbers.
+func TestCheckScopeNote_CheckKind_SaysWhatWasCompared(t *testing.T) {
+	tests := []struct {
+		name         string
+		skipCoverage bool
+		want         []string
+		notWant      []string
+	}{
+		{
+			name:         "carried forward",
+			skipCoverage: true,
+			want:         []string{"carried forward", "set of packages", "indicative"},
+			notWant:      []string{"load-dependent"},
+		},
+		{
+			name:    "recomputed",
+			want:    []string{"depend on the machine", "rsvg-convert", "uid 0", "load-dependent", "-skip-coverage"},
+			notWant: []string{"carried forward from the document"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkScopeNote(tt.skipCoverage)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("checkScopeNote(%v) = %q, want it to mention %q", tt.skipCoverage, got, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("checkScopeNote(%v) = %q, want it to omit %q", tt.skipCoverage, got, notWant)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckedScopeSuffix_CheckKind_QualifiesOnlyTheCarriedForwardRun verifies
+// an up-to-date report says when it never measured coverage, and says nothing
+// extra when it did.
+func TestCheckedScopeSuffix_CheckKind_QualifiesOnlyTheCarriedForwardRun(t *testing.T) {
+	if got := checkedScopeSuffix(false); got != "" {
+		t.Fatalf("checkedScopeSuffix(false) = %q, want no qualifier", got)
+	}
+	if got := checkedScopeSuffix(true); !strings.Contains(got, "carried forward") {
+		t.Fatalf("checkedScopeSuffix(true) = %q, want it to say the values were carried forward", got)
+	}
+}
+
+// TestLineDifferenceReport_DocumentShapes_PointAtTheFirstLines verifies the
+// failing-check report names the differing line numbers, pairs a line the other
+// document does not have with a placeholder, and stops at the limit.
+func TestLineDifferenceReport_DocumentShapes_PointAtTheFirstLines(t *testing.T) {
+	tests := []struct {
+		name      string
+		committed string
+		generated string
+		limit     int
+		want      []string
+		notWant   []string
+	}{
+		{
+			name:      "one changed value",
+			committed: "header\n| cmdutil | 8 | 100.0% |\ntail\n",
+			generated: "header\n| cmdutil | 9 | 100.0% |\ntail\n",
+			limit:     10,
+			want:      []string{"line 2:", "-| cmdutil | 8 | 100.0% |", "+| cmdutil | 9 | 100.0% |"},
+			notWant:   []string{"line 1:", "further differences"},
+		},
+		{
+			name:      "generated document is longer",
+			committed: "header\n",
+			generated: "header\nextra\n",
+			limit:     10,
+			want:      []string{"line 2:", "+extra"},
+		},
+		{
+			name:      "committed document is longer",
+			committed: "header\nextra\n",
+			generated: "header\n",
+			limit:     10,
+			want:      []string{"line 2:", "-extra", "+<no such line>"},
+		},
+		{
+			name:      "limit reached",
+			committed: "a\nb\nc\n",
+			generated: "x\ny\nz\n",
+			limit:     2,
+			want:      []string{"line 1:", "line 2:", "further differences not shown"},
+			notWant:   []string{"line 3:"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lineDifferenceReport(tt.committed, tt.generated, tt.limit)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("lineDifferenceReport() = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("lineDifferenceReport() = %q, want it to omit %q", got, notWant)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -800,24 +800,56 @@ Regenerates the managed test-metrics block in `docs/development/testing/testing.
 # Regenerate, including coverage runs
 go run ./cmd/gen_testing_docs/
 
-# CI gate
+# CI gate: everything a checkout determines, in seconds
+go run ./cmd/gen_testing_docs/ --check -skip-coverage
+
+# Refresh the counts without recomputing coverage, keeping the recorded values
+go run ./cmd/gen_testing_docs/ -skip-coverage
+
+# Verify the coverage values as well, which takes minutes
 go run ./cmd/gen_testing_docs/ -check
 
-# Fast path: skip the coverage runs
-go run ./cmd/gen_testing_docs/ -skip-coverage
+# Give a slow package more room than the 30 minutes each go test run gets
+go run ./cmd/gen_testing_docs/ -timeout 45m
 ```
+
+`-skip-coverage` carries the coverage already recorded in the document forward
+instead of blanking it, so it is a real refresh of everything else and, with
+`--check`, a freshness gate that holds everything the source tree determines:
+the counts, the naming breakdown, the per-layer tables, and the set of packages
+in the coverage tables, which is what caught `cmd/audit_install_buttons` missing
+from them. It takes seconds, because it runs no coverage at all.
+
+The coverage values are not gated, because they are a property of the machine as
+much as of the tree. Several tests assert refusals that permission bits never
+produce for uid 0 and skip when the process is privileged, so
+`cmd/format_md_tables` measures 95.8% as root and 96.7% otherwise, and
+`internal/tools/projectimportexport` 99.5% and 100.0%. `rsvg-convert` and
+`cwebp`, installed on the maintainer machine and deliberately absent from CI,
+move `cmd/gen_icon_webp` from 90.2% to 92.3%. `cmd/server` measures 95.7% run on
+its own and 95.6% inside a loaded full pass, on a branch that depends on timing.
+A byte-exact check of those columns cannot pass in two places at once, so
+`make gen-testing-docs` refreshes them and no gate holds them.
+
+`-timeout` is the bound handed to every `go test` this generator runs, not just
+its own deadline. Without it the coverage pass obeyed the 10 minutes `go test`
+applies by default, which `cmd/audit_metrics` exceeds under coverage
+instrumentation on a loaded machine, and nothing outside the generator could
+raise it. The generation as a whole gets that budget once per `go test` run it
+issues, plus five minutes for package listing, the coverage summary and the
+document write.
 
 #### Flags
 
-| Flag               | Type     | Default                               | Description                                                              |
-| ------------------ | -------- | ------------------------------------- | ------------------------------------------------------------------------ |
-| `-check`           | `bool`   | `false`                               | Fail if the generated section is not current                             |
-| `-coverage-dir`    | `string` | `""`                                  | Directory for temporary coverage profiles; defaults to a temp directory  |
-| `-file`            | `string` | `docs/development/testing/testing.md` | Testing documentation file to update                                     |
-| `-include-e2e-run` | `bool`   | `false`                               | Also run the build-tagged E2E suite; requires a GitLab test environment  |
-| `-skip-coverage`   | `bool`   | `false`                               | Skip `go test` coverage execution and update count-only sections         |
-| `-timeout`         | `string` | (from environment)                    | `go test` timeout for coverage runs                                      |
-| `-top-tool-rows`   | `int`    | `25`                                  | Number of high-test-count tool sub-packages to show in the summary table |
+| Flag               | Type       | Default                               | Description                                                              |
+| ------------------ | ---------- | ------------------------------------- | ------------------------------------------------------------------------ |
+| `-check`           | `bool`     | `false`                               | Fail if the generated section is not current                             |
+| `-coverage-dir`    | `string`   | `""`                                  | Directory for temporary coverage profiles; defaults to a temp directory  |
+| `-file`            | `string`   | `docs/development/testing/testing.md` | Testing documentation file to update                                     |
+| `-include-e2e-run` | `bool`     | `false`                               | Also run the build-tagged E2E suite; requires a GitLab test environment  |
+| `-skip-coverage`   | `bool`     | `false`                               | Skip the `go test` coverage run and keep the values already recorded     |
+| `-timeout`         | `duration` | `30m`                                 | Per-package timeout handed to each `go test` run                         |
+| `-top-tool-rows`   | `int`      | `25`                                  | Number of high-test-count tool sub-packages to show in the summary table |
 
 #### Output
 
@@ -825,7 +857,9 @@ Rewrites the managed sections of `docs/development/testing/testing.md`.
 
 #### Make targets
 
-- `make gen-testing-docs`, also part of `make audit-docs` (with `-check`).
+- `make gen-testing-docs` to regenerate, `make check-testing-docs` to verify.
+  The check runs in `make audit-docs` and in the CI `Test` job, beside the
+  other generated-artifact gates.
 
 ### gen_docker_tools
 
@@ -932,6 +966,6 @@ The following utilities expose a verification mode (`--check` or `-check`, or an
 | `audit-godocs-check`                     | `godoc_tool audit`             | No package, symbol, or test Godoc findings remain                                    | Non-zero when findings are present                        |
 | `audit-dynamic-aliases`                  | `audit_dynamic_aliases`        | No error-severity alias governance finding (collisions, ambiguity)                   | Non-zero (`1`) if any error-severity finding exists       |
 | `audit-docs` → `format_md_tables -check` | `format_md_tables`             | All Markdown pipe tables are normalized                                              | Non-zero if any table needs formatting                    |
-| `audit-docs` → `gen_testing_docs -check` | `gen_testing_docs`             | The `docs/development/testing/testing.md` test-metrics block is current              | Non-zero if the generated section is stale                |
+| `check-testing-docs`                     | `gen_testing_docs`             | The `docs/development/testing/testing.md` test-metrics block is current              | Non-zero if the generated section is stale                |
 | `check-supply-chain`                     | `audit_supply_chain`           | The five release-configuration invariants still hold                                 | Non-zero if any is broken, or if the audit cannot be run  |
 | `check-readonly-graphql`                 | `audit_readonly_graphql`       | No action classified ReadOnly can reach a GraphQL mutation                           | Non-zero on any finding, or if the audit cannot be run    |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -6,7 +6,7 @@
 >
 > Comprehensive test documentation for gitlab-mcp-server.
 >
-> **Maintenance Rule**: Whenever tests are added, modified, or removed, run `go run ./cmd/gen_testing_docs/` to refresh the generated counts and coverage values.
+> **Maintenance Rule**: Whenever tests are added, modified, or removed, run `go run ./cmd/gen_testing_docs/` to refresh the generated counts and coverage values. CI verifies the generated block on every push and pull request (`make check-testing-docs`): the counts, the tables, and which packages appear in the coverage tables. The coverage **percentages** are indicative and are not gated, because they depend on the machine that measured them: tests asserting permission refusals skip for uid 0, `cmd/gen_icon_webp` needs `rsvg-convert` and `cwebp` installed, and `cmd/server` has a load-dependent branch. A full local run refreshes them.
 
 ---
 
@@ -18,12 +18,12 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,436 |
-| Unit test functions                                   | 12,878 |
+| Total test functions                                  | 13,485 |
+| Unit test functions                                   | 12,927 |
 | E2E test functions                                    |    558 |
-| cmd test functions                                    |  1,989 |
-| Test files (internal/)                                |    494 |
-| Test files (cmd/)                                     |    112 |
+| cmd test functions                                    |  2,033 |
+| Test files (internal/)                                |    495 |
+| Test files (cmd/)                                     |    117 |
 | Test files (test/e2e/)                                |    216 |
 | Tool sub-packages tested                              |    174 |
 | Core packages tested                                  |     21 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,218 | 83.5% |
+| `TestFunc_Scenario` (2-part)           | 11,224 | 83.2% |
 | `TestFunc` (no underscore)             |    965 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,253 |  9.3% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,296 |  9.6% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,177 |        130 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,182 |        131 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (174) |          8,411 |        351 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            558 |        216 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          1,989 |        112 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,436** |    **822** |                                                                                                 |
+| cmd packages            |          2,033 |        117 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,485** |    **828** |                                                                                                 |
 
 ### Core Packages
 
@@ -68,16 +68,16 @@
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        71 |    98.9% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        65 |    97.1% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        68 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       272 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
 | serverpool    |        91 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
-| testutil      |        35 |    89.8% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
+| testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       793 |    98.4% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,177** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,182** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -300,10 +300,11 @@
 
 | Package                                        | Coverage |
 | ---------------------------------------------- | -------: |
-| cmd/audit_1to1                                 |    70.4% |
-| cmd/audit_1to1/internal/actions                |    99.2% |
+| cmd/audit_1to1                                 |    71.1% |
+| cmd/audit_1to1/internal/actions                |    98.1% |
 | cmd/audit_1to1/internal/merge                  |    98.9% |
 | cmd/audit_1to1/internal/metadata               |   100.0% |
+| cmd/audit_1to1/internal/sdk                    |    97.0% |
 | cmd/audit_1to1/internal/shared                 |    96.0% |
 | cmd/audit_1to1/internal/structs                |    99.0% |
 | cmd/audit_catalog_first                        |    93.3% |
@@ -336,7 +337,7 @@
 | cmd/gen_lhm_manifest                           |    89.4% |
 | cmd/gen_llms                                   |    98.9% |
 | cmd/gen_stats                                  |    98.6% |
-| cmd/gen_testing_docs                           |    97.7% |
+| cmd/gen_testing_docs                           |    97.8% |
 | cmd/godoc_tool                                 |    93.7% |
 | cmd/internal/apidocs                           |   100.0% |
 | cmd/internal/auditshared                       |   100.0% |
@@ -360,14 +361,14 @@
 | gatewaycompat |    99.4% |
 | gitlab        |    98.9% |
 | mcpotel       |    99.0% |
-| oauth         |    97.1% |
+| oauth         |    98.4% |
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.4% |
 | serverpool    |    98.3% |
 | subscriptions |    98.5% |
 | telemetry     |    93.1% |
-| testutil      |    89.8% |
+| testutil      |    89.6% |
 | toolutil      |    98.4% |
 
 ### Tool Sub-Packages
@@ -553,7 +554,7 @@
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
 - **cmd/gen_action_catalog_manifest** (66.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/audit_1to1** (70.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **cmd/audit_1to1** (71.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (77.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **progress** (83.8%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.
 - **cmd/audit_install_buttons** (84.2%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
@@ -564,7 +565,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_names** (89.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_lhm_manifest** (89.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **testutil** (89.8%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
+- **testutil** (89.6%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 
 <!-- END TESTING STATS -->
 


### PR DESCRIPTION
`docs/development/testing/testing.md` is generated, and until now nothing regenerated it and nothing checked it. Both halves of that were real: the coverage pass the generator runs died on `go test`'s 10 minute per-package default, which `cmd/audit_metrics` exceeds under coverage instrumentation, and no CI job ever ran `gen_testing_docs --check`. The check that would have caught the drift was absent, and the tool that would have repaired it did not finish.

## The timeout

`-timeout` now reaches every `go test` the generator runs, and defaults to 30 minutes. The generation as a whole gets that budget once per test run it issues, plus five minutes for the package listing, the coverage summary and the document write. That margin is not decoration: it keeps `go test`'s own timer ahead of the process context, so a package that runs long is reported by `go test` with the goroutine dump that names the test, instead of being killed anonymously when the context cancels the command. Diagnosing the original failure depended on exactly that dump.

A full run now completes in 6m43s to 8m58s here, and between 13m13s and 18m49s when the machine is loaded with several other builds. `cmd/audit_metrics` alone takes 2m23s under `-covermode=count`, so it is contention rather than the package that pushed it past ten minutes, and 30 minutes leaves a wide margin either way. Whether that test should also be faster under instrumentation is left where the issue left it: the generator should not be the thing that decides it.

## The failing check now says what moved

`--check` printed "is out of date; run go run ./cmd/gen_testing_docs/" and nothing else, which is a whole coverage pass away from telling anyone whether a count moved, a coverage value moved, or a package appeared. It now prints the first lines on which the committed file and the generated block disagree, capped so a wholesale regeneration points at where to look rather than reprinting the document into a CI log. That output is what diagnosed the next part, from a CI log, on the first attempt.

## The gate holds what the tree determines, not what the machine does

I first wired the full `--check` into CI and watched it fail on machine differences rather than on drift. Three separate causes move the coverage columns without a line of code changing: privilege, because tests asserting permission refusals skip for uid 0, which is `cmd/format_md_tables` at 95.8% as root against 96.7% otherwise and `internal/tools/projectimportexport` at 99.5% against 100.0%; optional tooling, because `rsvg-convert` and `cwebp` are installed here and deliberately absent from a GitHub runner, which is `cmd/gen_icon_webp` at 92.3% against 90.2%; and load, because a timing-dependent branch in the server tests gives `cmd/server` 95.7% measured on its own three times over and 95.6% inside a loaded full pass, here and in CI alike. Installing the icon tools in CI is not a way out either: `TestRun_CheckModeAcceptsCommittedAssets` would then run there and compare committed WebP bytes against ones rendered by a different librsvg, which is exactly why `check-icon-webp` is already excluded from CI.

So the gate holds everything the source tree determines and none of what the machine determines: the counts, the naming breakdown, the per-layer tables, and the set of packages in the coverage tables, which is precisely what issue 434 caught when `cmd/audit_install_buttons` was missing from them. For that last part to hold, a package with tests now earns a row whether or not the run has a number for it, so one whose row was deleted, or one added since the last full run, reappears as `n/a` and fails the check instead of quietly staying absent. I verified both directions by hand: a deleted row for a package at 97.8% fails the check, and restoring it passes. The percentages themselves are indicative; `make gen-testing-docs` refreshes them.

What makes that possible is a fix `-skip-coverage` needed anyway, and which the issue itself called for: it used to blank every coverage column to `n/a`, which is not a refresh, and it now carries forward the values already recorded in the document. So `gen_testing_docs -skip-coverage` is a real counts-only refresh that takes seconds, and `--check -skip-coverage` is a freshness gate that runs no coverage at all. It lives in the `Test` job beside the other generated-artifact gates, where it adds about two seconds rather than the seven to thirteen minutes a second coverage pass would have added to the job SonarCloud waits on. Both the file and the check's own output say which half is enforced and which half is indicative, so nobody reads a percentage here as a promise.

## The refresh

Counts move with the tests this branch and the ones under it added, the naming percentages follow, and `cmd/audit_1to1/internal/sdk` appears in the coverage table for the first time: it was missing from it, not zero in it.

## Verification

`go build ./...`, `go test ./cmd/... -count=1`, `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `go run ./cmd/gen_testing_docs/ --check`, `make check-testing-docs`, `make check-test-file-names` and `go run ./cmd/audit_test_subtests/ -check` all pass on this branch.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/434


---

**The red `Cross-platform (windows-latest)` check is inherited, not from this branch.** The matrix is introduced in https://github.com/jmrplens/gitlab-mcp-server/pull/440 and the three Windows failures it found are fixed in https://github.com/jmrplens/gitlab-mcp-server/pull/444, above this pull request in the stack. PR 440's description explains each one and why they land there rather than here.
