### PR TITLE
Wire-level regression tests for the September security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,8 +473,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,041 |     220,939 |
 | Unit tests (`_test.go`)  |       612 |     361,265 |
-| End-to-end tests         |       218 |      59,303 |
-| **Total**                | **1,871** | **641,507** |
+| End-to-end tests         |       222 |      60,221 |
+| **Total**                | **1,875** | **642,425** |
 
 ### Functions
 
@@ -484,8 +484,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | . Exported (public)             |  2,787 |
 | . Unexported (private)          |  5,516 |
 | Unit test functions (`TestXxx`) | 12,927 |
-| Subtests (`t.Run(...)`)         |  4,760 |
-| End-to-end test functions       |    558 |
+| Subtests (`t.Run(...)`)         |  4,765 |
+| End-to-end test functions       |    564 |
 
 ### Ratios worth noting
 
@@ -501,8 +501,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,962 |
-| `defer` statements                 | 1,122 |
+| `if err != nil` checks             | 6,964 |
+| `defer` statements                 | 1,128 |
 | `struct` types defined             | 2,843 |
 | `//nolint` suppressions            |   270 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,13 +18,13 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,485 |
+| Total test functions                                  | 13,491 |
 | Unit test functions                                   | 12,927 |
-| E2E test functions                                    |    558 |
+| E2E test functions                                    |    564 |
 | cmd test functions                                    |  2,033 |
 | Test files (internal/)                                |    495 |
 | Test files (cmd/)                                     |    117 |
-| Test files (test/e2e/)                                |    216 |
+| Test files (test/e2e/)                                |    220 |
 | Tool sub-packages tested                              |    174 |
 | Core packages tested                                  |     21 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  97.8% |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,224 | 83.2% |
+| `TestFunc_Scenario` (2-part)           | 11,230 | 83.2% |
 | `TestFunc` (no underscore)             |    965 |  7.2% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,296 |  9.6% |
 
@@ -48,9 +48,9 @@
 | Core packages           |          2,182 |        131 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (174) |          8,411 |        351 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            558 |        216 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| E2E integration         |            564 |        220 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,033 |        117 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,485** |    **828** |                                                                                                 |
+| **Total**               |     **13,491** |    **832** |                                                                                                 |
 
 ### Core Packages
 

