### PR TITLE
fix(oauth): serve the protected-resource document only on its derived path

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,21 +459,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,048 |     221,542 |
-| Unit tests (`_test.go`)  |       618 |     362,953 |
-| End-to-end tests         |       223 |      60,462 |
-| **Total**                | **1,889** | **644,957** |
+| Source (`.go`, non-test) |     1,048 |     221,593 |
+| Unit tests (`_test.go`)  |       618 |     363,032 |
+| End-to-end tests         |       223 |      60,624 |
+| **Total**                | **1,889** | **645,249** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,319 |
-| . Exported (public)             |  2,790 |
-| . Unexported (private)          |  5,529 |
-| Unit test functions (`TestXxx`) | 12,963 |
-| Subtests (`t.Run(...)`)         |  4,780 |
-| End-to-end test functions       |    565 |
+| Source functions                |  8,321 |
+| . Exported (public)             |  2,791 |
+| . Unexported (private)          |  5,530 |
+| Unit test functions (`TestXxx`) | 12,965 |
+| Subtests (`t.Run(...)`)         |  4,786 |
+| End-to-end test functions       |    566 |
 
 ### Ratios worth noting
 
@@ -482,14 +482,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
 | Average test file length           |                 ~587 lines |
-| Comment lines in source            |  33,228 (~15.0% of source) |
+| Comment lines in source            |  33,268 (~15.0% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,972 |
+| `if err != nil` checks             | 6,975 |
 | `defer` statements                 | 1,139 |
 | `struct` types defined             | 2,839 |
 | `//nolint` suppressions            |   271 |
@@ -507,7 +507,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,523 lines      |
+| Longest source file | `cmd/server/main.go`. 4,528 lines      |
 | Longest test file   | `cmd/server/main_test.go`. 9,018 lines |
 
 ### Because why not
@@ -515,7 +515,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~4,028 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,251 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 13,253 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3062,16 +3062,21 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		Policy:         cfg.ResourcePolicyURI,
 		TermsOfService: cfg.ResourceTermsURI,
 	})
-	// Both derivations of RFC 9728 §3 resolve: the path-less form and the
-	// path-inserted form a client computes from a resource identifier that
-	// carries a path. Mounted without a method restriction so the SDK
-	// handler answers the CORS preflight itself (OPTIONS → 204 with
-	// Access-Control-Allow-Origin: *); a "GET "-restricted pattern would
-	// send the preflight to the catch-all gate and 401 it, locking out
-	// browser-based clients that fetch PRM cross-origin (claude.ai).
-	discovery := metadataDocument(prm)
-	mux.Handle("/.well-known/oauth-protected-resource", discovery)
-	mux.Handle("/.well-known/oauth-protected-resource/{rest...}", discovery)
+	// One path, the one RFC 9728 §3 derives from this deployment's resource
+	// identifier and the one the challenge above advertises, so the document
+	// answers where a client looks for it and nowhere else. What was here
+	// before also mounted a "/{rest...}" wildcard, which made a host running
+	// several MCP servers answer for its neighbors: see oauth.MetadataPathFor
+	// for why the path-less form is not mounted alongside it. An exact pattern
+	// is exact in Go only while it does not end in a slash, which is why the
+	// derivation trims one.
+	//
+	// Mounted without a method restriction so the SDK handler answers the CORS
+	// preflight itself (OPTIONS → 204 with Access-Control-Allow-Origin: *); a
+	// "GET "-restricted pattern would send the preflight to the catch-all gate
+	// and 401 it, locking out browser-based clients that fetch PRM
+	// cross-origin (claude.ai).
+	mux.Handle(oauth.MetadataPathFor(resourceID), metadataDocument(prm))
 	// Bearer only: oauth mode advertises the RFC 6750 scheme, so the legacy
 	// PRIVATE-TOKEN header alias is not silently rewritten into it here —
 	// what the challenge advertises is exactly what is accepted.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,9 +18,9 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,528 |
-| Unit test functions                                   | 12,963 |
-| E2E test functions                                    |    565 |
+| Total test functions                                  | 13,531 |
+| Unit test functions                                   | 12,965 |
+| E2E test functions                                    |    566 |
 | cmd test functions                                    |  2,047 |
 | Test files (internal/)                                |    498 |
 | Test files (cmd/)                                     |    120 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,255 | 83.2% |
