### PR TITLE
docs(http): say where the metadata lives for each deployment shape

### DIFF
--- a/docs/guides/http-server-mode.md
+++ b/docs/guides/http-server-mode.md
@@ -413,6 +413,42 @@ gitlab-mcp-server --http \
 > clients at `https://mcp.example.com/mcp` → `--public-url=https://mcp.example.com/mcp`
 > → metadata at `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`.
 
+#### Where the metadata lives: host root or sub-path
+
+RFC 9728 §3 derives the metadata URL by inserting `/.well-known/oauth-protected-resource`
+**between the host and the path** of the resource identifier. The well-known
+segment therefore always sits at the root of the host, and the resource's own
+path moves behind it. That produces two deployment shapes:
+
+| Deployment                     | `--public-url`                   | Metadata URL                                                          |
+| ------------------------------ | -------------------------------- | --------------------------------------------------------------------- |
+| One server owning the hostname | `https://mcp.example.com`        | `https://mcp.example.com/.well-known/oauth-protected-resource`        |
+| A server under a path prefix   | `https://mcp.example.com/gitlab` | `https://mcp.example.com/.well-known/oauth-protected-resource/gitlab` |
+
+The second row is the one that surprises people: the metadata for a server at
+`/gitlab` is **not** at `/gitlab/.well-known/...`. A reverse proxy therefore has
+to route `/.well-known/oauth-protected-resource/gitlab` to this server without
+rewriting it, and a proxy configured to forward only `/gitlab/*` will strand
+discovery while every MCP call keeps working, which is a confusing way to fail.
+
+Two rules follow, and they matter most on a host serving several MCP servers:
+
+- **Route the exact derived path, not a prefix.** A proxy `location` that sends
+  everything under `/.well-known/oauth-protected-resource/` to one server makes
+  that server answer for its neighbours too. A client asking about a different
+  server on the same host then receives this deployment's configuration,
+  describing a server it did not ask about. RFC 9728 §3.3 requires a conforming
+  client to discard a document whose `resource` value is not the identifier it
+  derived the URL from, so the answer is useless at best and misleading to a lax
+  client at worst.
+- **The path-less form belongs to the host root.** `/.well-known/oauth-protected-resource`
+  with no suffix is the document for a resource that _is_ the origin. If this
+  server lives under a path, that document is not its own, and it should neither
+  serve nor be routed it.
+
+A single server that owns its hostname has neither problem: the derived form is
+the path-less form, and there is no neighbour to speak for.
+
 **How it works:**
 
 ```mermaid
@@ -446,10 +482,18 @@ sequenceDiagram
 
 **Protected Resource Metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)):**
 
-In OAuth mode, the server exposes `/.well-known/oauth-protected-resource` with metadata for MCP clients that implement OAuth discovery:
+In OAuth mode, the server publishes the protected-resource document at the URL
+derived from `--public-url`, for MCP clients that implement OAuth discovery. The
+path below is the one a deployment that owns its hostname produces; a deployment
+under a path prefix serves it with that prefix appended, as the table above
+shows:
 
 ```bash
+# --public-url=https://mcp.example.com
 curl http://localhost:8080/.well-known/oauth-protected-resource
+
+# --public-url=https://mcp.example.com/gitlab
+curl http://localhost:8080/.well-known/oauth-protected-resource/gitlab
 ```
 
 ```json

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -153,6 +153,25 @@ gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth --pub
 `--public-url` declara el origen accesible desde fuera y **es el identificador de recurso RFC 9728**; el servidor se niega a arrancar en modo OAuth sin uno válido. La URL de metadatos se deriva de él insertando el segmento well-known entre el host y la ruta, así que `--public-url=https://mcp.example.com/gitlab` publica los metadatos en `https://mcp.example.com/.well-known/oauth-protected-resource/gitlab` — una ruta en la **raíz del host**, que un proxy inverso debe enrutar sin reescribirla.
 :::
 
+### Dónde viven los metadatos: raíz del host o sub-ruta
+
+El segmento well-known se sitúa siempre en la raíz del host, y la ruta propia del recurso pasa por detrás. Eso da dos formas de despliegue:
+
+| Despliegue                       | `--public-url`                   | URL de metadatos                                                      |
+| -------------------------------- | -------------------------------- | --------------------------------------------------------------------- |
+| Un servidor dueño del nombre     | `https://mcp.example.com`        | `https://mcp.example.com/.well-known/oauth-protected-resource`        |
+| Un servidor bajo prefijo de ruta | `https://mcp.example.com/gitlab` | `https://mcp.example.com/.well-known/oauth-protected-resource/gitlab` |
+
+La segunda fila es la que sorprende: los metadatos de un servidor en `/gitlab` **no** están en `/gitlab/.well-known/...`. Un proxy que reenvíe solo `/gitlab/*` deja el descubrimiento tirado mientras todas las llamadas MCP siguen funcionando, que es una forma confusa de fallar.
+
+:::danger[Varios servidores MCP en un mismo host]
+Enruta la ruta derivada **exacta**, nunca un prefijo. Un `location` que mande todo lo que cuelga de `/.well-known/oauth-protected-resource/` a un servidor hace que ese servidor responda por sus vecinos: quien pregunte por otro servidor del mismo host recibe la configuración de este despliegue, describiendo un servidor por el que no preguntó. El RFC 9728 sección 3.3 obliga a un cliente conforme a descartar ese documento, así que en el mejor caso no sirve de nada y en el peor engaña a un cliente laxo.
+
+La forma escueta, `/.well-known/oauth-protected-resource` sin sufijo, es el documento del recurso que **es** el origen. Un servidor que vive bajo una ruta no debería servirla ni recibirla.
+:::
+
+Un servidor único que es dueño de su nombre de host no tiene ninguno de los dos problemas: la forma derivada es la escueta, y no hay vecino por quien hablar.
+
 :::note[Se requiere un client ID pre-registrado]
 GitLab restringe los clientes OAuth registrados dinámicamente al scope `mcp`, que no concede acceso REST ni GraphQL — aquí fallarían todas las acciones. Crea una Aplicación OAuth de GitLab con el scope `api` y configura su Application ID en cada cliente.
 :::

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -153,6 +153,25 @@ gitlab-mcp-server --http --gitlab-url=https://gitlab.com --auth-mode=oauth --pub
 `--public-url` declares the externally reachable origin and **is the RFC 9728 resource identifier**; the server refuses to start in OAuth mode without a valid one. The metadata URL is derived from it by inserting the well-known segment between host and path, so `--public-url=https://mcp.example.com/gitlab` publishes metadata at `https://mcp.example.com/.well-known/oauth-protected-resource/gitlab` — a path at the **root of the host**, which a reverse proxy must route without rewriting.
 :::
 