--- a/test/e2e/http/exclusion_test.go
+++ b/test/e2e/http/exclusion_test.go
@@ -1,0 +1,226 @@
+//go:build httpe2e
+
+// exclusion_test.go pins that --exclude-tools removes an action from every
+// request path that serves it, not only from the tool surface.
+//
+// The tool surface is one of three ways to the same GitLab object with the
+// same credential. A resource template returns the identical project, and a
+// subscription polls for it on a schedule. internal/resources has carried the
+// narrowing mechanism since the security work and cmd/server passed it nothing
+// for a while, which is the worst of the three possible states: the package's
+// own tests passed and the guard was absent. Nothing inside either package can
+// see that, because each is correct on its own and the defect is entirely in
+// what connects them.
+//
+// Exclusion is also the mitigation this project recommends when an operator
+// wants an action gone. A mitigation that covers one of the ways to reach it
+// is worse than none, because it is believed.
+package httpe2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The two resources the cases below use. The first is the one an exclusion of
+// project.get must take away; the second is its sibling, which must survive,
+// because a narrowing that removed the whole resource surface would satisfy
+// every other assertion here.
+const (
+	exclusionProjectURI  = "gitlab://project/42"
+	exclusionIssuesURI   = "gitlab://project/42/issues"
+	exclusionProjectTmpl = "gitlab://project/{project_id}"
+	// exclusionProjectQuoted is the template with its closing quote, because
+	// every sibling template starts with the same prefix: a substring search
+	// for the bare form matches gitlab://project/{project_id}/issues too, and
+	// would report the exclusion as ineffective whatever it did.
+	exclusionProjectQuoted = exclusionProjectTmpl + `"`
+)
+
+// exclusionGitLab is a fake instance that records which project endpoints a
+// resource read actually reached.
+//
+// Arrival is half the finding. An excluded resource that is still registered
+// does not merely answer the client: it sends this deployment's credential to
+// GitLab for an object the operator believed they had retired, and a
+// subscription would go on doing so every few minutes.
+type exclusionGitLab struct {
+	url string
+
+	mu       sync.Mutex
+	requests []string
+}
+
+// startExclusionGitLab serves the startup probes, one project and its issues.
+func startExclusionGitLab(t *testing.T) *exclusionGitLab {
+	t.Helper()
+
+	fake := &exclusionGitLab{}
+	record := func(r *http.Request) {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		fake.requests = append(fake.requests, r.URL.Path)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":7,"username":"someone","name":"Some One","state":"active"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/42/issues", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":1,"iid":1,"title":"an issue","state":"opened"}]`))
+	})
+	mux.HandleFunc("/api/v4/projects/42", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":42,"name":"widgets","path_with_namespace":"acme/widgets"}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	fake.url = srv.URL
+	return fake
+}
+
+// seen returns the project endpoints that were asked for.
+func (f *exclusionGitLab) seen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.requests...)
+}
+
+// exclusionRead issues one resources/read and reports whether the server
+// served the resource, along with the answer for a failure message.
+//
+// The status is part of the answer rather than a precondition: an unregistered
+// resource is refused with a 400 carrying a JSON-RPC error, and a helper that
+// insisted on 200 would fail the case for the very behavior it is asserting.
+func exclusionRead(t *testing.T, srv *server, uri string) (served bool, answer string) {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"` + uri +
+		`","_meta":{"io.modelcontextprotocol/protocolVersion":"` + protocolVersion +
+		`","io.modelcontextprotocol/clientCapabilities":{}}}}`
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: body,
+		headers: map[string]string{
+			"PRIVATE-TOKEN": "glpat-whatever",
+			// Protocol 2026-07-28 makes Mcp-Name required for resources/read
+			// as well as for tools/call, and carries the URI in it. Without
+			// it the transport answers -32020 before any handler runs, which
+			// looks like a refusal and is not one.
+			"Mcp-Name": uri,
+		},
+	})
+	payload := jsonRPCPayload(t, got.body)
+	answer = fmt.Sprintf("HTTP %d: %s", got.status, truncate(payload))
+	if got.status != http.StatusOK {
+		return false, answer
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		t.Fatalf("resources/read %s answered something that is not JSON-RPC: %v: %s", uri, err, truncate(payload))
+	}
+	return decoded["error"] == nil, answer
+}
+
+// exclusionTemplates returns the body of a resources/templates/list call.
+//
+// Templates are listed by their own method rather than by resources/list: the
+// project resource is a template, so a test that looked only at resources/list
+// would find it absent whether it was registered or not.
+func exclusionTemplates(t *testing.T, srv *server) string {
+	t.Helper()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"resources/templates/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"` +
+		protocolVersion + `","io.modelcontextprotocol/clientCapabilities":{}}}}`
+	got := srv.do(t, request{
+		method: http.MethodPost, path: "/mcp", body: body,
+		headers: map[string]string{"PRIVATE-TOKEN": "glpat-whatever"},
+	})
+	if got.status != http.StatusOK {
+		t.Fatalf("resources/templates/list = %d, want 200: %s", got.status, truncate(got.body))
+	}
+	return jsonRPCPayload(t, got.body)
+}
+
+// TestExclusion_AnExcludedActionIsUnreachableThroughResources excludes one
+// canonical action and asserts the resource serving the same object goes with
+// it, while its siblings do not.
+//
+// project.get is named by its canonical ID rather than by a group, so what is
+// removed is exactly one action. That makes the sibling assertion meaningful:
+// gitlab://project/42/issues is served by issue.list, which nobody excluded,
+// and it must still answer. A narrowing that took the resource surface down
+// wholesale, or one that took nothing, both fail here.
+func TestExclusion_AnExcludedActionIsUnreachableThroughResources(t *testing.T) {
+	gitlab := startExclusionGitLab(t)
+	srv := startServer(t,
+		map[string]string{"GITLAB_MCP_EXCLUDE_TOOLS": "project.get"},
+		"--gitlab-url="+gitlab.url)
+
+	t.Run("the template is no longer offered", func(t *testing.T) {
+		if templates := exclusionTemplates(t, srv); strings.Contains(templates, exclusionProjectQuoted) {
+			t.Errorf("%s is still advertised despite the exclusion: %s", exclusionProjectTmpl, truncate(templates))
+		}
+	})
+
+	t.Run("reading it is refused and reaches no GitLab", func(t *testing.T) {
+		before := len(gitlab.seen())
+
+		served, answer := exclusionRead(t, srv, exclusionProjectURI)
+		if served {
+			t.Fatalf("an excluded resource was still readable: %s", answer)
+		}
+		if after := gitlab.seen(); len(after) != before {
+			t.Errorf("the refused read still spent the deployment's credential on GitLab: %v", after[before:])
+		}
+	})
+
+	t.Run("a sibling resource is untouched", func(t *testing.T) {
+		if served, answer := exclusionRead(t, srv, exclusionIssuesURI); !served {
+			t.Fatalf("excluding project.get also removed %s, which no operator asked for: %s",
+				exclusionIssuesURI, answer)
+		}
+	})
+}
+
+// TestExclusion_WithoutItTheSameResourceIsServed is the control for the case
+// above, and it is not optional.
+//
+// Every assertion there is satisfied by a server that serves no resources at
+// all, by one whose fake GitLab answers nothing, and by a URI nobody ever
+// registered. Reading the identical URI from an identical deployment that
+// excluded nothing is what tells those apart from the narrowing actually
+// working.
+func TestExclusion_WithoutItTheSameResourceIsServed(t *testing.T) {
+	gitlab := startExclusionGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	if templates := exclusionTemplates(t, srv); !strings.Contains(templates, exclusionProjectQuoted) {
+		t.Fatalf("%s is not offered even without an exclusion, so the case above proves nothing: %s",
+			exclusionProjectTmpl, truncate(templates))
+	}
+
+	if served, answer := exclusionRead(t, srv, exclusionProjectURI); !served {
+		t.Fatalf("reading %s failed without any exclusion: %s", exclusionProjectURI, answer)
+	}
+	if seen := gitlab.seen(); len(seen) == 0 {
+		t.Error("the successful read never reached GitLab, so the arrival assertion above is vacuous")
+	}
+}