+| `TestFunc_Scenario` (2-part)           | 11,258 | 83.2% |
 | `TestFunc` (no underscore)             |    968 |  7.2% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,305 |  9.6% |
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,182 |        131 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,184 |        131 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,433 |        354 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            565 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| E2E integration         |            566 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,047 |        120 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,528** |    **839** |                                                                                                 |
+| **Total**               |     **13,531** |    **839** |                                                                                                 |
 
 ### Core Packages
 
@@ -68,7 +68,7 @@
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        71 |    98.9% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        68 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        70 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       272 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
@@ -77,7 +77,7 @@
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       793 |    98.4% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,182** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,184** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/docs/guides/oauth-app-setup.md
+++ b/docs/guides/oauth-app-setup.md
@@ -162,7 +162,7 @@ Expected output:
 
 ```json
 {
-  "resource": "http://localhost:8080/mcp",
+  "resource": "https://mcp.example.com",
   "authorization_servers": ["https://gitlab.example.com"],
   "bearer_methods_supported": ["header"],
   "scopes_supported": ["api", "read_api"]
@@ -182,12 +182,17 @@ https://mcp.example.com/.well-known/oauth-protected-resource/gitlab
 That path lives at the **root of the host**, so a proxy that only forwards `/gitlab/` will not serve it. Add a route without rewriting:
 
 ```nginx
