### PR TITLE
fix: two known failures at the cause, not at the symptom

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,20 +471,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,041 |     220,939 |
-| Unit tests (`_test.go`)  |       612 |     361,265 |
+| Source (`.go`, non-test) |     1,041 |     221,041 |
+| Unit tests (`_test.go`)  |       612 |     361,716 |
 | End-to-end tests         |       222 |      60,221 |
-| **Total**                | **1,875** | **642,425** |
+| **Total**                | **1,875** | **642,978** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,303 |
+| Source functions                |  8,305 |
 | . Exported (public)             |  2,787 |
-| . Unexported (private)          |  5,516 |
-| Unit test functions (`TestXxx`) | 12,927 |
-| Subtests (`t.Run(...)`)         |  4,765 |
+| . Unexported (private)          |  5,518 |
+| Unit test functions (`TestXxx`) | 12,934 |
+| Subtests (`t.Run(...)`)         |  4,768 |
 | End-to-end test functions       |    564 |
 
 ### Ratios worth noting
@@ -493,16 +493,16 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~212 lines |
-| Average test file length           |                 ~590 lines |
-| Comment lines in source            |  32,842 (~14.9% of source) |
+| Average test file length           |                 ~591 lines |
+| Comment lines in source            |  32,919 (~14.9% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,964 |
-| `defer` statements                 | 1,128 |
+| `if err != nil` checks             | 6,959 |
+| `defer` statements                 | 1,132 |
 | `struct` types defined             | 2,843 |
 | `//nolint` suppressions            |   270 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -519,15 +519,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,432 lines      |
-| Longest test file   | `cmd/server/main_test.go`. 8,682 lines |
+| Longest source file | `cmd/server/main.go`. 4,513 lines      |
+| Longest test file   | `cmd/server/main_test.go`. 9,018 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,017 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,208 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,018 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,209 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixture_context_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixture_context_test.go
@@ -28,22 +28,30 @@ const (
 //
 // The test boots an httptest server that records every method+path it sees
 // and dispatches to handlers that simulate the group/project/branch/file
-// endpoints. It then calls the fixture's Ensure hook with a deterministic
-// idempotency key, asserting that the returned outputs match the expected
-// branch name and MR title, and that the recorded calls include the branch
-// POST and the repository file POST. This protects the live fixture from
-// regressions that would lose attempt scoping or skip file seeding.
+// endpoints. It then calls the fixture's Ensure hook, asserting that the
+// returned outputs match the expected branch name and MR title, and that the
+// recorded calls include the branch POST and the repository file POST. This
+// protects the live fixture from regressions that would lose attempt scoping
+// or skip file seeding.
+//
+// It states no idempotency key, which is how [fixtureOutputCache.ensure] is
+// told there is no identity to remember this fixture by, so the creation runs
+// every time. What is under test here is the work the fixture does, and every
+// assertion below is about the calls that work makes; going through the memo
+// instead put the subject and the code path out of line, and the test passed
+// once and then failed under -count=2 with "calls = " because the second run
+// was answered from the memo and made no calls at all. The memo has tests of
+// its own in case_fixtures_project_test.go.
 func TestMergeRequestSourceFixture_EnsuresAttemptBranchAndFile(t *testing.T) {
 	var calls []string
 	server := newMergeRequestSourceFixtureServer(t, &calls)
 	defer server.Close()
 
 	output, err := MergeRequestSourceFixture.Ensure(t.Context(), FixtureContext{
-		Client:         newFixtureTestClient(t, server.URL),
-		ModelName:      "openai:gpt-5.4-mini",
-		RunIndex:       1,
-		RunSuffix:      "abc123",
-		IdempotencyKey: "test:merge-request-source",
+		Client:    newFixtureTestClient(t, server.URL),
+		ModelName: "openai:gpt-5.4-mini",
+		RunIndex:  1,
+		RunSuffix: "abc123",
 	})
 	if err != nil {
 		t.Fatalf("MergeRequestSourceFixture.Ensure() error = %v\ncalls=%s", err, strings.Join(calls, ","))

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project.go
@@ -39,6 +39,19 @@ var attemptNameFixtureOutputs = []string{
 	"group_label_name_v2",
 }
 
+// fixtureOutputCache is what makes "prepared once per scope" true for the live
+// fixtures.
+//
+// An evaluation run has many cases sharing a fixture, and preparing one means
+// creating real resources on a real GitLab: a bootstrap project, a branch, a
+// seeded file. The key [fixtureIdempotencyKey] computes carries the scope, so
+// a bootstrap fixture is built once for the process, a run-scoped one once per
+// run suffix, an attempt-scoped one once per model and attempt. Without this,
+// every case declaring a shared fixture would reissue those creations.
+//
+// One process points at one instance for its whole run, so the key is the
+// fixture's identity within that run and nothing about the client belongs in
+// it.
 type fixtureOutputCache struct {
 	mu     sync.Mutex
 	values map[string]FixtureOutput
@@ -48,6 +61,11 @@ func newFixtureOutputCache() *fixtureOutputCache {
 	return &fixtureOutputCache{values: map[string]FixtureOutput{}}
 }
 
+// ensure returns the outputs remembered for key, creating them the first time.
+//
+// An empty key means the caller computed no identity to remember the fixture
+// by, and create runs every time. Copies go in and out, so a caller that
+// mutates what it received cannot reach into what the next one is handed.
 func (cache *fixtureOutputCache) ensure(key string, create func() (FixtureOutput, error)) (FixtureOutput, error) {
 	if key == "" {
 		return create()

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
@@ -348,3 +348,71 @@ func TestAttemptCaseSuffix_KeepsAlphanumericsOnly(t *testing.T) {
 		})
 	}
 }
+
+// TestFixtureOutputCache_Ensure_EmptyKeyMeansNoIdentity verifies that a caller
+// which computed no idempotency key gets the creation run every time, and that
+// two different keys are remembered apart.
+//
+// The empty key is the contract a test relies on when what it is testing is the
+// work a fixture does rather than the memo around it: the merge-request source
+// fixture test asserts on the API calls the fixture makes, and going through
+// the memo meant its second run in one process made no calls at all.
+// TestFixtureOutputCache_ReusesClonedOutputForSameKey covers the remembering
+// half and the defensive copies.
+func TestFixtureOutputCache_Ensure_EmptyKeyMeansNoIdentity(t *testing.T) {
+	cache := newFixtureOutputCache()
+	calls := map[string]int{}
+	create := func(name string) func() (FixtureOutput, error) {
+		return func() (FixtureOutput, error) {
+			calls[name]++
+			return FixtureOutput{"name": name}, nil
+		}
+	}
+
+	// The repeated keys only mean anything in order, as a second call after a
+	// first against the same cache.
+	// sequential: dependent steps against one cache, not independent cases
+	for _, key := range []string{"scope:one", "scope:one", "scope:two", "", ""} {
+		if _, err := cache.ensure(key, create(key)); err != nil {
+			t.Fatalf("ensure(%q) error = %v", key, err)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		key  string
+		want int
+	}{
+		{name: "remembered key", key: "scope:one", want: 1},
+		{name: "second key", key: "scope:two", want: 1},
+		{name: "no key", key: "", want: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if calls[tc.key] != tc.want {
+				t.Errorf("creations for key %q = %d, want %d", tc.key, calls[tc.key], tc.want)
+			}
+		})
+	}
+}
+
+// TestFixtureOutputCache_Ensure_RemembersNothingAfterAFailure verifies a failed
+// creation is not memoized, so the next case that needs the fixture retries it
+// rather than inheriting the failure for the rest of the run.
+func TestFixtureOutputCache_Ensure_RemembersNothingAfterAFailure(t *testing.T) {
+	cache := newFixtureOutputCache()
+	if _, err := cache.ensure("scope:one", func() (FixtureOutput, error) {
+		return nil, errors.New("provisioning failed")
+	}); err == nil {
+		t.Fatal("ensure() error = nil, want the creation failure")
+	}
+
+	output, err := cache.ensure("scope:one", func() (FixtureOutput, error) {
+		return FixtureOutput{"name": "second try"}, nil
+	})
+	if err != nil {
+		t.Fatalf("ensure() after a failure error = %v", err)
+	}
+	if output["name"] != "second try" {
+		t.Errorf("ensure() = %+v, want the retry to have run", output)
+	}
+}

--- a/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/case_fixtures_project_test.go
@@ -398,6 +398,11 @@ func TestFixtureOutputCache_Ensure_EmptyKeyMeansNoIdentity(t *testing.T) {
 // TestFixtureOutputCache_Ensure_RemembersNothingAfterAFailure verifies a failed
 // creation is not memoized, so the next case that needs the fixture retries it
 // rather than inheriting the failure for the rest of the run.
+//
+// Two ordered steps against one cache, not two cases, which is why there is no
+// table here and no subtest per step: the retry means nothing except as the
+// call after the failure, and neither step can be read or run on its own. The
+// sibling above asserts per key independently, so it is a table and has them.
 func TestFixtureOutputCache_Ensure_RemembersNothingAfterAFailure(t *testing.T) {
 	cache := newFixtureOutputCache()
 	if _, err := cache.ensure("scope:one", func() (FixtureOutput, error) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2065,8 +2065,8 @@ const httpShutdownTimeout = 15 * time.Second
 // An exhausted budget is not an error, and that single line is the whole
 // history of this flake. One connection that had not gone idle turned an
 // ordinary stop into "http server shutdown: context deadline exceeded" and
-// exit 1 — a failed unit to a supervisor, a broken build to CI — and it was
-// answered twice by raising the number and once by widening a test's outer
+// exit 1, which is a failed unit to a supervisor and a broken build to CI. It
+// was answered twice by raising the number and once by widening a test's outer
 // wait, none of which touched the classification. The connections that did not
 // drain are about to be dropped by process exit anyway, so this drops them
 // itself and logs what it did. Anything else Shutdown reports is still an

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2013,101 +2013,15 @@ func excludeFromCatalog(catalog *actioncatalog.Catalog, excludeTools []string) *
 	return filtered
 }
 
-// httpShutdownTimeout is the default budget for draining in-flight requests
-// after the process context is cancelled.
-//
-// It is a liveness backstop, not a service-level objective, and mistaking it
-// for one is what sent this number up and down twice. [http.Server.Shutdown]
-// returns the moment every connection is idle, so a clean drain costs
-// milliseconds on the quickest Linux runner and on the slowest Windows one
-// alike: no value here is "safe under load", because load is not what makes
-// the drain block. What blocks it is a request still executing, a stream still
-// open, or a peer holding a connection it never finishes.
-//
-// So the value is bracketed rather than picked:
-//
-//   - It has to outlast the work a request can legitimately be doing when the
-//     signal lands. The expensive one is a pool entry's first request, which
-//     builds a catalog: milliseconds on the dynamic surface, a second or two
-//     on the individual one, tens of seconds under the race detector, which is
-//     why the transport tests pin the dynamic surface.
-//   - It has to stay above the grace period test/e2e/http gives the real
-//     binary to exit after SIGTERM (10 seconds). Below that, a drain hung on a
-//     stream nothing can close becomes indistinguishable from a prompt exit,
-//     and the regression test guarding that bug stops testing anything.
-//   - There is nothing to buy above the supervisor's own grace, which ends the
-//     process whatever this says: docker stop waits 10 seconds, Kubernetes 30,
-//     systemd 90. Past that we are killed mid-drain and the orderly exit which
-//     follows, [telemetryShutdownTimeout] included, never runs at all.
-//
-// Fifteen seconds sits inside that bracket. What stops its exact value from
-// mattering is [shutdownHTTPServer]: an exhausted budget is no longer reported
-// as a process failure, so a drain that runs long costs a warning and a forced
-// close instead of exit 1 and a red build.
+// httpShutdownTimeout bounds graceful HTTP shutdown after the process context
+// is cancelled.
+// 15 seconds rather than 5: under CI load or an instrumented build, five
+// seconds of drain was routinely not enough and shutdown returned a
+// context-deadline error for perfectly healthy in-flight requests. A
+// larger budget never slows a clean shutdown — Shutdown returns as soon as
+// the connections drain — it only stops a loaded one from being reported
+// as a failure.
 const httpShutdownTimeout = 15 * time.Second
-
-// shutdownHTTPServer drains httpServer's in-flight requests, and closes
-// whatever has not finished when the budget runs out.
-//
-// The budget is [httpShutdownTimeout] or what the caller's deadline leaves,
-// whichever is smaller, which is the rule [telemetry.Provider.Shutdown]
-// follows and for the same reason: an internal bound that silently overrides a
-// tighter one the caller stated makes the caller's bound dead code. The
-// caller's cancellation is detached, since the drain runs precisely because
-// the serve context is done.
-//
-// Where this differs from the telemetry provider is that the context is
-// already done when the budget is computed, so a deadline in the past leaves
-// no budget at all. That is honored literally rather than clamped: a caller
-// whose time is up gets the forced close and nothing else. Which is only a
-// sane answer because the forced close exists.
-//
-// An exhausted budget is not an error, and that single line is the whole
-// history of this flake. One connection that had not gone idle turned an
-// ordinary stop into "http server shutdown: context deadline exceeded" and
-// exit 1 — a failed unit to a supervisor, a broken build to CI — and it was
-// answered twice by raising the number and once by widening a test's outer
-// wait, none of which touched the classification. The connections that did not
-// drain are about to be dropped by process exit anyway, so this drops them
-// itself and logs what it did. Anything else Shutdown reports is still an
-// error.
-func shutdownHTTPServer(ctx context.Context, httpServer *http.Server) error {
-	budget := httpShutdownBudget(ctx)
-	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
-	defer cancel()
-
-	err := httpServer.Shutdown(shutdownCtx)
-	switch {
-	case err == nil:
-		return nil
-	case !errors.Is(err, context.DeadlineExceeded):
-		return fmt.Errorf("http server shutdown: %w", err)
-	}
-
-	slog.WarnContext(ctx,
-		"HTTP drain budget exhausted, closing the connections that did not finish",
-		"budget", budget)
-	// Shutdown has already closed the listeners, so Close finds them closed
-	// and says so. That is expected here and says nothing about the
-	// connections, which are what this call is for.
-	if closeErr := httpServer.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
-		return fmt.Errorf("http server close after drain budget: %w", closeErr)
-	}
-	return nil
-}
-
-// httpShutdownBudget returns how long the drain may take: the default, or what
-// the caller's deadline leaves, whichever is smaller.
-//
-// A non-positive result is a caller with no time left and means the drain is
-// skipped, not that it is given a default; see [shutdownHTTPServer].
-func httpShutdownBudget(ctx context.Context) time.Duration {
-	budget := httpShutdownTimeout
-	if deadline, ok := ctx.Deadline(); ok {
-		budget = min(budget, time.Until(deadline))
-	}
-	return budget
-}
 
 // effectiveIdleTimeout maps a user-supplied value to the duration passed to
 // [http.Server.IdleTimeout]. When the caller passes 0 (meaning "disable idle
@@ -2569,7 +2483,12 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	select {
 	case <-ctx.Done():
 		slog.InfoContext(ctx, "HTTP server shutdown requested")
-		return shutdownHTTPServer(ctx, httpServer)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), httpShutdownTimeout)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("http server shutdown: %w", err)
+		}
+		return nil
 	case err := <-serverErr:
 		return fmt.Errorf("mcp server error (http): %w", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2013,15 +2013,101 @@ func excludeFromCatalog(catalog *actioncatalog.Catalog, excludeTools []string) *
 	return filtered
 }
 
-// httpShutdownTimeout bounds graceful HTTP shutdown after the process context
-// is cancelled.
-// 15 seconds rather than 5: under CI load or an instrumented build, five
-// seconds of drain was routinely not enough and shutdown returned a
-// context-deadline error for perfectly healthy in-flight requests. A
-// larger budget never slows a clean shutdown — Shutdown returns as soon as
-// the connections drain — it only stops a loaded one from being reported
-// as a failure.
+// httpShutdownTimeout is the default budget for draining in-flight requests
+// after the process context is cancelled.
+//
+// It is a liveness backstop, not a service-level objective, and mistaking it
+// for one is what sent this number up and down twice. [http.Server.Shutdown]
+// returns the moment every connection is idle, so a clean drain costs
+// milliseconds on the quickest Linux runner and on the slowest Windows one
+// alike: no value here is "safe under load", because load is not what makes
+// the drain block. What blocks it is a request still executing, a stream still
+// open, or a peer holding a connection it never finishes.
+//
+// So the value is bracketed rather than picked:
+//
+//   - It has to outlast the work a request can legitimately be doing when the
+//     signal lands. The expensive one is a pool entry's first request, which
+//     builds a catalog: milliseconds on the dynamic surface, a second or two
+//     on the individual one, tens of seconds under the race detector, which is
+//     why the transport tests pin the dynamic surface.
+//   - It has to stay above the grace period test/e2e/http gives the real
+//     binary to exit after SIGTERM (10 seconds). Below that, a drain hung on a
+//     stream nothing can close becomes indistinguishable from a prompt exit,
+//     and the regression test guarding that bug stops testing anything.
+//   - There is nothing to buy above the supervisor's own grace, which ends the
+//     process whatever this says: docker stop waits 10 seconds, Kubernetes 30,
+//     systemd 90. Past that we are killed mid-drain and the orderly exit which
+//     follows, [telemetryShutdownTimeout] included, never runs at all.
+//
+// Fifteen seconds sits inside that bracket. What stops its exact value from
+// mattering is [shutdownHTTPServer]: an exhausted budget is no longer reported
+// as a process failure, so a drain that runs long costs a warning and a forced
+// close instead of exit 1 and a red build.
 const httpShutdownTimeout = 15 * time.Second
+
+// shutdownHTTPServer drains httpServer's in-flight requests, and closes
+// whatever has not finished when the budget runs out.
+//
+// The budget is [httpShutdownTimeout] or what the caller's deadline leaves,
+// whichever is smaller, which is the rule [telemetry.Provider.Shutdown]
+// follows and for the same reason: an internal bound that silently overrides a
+// tighter one the caller stated makes the caller's bound dead code. The
+// caller's cancellation is detached, since the drain runs precisely because
+// the serve context is done.
+//
+// Where this differs from the telemetry provider is that the context is
+// already done when the budget is computed, so a deadline in the past leaves
+// no budget at all. That is honored literally rather than clamped: a caller
+// whose time is up gets the forced close and nothing else. Which is only a
+// sane answer because the forced close exists.
+//
+// An exhausted budget is not an error, and that single line is the whole
+// history of this flake. One connection that had not gone idle turned an
+// ordinary stop into "http server shutdown: context deadline exceeded" and
+// exit 1 — a failed unit to a supervisor, a broken build to CI — and it was
+// answered twice by raising the number and once by widening a test's outer
+// wait, none of which touched the classification. The connections that did not
+// drain are about to be dropped by process exit anyway, so this drops them
+// itself and logs what it did. Anything else Shutdown reports is still an
+// error.
+func shutdownHTTPServer(ctx context.Context, httpServer *http.Server) error {
+	budget := httpShutdownBudget(ctx)
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
+	defer cancel()
+
+	err := httpServer.Shutdown(shutdownCtx)
+	switch {
+	case err == nil:
+		return nil
+	case !errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("http server shutdown: %w", err)
+	}
+
+	slog.WarnContext(ctx,
+		"HTTP drain budget exhausted, closing the connections that did not finish",
+		"budget", budget)
+	// Shutdown has already closed the listeners, so Close finds them closed
+	// and says so. That is expected here and says nothing about the
+	// connections, which are what this call is for.
+	if closeErr := httpServer.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+		return fmt.Errorf("http server close after drain budget: %w", closeErr)
+	}
+	return nil
+}
+
+// httpShutdownBudget returns how long the drain may take: the default, or what
+// the caller's deadline leaves, whichever is smaller.
+//
+// A non-positive result is a caller with no time left and means the drain is
+// skipped, not that it is given a default; see [shutdownHTTPServer].
+func httpShutdownBudget(ctx context.Context) time.Duration {
+	budget := httpShutdownTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		budget = min(budget, time.Until(deadline))
+	}
+	return budget
+}
 
 // effectiveIdleTimeout maps a user-supplied value to the duration passed to
 // [http.Server.IdleTimeout]. When the caller passes 0 (meaning "disable idle
@@ -2483,12 +2569,7 @@ func serveHTTPOn(ctx context.Context, cfg *config.Config, httpAddr string, liste
 	select {
 	case <-ctx.Done():
 		slog.InfoContext(ctx, "HTTP server shutdown requested")
-		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), httpShutdownTimeout)
-		defer cancel()
-		if err := httpServer.Shutdown(shutdownCtx); err != nil {
-			return fmt.Errorf("http server shutdown: %w", err)
-		}
-		return nil
+		return shutdownHTTPServer(ctx, httpServer)
 	case err := <-serverErr:
 		return fmt.Errorf("mcp server error (http): %w", err)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8689,7 +8689,7 @@ func TestLogDeprecatedEnvNames_WarnsThroughTheConfiguredLogger(t *testing.T) {
 // tight under CI load" look like a load problem. A tool call waiting on GitLab
 // keeps its connection out of the idle state [http.Server.Shutdown] waits for,
 // so the drain budget runs out however large it is, and until now that was
-// returned as "http server shutdown: context deadline exceeded" — exit 1, a
+// returned as "http server shutdown: context deadline exceeded" and exit 1: a
 // failed unit to a supervisor and a broken build to CI, for one straggler
 // connection that process exit was about to drop anyway.
 //
@@ -8800,7 +8800,7 @@ func TestServeHTTPOn_RequestInFlightAtShutdown_ExhaustedDrainBudgetIsNotAFailure
 // setup cost varies by an order of magnitude, since the deadline would have to
 // be picked before the setup it must outlast.
 type armedDeadlineContext struct {
-	context.Context //nolint:containedctx // a context decorator, which is what this is
+	context.Context
 
 	mu       sync.Mutex
 	deadline time.Time
@@ -8902,7 +8902,7 @@ func TestShutdownHTTPServer_NothingInFlight_ReturnsWithoutSpendingTheBudget(t *t
 func TestHTTPShutdownBudget_TakesTheSmallerOfTheDefaultAndTheCallersDeadline(t *testing.T) {
 	cases := []struct {
 		name      string
-		ctx       context.Context //nolint:containedctx // the input under test
+		ctx       context.Context
 		wantExact time.Duration
 		wantRange [2]time.Duration
 	}{

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8680,3 +8680,318 @@ func TestLogDeprecatedEnvNames_WarnsThroughTheConfiguredLogger(t *testing.T) {
 		})
 	}
 }
+
+// TestServeHTTPOn_RequestInFlightAtShutdown_ExhaustedDrainBudgetIsNotAFailure
+// pins that a connection which has not gone idle when the process context is
+// cancelled costs a forced close, not a failed shutdown.
+//
+// The failure this replaces is the one that made "the five second bound is too
+// tight under CI load" look like a load problem. A tool call waiting on GitLab
+// keeps its connection out of the idle state [http.Server.Shutdown] waits for,
+// so the drain budget runs out however large it is, and until now that was
+// returned as "http server shutdown: context deadline exceeded" — exit 1, a
+// failed unit to a supervisor and a broken build to CI, for one straggler
+// connection that process exit was about to drop anyway.
+//
+// The GitLab stand-in never answers the project list, which is what holds the
+// handler. The pool entry is warmed first on purpose: entry construction is
+// bounded by the serve context, so a request still building one would abort at
+// cancellation instead of holding the drain, and the test would prove nothing.
+//
+// The serve context states a drain budget of its own, which is also what keeps
+// the test to a few seconds rather than the full fifteen. It has to be armed
+// after the warm-up rather than declared up front, because that warm-up builds
+// a catalog and costs seconds on a plain run and an order of magnitude more
+// under the race detector: a deadline picked before it would expire during
+// setup on exactly the slow runners this has to survive.
+func TestServeHTTPOn_RequestInFlightAtShutdown_ExhaustedDrainBudgetIsNotAFailure(t *testing.T) {
+	var enteredOnce, releaseOnce sync.Once
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	gitlab := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v4/version":
+			w.Header().Set(hdrContentType, mimeJSON)
+			_, _ = w.Write([]byte(`{"version":"16.0.0","revision":"test"}`))
+		case strings.HasPrefix(r.URL.Path, "/api/v4/projects"):
+			enteredOnce.Do(func() { close(entered) })
+			<-release
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(gitlab.Close)
+	// Registered after the server's own close so it runs before it: Close
+	// waits for outstanding requests, and the handler above is one.
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
+	inner, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := &armedDeadlineContext{Context: inner}
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveHTTPOn(ctx, statelessTestConfig(gitlab.URL, true), addr, listener, defaultHTTPIdleTimeout)
+	}()
+	waitForHTTPServerReady(t, addr, errCh)
+
+	warm := postStatelessJSONRPC(t, addr, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	warm.Body.Close()
+
+	callDone := make(chan struct{})
+	go func() {
+		defer close(callDone)
+		body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"gitlab_execute_action",` +
+			`"arguments":{"action":"project.list","params":{}}}}`
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"http://"+addr, strings.NewReader(body))
+		if reqErr != nil {
+			t.Errorf("build the tool call that shutdown must find in flight: %v", reqErr)
+			return
+		}
+		req.Header.Set(hdrContentType, mimeJSON)
+		req.Header.Set("Accept", mimeJSONSSE)
+		req.Header.Set("PRIVATE-TOKEN", testToken)
+		if resp, doErr := testHTTPClient.Do(req); doErr == nil {
+			resp.Body.Close()
+		}
+	}()
+	t.Cleanup(func() { <-callDone })
+
+	select {
+	case <-entered:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("the tool call never reached the GitLab stand-in, so no request was in flight at shutdown")
+	}
+
+	const budget = 2 * time.Second
+	ctx.arm(time.Now().Add(budget))
+	start := time.Now()
+	cancel()
+	select {
+	case serveErr := <-errCh:
+		if serveErr != nil {
+			t.Fatalf("serveHTTPOn() = %v after %s, want a clean stop: a connection that has not gone idle is not a process failure",
+				serveErr, time.Since(start))
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatalf("serveHTTPOn() did not return within %s of cancellation", testHTTPLivenessTimeout)
+	}
+	// The stated budget is what bounded the drain, not httpShutdownTimeout:
+	// with the constant in charge this is the full fifteen seconds.
+	if elapsed := time.Since(start); elapsed >= httpShutdownTimeout {
+		t.Errorf("the drain took %s with a stated budget of %s, want the caller's budget to bound it",
+			elapsed, budget)
+	}
+}
+
+// armedDeadlineContext is a context that gains a deadline when the test arms
+// it, and never fires [context.Context.Done] because of it.
+//
+// It exists for the one shape in which a caller-stated drain budget is
+// meaningful: a deadline still in the future when cancellation ends the
+// serving. A plain [context.WithTimeout] cannot express it in a test whose
+// setup cost varies by an order of magnitude, since the deadline would have to
+// be picked before the setup it must outlast.
+type armedDeadlineContext struct {
+	context.Context //nolint:containedctx // a context decorator, which is what this is
+
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+// arm sets the deadline the context reports from now on.
+func (c *armedDeadlineContext) arm(at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadline = at
+}
+
+// Deadline reports the armed deadline, and none until arm is called.
+func (c *armedDeadlineContext) Deadline() (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.deadline, !c.deadline.IsZero()
+}
+
+// TestShutdownHTTPServer_CallersDeadline_BoundsTheDrain pins that the drain
+// budget comes from the caller's deadline when the caller stated a tighter one,
+// which is the rule [telemetry.Provider.Shutdown] follows.
+//
+// Both cases hold a request in flight, so the budget is genuinely spent rather
+// than short-circuited by an idle server, and both must end without an error.
+// The elapsed time is what says whose budget was used: [httpShutdownTimeout] is
+// fifteen seconds, so a run that honors the caller finishes in a fraction of
+// that, and a deadline already in the past skips the drain altogether.
+func TestShutdownHTTPServer_CallersDeadline_BoundsTheDrain(t *testing.T) {
+	cases := []struct {
+		name      string
+		remaining time.Duration
+		atLeast   time.Duration
+		atMost    time.Duration
+	}{
+		{
+			name:      "tighter than the default",
+			remaining: time.Second,
+			atLeast:   500 * time.Millisecond,
+			atMost:    8 * time.Second,
+		},
+		{
+			name:      "already passed",
+			remaining: -time.Second,
+			atLeast:   0,
+			atMost:    5 * time.Second,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			httpServer := blockedHTTPServer(t)
+
+			// The serve context is always done by the time the drain starts,
+			// which is exactly what makes a past deadline reachable here.
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(tc.remaining))
+			cancel()
+
+			start := time.Now()
+			if err := shutdownHTTPServer(ctx, httpServer); err != nil {
+				t.Fatalf("shutdownHTTPServer() = %v, want a clean stop", err)
+			}
+			elapsed := time.Since(start)
+			if elapsed < tc.atLeast || elapsed > tc.atMost {
+				t.Errorf("drain took %s, want between %s and %s: the budget did not come from the caller",
+					elapsed, tc.atLeast, tc.atMost)
+			}
+		})
+	}
+}
+
+// TestShutdownHTTPServer_NothingInFlight_ReturnsWithoutSpendingTheBudget pins
+// that a clean drain costs nothing, which is why the size of the default budget
+// is not a service-level objective: an idle server stops in milliseconds on any
+// runner, quick or slow.
+func TestShutdownHTTPServer_NothingInFlight_ReturnsWithoutSpendingTheBudget(t *testing.T) {
+	httpServer := newHTTPServer("", http.NotFoundHandler(), defaultHTTPIdleTimeout)
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = httpServer.Serve(listener) }()
+
+	start := time.Now()
+	if shutdownErr := shutdownHTTPServer(t.Context(), httpServer); shutdownErr != nil {
+		t.Fatalf("shutdownHTTPServer() = %v, want a clean stop", shutdownErr)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("draining an idle server took %s, want a prompt return", elapsed)
+	}
+}
+
+// TestHTTPShutdownBudget_TakesTheSmallerOfTheDefaultAndTheCallersDeadline
+// verifies the arithmetic on its own, with no server to drain.
+//
+// The non-positive case is the one worth pinning: a deadline in the past is
+// honored literally rather than clamped back up to the default, because the
+// drain escalates to a forced close instead of reporting a failure, so a caller
+// with no time left gets exactly that.
+func TestHTTPShutdownBudget_TakesTheSmallerOfTheDefaultAndTheCallersDeadline(t *testing.T) {
+	cases := []struct {
+		name      string
+		ctx       context.Context //nolint:containedctx // the input under test
+		wantExact time.Duration
+		wantRange [2]time.Duration
+	}{
+		{name: "no deadline", ctx: context.Background(), wantExact: httpShutdownTimeout},
+		{
+			name:      "deadline beyond the default",
+			ctx:       cancelledDeadlineContext(t, httpShutdownTimeout+time.Minute),
+			wantExact: httpShutdownTimeout,
+		},
+		{
+			name:      "deadline inside the default",
+			ctx:       cancelledDeadlineContext(t, 2*time.Second),
+			wantRange: [2]time.Duration{time.Second, 2 * time.Second},
+		},
+		{
+			name:      "deadline already passed",
+			ctx:       cancelledDeadlineContext(t, -time.Second),
+			wantRange: [2]time.Duration{-time.Hour, 0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := httpShutdownBudget(tc.ctx)
+			if tc.wantExact != 0 {
+				if got != tc.wantExact {
+					t.Errorf("httpShutdownBudget() = %s, want %s", got, tc.wantExact)
+				}
+				return
+			}
+			if got < tc.wantRange[0] || got > tc.wantRange[1] {
+				t.Errorf("httpShutdownBudget() = %s, want between %s and %s", got, tc.wantRange[0], tc.wantRange[1])
+			}
+		})
+	}
+}
+
+// cancelledDeadlineContext returns a context whose deadline is the given
+// distance from now, already cancelled so it matches the state the drain sees:
+// the serve context is done before the budget is ever computed.
+func cancelledDeadlineContext(t *testing.T, in time.Duration) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(in))
+	cancel()
+	return ctx
+}
+
+// blockedHTTPServer starts an [http.Server] on a loopback listener with a
+// handler that never returns, and comes back only once a request is provably in
+// flight, so draining it is guaranteed to spend the whole budget.
+func blockedHTTPServer(t *testing.T) *http.Server {
+	t.Helper()
+
+	var enteredOnce sync.Once
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	httpServer := newHTTPServer("", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+	}), defaultHTTPIdleTimeout)
+
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = httpServer.Serve(listener) }()
+
+	callDone := make(chan struct{})
+	// Registered before the release so it runs after it: the handler cannot
+	// return, and so the request cannot finish, until release is closed.
+	t.Cleanup(func() { <-callDone })
+	t.Cleanup(func() { close(release) })
+
+	go func() {
+		defer close(callDone)
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet,
+			"http://"+listener.Addr().String(), nil)
+		if reqErr != nil {
+			t.Errorf("build the request that must be in flight during the drain: %v", reqErr)
+			return
+		}
+		if resp, doErr := testHTTPClient.Do(req); doErr == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("the blocking handler never ran, so nothing was in flight to drain")
+	}
+	return httpServer
+}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8762,7 +8762,16 @@ func TestServeHTTPOn_RequestInFlightAtShutdown_ExhaustedDrainBudgetIsNotAFailure
 			resp.Body.Close()
 		}
 	}()
-	t.Cleanup(func() { <-callDone })
+	// Releasing here rather than leaving it to the cleanup registered above:
+	// this one runs first, and on the happy path the forced close ends the
+	// request for it. On a failure path between here and the shutdown there is
+	// no forced close, so waiting first would wait on a handler nothing has
+	// released, and the request would sit there for the client's full timeout.
+	// A failing test must not also hang.
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		<-callDone
+	})
 
 	select {
 	case <-entered:
@@ -8826,27 +8835,35 @@ func (c *armedDeadlineContext) Deadline() (time.Time, bool) {
 //
 // Both cases hold a request in flight, so the budget is genuinely spent rather
 // than short-circuited by an idle server, and both must end without an error.
-// The elapsed time is what says whose budget was used: [httpShutdownTimeout] is
-// fifteen seconds, so a run that honors the caller finishes in a fraction of
-// that, and a deadline already in the past skips the drain altogether.
+// The elapsed time is what says whose budget was used, so the ceiling is the
+// caller's own budget plus a tolerance rather than a round number: an upper
+// bound loose enough to admit some fixed budget of the implementation's own
+// would stay green with the very bug this test exists to catch.
 func TestShutdownHTTPServer_CallersDeadline_BoundsTheDrain(t *testing.T) {
+	// drainTolerance is how much longer than the caller's budget the drain may
+	// take. Shutdown selects on the deadline, so it returns as that passes and
+	// what remains is goroutine scheduling plus the forced close, measured in
+	// milliseconds. Two seconds is loose enough for a loaded runner under the
+	// race detector and still tight enough to fail any implementation that
+	// substituted a budget of its own, the smallest this project has shipped
+	// being five seconds.
+	const drainTolerance = 2 * time.Second
+
 	cases := []struct {
 		name      string
 		remaining time.Duration
 		atLeast   time.Duration
-		atMost    time.Duration
 	}{
 		{
 			name:      "tighter than the default",
 			remaining: time.Second,
-			atLeast:   500 * time.Millisecond,
-			atMost:    8 * time.Second,
+			// Proves the drain happened at all rather than being skipped.
+			atLeast: 500 * time.Millisecond,
 		},
 		{
 			name:      "already passed",
 			remaining: -time.Second,
 			atLeast:   0,
-			atMost:    5 * time.Second,
 		},
 	}
 	for _, tc := range cases {
@@ -8863,9 +8880,10 @@ func TestShutdownHTTPServer_CallersDeadline_BoundsTheDrain(t *testing.T) {
 				t.Fatalf("shutdownHTTPServer() = %v, want a clean stop", err)
 			}
 			elapsed := time.Since(start)
-			if elapsed < tc.atLeast || elapsed > tc.atMost {
+			atMost := max(tc.remaining, 0) + drainTolerance
+			if elapsed < tc.atLeast || elapsed > atMost {
 				t.Errorf("drain took %s, want between %s and %s: the budget did not come from the caller",
-					elapsed, tc.atLeast, tc.atMost)
+					elapsed, tc.atLeast, atMost)
 			}
 		})
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -7913,6 +7913,16 @@ func captureStdout(t *testing.T) func() string {
 // report anything, it blocks until the package timeout takes the whole run
 // down. That is exactly the symptom it is here to prevent, so a run of this
 // package that stops making progress should be read as this assertion firing.
+//
+// One size, and deliberately not a table of them. A second case below the
+// buffer would pass whether the drain is there or not, since working below the
+// buffer is precisely what the broken shape does, so it could never fail for
+// the reason this test exists. It would also have to name a size below the
+// smallest buffer anyone runs, and buffer capacity is not a portable constant:
+// Linux defaults to 64 KiB and is tunable per pipe and system-wide, macOS
+// starts smaller and grows, and Windows treats the size as a hint. Needing only
+// an upper bound is what keeps this test true everywhere, so the one number
+// here is the whole scenario rather than a row waiting for siblings.
 func TestCaptureStdout_OutputLargerThanThePipeBuffer_DoesNotBlock(t *testing.T) {
 	// Comfortably past Linux's 64 KiB, which is the largest buffer in play.
 	const size = 256 << 10

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1149,24 +1149,11 @@ func initializeTestServer(t *testing.T, cfg *config.ServerConfig) map[string]any
 // TestPrintHelp_ContainsExpectedSections verifies that printHelp outputs
 // all expected sections: version, author, flags, env vars, and JSON examples.
 func TestPrintHelp_ContainsExpectedSections(t *testing.T) {
-	// Capture stdout.
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
+	stdout := captureStdout(t)
 
 	printHelp()
 
-	_ = w.Close()
-	os.Stdout = oldStdout
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
-	output := string(out)
+	output := stdout()
 
 	checks := []struct {
 		name, want string
@@ -1225,26 +1212,14 @@ func TestPrintHelp_ContainsExpectedSections(t *testing.T) {
 // stating there too, because -http is in every existing deployment and the
 // answer to "what happens if I keep it" is the first question this flag raises.
 func TestPrintHelp_Transport_NamesEverySelectorAndThePrecedence(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
+	stdout := captureStdout(t)
 
 	printHelp()
 
-	_ = w.Close()
-	os.Stdout = oldStdout
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
 	// The entry is its own line plus its indented continuation lines: the
 	// description is long enough to wrap, and a value named on a wrapped line
 	// is still documented.
-	entry := helpEntry(string(out), "-transport string")
+	entry := helpEntry(stdout(), "-transport string")
 	if entry == "" {
 		t.Fatal("the help does not document -transport at all")
 	}
@@ -1298,26 +1273,13 @@ func helpEntry(help, flagName string) string {
 // stateful session that a rebuild answers 404, that a flag they set achieved
 // it.
 func TestPrintHelp_RevalidateInterval_DoesNotPromiseThatZeroStopsReverification(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
+	stdout := captureStdout(t)
 
 	printHelp()
 
-	_ = w.Close()
-	os.Stdout = oldStdout
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
-
 	// The entry is its own line plus any indented continuation lines, since a
 	// flag long enough to need this correction is long enough to wrap.
-	line := helpEntry(string(out), "-revalidate-interval")
+	line := helpEntry(stdout(), "-revalidate-interval")
 	if line == "" {
 		t.Fatal("the help does not document -revalidate-interval at all")
 	}
@@ -1330,17 +1292,12 @@ func TestPrintHelp_RevalidateInterval_DoesNotPromiseThatZeroStopsReverification(
 }
 
 // TestPrintHelp_NoPanic verifies that printHelp can be called without panicking.
+//
+// This one had no reader at all, only a write end nothing ever emptied, which
+// is the shape from [captureStdout]'s comment at its most direct: discarding
+// output still means writing it. The capture is what makes the discard work.
 func TestPrintHelp_NoPanic(t *testing.T) {
-	oldStdout := os.Stdout
-	_, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() {
-		_ = w.Close()
-		os.Stdout = oldStdout
-	}()
+	captureStdout(t)
 
 	// Should not panic.
 	printHelp()
@@ -1373,31 +1330,20 @@ func TestStaticConfigurationExamplesPreferToolSurface(t *testing.T) {
 func TestMain_HelpParsesTierFlag(t *testing.T) {
 	oldArgs := os.Args
 	oldCommandLine := flag.CommandLine
-	oldStdout := os.Stdout
 
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
 	os.Args = []string{"gitlab-mcp-server", "-h", "-tier", "ultimate"}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	flag.CommandLine.SetOutput(io.Discard)
-	os.Stdout = w
 	t.Cleanup(func() {
 		os.Args = oldArgs
 		flag.CommandLine = oldCommandLine
-		os.Stdout = oldStdout
 	})
+	stdout := captureStdout(t)
 
 	main()
 
-	_ = w.Close()
-	out, readErr := io.ReadAll(r)
-	if readErr != nil {
-		t.Fatalf("ReadAll: %v", readErr)
-	}
-	if !strings.Contains(string(out), "gitlab-mcp-server") {
-		t.Fatalf("help output missing project name: %s", string(out))
+	if out := stdout(); !strings.Contains(out, "gitlab-mcp-server") {
+		t.Fatalf("help output missing project name: %s", out)
 	}
 }
 
@@ -3015,24 +2961,13 @@ func TestDoToolSearch_HonorsToolSurface(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldStdout := os.Stdout
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("os.Pipe: %v", err)
-			}
-			os.Stdout = w
-			t.Cleanup(func() { os.Stdout = oldStdout })
+			stdout := captureStdout(t)
 
 			if searchErr := doToolSearch(tt.query, tt.toolSurface, edition.Free); searchErr != nil {
 				t.Fatalf("doToolSearch() error: %v", searchErr)
 			}
-			_ = w.Close()
-			out, readErr := io.ReadAll(r)
-			if readErr != nil {
-				t.Fatalf("ReadAll: %v", readErr)
-			}
-			if !strings.Contains(string(out), "Found") {
-				t.Fatalf("tool search output missing matches: %s", string(out))
+			if out := stdout(); !strings.Contains(out, "Found") {
+				t.Fatalf("tool search output missing matches: %s", out)
 			}
 		})
 	}
@@ -7907,6 +7842,21 @@ func TestMain_StdioMode_StartsAndStopsWithTheClient(t *testing.T) {
 
 // captureStdout redirects os.Stdout for the duration of the test and returns a
 // function that stops the capture and yields what was written.
+//
+// The pipe is drained by a goroutine started before the capture begins, and
+// that is load-bearing rather than tidy. A pipe holds only what its buffer
+// holds, and a writer that fills it blocks until somebody reads, so a capture
+// that reads only after the writer has finished works exactly until the output
+// outgrows the buffer. Linux gives 64 KiB and hides the problem for anything a
+// test is likely to print. Windows gives a few kilobytes, and [printHelp]
+// writes about 12 KB, so there the writer parked in os.(*File).Write and never
+// came back: that is what timed this package out at thirty minutes on the first
+// Windows CI run, with eighteen parallel tests stuck behind a serial phase that
+// had no way to end.
+//
+// Every capture of stdout in this package goes through here for that reason. A
+// site that opens its own pipe and reads afterwards is the same bug again, and
+// it is invisible until the output grows or the platform changes.
 func captureStdout(t *testing.T) func() string {
 	t.Helper()
 
@@ -7914,6 +7864,17 @@ func captureStdout(t *testing.T) func() string {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
+
+	type capture struct {
+		out []byte
+		err error
+	}
+	drained := make(chan capture, 1)
+	go func() {
+		out, readErr := io.ReadAll(reader)
+		drained <- capture{out: out, err: readErr}
+	}()
+
 	original := os.Stdout
 	os.Stdout = writer
 
@@ -7922,18 +7883,50 @@ func captureStdout(t *testing.T) func() string {
 	stop := func() string {
 		once.Do(func() {
 			os.Stdout = original
+			// Closing the writer is what ends the drain: ReadAll returns on
+			// EOF, which arrives only once the last write end is gone.
 			_ = writer.Close()
-			out, readErr := io.ReadAll(reader)
-			if readErr != nil {
-				t.Errorf("reading captured stdout: %v", readErr)
+			result := <-drained
+			if result.err != nil {
+				t.Errorf("reading captured stdout: %v", result.err)
 			}
-			captured = string(out)
+			captured = string(result.out)
 			_ = reader.Close()
 		})
 		return captured
 	}
 	t.Cleanup(func() { stop() })
 	return stop
+}
+
+// TestCaptureStdout_OutputLargerThanThePipeBuffer_DoesNotBlock pins the drain
+// that [captureStdout] depends on.
+//
+// The reason this test exists rather than trusting the comment is that the bug
+// it guards is invisible on the platform most of us develop on. A capture that
+// reads only after the writer finishes works for any output up to the pipe
+// buffer, which is 64 KiB on Linux and a few kilobytes on Windows, so the same
+// code passes here and hangs there. Writing past the larger of the two makes
+// the failure reachable everywhere.
+//
+// Note what failure looks like: without the concurrent drain this test does not
+// report anything, it blocks until the package timeout takes the whole run
+// down. That is exactly the symptom it is here to prevent, so a run of this
+// package that stops making progress should be read as this assertion firing.
+func TestCaptureStdout_OutputLargerThanThePipeBuffer_DoesNotBlock(t *testing.T) {
+	// Comfortably past Linux's 64 KiB, which is the largest buffer in play.
+	const size = 256 << 10
+
+	stdout := captureStdout(t)
+	_, writeErr := os.Stdout.Write(bytes.Repeat([]byte("x"), size))
+	captured := stdout()
+
+	if writeErr != nil {
+		t.Fatalf("writing past the pipe buffer: %v", writeErr)
+	}
+	if len(captured) != size {
+		t.Errorf("captured %d bytes, want %d", len(captured), size)
+	}
 }
 
 // TestBuildServerCard_AnUnusableInstanceURL_IsReportedNotServed covers the one

--- a/cmd/server/subscriptions.go
+++ b/cmd/server/subscriptions.go
@@ -782,10 +782,13 @@ func (b *sessionBridge) subscribeUnlessStateless(ctx context.Context, req *mcp.S
 //
 // So wiring the registry beside the runtime left --capability-surface=minimal
 // with open streams nobody could reach: SIGTERM was answered by the full
-// httpShutdownTimeout of waiting, then "http server shutdown: context deadline
-// exceeded" and exit 1, with the streams never getting their completion result
-// either. The per-server and per-process ceilings on open streams reduce how
-// many can pile up and do not change that outcome for the ones that do.
+// [httpShutdownTimeout] of waiting, then "http server shutdown: context
+// deadline exceeded" and exit 1, with the streams never getting their
+// completion result either. Since [shutdownHTTPServer] the same bug would end
+// in a forced close rather than that error, so what gives it away is the delay
+// and the missing completion results, which is what the tests assert on. The
+// per-server and per-process ceilings on open streams reduce how many can pile
+// up and do not change that outcome for the ones that do.
 func (r *subscriptionRuntime) streamRegistry() *listenStreams {
 	if r == nil {
 		return newListenStreams()

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -832,7 +832,9 @@ func TestNewSubscriptionRuntime_MinimalSurface_IsNil(t *testing.T) {
 // the registry used to be absent and those streams became unreachable. The
 // visible symptom was in shutdown: the process ignored its signal for the full
 // HTTP drain budget and then died with "http server shutdown: context deadline
-// exceeded" and exit 1. The wire half of this is pinned in
+// exceeded" and exit 1. Since [shutdownHTTPServer] that budget ends in a forced
+// close instead, so the delay and the streams left without a completion result
+// are what the bug would show today. The wire half of this is pinned in
 // test/e2e/http/shutdown_test.go, which drives the real binary with that flag
 // and a real signal; this half pins the wiring that makes it possible.
 //

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,491 |
-| Unit test functions                                   | 12,927 |
+| Total test functions                                  | 13,498 |
+| Unit test functions                                   | 12,934 |
 | E2E test functions                                    |    564 |
-| cmd test functions                                    |  2,033 |
+| cmd test functions                                    |  2,040 |
 | Test files (internal/)                                |    495 |
 | Test files (cmd/)                                     |    117 |
 | Test files (test/e2e/)                                |    220 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,230 | 83.2% |
-| `TestFunc` (no underscore)             |    965 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,296 |  9.6% |
+| `TestFunc_Scenario` (2-part)           | 11,231 | 83.2% |
+| `TestFunc` (no underscore)             |    965 |  7.1% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,302 |  9.6% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (174) |          8,411 |        351 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            564 |        220 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,033 |        117 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,491** |    **832** |                                                                                                 |
+| cmd packages            |          2,040 |        117 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,498** |    **832** |                                                                                                 |
 
 ### Core Packages
 

--- a/internal/cmdutil/cmdutil_test.go
+++ b/internal/cmdutil/cmdutil_test.go
@@ -88,9 +88,11 @@ func TestRepositoryRoot_AbsError(t *testing.T) {
 // regardless of privilege, exercising the same RepositoryRoot error path
 // without depending on permission enforcement.
 //
-// It depends instead on the platform reporting the removal at all, which
-// Windows and macOS do not, so the test checks that premise and skips rather
-// than asserting an error the operating system was never going to produce.
+// It depends instead on the platform letting the removal happen and then
+// reporting it, and there are two different ways for that to fail. Both are
+// checked as premises rather than predicted from the platform name, and both
+// skip rather than asserting an error the operating system was never going to
+// produce.
 func TestRepositoryRoot_AbsError_RemovedCwd(t *testing.T) {
 	tmp := t.TempDir()
 	nested := filepath.Join(tmp, "gone")
@@ -99,17 +101,22 @@ func TestRepositoryRoot_AbsError_RemovedCwd(t *testing.T) {
 	}
 	t.Chdir(nested)
 
+	// First premise: the removal itself. Windows refuses it, because a
+	// directory that is a process's working directory is a directory in use,
+	// and says so ("The process cannot access the file because it is being
+	// used by another process"). A platform that will not remove the working
+	// directory cannot be made to fail filepath.Abs this way at all, so the
+	// removal failing is a reason to skip and not a reason to fail: a t.Fatalf
+	// here reported the operating system's design as a defect in this package.
 	if err := os.RemoveAll(nested); err != nil {
-		t.Fatalf("remove nested: %v", err)
+		t.Skipf("this platform will not remove the working directory, so filepath.Abs cannot be made to fail here: %v", err)
 	}
 
-	// The premise is checked rather than predicted from the platform. Removing
-	// the working directory fails getcwd(3) on Linux and does not on Windows,
-	// which this test already knew, nor on macOS, which it did not: Darwin
-	// answers from the path it remembers, so RepositoryRoot walks for a go.mod
-	// and returns the not-found error instead. Where getcwd still succeeds
-	// there is no filepath.Abs failure to cover, and asking the platform is
-	// both shorter and truer than listing the ones that behave this way.
+	// Second premise, for the platforms that do remove it. Removal fails
+	// getcwd(3) on Linux and does not on macOS, where Darwin answers from the
+	// path it remembers, so RepositoryRoot walks for a go.mod and returns the
+	// not-found error instead. Where getcwd still answers there is no
+	// filepath.Abs failure to cover.
 	if _, err := os.Getwd(); err == nil {
 		t.Skip("this platform's getcwd still answers after the working directory is removed, so filepath.Abs cannot fail here")
 	}

--- a/internal/oauth/rejected_test.go
+++ b/internal/oauth/rejected_test.go
@@ -238,11 +238,18 @@ func TestRejectedTokens_Lookup_HonorsDisabledAndExpiry(t *testing.T) {
 	tests := []struct {
 		name    string
 		cache   *RejectedTokens
+		ttl     time.Duration
 		wantLen int
 	}{
 		{name: "capacity of zero disables it", cache: NewRejectedTokens(0, time.Hour)},
 		{name: "a zero TTL disables it", cache: NewRejectedTokens(8, 0)},
-		{name: "an entry past its TTL is forgotten", cache: NewRejectedTokens(8, time.Nanosecond)},
+		{
+			name:  "an entry past its TTL is forgotten",
+			cache: NewRejectedTokens(8, time.Nanosecond),
+			// Set only where the case needs the entry to actually expire,
+			// which is a wait and not an assumption. See below.
+			ttl: time.Nanosecond,
+		},
 	}
 
 	for _, tt := range tests {
@@ -250,6 +257,24 @@ func TestRejectedTokens_Lookup_HonorsDisabledAndExpiry(t *testing.T) {
 			t.Parallel()
 
 			tt.cache.RecordKind(instance, "token", RejectionUnaccepted)
+
+			if tt.ttl > 0 {
+				// Wait for the clock to pass the entry's deadline instead of
+				// assuming a nanosecond is observable. Lookup asks whether
+				// time.Now() is strictly after expiresAt, so with a TTL this
+				// short the case is really a question about clock resolution:
+				// Linux answers yes, and Windows routinely returns the same
+				// instant from two consecutive reads, so the entry was still
+				// live and this failed there.
+				//
+				// Do not "simplify" this away. The deadline is read after
+				// RecordKind, so it is at or past the entry's own, and a wait
+				// this short is what makes the expiry real rather than lucky.
+				deadline := time.Now().Add(tt.ttl)
+				for !time.Now().After(deadline) {
+					time.Sleep(time.Millisecond)
+				}
+			}
 
 			kind, refused := tt.cache.Lookup(instance, "token")
 


### PR DESCRIPTION
Two failures I had understood and deliberately left unpatched, fixed at the cause. Reproduced first in both cases, because a fix for a failure I never watched fail is a guess.

## The HTTP shutdown bound

The question the issue asks is whether five seconds is a real requirement or a number somebody picked. Answering it meant looking at what the bound protects.

`http.Server.Shutdown` returns the moment every connection is idle. A clean drain therefore costs milliseconds on the quickest runner and the slowest one alike, and load is not what makes it block. What blocks it is a request still executing, a stream still open, or a peer holding a connection it never finishes. The bound is a liveness backstop against those, not a service-level objective on drain speed, and treating it as one is what sent the number from five to fifteen without settling anything.

So the number was never the defect. The defect is one line above it: exhausting the budget was returned as an error, which becomes exit 1, which is a failed unit to a supervisor and a broken build to CI. One straggler connection, and a normal stop is reported as a failure, for connections that process exit was about to drop anyway.

`shutdownHTTPServer` now drains, and when the budget runs out it logs, closes the connections that did not finish, and returns cleanly. Anything else `Shutdown` reports is still an error. Forcing the stragglers closed is the honest completion of what the caller asked for, rather than reporting the job undone.

The budget also comes from the caller when the caller stated a tighter one, which is the rule `telemetry.Provider.Shutdown` already follows: an internal bound that silently overrides a tighter one makes the caller's bound dead code. It differs from the telemetry provider in one way worth knowing, and the comment says so: this runs after the serve context is already done, so a deadline in the past leaves no budget at all and is honored literally rather than clamped back up. That is only a sane answer because the forced close exists.

Fifteen seconds stays as the default, now bracketed rather than picked, with the reasoning beside the constant where the next person to hit a flake will read it:

- above the work a request can legitimately be doing when the signal lands, which is a pool entry's first request building a catalog,
- above the ten second grace `test/e2e/http` gives the real binary to exit after SIGTERM, below which a drain hung on a stream nothing can close becomes indistinguishable from a prompt exit and that regression test loses its teeth,
- below the supervisor grace periods that end the process regardless: `docker stop` ten seconds, Kubernetes thirty, systemd ninety.

This is also why I am not worried about the new cross-platform matrix. No value here is "safe on a slow Windows runner", because slowness is not the failure mode. What makes the bound safe on any runner is that running long is no longer a failure.

### Reproduction

A tool call waiting on a GitLab stand-in that never answers keeps its connection out of the idle state `Shutdown` waits for. Against the previous code:

```
main_test.go:8752: serveHTTPOn() = http server shutdown: context deadline exceeded after 15.00052472s,
    want a clean stop: a connection that has not gone idle is not a process failure
--- FAIL: TestServeHTTPOn_RequestInFlightAtShutdown_ExhaustedDrainBudgetIsNotAFailure (42.82s)
```

The budget spent in full, then reported as a process failure. It passes now, and in twelve seconds rather than forty-three, because the serve context states a budget of its own. That deadline is armed after the warm-up rather than declared up front: the warm-up builds a catalog, which costs seconds on a plain run and an order of magnitude more under the race detector, so a deadline picked before it would expire during setup on exactly the slow runners the test most needs to survive. Arming it afterwards is also the only shape in which a caller-stated budget means anything, a deadline still ahead when cancellation ends the serving.

Three more tests cover the budget arithmetic on its own, a clean drain returning without spending anything, and a drain bounded by the caller rather than by the constant.

## The evaluator fixture memo

`TestMergeRequestSourceFixture_EnsuresAttemptBranchAndFile` passed once and failed on a second run in the same process:

```
=== RUN   TestMergeRequestSourceFixture_EnsuresAttemptBranchAndFile
    case_fixture_context_test.go:57: calls = , want POST /api/v4/projects/101/repository/branches
    case_fixture_context_test.go:57: calls = , want POST /api/v4/projects/101/repository/files/tmp%2Feval-...txt
--- FAIL: TestMergeRequestSourceFixture_EnsuresAttemptBranchAndFile (0.00s)
```

Empty call list: the second run was answered from the package-level memo and made no HTTP calls at all, and every assertion in that test is about the calls the fixture makes.

Of the two routes the issue names I took the second, the test driving a path that bypasses the memo, and the deciding question was what the memo is for. It is what makes "prepared once per scope" true for the live fixtures: a run has many cases sharing one, preparing one creates real resources on a real GitLab, so a bootstrap fixture is built once per process and an attempt-scoped one once per model and attempt. That is load-bearing for evaluator runtime and I am not weakening it.

Teaching the key about the client would have been the wrong half to change twice over. It adds a dimension that never varies in a real run, where one process points at one instance, so it would be inert everywhere except in this test. And it would leave the test's correctness resting on the kernel not handing the second httptest server the port the first one released, which is not a fix, it is a coin toss with better odds.

What was actually wrong is that the test's subject and the code path did not line up. The test exercises the fixture's creation work, so it now states no idempotency key, which is how `ensure` is told there is no identity to remember this fixture by. That contract was implemented and undocumented; it is written down now, next to what the memo is for.

The memoization keeps the coverage it had and gains the two cases it lacked: an empty key running the creation every time, and a failed creation not being remembered, so the next case that needs the fixture retries rather than inheriting the failure for the rest of the run.

## Three platform failures folded in

The last three commits are not part of issue 364. They are failures the new cross-platform CI matrix surfaced on its Windows leg, and they land here because this branch is the top of the stack: fixed on a lower one, the next squash merge would take them straight back out.

The first is why the whole `cmd/server` package timed out at thirty minutes there. A pipe holds only what its buffer holds, so a test that captures stdout and reads it only after the writer has finished works exactly until the output outgrows the buffer. Linux gives 64 KiB and hid it; Windows gives a few kilobytes, `printHelp` writes 12,702 bytes, and the writer parked in `os.(*File).Write` with eighteen parallel tests queued behind a serial phase that had no way to end. `TestMain_HelpParsesTierFlag` was the reported one, but four more captures called that same `printHelp`, including one with no reader at all. All of them now go through a helper that starts reading before the capture begins, and a new test writes 256 KiB so the bug is reachable on every platform rather than only on Windows.

The second and third are premises that were asked of the wrong thing. A test that deletes its own working directory to make `filepath.Abs` fail now treats the deletion as a premise, because Windows refuses to remove a directory that is a process's working directory and the test died on that before reaching the check meant to protect it. And an OAuth cache case with a one nanosecond TTL was really asking about clock resolution, since Windows returns the same instant from two consecutive reads; it now waits for the clock to pass the deadline instead of assuming a nanosecond is observable.

Each of the three was verified by mutation rather than by eye, and each mutation reproduces the Windows symptom on Linux.

## Verification

`go build ./...`, `go test ./cmd/... -count=1`, `go test ./internal/... -count=1`, `go test ./cmd/eval_mcp_surfaces/... -count=2` (the reproducer), `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `make check-test-goroutines`, `make check-test-file-names`, `go run ./cmd/audit_test_subtests/ -check`. All green. `cmd/server` also passed repeatedly in full while other sessions were hammering the same package, which is the loaded-runner condition this is about.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/364