--- a/test/e2e/http/localpath_test.go
+++ b/test/e2e/http/localpath_test.go
@@ -1,0 +1,225 @@
+//go:build httpe2e
+
+// localpath_test.go pins the transport rule for caller-supplied local paths:
+// a server reached over HTTP honors none of them.
+//
+// The rule cannot be checked from inside the process. It is decided by
+// toolutil.SetLocalFilesystemAccess, which cmd/server calls once with the
+// transport it is about to serve, so a unit test on the helper asserts on a
+// flag it set itself and a test on a handler never reaches the decision at
+// all. What an operator needs to know is different in kind: this binary,
+// started with --http and reachable by somebody with no files on this machine,
+// must refuse every path that somebody can name, and must still accept the
+// inline form so the legitimate remote upload keeps working. Only a running
+// process answers that.
+//
+// The paths used here are inside the OS temporary directory, which is an
+// always-allowed root. That is deliberate: the containment allow-list would
+// accept them, so the refusal under test can only be the transport rule and
+// nothing else.
+package httpe2e
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// localPathProject is what the fake instance answers a project write with, so
+// the accepted call has somewhere to land and a result to report.
+const localPathProject = `{"id":42,"name":"widgets","path_with_namespace":"acme/widgets","web_url":"https://gitlab.example.com/acme/widgets"}`
+
+// localPathGitLab is a fake instance that records everything a tool call asks
+// it for.
+//
+// The record is the second half of every assertion here. A refusal that
+// reaches GitLab first has already read the file and put it on the wire, so
+// "the call was refused" is only worth asserting beside "and nothing left the
+// process": the startup probes are excluded from the record precisely so that
+// what remains is attributable to the tool call.
+type localPathGitLab struct {
+	url string
+
+	mu       sync.Mutex
+	requests []string
+}
+
+// startLocalPathGitLab serves the two startup probes plus a project write.
+func startLocalPathGitLab(t *testing.T) *localPathGitLab {
+	t.Helper()
+
+	fake := &localPathGitLab{}
+	record := func(r *http.Request) {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		fake.requests = append(fake.requests, r.Method+" "+r.URL.Path)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":7,"username":"someone","name":"Some One","state":"active"}`))
+	})
+	// The tier and scope probes are answered without being recorded. They are
+	// the pool's, not the tool call's, and they arrive lazily on the first
+	// request rather than at startup, so leaving them in the record would
+	// charge the first case with two requests it never made.
+	for _, probe := range []string{"/api/v4/license", "/api/v4/personal_access_tokens/self", "/oauth/token/info"} {
+		mux.HandleFunc(probe, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+	}
+	mux.HandleFunc("PUT /api/v4/projects/42", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(localPathProject))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	fake.url = srv.URL
+	return fake
+}
+
+// seen returns every request the fake received that was not a startup probe.
+func (f *localPathGitLab) seen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.requests...)
+}
+
+// localPathSecret writes a file a remote caller must never be able to read
+// through this server and returns its path.
+//
+// It goes in the OS temporary directory rather than somewhere exotic because
+// that directory is an always-allowed containment root: a path there passes
+// every check except the transport rule, which is the one under test.
+func localPathSecret(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "local-secret.png")
+	if err := os.WriteFile(path, []byte("bytes belonging to whoever runs this server"), 0o600); err != nil {
+		t.Fatalf("writing the local file: %v", err)
+	}
+	return path
+}
+
+// TestLocalPath_HTTPRefusesEveryCallerSuppliedPath drives one tools/call per
+// local-path input over the real HTTP transport and asserts each is refused
+// before anything reaches GitLab.
+//
+// Three distinct inputs are covered because they are three distinct helpers
+// with three distinct refusal points, and the audit finding was that a remote
+// caller can name a path on somebody else's machine through any of them:
+// file_path reads a file, output_path writes one, and directory_path reads a
+// whole tree. A test covering only the first would leave the other two able to
+// regress in silence.
+//
+// The refusal must also be legible. A model told only "invalid input" retries
+// with another path; one told the input is disabled on this transport, and
+// which input to use instead, stops. That is why the message is asserted and
+// not merely the failure.
+func TestLocalPath_HTTPRefusesEveryCallerSuppliedPath(t *testing.T) {
+	gitlab := startLocalPathGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	secret := localPathSecret(t)
+	directory := filepath.Dir(secret)
+
+	tests := []struct {
+		name   string
+		action string
+		params string
+		// wantInput is the parameter name the refusal must identify.
+		wantInput string
+	}{
+		{
+			name:      "file_path reads a file from the server's own disk",
+			action:    "project.upload_avatar",
+			params:    `{"project_id":"42","filename":"avatar.png","file_path":"` + secret + `"}`,
+			wantInput: "file_path",
+		},
+		{
+			name:      "output_path writes one to it",
+			action:    "package.download",
+			params:    `{"project_id":"42","package_name":"pkg","package_version":"1.0.0","file_name":"asset.bin","output_path":"` + filepath.Join(directory, "written.bin") + `"}`,
+			wantInput: "output_path",
+		},
+		{
+			name:      "directory_path reads a whole tree",
+			action:    "package.publish_directory",
+			params:    `{"project_id":"42","package_name":"pkg","package_version":"1.0.0","directory_path":"` + directory + `"}`,
+			wantInput: "directory_path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(gitlab.seen())
+
+			body, isError := toolResultsText(t, toolResultsCall(t, srv, tt.action, tt.params))
+			if !isError {
+				t.Fatalf("%s was accepted over HTTP: %s", tt.wantInput, toolResultsTruncate(body))
+			}
+			if !strings.Contains(body, tt.wantInput) {
+				t.Errorf("the refusal does not name %s, so a model cannot tell which input to drop: %s",
+					tt.wantInput, toolResultsTruncate(body))
+			}
+			if !strings.Contains(body, "reached over HTTP") {
+				t.Errorf("the refusal does not say the transport is the reason, so it reads as a bad path: %s",
+					toolResultsTruncate(body))
+			}
+
+			// A refusal that has already sent the request has already leaked
+			// whatever it was asked for.
+			if after := gitlab.seen(); len(after) != before {
+				t.Errorf("the refused call still reached GitLab: %v", after[before:])
+			}
+		})
+	}
+}
+
+// TestLocalPath_HTTPStillAcceptsInlineContent is the other half of the same
+// rule, and the reason the fix refuses at the shared helper instead of
+// removing the actions from the catalog.
+//
+// project.upload_avatar takes either a local path or the bytes themselves. A
+// remote caller has the bytes and has no files here, so the inline form is the
+// one that was always meant for them; deregistering the action would have taken
+// it away along with the path. Without this case the refusal above could be
+// satisfied by an action that simply stopped working, which is a different and
+// worse outcome that no assertion here would have noticed.
+func TestLocalPath_HTTPStillAcceptsInlineContent(t *testing.T) {
+	gitlab := startLocalPathGitLab(t)
+	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+
+	inline := base64.StdEncoding.EncodeToString([]byte("bytes the caller already holds"))
+	payload := toolResultsCall(t, srv, "project.upload_avatar",
+		`{"project_id":"42","filename":"avatar.png","content_base64":"`+inline+`"}`)
+
+	body, isError := toolResultsText(t, payload)
+	if isError {
+		t.Fatalf("content_base64 was refused too, so the transport rule took the remote path with it: %s",
+			toolResultsTruncate(body))
+	}
+	if !strings.Contains(body, "acme/widgets") {
+		t.Errorf("the accepted upload did not return the project GitLab answered with: %s", toolResultsTruncate(body))
+	}
+	if seen := gitlab.seen(); !slices.Contains(seen, "PUT /api/v4/projects/42") {
+		t.Errorf("the accepted upload never reached GitLab, so nothing was uploaded: %v", seen)
+	}
+}