-location /.well-known/oauth-protected-resource {
+location = /.well-known/oauth-protected-resource/gitlab {
     proxy_pass http://gitlab-mcp:8080;   # no path rewrite
 }
 ```
 
-The server answers both the bare and the path-suffixed form, so no rewriting is needed — and the suffix keeps multiple MCP servers on one host distinguishable.
+`location =` is an exact match, and that is the point rather than a detail: a
+prefix `location` would forward every suffix under
+`/.well-known/oauth-protected-resource/` to this server, which then answers for
+the neighbours sharing the host. The server itself serves only the one path its
+`--public-url` derives, so the proxy has nothing else to forward. A deployment
+that owns its hostname derives the bare path instead and routes that exact one.
 
 Two more things the deployment must get right:
 

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -64,7 +64,8 @@ type ResourceLinks struct {
 // carrying a client identifier, and §5.3 leaves establishing one "out of
 // scope".
 //
-// The handler is registered at /.well-known/oauth-protected-resource.
+// The handler is registered at the single path [MetadataPathFor] derives from
+// the resource identifier.
 func NewProtectedResourceHandler(resourceURL string, gitlabURLs, supportedScopes []string, links ResourceLinks) http.Handler {
 	documentationURL := links.Documentation
 	if documentationURL == "" {
@@ -95,6 +96,12 @@ func NewProtectedResourceHandler(resourceURL string, gitlabURLs, supportedScopes
 	return auth.ProtectedResourceMetadataHandler(metadata)
 }
 
+// MetadataPath is the RFC 9728 §3 well-known URI suffix for protected-resource
+// metadata. On its own it is the metadata path of the resource that *is* the
+// origin; a resource with a path of its own derives a longer one through
+// [MetadataPathFor].
+const MetadataPath = "/.well-known/oauth-protected-resource"
+
 // MetadataURLFor derives the RFC 9728 §3 protected-resource metadata URL
 // from a resource identifier: the well-known path segment is inserted
 // between the host component and the resource's path, so
@@ -106,9 +113,48 @@ func NewProtectedResourceHandler(resourceURL string, gitlabURLs, supportedScopes
 func MetadataURLFor(resourceID string) string {
 	u, err := url.Parse(resourceID)
 	if err != nil || u.Host == "" {
-		return strings.TrimSuffix(resourceID, "/") + "/.well-known/oauth-protected-resource"
+		return strings.TrimSuffix(resourceID, "/") + MetadataPath
 	}
-	path := u.Path
-	u.Path = "/.well-known/oauth-protected-resource" + path
+	u.Path = metadataPath(u)
 	return u.String()
+}
+
+// MetadataPathFor returns the one path on which a deployment publishing
+// resourceID serves its protected-resource document: the path component of
+// [MetadataURLFor], so what a server mounts and what its challenge advertises
+// cannot drift apart.
+//
+// It exists as its own function, rather than inline at the mount, because a
+// host can run several MCP servers and each of them has to get this right.
+// This one used to mount the document twice, the second time under a
+// "/{rest...}" wildcard, so every suffix returned the same body: asked about
+// the neighbor at /libgen, it answered with a document naming *this*
+// deployment's resource and demanding OAuth against this deployment's GitLab.
+// RFC 9728 §3.3 tells a client to discard a document whose resource value is
+// not the identifier it derived the URL from, so the extra paths bought a
+// conforming client nothing and told a lax one something false.
+//
+// The path-less form is served only when the resource identifier has no path,
+// and that is a decision rather than an omission. /.well-known/oauth-protected-resource
+// is by construction the metadata of the resource at the host root: a server
+// mounted at /gitlab answering it is claiming an identity that is not its own,
+// which is the wildcard's harm in a different spelling. Where --public-url has
+// no path the bare form *is* the derived form, so this is one rule and not two
+// cases, and a server that owns its hostname loses nothing.
+//
+// A trailing slash is trimmed because the derived path is mounted as an exact
+// http.ServeMux pattern, and a pattern ending in "/" is a subtree match in Go:
+// keeping the slash would quietly restore the wildcard this replaced.
+func MetadataPathFor(resourceID string) string {
+	u, err := url.Parse(resourceID)
+	if err != nil || u.Host == "" {
+		return MetadataPath
+	}
+	return metadataPath(u)
+}
+
+// metadataPath inserts the well-known segment between the host and the
+// resource's own path, for an identifier already known to parse.
+func metadataPath(u *url.URL) string {
+	return MetadataPath + strings.TrimSuffix(u.Path, "/")
 }

--- a/internal/oauth/metadata_test.go
+++ b/internal/oauth/metadata_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -248,4 +250,81 @@ func TestProtectedResourceHandler_OptionalLinksAreOmittedUnlessNamed(t *testing.
 			t.Errorf("resource_tos_uri = %v, want it omitted; a deployment may have one page and not the other", value)
 		}
 	})
+}
+
+// TestMetadataPathFor_DerivesTheOnePathTheDocumentIsServedOn verifies the path
+// a deployment mounts its protected-resource document on, which is the path
+// component of the URL its challenge advertises and nothing wider.
+//
+// Two properties matter beyond the arithmetic. A resource that carries a path
+// derives a path-suffixed metadata URL and must NOT also answer the bare
+// well-known path, which belongs to the resource at the host root: answering it
+// is how one MCP server on a shared host speaks for its neighbors. And the
+// derived path must never end in a slash, because it is mounted as an
+// http.ServeMux pattern and a trailing slash there means "everything below
+// this", which is the wildcard this derivation exists to remove.
+func TestMetadataPathFor_DerivesTheOnePathTheDocumentIsServedOn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{"a server owning the hostname serves the path-less form", "https://mcp.example.com", MetadataPath},
+		{"a server under a prefix serves the suffixed form", "https://mcp.example.com/gitlab", MetadataPath + "/gitlab"},
+		{"the endpoint path is a prefix like any other", "https://mcp.example.com/mcp", MetadataPath + "/mcp"},
+		{"a nested prefix keeps all of its segments", "https://mcp.example.com/team/gitlab", MetadataPath + "/team/gitlab"},
+		{"loopback development derives the same way", "http://localhost:8080", MetadataPath},
+		// Config validation rejects a trailing slash before it reaches here.
+		// The trim is what keeps the mount an exact ServeMux pattern anyway,
+		// so it is pinned rather than left to the validator.
+		{"a trailing slash is trimmed, not mounted as a subtree", "https://mcp.example.com/gitlab/", MetadataPath + "/gitlab"},
+		// An identifier with no host cannot be split into host and path. The
+		// fallback is the bare path rather than something derived from the
+		// junk, since a mount pattern has to be a path.
+		{"an unparseable identifier falls back to the bare path", "://not a url", MetadataPath},
+		{"a host-less identifier falls back to the bare path", "/gitlab/", MetadataPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := MetadataPathFor(tt.resource); got != tt.want {
+				t.Errorf("MetadataPathFor(%q) = %q, want %q", tt.resource, got, tt.want)
+			}
+			if strings.HasSuffix(MetadataPathFor(tt.resource), "/") {
+				t.Errorf("MetadataPathFor(%q) ends in a slash, which mounts a subtree and answers for every suffix", tt.resource)
+			}
+		})
+	}
+}
+
+// TestMetadataPathFor_IsThePathOfTheAdvertisedURL verifies that the mount and
+// the challenge cannot drift apart.
+//
+// The challenge carries MetadataURLFor and the mux answers MetadataPathFor. If
+// those two ever disagreed the failure would be silent and total: every client
+// would follow the challenge to a 404, having been told exactly where to look.
+func TestMetadataPathFor_IsThePathOfTheAdvertisedURL(t *testing.T) {
+	t.Parallel()
+
+	resources := []string{
+		"https://mcp.example.com",
+		"https://mcp.example.com/gitlab",
+		"https://mcp.example.com/mcp",
+		"https://mcp.example.com/team/gitlab",
+		"http://localhost:8080",
+	}
+	for _, resource := range resources {
+		t.Run(resource, func(t *testing.T) {
+			t.Parallel()
+			advertised, err := url.Parse(MetadataURLFor(resource))
+			if err != nil {
+				t.Fatalf("MetadataURLFor(%q) is not a URL: %v", resource, err)
+			}
+			if got := MetadataPathFor(resource); got != advertised.Path {
+				t.Errorf("mounted %q but advertised %q; a client following the challenge gets a 404", got, advertised.Path)
+			}
+		})
+	}
 }

--- a/test/e2e/http/discovery_test.go
+++ b/test/e2e/http/discovery_test.go
@@ -30,7 +30,11 @@ func TestProtectedResourceMetadata_BehavesLikeAnHTTPDocument(t *testing.T) {
 		"--public-url=https://mcp.example.invalid/gitlab",
 	)
 
-	const path = "/.well-known/oauth-protected-resource"
+	// The path RFC 9728 §3 derives from that identifier, and the only one this
+	// deployment serves the document on. See
+	// TestOAuth_MetadataAnswersOnlyItsOwnDerivedPath for why the bare form is
+	// not this server's to answer.
+	const path = "/.well-known/oauth-protected-resource/gitlab"
 
 	t.Run("GET returns the document and allows it to be cached", func(t *testing.T) {
 		got := srv.do(t, request{method: http.MethodGet, path: path})
@@ -75,12 +79,21 @@ func TestProtectedResourceMetadata_BehavesLikeAnHTTPDocument(t *testing.T) {
 		}
 	})
 
-	t.Run("the path-inserted derivation behaves the same", func(t *testing.T) {
-		// RFC 9728 §3 gives two derivations, and a client that computed the
-		// path-carrying one must not meet different rules.
-		got := srv.do(t, request{method: http.MethodHead, path: path + "/gitlab"})
-		if got.status != http.StatusOK {
-			t.Errorf("status = %d, want 200 for the path-inserted form", got.status)
+	t.Run("the CORS preflight is answered, not authenticated", func(t *testing.T) {
+		// The document is mounted without a method restriction so the SDK
+		// handler answers OPTIONS itself. A "GET "-restricted pattern would
+		// send the preflight to the catch-all instead, locking out the
+		// browser-based clients that fetch this cross-origin.
+		got := srv.do(t, request{
+			method:  http.MethodOptions,
+			path:    path,
+			headers: map[string]string{"Origin": "https://claude.ai", "Access-Control-Request-Method": "GET"},
+		})
+		if got.status != http.StatusNoContent && got.status != http.StatusOK {
+			t.Fatalf("status = %d, want the preflight answered rather than refused", got.status)
+		}
+		if allowed := got.header.Get("Access-Control-Allow-Origin"); allowed == "" {
+			t.Error("the preflight carries no Access-Control-Allow-Origin, so a browser drops the fetch")
 		}
 	})
 }

--- a/test/e2e/http/oauth_test.go
+++ b/test/e2e/http/oauth_test.go
@@ -16,6 +16,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"testing"
@@ -650,28 +651,176 @@ func TestOAuth_SatisfiesRemoteDirectoryAuthProbe(t *testing.T) {
 }
 
 // TestOAuth_DirectoryReadableMetadata verifies the metadata document a remote
-// directory fetches after following the challenge, at both locations one may
-// request: the bare well-known path RFC 9728 names for a resource with no path
-// component, and the path-suffixed form for one mounted under a prefix. A
-// deployment serving only the suffixed form answers 404 to the only URL some
-// directories try.
+// directory fetches after following the challenge, for both shapes RFC 9728 §3
+// derives: a server that owns its hostname publishes at the bare well-known
+// path, and one mounted under a path prefix publishes at the suffixed form.
+//
+// The path is read out of the challenge rather than written down here, because
+// a readable document is only worth anything at the URL clients are told to
+// fetch. Which paths do NOT answer is
+// TestOAuth_MetadataAnswersOnlyItsOwnDerivedPath.
 func TestOAuth_DirectoryReadableMetadata(t *testing.T) {
 	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
-	srv := oauthServer(t, gitlab.url)
 
-	paths := []string{
-		"/.well-known/oauth-protected-resource",
-		"/.well-known/oauth-protected-resource/mcp",
+	deployments := []struct {
+		name      string
+		publicURL string
+		want      string
+	}{
+		{"a server owning its hostname", publicURL, metadataBasePath},
+		{"a server under a path prefix", publicURL + "/gitlab", metadataBasePath + "/gitlab"},
 	}
 
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
+	for _, deployment := range deployments {
+		t.Run(deployment.name, func(t *testing.T) {
+			srv := startServer(t, nil,
+				"--gitlab-url="+gitlab.url,
+				"--auth-mode=oauth",
+				"--public-url="+deployment.publicURL,
+			)
+
+			path := metadataPathFromChallenge(t, srv)
+			if path != deployment.want {
+				t.Fatalf("challenge points at %q, want %q", path, deployment.want)
+			}
+
 			got := srv.do(t, request{method: http.MethodGet, path: path})
 			if got.status != http.StatusOK {
 				t.Fatalf("status = %d, want %d", got.status, http.StatusOK)
 			}
 			assertDirectoryMetadata(t, got.body)
 		})
+	}
+}
+
+// metadataBasePath is the RFC 9728 well-known path suffix, and the whole
+// metadata path of a resource that has no path of its own.
+const metadataBasePath = "/.well-known/oauth-protected-resource"
+
+// metadataPathFromChallenge returns the path component of the resource_metadata
+// URL an unauthenticated request is answered with, which is where a client
+// actually goes looking for the document.
+func metadataPathFromChallenge(t *testing.T, srv *server) string {
+	t.Helper()
+
+	got := srv.do(t, mcpPOST(nil))
+	if got.status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 to get a challenge: %s", got.status, got.body)
+	}
+	challenge := got.header.Get("WWW-Authenticate")
+	_, after, found := strings.Cut(challenge, `resource_metadata="`)
+	if !found {
+		t.Fatalf("challenge %q carries no resource_metadata pointer", challenge)
+	}
+	raw, _, found := strings.Cut(after, `"`)
+	if !found {
+		t.Fatalf("challenge %q has an unterminated resource_metadata value", challenge)
+	}
+	metadataURL, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("resource_metadata %q is not a URL: %v", raw, err)
+	}
+	return metadataURL.Path
+}
+
+// TestOAuth_MetadataAnswersOnlyItsOwnDerivedPath pins that the
+// protected-resource document is served on exactly the one path RFC 9728 §3
+// derives from this deployment's resource identifier, and on no other.
+//
+// It used to be mounted twice, the second time under a "/{rest...}" wildcard,
+// so every suffix returned the same body. On a host running several MCP
+// servers behind one name, asking about the neighbor at
+// /.well-known/oauth-protected-resource/libgen got this deployment's document
+// back: a configuration demanding OAuth against this deployment's GitLab,
+// describing a server that is not it. RFC 9728 §3.3 tells a client to discard a
+// document whose resource value is not the identifier it derived the URL from,
+// so the extra paths were worthless to a conforming client and a false
+// statement to a lax one.
+//
+// This is on the wire rather than on the handler because what changed is a
+// property of the running server's routing table. The handler was right the
+// whole time, and every happy path kept working while the wildcard was there,
+// which is precisely why nothing noticed.
+func TestOAuth_MetadataAnswersOnlyItsOwnDerivedPath(t *testing.T) {
+	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
+
+	t.Run("a server under a path prefix answers only the suffixed form", func(t *testing.T) {
+		srv := startServer(t, nil,
+			"--gitlab-url="+gitlab.url,
+			"--auth-mode=oauth",
+			"--public-url="+publicURL+"/gitlab",
+		)
+
+		assertMetadataDocumentAt(t, srv, metadataBasePath+"/gitlab", publicURL+"/gitlab")
+
+		foreign := []struct {
+			name string
+			path string
+		}{
+			{"a neighboring MCP server on the same host", metadataBasePath + "/libgen"},
+			{"a suffix nobody deployed", metadataBasePath + "/zzz-invented"},
+			// The path-less form is the document of the resource that IS the
+			// origin. This deployment lives under /gitlab, so answering it
+			// would be claiming the host root's identity.
+			{"the host root's own document", metadataBasePath},
+			// A trailing-slash mount would be a ServeMux subtree, which is the
+			// wildcard again under another name.
+			{"anything below the derived path", metadataBasePath + "/gitlab/deeper"},
+			{"the derived path with a trailing slash", metadataBasePath + "/gitlab/"},
+		}
+		for _, probe := range foreign {
+			t.Run(probe.name, func(t *testing.T) {
+				assertNoMetadataAt(t, srv, probe.path)
+			})
+		}
+	})
+
+	t.Run("a server owning its hostname answers only the path-less form", func(t *testing.T) {
+		srv := oauthServer(t, gitlab.url)
+
+		assertMetadataDocumentAt(t, srv, metadataBasePath, publicURL)
+
+		for _, path := range []string{metadataBasePath + "/gitlab", metadataBasePath + "/libgen"} {
+			t.Run(path, func(t *testing.T) {
+				assertNoMetadataAt(t, srv, path)
+			})
+		}
+	})
+}
+
+// assertMetadataDocumentAt checks that the document is served at path and
+// claims exactly the identifier the deployment was started with. Both halves
+// matter: a client that fetched it compares the two and discards a mismatch.
+func assertMetadataDocumentAt(t *testing.T, srv *server, path, wantResource string) {
+	t.Helper()
+
+	got := srv.do(t, request{method: http.MethodGet, path: path})
+	if got.status != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200; the derived path must serve the document: %s", path, got.status, got.body)
+	}
+	var metadata struct {
+		Resource string `json:"resource"`
+	}
+	if err := json.Unmarshal([]byte(got.body), &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata.Resource != wantResource {
+		t.Errorf("resource = %q, want %q", metadata.Resource, wantResource)
+	}
+}
+
+// assertNoMetadataAt fails when a path this deployment does not own answers at
+// all, and says so loudly when it answers with the document, which is the harm
+// rather than the symptom.
+func assertNoMetadataAt(t *testing.T, srv *server, path string) {
+	t.Helper()
+
+	got := srv.do(t, request{method: http.MethodGet, path: path})
+	if strings.Contains(got.body, "authorization_servers") {
+		t.Errorf("GET %s served the protected-resource document; this deployment is speaking for a resource that is not it: %s", path, got.body)
+	}
+	if got.status != http.StatusNotFound {
+		t.Errorf("GET %s = %d, want 404", path, got.status)
 	}
 }
 