+### Where the metadata lives: host root or sub-path
+
+The well-known segment always sits at the root of the host, and the resource's own path moves behind it. That gives two deployment shapes:
+
+| Deployment                     | `--public-url`                   | Metadata URL                                                          |
+| ------------------------------ | -------------------------------- | --------------------------------------------------------------------- |
+| One server owning the hostname | `https://mcp.example.com`        | `https://mcp.example.com/.well-known/oauth-protected-resource`        |
+| A server under a path prefix   | `https://mcp.example.com/gitlab` | `https://mcp.example.com/.well-known/oauth-protected-resource/gitlab` |
+
+The second row is the one that surprises people: the metadata for a server at `/gitlab` is **not** at `/gitlab/.well-known/...`. A proxy forwarding only `/gitlab/*` strands discovery while every MCP call keeps working, which is a confusing way to fail.
+
+:::danger[Several MCP servers on one hostname]
+Route the **exact** derived path, never a prefix. A `location` that sends everything under `/.well-known/oauth-protected-resource/` to one server makes it answer for its neighbours: a client asking about a different server on the same host receives this deployment's configuration, describing a server it never asked about. RFC 9728 section 3.3 makes a conforming client discard such a document, so it is useless at best and misleading to a lax client at worst.
+
+The path-less form, `/.well-known/oauth-protected-resource` with no suffix, is the document for a resource that **is** the origin. A server living under a path should neither serve nor be routed it.
+:::
+
+A single server that owns its hostname has neither problem: the derived form is the path-less form, and there is no neighbour to speak for.
+
 :::note[Pre-registered client ID required]
 GitLab restricts dynamically-registered OAuth clients to the `mcp` scope, which grants no REST or GraphQL access — every action here would fail. Create a GitLab OAuth Application with the `api` scope and configure its Application ID in each client.
 :::


### PR DESCRIPTION
Both guides already said that the RFC 9728 metadata URL is derived by inserting the well-known segment between host and path, and then left the operator to work out what that means for their own deployment. This puts the two shapes side by side with the URL each one produces, so nobody has to derive it from a sentence.

The second shape is the one that surprises people: the metadata for a server at `/gitlab` is not at `/gitlab/.well-known/...`, it is at the root of the host with the prefix moved behind the well-known segment. A reverse proxy forwarding only `/gitlab/*` therefore strands discovery while every MCP call keeps working, which is a confusing way to fail and is not something the existing text warned about.

Two rules are written down for a host serving several MCP servers, because that is where getting this wrong stops being cosmetic. Route the exact derived path rather than a prefix, or one server answers for its neighbours and a client asking about a different server receives this deployment's configuration, describing a server it never asked about. And the path-less form, `/.well-known/oauth-protected-resource` with no suffix, belongs to a resource that is the origin, so a server living under a path should neither serve nor be routed it. A single server that owns its hostname has neither problem, since the derived form is the path-less form and there is no neighbour to speak for.

The reference `curl` gained the second form as well. It showed only the path-less one, which is right for a deployment that owns its hostname and wrong for every other.

This is the operator-facing half of https://github.com/jmrplens/gitlab-mcp-server/issues/450, which is about the server itself answering on any sub-path. The documentation here is correct before and after that fix: it describes the derived path an operator must publish and route, and never asks the reader to rely on the extra paths the binary currently also answers.

Verified with `pnpm run i18n:check` (43 EN pages each with an ES translation), `pnpm run build` (87 pages, zero errors), `markdownlint-cli2` on the changed Markdown, and `format_md_tables --check`.

## Summary by Sourcery

Document the derived RFC 9728 metadata paths and proxy-routing rules for each HTTP deployment shape.

Enhancements:
- Clarify RFC 9728 metadata locations for hostname-root and path-prefixed deployments, including exact proxy-routing requirements and the distinction between root and suffixed well-known paths.

Documentation:
- Update English and Spanish HTTP server documentation with side-by-side metadata URL examples and guidance for deployments hosting multiple MCP servers.