--- a/test/e2e/http/redirect_test.go
+++ b/test/e2e/http/redirect_test.go
@@ -1,0 +1,170 @@
+//go:build httpe2e
+
+// redirect_test.go pins what happens to this deployment's GitLab credential
+// when the instance answers a tool call with a redirect somewhere else.
+//
+// Following the redirect is deliberate and cannot be given up: GitLab answers
+// artifact, trace and package reads with a 302 to object storage whenever
+// object storage is configured, which is GitLab.com and most self-managed
+// instances, and several shipped read-only actions exist only because that hop
+// is followed. Those destinations authenticate through the query string, so the
+// credential headers cost nothing to withhold.
+//
+// net/http withholds Authorization, Cookie and a few others across a change of
+// host, and nothing else. It never touches PRIVATE-TOKEN, which is the only
+// credential stdio mode has and legacy HTTP mode's default; and because it
+// compares hostnames alone, it keeps even Authorization across an https-to-http
+// downgrade. Both gaps are closed by this project's own redirect policy, which
+// is why the case below is a downgrade on one host: the standard library would
+// carry the credential through it.
+//
+// The policy has unit tests. What they cannot show is that the policy is
+// installed on the client a tool call actually uses, that it survives the
+// assembled request path, and that the line it writes reaches the operator's
+// log without dragging a presigned URL along with it. Those need a process.
+package httpe2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// redirectPresignedQuery is the query string the instance attaches to the
+// destination it names.
+//
+// It stands in for the presigned parameters real object storage uses, which
+// are themselves a working credential: the whole point of recording the hop as
+// a host and a scheme rather than as a URL is that logging the URL would write
+// one credential to stderr while reporting that another was withheld.
+const redirectPresignedQuery = "X-Amz-Signature=thisvalueisitselfacredential"
+
+// redirectDestination records what arrived at the host the instance redirected
+// to.
+type redirectDestination struct {
+	url string
+
+	mu       sync.Mutex
+	arrived  bool
+	carried  []string
+	rawQuery string
+}
+
+// startRedirectDestination serves the object-storage stand-in: it records the
+// credential headers it received and answers with the project, so the tool
+// call completes and the assertions are about the credential rather than about
+// a failure.
+func startRedirectDestination(t *testing.T) *redirectDestination {
+	t.Helper()
+
+	dest := &redirectDestination{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dest.mu.Lock()
+		dest.arrived = true
+		dest.rawQuery = r.URL.RawQuery
+		for _, name := range []string{"PRIVATE-TOKEN", "Authorization", "Sudo", "Job-Token"} {
+			if r.Header.Get(name) != "" {
+				dest.carried = append(dest.carried, name)
+			}
+		}
+		dest.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":42,"name":"widgets","path_with_namespace":"acme/widgets"}`))
+	}))
+	t.Cleanup(srv.Close)
+	dest.url = srv.URL
+	return dest
+}
+
+// observed returns what reached the destination.
+func (d *redirectDestination) observed() (arrived bool, carried []string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.arrived, append([]string(nil), d.carried...)
+}
+
+// startRedirectingGitLab serves an https instance whose project endpoint
+// answers a 302 to destination over plain http.
+//
+// https for the instance and http for the destination is what makes this a
+// downgrade rather than a change of host, and a downgrade on the same host is
+// precisely the hop net/http considers safe. Choosing it means a passing case
+// cannot be explained by the standard library doing the work.
+func startRedirectingGitLab(t *testing.T, destination string) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":7,"username":"someone","name":"Some One","state":"active"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/42", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination+"/storage/project-42?"+redirectPresignedQuery, http.StatusFound)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The certificate httptest generates is self-signed, which is what
+	// --skip-tls-verify exists for; the server under test is given that flag,
+	// so nothing here depends on the certificate being trusted.
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestRedirect_OffTheInstanceCarriesNoCredentialAndIsRecorded drives a tool
+// call whose instance answers with a redirect that leaves the credential scope,
+// and asserts three things about the hop that follows.
+//
+// The credential must not arrive: that is the fix, and the destination is a
+// host the operator never configured. The call must still succeed: refusing
+// cross-scope redirects outright would be simpler and would break every
+// artifact, trace and package read on an instance with object storage. And the
+// server must say it withheld something, because an operator looking at a 401
+// from object storage otherwise cannot tell a credential this server
+// deliberately dropped from a credential that was never valid, and those two
+// call for opposite responses.
+func TestRedirect_OffTheInstanceCarriesNoCredentialAndIsRecorded(t *testing.T) {
+	destination := startRedirectDestination(t)
+	instance := startRedirectingGitLab(t, destination.url)
+	srv := startServer(t, nil, "--gitlab-url="+instance, "--skip-tls-verify")
+
+	body, isError := toolResultsText(t, toolResultsCall(t, srv, "project.get", `{"project_id":"42"}`))
+	if isError {
+		t.Fatalf("the redirect was not followed, so no hop was made to test: %s", toolResultsTruncate(body))
+	}
+
+	arrived, carried := destination.observed()
+	if !arrived {
+		t.Fatal("nothing reached the redirect destination, so the assertions below have nothing to prove")
+	}
+	if len(carried) > 0 {
+		t.Errorf("the redirect carried %v to a host the operator never configured", carried)
+	}
+
+	logs := awaitLog(t, srv, "dropped credential headers on redirect")
+	if logs == "" {
+		t.Fatalf("the server withheld the credential and never said so:\n%s", truncate(srv.logs()))
+	}
+	if !strings.Contains(logs, "redirect downgrades https to http") {
+		t.Errorf("the log does not say which rule withheld the credential: %s", truncate(logs))
+	}
+	if !strings.Contains(logs, "PRIVATE-TOKEN") {
+		t.Errorf("the log does not name the header it withheld, which is the detail that makes it actionable: %s",
+			truncate(logs))
+	}
+	// The destination is recorded as a host and a scheme. Recording the URL
+	// would put the presigned parameters, which are themselves a credential,
+	// into the log that reports a credential being withheld.
+	if strings.Contains(logs, redirectPresignedQuery) {
+		t.Errorf("the log carries the destination's query string, which authenticates the request: %s", truncate(logs))
+	}
+}