### PR DESCRIPTION
The RFC 9728 protected-resource document was mounted twice, and the second pattern was a wildcard, so every suffix under `/.well-known/oauth-protected-resource/` returned the same body. On a host serving several MCP servers behind one name, which is what `mcp.jmrp.io` is, that means this binary answers for its neighbours: asked about the anonymous server at `/libgen`, it returns a configuration demanding OAuth against `gitlab.com` with scope `api`, describing a server that is not it. RFC 9728 section 3.3 has a conforming client discard a document whose `resource` value is not the identifier it derived the URL from, so the extra paths bought a correct client nothing and told a lax one something false. The production proxy already refuses those paths, which is defence in depth working and not a reason to leave the binary wrong, since anyone running this server without that proxy has the behaviour above.

The mount now takes the single path `oauth.MetadataPathFor` derives from the resource identifier. That derivation lives in `internal/oauth` beside `MetadataURLFor` rather than inline at the handler, both because a sibling project will reuse it and because the two must agree: the path a server mounts is by construction the path component of the URL its challenge advertises, so they cannot drift apart and send every client from a 401 straight into a 404. It also trims a trailing slash, because an `http.ServeMux` pattern that ends in one is a subtree match in Go, which would be the wildcard again under another name.

I kept the reading I wrote in the issue on the path-less form, and the reason is now written beside the code. `/.well-known/oauth-protected-resource` with no suffix is by construction the document of the resource that is the origin, so a deployment mounted at `/gitlab` answering it is claiming a neighbour's identity, which is the same harm in a different spelling rather than a harmless extra. When `--public-url` carries no path the bare form is the derived form, so the rule stays one rule instead of two cases, and a server that owns its hostname loses nothing.

