### PR TITLE
docs(deployment): a remote deployment guide, with the balancing answer

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,7 @@ current, or getting unstuck. New here? Start with
 | [IDE Configuration](ide-configuration.md)               | Configure the MCP server in VS Code, Cursor, JetBrains, and other clients (stdio, HTTP legacy, HTTP OAuth)                                               |
 | [Claude Desktop Extension](claude-desktop-extension.md) | Install or build the one-click `.mcpb` desktop extension for Claude Desktop                                                                              |
 | [HTTP Server Mode](http-server-mode.md)                 | Run the multi-user HTTP transport with a per-token+URL server pool                                                                                       |
+| [Remote Deployment](remote-deployment.md)               | Stand it up for other people: OS service, Docker, reverse proxies, TLS, and balancing several instances                                                  |
 | [OAuth App Setup](oauth-app-setup.md)                   | Create a GitLab OAuth application so MCP clients can authenticate                                                                                        |
 | [CI/CD Usage](ci-cd.md)                                 | Use the server inside CI/CD pipelines, with or without an LLM in the loop                                                                                |
 | [Client Compatibility](client-compatibility.md)         | Understand per-client response profiles (OpenAI Codex) and known client-side limits                                                                      |

--- a/docs/guides/http-server-mode.md
+++ b/docs/guides/http-server-mode.md
@@ -282,7 +282,7 @@ When exactly one instance is pinned with `--gitlab-url`, the server always uses 
 
 ### Publishing more than one instance
 
-`--gitlab-url` may be given more than once (or once, comma-separated). The first entry is the deployment's default, and `GITLAB-URL` becomes a choice **among the published instances**:
+`--gitlab-url` may be given more than once (or once, comma-separated). `GITLAB-URL` then becomes a choice **among the published instances**, and a required one: choosing for the caller would send their token to an instance they never named.
 
 ```bash
 gitlab-mcp-server --http --auth-mode=oauth \
@@ -291,13 +291,17 @@ gitlab-mcp-server --http --auth-mode=oauth \
   --gitlab-url=https://gitlab.internal.example.com
 ```
 
-| Instances published | No `GITLAB-URL` header | Header naming a published instance | Header naming anything else                       |
-| ------------------- | ---------------------- | ---------------------------------- | ------------------------------------------------- |
-| none                | public `gitlab.com`    | honored                            | honored                                           |
-| one                 | that instance          | ignored                            | ignored                                           |
-| several             | the first              | honored                            | **refused**: `403` in OAuth mode, `400` in legacy |
+| Instances published             | No `GITLAB-URL` header | Header naming a published instance | Header naming anything else                       |
+| ------------------------------- | ---------------------- | ---------------------------------- | ------------------------------------------------- |
+| none (`--allow-any-gitlab-url`) | **refused**: `400`     | honored                            | honored                                           |
+| one                             | that instance          | ignored                            | ignored                                           |
+| several                         | **refused**: `400`     | honored                            | **refused**: `403` in OAuth mode, `400` in legacy |
 
-The two statuses differ because the layers differ: OAuth mode refuses in the bearer guard, before the credential is sent anywhere, which is a permission decision (`403`); legacy mode refuses while resolving the request options, which is a malformed request (`400`). Either way the instance is never contacted.
+A request that names no instance is refused rather than resolved to a default, in both the none and several rows. Publishing nothing means the caller chooses, so there is nothing to fall back to; publishing several means the operator deliberately declined to choose, so falling back to the first would put the caller's token on the wire to an instance they never named. Only the one-instance row has an unambiguous answer, and it is the instance the operator pinned.
+
+The two refusal statuses for a header naming an unpublished instance differ because the layers differ: OAuth mode refuses in the bearer guard, before the credential is sent anywhere, which is a permission decision (`403`); legacy mode refuses while resolving the request options, which is a malformed request (`400`). Either way the instance is never contacted.
+
+The refusal for a **missing** header is `400` in both modes, and only its message differs: OAuth mode names the published instances, since RFC 9728 metadata already serves that same set unauthenticated, while legacy mode says to ask the operator, so that any non-empty token cannot be used to enumerate the operator's hostnames.
 
 The refusal is the point. In OAuth mode the server **verifies the bearer token against the instance it is about to use**, so a free-form header would let a caller name a host of their own and be handed the token. An allow-list keeps that choice with the operator: the published instances are listed in the RFC 9728 `authorization_servers` array, so a client discovers which ones it may pick, and a token is verified — and cached — per instance, never across them. A rejection is scoped the same way, so a `401` from one published instance never refuses a valid token on another.
 

--- a/docs/guides/http-server-mode.md
+++ b/docs/guides/http-server-mode.md
@@ -969,6 +969,7 @@ that forwards its prefix rather than stripping it.
 
 ## Further Reading
 
+- [Remote Deployment](remote-deployment.md) — running it as a service, in Docker, behind a proxy, and across several instances
 - [Configuration](../reference/configuration.md) — full configuration reference
 - [Architecture](../concepts/architecture.md) — system architecture with diagrams
 - [Resource Consumption](../concepts/resource-consumption.md) — memory and CPU analysis at scale