--- a/test/e2e/stdio/localpath_test.go
+++ b/test/e2e/stdio/localpath_test.go
@@ -1,0 +1,297 @@
+//go:build stdioe2e
+
+// localpath_test.go pins which directories a caller-supplied local path may
+// resolve into on stdio, where such paths are honored at all.
+//
+// The roots are computed from the process: its working directory, its
+// os.TempDir, and the allow-list variables it was given. A unit test can only
+// ask the helper about the directory the test binary happens to be running in,
+// which is the package directory and never the interesting one. The case that
+// matters is a server started in the user's home directory, and the only way
+// to produce it is to start a process there.
+//
+// It is not a hypothetical arrangement. Claude Desktop starts its servers in
+// "/", other clients start them in the user's home, and neither asks. A home
+// directory kept as an implicit root allow-lists ~/.ssh, ~/.aws, the browser
+// profiles and this server's own ~/.gitlab-mcp-server.env, so a file_path
+// naming that last file uploads the very GITLAB_TOKEN the containment exists
+// to protect, using that same token.
+package stdioe2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// localPathHomeEnvFile is the home file this server documents for credentials.
+// Uploading it is the concrete harm the containment prevents, which is why the
+// case names that file rather than an anonymous one.
+const localPathHomeEnvFile = ".gitlab-mcp-server.env"
+
+// localPathGitLab is a fake instance that records the avatar upload.
+//
+// A refusal is only worth asserting beside evidence that nothing left the
+// process: a call refused after the request went out has already put the
+// file's contents on the wire. The startup probes are answered without being
+// recorded so that whatever remains belongs to the tool call.
+type localPathGitLab struct {
+	url string
+
+	mu      sync.Mutex
+	uploads int
+}
+
+// startLocalPathGitLab serves the startup probes plus the project write that
+// an avatar upload performs.
+func startLocalPathGitLab(t *testing.T) *localPathGitLab {
+	t.Helper()
+
+	fake := &localPathGitLab{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"version":"17.0.0","revision":"abcdef"}`)
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"id":7,"username":"someone","name":"Some One"}`)
+	})
+	mux.HandleFunc("PUT /api/v4/projects/42", func(w http.ResponseWriter, _ *http.Request) {
+		fake.mu.Lock()
+		fake.uploads++
+		fake.mu.Unlock()
+		writeJSON(w, `{"id":42,"name":"widgets","path_with_namespace":"acme/widgets"}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	fake.url = srv.URL
+	return fake
+}
+
+// uploadCount returns how many avatar uploads reached the instance.
+func (f *localPathGitLab) uploadCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.uploads
+}
+
+// localPathUploadCall drives one avatar upload naming a local file and returns
+// the text of the result plus whether it was reported as a failure.
+func localPathUploadCall(t *testing.T, s *session, filePath string) (text string, isError bool) {
+	t.Helper()
+
+	params, err := json.Marshal(map[string]any{
+		"project_id": "42",
+		"filename":   "avatar.png",
+		"file_path":  filePath,
+	})
+	if err != nil {
+		t.Fatalf("building the call parameters: %v", err)
+	}
+	arguments := `{"action":"project.upload_avatar","params":` + string(params) + `}`
+	got := s.call(t, request(1, "tools/call",
+		`{"name":"gitlab_execute_action","arguments":`+arguments+`}`))
+
+	return toolResultText(t, got)
+}
+
+// toolResultText pulls the text blocks and the failure flag out of a decoded
+// tools/call response.
+//
+// The text blocks are what a client prints and a model reads, so they are what
+// the refusal has to be legible in. A protocol-level error is returned rather
+// than failed on, because a case that expects one should say so itself.
+func toolResultText(t *testing.T, msg map[string]any) (text string, isError bool) {
+	t.Helper()
+
+	encoded, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("re-encoding the response: %v", err)
+	}
+	var decoded struct {
+		Result *struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if unmarshalErr := json.Unmarshal(encoded, &decoded); unmarshalErr != nil {
+		t.Fatalf("the response is not a tool result: %v: %s", unmarshalErr, encoded)
+	}
+	if decoded.Result == nil {
+		if decoded.Error != nil {
+			return decoded.Error.Message, true
+		}
+		t.Fatalf("the response carries neither a result nor an error: %s", encoded)
+	}
+	var b strings.Builder
+	for _, block := range decoded.Result.Content {
+		b.WriteString(block.Text)
+	}
+	return b.String(), decoded.Result.IsError
+}
+
+// localPathEnv is the environment for a case that chooses where the server
+// believes its home and its temporary directory are.
+//
+// os.TempDir is always an allow-list root, and t.TempDir hands out
+// subdirectories of it, so a home directory left under the real temporary
+// directory would be allow-listed for a reason that has nothing to do with the
+// behavior under test. Pointing the server's temporary directory somewhere
+// else is what makes the home case observable. All three spellings are set
+// because os.TempDir reads TMPDIR on unix and TMP or TEMP on Windows.
+//
+// It goes in the environment handed to the child rather than through a
+// t.Setenv-style helper: what has to be isolated is the temporary directory of
+// the server process, and this test process has no say in that one. A helper
+// that set the variables here would change the wrong process and the case
+// would assert nothing.
+func localPathEnv(gitlabURL, home, tempDir string) map[string]string {
+	env := baseEnv(gitlabURL)
+	env["HOME"] = home
+	env["TMPDIR"] = tempDir
+	env["TMP"] = tempDir
+	env["TEMP"] = tempDir
+	return env
+}
+
+// TestLocalPath_HomeDirectoryIsNotAnImplicitAllowlistRoot starts the real
+// binary in the user's home directory and asserts a file_path naming a file
+// there is refused, while the same containment still accepts the directories
+// it is meant to.
+//
+// The three rows are one decision seen from three sides, and any one of them
+// alone would pass against a broken implementation. The first is the fix. The
+// second is the escape hatch that keeps it a default rather than a policy: an
+// operator whose workspace really is their home directory names it and gets it
+// back. The third is the guard against over-correcting, because dropping the
+// working directory as a root altogether would satisfy the first two rows and
+// break every ordinary upload.
+//
+// The refusal is checked for the variable that widens the roots as well as for
+// the refusal itself. Without it the case reads as a bad path, and the person
+// whose setup just stopped working has nothing to act on.
+func TestLocalPath_HomeDirectoryIsNotAnImplicitAllowlistRoot(t *testing.T) {
+	gitlab := startLocalPathGitLab(t)
+
+	home := t.TempDir()
+	// Somewhere the server may legitimately read from, chosen so it is not an
+	// ancestor of the home directory: otherwise the temporary root would allow
+	// the home file and the first row could never refuse.
+	serverTemp := t.TempDir()
+
+	secret := filepath.Join(home, localPathHomeEnvFile)
+	if err := os.WriteFile(secret, []byte("GITLAB_TOKEN=glpat-the-operators-own-token\n"), 0o600); err != nil {
+		t.Fatalf("writing the home credential file: %v", err)
+	}
+
+	workspace := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatalf("creating the workspace directory: %v", err)
+	}
+	inWorkspace := filepath.Join(workspace, "avatar.png")
+	if err := os.WriteFile(inWorkspace, []byte("an ordinary file in the project being worked on"), 0o600); err != nil {
+		t.Fatalf("writing the workspace file: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		// dir is the working directory the client starts the server in.
+		dir string
+		// allowlist is what GITLAB_MCP_ALLOWED_UPLOAD_DIRS is set to, if
+		// anything.
+		allowlist string
+		filePath  string
+		// wantRefused says whether the upload must be refused.
+		wantRefused bool
+	}{
+		{
+			name:        "a file in the home directory the server was started in",
+			dir:         home,
+			filePath:    secret,
+			wantRefused: true,
+		},
+		{
+			name:      "the same file once the operator allow-lists that directory",
+			dir:       home,
+			allowlist: home,
+			filePath:  secret,
+		},
+		{
+			name:     "a file in the workspace the server was started in",
+			dir:      workspace,
+			filePath: inWorkspace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := localPathEnv(gitlab.url, home, serverTemp)
+			if tt.allowlist != "" {
+				env["GITLAB_MCP_ALLOWED_UPLOAD_DIRS"] = tt.allowlist
+			}
+			before := gitlab.uploadCount()
+
+			s := startSessionInDir(t, tt.dir, env)
+			body, isError := localPathUploadCall(t, s, tt.filePath)
+
+			if tt.wantRefused {
+				assertUploadRefused(t, s, gitlab, before, body, isError)
+				return
+			}
+			assertUploadAccepted(t, gitlab, before, body, isError)
+		})
+	}
+}
+
+// assertUploadRefused checks everything a containment refusal owes its caller:
+// that it happened, that it says what it was and which variable widens the
+// roots, that nothing left the process, and that the server explained why the
+// working directory stopped being one.
+func assertUploadRefused(t *testing.T, s *session, gitlab *localPathGitLab, before int, body string, isError bool) {
+	t.Helper()
+
+	if !isError {
+		t.Fatalf("a file in the home directory was uploaded: %s", body)
+	}
+	if !strings.Contains(body, "outside allowed directories") {
+		t.Errorf("the refusal does not say the path was outside the allowed roots: %s", body)
+	}
+	if !strings.Contains(body, "GITLAB_MCP_ALLOWED_UPLOAD_DIRS") {
+		t.Errorf("the refusal does not name the variable that widens the roots, so nobody can act on it: %s", body)
+	}
+	if got := gitlab.uploadCount(); got != before {
+		t.Errorf("the refused upload still reached GitLab (%d uploads, was %d)", got, before)
+	}
+	// The narrowing is silent otherwise, and a working setup that stops
+	// working deserves the reason rather than a puzzle.
+	awaitStderr(t, s, "working directory is the home directory", 10*time.Second)
+}
+
+// assertUploadAccepted checks that an allowed path was not merely tolerated
+// but actually uploaded, since a refusal that reported success would satisfy
+// the first half alone.
+func assertUploadAccepted(t *testing.T, gitlab *localPathGitLab, before int, body string, isError bool) {
+	t.Helper()
+
+	if isError {
+		t.Fatalf("an allowed path was refused: %s", body)
+	}
+	if gitlab.uploadCount() == before {
+		t.Errorf("the accepted upload never reached GitLab, so nothing was uploaded: %s", body)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/jmrplens/gitlab-mcp-server/issues/404.

Several of the September 2026 security fixes close a defect that no test inside the process can see, because what they change is a property of the running server rather than of a function. A unit test on the helper asserts against a flag it set itself; a unit test on a handler never reaches the decision. `test/e2e/http` and `test/e2e/stdio` start the real binary, need no GitLab and no credential, and run on every push, so that is where these belong.

I wrote four tests rather than one per bullet in the issue, chosen for the fixes whose failure mode is invisible from inside: what a caller-supplied local path can touch, what an excluded action stays reachable through, and what the credential does on a hop the operator never configured. Every one of them I verified by reverting its fix locally and watching it fail. The exact failures are below, because a test I cannot make fail is not a regression test.

## What each test pins

**`TestLocalPath_HTTPRefusesEveryCallerSuppliedPath`** and **`TestLocalPath_HTTPStillAcceptsInlineContent`** (`test/e2e/http`) pin the transport rule for caller-supplied paths, in three rows because there are three helpers with three refusal points. Reverting the rule (making `requireLocalFilesystemAccess` always return nil) fails all three: `file_path` uploads a file from the server's own disk and GitLab answers with the project; `output_path` reaches `GET /api/v4/projects/42/packages/generic/pkg/1.0.0/asset.bin`; `directory_path` publishes the directory and names its files back to the model. The paths are inside the OS temporary directory on purpose, which is an always-allowed containment root, so the refusal under test can only be the transport rule. The second test is the half that keeps the first honest: `content_base64` still works, which is why the fix refuses at the shared helper instead of deregistering the actions.

**`TestLocalPath_HomeDirectoryIsNotAnImplicitAllowlistRoot`** (`test/e2e/stdio`) starts the binary with its working directory set to the home directory and asks it to upload `~/.gitlab-mcp-server.env`. Reverting the fix, so the working directory is an implicit root again, fails with `a file in the home directory was uploaded` and the project GitLab answered with: the operator's own `GITLAB_TOKEN` goes to GitLab using that same token. Two rows are controls and pass either way, deliberately: an operator who names that directory in `GITLAB_MCP_ALLOWED_UPLOAD_DIRS` gets it back, and an ordinary workspace is still a root, so an over-correction that dropped the working directory altogether fails here too. The temporary directory is isolated through the child's own environment (`TMPDIR`, `TMP` and `TEMP`), not the test process's, since what has to be isolated is the server's `os.TempDir` and this process has no say in it.

**`TestExclusion_AnExcludedActionIsUnreachableThroughResources`** and **`TestExclusion_WithoutItTheSameResourceIsServed`** (`test/e2e/http`) pin that `--exclude-tools` reaches `resources/read`, not only the tool surface. Reverting the wiring to `resources.Register(server, client)` fails with `gitlab://project/{project_id} is still advertised despite the exclusion` and `an excluded resource was still readable: HTTP 200`. One canonical action is excluded rather than a group, so the sibling row means something: `gitlab://project/42/issues` is served by `issue.list`, which nobody excluded, and it must still answer. The second test is the control, and it is not optional: every assertion in the first is also satisfied by a server that serves no resources at all.

**`TestRedirect_OffTheInstanceCarriesNoCredentialAndIsRecorded`** (`test/e2e/http`) pins both halves of the redirect policy on the client a tool call actually uses. Removing `logCredentialDrop` fails with `the server withheld the credential and never said so`; removing the header deletion as well adds `the redirect carried [PRIVATE-TOKEN] to a host the operator never configured`. The hop is an https-to-http downgrade on one host, which is precisely the one `net/http` considers safe, so a pass here cannot be explained by the standard library doing the work. It also asserts the log records a host and a scheme and not the destination's query string, since a presigned URL is itself a credential and writing one to stderr while reporting that another was withheld would be a poor trade.

## Already covered, so not duplicated

- The hostile working-directory dotenv (CM-02) is
  `TestWorkingDirEnvFile_HostileDotenvConfiguresNothing` in
  `test/e2e/stdio/envfile_test.go`.
- The control bytes and the upstream gateway page (GC-01 / MTG-04) are
  `TestToolResults_ControlBytesFromGitLabNeverReachTheModel` and
  `TestToolResults_UpstreamGatewayPageIsNotReflectedToTheModel`.
- The instance allow-list and the per-address failure budget (CM-06 /
  HI-03) are `TestGate_PublishedInstances_HeaderCannotRedirectTheCredential`,
  `TestGate_InstanceEscapeHatch_AcceptsAHeaderNamedInstance`,
  `TestGate_FailureBudgetIsPerAddress` and
  `TestGate_RotatingProxyHeader_IsBoundedByTheTransportSource`.
  `TestRobust_GitLabURLHostIsNotRestricted` has since been rewritten and no
  longer pins removed behaviour.
- The shutdown of open listen streams on `--capability-surface=minimal`
  (HI-01) is `TestShutdown_OpenListenStreams_ProcessExitsCleanlyOnEverySurface`,
  which already runs the minimal and full surfaces as two rows.
- The collector credentials (OTEL-06) are
  `TestTelemetry_CollectorCredentialsNeverReachTheLogs`.

## What I could not make fail, and why

The issue's `TestToolCall_AbandonedByOldProtocolClient_StopsUpstreamRetries` would test a fix that is not in the tree. I checked it rather than assuming: with a throwaway case I confirmed that a pre-2026-07-28 client which abandons a `tools/call` leaves the server retrying upstream after it is gone, at the clamped five-second interval, with the attempt count going from 0 at abandonment to 2 fourteen seconds later. That is the half of MTG-03 the remediation branch recorded as unfinished: `toolutil.WrapAction` still installs no per-call deadline, and nothing propagates the carrier request's cancellation. Writing the test now would add a red test, and making it pass means editing `toolutil.WrapAction` and `cmd/server`, which belong to other pull requests in this stack. It deserves its own change.

## Verification

`go build ./...`, `make test-e2e-http` (376 tests), `make test-e2e-stdio` (73 tests), `go test ./cmd/... ./internal/... -count=1`, `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `make check-test-file-names`, `go run ./cmd/audit_test_subtests/ -check` and `go run ./cmd/audit_test_goroutines/ --check` all pass. Nothing here uses a unix socket path or a signal, so the new cases are fine on the macOS leg of the matrix; the temporary-directory isolation is spelled for Windows too, even though the transport modules do not run there.



---

**The red `Cross-platform (windows-latest)` check is inherited, not from this branch.** The matrix is introduced in https://github.com/jmrplens/gitlab-mcp-server/pull/440 and the three Windows failures it found are fixed in https://github.com/jmrplens/gitlab-mcp-server/pull/444, above this pull request in the stack. PR 440's description explains each one and why they land there rather than here.