So a deployment at `https://mcp.example.com/gitlab` now answers only `/.well-known/oauth-protected-resource/gitlab`, and 404s the bare form, `/libgen`, any invented suffix, anything below its own derived path, and its own path with a trailing slash appended. A deployment at `https://mcp.example.com` answers only the bare form and 404s every suffix. The refusal is the ordinary unauthenticated 404 from the catch-all, since routing happens before authentication and whether a document exists is not a secret.

The regression test is on the wire in `test/e2e/http` rather than as a unit test on the handler, because what changed is a property of the running server's routing table: the handler was right the whole time, and every happy path kept working while the wildcard was there, which is exactly why nothing noticed for so long. Reverting the mount and running only the new test reproduces the defect precisely, with seven subtests reporting that a path this deployment does not own served the protected-resource document naming another resource. Two existing tests moved to the derived path with it, and the subtest that asserted both forms answer is replaced by one pinning that the CORS preflight is still answered rather than authenticated, which is the other property of mounting this without a method restriction.

The reverse-proxy example in the OAuth guide changes for the same reason: it showed a prefix `location`, which is the proxy-side spelling of the wildcard, and a sentence promising that the server answers both forms. It is now an exact `location =` on the derived path, and says why. The documentation half that landed in https://github.com/jmrplens/gitlab-mcp-server/pull/452 already described the derived path per deployment shape and needed no change, which is what it was written for. I also corrected the `resource` value in the same guide's expected output, which showed `http://localhost:8080/mcp` for a server started with `--public-url=https://mcp.example.com`.