--- a/docs/guides/remote-deployment.md
+++ b/docs/guides/remote-deployment.md
@@ -1,0 +1,892 @@
+# Remote Deployment
+
+[HTTP Server Mode](http-server-mode.md) documents the transport flag by flag.
+This guide is the other half: how to stand one up for other people, on a machine
+that stays running, reachable from somewhere other than the operator's laptop.
+
+Everything here assumes HTTP mode. There is no remote form of stdio: stdio is a
+pipe between one client process and one server process on the same machine, and
+the moment a second person needs to reach it the answer is HTTP.
+
+One property shapes every section, so it is worth stating before the first
+snippet. **In HTTP mode the server holds no credential of its own.** Each
+request carries the caller's GitLab token, and the server keeps a pooled MCP
+server per `(token, GitLab URL)` pair. That is why there is no server token to
+hide in a unit file, why `/health` can be unauthenticated, and why running
+several instances is a caching problem rather than a state-replication one.
+
+## Pick a shape first
+
+| Situation                           | Shape                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| One host, proxy and server together | Unix socket: `--http-addr=/run/gitlab-mcp/server.sock`                                                   |
+| Proxy on another host               | `--tls-cert` and `--tls-key` on the listener                                                             |
+| No proxy at all                     | `--tls-cert` and `--tls-key` plus `--auth-mode=oauth`; read [Direct exposure](#direct-exposure-no-proxy) |
+| Containers                          | The published image, read-only root filesystem, digest pin                                               |
+| More than one instance              | A balancer with token affinity: [Several instances](#several-instances-behind-one-proxy)                 |
+
+## Run it as a service
+
+### systemd
+
+Two shapes, and what separates them is whether a same-host proxy has to reach a
+unix socket.
+
+**Loopback TCP with a dynamic user** is the least privileged form, and the one
+to use when the proxy talks to `127.0.0.1`:
+
+```ini
+# /etc/systemd/system/gitlab-mcp-server.service
+[Unit]
+Description=GitLab MCP Server
+Documentation=https://jmrp.io/docs/gitlab-mcp-server/operations/http-server/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+DynamicUser=yes
+EnvironmentFile=/etc/gitlab-mcp-server/env
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=127.0.0.1:8080 \
+    --gitlab-url=https://gitlab.example.com \
+    --auth-mode=oauth \
+    --public-url=https://mcp.example.com \
+    --trusted-proxy-header=X-Real-IP
+Restart=on-failure
+RestartSec=2s
+StandardInput=null
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+CapabilityBoundingSet=
+AmbientCapabilities=
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ProtectSystem=strict` mounts the whole filesystem read-only and the server is
+fine with that: it writes nothing to disk. Logs go to standard error, which
+`journald` collects, and the only file it ever creates is the unix socket in the
+second shape below. Reads are unaffected, so TLS certificates and the
+environment file stay readable.
+
+`RestrictAddressFamilies=` deliberately omits `AF_NETLINK`. The released binary
+is built with `CGO_ENABLED=0`, so it uses Go's own resolver, which reaches DNS
+over UDP and TCP and asks the kernel nothing through netlink. Verified against
+this unit: a credential check that had to resolve and reach `gitlab.com` was
+answered by GitLab with and without `AF_NETLINK` in the list.
+
+`MemoryMax=512M` is the documented floor for HTTP mode rather than a target. The
+base process is around 50 MB and each pooled token adds roughly 130 KB, so the
+default `--max-http-clients=100` lands near 63 MB. See
+[Resource Consumption](../concepts/resource-consumption.md) before sizing for
+hundreds of callers.
+
+**A unix socket needs a fixed user.** `DynamicUser=yes` allocates a transient
+user and group per start, so there is no group the proxy can be added to. Create
+a system user and share a real group:
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin gitlab-mcp
+sudo usermod -aG gitlab-mcp www-data   # or nginx, or caddy
+```
+
+Then replace the identity and address lines:
+
+```ini
+User=gitlab-mcp
+Group=gitlab-mcp
+RuntimeDirectory=gitlab-mcp
+RuntimeDirectoryMode=0750
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=/run/gitlab-mcp/server.sock \
+    --http-socket-mode=0660 \
+    --gitlab-url=https://gitlab.example.com
+```
+
+`RuntimeDirectory=` is what makes `/run/gitlab-mcp` exist, be owned by the
+service, and be removed on stop. It also has to be **writable**, which it is:
+the server does not bind the published path directly. It creates a `0700`
+staging directory beside it, binds and chmods the socket there, then links it
+into place, so a socket only ever appears with its final permissions. A
+read-only parent directory therefore fails, even though the process writes
+nothing else.
+
+Four things about a unit file that are specific to this server:
+
+- **State the transport.** `--transport auto` reads file descriptor 0 and picks
+  HTTP only when stdin is `/dev/null`. systemd's default `StandardInput=null`
+  happens to give the same answer, but a unit that sets `StandardInput=socket`
+  or `tty` gets stdio instead. `--http` says what you mean and cannot be moved
+  by how the supervisor wires a file descriptor.
+- **Socket activation is not supported.** A `.socket` unit hands the listening
+  socket to the service on file descriptor 0, and this server reads a socket
+  there as "a supervisor handed me a stdio channel", so it would speak JSON-RPC
+  down it instead of accepting connections. Bind the socket yourself with
+  `--http-addr` and `RuntimeDirectory=`.
+- **Secrets belong in `EnvironmentFile=`, never in `ExecStart=`.** A unit's
+  command line is readable through `systemctl show` and `/proc` by any local
+  user. HTTP mode has no GitLab token to hide there, but two real secrets exist:
+  `GITLAB_MCP_TELEMETRY_IDENTITY_KEY`, which has no flag for exactly this
+  reason, and whatever `OTEL_EXPORTER_OTLP_HEADERS` carries. Keep
+  `/etc/gitlab-mcp-server/env` at mode `0600` owned by root; systemd reads it
+  before dropping privileges.
+- **A leftover socket is not always cleaned up for you.** On start the server
+  probes an existing socket and removes it only when the connection is refused,
+  which proves nothing is listening. A socket that is live is refused rather
+  than stolen, a path that is not a socket is never deleted, and a probe that
+  fails for any other reason (a permission-restricted directory, for instance)
+  refuses to start and tells you to remove the file by hand.
+
+Install and check:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now gitlab-mcp-server
+curl -fsS http://127.0.0.1:8080/health
+journalctl -u gitlab-mcp-server -f
+```
+
+### launchd
+
+macOS, as a system daemon under `/Library/LaunchDaemons/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.github.jmrplens.gitlab-mcp-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/gitlab-mcp-server</string>
+        <string>--http</string>
+        <string>--http-addr=127.0.0.1:8080</string>
+        <string>--gitlab-url=https://gitlab.example.com</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>UserName</key>
+    <string>_gitlabmcp</string>
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/gitlab-mcp-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/gitlab-mcp-server.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GITLAB_MCP_LOG_LEVEL</key>
+        <string>info</string>
+    </dict>
+</dict>
+</plist>
+```
+
+```bash
+sudo launchctl load -w /Library/LaunchDaemons/io.github.jmrplens.gitlab-mcp-server.plist
+sudo launchctl print system/io.github.jmrplens.gitlab-mcp-server
+```
+
+The same two cautions apply. State `--http` rather than relying on `auto`, and
+do not use launchd's `Sockets` key: it is socket activation by another name and
+lands in the same misreading. A plist is world-readable, so a secret does not
+belong in `EnvironmentVariables`; put it in a file the daemon reads instead,
+named by `GITLAB_MCP_ENV_FILE` with an absolute path.
+
+### Windows service
+
+`sc.exe create` on its own does not work. The Service Control Manager expects
+the executable it starts to register a service control handler and report back,
+and a plain console binary does not, so the start fails with error 1053, "did
+not respond to the start request in a timely fashion". A service wrapper bridges
+that gap:
+
+```powershell
+nssm install GitLabMcpServer "C:\Program Files\gitlab-mcp-server\gitlab-mcp-server.exe"
+nssm set GitLabMcpServer AppParameters "--http --http-addr=127.0.0.1:8080 --gitlab-url=https://gitlab.example.com"
+nssm set GitLabMcpServer AppStdout "C:\ProgramData\gitlab-mcp-server\out.log"
+nssm set GitLabMcpServer AppStderr "C:\ProgramData\gitlab-mcp-server\err.log"
+nssm set GitLabMcpServer Start SERVICE_AUTO_START
+nssm start GitLabMcpServer
+```
+
+`winget install --id jmrplens.gitlab-mcp-server -e` installs a **user-scope**
+portable package under `%LOCALAPPDATA%\Microsoft\WinGet\Packages\`, reachable
+through a symlink in a per-user `Links` directory. A service does not run as
+that user and must not depend on that path, so for a service install either add
+`--scope machine`, which installs under `%PROGRAMFILES%\WinGet\`, or copy the
+executable to a machine-wide directory and point the wrapper at the real file
+rather than at the symlink.
+
+`--http-socket-mode` is accepted on Windows and not enforced: the server logs a
+warning and lets the directory ACL decide. Use a TCP listener there.
+
+## Run it with Docker
+
+The image and its command line are described in
+[Installation](installation.md#docker). What follows is the deployment shape.
+
+### One container
+
+```bash
+docker run -d --name gitlab-mcp \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  --read-only \
+  --tmpfs /tmp:rw,size=64m,mode=1777 \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --memory 512m \
+  -e GITLAB_URL=https://gitlab.example.com \
+  ghcr.io/jmrplens/gitlab-mcp-server:2.7.5@sha256:8eec1825b266712cd544bf1b2144e55c1eb711b4540def40e963a664c4e97168
+```
+
+Five details worth a sentence each.
+
+**The instance arrives as an environment variable, not an argument.** Any
+argument after the image name replaces `CMD` wholesale, and `CMD` is
+`--transport auto --http-addr 0.0.0.0:8080`. Writing
+`docker run <image> --gitlab-url=…` would silently drop both, leaving the server
+on its own `:8080` default with the transport inferred rather than stated.
+`-e GITLAB_URL=` fills the instance list without touching the command.
+
+**No `-i`.** `auto` serves HTTP precisely when stdin is `/dev/null`, which is
+what `docker run` without `-i` gives it. Adding `-i` hands the container a pipe,
+which means a client, and the container speaks stdio to nobody.
+
+**`-p 127.0.0.1:8080:8080` binds the published port to loopback.** `-p
+8080:8080` publishes on every interface and, with Docker's default iptables
+integration, that goes around the host firewall.
+
+**`--read-only` works because the image writes nothing at runtime.** The one
+exception is a unix socket: binding one needs a writable parent directory for
+the staging step described above, so give it a `--tmpfs` or a volume. The
+container already runs as `appuser` (uid 10001), so `--user` is redundant, and
+`--cap-drop ALL` is safe because nothing binds a privileged port.
+
+**The image is pinned by digest, not only by tag.** A tag can be re-pushed; a
+digest is what a client actually resolves. `2.7.5` and `latest` resolved to the
+digest above on 2026-09-01, on `ghcr.io` and on the Docker Hub mirror.
+
+### Compose
+
+```yaml
+services:
+  gitlab-mcp-server:
+    image: ghcr.io/jmrplens/gitlab-mcp-server:2.7.5
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    command:
+      - "--http"
+      - "--http-addr=0.0.0.0:8080"
+      - "--gitlab-url=https://gitlab.example.com"
+      - "--auth-mode=oauth"
+      - "--public-url=https://mcp.example.com"
+      - "--trusted-proxy-header=X-Real-IP"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=64m,mode=1777
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "2.0" }
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+```
+
+A `command:` list replaces `CMD`, which is why `--http` and `--http-addr` are
+spelled out again. Naming an instance is not optional: HTTP mode exits with
+`--gitlab-url is required in HTTP mode` when none is given, because a deployment
+that names no instance would send whatever token a caller supplied to whatever
+host that caller put in `GITLAB-URL`.
+
+Several flags have **no environment-variable equivalent** and must be arguments
+here: `--http-addr`, `--http-socket-mode`, `--tls-cert`, `--tls-key`,
+`--trusted-proxy-header`, `--stateless`, `--json-response`,
+`--http-idle-timeout`, `--max-request-body-bytes` and `--allow-any-gitlab-url`.
+Most of the rest can come from the environment, `--rate-limit-rps` and
+`--rate-limit-burst` included, where an explicitly passed flag still wins.
+
+The image already carries a `HEALTHCHECK`. The Compose block restates it so a
+change to the image's interval does not silently change the deployment's, and
+because the image's check is hardcoded to `http://localhost:8080/health`: move
+the listener to another port, to a unix socket, or behind `--tls-cert`, and the
+container is marked unhealthy while serving perfectly. Restate the check to
+match whatever you changed.
+
+### Secrets
+
+HTTP mode has no GitLab token to inject: every request brings its own. What is
+left is telemetry credentials, and those do not belong in `environment:`, which
+`docker inspect` prints in full. Mount the file and name it:
+
+```yaml
+    secrets:
+      - source: mcp_env
+        target: /run/secrets/mcp.env
+    environment:
+      GITLAB_MCP_ENV_FILE: /run/secrets/mcp.env
+
+secrets:
+  mcp_env:
+    file: ./secrets/mcp.env
+```
+
+`GITLAB_MCP_ENV_FILE` is resolved once from the process environment before any
+dotenv file is loaded, so a loaded file cannot nominate another one, and it must
+be an absolute path. It composes with `read_only: true`, because the secret
+arrives as a read-only mount.
+
+### One instance or several
+
+`--gitlab-url` may be given more than once, or once comma-separated. One
+instance pins the deployment and a `GITLAB-URL` header is ignored. Several
+publish an allow-list, the header becomes required, and a header naming anything
+outside the list is refused rather than honored. `--allow-any-gitlab-url` starts
+with none published and lets the header name any host; a request that then omits
+the header is refused with `400` rather than resolved to a default. It warns at
+startup and belongs on a single-user local deployment only. The full table is in
+[Publishing more than one instance](http-server-mode.md#publishing-more-than-one-instance).
+
+## Behind a reverse proxy
+
+### What every proxy has to get right
+
+| Requirement                     | Why                                                                                                                                                                                           |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No response buffering           | Streamable HTTP answers with `text/event-stream`. A buffering proxy turns a live stream into one delivery at the end                                                                          |
+| Long read timeout               | A `subscriptions/listen` stream is silent between notifications. The server's SSE keep-alive fires every 25 seconds, under nginx's 60-second default, but a quiet stream still wants headroom |
+| HTTP/1.1 upstream               | HTTP/1.0 to the upstream has no chunked transfer, which is what an SSE body uses                                                                                                              |
+| Forward `Authorization`         | OAuth mode reads the bearer token from it; stripping it turns every request into a `401`                                                                                                      |
+| Forward `PRIVATE-TOKEN`         | Legacy mode's header                                                                                                                                                                          |
+| Forward `GITLAB-URL`            | Selects the instance when several are published                                                                                                                                               |
+| Real client address             | `--trusted-proxy-header` names the header the proxy sets, so the authentication-failure limiter counts callers rather than the proxy                                                          |
+| Route `/.well-known/` unchanged | In OAuth mode the RFC 9728 metadata lives at the **host root**, not under the path prefix                                                                                                     |
+| Add no CORS headers             | The server answers preflight itself. Two `Access-Control-Allow-Origin` headers is a CORS failure, not a merge                                                                                 |
+
+Three of those repay a longer look.
+
+**The metadata path is at the host root.** `--public-url` is the RFC 9728
+resource identifier, and the metadata URL is derived by inserting the well-known
+segment between host and path. Started with
+`--public-url=https://mcp.example.com/gitlab`, the server answers:
+
+| Path                                                  | Result |
+| ----------------------------------------------------- | ------ |
+| `/gitlab/health`, `/health`                           | `200`  |
+| `/gitlab/server-card`, `/server-card`                 | `200`  |
+| `/.well-known/oauth-protected-resource`               | `200`  |
+| `/.well-known/oauth-protected-resource/gitlab`        | `200`  |
+| `/gitlab/.well-known/oauth-protected-resource/gitlab` | `404`  |
+
+`/health` and the server card are mounted under the prefix as well as at the
+root; the OAuth metadata is not, and the `401` challenge points at the host-root
+form. A proxy that routes only `/gitlab` will answer `404` for the document
+every OAuth client fetches first, and discovery fails before the MCP endpoint is
+ever reached. Route `/.well-known/oauth-protected-resource` to the same
+upstream without rewriting it. The derivation itself is documented under
+[OAuth Mode](http-server-mode.md#oauth-mode).
+
+**Do not let the proxy speak CORS.** The server answers its own preflight from
+`--trusted-origins`, to which the `--public-url` origin is added automatically.
+A proxy that also emits `Access-Control-Allow-Origin` produces two of them.
+Browsers reject that outright while `curl` reports a cheerful `200`, so it is a
+failure visible only in the one client that matters. `test/e2e/http` pins it
+with a real nginx; the remedy is in [Security](../concepts/security.md).
+
+**Anything the proxy does not route is a `404`, not a `401`.** The MCP endpoint
+is mounted on specific patterns rather than as a catch-all, so a misrouted path
+answers `{"error":"not found"}` without authentication. A `404` where you
+expected a `401` usually means the path never reached the handler.
+
+### nginx
+
+```nginx
+upstream gitlab_mcp {
+    server 127.0.0.1:8080;
+    keepalive 16;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name mcp.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/mcp.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcp.example.com/privkey.pem;
+
+    # RFC 9728 metadata: host root, never rewritten.
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Server-sent events must not be held.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+}
+```
+
+Pair it with `--trusted-proxy-header=X-Real-IP`. Either header works, and the
+choice matters more than it looks. The server reads the **rightmost** entry of
+the value, which is the hop the nearest trusted proxy appended, so a value a
+client invented on the left is never mistaken for its address. With a single
+nginx in front, the rightmost entry of `$proxy_add_x_forwarded_for` is the
+client; add a second proxy in front of that one and the rightmost entry becomes
+the intermediate proxy instead. `X-Real-IP` set from `$remote_addr` at the hop
+nearest the server has no such ambiguity, and it is the header the project's own
+end-to-end proxy test uses.
+
+There is no allow-list of proxy addresses behind this. Setting the flag trusts
+the header unconditionally, so enable it only where the server cannot be reached
+except through that proxy. Otherwise a caller sends the header itself and walks
+around the limiter.
+
+nginx passes client request headers upstream by default, so `Authorization`,
+`PRIVATE-TOKEN` and `GITLAB-URL` arrive with no `proxy_set_header` line. The one
+nginx habit to know is that it drops headers containing underscores unless
+`underscores_in_headers on` is set; none of this server's headers contain one.
+
+### Caddy
+
+```text
+# Caddyfile
+mcp.example.com {
+    reverse_proxy 127.0.0.1:8080 {
+        flush_interval -1
+        transport http {
+            read_timeout 1h
+        }
+    }
+}
+```
+
+Caddy obtains and renews the certificate itself and forwards request headers
+unchanged, so most of the list above needs no configuration. `flush_interval -1`
+disables response buffering explicitly: Caddy already flushes immediately for
+`text/event-stream`, and `-1` means the behaviour no longer depends on the
+upstream getting its content type right.
+
+Caddy sets `X-Forwarded-For` by default, so `--trusted-proxy-header=X-Forwarded-For`
+pairs with this. A single site block covers the whole host, so the well-known
+path is already routed.
+
+### Traefik
+
+With the Docker provider, on the container from the Compose block above:
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mcp.rule=Host(`mcp.example.com`)"
+      - "traefik.http.routers.mcp.entrypoints=websecure"
+      - "traefik.http.routers.mcp.tls.certresolver=le"
+      - "traefik.http.services.mcp.loadbalancer.server.port=8080"
+```
+
+Traefik does not buffer responses unless a `buffering` middleware is added, so
+the fix here is to not add one. What does need attention is the entry point's
+responding timeout, which is global rather than per route:
+
+```yaml
+# traefik static configuration
+entryPoints:
+  websecure:
+    address: ":443"
+    transport:
+      respondingTimeouts:
+        readTimeout: 0
+        idleTimeout: 3m
+```
+
+`readTimeout: 0` removes the limit on how long a request may take, which is what
+a long-lived stream needs. Traefik sets `X-Forwarded-For` when it is the edge,
+or when the previous hop is listed in `forwardedHeaders.trustedIPs`.
+
+A `Host()` rule matches every path on the host, so the well-known document is
+covered. A `PathPrefix()` rule is where the trap opens: add a second router for
+`PathPrefix('/.well-known/oauth-protected-resource')` pointing at the same
+service.
+
+### Apache
+
+```apache
+<VirtualHost *:443>
+    ServerName mcp.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/mcp.example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/mcp.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyPass        / http://127.0.0.1:8080/ flushpackets=on timeout=3600 connectiontimeout=10
+    ProxyPassReverse / http://127.0.0.1:8080/
+
+    RequestHeader set X-Forwarded-Proto "https"
+</VirtualHost>
+```
+
+`flushpackets=on` is the one that matters: without it `mod_proxy_http` buffers
+the response body and the stream arrives all at once. `timeout=3600` is this
+route's read timeout, separate from the server-wide `Timeout`.
+
+Leave authentication to the MCP server, so nothing here should sit behind
+`Require valid-user`; Apache forwards `Authorization` upstream when it is not
+consuming it itself. `mod_remoteip` with `RemoteIPHeader X-Forwarded-For` fixes
+the address in Apache's own logs, and the MCP server still needs
+`--trusted-proxy-header` for its own limiter.
+
+Modules required: `proxy`, `proxy_http`, `ssl`, `headers`, and `remoteip` if you
+use it.
+
+### Cloudflare Tunnel
+
+A tunnel replaces the inbound listener entirely: `cloudflared` dials out, so the
+host needs no open port and no certificate of its own.
+
+```yaml
+# ~/.cloudflared/config.yml
+tunnel: <tunnel-uuid>
+credentials-file: /etc/cloudflared/<tunnel-uuid>.json
+
+ingress:
+  - hostname: mcp.example.com
+    service: http://127.0.0.1:8080
+    originRequest:
+      connectTimeout: 10s
+      disableChunkedEncoding: false
+      noTLSVerify: false
+  - service: http_status:404
+```
+
+Leave `disableChunkedEncoding` false. Setting it removes chunked transfer
+encoding to the origin, which is what an SSE body needs.
+
+Cloudflare sets `CF-Connecting-IP`, so name that one:
+`--trusted-proxy-header=CF-Connecting-IP`. Prefer it over `X-Forwarded-For`
+here, because Cloudflare rewrites `CF-Connecting-IP` on every request and a
+client cannot forge it through the edge.
+
+Two Cloudflare behaviours to check before blaming the server. The proxy applies
+an inactivity limit to a response that a quiet `subscriptions/listen` stream can
+reach even while the server's keep-alive holds the connection open at the TCP
+level; and Cloudflare's own CORS and caching rules, if enabled for the hostname,
+land in exactly the same collision as a proxy-level `Access-Control-Allow-Origin`.
+
+## TLS between the proxy and the server
+
+When the proxy shares the machine, remove the hop rather than encrypting it:
+`--http-addr=/run/gitlab-mcp/server.sock`. When the proxy is elsewhere, the
+binary terminates TLS itself and no sidecar is needed:
+
+```bash
+gitlab-mcp-server --http --http-addr=:8443 \
+  --tls-cert=/etc/ssl/mcp.crt --tls-key=/etc/ssl/mcp.key \
+  --gitlab-url=https://gitlab.example.com
+```
+
+Both flags or neither: `--tls-cert requires --tls-key` is a startup error, not a
+warning. TLS 1.2 is the floor with no ceiling, so a current proxy negotiates
+1.3 and anything below 1.2 is refused.
+
+The pair is loaded at startup, and that has an operational consequence: **a
+renewed certificate does not take effect until the process restarts.** There is
+no reload signal; the only signals handled are `SIGINT` and `SIGTERM`, and both
+mean shutdown. With certbot, that is a deploy hook:
+
+```bash
+# /etc/letsencrypt/renewal-hooks/deploy/gitlab-mcp-server.sh
+#!/bin/sh
+systemctl restart gitlab-mcp-server
+```
+
+A restart drops the pool and cuts open streams, so schedule renewal where a
+brief reconnect is acceptable, or terminate TLS at a proxy that does reload in
+place. The mechanics of both listeners are in
+[Listening on a unix socket, or on TLS](http-server-mode.md#listening-on-a-unix-socket-or-on-tls).
+
+## Direct exposure, no proxy
+
+The binary answers its own CORS preflights, its own `404`s, its own security
+headers, and can terminate TLS or listen on a unix socket. Nothing here needs a
+proxy to be correct. A deployment without one should still be deliberate about
+five things:
+
+- **`--auth-mode=oauth`.** Bearer verification against the instance the request
+  selected, with RFC 9728 metadata so clients discover it. `--public-url` is
+  required and must be the externally reachable https origin.
+- **Certificates and their renewal.** Loaded at startup, so renewal means a
+  restart. See above.
+- **Rate limiting.** `--rate-limit-rps` defaults to 10 in HTTP mode with a burst
+  of 40, counted per pooled token rather than per address, and there is a
+  separate per-address budget for authentication failures, which is the one that
+  answers `429` with `Retry-After`. A throttled `tools/call` is not a `429`: it
+  is a normal MCP result carrying an error, so it will not show up in HTTP-level
+  monitoring.
+- **Bounds.** `--max-http-clients` caps pooled entries, not sessions or
+  concurrent requests. `--pool-idle-timeout` reclaims unused ones, and
+  `--session-timeout` applies to stateful mode only.
+- **The token passes through the box.** Every caller's GitLab token reaches this
+  process, authenticates one request, and is never persisted. That is a property
+  of the software. Whether the people whose tokens they are consider the machine
+  trustworthy is a question the software cannot answer, so ask them rather than
+  answering for them.
+
+## Several instances behind one proxy
+
+### Affinity is structural, not a preference
+
+Each instance keeps two caches. Both are per process, both are keyed on the
+caller, and neither can be shared:
+
+- The **server pool**, keyed on `SHA-256(token + "\x00" + gitlabURL)`. On a miss
+  the entry is built: the token's scopes are probed, the instance's licensing
+  tier is detected, and a whole tool catalog is registered and pruned to that
+  tier. The catalog build is the entire cost, measured at **1.8 seconds on the
+  dynamic surface and 3.0 seconds on individual**, and it is paid on the first
+  request of every credential rather than once per process the way stdio pays
+  it. The handshake itself is answered immediately from a shell, so the cost
+  lands on the first tool call rather than on `initialize`.
+- The **OAuth identity cache**, keyed on instance and token, with
+  `--oauth-cache-ttl` at 15 minutes by default. A miss is a round trip to GitLab
+  to verify the credential.
+
+Both hold live objects rather than serializable state, so there is no version of
+this where a second instance reads the first one's cache. The question for a
+balancer is therefore not whether requests will work anywhere. Under the default
+`--stateless=true` every POST is self-contained and every instance answers
+correctly. The question is how many times you are willing to pay for a cache
+designed to be paid once.
+
+Two things do not merely cost extra when a caller moves, they break. A stateful
+session (`--stateless=false`) lives in the process that minted its
+`Mcp-Session-Id`, and another instance answers that id with `404`, which a client
+reads as its session having been terminated. Resource subscriptions are watchers
+held by one process and disappear with it. If you run either, affinity is not an
+optimization.
+
+### The three distributions
+
+| Distribution | Key                               | What it costs                                                                                                                                                                                                                                                                                                                              |
+| ------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Round robin  | none                              | Every instance eventually holds an entry for every caller, so pool memory multiplies by the instance count and each caller pays a 1.8 to 3.0 second catalog build on each instance it first touches. Token verification against GitLab goes from once per cache TTL to roughly once per TTL per instance. Correct, and pays N times over   |
+| IP hash      | the client address                | Free, one directive, no secret to keep. The key is the wrong grain in both directions: an office, a VPN concentrator or a CI runner fleet is one address, so all of it collapses onto one instance, while one caller roaming between networks changes key and lands cold each time. Behind a CDN it needs the real address recovered first |
+| Token hash   | a salted digest of the credential | Matches the grain of what is cached, because the pool key is derived from the token. Costs one secret to manage, a fallback for credential-less requests, and one cold entry whenever a caller rotates its token. This is what the hosted endpoint runs                                                                                    |
+
+Token hash is the right answer here, and the reason is narrow enough to state
+exactly: the thing being cached is keyed on the token, so the routing key should
+be too. Neither of the others is wrong, and both are fine wherever one instance
+serves the whole caller population, which is most deployments. Reach for a second
+instance for availability, not for throughput: the ceiling that usually binds is
+GitLab's own rate limit against one token, which no number of instances raises.
+
+### Hashing the token without routing on it
+
+The credential must not become the routing key. An affinity key ends up in the
+balancer's memory, in its access log if the log format names the variable, and
+in whatever upstream selection it drives. A raw bearer token in any of those is
+a credential leak with extra steps.
+
+The fix is a salted digest: hash a per-deployment secret together with the
+credential, and route on that. The digest is a distribution function rather than
+a security primitive; the salt is what does the security work. Without it the
+key is a token fingerprint that anyone holding a candidate token could confirm.
+With it the key is meaningless outside this deployment and cannot be replayed as
+a credential.
+
+Three details decide whether the affinity actually holds:
+
+- **Normalize before hashing.** Strip the `Bearer` scheme prefix and surrounding
+  whitespace. The same token spelled two ways hashes two ways and lands on two
+  instances.
+- **Fall back to the address, not to nothing.** A request with no credential has
+  no key, and an empty key makes every anonymous request hash identically onto
+  one instance. `$remote_addr` spreads them.
+- **Use consistent hashing.** Removing one of three instances then relocates
+  roughly a third of the callers instead of reshuffling all of them, which is
+  the difference between a rolling update that warms one cold pool and one that
+  warms every pool.
+
+### A worked nginx balancer
+
+`hash` accepts a string with variables and hashes it itself, so the salt can go
+into the key expression without ever becoming a loggable variable of its own.
+This needs no third-party module:
+
+```nginx
+# Keep the salt out of the repository: include it from a 0600 file.
+map $host $mcp_salt {
+    default "a-long-random-per-deployment-salt";
+}
+
+# The bearer credential, without its scheme prefix.
+map $http_authorization $mcp_bearer {
+    default                     "";
+    "~*^Bearer[ ]+(?<tok>\S+)$" $tok;
+}
+
+# Legacy-mode callers send PRIVATE-TOKEN instead.
+map $mcp_bearer $mcp_credential {
+    default $mcp_bearer;
+    ""      $http_private_token;
+}
+
+# No credential: fall back to the client address.
+map $mcp_credential $mcp_affinity {
+    default $mcp_credential;
+    ""      $remote_addr;
+}
+
+upstream gitlab_mcp {
+    hash "$mcp_salt$mcp_affinity" consistent;
+    server 10.0.0.11:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.12:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.13:8080 max_fails=2 fail_timeout=10s;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+
+        # Retry only what was never delivered.
+        proxy_next_upstream error timeout;
+        proxy_next_upstream_tries 2;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+}
+```
+
+Do not log `$mcp_affinity` or `$mcp_credential`. Where an explicit digest is
+preferred, `set_md5 $key "$mcp_salt$mcp_affinity"` from
+`ngx_http_set_misc_module` (OpenResty, or Debian and Ubuntu's `nginx-extras`)
+produces one, and njs does the same in a few lines. The hosted endpoint at
+`mcp.jmrp.io` computes `md5(salt + bearer)` that way.
+
+**Never add `non_idempotent` to `proxy_next_upstream`.** Without it, nginx
+retries a `POST` on another instance only when the request was never sent, which
+is exactly the guarantee wanted here: a `tools/call` that created an issue and
+then lost its response must not be replayed on a second instance. `error
+timeout` on its own is connection-level. Adding `http_500` or `non_idempotent`
+turns one delivered mutating call into two.
+
+Prove the affinity rather than assuming it. Two instances, eight tokens, six
+requests each, reading the backend out of the access log:
+
+```bash
+for t in alpha bravo charlie delta echo foxtrot golf hotel; do
+  for _ in $(seq 1 6); do
+    curl -s -o /dev/null -H "Authorization: Bearer token-$t" \
+      https://mcp.example.com/health
+  done
+done
+```
+
+Every token must show exactly one backend across its six requests, and the eight
+tokens must not all show the same one. Run the same loop with no `Authorization`
+header and with `PRIVATE-TOKEN` instead, to confirm both fallbacks pin as well.
+
+### Rolling updates, probes and egress
+
+**Take an instance out of rotation before you signal it.** The process gives no
+draining signal of its own: on `SIGTERM` it closes the listener first, so
+`/health` stops answering immediately rather than reporting unhealthy, and it
+never returns `503` on the way down. In-flight requests then get up to 15
+seconds to finish before the remaining connections are closed. Remove the
+backend at the balancer, let streams drain, then restart. Under consistent
+hashing the callers pinned to it move to a neighbour, warm an entry there, and
+come back when it returns.
+
+**`/health` is the probe, and it is honest about what it knows.** No credential,
+no GitLab round trip, `200` with `status`, `version`, `commit`, `started_at` and
+`uptime_seconds`. `status` is the constant `ok`; the HTTP status carries
+liveness. It deliberately does not test GitLab reachability, so a balancer must
+not read a `200` as "GitLab is up", and there is no separate readiness endpoint.
+
+**Give the fleet a fixed egress address.** GitLab applies its own rate limits and
+any IP allow-lists per source address. Instances behind a NAT gateway with a
+stable address are one caller to GitLab; instances with ephemeral public
+addresses are several unpredictable ones, and an allow-list cannot be written
+for them.
+
+**Remember the limiter multiplies.** `--rate-limit-rps` is per pooled token
+entry inside one process, so three instances mean up to three buckets for one
+caller unless affinity pins it to one. With token affinity the configured number
+is the number. Under round robin, either divide it by the instance count or put
+the real limit on the balancer.
+
+**Revalidation keeps running per instance.** `--revalidate-interval` re-checks
+pooled credentials every 15 minutes by default and evicts the ones GitLab now
+rejects; setting it to `0` does not make a revoked token last forever, because
+an entry older than an hour is rebuilt on next use anyway. That is per instance,
+so the same token is re-checked once per instance holding it, which is one more
+thing affinity keeps to one.
+
+## Further reading
+
+- [HTTP Server Mode](http-server-mode.md) for every flag, the server pool, and the OAuth derivation rules
+- [OAuth App Setup](oauth-app-setup.md) for creating the GitLab application clients authorize against
+- [Security](../concepts/security.md) for the threat model, CORS, and the hardening checklist
+- [Resource Consumption](../concepts/resource-consumption.md) for sizing an instance
+- [Telemetry](telemetry.md) for what an instance can report about itself
+- [Troubleshooting](troubleshooting.md) for symptoms and their usual causes

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -752,6 +752,11 @@ export default defineConfig({
 							translations: { es: "Servidor HTTP" },
 						},
 						{
+							slug: "operations/remote-deployment",
+							label: "Remote Deployment",
+							translations: { es: "Despliegue remoto" },
+						},
+						{
 							slug: "operations/error-handling",
 							label: "Error Handling",
 							translations: { es: "Errores y formato" },

--- a/site/scripts/gen-llms.mjs
+++ b/site/scripts/gen-llms.mjs
@@ -173,6 +173,7 @@ const SECTIONS = [
 			"operations/privacy",
 			"operations/telemetry",
 			"operations/http-server",
+			"operations/remote-deployment",
 			"operations/error-handling",
 			"operations/ci-cd",
 			"operations/docker-testing",

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -85,7 +85,7 @@ El servidor comienza a escuchar en el puerto 8080 por defecto. El endpoint MCP e
 | `--max-request-body-bytes` | `0`               | Tamaño máximo del cuerpo de las peticiones HTTP streamable en bytes; `0` usa el valor por defecto del SDK (4 MiB); los valores negativos se rechazan al arrancar. Los cuerpos que lo superan se rechazan con `413`                                                                                                                          |
 
 :::note
-Lo que significa `GITLAB-URL` depende de cuántas instancias publique el despliegue. **Ninguna**: elige el cliente, con `https://gitlab.com` como último recurso. **Una**: es autoritativa, la cabecera se ignora y se registra en `ignored_options`. **Varias**: la cabecera elige entre las publicadas, y un valor que nombre cualquier otra cosa se **rechaza** —`403` en modo OAuth, `400` en legacy—, nunca se responde en silencio con la instancia de otro. En modo OAuth todas las instancias publicadas deben ser `https`, porque el token bearer se reenvía a la que haya elegido la petición.
+Lo que significa `GITLAB-URL` depende de cuántas instancias publique el despliegue. **Ninguna**: solo es posible con `--allow-any-gitlab-url`, y entonces elige el cliente, con una petición que no nombre ninguna instancia rechazada en lugar de dirigida a `https://gitlab.com`. **Una**: es autoritativa, la cabecera se ignora y se registra en `ignored_options`. **Varias**: la cabecera es **obligatoria** y elige entre las publicadas. Una petición que no la envíe se rechaza con `400`, porque responderla pondría el token de quien llama en la red hacia una instancia que nunca nombró; el rechazo nombra las instancias publicadas en modo OAuth y te dice que preguntes a quien administra en modo legacy, de forma que ningún token no vacío pueda enumerarlas. Un valor fuera de la lista se **rechaza** igualmente —`403` en modo OAuth, `400` en legacy—, nunca se responde en silencio con la instancia de otro. En modo OAuth todas las instancias publicadas deben ser `https`, porque el token bearer se reenvía a la que haya elegido la petición.
 :::
 
 ### Opciones de superficie de herramientas y capacidades
@@ -118,7 +118,7 @@ Cuando el servidor arranca con `--allow-any-gitlab-url` y no publica ninguna ins
 GITLAB-URL: https://gitlab.ejemplo.com
 ```
 
-Si el despliegue fija exactamente una instancia, esta cabecera se ignora y se registra. Si publica varias, la cabecera elige una de ellas y cualquier otro valor se rechaza. Si no fija ninguna y la cabecera se omite, la petición se rechaza.
+Si el despliegue fija exactamente una instancia, esta cabecera se ignora y se registra. Si publica varias, la cabecera elige una de ellas y cualquier otro valor se rechaza. Si no fija ninguna y la cabecera se omite, la petición se rechaza con `400` en lugar de resolverse a `https://gitlab.com`.
 
 ### Cabecera private-token (recomendada)
 

--- a/site/src/content/docs/es/operations/remote-deployment.mdx
+++ b/site/src/content/docs/es/operations/remote-deployment.mdx
@@ -1,0 +1,861 @@
+---
+title: Despliegue remoto
+description: "Ejecuta GitLab MCP Server para otras personas: como servicio del sistema, en Docker, tras nginx, Caddy, Traefik, Apache o un túnel de Cloudflare, y con varias instancias usando afinidad por token."
+datePublished: "2026-09-04"
+faq:
+  - q: "¿Puedo balancear varias instancias con round robin?"
+    a: "Funciona, y paga varias veces por la misma caché. Cada instancia mantiene un pool de servidores indexado por un hash del token y la URL de GitLab, y una caché de identidad OAuth indexada por instancia y token. Ambas son por proceso y guardan objetos vivos, así que no se comparte nada entre instancias. Un cliente que aterriza en una instancia distinta en cada petición reconstruye allí una entrada del pool (una construcción del catálogo medida en 1,8 segundos en la superficie dinámica y 3,0 en la individual) y vuelve a verificar su token contra GitLab. El round robin es correcto; simplemente paga N veces. La afinidad por token fija a cada cliente en la instancia que ya tiene su entrada."
+  - q: "¿Por qué no usar simplemente IP hash para la afinidad?"
+    a: "Porque la dirección es la granularidad equivocada. Una oficina, un concentrador VPN o una flota de runners de CI es una sola dirección, así que todo eso se agolpa en una instancia; y un cliente que se mueve entre redes cambia de clave y aterriza frío cada vez. Tras una CDN el balanceador además tiene que recuperar primero la dirección real. El IP hash es barato y no necesita ningún secreto, lo cual es una ventaja real, pero lo que se cachea está indexado por el token, así que la clave de enrutado también debería estarlo."
+  - q: "¿Necesito un proxy inverso?"
+    a: "No. El binario responde sus propios preflight de CORS, sus propios 404, sus propias cabeceras de seguridad, y termina TLS con `--tls-cert` y `--tls-key`. Cuando el proxy comparte máquina, `--http-addr=/run/gitlab-mcp/server.sock` elimina el salto en lugar de cifrarlo. Un proxy se gana su sitio por la renovación de certificados sin reinicio, por alojar otros servicios en el mismo nombre y por balancear varias instancias."
+  - q: "Mis clientes OAuth reciben un 404 durante el descubrimiento. ¿Qué falla?"
+    a: "Casi seguro que el proxy solo enruta el prefijo de ruta. El documento de metadatos RFC 9728 vive en la **raíz del host**, no bajo la ruta de `--public-url`: arrancado con `--public-url=https://mcp.example.com/gitlab`, el servidor lo sirve en `/.well-known/oauth-protected-resource/gitlab` y responde 404 a `/gitlab/.well-known/oauth-protected-resource/gitlab`. `/health` y la tarjeta del servidor *sí* se montan además bajo el prefijo; los metadatos OAuth no. Enruta `/.well-known/oauth-protected-resource` al mismo upstream sin reescribirla."
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import FAQ from "../../../../components/FAQ.astro";
+
+:::tip[De un vistazo]
+
+- **En modo HTTP el servidor no guarda ninguna credencial propia.** Cada petición lleva el token de quien llama, así que no hay ningún token de servidor que esconder en un fichero de unidad y `/health` no necesita autenticación.
+- **Nada de esto necesita un proxy inverso para ser correcto.** El binario termina TLS, responde sus propios preflight de CORS y puede escuchar en un socket unix.
+- **Varias instancias no se balancean con round robin gratis.** El pool de servidores y la caché de identidad OAuth son por proceso, así que un cliente que se mueve reconstruye ambas. Fíjalo con afinidad por token.
+
+:::
+
+[Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) documenta el
+transporte opción por opción. Esta página es la otra mitad: cómo levantarlo para
+otras personas, en una máquina que se queda encendida, accesible desde algún
+sitio que no sea el portátil de quien lo administra.
+
+Todo aquí asume modo HTTP. No existe una forma remota de stdio: stdio es una
+tubería entre un proceso cliente y un proceso servidor en la misma máquina, y en
+cuanto una segunda persona necesita llegar hasta él la respuesta es HTTP.
+
+## Elige primero la forma
+
+| Situación                        | Forma                                                                                                       |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Un host, proxy y servidor juntos | Socket unix: `--http-addr=/run/gitlab-mcp/server.sock`                                                      |
+| Proxy en otra máquina            | `--tls-cert` y `--tls-key` en el propio listener                                                            |
+| Sin ningún proxy                 | `--tls-cert` y `--tls-key` más `--auth-mode=oauth`; lee [Exposición directa](#exposición-directa-sin-proxy) |
+| Contenedores                     | La imagen publicada, sistema de ficheros raíz de solo lectura, digest fijado                                |
+| Más de una instancia             | Un balanceador con afinidad por token: [Varias instancias](#varias-instancias-tras-un-mismo-proxy)          |
+
+## Ejecutarlo como servicio
+
+<Tabs>
+<TabItem label="systemd">
+
+Dos formas, y lo que las separa es si un proxy en la misma máquina tiene que
+llegar a un socket unix. **TCP en loopback con usuario dinámico** es la forma con
+menos privilegios:
+
+```ini
+# /etc/systemd/system/gitlab-mcp-server.service
+[Unit]
+Description=GitLab MCP Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+DynamicUser=yes
+EnvironmentFile=/etc/gitlab-mcp-server/env
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=127.0.0.1:8080 \
+    --gitlab-url=https://gitlab.example.com \
+    --auth-mode=oauth \
+    --public-url=https://mcp.example.com \
+    --trusted-proxy-header=X-Real-IP
+Restart=on-failure
+RestartSec=2s
+StandardInput=null
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+CapabilityBoundingSet=
+AmbientCapabilities=
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ProtectSystem=strict` monta todo el sistema de ficheros en solo lectura y al
+servidor le da igual: no escribe nada en disco. Los registros van a la salida de
+error estándar, que recoge `journald`. Las lecturas no se ven afectadas, así que
+los certificados y el fichero de entorno siguen siendo legibles.
+
+`RestrictAddressFamilies=` omite `AF_NETLINK` a propósito. El binario publicado
+se compila con `CGO_ENABLED=0` y usa el resolvedor propio de Go, que llega al
+DNS por UDP y TCP y no pregunta nada al núcleo por netlink. Verificado contra
+esta misma unidad: una comprobación de credencial que tuvo que resolver y llegar
+a `gitlab.com` fue respondida por GitLab con y sin `AF_NETLINK` en la lista.
+
+**Un socket unix necesita un usuario fijo.** `DynamicUser=yes` asigna un usuario
+y un grupo transitorios en cada arranque, así que no hay ningún grupo al que
+añadir el proxy:
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin gitlab-mcp
+sudo usermod -aG gitlab-mcp www-data   # o nginx, o caddy
+```
+
+```ini
+User=gitlab-mcp
+Group=gitlab-mcp
+RuntimeDirectory=gitlab-mcp
+RuntimeDirectoryMode=0750
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=/run/gitlab-mcp/server.sock \
+    --http-socket-mode=0660 \
+    --gitlab-url=https://gitlab.example.com
+```
+
+`RuntimeDirectory=` hace que `/run/gitlab-mcp` exista, pertenezca al servicio y
+se elimine al parar. Además tiene que poder **escribirse**: el servidor no
+vincula la ruta publicada directamente. Crea un directorio de preparación `0700`
+al lado, vincula el socket allí y le aplica los permisos, y después lo enlaza a
+su sitio, de modo que un socket solo aparece ya con sus permisos definitivos.
+
+</TabItem>
+<TabItem label="launchd">
+
+macOS, como demonio del sistema bajo `/Library/LaunchDaemons/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.github.jmrplens.gitlab-mcp-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/gitlab-mcp-server</string>
+        <string>--http</string>
+        <string>--http-addr=127.0.0.1:8080</string>
+        <string>--gitlab-url=https://gitlab.example.com</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>UserName</key>
+    <string>_gitlabmcp</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/gitlab-mcp-server.log</string>
+</dict>
+</plist>
+```
+
+```bash
+sudo launchctl load -w /Library/LaunchDaemons/io.github.jmrplens.gitlab-mcp-server.plist
+sudo launchctl print system/io.github.jmrplens.gitlab-mcp-server
+```
+
+Un plist es legible por cualquiera, así que un secreto no va en
+`EnvironmentVariables`. Ponlo en un fichero que lea el demonio, nombrado por
+`GITLAB_MCP_ENV_FILE` con una ruta absoluta.
+
+</TabItem>
+<TabItem label="Windows">
+
+`sc.exe create` por sí solo no funciona. El Administrador de control de
+servicios espera que el ejecutable que arranca registre un manejador de control
+de servicio y le responda, y un binario de consola normal no lo hace, así que el
+arranque falla con el error 1053, «no respondió a la petición de inicio a
+tiempo». Un envoltorio de servicio cubre esa distancia:
+
+```powershell
+nssm install GitLabMcpServer "C:\Program Files\gitlab-mcp-server\gitlab-mcp-server.exe"
+nssm set GitLabMcpServer AppParameters "--http --http-addr=127.0.0.1:8080 --gitlab-url=https://gitlab.example.com"
+nssm set GitLabMcpServer AppStdout "C:\ProgramData\gitlab-mcp-server\out.log"
+nssm set GitLabMcpServer AppStderr "C:\ProgramData\gitlab-mcp-server\err.log"
+nssm set GitLabMcpServer Start SERVICE_AUTO_START
+nssm start GitLabMcpServer
+```
+
+`winget install --id jmrplens.gitlab-mcp-server -e` instala un paquete portable
+de **ámbito de usuario** bajo `%LOCALAPPDATA%\Microsoft\WinGet\Packages\`,
+accesible mediante un enlace simbólico en un directorio `Links` por usuario. Un
+servicio no se ejecuta como ese usuario y no debe depender de esa ruta, así que
+añade `--scope machine` o copia el ejecutable a un directorio de máquina y apunta
+el envoltorio al fichero real y no al enlace.
+
+`--http-socket-mode` se acepta en Windows y no se aplica: el servidor registra
+un aviso y deja que decida la ACL del directorio. Usa allí un listener TCP.
+
+</TabItem>
+</Tabs>
+
+### Tres cosas que todo gestor de servicios se equivoca
+
+- **Declara el transporte.** `--transport auto` lee el descriptor de fichero 0 y
+  elige HTTP solo cuando la entrada estándar es `/dev/null`. El
+  `StandardInput=null` por defecto de systemd da la misma respuesta por
+  casualidad, pero una unidad que ponga `StandardInput=socket` o `tty` obtiene
+  stdio. `--http` dice lo que quieres decir y no lo mueve cómo el supervisor
+  conecte un descriptor de fichero.
+- **La activación por socket no está soportada.** Una unidad `.socket`, o la
+  clave `Sockets` de launchd, entrega el socket de escucha al servicio en el
+  descriptor de fichero 0, y este servidor lee un socket ahí como «un supervisor
+  me ha dado un canal stdio». Vincula el socket tú mismo con `--http-addr`.
+- **Los secretos van en un fichero de entorno, nunca en la línea de órdenes.** La
+  línea de órdenes de un servicio la puede leer cualquier usuario local. El modo
+  HTTP no tiene ningún token de GitLab que esconder, pero existen dos secretos
+  reales: `GITLAB_MCP_TELEMETRY_IDENTITY_KEY`, que no tiene opción de línea de
+  órdenes precisamente por esto, y lo que lleve `OTEL_EXPORTER_OTLP_HEADERS`.
+
+Un socket huérfano no siempre se limpia solo. Al arrancar, el servidor sondea un
+socket existente y lo elimina únicamente cuando la conexión es rechazada, lo que
+demuestra que nadie está escuchando. Un socket vivo se rechaza en lugar de
+robarse, una ruta que no es un socket nunca se borra, y un sondeo que falla por
+cualquier otro motivo se niega a arrancar y te dice que elimines el fichero a
+mano.
+
+## Ejecutarlo con Docker
+
+La imagen y su línea de órdenes están descritas en
+[Docker](/gitlab-mcp-server/install/docker/). Lo que sigue es la forma de
+despliegue.
+
+```bash
+docker run -d --name gitlab-mcp \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  --read-only \
+  --tmpfs /tmp:rw,size=64m,mode=1777 \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --memory 512m \
+  -e GITLAB_URL=https://gitlab.example.com \
+  ghcr.io/jmrplens/gitlab-mcp-server:2.7.5
+```
+
+**La instancia llega como variable de entorno, no como argumento.** Cualquier
+argumento después del nombre de la imagen reemplaza el `CMD` por completo, y el
+`CMD` es `--transport auto --http-addr 0.0.0.0:8080`. Escribir
+`docker run <imagen> --gitlab-url=…` los perdería ambos en silencio.
+
+**Sin `-i`.** `auto` sirve HTTP exactamente cuando la entrada estándar es
+`/dev/null`, que es lo que da `docker run` sin `-i`. Añadir `-i` le entrega al
+contenedor una tubería, lo que significa un cliente, y el contenedor le habla
+stdio a nadie.
+
+**`--read-only` funciona porque la imagen no escribe nada en ejecución.** La
+única excepción es un socket unix, cuya vinculación necesita un directorio padre
+con permiso de escritura para el paso de preparación descrito arriba. El
+contenedor ya se ejecuta como `appuser` (uid 10001), así que `--user` sobra.
+
+**Fija el digest, no solo la etiqueta.** Una etiqueta se puede volver a subir; un
+digest es lo que un cliente resuelve de verdad. `2.7.5` y `latest` resolvían a
+`sha256:8eec1825b266712cd544bf1b2144e55c1eb711b4540def40e963a664c4e97168` el
+2026-09-01, tanto en `ghcr.io` como en el espejo de Docker Hub.
+
+### Compose
+
+```yaml
+services:
+  gitlab-mcp-server:
+    image: ghcr.io/jmrplens/gitlab-mcp-server:2.7.5
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    command:
+      - "--http"
+      - "--http-addr=0.0.0.0:8080"
+      - "--gitlab-url=https://gitlab.example.com"
+      - "--auth-mode=oauth"
+      - "--public-url=https://mcp.example.com"
+      - "--trusted-proxy-header=X-Real-IP"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=64m,mode=1777
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "2.0" }
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+```
+
+Nombrar una instancia no es opcional: el modo HTTP termina con `--gitlab-url is
+required in HTTP mode` cuando no se da ninguna, porque un despliegue que no
+nombra ninguna instancia enviaría el token que aporte quien llama al host que
+esa misma persona ponga en `GITLAB-URL`.
+
+Varias opciones **no tienen equivalente en variable de entorno** y deben ir como
+argumentos: `--http-addr`, `--http-socket-mode`, `--tls-cert`, `--tls-key`,
+`--trusted-proxy-header`, `--stateless`, `--json-response`,
+`--http-idle-timeout`, `--max-request-body-bytes` y `--allow-any-gitlab-url`.
+
+El `HEALTHCHECK` de la propia imagen está fijado a
+`http://localhost:8080/health`. Mueve el listener a otro puerto, a un socket
+unix o detrás de `--tls-cert`, y el contenedor queda marcado como no saludable
+mientras sirve perfectamente. Vuelve a declarar la comprobación acorde a lo que
+hayas cambiado.
+
+### Secretos
+
+El modo HTTP no tiene ningún token de GitLab que inyectar. Lo que queda son
+credenciales de telemetría, y esas no van en `environment:`, que `docker
+inspect` imprime entero. Monta el fichero y nómbralo:
+
+```yaml
+    secrets:
+      - source: mcp_env
+        target: /run/secrets/mcp.env
+    environment:
+      GITLAB_MCP_ENV_FILE: /run/secrets/mcp.env
+
+secrets:
+  mcp_env:
+    file: ./secrets/mcp.env
+```
+
+`GITLAB_MCP_ENV_FILE` se resuelve una sola vez desde el entorno del proceso
+antes de cargar ningún fichero dotenv, así que un fichero cargado no puede
+nombrar otro, y debe ser una ruta absoluta. Se lleva bien con `read_only: true`.
+
+## Tras un proxy inverso
+
+### Lo que todo proxy tiene que acertar
+
+| Requisito                           | Por qué                                                                                                                                                                                                                   |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sin búfer de respuesta              | El HTTP transmisible responde con `text/event-stream`. Un proxy con búfer convierte un stream vivo en una única entrega al final                                                                                          |
+| Timeout de lectura largo            | Un stream `subscriptions/listen` está en silencio entre notificaciones. El keep-alive SSE del servidor sale cada 25 segundos, por debajo del valor por defecto de 60 de nginx, pero un stream tranquilo quiere más margen |
+| HTTP/1.1 hacia el upstream          | HTTP/1.0 hacia el upstream no tiene transferencia troceada, que es lo que usa un cuerpo SSE                                                                                                                               |
+| Reenviar `Authorization`            | El modo OAuth lee de ahí el token bearer; quitarla convierte cada petición en un `401`                                                                                                                                    |
+| Reenviar `PRIVATE-TOKEN`            | La cabecera del modo legacy                                                                                                                                                                                               |
+| Reenviar `GITLAB-URL`               | Selecciona la instancia cuando se publican varias                                                                                                                                                                         |
+| Dirección real del cliente          | `--trusted-proxy-header` nombra la cabecera que pone el proxy, para que el limitador de fallos de autenticación cuente clientes y no al proxy                                                                             |
+| Enrutar `/.well-known/` sin cambios | En modo OAuth los metadatos RFC 9728 viven en la **raíz del host**, no bajo el prefijo de ruta                                                                                                                            |
+| No añadir cabeceras CORS            | El servidor responde el preflight por sí mismo. Dos cabeceras `Access-Control-Allow-Origin` son un fallo de CORS, no una fusión                                                                                           |
+
+:::caution[La ruta de metadatos está en la raíz del host]
+
+Arrancado con `--public-url=https://mcp.example.com/gitlab`, el servidor
+responde:
+
+| Ruta                                                  | Resultado |
+| ----------------------------------------------------- | --------- |
+| `/gitlab/health`, `/health`                           | `200`     |
+| `/gitlab/server-card`, `/server-card`                 | `200`     |
+| `/.well-known/oauth-protected-resource`               | `200`     |
+| `/.well-known/oauth-protected-resource/gitlab`        | `200`     |
+| `/gitlab/.well-known/oauth-protected-resource/gitlab` | `404`     |
+
+`/health` y la tarjeta del servidor se montan bajo el prefijo además de en la
+raíz; los metadatos OAuth no, y el desafío `401` apunta a la forma de la raíz
+del host. Un proxy que solo enruta `/gitlab` responde `404` al documento que
+todo cliente OAuth pide primero, y el descubrimiento falla antes de llegar
+siquiera al endpoint MCP.
+
+:::
+
+Dos más que muerden. **No dejes que el proxy hable CORS:** el servidor responde
+su propio preflight a partir de `--trusted-origins`, a la que se añade
+automáticamente el origen de `--public-url`, y un proxy que también emita
+`Access-Control-Allow-Origin` produce dos, que los navegadores rechazan de
+plano mientras `curl` informa de un alegre `200`. Y **todo lo que el proxy no
+enrute es un `404`, no un `401`**, porque el endpoint MCP se monta en patrones
+concretos y no como comodín.
+
+<Tabs>
+<TabItem label="nginx">
+
+```nginx
+upstream gitlab_mcp {
+    server 127.0.0.1:8080;
+    keepalive 16;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name mcp.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/mcp.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcp.example.com/privkey.pem;
+
+    # Metadatos RFC 9728: raíz del host, nunca reescrita.
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+}
+```
+
+Acompáñalo de `--trusted-proxy-header=X-Real-IP`. El servidor lee la entrada
+**más a la derecha** del valor, que es el salto que añadió el proxy de confianza
+más cercano, así que un valor que un cliente se inventara por la izquierda nunca
+se confunde con su dirección. Con un único nginx delante, la entrada más a la
+derecha de `$proxy_add_x_forwarded_for` es el cliente; añade un segundo proxy por
+delante de ese y pasa a ser el proxy intermedio. `X-Real-IP` puesta desde
+`$remote_addr` en el salto más cercano al servidor no tiene esa ambigüedad.
+
+No hay ninguna lista blanca de direcciones de proxy detrás de esta opción:
+activarla confía en la cabecera sin condiciones, así que hazlo solo donde al
+servidor no se pueda llegar salvo a través de ese proxy.
+
+nginx pasa las cabeceras de petición del cliente al upstream por defecto, así
+que `Authorization`, `PRIVATE-TOKEN` y `GITLAB-URL` llegan sin ninguna línea
+`proxy_set_header`.
+
+</TabItem>
+<TabItem label="Caddy">
+
+```text
+# Caddyfile
+mcp.example.com {
+    reverse_proxy 127.0.0.1:8080 {
+        flush_interval -1
+        transport http {
+            read_timeout 1h
+        }
+    }
+}
+```
+
+Caddy obtiene y renueva el certificado por su cuenta y reenvía las cabeceras de
+petición sin tocarlas, así que casi toda la lista de arriba no necesita
+configuración. `flush_interval -1` desactiva el búfer de respuesta de forma
+explícita: Caddy ya vacía de inmediato para `text/event-stream`, y `-1` hace que
+el comportamiento deje de depender de que el upstream acierte con su tipo de
+contenido.
+
+Caddy pone `X-Forwarded-For` por defecto, así que
+`--trusted-proxy-header=X-Forwarded-For` encaja aquí. Un único bloque de sitio
+cubre todo el host, de modo que la ruta well-known ya queda enrutada.
+
+</TabItem>
+<TabItem label="Traefik">
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mcp.rule=Host(`mcp.example.com`)"
+      - "traefik.http.routers.mcp.entrypoints=websecure"
+      - "traefik.http.routers.mcp.tls.certresolver=le"
+      - "traefik.http.services.mcp.loadbalancer.server.port=8080"
+```
+
+Traefik no hace búfer de las respuestas salvo que se añada un middleware
+`buffering`, así que aquí el arreglo es no añadirlo. Lo que sí requiere atención
+es el timeout de respuesta del entry point, que es global y no por ruta:
+
+```yaml
+entryPoints:
+  websecure:
+    address: ":443"
+    transport:
+      respondingTimeouts:
+        readTimeout: 0
+        idleTimeout: 3m
+```
+
+`readTimeout: 0` elimina el límite de cuánto puede durar una petición. Traefik
+pone `X-Forwarded-For` cuando es el borde, o cuando el salto anterior está en
+`forwardedHeaders.trustedIPs`.
+
+Una regla `Host()` casa con todas las rutas del host, así que el documento
+well-known queda cubierto. Una regla `PathPrefix()` es donde se abre la trampa:
+añade un segundo router para
+`PathPrefix('/.well-known/oauth-protected-resource')` apuntando al mismo
+servicio.
+
+</TabItem>
+<TabItem label="Apache">
+
+```apache
+<VirtualHost *:443>
+    ServerName mcp.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/mcp.example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/mcp.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyPass        / http://127.0.0.1:8080/ flushpackets=on timeout=3600 connectiontimeout=10
+    ProxyPassReverse / http://127.0.0.1:8080/
+
+    RequestHeader set X-Forwarded-Proto "https"
+</VirtualHost>
+```
+
+`flushpackets=on` es la que importa: sin ella `mod_proxy_http` hace búfer del
+cuerpo de la respuesta y el stream llega todo de golpe. `timeout=3600` es el
+timeout de lectura de esta ruta, distinto del `Timeout` global del servidor.
+
+Deja la autenticación al servidor MCP, así que nada de esto debería estar tras
+`Require valid-user`. `mod_remoteip` con `RemoteIPHeader X-Forwarded-For`
+corrige la dirección en los propios registros de Apache, y el servidor MCP sigue
+necesitando `--trusted-proxy-header` para su propio limitador.
+
+Módulos necesarios: `proxy`, `proxy_http`, `ssl`, `headers`, y `remoteip` si lo
+usas.
+
+</TabItem>
+<TabItem label="Túnel de Cloudflare">
+
+Un túnel sustituye por completo al listener entrante: `cloudflared` marca hacia
+fuera, así que la máquina no necesita ningún puerto abierto ni certificado
+propio.
+
+```yaml
+# ~/.cloudflared/config.yml
+tunnel: <uuid-del-tunel>
+credentials-file: /etc/cloudflared/<uuid-del-tunel>.json
+
+ingress:
+  - hostname: mcp.example.com
+    service: http://127.0.0.1:8080
+    originRequest:
+      connectTimeout: 10s
+      disableChunkedEncoding: false
+      noTLSVerify: false
+  - service: http_status:404
+```
+
+Deja `disableChunkedEncoding` en false. Activarlo elimina la transferencia
+troceada hacia el origen, que es lo que necesita un cuerpo SSE.
+
+Cloudflare pone `CF-Connecting-IP`, así que nombra esa:
+`--trusted-proxy-header=CF-Connecting-IP`. Prefiérela a `X-Forwarded-For` aquí,
+porque Cloudflare la reescribe en cada petición y un cliente no puede
+falsificarla a través del borde.
+
+Dos comportamientos de Cloudflare que conviene comprobar antes de culpar al
+servidor. El proxy aplica un límite de inactividad a una respuesta que un stream
+`subscriptions/listen` tranquilo puede alcanzar aunque el keep-alive del
+servidor mantenga la conexión abierta a nivel TCP; y las propias reglas de CORS
+y de caché de Cloudflare, si están activadas para ese nombre, aterrizan
+exactamente en la misma colisión que un `Access-Control-Allow-Origin` puesto por
+el proxy.
+
+</TabItem>
+</Tabs>
+
+## TLS entre el proxy y el servidor
+
+Cuando el proxy comparte máquina, elimina el salto en lugar de cifrarlo:
+`--http-addr=/run/gitlab-mcp/server.sock`. Cuando el proxy está en otro sitio, el
+binario termina TLS por sí mismo y no hace falta ningún sidecar:
+
+```bash
+gitlab-mcp-server --http --http-addr=:8443 \
+  --tls-cert=/etc/ssl/mcp.crt --tls-key=/etc/ssl/mcp.key \
+  --gitlab-url=https://gitlab.example.com
+```
+
+Las dos opciones o ninguna: `--tls-cert requires --tls-key` es un error de
+arranque, no un aviso. TLS 1.2 es el suelo y no hay techo, así que un proxy
+actual negocia 1.3 y todo lo anterior a 1.2 se rechaza.
+
+:::caution[Los certificados se cargan al arrancar]
+
+Un certificado renovado no surte efecto hasta que el proceso se reinicia. No hay
+señal de recarga; las únicas señales atendidas son `SIGINT` y `SIGTERM`, y ambas
+significan apagado. Con certbot, eso es un hook de despliegue:
+
+```bash
+# /etc/letsencrypt/renewal-hooks/deploy/gitlab-mcp-server.sh
+#!/bin/sh
+systemctl restart gitlab-mcp-server
+```
+
+Un reinicio tira el pool y corta los streams abiertos, así que programa la
+renovación donde una reconexión breve sea aceptable, o termina TLS en un proxy
+que sí recargue en caliente.
+
+:::
+
+## Exposición directa, sin proxy
+
+El binario responde sus propios preflight de CORS, sus propios `404`, sus
+propias cabeceras de seguridad, y puede terminar TLS o escuchar en un socket
+unix. Un despliegue sin proxy debería aun así ser deliberado en cinco cosas:
+
+- **`--auth-mode=oauth`.** Verificación del bearer contra la instancia que la
+  petición seleccionó, con metadatos RFC 9728 para que los clientes la
+  descubran. `--public-url` es obligatoria y debe ser el origen https accesible
+  desde fuera.
+- **Los certificados y su renovación.** Se cargan al arrancar, así que renovar
+  significa reiniciar.
+- **Limitación de tasa.** `--rate-limit-rps` vale 10 por defecto en modo HTTP con
+  una ráfaga de 40, contada por token del pool y no por dirección, y un
+  presupuesto aparte por dirección cubre los fallos de autenticación, que es el
+  que responde `429` con `Retry-After`. Un `tools/call` limitado no es un `429`:
+  es un resultado MCP normal que lleva un error, así que no aparecerá en la
+  monitorización a nivel HTTP.
+- **Límites.** `--max-http-clients` acota las entradas del pool, no las sesiones
+  ni las peticiones concurrentes. `--pool-idle-timeout` recupera las que no se
+  usan, y `--session-timeout` solo se aplica al modo con estado.
+- **El token pasa por esta máquina.** El token de GitLab de cada cliente llega a
+  este proceso, autentica una petición y nunca se persiste. Si las personas
+  dueñas de esos tokens consideran de fiar esa máquina es una pregunta que el
+  software no puede responder, así que pregúntaselo en vez de responder por
+  ellas.
+
+## Varias instancias tras un mismo proxy
+
+### La afinidad es estructural, no una preferencia
+
+Cada instancia mantiene dos cachés. Ambas son por proceso, ambas están indexadas
+por quien llama, y ninguna se puede compartir:
+
+- El **pool de servidores**, indexado por
+  `SHA-256(token + "\x00" + urlDeGitLab)`. En un fallo de caché se construye la
+  entrada: se sondean los ámbitos del token, se detecta el nivel de licencia de
+  la instancia y se registra y poda todo un catálogo de herramientas para ese
+  nivel. La construcción del catálogo es el coste entero, medido en **1,8
+  segundos en la superficie dinámica y 3,0 segundos en la individual**, y se
+  paga en la primera petición de cada credencial en lugar de una vez por proceso
+  como lo paga stdio. El saludo inicial se responde de inmediato desde un
+  esqueleto, así que el coste cae en la primera llamada a herramienta y no en
+  `initialize`.
+- La **caché de identidad OAuth**, indexada por instancia y token, con
+  `--oauth-cache-ttl` en 15 minutos por defecto. Un fallo de caché es una ida y
+  vuelta a GitLab para verificar la credencial.
+
+Ambas guardan objetos vivos en lugar de estado serializable, así que no existe
+ninguna versión de esto en la que una segunda instancia lea la caché de la
+primera. La pregunta para un balanceador no es, por tanto, si las peticiones
+funcionarán en cualquier sitio: con el `--stateless=true` por defecto cada POST
+se basta a sí mismo y cualquier instancia responde correctamente. La pregunta es
+cuántas veces estás dispuesto a pagar por una caché pensada para pagarse una.
+
+Dos cosas no solo cuestan de más cuando un cliente se mueve, se rompen. Una
+sesión con estado (`--stateless=false`) vive en el proceso que acuñó su
+`Mcp-Session-Id`, y otra instancia responde a ese identificador con `404`, que un
+cliente lee como que su sesión ha terminado. Las suscripciones a recursos son
+observadores que mantiene un proceso y desaparecen con él.
+
+### Las tres distribuciones
+
+| Distribución   | Clave                               | Lo que cuesta                                                                                                                                                                                                                                                                                                                                                                                     |
+| -------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Round robin    | ninguna                             | Toda instancia acaba con una entrada para cada cliente, así que la memoria del pool se multiplica por el número de instancias y cada cliente paga una construcción de catálogo de 1,8 a 3,0 segundos en cada instancia que toca por primera vez. La verificación del token contra GitLab pasa de una vez por TTL a una vez por TTL y por instancia. Correcto, y paga N veces                      |
+| IP hash        | la dirección del cliente            | Gratis, una directiva, ningún secreto que guardar. La clave es la granularidad equivocada en ambos sentidos: una oficina, un concentrador VPN o una flota de runners de CI es una sola dirección, así que todo eso se agolpa en una instancia, mientras que un cliente que se mueve entre redes cambia de clave y aterriza frío cada vez. Tras una CDN necesita recuperar antes la dirección real |
+| Hash del token | un resumen con sal de la credencial | Encaja con la granularidad de lo que se cachea, porque la clave del pool se deriva del token. Cuesta un secreto que gestionar, un plan alternativo para las peticiones sin credencial y una entrada fría cada vez que un cliente rota su token. Es lo que hace el endpoint alojado                                                                                                                |
+
+El hash del token es la respuesta correcta aquí, y la razón es lo bastante
+concreta como para decirla exacta: lo que se cachea está indexado por el token,
+así que la clave de enrutado también debería estarlo. Ninguna de las otras dos
+está mal, y ambas van bien allí donde una sola instancia atiende a toda la
+población de clientes, que es la mayoría de los despliegues. Ve a por una
+segunda instancia por disponibilidad, no por rendimiento: el techo que suele
+apretar es el propio límite de tasa de GitLab contra un token, que no sube por
+muchas instancias que pongas.
+
+### Resumir el token sin enrutar por él
+
+La credencial no debe convertirse en la clave de enrutado. Una clave de afinidad
+acaba en la memoria del balanceador, en su registro de acceso si el formato
+nombra la variable, y en la selección de upstream que gobierne. Un token bearer
+en crudo en cualquiera de esos sitios es una fuga de credenciales con pasos
+extra.
+
+El arreglo es un resumen con sal: mezcla un secreto propio del despliegue con la
+credencial y enruta por eso. El resumen es una función de distribución más que
+una primitiva de seguridad; la sal es la que hace el trabajo de seguridad. Sin
+ella la clave es una huella del token que cualquiera con un token candidato
+podría confirmar. Con ella la clave no significa nada fuera de este despliegue y
+no se puede reutilizar como credencial.
+
+Tres detalles deciden si la afinidad se sostiene de verdad:
+
+- **Normaliza antes de resumir.** Quita el prefijo de esquema `Bearer` y los
+  espacios alrededor. El mismo token escrito de dos formas resume de dos formas.
+- **Recurre a la dirección, no a nada.** Una clave vacía hace que todas las
+  peticiones anónimas resuman igual y se amontonen en una instancia.
+- **Usa hashing consistente.** Quitar una de tres instancias reubica entonces
+  aproximadamente un tercio de los clientes en lugar de rebarajarlos a todos.
+
+### Un balanceador nginx completo
+
+`hash` acepta una cadena con variables y la resume él mismo, así que la sal entra
+en la expresión de la clave sin llegar a ser nunca una variable registrable por
+su cuenta. Esto no necesita ningún módulo de terceros:
+
+```nginx
+# Mantén la sal fuera del repositorio: inclúyela desde un fichero 0600.
+map $host $mcp_salt {
+    default "una-sal-larga-y-aleatoria-por-despliegue";
+}
+
+# La credencial bearer, sin su prefijo de esquema.
+map $http_authorization $mcp_bearer {
+    default                     "";
+    "~*^Bearer[ ]+(?<tok>\S+)$" $tok;
+}
+
+# Los clientes en modo legacy envían PRIVATE-TOKEN en su lugar.
+map $mcp_bearer $mcp_credential {
+    default $mcp_bearer;
+    ""      $http_private_token;
+}
+
+# Sin credencial: recurre a la dirección del cliente.
+map $mcp_credential $mcp_affinity {
+    default $mcp_credential;
+    ""      $remote_addr;
+}
+
+upstream gitlab_mcp {
+    hash "$mcp_salt$mcp_affinity" consistent;
+    server 10.0.0.11:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.12:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.13:8080 max_fails=2 fail_timeout=10s;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+
+        # Reintenta solo lo que nunca se entregó.
+        proxy_next_upstream error timeout;
+        proxy_next_upstream_tries 2;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+}
+```
+
+No registres `$mcp_affinity` ni `$mcp_credential`. Donde se prefiera un resumen
+explícito, `set_md5 $key "$mcp_salt$mcp_affinity"` de
+`ngx_http_set_misc_module` (OpenResty, o el `nginx-extras` de Debian y Ubuntu)
+produce uno, y njs hace lo mismo en unas pocas líneas. El endpoint alojado en
+`mcp.jmrp.io` calcula así `md5(sal + bearer)`.
+
+:::danger[Nunca añadas `non_idempotent` a `proxy_next_upstream`]
+
+Sin él, nginx reintenta un `POST` en otra instancia solo cuando la petición no
+llegó a enviarse, que es exactamente la garantía que se quiere aquí: un
+`tools/call` que creó una incidencia y luego perdió su respuesta no debe
+repetirse en una segunda instancia. `error timeout` por sí solo es a nivel de
+conexión. Añadir `http_500` o `non_idempotent` convierte una llamada mutadora ya
+entregada en dos.
+
+:::
+
+Demuestra la afinidad en lugar de darla por supuesta. Dos instancias, ocho
+tokens, seis peticiones cada uno, leyendo el backend del registro de acceso:
+
+```bash
+for t in alpha bravo charlie delta echo foxtrot golf hotel; do
+  for _ in $(seq 1 6); do
+    curl -s -o /dev/null -H "Authorization: Bearer token-$t" \
+      https://mcp.example.com/health
+  done
+done
+```
+
+Cada token debe mostrar exactamente un backend a lo largo de sus seis
+peticiones, y los ocho tokens no deben mostrar todos el mismo. Repite el mismo
+bucle sin cabecera `Authorization` y con `PRIVATE-TOKEN` en su lugar, para
+confirmar que ambos planes alternativos también fijan.
+
+### Actualizaciones progresivas, sondas y salida
+
+**Saca la instancia de la rotación antes de señalarla.** El proceso no da ninguna
+señal de vaciado propia: con `SIGTERM` cierra primero el listener, así que
+`/health` deja de responder de inmediato en lugar de informar de mala salud, y
+nunca devuelve `503` de camino a la salida. Las peticiones en vuelo tienen
+después hasta 15 segundos para terminar antes de que se cierren las conexiones
+restantes.
+
+**`/health` es la sonda, y es honesta sobre lo que sabe.** Sin credencial, sin
+ida y vuelta a GitLab, `200` con `status`, `version`, `commit`, `started_at` y
+`uptime_seconds`. `status` es la constante `ok`; el estado HTTP es el que lleva
+la señal de vida. A propósito no comprueba si GitLab está accesible, y no hay un
+endpoint de disponibilidad aparte.
+
+**Dale a la flota una dirección de salida fija.** GitLab aplica sus propios
+límites de tasa y cualquier lista blanca de IP por dirección de origen. Unas
+instancias tras una pasarela NAT con dirección estable son un solo cliente para
+GitLab; unas instancias con direcciones públicas efímeras son varias
+impredecibles.
+
+**Recuerda que el limitador se multiplica.** `--rate-limit-rps` es por entrada de
+token del pool dentro de un proceso, así que tres instancias significan hasta
+tres cubos para un mismo cliente salvo que la afinidad lo fije a uno. Con round
+robin, o lo divides entre el número de instancias o pones el límite real en el
+balanceador.
+
+**La revalidación sigue corriendo por instancia.** `--revalidate-interval`
+vuelve a comprobar las credenciales del pool cada 15 minutos por defecto y
+desaloja las que GitLab ya rechaza; ponerlo a `0` no hace que un token revocado
+dure para siempre, porque una entrada de más de una hora se reconstruye en el
+siguiente uso de todas formas. Eso es por instancia, así que la afinidad lo
+mantiene en una.
+
+## Para seguir leyendo
+
+- [Modo servidor HTTP](/gitlab-mcp-server/operations/http-server/) para cada opción, el pool de servidores y las reglas de derivación de OAuth
+- [Seguridad](/gitlab-mcp-server/operations/security/) para el modelo de amenazas, CORS y la lista de comprobación de fortificación
+- [OpenTelemetry](/gitlab-mcp-server/operations/telemetry/) para lo que una instancia puede contar sobre sí misma
+- [Solución de problemas](/gitlab-mcp-server/operations/troubleshooting/) para síntomas y sus causas habituales
+
+<FAQ />

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -85,7 +85,7 @@ The server starts listening on port 8080 by default. The MCP endpoint is availab
 | `--max-request-body-bytes` | `0`            | Maximum streamable HTTP request body size in bytes; `0` uses the SDK default (4 MiB); negative values are rejected at startup. Oversized bodies are rejected with `413`                                                                                                                     |
 
 :::note
-What `GITLAB-URL` means depends on how many instances the deployment publishes. **None**: only possible with `--allow-any-gitlab-url`, and then the client chooses, with a request naming no instance refused rather than sent to `https://gitlab.com`. **One**: it is authoritative, the header is ignored and logged in `ignored_options`. **Several**: the header is **required** and selects among the published instances. A request that sends none is refused with `400` naming them, because answering it would put the caller's token on the wire to an instance they never named; a value outside the list is **refused** too — `403` in OAuth mode, `400` in legacy — never silently answered with someone else's instance. In OAuth mode every published instance must be `https`, because the bearer token is forwarded to whichever one the request selected.
+What `GITLAB-URL` means depends on how many instances the deployment publishes. **None**: only possible with `--allow-any-gitlab-url`, and then the client chooses, with a request naming no instance refused rather than sent to `https://gitlab.com`. **One**: it is authoritative, the header is ignored and logged in `ignored_options`. **Several**: the header is **required** and selects among the published instances. A request that sends none is refused with `400`, because answering it would put the caller's token on the wire to an instance they never named; the refusal names the published instances in OAuth mode and tells you to ask the operator in legacy mode, so that no non-empty token can enumerate them. A value outside the list is **refused** too — `403` in OAuth mode, `400` in legacy — never silently answered with someone else's instance. In OAuth mode every published instance must be `https`, because the bearer token is forwarded to whichever one the request selected.
 :::
 
 ### Tool and capability surface options
@@ -118,7 +118,7 @@ When the server starts with `--allow-any-gitlab-url` and publishes no instance, 
 GITLAB-URL: https://gitlab.example.com
 ```
 
-If the deployment pins exactly one instance, this header is ignored and logged. If it publishes several, the header picks one of them and any other value is refused. If it pins none and the header is omitted, `https://gitlab.com` is used.
+If the deployment pins exactly one instance, this header is ignored and logged. If it publishes several, the header picks one of them and any other value is refused. If it pins none and the header is omitted, the request is refused with `400` rather than resolved to `https://gitlab.com`.
 
 ### Private-token header (recommended)
 

--- a/site/src/content/docs/operations/remote-deployment.mdx
+++ b/site/src/content/docs/operations/remote-deployment.mdx
@@ -1,0 +1,837 @@
+---
+title: Remote Deployment
+description: "Run GitLab MCP Server for other people: as an OS service, in Docker, behind nginx, Caddy, Traefik, Apache or a Cloudflare Tunnel, and across several instances with token affinity."
+datePublished: "2026-09-04"
+faq:
+  - q: "Can I load-balance several instances round-robin?"
+    a: "It works, and it pays for the same cache several times. Each instance keeps a server pool keyed on a hash of the token and GitLab URL, and an OAuth identity cache keyed on the instance and token. Both are per process and hold live objects, so nothing is shared between instances. A caller that lands on a different instance each request rebuilds a pool entry there (a catalog build measured at 1.8 seconds on the dynamic surface, 3.0 on individual) and re-verifies its token against GitLab. Round robin is correct; it just pays N times. Token affinity pins a caller to the instance that already holds its entry."
+  - q: "Why not just use IP hash for affinity?"
+    a: "Because the address is the wrong grain. An office, a VPN concentrator or a CI runner fleet is one address, so all of it collapses onto one instance; and one caller roaming between networks changes key and lands on a cold instance each time. Behind a CDN the balancer also has to recover the real address first. IP hash is cheap and needs no secret, which is a real advantage, but the thing being cached is keyed on the token, so the routing key should be too."
+  - q: "Do I need a reverse proxy at all?"
+    a: "No. The binary answers its own CORS preflights, its own 404s, its own security headers, and terminates TLS with `--tls-cert` and `--tls-key`. Where a proxy shares the machine, `--http-addr=/run/gitlab-mcp/server.sock` removes the hop instead of encrypting it. A proxy earns its place for certificate renewal without a restart, for hosting other services on the same name, and for balancing several instances."
+  - q: "My OAuth clients get a 404 during discovery. What is wrong?"
+    a: "The proxy is almost certainly routing only the path prefix. The RFC 9728 metadata document lives at the **host root**, not under `--public-url`'s path: started with `--public-url=https://mcp.example.com/gitlab`, the server serves it at `/.well-known/oauth-protected-resource/gitlab` and answers 404 for `/gitlab/.well-known/oauth-protected-resource/gitlab`. `/health` and the server card *are* mounted under the prefix as well; the OAuth metadata is not. Route `/.well-known/oauth-protected-resource` to the same upstream without rewriting it."
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import FAQ from "../../../components/FAQ.astro";
+
+:::tip[At a glance]
+
+- **In HTTP mode the server holds no credential of its own.** Every request carries the caller's token, so there is no server token to hide in a unit file and `/health` needs no authentication.
+- **Nothing here needs a reverse proxy to be correct.** The binary terminates TLS, answers its own CORS preflights, and can listen on a unix socket.
+- **Several instances cannot be balanced round-robin for free.** The server pool and the OAuth identity cache are per process, so a caller that moves rebuilds both. Pin it with token affinity.
+
+:::
+
+[HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) documents the
+transport flag by flag. This page is the other half: how to stand one up for
+other people, on a machine that stays running, reachable from somewhere other
+than the operator's laptop.
+
+Everything here assumes HTTP mode. There is no remote form of stdio: stdio is a
+pipe between one client process and one server process on the same machine, and
+the moment a second person needs to reach it the answer is HTTP.
+
+## Pick a shape first
+
+| Situation                           | Shape                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| One host, proxy and server together | Unix socket: `--http-addr=/run/gitlab-mcp/server.sock`                                                   |
+| Proxy on another host               | `--tls-cert` and `--tls-key` on the listener                                                             |
+| No proxy at all                     | `--tls-cert` and `--tls-key` plus `--auth-mode=oauth`; read [Direct exposure](#direct-exposure-no-proxy) |
+| Containers                          | The published image, read-only root filesystem, digest pin                                               |
+| More than one instance              | A balancer with token affinity: [Several instances](#several-instances-behind-one-proxy)                 |
+
+## Run it as a service
+
+<Tabs>
+<TabItem label="systemd">
+
+Two shapes, and what separates them is whether a same-host proxy has to reach a
+unix socket. **Loopback TCP with a dynamic user** is the least privileged form:
+
+```ini
+# /etc/systemd/system/gitlab-mcp-server.service
+[Unit]
+Description=GitLab MCP Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+DynamicUser=yes
+EnvironmentFile=/etc/gitlab-mcp-server/env
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=127.0.0.1:8080 \
+    --gitlab-url=https://gitlab.example.com \
+    --auth-mode=oauth \
+    --public-url=https://mcp.example.com \
+    --trusted-proxy-header=X-Real-IP
+Restart=on-failure
+RestartSec=2s
+StandardInput=null
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+CapabilityBoundingSet=
+AmbientCapabilities=
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ProtectSystem=strict` mounts the whole filesystem read-only and the server is
+fine with that: it writes nothing to disk. Logs go to standard error, which
+`journald` collects. Reads are unaffected, so certificates and the environment
+file stay readable.
+
+`RestrictAddressFamilies=` deliberately omits `AF_NETLINK`. The released binary
+is built with `CGO_ENABLED=0` and uses Go's own resolver, which reaches DNS over
+UDP and TCP and asks the kernel nothing through netlink. Verified against this
+unit: a credential check that had to resolve and reach `gitlab.com` was answered
+by GitLab with and without `AF_NETLINK` in the list.
+
+**A unix socket needs a fixed user.** `DynamicUser=yes` allocates a transient
+user and group per start, so there is no group the proxy can be added to:
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin gitlab-mcp
+sudo usermod -aG gitlab-mcp www-data   # or nginx, or caddy
+```
+
+```ini
+User=gitlab-mcp
+Group=gitlab-mcp
+RuntimeDirectory=gitlab-mcp
+RuntimeDirectoryMode=0750
+ExecStart=/usr/local/bin/gitlab-mcp-server \
+    --http \
+    --http-addr=/run/gitlab-mcp/server.sock \
+    --http-socket-mode=0660 \
+    --gitlab-url=https://gitlab.example.com
+```
+
+`RuntimeDirectory=` makes `/run/gitlab-mcp` exist, be owned by the service, and
+be removed on stop. It also has to be **writable**: the server does not bind the
+published path directly. It creates a `0700` staging directory beside it, binds
+and chmods the socket there, then links it into place, so a socket only ever
+appears with its final permissions.
+
+</TabItem>
+<TabItem label="launchd">
+
+macOS, as a system daemon under `/Library/LaunchDaemons/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.github.jmrplens.gitlab-mcp-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/gitlab-mcp-server</string>
+        <string>--http</string>
+        <string>--http-addr=127.0.0.1:8080</string>
+        <string>--gitlab-url=https://gitlab.example.com</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>UserName</key>
+    <string>_gitlabmcp</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/gitlab-mcp-server.log</string>
+</dict>
+</plist>
+```
+
+```bash
+sudo launchctl load -w /Library/LaunchDaemons/io.github.jmrplens.gitlab-mcp-server.plist
+sudo launchctl print system/io.github.jmrplens.gitlab-mcp-server
+```
+
+A plist is world-readable, so a secret does not belong in
+`EnvironmentVariables`. Put it in a file the daemon reads instead, named by
+`GITLAB_MCP_ENV_FILE` with an absolute path.
+
+</TabItem>
+<TabItem label="Windows">
+
+`sc.exe create` on its own does not work. The Service Control Manager expects
+the executable it starts to register a service control handler and report back,
+and a plain console binary does not, so the start fails with error 1053, "did
+not respond to the start request in a timely fashion". A service wrapper bridges
+that gap:
+
+```powershell
+nssm install GitLabMcpServer "C:\Program Files\gitlab-mcp-server\gitlab-mcp-server.exe"
+nssm set GitLabMcpServer AppParameters "--http --http-addr=127.0.0.1:8080 --gitlab-url=https://gitlab.example.com"
+nssm set GitLabMcpServer AppStdout "C:\ProgramData\gitlab-mcp-server\out.log"
+nssm set GitLabMcpServer AppStderr "C:\ProgramData\gitlab-mcp-server\err.log"
+nssm set GitLabMcpServer Start SERVICE_AUTO_START
+nssm start GitLabMcpServer
+```
+
+`winget install --id jmrplens.gitlab-mcp-server -e` installs a **user-scope**
+portable package under `%LOCALAPPDATA%\Microsoft\WinGet\Packages\`, reachable
+through a symlink in a per-user `Links` directory. A service does not run as
+that user and must not depend on that path, so add `--scope machine` or copy the
+executable to a machine-wide directory and point the wrapper at the real file
+rather than at the symlink.
+
+`--http-socket-mode` is accepted on Windows and not enforced: the server logs a
+warning and lets the directory ACL decide. Use a TCP listener there.
+
+</TabItem>
+</Tabs>
+
+### Three things every service manager gets wrong
+
+- **State the transport.** `--transport auto` reads file descriptor 0 and picks
+  HTTP only when stdin is `/dev/null`. systemd's default `StandardInput=null`
+  happens to give the same answer, but a unit that sets `StandardInput=socket`
+  or `tty` gets stdio instead. `--http` says what you mean and cannot be moved
+  by how the supervisor wires a file descriptor.
+- **Socket activation is not supported.** A `.socket` unit, or launchd's
+  `Sockets` key, hands the listening socket to the service on file descriptor 0,
+  and this server reads a socket there as "a supervisor handed me a stdio
+  channel". Bind the socket yourself with `--http-addr`.
+- **Secrets belong in an environment file, never on the command line.** A
+  service's command line is readable by any local user. HTTP mode has no GitLab
+  token to hide, but two real secrets exist:
+  `GITLAB_MCP_TELEMETRY_IDENTITY_KEY`, which has no flag for exactly this
+  reason, and whatever `OTEL_EXPORTER_OTLP_HEADERS` carries.
+
+A leftover socket is not always cleaned up for you. On start the server probes
+an existing socket and removes it only when the connection is refused, which
+proves nothing is listening. A live socket is refused rather than stolen, a path
+that is not a socket is never deleted, and a probe that fails for any other
+reason refuses to start and tells you to remove the file by hand.
+
+## Run it with Docker
+
+The image and its command line are described in
+[Docker](/gitlab-mcp-server/install/docker/). What follows is the deployment
+shape.
+
+```bash
+docker run -d --name gitlab-mcp \
+  --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  --read-only \
+  --tmpfs /tmp:rw,size=64m,mode=1777 \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --memory 512m \
+  -e GITLAB_URL=https://gitlab.example.com \
+  ghcr.io/jmrplens/gitlab-mcp-server:2.7.5
+```
+
+**The instance arrives as an environment variable, not an argument.** Any
+argument after the image name replaces `CMD` wholesale, and `CMD` is
+`--transport auto --http-addr 0.0.0.0:8080`. Writing
+`docker run <image> --gitlab-url=…` would silently drop both.
+
+**No `-i`.** `auto` serves HTTP precisely when stdin is `/dev/null`, which is
+what `docker run` without `-i` gives it. Adding `-i` hands the container a pipe,
+which means a client, and the container speaks stdio to nobody.
+
+**`--read-only` works because the image writes nothing at runtime.** The one
+exception is a unix socket, whose bind needs a writable parent directory for the
+staging step described above. The container already runs as `appuser` (uid
+10001), so `--user` is redundant.
+
+**Pin the digest, not only the tag.** A tag can be re-pushed; a digest is what a
+client actually resolves. `2.7.5` and `latest` resolved to
+`sha256:8eec1825b266712cd544bf1b2144e55c1eb711b4540def40e963a664c4e97168` on
+2026-09-01, on `ghcr.io` and on the Docker Hub mirror.
+
+### Compose
+
+```yaml
+services:
+  gitlab-mcp-server:
+    image: ghcr.io/jmrplens/gitlab-mcp-server:2.7.5
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    command:
+      - "--http"
+      - "--http-addr=0.0.0.0:8080"
+      - "--gitlab-url=https://gitlab.example.com"
+      - "--auth-mode=oauth"
+      - "--public-url=https://mcp.example.com"
+      - "--trusted-proxy-header=X-Real-IP"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,size=64m,mode=1777
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    deploy:
+      resources:
+        limits: { memory: 512M, cpus: "2.0" }
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+```
+
+Naming an instance is not optional: HTTP mode exits with `--gitlab-url is
+required in HTTP mode` when none is given, because a deployment that names no
+instance would send whatever token a caller supplied to whatever host that
+caller put in `GITLAB-URL`.
+
+Several flags have **no environment-variable equivalent** and must be arguments:
+`--http-addr`, `--http-socket-mode`, `--tls-cert`, `--tls-key`,
+`--trusted-proxy-header`, `--stateless`, `--json-response`,
+`--http-idle-timeout`, `--max-request-body-bytes` and `--allow-any-gitlab-url`.
+
+The image's own `HEALTHCHECK` is hardcoded to `http://localhost:8080/health`.
+Move the listener to another port, to a unix socket, or behind `--tls-cert`, and
+the container is marked unhealthy while serving perfectly. Restate the check to
+match whatever you changed.
+
+### Secrets
+
+HTTP mode has no GitLab token to inject. What is left is telemetry credentials,
+and those do not belong in `environment:`, which `docker inspect` prints in
+full. Mount the file and name it:
+
+```yaml
+    secrets:
+      - source: mcp_env
+        target: /run/secrets/mcp.env
+    environment:
+      GITLAB_MCP_ENV_FILE: /run/secrets/mcp.env
+
+secrets:
+  mcp_env:
+    file: ./secrets/mcp.env
+```
+
+`GITLAB_MCP_ENV_FILE` is resolved once from the process environment before any
+dotenv file is loaded, so a loaded file cannot nominate another one, and it must
+be an absolute path. It composes with `read_only: true`.
+
+## Behind a reverse proxy
+
+### What every proxy has to get right
+
+| Requirement                     | Why                                                                                                                                                                                           |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No response buffering           | Streamable HTTP answers with `text/event-stream`. A buffering proxy turns a live stream into one delivery at the end                                                                          |
+| Long read timeout               | A `subscriptions/listen` stream is silent between notifications. The server's SSE keep-alive fires every 25 seconds, under nginx's 60-second default, but a quiet stream still wants headroom |
+| HTTP/1.1 upstream               | HTTP/1.0 to the upstream has no chunked transfer, which is what an SSE body uses                                                                                                              |
+| Forward `Authorization`         | OAuth mode reads the bearer token from it; stripping it turns every request into a `401`                                                                                                      |
+| Forward `PRIVATE-TOKEN`         | Legacy mode's header                                                                                                                                                                          |
+| Forward `GITLAB-URL`            | Selects the instance when several are published                                                                                                                                               |
+| Real client address             | `--trusted-proxy-header` names the header the proxy sets, so the authentication-failure limiter counts callers rather than the proxy                                                          |
+| Route `/.well-known/` unchanged | In OAuth mode the RFC 9728 metadata lives at the **host root**, not under the path prefix                                                                                                     |
+| Add no CORS headers             | The server answers preflight itself. Two `Access-Control-Allow-Origin` headers is a CORS failure, not a merge                                                                                 |
+
+:::caution[The metadata path is at the host root]
+
+Started with `--public-url=https://mcp.example.com/gitlab`, the server answers:
+
+| Path                                                  | Result |
+| ----------------------------------------------------- | ------ |
+| `/gitlab/health`, `/health`                           | `200`  |
+| `/gitlab/server-card`, `/server-card`                 | `200`  |
+| `/.well-known/oauth-protected-resource`               | `200`  |
+| `/.well-known/oauth-protected-resource/gitlab`        | `200`  |
+| `/gitlab/.well-known/oauth-protected-resource/gitlab` | `404`  |
+
+`/health` and the server card are mounted under the prefix as well as at the
+root; the OAuth metadata is not, and the `401` challenge points at the host-root
+form. A proxy that routes only `/gitlab` answers `404` for the document every
+OAuth client fetches first, and discovery fails before the MCP endpoint is ever
+reached.
+
+:::
+
+Two more that bite. **Do not let the proxy speak CORS:** the server answers its
+own preflight from `--trusted-origins`, to which the `--public-url` origin is
+added automatically, and a proxy that also emits `Access-Control-Allow-Origin`
+produces two of them, which browsers reject outright while `curl` reports a
+cheerful `200`. And **anything the proxy does not route is a `404`, not a
+`401`**, because the MCP endpoint is mounted on specific patterns rather than as
+a catch-all.
+
+<Tabs>
+<TabItem label="nginx">
+
+```nginx
+upstream gitlab_mcp {
+    server 127.0.0.1:8080;
+    keepalive 16;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name mcp.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/mcp.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcp.example.com/privkey.pem;
+
+    # RFC 9728 metadata: host root, never rewritten.
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+}
+```
+
+Pair it with `--trusted-proxy-header=X-Real-IP`. The server reads the
+**rightmost** entry of the value, which is the hop the nearest trusted proxy
+appended, so a value a client invented on the left is never mistaken for its
+address. With a single nginx in front, the rightmost entry of
+`$proxy_add_x_forwarded_for` is the client; add a second proxy in front of that
+one and it becomes the intermediate proxy instead. `X-Real-IP` set from
+`$remote_addr` at the hop nearest the server has no such ambiguity.
+
+There is no allow-list of proxy addresses behind this flag: setting it trusts
+the header unconditionally, so enable it only where the server cannot be reached
+except through that proxy.
+
+nginx passes client request headers upstream by default, so `Authorization`,
+`PRIVATE-TOKEN` and `GITLAB-URL` arrive with no `proxy_set_header` line.
+
+</TabItem>
+<TabItem label="Caddy">
+
+```text
+# Caddyfile
+mcp.example.com {
+    reverse_proxy 127.0.0.1:8080 {
+        flush_interval -1
+        transport http {
+            read_timeout 1h
+        }
+    }
+}
+```
+
+Caddy obtains and renews the certificate itself and forwards request headers
+unchanged, so most of the list above needs no configuration. `flush_interval -1`
+disables response buffering explicitly: Caddy already flushes immediately for
+`text/event-stream`, and `-1` means the behaviour no longer depends on the
+upstream getting its content type right.
+
+Caddy sets `X-Forwarded-For` by default, so
+`--trusted-proxy-header=X-Forwarded-For` pairs with this. A single site block
+covers the whole host, so the well-known path is already routed.
+
+</TabItem>
+<TabItem label="Traefik">
+
+```yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mcp.rule=Host(`mcp.example.com`)"
+      - "traefik.http.routers.mcp.entrypoints=websecure"
+      - "traefik.http.routers.mcp.tls.certresolver=le"
+      - "traefik.http.services.mcp.loadbalancer.server.port=8080"
+```
+
+Traefik does not buffer responses unless a `buffering` middleware is added, so
+the fix here is to not add one. What does need attention is the entry point's
+responding timeout, which is global rather than per route:
+
+```yaml
+entryPoints:
+  websecure:
+    address: ":443"
+    transport:
+      respondingTimeouts:
+        readTimeout: 0
+        idleTimeout: 3m
+```
+
+`readTimeout: 0` removes the limit on how long a request may take. Traefik sets
+`X-Forwarded-For` when it is the edge, or when the previous hop is listed in
+`forwardedHeaders.trustedIPs`.
+
+A `Host()` rule matches every path on the host, so the well-known document is
+covered. A `PathPrefix()` rule is where the trap opens: add a second router for
+`PathPrefix('/.well-known/oauth-protected-resource')` pointing at the same
+service.
+
+</TabItem>
+<TabItem label="Apache">
+
+```apache
+<VirtualHost *:443>
+    ServerName mcp.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/mcp.example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/mcp.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    ProxyPass        / http://127.0.0.1:8080/ flushpackets=on timeout=3600 connectiontimeout=10
+    ProxyPassReverse / http://127.0.0.1:8080/
+
+    RequestHeader set X-Forwarded-Proto "https"
+</VirtualHost>
+```
+
+`flushpackets=on` is the one that matters: without it `mod_proxy_http` buffers
+the response body and the stream arrives all at once. `timeout=3600` is this
+route's read timeout, separate from the server-wide `Timeout`.
+
+Leave authentication to the MCP server, so nothing here should sit behind
+`Require valid-user`. `mod_remoteip` with `RemoteIPHeader X-Forwarded-For` fixes
+the address in Apache's own logs, and the MCP server still needs
+`--trusted-proxy-header` for its own limiter.
+
+Modules required: `proxy`, `proxy_http`, `ssl`, `headers`, and `remoteip` if you
+use it.
+
+</TabItem>
+<TabItem label="Cloudflare Tunnel">
+
+A tunnel replaces the inbound listener entirely: `cloudflared` dials out, so the
+host needs no open port and no certificate of its own.
+
+```yaml
+# ~/.cloudflared/config.yml
+tunnel: <tunnel-uuid>
+credentials-file: /etc/cloudflared/<tunnel-uuid>.json
+
+ingress:
+  - hostname: mcp.example.com
+    service: http://127.0.0.1:8080
+    originRequest:
+      connectTimeout: 10s
+      disableChunkedEncoding: false
+      noTLSVerify: false
+  - service: http_status:404
+```
+
+Leave `disableChunkedEncoding` false. Setting it removes chunked transfer
+encoding to the origin, which is what an SSE body needs.
+
+Cloudflare sets `CF-Connecting-IP`, so name that one:
+`--trusted-proxy-header=CF-Connecting-IP`. Prefer it over `X-Forwarded-For`
+here, because Cloudflare rewrites it on every request and a client cannot forge
+it through the edge.
+
+Two Cloudflare behaviours to check before blaming the server. The proxy applies
+an inactivity limit to a response that a quiet `subscriptions/listen` stream can
+reach even while the server's keep-alive holds the connection open at the TCP
+level; and Cloudflare's own CORS and caching rules, if enabled for the hostname,
+land in exactly the same collision as a proxy-level
+`Access-Control-Allow-Origin`.
+
+</TabItem>
+</Tabs>
+
+## TLS between the proxy and the server
+
+When the proxy shares the machine, remove the hop rather than encrypting it:
+`--http-addr=/run/gitlab-mcp/server.sock`. When the proxy is elsewhere, the
+binary terminates TLS itself and no sidecar is needed:
+
+```bash
+gitlab-mcp-server --http --http-addr=:8443 \
+  --tls-cert=/etc/ssl/mcp.crt --tls-key=/etc/ssl/mcp.key \
+  --gitlab-url=https://gitlab.example.com
+```
+
+Both flags or neither: `--tls-cert requires --tls-key` is a startup error, not a
+warning. TLS 1.2 is the floor with no ceiling, so a current proxy negotiates 1.3
+and anything below 1.2 is refused.
+
+:::caution[Certificates load at startup]
+
+A renewed certificate does not take effect until the process restarts. There is
+no reload signal; the only signals handled are `SIGINT` and `SIGTERM`, and both
+mean shutdown. With certbot, that is a deploy hook:
+
+```bash
+# /etc/letsencrypt/renewal-hooks/deploy/gitlab-mcp-server.sh
+#!/bin/sh
+systemctl restart gitlab-mcp-server
+```
+
+A restart drops the pool and cuts open streams, so schedule renewal where a
+brief reconnect is acceptable, or terminate TLS at a proxy that reloads in
+place.
+
+:::
+
+## Direct exposure, no proxy
+
+The binary answers its own CORS preflights, its own `404`s, its own security
+headers, and can terminate TLS or listen on a unix socket. A deployment without
+a proxy should still be deliberate about five things:
+
+- **`--auth-mode=oauth`.** Bearer verification against the instance the request
+  selected, with RFC 9728 metadata so clients discover it. `--public-url` is
+  required and must be the externally reachable https origin.
+- **Certificates and their renewal.** Loaded at startup, so renewal means a
+  restart.
+- **Rate limiting.** `--rate-limit-rps` defaults to 10 in HTTP mode with a burst
+  of 40, counted per pooled token rather than per address, and a separate
+  per-address budget covers authentication failures, which is the one that
+  answers `429` with `Retry-After`. A throttled `tools/call` is not a `429`: it
+  is a normal MCP result carrying an error, so it will not show up in HTTP-level
+  monitoring.
+- **Bounds.** `--max-http-clients` caps pooled entries, not sessions or
+  concurrent requests. `--pool-idle-timeout` reclaims unused ones, and
+  `--session-timeout` applies to stateful mode only.
+- **The token passes through the box.** Every caller's GitLab token reaches this
+  process, authenticates one request, and is never persisted. Whether the people
+  whose tokens they are consider the machine trustworthy is a question the
+  software cannot answer, so ask them rather than answering for them.
+
+## Several instances behind one proxy
+
+### Affinity is structural, not a preference
+
+Each instance keeps two caches. Both are per process, both are keyed on the
+caller, and neither can be shared:
+
+- The **server pool**, keyed on `SHA-256(token + "\x00" + gitlabURL)`. On a miss
+  the entry is built: the token's scopes are probed, the instance's licensing
+  tier is detected, and a whole tool catalog is registered and pruned to that
+  tier. The catalog build is the entire cost, measured at **1.8 seconds on the
+  dynamic surface and 3.0 seconds on individual**, and it is paid on the first
+  request of every credential rather than once per process the way stdio pays
+  it. The handshake is answered immediately from a shell, so the cost lands on
+  the first tool call rather than on `initialize`.
+- The **OAuth identity cache**, keyed on instance and token, with
+  `--oauth-cache-ttl` at 15 minutes by default. A miss is a round trip to GitLab
+  to verify the credential.
+
+Both hold live objects rather than serializable state, so there is no version of
+this where a second instance reads the first one's cache. The question for a
+balancer is therefore not whether requests will work anywhere: under the default
+`--stateless=true` every POST is self-contained and every instance answers
+correctly. The question is how many times you are willing to pay for a cache
+designed to be paid once.
+
+Two things do not merely cost extra when a caller moves, they break. A stateful
+session (`--stateless=false`) lives in the process that minted its
+`Mcp-Session-Id`, and another instance answers that id with `404`, which a
+client reads as its session having been terminated. Resource subscriptions are
+watchers held by one process and disappear with it.
+
+### The three distributions
+
+| Distribution | Key                               | What it costs                                                                                                                                                                                                                                                                                                                              |
+| ------------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Round robin  | none                              | Every instance eventually holds an entry for every caller, so pool memory multiplies by the instance count and each caller pays a 1.8 to 3.0 second catalog build on each instance it first touches. Token verification against GitLab goes from once per cache TTL to roughly once per TTL per instance. Correct, and pays N times over   |
+| IP hash      | the client address                | Free, one directive, no secret to keep. The key is the wrong grain in both directions: an office, a VPN concentrator or a CI runner fleet is one address, so all of it collapses onto one instance, while one caller roaming between networks changes key and lands cold each time. Behind a CDN it needs the real address recovered first |
+| Token hash   | a salted digest of the credential | Matches the grain of what is cached, because the pool key is derived from the token. Costs one secret to manage, a fallback for credential-less requests, and one cold entry whenever a caller rotates its token. This is what the hosted endpoint runs                                                                                    |
+
+Token hash is the right answer here, and the reason is narrow enough to state
+exactly: the thing being cached is keyed on the token, so the routing key should
+be too. Neither of the others is wrong, and both are fine wherever one instance
+serves the whole caller population, which is most deployments. Reach for a
+second instance for availability, not for throughput: the ceiling that usually
+binds is GitLab's own rate limit against one token, which no number of instances
+raises.
+
+### Hashing the token without routing on it
+
+The credential must not become the routing key. An affinity key ends up in the
+balancer's memory, in its access log if the log format names the variable, and
+in whatever upstream selection it drives. A raw bearer token in any of those is
+a credential leak with extra steps.
+
+The fix is a salted digest: hash a per-deployment secret together with the
+credential, and route on that. The digest is a distribution function rather than
+a security primitive; the salt is what does the security work. Without it the
+key is a token fingerprint that anyone holding a candidate token could confirm.
+With it the key is meaningless outside this deployment and cannot be replayed as
+a credential.
+
+Three details decide whether the affinity actually holds:
+
+- **Normalize before hashing.** Strip the `Bearer` scheme prefix and surrounding
+  whitespace. The same token spelled two ways hashes two ways.
+- **Fall back to the address, not to nothing.** An empty key makes every
+  anonymous request hash identically onto one instance.
+- **Use consistent hashing.** Removing one of three instances then relocates
+  roughly a third of the callers instead of reshuffling all of them.
+
+### A worked nginx balancer
+
+`hash` accepts a string with variables and hashes it itself, so the salt goes
+into the key expression without ever becoming a loggable variable of its own.
+This needs no third-party module:
+
+```nginx
+# Keep the salt out of the repository: include it from a 0600 file.
+map $host $mcp_salt {
+    default "a-long-random-per-deployment-salt";
+}
+
+# The bearer credential, without its scheme prefix.
+map $http_authorization $mcp_bearer {
+    default                     "";
+    "~*^Bearer[ ]+(?<tok>\S+)$" $tok;
+}
+
+# Legacy-mode callers send PRIVATE-TOKEN instead.
+map $mcp_bearer $mcp_credential {
+    default $mcp_bearer;
+    ""      $http_private_token;
+}
+
+# No credential: fall back to the client address.
+map $mcp_credential $mcp_affinity {
+    default $mcp_credential;
+    ""      $remote_addr;
+}
+
+upstream gitlab_mcp {
+    hash "$mcp_salt$mcp_affinity" consistent;
+    server 10.0.0.11:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.12:8080 max_fails=2 fail_timeout=10s;
+    server 10.0.0.13:8080 max_fails=2 fail_timeout=10s;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl;
+    server_name mcp.example.com;
+
+    location / {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+
+        # Retry only what was never delivered.
+        proxy_next_upstream error timeout;
+        proxy_next_upstream_tries 2;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        proxy_pass http://gitlab_mcp;
+        proxy_http_version 1.1;
+    }
+}
+```
+
+Do not log `$mcp_affinity` or `$mcp_credential`. Where an explicit digest is
+preferred, `set_md5 $key "$mcp_salt$mcp_affinity"` from
+`ngx_http_set_misc_module` (OpenResty, or Debian and Ubuntu's `nginx-extras`)
+produces one, and njs does the same in a few lines. The hosted endpoint at
+`mcp.jmrp.io` computes `md5(salt + bearer)` that way.
+
+:::danger[Never add `non_idempotent` to `proxy_next_upstream`]
+
+Without it, nginx retries a `POST` on another instance only when the request was
+never sent, which is exactly the guarantee wanted here: a `tools/call` that
+created an issue and then lost its response must not be replayed on a second
+instance. `error timeout` on its own is connection-level. Adding `http_500` or
+`non_idempotent` turns one delivered mutating call into two.
+
+:::
+
+Prove the affinity rather than assuming it. Two instances, eight tokens, six
+requests each, reading the backend out of the access log:
+
+```bash
+for t in alpha bravo charlie delta echo foxtrot golf hotel; do
+  for _ in $(seq 1 6); do
+    curl -s -o /dev/null -H "Authorization: Bearer token-$t" \
+      https://mcp.example.com/health
+  done
+done
+```
+
+Every token must show exactly one backend across its six requests, and the eight
+tokens must not all show the same one. Run the same loop with no `Authorization`
+header and with `PRIVATE-TOKEN` instead, to confirm both fallbacks pin as well.
+
+### Rolling updates, probes and egress
+
+**Take an instance out of rotation before you signal it.** The process gives no
+draining signal of its own: on `SIGTERM` it closes the listener first, so
+`/health` stops answering immediately rather than reporting unhealthy, and it
+never returns `503` on the way down. In-flight requests then get up to 15
+seconds to finish before the remaining connections are closed.
+
+**`/health` is the probe, and it is honest about what it knows.** No credential,
+no GitLab round trip, `200` with `status`, `version`, `commit`, `started_at` and
+`uptime_seconds`. `status` is the constant `ok`; the HTTP status carries
+liveness. It deliberately does not test GitLab reachability, and there is no
+separate readiness endpoint.
+
+**Give the fleet a fixed egress address.** GitLab applies its own rate limits and
+any IP allow-lists per source address. Instances behind a NAT gateway with a
+stable address are one caller to GitLab; instances with ephemeral public
+addresses are several unpredictable ones.
+
+**Remember the limiter multiplies.** `--rate-limit-rps` is per pooled token
+entry inside one process, so three instances mean up to three buckets for one
+caller unless affinity pins it to one. Under round robin, either divide it by
+the instance count or put the real limit on the balancer.
+
+**Revalidation keeps running per instance.** `--revalidate-interval` re-checks
+pooled credentials every 15 minutes by default and evicts the ones GitLab now
+rejects; setting it to `0` does not make a revoked token last forever, because
+an entry older than an hour is rebuilt on next use anyway. That is per instance,
+so affinity keeps it to one.
+
+## Further reading
+
+- [HTTP Server Mode](/gitlab-mcp-server/operations/http-server/) for every flag, the server pool, and the OAuth derivation rules
+- [Security](/gitlab-mcp-server/operations/security/) for the threat model, CORS, and the hardening checklist
+- [OpenTelemetry](/gitlab-mcp-server/operations/telemetry/) for what an instance can report about itself
+- [Troubleshooting](/gitlab-mcp-server/operations/troubleshooting/) for symptoms and their usual causes
+
+<FAQ />


### PR DESCRIPTION
HTTP mode has been documented flag by flag for a long time and never as a deployment, so anyone wanting to run this server for other people had to assemble the answer out of a reference page, a security page and their own guesswork. This adds the missing guide: running it as an OS service under systemd, launchd and a Windows service wrapper, running it in Docker, putting it behind nginx, Caddy, Traefik, Apache or a Cloudflare Tunnel, terminating TLS between the proxy and the server or doing without a proxy altogether, and balancing several instances. It lands as `docs/guides/remote-deployment.md` for the developer docs and as `operations/remote-deployment` on the site in both languages, in the existing Operations section rather than a new one of its own.

The balancing part is the reason the issue existed rather than being a template dump, and it is the part I most wanted written down. Each instance keeps a server pool keyed on a hash of the token and the GitLab URL, and an OAuth identity cache keyed on the instance and the token. Both are per process and both hold live objects, so there is no version of this where a second instance reads the first one's cache. A caller that lands somewhere new pays a catalog build that the code itself measures at 1.8 seconds on the dynamic surface and 3.0 seconds on individual, and re-verifies its token against GitLab. So round robin is correct and pays N times over, IP hash is free and needs no secret but keys on the wrong grain in both directions, and hashing a salted digest of the credential matches the grain of what is actually cached, which is what the hosted endpoint does. The guide gives all three with what each one costs instead of naming a winner and moving on, and it says plainly that one instance is the right answer for most deployments and that a second one buys availability rather than throughput.

I ran everything I asserted against the binary rather than taking it from a generic guide, and three things changed as a result. The systemd hardening block does not need `AF_NETLINK` after all: the released binary is `CGO_ENABLED=0` and uses Go's own resolver, and a credential check that had to resolve and reach gitlab.com was answered by GitLab with and without it in the list. `/health` and the server card are mounted under the `--public-url` path prefix but the RFC 9728 metadata is not, so a proxy routing only the prefix answers 404 to the one document every OAuth client fetches first, which is the single most likely way to get a working deployment that no OAuth client can reach. And the process gives no draining signal at all: `SIGTERM` closes the listener before anything else, so `/health` stops answering rather than reporting unhealthy and no 503 is ever returned, which makes removal from the balancer something that has to happen before the signal rather than something the probe will notice on its own.

The two-instance affinity check the guide describes is one I actually ran: two instances behind an nginx consistent hash over a salt plus the credential, eight tokens, six requests each. Every token landed on exactly one backend and the eight spread across both, and the no-credential and `PRIVATE-TOKEN` fallbacks pinned the same way. The nginx form in the guide is the stock one, since `hash` accepts a string with variables and hashes it itself, which keeps the salt out of any loggable variable without needing a third-party module; the explicit `md5` variant is mentioned for where one is preferred. I also verified the socket mode, the TLS floor and its 1.3 negotiation, both half-configured-TLS refusals, the `--gitlab-url` refusal, the fact that a `--http-addr` value with no path separator is read as a hostname, and the full systemd hardening block starting and serving.

A second commit fixes something I found while writing the guide and had initially only steered around, which was the wrong call: the instance table in the HTTP server guide claimed that a deployment publishing no instance resolves a headerless request to public gitlab.com, and that one publishing several resolves it to the first. Both are refusals. I confirmed every cell by running it rather than by reading the code, because the table describes several instance counts and only some of them were wrong. Publishing none with `--allow-any-gitlab-url` and sending no header returns 400, publishing two and sending no header returns 400, and the other five cells were right: with none published a header naming any host is honored, with one the header is ignored either way, and with several a published name is honored while anything else is refused with 403 under OAuth and 400 under legacy. The 401s that came back in the honored cases are GitLab rejecting a deliberately invalid token, which is what proves the request actually reached the instance the cell claims. Two smaller things fell out of that: the missing-header refusal is 400 in both auth modes and only its message differs, since OAuth names the published instances while legacy tells you to ask the operator so that a non-empty token cannot enumerate them, and the sentence introducing the table called the first entry the deployment's default, which is what the wrong row rested on.

That same claim lives on the Starlight pages as prose rather than as a table, and the two locales had drifted in opposite directions: the English summary was right and its later sentence wrong, the Spanish the other way round. Both are corrected, and the Spanish summary gains the several-instances refusal that only the English carried.

Gates, re-run after that second commit: `pnpm run i18n:check`, `pnpm run build` (zero errors and zero warnings, internal links validated), `markdownlint-cli2` on every changed file, `go run ./cmd/format_md_tables/ --check`, `go run ./cmd/audit_doc_tool_names/ --check`, `make check-site-stats`, plus the site's `facts:check`, `chips:check`, `llms:check`, `a11y:check`, `eslint` and `format:check`. No Go code is touched. The one non-content change is adding the new slug to `SECTIONS` in `site/scripts/gen-llms.mjs`, which the llms index gate requires for any new page.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/355

## Summary by Sourcery

Provide a complete, security-conscious remote deployment guide and correct the documented GitLab instance-selection behavior across all documentation.

New Features:
- Add comprehensive remote deployment guidance covering OS services, Docker, reverse proxies, TLS, direct exposure, and multi-instance balancing in English and Spanish documentation.

Bug Fixes:
- Correct HTTP instance-selection documentation so requests without a required GitLab URL are refused instead of falling back to an unintended instance.
- Align English and Spanish site documentation with the corrected multi-instance and missing-header behavior.

Enhancements:
- Document token-affinity trade-offs, proxy requirements, OAuth metadata routing, health checks, graceful instance removal, and secure credential hashing for multi-instance deployments.

Documentation:
- Add the remote deployment guide to the developer guides and Operations section of the site, including localized content and deployment examples for systemd, launchd, Windows services, Docker, nginx, Caddy, Traefik, Apache, and Cloudflare Tunnel.

Chores:
- Register the new Operations page in the generated LLM documentation sections.