Verified locally: `go build ./...`, `go test ./cmd/... ./internal/... -count=1`, `make test-e2e-http` (389 tests), `golangci-lint run --build-tags e2e,httpe2e,stdioe2e ./...`, `make check-test-goroutines`, `make check-test-file-names`, `go run ./cmd/audit_test_subtests/ -check`, plus the regenerated stats and testing reference. `make test-e2e-stdio` has one failure, `TestTelemetry_SDKDisabledVetoesTheSwitch`, which reproduces unchanged on this branch's base commit and is unrelated to this change: the process writes nothing to stderr at all, so the assertion that the veto announces itself finds no line to read.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/450

## Summary by Sourcery

Serve each deployment's protected-resource metadata only on the RFC 9728 path derived from its resource identifier.

Bug Fixes:
- Restrict protected-resource metadata discovery to the single RFC 9728-derived path for each deployment, preventing servers on shared hosts from answering for neighboring resources.

Enhancements:
- Centralize protected-resource metadata path derivation so routing and advertised OAuth challenge URLs remain consistent, including safe handling of trailing slashes and path-less resources.
- Preserve CORS preflight handling for protected-resource metadata requests.

Deployment:
- Update the OAuth reverse-proxy example to use an exact route for each deployment's derived metadata path.

Documentation:
- Correct the OAuth guide's example resource identifier and document exact-path proxy routing.

Tests:
- Add unit and end-to-end coverage verifying metadata is available only at its derived path, unrelated paths return 404, advertised URLs match mounted paths, and CORS preflights remain supported.

Chores:
- Regenerate repository code and testing statistics.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->