### PR TITLE
Bound two unbounded downloads and let --exclude-tools reach the prompt surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,21 +459,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,048 |     221,593 |
-| Unit tests (`_test.go`)  |       618 |     363,032 |
-| End-to-end tests         |       223 |      60,624 |
-| **Total**                | **1,889** | **645,249** |
+| Source (`.go`, non-test) |     1,049 |     221,856 |
+| Unit tests (`_test.go`)  |       619 |     363,342 |
+| End-to-end tests         |       223 |      60,462 |
+| **Total**                | **1,891** | **645,660** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,321 |
+| Source functions                |  8,324 |
 | . Exported (public)             |  2,791 |
-| . Unexported (private)          |  5,530 |
-| Unit test functions (`TestXxx`) | 12,965 |
-| Subtests (`t.Run(...)`)         |  4,786 |
-| End-to-end test functions       |    566 |
+| . Unexported (private)          |  5,533 |
+| Unit test functions (`TestXxx`) | 12,971 |
+| Subtests (`t.Run(...)`)         |  4,789 |
+| End-to-end test functions       |    565 |
 
 ### Ratios worth noting
 
@@ -481,17 +481,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~587 lines |
-| Comment lines in source            |  33,268 (~15.0% of source) |
+| Average test file length           |                 ~586 lines |
+| Comment lines in source            |  33,390 (~15.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,975 |
+| `if err != nil` checks             | 6,978 |
 | `defer` statements                 | 1,139 |
-| `struct` types defined             | 2,839 |
+| `struct` types defined             | 2,841 |
 | `//nolint` suppressions            |   271 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -507,15 +507,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,528 lines      |
+| Longest source file | `cmd/server/main.go`. 4,523 lines      |
 | Longest test file   | `cmd/server/main_test.go`. 9,018 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,028 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,253 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,033 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,265 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,049 |     221,913 |
-| Unit tests (`_test.go`)  |       619 |     363,421 |
+| Unit tests (`_test.go`)  |       619 |     363,434 |
 | End-to-end tests         |       223 |      60,624 |
-| **Total**                | **1,891** | **645,958** |
+| **Total**                | **1,891** | **645,971** |
 
 ### Functions
 

--- a/README.md
+++ b/README.md
@@ -459,21 +459,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,049 |     221,856 |
-| Unit tests (`_test.go`)  |       619 |     363,342 |
-| End-to-end tests         |       223 |      60,462 |
-| **Total**                | **1,891** | **645,660** |
+| Source (`.go`, non-test) |     1,049 |     221,913 |
+| Unit tests (`_test.go`)  |       619 |     363,421 |
+| End-to-end tests         |       223 |      60,624 |
+| **Total**                | **1,891** | **645,958** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,324 |
-| . Exported (public)             |  2,791 |
-| . Unexported (private)          |  5,533 |
-| Unit test functions (`TestXxx`) | 12,971 |
-| Subtests (`t.Run(...)`)         |  4,789 |
-| End-to-end test functions       |    565 |
+| Source functions                |  8,326 |
+| . Exported (public)             |  2,792 |
+| . Unexported (private)          |  5,534 |
+| Unit test functions (`TestXxx`) | 12,973 |
+| Subtests (`t.Run(...)`)         |  4,795 |
+| End-to-end test functions       |    566 |
 
 ### Ratios worth noting
 
@@ -481,15 +481,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~211 lines |
-| Average test file length           |                 ~586 lines |
-| Comment lines in source            |  33,390 (~15.1% of source) |
+| Average test file length           |                 ~587 lines |
+| Comment lines in source            |  33,436 (~15.1% of source) |
 | Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 6,978 |
+| `if err != nil` checks             | 6,981 |
 | `defer` statements                 | 1,139 |
 | `struct` types defined             | 2,841 |
 | `//nolint` suppressions            |   271 |
@@ -507,15 +507,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                   |
 | ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,523 lines      |
+| Longest source file | `cmd/server/main.go`. 4,534 lines      |
 | Longest test file   | `cmd/server/main_test.go`. 9,018 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,033 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,265 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,034 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,267 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1890,7 +1890,13 @@ func registerConfiguredCapabilities(
 	if capabilitySurface == config.CapabilitySurfaceFull {
 		resources.Register(server, client, resources.RegisterOptions{ExcludedActions: excludedActions})
 		resources.RegisterWorkflowGuides(server)
-		prompts.Register(server, client)
+		// Prompts take the same exclusions as resources, and for the same
+		// reason: a prompt is a third request path carrying the same
+		// credential, so a prompt that serves data from an excluded action
+		// would be a way around --exclude-tools rather than a separate
+		// feature. The mechanism arrived with the prompt surface's own
+		// change; this is the line that makes it take effect in the binary.
+		prompts.Register(server, client, prompts.RegisterOptions{ExcludedActions: excludedActions})
 	}
 }
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,11 +18,11 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,531 |
-| Unit test functions                                   | 12,965 |
-| E2E test functions                                    |    566 |
+| Total test functions                                  | 13,536 |
+| Unit test functions                                   | 12,971 |
+| E2E test functions                                    |    565 |
 | cmd test functions                                    |  2,047 |
-| Test files (internal/)                                |    498 |
+| Test files (internal/)                                |    499 |
 | Test files (cmd/)                                     |    120 |
 | Test files (test/e2e/)                                |    221 |
 | Tool sub-packages tested                              |    175 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,258 | 83.2% |
+| `TestFunc_Scenario` (2-part)           | 11,261 | 83.2% |
 | `TestFunc` (no underscore)             |    968 |  7.2% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,305 |  9.6% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,307 |  9.7% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,184 |        131 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,185 |        132 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (175) |          8,433 |        354 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            566 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| Tool sub-packages (175) |          8,438 |        354 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            565 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,047 |        120 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,531** |    **839** |                                                                                                 |
+| **Total**               |     **13,536** |    **840** |                                                                                                 |
 
 ### Core Packages
 
@@ -68,22 +68,22 @@
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        71 |    98.9% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        70 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        68 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
-| prompts       |       272 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
+| prompts       |       275 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
 | serverpool    |        91 |    98.3% | Package serverpool manages a pool of MCP servers keyed by GitLab token and URL.                                                                                                                                                                                    |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       793 |    98.4% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,184** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,185** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
 | Sub-package       | Tests | Coverage | Tools |
 | ----------------- | ----: | -------: | ----: |
-| projects          |   390 |   100.0% |    57 |
+| projects          |   392 |   100.0% |    57 |
 | groups            |   249 |   100.0% |    37 |
 | mergerequests     |   242 |   100.0% |    30 |
 | issues            |   223 |   100.0% |    21 |
@@ -246,7 +246,7 @@
 | projectimportexport     |        40 |          1 |    99.5% |         5 |
 | projectiterations       |        18 |          1 |   100.0% |         1 |
 | projectmirrors          |        63 |          2 |   100.0% |         7 |
-| projects                |       390 |          6 |   100.0% |        57 |
+| projects                |       392 |          6 |   100.0% |        57 |
 | projectserviceaccounts  |        11 |          2 |   100.0% |         8 |
 | projectstatistics       |         8 |          2 |   100.0% |         1 |
 | projectstoragemoves     |        19 |          2 |   100.0% |         6 |
@@ -282,7 +282,7 @@
 | todos                   |        35 |          2 |   100.0% |         3 |
 | topics                  |        29 |          2 |   100.0% |         5 |
 | uploads                 |        49 |          2 |   100.0% |         4 |
-| usagedata               |        28 |          1 |   100.0% |         6 |
+| usagedata               |        31 |          1 |   100.0% |         6 |
 | useremails              |        24 |          2 |   100.0% |         6 |
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       210 |          7 |   100.0% |        38 |
@@ -291,7 +291,7 @@
 | wikis                   |        60 |          2 |   100.0% |         6 |
 | workitems               |        95 |          3 |   100.0% |         6 |
 | workitemsavedviews      |        49 |          4 |   100.0% |         7 |
-| **Total**               | **8,433** |    **354** |          | **1,175** |
+| **Total**               | **8,438** |    **354** |          | **1,175** |
 
 </details>
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,9 +18,9 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,536 |
-| Unit test functions                                   | 12,971 |
-| E2E test functions                                    |    565 |
+| Total test functions                                  | 13,539 |
+| Unit test functions                                   | 12,973 |
+| E2E test functions                                    |    566 |
 | cmd test functions                                    |  2,047 |
 | Test files (internal/)                                |    499 |
 | Test files (cmd/)                                     |    120 |
@@ -35,8 +35,8 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,261 | 83.2% |
-| `TestFunc` (no underscore)             |    968 |  7.2% |
+| `TestFunc_Scenario` (2-part)           | 11,264 | 83.2% |
+| `TestFunc` (no underscore)             |    968 |  7.1% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,307 |  9.7% |
 
 ## Test Distribution
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,185 |        132 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,187 |        132 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            301 |         13 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (175) |          8,438 |        354 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            565 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| E2E integration         |            566 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,047 |        120 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,536** |    **840** |                                                                                                 |
+| **Total**               |     **13,539** |    **840** |                                                                                                 |
 
 ### Core Packages
 
@@ -68,7 +68,7 @@
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        71 |    98.9% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        68 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        70 |    98.4% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       275 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |    99.4% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
@@ -77,7 +77,7 @@
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       793 |    98.4% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,185** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,187** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/docs/development/token-footprint.md
+++ b/docs/development/token-footprint.md
@@ -37,7 +37,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Free/CE  |            33 |               858 | `compact`                      |            191,524 |           170 |      191,694 |
 | `meta` / `full` (full)       | Free/CE  |            33 |               858 | `full`                         |            283,429 |         8,832 |      292,261 |
 | `meta` / `minimal` (full)    | Free/CE  |            33 |               858 | `full`                         |            283,429 |           170 |      283,599 |
-| `individual` / `full`        | Free/CE  |           854 |               854 | n/a                            |            501,753 |         8,832 |      510,585 |
+| `individual` / `full`        | Free/CE  |           854 |               854 | n/a                            |            501,763 |         8,832 |      510,595 |
 | `dynamic` / `full` (default) | Premium  |             2 |             1,011 | n/a                            |              1,501 |         8,832 |       10,333 |
 | `dynamic` / `minimal`        | Premium  |             2 |             1,011 | n/a                            |              1,501 |           170 |        1,671 |
 | `meta` / `full` (opaque)     | Premium  |            39 |             1,011 | `opaque`                       |            144,656 |         8,832 |      153,488 |
@@ -46,7 +46,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Premium  |            39 |             1,011 | `compact`                      |            222,477 |           170 |      222,647 |
 | `meta` / `full` (full)       | Premium  |            39 |             1,011 | `full`                         |            328,694 |         8,832 |      337,526 |
 | `meta` / `minimal` (full)    | Premium  |            39 |             1,011 | `full`                         |            328,694 |           170 |      328,864 |
-| `individual` / `full`        | Premium  |         1,007 |             1,007 | n/a                            |            600,492 |         8,832 |      609,324 |
+| `individual` / `full`        | Premium  |         1,007 |             1,007 | n/a                            |            600,502 |         8,832 |      609,334 |
 | `dynamic` / `full` (default) | Ultimate |             2 |             1,077 | n/a                            |              1,501 |         8,832 |       10,333 |
 | `dynamic` / `minimal`        | Ultimate |             2 |             1,077 | n/a                            |              1,501 |           170 |        1,671 |
 | `meta` / `full` (opaque)     | Ultimate |            50 |             1,077 | `opaque`                       |            156,570 |         8,832 |      165,402 |
@@ -55,7 +55,7 @@ All measurements are against the current source tree. The catalog is built in-me
 | `meta` / `minimal` (compact) | Ultimate |            50 |             1,077 | `compact`                      |            238,812 |           170 |      238,982 |
 | `meta` / `full` (full)       | Ultimate |            50 |             1,077 | `full`                         |            349,854 |         8,832 |      358,686 |
 | `meta` / `minimal` (full)    | Ultimate |            50 |             1,077 | `full`                         |            349,854 |           170 |      350,024 |
-| `individual` / `full`        | Ultimate |         1,073 |             1,073 | n/a                            |            629,506 |         8,832 |      638,338 |
+| `individual` / `full`        | Ultimate |         1,073 |             1,073 | n/a                            |            629,516 |         8,832 |      638,348 |
 
 ## Interpretation guide
 

--- a/internal/prompts/doc.go
+++ b/internal/prompts/doc.go
@@ -20,4 +20,19 @@
 // [Register] adds every prompt template to an MCP server. Prompt handlers use
 // shared helpers in this package to keep GitLab API access, pagination, and
 // Markdown assembly consistent across prompt families.
+//
+// # Narrowing
+//
+// A prompt is a third request path to data a tool also returns, running handler
+// code with the same credential, so the operator's --exclude-tools must reach
+// it: [RegisterOptions] carries the excluded catalog actions and
+// promptBackingActions is the table relating the two surfaces. This mirrors the
+// resource surface exactly, and for the same reason: exclusion is the
+// recommended mitigation for a tool, and a mitigation that covers one of three
+// paths is not one.
+//
+// One control still does not reach this surface, because it is applied where
+// tools are registered rather than here: the tools/call rate limiter does not
+// meter prompts/get, so a prompt remains an unmetered proxy to GitLab. It is
+// noted so the silence does not read as coverage.
 package prompts

--- a/internal/prompts/exclusion.go
+++ b/internal/prompts/exclusion.go
@@ -1,0 +1,191 @@
+package prompts
+
+import (
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// registrar is the subset of *mcp.Server that prompt registration uses.
+//
+// The registration helpers take this interface rather than the concrete server
+// so a wrapper can decide, per prompt, whether the call reaches the server at
+// all. That is the only place the decision fits: every prompt in this package
+// is registered through [addPrompt], and a filter there covers all 37 without
+// any of them knowing it exists.
+type registrar interface {
+	AddPrompt(prompt *mcp.Prompt, handler mcp.PromptHandler)
+}
+
+// RegisterOptions narrows the prompt surface the way --exclude-tools narrows
+// the tool surface.
+//
+// Prompts were the third request path to GitLab and the last one an operator
+// could not narrow. A prompt runs handler code holding the caller's credential
+// and returns the same data a tool would: review_mr reads the merge request and
+// its diffs, team_overview reads a group's members. So an operator who excluded
+// gitlab_mr_changes_get removed it from tools/list and from resources/read, and
+// was still served the identical diffs by asking for the review_mr prompt. That
+// mattered most where exclusion is the recommended mitigation for a tool, since
+// the mitigation covered two thirds of the ways to reach it.
+type RegisterOptions struct {
+	// ExcludedActions holds canonical catalog action IDs ("merge_request.get")
+	// the operator removed on the active surface.
+	//
+	// Canonical IDs rather than tool names on purpose, and for the reason
+	// [resources.RegisterOptions] gives: --exclude-tools accepts a group name,
+	// an individual tool name or an action ID, and only the action catalog can
+	// resolve those three spellings to the same action. The caller resolves
+	// them once against the catalog it just filtered, so this package needs one
+	// table keyed by one kind of name.
+	ExcludedActions []string
+}
+
+// promptBackingActions maps every prompt this package registers to the
+// canonical catalog actions that return the same GitLab data through a tool.
+//
+// Hand-kept, like the resource table it mirrors, because nothing relates a
+// prompt to the actions its handler calls: the handlers reach the GitLab client
+// directly rather than dispatching through the catalog, so the relationship
+// exists only in what the code does. Keeping it here, beside [Register], is
+// also the point: it is the one place a reviewer can see which tools a prompt
+// duplicates. Two tests hold it honest, one failing when a registered prompt is
+// missing from the table and the other when an action ID in it is not in the
+// real catalog.
+//
+// A prompt lists every action whose data it reads, not just its headline one.
+// project_health_check reads the project, its latest pipeline, its merge
+// requests and its branches, and an operator who excluded any one of those
+// asked for that data not to be reachable.
+var promptBackingActions = map[string][]string{
+	// Project prompts.
+	"summarize_mr_changes":      {"mr_review.changes_get"},
+	"review_mr":                 {"merge_request.get", "mr_review.changes_get"},
+	"summarize_pipeline_status": {"pipeline.latest", "job.list"},
+	"suggest_mr_reviewers":      {"project.members"},
+	"generate_release_notes":    {"repository.compare"},
+	"summarize_open_mrs":        {"merge_request.list"},
+	"project_health_check":      {"project.get", "pipeline.latest", "merge_request.list", "branch.list"},
+	"compare_branches":          {"repository.compare"},
+	"daily_standup":             {"user.event_list_contributions", "user.contribution_events", "merge_request.list", "issue.list"},
+	"mr_risk_assessment":        {"merge_request.get", "mr_review.changes_get"},
+	"team_member_workload":      {"merge_request.list", "issue.list"},
+	"user_stats":                {"user.current", "user.list", "merge_request.list", "issue.list"},
+
+	// Cross-project prompts (personal dashboards).
+	"my_open_mrs":         {"merge_request.list_global"},
+	"my_pending_reviews":  {"merge_request.list_global"},
+	"my_issues":           {"issue.list_all"},
+	"my_activity_summary": {"merge_request.list_global"},
+
+	// Team prompts (group-level).
+	"user_activity_report": {"merge_request.list_global"},
+	"team_overview":        {"group.members", "merge_request.list_group"},
+	"group_mr_dashboard":   {"merge_request.list_group"},
+	"reviewer_workload":    {"group.members", "merge_request.list_group"},
+
+	// Project report prompts.
+	"branch_mr_summary":       {"merge_request.list"},
+	"project_activity_report": {"user.event_list_project", "merge_request.list", "issue.list"},
+	"mr_discussion_health":    {"merge_request.list", "mr_review.discussion_list"},
+	"unassigned_items":        {"merge_request.list", "issue.list"},
+	"stale_items_report":      {"merge_request.list", "issue.list"},
+
+	// Analytics prompts.
+	"merge_velocity":    {"merge_request.list"},
+	"release_readiness": {"merge_request.list", "mr_review.discussion_list"},
+	"release_cadence":   {"release.list"},
+	"weekly_team_recap": {"merge_request.list_group", "issue.list_group"},
+
+	// Milestone, label and contributor prompts.
+	"milestone_progress":       {"project.milestone_list", "project.milestone_issues", "project.milestone_merge_requests"},
+	"label_distribution":       {"project.label_list"},
+	"group_milestone_progress": {"group.group_milestone_list", "group.group_milestone_issues", "group.group_milestone_merge_requests"},
+	"project_contributors":     {"repository.contributors"},
+
+	// Git workflow prompts.
+	"audit_commit_hygiene":   {"repository.compare"},
+	"mr_description_quality": {"merge_request.get", "mr_review.changes_get"},
+
+	// Project audit prompts.
+	"audit_project_workflow": {
+		"project.get",
+		"project.label_list",
+		"project.milestone_list",
+		"template.project_template_list",
+	},
+	"audit_project_full": {
+		"project.get",
+		"branch.list_protected",
+		"project.members",
+		"project.label_list",
+		"project.milestone_list",
+		"template.project_template_list",
+		"project.push_rule_get",
+		"project.hook_list",
+	},
+}
+
+// excludingRegistrar drops the prompts whose data an excluded action served,
+// and forwards the rest unchanged.
+//
+// It wraps the registrar rather than editing [Register] so the registration
+// calls stay a flat list of what this server offers, and the narrowing stays
+// one decision in one place.
+type excludingRegistrar struct {
+	inner    registrar
+	excluded map[string]struct{}
+}
+
+func (r *excludingRegistrar) AddPrompt(prompt *mcp.Prompt, handler mcp.PromptHandler) {
+	if _, blocked := r.excluded[prompt.Name]; blocked {
+		return
+	}
+	r.inner.AddPrompt(prompt, handler)
+}
+
+// registrarFor returns the registrar the registration calls should be given
+// for these options: the plain one when nothing is excluded, and a filtering
+// wrapper otherwise.
+func registrarFor(inner registrar, opts []RegisterOptions) registrar {
+	excluded := excludedPromptNames(opts)
+	if len(excluded) == 0 {
+		return inner
+	}
+	return &excludingRegistrar{inner: inner, excluded: excluded}
+}
+
+// excludedPromptNames returns the names of the prompts whose data an excluded
+// action served.
+//
+// A prompt goes when *any* of its backing actions was excluded, not only when
+// all of them were, which is the same conservative reading the resource surface
+// takes. The operator removed a way to read that data; a prompt that reads it
+// with the same credential is what the exclusion was meant to close, and a
+// prompt stripped of one of its sources would report on data it could no longer
+// see. A prompt missing from the table is kept, because withholding a prompt
+// because a table is incomplete would be a worse failure than the one this
+// closes, and the drift test is what keeps the table complete.
+func excludedPromptNames(opts []RegisterOptions) map[string]struct{} {
+	actions := make(map[string]struct{})
+	for _, opt := range opts {
+		for _, action := range opt.ExcludedActions {
+			if action = strings.TrimSpace(action); action != "" {
+				actions[action] = struct{}{}
+			}
+		}
+	}
+	if len(actions) == 0 {
+		return nil
+	}
+	excluded := make(map[string]struct{})
+	for name, backing := range promptBackingActions {
+		for _, action := range backing {
+			if _, ok := actions[action]; ok {
+				excluded[name] = struct{}{}
+				break
+			}
+		}
+	}
+	return excluded
+}

--- a/internal/prompts/exclusion_test.go
+++ b/internal/prompts/exclusion_test.go
@@ -1,0 +1,208 @@
+package prompts
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	gitlabtools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
+)
+
+// collectingRegistrar records what registerAll offers without a server.
+type collectingRegistrar struct {
+	names []string
+}
+
+func (r *collectingRegistrar) AddPrompt(prompt *mcp.Prompt, _ mcp.PromptHandler) {
+	r.names = append(r.names, prompt.Name)
+}
+
+// registeredPromptNames returns every prompt registerAll offers, with the
+// options applied.
+func registeredPromptNames(client *gitlabclient.Client, opts ...RegisterOptions) []string {
+	collector := &collectingRegistrar{}
+	registerAll(registrarFor(collector, opts), client)
+	return collector.names
+}
+
+// TestRegister_ExcludingAnActionRemovesThePromptServingTheSameData verifies
+// that an operator's --exclude-tools reaches the prompt surface, which was the
+// third request path to the same GitLab data with the same credential and the
+// last one that took no options at all.
+//
+// Excluding gitlab_mr_changes_get used to leave review_mr returning the
+// identical diffs, so the narrowing an operator configured was two thirds of a
+// contract. Each subtest asserts both directions: the prompt whose data went is
+// gone, and every prompt that shares no action with the exclusion is still
+// there, because a filter that removes too much is its own defect.
+func TestRegister_ExcludingAnActionRemovesThePromptServingTheSameData(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []RegisterOptions
+		gone    []string
+		present []string
+	}{
+		{
+			name:    "no options registers everything",
+			opts:    nil,
+			present: []string{"review_mr", "team_overview", "release_cadence"},
+		},
+		{
+			name:    "empty exclusion list registers everything",
+			opts:    []RegisterOptions{{}},
+			present: []string{"review_mr", "team_overview", "release_cadence"},
+		},
+		{
+			name:    "excluding an action removes every prompt reading it",
+			opts:    []RegisterOptions{{ExcludedActions: []string{"mr_review.changes_get"}}},
+			gone:    []string{"review_mr", "summarize_mr_changes", "mr_risk_assessment", "mr_description_quality"},
+			present: []string{"team_overview", "release_cadence", "label_distribution"},
+		},
+		{
+			name:    "one of several backing actions is enough",
+			opts:    []RegisterOptions{{ExcludedActions: []string{"branch.list"}}},
+			gone:    []string{"project_health_check"},
+			present: []string{"compare_branches", "review_mr"},
+		},
+		{
+			name:    "excluding a group action removes the group prompts",
+			opts:    []RegisterOptions{{ExcludedActions: []string{"merge_request.list_group"}}},
+			gone:    []string{"team_overview", "group_mr_dashboard", "reviewer_workload", "weekly_team_recap"},
+			present: []string{"review_mr", "label_distribution"},
+		},
+		{
+			name: "several exclusions compose",
+			opts: []RegisterOptions{{ExcludedActions: []string{"release.list", "repository.contributors"}}},
+			gone: []string{"release_cadence", "project_contributors"},
+			present: []string{
+				"review_mr",
+				"label_distribution",
+			},
+		},
+		{
+			name:    "blank and unknown entries change nothing",
+			opts:    []RegisterOptions{{ExcludedActions: []string{"", "   ", "not.an_action"}}},
+			present: []string{"review_mr", "team_overview", "release_cadence"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registered := registeredPromptNames(nil, tt.opts...)
+			for _, name := range tt.gone {
+				if slices.Contains(registered, name) {
+					t.Errorf("prompt %q is still registered after excluding %v", name, tt.opts)
+				}
+			}
+			for _, name := range tt.present {
+				if !slices.Contains(registered, name) {
+					t.Errorf("prompt %q was removed by excluding %v, which does not name it", name, tt.opts)
+				}
+			}
+		})
+	}
+}
+
+// TestRegister_ExcludedPromptIsNotListedByTheServer verifies the same thing on
+// the wire: a client's prompts/list must not offer what the operator excluded,
+// since a listed prompt is one a model will try to get, and prompts/get must
+// refuse it rather than run the handler anyway.
+//
+// Filtering only the listing would be the worse half of the fix. A model that
+// remembers a prompt name, or a client working from a cached list, calls
+// prompts/get directly, and the handler holds the same credential whether or
+// not the prompt was advertised.
+func TestRegister_ExcludedPromptIsNotListedByTheServer(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	Register(server, nil, RegisterOptions{ExcludedActions: []string{"mr_review.changes_get"}})
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server.Connect() error = %v", err)
+	}
+	session, err := mcp.NewClient(&mcp.Implementation{Name: "probe", Version: "0.0.1"}, nil).Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	list, err := session.ListPrompts(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListPrompts() error = %v", err)
+	}
+	names := make([]string, 0, len(list.Prompts))
+	for _, prompt := range list.Prompts {
+		names = append(names, prompt.Name)
+	}
+
+	t.Run("excluded prompt is not listed", func(t *testing.T) {
+		if slices.Contains(names, "review_mr") {
+			t.Error("prompts/list still offers review_mr after its diffs action was excluded")
+		}
+	})
+	t.Run("unrelated prompt is still listed", func(t *testing.T) {
+		if !slices.Contains(names, "team_overview") {
+			t.Error("prompts/list no longer offers team_overview, which the exclusion does not name")
+		}
+	})
+	t.Run("excluded prompt cannot be fetched", func(t *testing.T) {
+		_, getErr := session.GetPrompt(ctx, &mcp.GetPromptParams{
+			Name:      "review_mr",
+			Arguments: map[string]string{argProjectID: "1", argMRIID: "1"},
+		})
+		if getErr == nil {
+			t.Error("prompts/get served review_mr after it was excluded")
+		}
+	})
+}
+
+// TestPromptBackingActions_StaysAlignedWithBothSurfaces guards the two ways
+// the hand-kept overlap table can rot.
+//
+// The table is the only thing relating a prompt to the tools serving the same
+// data, so it fails in two directions: a prompt added to registerAll without an
+// entry would silently escape every exclusion, and an action ID that no longer
+// exists in the catalog would make an entry a dead string nobody notices.
+// Neither is visible from either package alone.
+func TestPromptBackingActions_StaysAlignedWithBothSurfaces(t *testing.T) {
+	catalog, err := gitlabtools.BuildActionCatalog(nil, gitlabtools.ActionCatalogOptions{Tier: edition.Ultimate, IncludeMCP: true})
+	if err != nil {
+		t.Fatalf("BuildActionCatalog() error = %v", err)
+	}
+
+	t.Run("every registered prompt is classified", func(t *testing.T) {
+		for _, name := range registeredPromptNames(nil) {
+			if _, ok := promptBackingActions[name]; !ok {
+				t.Errorf("prompt %q has no entry in promptBackingActions, so --exclude-tools cannot reach it", name)
+			}
+		}
+	})
+
+	t.Run("no entry describes a prompt that is gone", func(t *testing.T) {
+		registered := registeredPromptNames(nil)
+		for name := range promptBackingActions {
+			if !slices.Contains(registered, name) {
+				t.Errorf("promptBackingActions names %q, which registerAll no longer registers", name)
+			}
+		}
+	})
+
+	t.Run("every named action exists in the catalog", func(t *testing.T) {
+		for name, backing := range promptBackingActions {
+			if len(backing) == 0 {
+				t.Errorf("prompt %q lists no backing action; give it one or state why it has none", name)
+				continue
+			}
+			for _, id := range backing {
+				if _, ok := catalog.Action(actioncatalog.ActionID(id)); !ok {
+					t.Errorf("prompt %q names action %q, which is not in the action catalog", name, id)
+				}
+			}
+		}
+	})
+}

--- a/internal/prompts/prompt_analytics.go
+++ b/internal/prompts/prompt_analytics.go
@@ -26,7 +26,7 @@ import (
 //   - release_cadence: time-between-releases analysis with a release history table.
 //   - weekly_team_recap: group-level weekly recap combining merged MRs, open
 //     MRs, and open issues.
-func registerAnalyticsPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerAnalyticsPrompts(server registrar, client *gitlabclient.Client) {
 	registerMergeVelocityPrompt(server, client)
 	registerReleaseReadinessPrompt(server, client)
 	registerReleaseCadencePrompt(server, client)
@@ -34,7 +34,7 @@ func registerAnalyticsPrompts(server *mcp.Server, client *gitlabclient.Client) {
 }
 
 // registerMergeVelocityPrompt registers the merge_velocity prompt.
-func registerMergeVelocityPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMergeVelocityPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "merge_velocity",
 		Title:       toolutil.TitleFromName("merge_velocity"),
@@ -141,7 +141,7 @@ func writeDailyMergeChart(b *strings.Builder, mrs []*gl.BasicMergeRequest) {
 }
 
 // registerReleaseReadinessPrompt registers the release_readiness prompt.
-func registerReleaseReadinessPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerReleaseReadinessPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "release_readiness",
 		Title:       toolutil.TitleFromName("release_readiness"),
@@ -246,7 +246,7 @@ func readinessLabel(blockers int) string {
 }
 
 // registerReleaseCadencePrompt registers the release_cadence prompt.
-func registerReleaseCadencePrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerReleaseCadencePrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "release_cadence",
 		Title:       toolutil.TitleFromName("release_cadence"),
@@ -362,7 +362,7 @@ func releaseDate(r *gl.Release) time.Time {
 }
 
 // registerWeeklyTeamRecapPrompt registers the weekly_team_recap prompt.
-func registerWeeklyTeamRecapPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerWeeklyTeamRecapPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "weekly_team_recap",
 		Title:       toolutil.TitleFromName("weekly_team_recap"),

--- a/internal/prompts/prompt_audit.go
+++ b/internal/prompts/prompt_audit.go
@@ -58,7 +58,7 @@ func isDefaultBranchProtected(branches []*gl.ProtectedBranch, defaultBranch stri
 //   - audit_project_full: a comprehensive audit covering settings, branch
 //     protection, access, labels, milestones, templates, webhooks, and
 //     push rules.
-func registerAuditPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerAuditPrompts(server registrar, client *gitlabclient.Client) {
 	registerAuditProjectWorkflowPrompt(server, client)
 	registerAuditProjectFullPrompt(server, client)
 }
@@ -387,7 +387,7 @@ func writeMemberTable(b *strings.Builder, members []*gl.ProjectMember) {
 // audit_project_workflow.
 
 // registerAuditProjectWorkflowPrompt registers the audit_project_workflow prompt.
-func registerAuditProjectWorkflowPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerAuditProjectWorkflowPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:  "audit_project_workflow",
 		Title: toolutil.TitleFromName("audit_project_workflow"),
@@ -544,7 +544,7 @@ func writeTemplatesAudit(b *strings.Builder, issueTPL, mrTPL []*gl.ProjectTempla
 // audit_project_full.
 
 // registerAuditProjectFullPrompt registers the audit_project_full prompt.
-func registerAuditProjectFullPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerAuditProjectFullPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:  "audit_project_full",
 		Title: toolutil.TitleFromName("audit_project_full"),

--- a/internal/prompts/prompt_cross_project.go
+++ b/internal/prompts/prompt_cross_project.go
@@ -15,7 +15,7 @@ import (
 )
 
 // registerMyOpenMRsPrompt registers the my_open_mrs prompt.
-func registerMyOpenMRsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMyOpenMRsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_open_mrs",
 		Title:       toolutil.TitleFromName("my_open_mrs"),
@@ -108,7 +108,7 @@ func handleMyOpenMRs(ctx context.Context, client *gitlabclient.Client, req *mcp.
 }
 
 // registerMyPendingReviewsPrompt registers the my_pending_reviews prompt.
-func registerMyPendingReviewsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMyPendingReviewsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_pending_reviews",
 		Title:       toolutil.TitleFromName("my_pending_reviews"),
@@ -163,7 +163,7 @@ func handleMyPendingReviews(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerMyIssuesPrompt registers the my_issues prompt.
-func registerMyIssuesPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMyIssuesPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_issues",
 		Title:       toolutil.TitleFromName("my_issues"),
@@ -235,7 +235,7 @@ func handleMyIssues(ctx context.Context, client *gitlabclient.Client, req *mcp.G
 }
 
 // registerMyActivitySummaryPrompt registers the my_activity_summary prompt.
-func registerMyActivitySummaryPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMyActivitySummaryPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_activity_summary",
 		Title:       toolutil.TitleFromName("my_activity_summary"),
@@ -345,7 +345,7 @@ func writeDailyActivityChart(b *strings.Builder, dailyData []dayActivity) {
 }
 
 // registerCrossProjectPrompts registers all cross-project prompts.
-func registerCrossProjectPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerCrossProjectPrompts(server registrar, client *gitlabclient.Client) {
 	registerMyOpenMRsPrompt(server, client)
 	registerMyPendingReviewsPrompt(server, client)
 	registerMyIssuesPrompt(server, client)

--- a/internal/prompts/prompt_git_workflow.go
+++ b/internal/prompts/prompt_git_workflow.go
@@ -23,13 +23,13 @@ var (
 )
 
 // registerGitWorkflowPrompts registers prompts for Git history and MR authoring quality.
-func registerGitWorkflowPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerGitWorkflowPrompts(server registrar, client *gitlabclient.Client) {
 	registerAuditCommitHygienePrompt(server, client)
 	registerMRDescriptionQualityPrompt(server, client)
 }
 
 // registerAuditCommitHygienePrompt registers the audit_commit_hygiene prompt.
-func registerAuditCommitHygienePrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerAuditCommitHygienePrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "audit_commit_hygiene",
 		Title:       toolutil.TitleFromName("audit_commit_hygiene"),
@@ -94,7 +94,7 @@ func handleAuditCommitHygiene(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerMRDescriptionQualityPrompt registers the mr_description_quality prompt.
-func registerMRDescriptionQualityPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMRDescriptionQualityPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_description_quality",
 		Title:       toolutil.TitleFromName("mr_description_quality"),

--- a/internal/prompts/prompt_helpers.go
+++ b/internal/prompts/prompt_helpers.go
@@ -37,7 +37,7 @@ import (
 // later would have to remember. Registration is the one place every error
 // passes through, so the -32603 default lands here and the explicit
 // [errInvalidParams] calls in the handlers take precedence over it.
-func addPrompt(server *mcp.Server, prompt *mcp.Prompt, handler mcp.PromptHandler) {
+func addPrompt(server registrar, prompt *mcp.Prompt, handler mcp.PromptHandler) {
 	server.AddPrompt(prompt, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		result, err := handler(ctx, req)
 		if err == nil {

--- a/internal/prompts/prompt_milestone_label.go
+++ b/internal/prompts/prompt_milestone_label.go
@@ -16,7 +16,7 @@ import (
 )
 
 // registerMilestoneLabelPrompts registers all milestone and label prompts.
-func registerMilestoneLabelPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerMilestoneLabelPrompts(server registrar, client *gitlabclient.Client) {
 	registerMilestoneProgressPrompt(server, client)
 	registerLabelDistributionPrompt(server, client)
 	registerGroupMilestoneProgressPrompt(server, client)
@@ -63,7 +63,7 @@ func writeDueDateSection(b *strings.Builder, dueDate *gl.ISOTime) {
 }
 
 // registerMilestoneProgressPrompt registers the milestone_progress prompt.
-func registerMilestoneProgressPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMilestoneProgressPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "milestone_progress",
 		Title:       toolutil.TitleFromName("milestone_progress"),
@@ -143,7 +143,7 @@ func handleMilestoneProgress(ctx context.Context, client *gitlabclient.Client, r
 }
 
 // registerLabelDistributionPrompt registers the label_distribution prompt.
-func registerLabelDistributionPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerLabelDistributionPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "label_distribution",
 		Title:       toolutil.TitleFromName("label_distribution"),
@@ -223,7 +223,7 @@ func handleLabelDistribution(ctx context.Context, client *gitlabclient.Client, r
 }
 
 // registerGroupMilestoneProgressPrompt registers the group_milestone_progress prompt.
-func registerGroupMilestoneProgressPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerGroupMilestoneProgressPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "group_milestone_progress",
 		Title:       toolutil.TitleFromName("group_milestone_progress"),
@@ -292,7 +292,7 @@ func handleGroupMilestoneProgress(ctx context.Context, client *gitlabclient.Clie
 }
 
 // registerProjectContributorsPrompt registers the project_contributors prompt.
-func registerProjectContributorsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerProjectContributorsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_contributors",
 		Title:       toolutil.TitleFromName("project_contributors"),

--- a/internal/prompts/prompt_project_reports.go
+++ b/internal/prompts/prompt_project_reports.go
@@ -23,7 +23,7 @@ const (
 )
 
 // registerProjectReportPrompts registers all project-level report prompts.
-func registerProjectReportPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerProjectReportPrompts(server registrar, client *gitlabclient.Client) {
 	registerBranchMRSummaryPrompt(server, client)
 	registerProjectActivityReportPrompt(server, client)
 	registerMRDiscussionHealthPrompt(server, client)
@@ -32,7 +32,7 @@ func registerProjectReportPrompts(server *mcp.Server, client *gitlabclient.Clien
 }
 
 // registerBranchMRSummaryPrompt registers the branch_mr_summary prompt.
-func registerBranchMRSummaryPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerBranchMRSummaryPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "branch_mr_summary",
 		Title:       toolutil.TitleFromName("branch_mr_summary"),
@@ -102,7 +102,7 @@ func handleBranchMRSummary(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerProjectActivityReportPrompt registers the project_activity_report prompt.
-func registerProjectActivityReportPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerProjectActivityReportPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_activity_report",
 		Title:       toolutil.TitleFromName("project_activity_report"),
@@ -193,7 +193,7 @@ func handleProjectActivityReport(ctx context.Context, client *gitlabclient.Clien
 }
 
 // registerMRDiscussionHealthPrompt registers the mr_discussion_health prompt.
-func registerMRDiscussionHealthPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMRDiscussionHealthPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_discussion_health",
 		Title:       toolutil.TitleFromName("mr_discussion_health"),
@@ -311,7 +311,7 @@ func countDiscussionThreads(info *mrDiscussionInfo, discussions []*gl.Discussion
 }
 
 // registerUnassignedItemsPrompt registers the unassigned_items prompt.
-func registerUnassignedItemsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerUnassignedItemsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "unassigned_items",
 		Title:       toolutil.TitleFromName("unassigned_items"),
@@ -377,7 +377,7 @@ func handleUnassignedItems(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerStaleItemsReportPrompt registers the stale_items_report prompt.
-func registerStaleItemsReportPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerStaleItemsReportPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "stale_items_report",
 		Title:       toolutil.TitleFromName("stale_items_report"),

--- a/internal/prompts/prompt_team.go
+++ b/internal/prompts/prompt_team.go
@@ -35,7 +35,7 @@ type reviewerWorkloadStats struct {
 }
 
 // registerTeamPrompts registers all team management prompts.
-func registerTeamPrompts(server *mcp.Server, client *gitlabclient.Client) {
+func registerTeamPrompts(server registrar, client *gitlabclient.Client) {
 	registerUserActivityReportPrompt(server, client)
 	registerTeamOverviewPrompt(server, client)
 	registerGroupMRDashboardPrompt(server, client)
@@ -43,7 +43,7 @@ func registerTeamPrompts(server *mcp.Server, client *gitlabclient.Client) {
 }
 
 // registerUserActivityReportPrompt registers the user_activity_report prompt.
-func registerUserActivityReportPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerUserActivityReportPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "user_activity_report",
 		Title:       toolutil.TitleFromName("user_activity_report"),
@@ -162,7 +162,7 @@ func handleUserActivityReport(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerTeamOverviewPrompt registers the team_overview prompt.
-func registerTeamOverviewPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerTeamOverviewPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "team_overview",
 		Title:       toolutil.TitleFromName("team_overview"),
@@ -286,7 +286,7 @@ func writeTeamOverviewChart(b *strings.Builder, stats map[string]*teamOverviewMe
 }
 
 // registerGroupMRDashboardPrompt registers the group_mr_dashboard prompt.
-func registerGroupMRDashboardPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerGroupMRDashboardPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "group_mr_dashboard",
 		Title:       toolutil.TitleFromName("group_mr_dashboard"),
@@ -367,7 +367,7 @@ func handleGroupMRDashboard(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerReviewerWorkloadPrompt registers the reviewer_workload prompt.
-func registerReviewerWorkloadPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerReviewerWorkloadPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "reviewer_workload",
 		Title:       toolutil.TitleFromName("reviewer_workload"),

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -69,7 +69,21 @@ func mrIIDArg() *mcp.PromptArgument {
 //
 // All prompt handlers in this package share the helpers in prompt_helpers.go
 // to keep GitLab API access, pagination, and Markdown assembly consistent.
-func Register(server *mcp.Server, client *gitlabclient.Client) {
+//
+// The optional [RegisterOptions] narrow the surface: a prompt whose data an
+// excluded action served is not registered, so an operator's --exclude-tools
+// reaches this request path as well as tools/call and resources/read. Passing
+// none registers all 37, which is what a deployment that excludes nothing
+// wants and what every existing caller gets unchanged.
+func Register(server *mcp.Server, client *gitlabclient.Client, opts ...RegisterOptions) {
+	registerAll(registrarFor(server, opts), client)
+}
+
+// registerAll performs every prompt registration against the given registrar.
+//
+// Split from [Register] so the filtering wrapper is applied once, and so a
+// test can collect what would be registered without standing up a server.
+func registerAll(server registrar, client *gitlabclient.Client) {
 	registerSummarizeMRChangesPrompt(server, client)
 	registerReviewMRPrompt(server, client)
 	registerSummarizePipelineStatusPrompt(server, client)
@@ -106,7 +120,7 @@ func Register(server *mcp.Server, client *gitlabclient.Client) {
 }
 
 // registerSummarizeMRChangesPrompt registers the summarize_mr_changes prompt.
-func registerSummarizeMRChangesPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerSummarizeMRChangesPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_mr_changes",
 		Title:       toolutil.TitleFromName("summarize_mr_changes"),
@@ -146,7 +160,7 @@ func handleSummarizeMRChanges(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerReviewMRPrompt registers the review_mr prompt.
-func registerReviewMRPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerReviewMRPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "review_mr",
 		Title:       toolutil.TitleFromName("review_mr"),
@@ -269,7 +283,7 @@ func handleReviewMR(ctx context.Context, client *gitlabclient.Client, req *mcp.G
 }
 
 // registerSummarizePipelineStatusPrompt registers the summarize_pipeline_status prompt.
-func registerSummarizePipelineStatusPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerSummarizePipelineStatusPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_pipeline_status",
 		Title:       toolutil.TitleFromName("summarize_pipeline_status"),
@@ -349,7 +363,7 @@ func handleSummarizePipelineStatus(ctx context.Context, client *gitlabclient.Cli
 }
 
 // registerSuggestMRReviewersPrompt registers the suggest_mr_reviewers prompt.
-func registerSuggestMRReviewersPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerSuggestMRReviewersPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "suggest_mr_reviewers",
 		Title:       toolutil.TitleFromName("suggest_mr_reviewers"),
@@ -404,7 +418,7 @@ func handleSuggestMRReviewers(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerGenerateReleaseNotesPrompt registers the generate_release_notes prompt.
-func registerGenerateReleaseNotesPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerGenerateReleaseNotesPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "generate_release_notes",
 		Title:       toolutil.TitleFromName("generate_release_notes"),
@@ -564,7 +578,7 @@ func writeReleaseNotesStats(b *strings.Builder, comparison *gl.Compare) {
 }
 
 // registerSummarizeOpenMRsPrompt registers the summarize_open_mrs prompt.
-func registerSummarizeOpenMRsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerSummarizeOpenMRsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_open_mrs",
 		Title:       toolutil.TitleFromName("summarize_open_mrs"),
@@ -621,7 +635,7 @@ func handleSummarizeOpenMRs(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerProjectHealthCheckPrompt registers the project_health_check prompt.
-func registerProjectHealthCheckPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerProjectHealthCheckPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_health_check",
 		Title:       toolutil.TitleFromName("project_health_check"),
@@ -719,7 +733,7 @@ func countBranchStats(branches []*gl.Branch) (merged, stale int) {
 }
 
 // registerCompareBranchesPrompt registers the compare_branches prompt.
-func registerCompareBranchesPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerCompareBranchesPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "compare_branches",
 		Title:       toolutil.TitleFromName("compare_branches"),
@@ -787,7 +801,7 @@ func handleCompareBranches(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerDailyStandupPrompt registers the daily_standup prompt.
-func registerDailyStandupPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerDailyStandupPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "daily_standup",
 		Title:       toolutil.TitleFromName("daily_standup"),
@@ -949,7 +963,7 @@ func writeIssueSection(b *strings.Builder, heading, username string, issues []*g
 }
 
 // registerTeamMemberWorkloadPrompt registers the team_member_workload prompt.
-func registerTeamMemberWorkloadPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerTeamMemberWorkloadPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "team_member_workload",
 		Title:       toolutil.TitleFromName("team_member_workload"),
@@ -1095,7 +1109,7 @@ func writeCountRow(b *strings.Builder, label string, count int, fetchErr error) 
 }
 
 // registerUserStatsPrompt registers the user_stats prompt.
-func registerUserStatsPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerUserStatsPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "user_stats",
 		Title:       toolutil.TitleFromName("user_stats"),
@@ -1319,7 +1333,7 @@ func safeLen(count int, err error) int {
 }
 
 // registerMRRiskAssessmentPrompt registers the mr_risk_assessment prompt.
-func registerMRRiskAssessmentPrompt(server *mcp.Server, client *gitlabclient.Client) {
+func registerMRRiskAssessmentPrompt(server registrar, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_risk_assessment",
 		Title:       toolutil.TitleFromName("mr_risk_assessment"),

--- a/internal/resources/doc.go
+++ b/internal/resources/doc.go
@@ -30,9 +30,14 @@
 // and workflow-guide resources are static documents about this server and are
 // never narrowed.
 //
-// Two controls still do not reach this surface, both because they are applied
-// where tools are registered rather than here: the tools/call rate limiter,
-// which does not meter resources/read, and the prompt surface, which is a third
-// path to the same data and takes no options at all. Both are noted so the
-// silence does not read as coverage.
+// The prompt surface, which was the third path to the same data, now takes the
+// same options: [github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts.RegisterOptions]
+// carries the excluded actions and that package keeps its own prompt-to-action
+// table.
+//
+// One control still does not reach this surface, because it is applied where
+// tools are registered rather than here: the tools/call rate limiter does not
+// meter resources/read, resources/subscribe or prompts/get, so all three remain
+// unmetered proxies to GitLab. It is noted so the silence does not read as
+// coverage.
 package resources

--- a/internal/tools/projects/projects.go
+++ b/internal/tools/projects/projects.go
@@ -3721,6 +3721,34 @@ type DownloadAvatarOutput struct {
 	SizeBytes     int    `json:"size_bytes"`
 }
 
+// maxAvatarBytes is the largest avatar image this action returns in one
+// response, measured against the decoded image rather than the base64 text.
+//
+// Decoded is the side worth naming because it is the side a caller can reason
+// about: it is the size GitLab reports for the file, and the size the upload
+// action accepts. What the response costs is a multiple of it, since the
+// decoded bytes and the base64 copy a third larger again are held at the same
+// time and then copied into a JSON-RPC message, so a ceiling of 1 MiB bounds a
+// call at roughly 2.3 MiB rather than at 1.
+//
+// 1 MiB comes from the endpoint itself: GitLab caps an avatar upload at 200 KB,
+// which the sibling upload action already tells the caller. Five times that
+// leaves room for an avatar stored before the limit existed, or through an
+// import that did not enforce it, while staying far below a size worth
+// streaming. The action is registered read-only, so this is a ceiling any
+// tenant with a token can reach, and it is the reason it exists.
+//
+// An avatar above the ceiling is refused rather than truncated. Truncation is
+// right for a job trace, which stays readable when it is cut; the prefix of a
+// PNG or a JPEG decodes to no image at all, so a partial answer here would be
+// a wrong answer wearing a flag.
+const maxAvatarBytes = 1 << 20
+
+// errAvatarTooLarge is the hint for an avatar this action will not carry,
+// whichever ceiling stopped it: this one, or the client-wide response ceiling
+// that stops the read before it reaches here.
+const errAvatarTooLarge = "the avatar is too large to return in one MCP response; download it from GitLab directly (GET /projects/:id/avatar)"
+
 // DownloadAvatar downloads the avatar image for a project as base64-encoded data.
 func DownloadAvatar(ctx context.Context, client *gitlabclient.Client, input DownloadAvatarInput) (DownloadAvatarOutput, error) {
 	if err := ctx.Err(); err != nil {
@@ -3731,6 +3759,9 @@ func DownloadAvatar(ctx context.Context, client *gitlabclient.Client, input Down
 	}
 	reader, _, err := client.GL().Projects.DownloadAvatar(string(input.ProjectID), gl.WithContext(ctx))
 	if err != nil {
+		if errors.Is(err, gitlabclient.ErrResponseTooLarge) {
+			return DownloadAvatarOutput{}, toolutil.WrapErrWithHint("projectDownloadAvatar", err, errAvatarTooLarge)
+		}
 		return DownloadAvatarOutput{}, toolutil.WrapErrWithStatusHint("projectDownloadAvatar", err, http.StatusNotFound,
 			"project has no custom avatar configured. GitLab serves a generated identicon when no avatar is set")
 	}
@@ -3738,9 +3769,16 @@ func DownloadAvatar(ctx context.Context, client *gitlabclient.Client, input Down
 }
 
 func downloadAvatarOutputFromReader(reader io.Reader) (DownloadAvatarOutput, error) {
-	data, err := io.ReadAll(reader)
+	data, err := io.ReadAll(io.LimitReader(reader, maxAvatarBytes+1))
 	if err != nil {
 		return DownloadAvatarOutput{}, fmt.Errorf("projectDownloadAvatar: reading response: %w", err)
+	}
+	if len(data) > maxAvatarBytes {
+		return DownloadAvatarOutput{}, toolutil.WrapErrWithHint(
+			"projectDownloadAvatar",
+			fmt.Errorf("the avatar exceeds the %d MiB this action returns", maxAvatarBytes>>20),
+			errAvatarTooLarge,
+		)
 	}
 	return DownloadAvatarOutput{
 		ContentBase64: base64.StdEncoding.EncodeToString(data),

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -4,6 +4,7 @@
 package projects
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -6393,6 +6394,87 @@ func TestDownloadAvatar_Success(t *testing.T) {
 	expectedB64 := base64.StdEncoding.EncodeToString(rawBytes)
 	if out.ContentBase64 != expectedB64 {
 		t.Errorf("ContentBase64 mismatch")
+	}
+}
+
+// TestDownloadAvatarOutputFromReader_AvatarOverTheCeiling_IsRefusedNotTruncated
+// verifies that the image this action turns into base64 and copies into a
+// JSON-RPC message is bounded, and that an image above the bound produces an
+// error naming the way out rather than a partial image.
+//
+// The action is registered read-only, so before the ceiling existed any tenant
+// holding a token could make the server buffer a whole response and then hold a
+// base64 copy a third larger beside it, with only the client-wide response
+// ceiling in the way. The prefix of a PNG decodes to no image, so this refuses
+// where the job trace truncates. The exactly-at-the-ceiling case is here
+// because an off-by-one in the limit reader would refuse an avatar that fits.
+func TestDownloadAvatarOutputFromReader_AvatarOverTheCeiling_IsRefusedNotTruncated(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{name: "ordinary avatar is returned whole", size: 4096},
+		{name: "avatar exactly at the ceiling is returned whole", size: maxAvatarBytes},
+		{name: "avatar one byte over the ceiling is refused", size: maxAvatarBytes + 1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := downloadAvatarOutputFromReader(bytes.NewReader(make([]byte, tt.size)))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("downloadAvatarOutputFromReader(%d bytes) error = nil, want a refusal", tt.size)
+				}
+				if !strings.Contains(err.Error(), "download it from GitLab directly") {
+					t.Errorf("downloadAvatarOutputFromReader(%d bytes) error = %v, want it to name the way out", tt.size, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("downloadAvatarOutputFromReader(%d bytes) error = %v", tt.size, err)
+			}
+			if out.SizeBytes != tt.size {
+				t.Errorf("SizeBytes = %d, want %d", out.SizeBytes, tt.size)
+			}
+		})
+	}
+}
+
+// countingAvatarReader serves a fixed number of bytes and records how many
+// were read, so a test can see how much of a stream the action consumed.
+type countingAvatarReader struct {
+	remaining int
+	read      int
+}
+
+func (r *countingAvatarReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(p), r.remaining)
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+// TestDownloadAvatarOutputFromReader_StopsReadingAtTheCeiling verifies that the
+// ceiling bounds the read itself, not only the answer the caller gets.
+//
+// The refusal test above passes with the io.LimitReader removed, because
+// checking the length after buffering the whole body refuses exactly the same
+// downloads. It refuses them having already done the thing the ceiling exists
+// to prevent: an unbounded response is held in memory first and rejected
+// second, which is no protection at all against a tenant pointing this
+// read-only action at a large object. Only the byte count distinguishes the
+// two.
+func TestDownloadAvatarOutputFromReader_StopsReadingAtTheCeiling(t *testing.T) {
+	reader := &countingAvatarReader{remaining: 8 * maxAvatarBytes}
+	if _, err := downloadAvatarOutputFromReader(reader); err == nil {
+		t.Fatal("downloadAvatarOutputFromReader() error = nil, want a refusal")
+	}
+	if reader.read > 2*maxAvatarBytes {
+		t.Errorf("read %d bytes of an %d-byte stream, want the ceiling to stop it near %d",
+			reader.read, 8*maxAvatarBytes, maxAvatarBytes)
 	}
 }
 

--- a/internal/tools/testdata/tools_individual.json
+++ b/internal/tools/testdata/tools_individual.json
@@ -36703,12 +36703,16 @@
             "array"
           ]
         },
+        "truncated": {
+          "type": "boolean"
+        },
         "yaml": {
           "type": "string"
         }
       },
       "required": [
-        "yaml"
+        "yaml",
+        "truncated"
       ],
       "type": "object"
     },

--- a/internal/tools/usagedata/markdown.go
+++ b/internal/tools/usagedata/markdown.go
@@ -96,6 +96,13 @@ func FormatMetricDefinitionsMarkdown(out MetricDefinitionsOutput) string {
 	}
 	sb.WriteString(yaml)
 	sb.WriteString("\n```\n")
+	// Two different cuts can reach this point and the model must not read the
+	// second as the first: the block above shortens a long document for display
+	// only, while Truncated means the server stopped reading and the rest of the
+	// document is not in this response at all.
+	if out.Truncated {
+		sb.WriteString("\n- " + toolutil.EmojiWarning + " **Truncated**: the document exceeded the size this action returns, so it was cut short. Read the remainder from GitLab directly (GET /usage_data/metric_definitions)\n")
+	}
 	toolutil.WriteHints(&sb, "Use metric key names to query specific usage data")
 	return sb.String()
 }

--- a/internal/tools/usagedata/usagedata.go
+++ b/internal/tools/usagedata/usagedata.go
@@ -200,7 +200,31 @@ type GetMetricDefinitionsInput struct{}
 type MetricDefinitionsOutput struct {
 	toolutil.HintableOutput
 	YAML string `json:"yaml"`
+	// Truncated reports that the document was cut at [maxMetricDefinitionsBytes]
+	// and that YAML holds a prefix rather than the whole definition set.
+	Truncated bool `json:"truncated"`
 }
+
+// maxMetricDefinitionsBytes is the largest metric-definition document this
+// action reads into memory.
+//
+// The ceiling is on the bytes read, which here is also the bytes returned:
+// unlike the archive and avatar downloads this document is returned as text
+// rather than base64, so there is no encoded copy a third larger to account for
+// and the two ways of expressing the ceiling are the same number.
+//
+// 2 MiB sits above the definition set GitLab actually ships and below the 4 MiB
+// default message ceiling both transports apply. That upper bound is the real
+// constraint: the whole document goes into the JSON response, so a ceiling at
+// or above the message limit would trade an unbounded read for a response the
+// transport refuses, which answers the caller no better than the read did.
+//
+// This endpoint is admin-only, so it is not the ordinary-tenant exposure the
+// avatar download is. It is bounded for the same reason regardless: an
+// unbounded read of a remote response is a ceiling nobody chose, and being
+// reachable only by an administrator makes it a smaller problem rather than
+// a different one.
+const maxMetricDefinitionsBytes = 2 << 20
 
 // GetMetricDefinitions retrieves metric definitions as YAML (admin-only).
 func GetMetricDefinitions(ctx context.Context, client *gitlabclient.Client, _ GetMetricDefinitionsInput) (MetricDefinitionsOutput, error) {
@@ -211,11 +235,31 @@ func GetMetricDefinitions(ctx context.Context, client *gitlabclient.Client, _ Ge
 	}
 	defer reader.Close()
 
-	data, err := io.ReadAll(reader)
+	return metricDefinitionsOutput(reader)
+}
+
+// metricDefinitionsOutput reads a definition document up to
+// [maxMetricDefinitionsBytes] and reports whether it had to stop early.
+//
+// Split out from [GetMetricDefinitions] so a test can hand it a reader and
+// observe how much of it was consumed. That is the only way to see this
+// ceiling: truncating the slice afterwards produces the identical output
+// whether or not the read itself was bounded, so a test written against the
+// output alone passes with the bound removed and proves nothing.
+func metricDefinitionsOutput(reader io.Reader) (MetricDefinitionsOutput, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxMetricDefinitionsBytes+1))
 	if err != nil {
 		return MetricDefinitionsOutput{}, toolutil.WrapErrWithMessage("get_metric_definitions", fmt.Errorf("reading response body: %w", err))
 	}
-	return MetricDefinitionsOutput{YAML: string(data)}, nil
+	// Truncated rather than refused, which is the opposite of what the archive
+	// and avatar downloads do: those return a file whose prefix is not a file,
+	// while a prefix of this document still reads as the definitions it holds,
+	// the way a truncated job trace does.
+	truncated := len(data) > maxMetricDefinitionsBytes
+	if truncated {
+		data = data[:maxMetricDefinitionsBytes]
+	}
+	return MetricDefinitionsOutput{YAML: string(data), Truncated: truncated}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/usagedata/usagedata_test.go
+++ b/internal/tools/usagedata/usagedata_test.go
@@ -5,6 +5,7 @@ package usagedata
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -217,6 +218,117 @@ func TestGetMetricDefinitions(t *testing.T) {
 	}
 	if out.YAML != yamlContent {
 		t.Errorf("YAML = %q, want %q", out.YAML, yamlContent)
+	}
+	if out.Truncated {
+		t.Error("Truncated = true for a document well under the ceiling, want false")
+	}
+}
+
+// countingReader serves a fixed number of bytes and records how many were read.
+//
+// Deliberately finite. An endless reader also proves the point, by hanging
+// until the test binary's timeout, but it proves it by making a regression cost
+// a 30-second stall and however much memory io.ReadAll manages to claim first.
+// A stream a few times the ceiling fails on the byte count instead, which is
+// the same evidence delivered as an assertion.
+type countingReader struct {
+	remaining int
+	read      int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(p), r.remaining)
+	for i := range p[:n] {
+		p[i] = 'y'
+	}
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+// TestMetricDefinitionsOutput_StopsReadingAtTheCeiling verifies that the
+// ceiling bounds the read itself rather than only the value returned.
+//
+// This is the assertion that separates a real ceiling from a cosmetic one.
+// Slicing the buffer after reading it produces exactly the same output either
+// way, so a test written against YAML and Truncated alone still passes with the
+// io.LimitReader deleted. The defect being fixed is the memory the process
+// holds while an instance streams at it, and the byte count is the only thing
+// in the returned value that can see it.
+func TestMetricDefinitionsOutput_StopsReadingAtTheCeiling(t *testing.T) {
+	reader := &countingReader{remaining: 8 * maxMetricDefinitionsBytes}
+	out, err := metricDefinitionsOutput(reader)
+	if err != nil {
+		t.Fatalf("metricDefinitionsOutput() error = %v", err)
+	}
+	if !out.Truncated {
+		t.Error("Truncated = false for an oversized document, want true")
+	}
+	if len(out.YAML) != maxMetricDefinitionsBytes {
+		t.Errorf("len(YAML) = %d, want %d", len(out.YAML), maxMetricDefinitionsBytes)
+	}
+	// io.ReadAll grows its buffer, so it asks for a little more than it keeps;
+	// what matters is that the stream was not drained, not an exact count.
+	if reader.read > 2*maxMetricDefinitionsBytes {
+		t.Errorf("read %d bytes of an %d-byte stream, want the ceiling to stop it near %d",
+			reader.read, 8*maxMetricDefinitionsBytes, maxMetricDefinitionsBytes)
+	}
+}
+
+// TestMetricDefinitionsOutput_DocumentSizes_AreTruncatedAndFlagged verifies
+// that a document above the ceiling comes back cut and marked, and one at or
+// below it comes back whole and unmarked.
+//
+// The flag is half the fix: a prefix of this document reads as valid
+// definitions, so a caller told nothing would treat a truncated answer as the
+// complete set. The exactly-at-the-ceiling case is here because an off-by-one
+// in the limit reader would flag a document that fits.
+func TestMetricDefinitionsOutput_DocumentSizes_AreTruncatedAndFlagged(t *testing.T) {
+	tests := []struct {
+		name          string
+		size          int
+		wantTruncated bool
+	}{
+		{name: "document under the ceiling is returned whole", size: 1024},
+		{name: "document exactly at the ceiling is returned whole", size: maxMetricDefinitionsBytes},
+		{name: "document over the ceiling is cut and flagged", size: maxMetricDefinitionsBytes + 1, wantTruncated: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := metricDefinitionsOutput(strings.NewReader(strings.Repeat("y", tt.size)))
+			if err != nil {
+				t.Fatalf("metricDefinitionsOutput(%d bytes) error = %v", tt.size, err)
+			}
+			if out.Truncated != tt.wantTruncated {
+				t.Errorf("Truncated = %v, want %v", out.Truncated, tt.wantTruncated)
+			}
+			wantLen := min(tt.size, maxMetricDefinitionsBytes)
+			if len(out.YAML) != wantLen {
+				t.Errorf("len(YAML) = %d, want %d", len(out.YAML), wantLen)
+			}
+		})
+	}
+}
+
+// TestFormatMetricDefinitionsMarkdown_Truncated verifies that a truncated
+// document says so in the Markdown a model reads.
+//
+// The formatter already shortens a long document for display, which looks the
+// same in the rendered output and means something different: that cut is
+// cosmetic and the whole document is still in the response, while this one
+// means the rest was never read. Without a distinct line the model cannot tell
+// a complete answer from a partial one.
+func TestFormatMetricDefinitionsMarkdown_Truncated(t *testing.T) {
+	truncated := FormatMetricDefinitionsMarkdown(MetricDefinitionsOutput{YAML: "metrics: []", Truncated: true})
+	if !strings.Contains(truncated, "Truncated") {
+		t.Errorf("markdown for a truncated document = %q, want it to say so", truncated)
+	}
+	whole := FormatMetricDefinitionsMarkdown(MetricDefinitionsOutput{YAML: "metrics: []"})
+	if strings.Contains(whole, "Truncated") {
+		t.Errorf("markdown for a whole document = %q, want no truncation notice", whole)
 	}
 }
 

--- a/llms-full-meta-tools.txt
+++ b/llms-full-meta-tools.txt
@@ -1586,7 +1586,7 @@ Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true
 <details><summary>usage_data_metric_definitions</summary>
 
 ```json
-{"additionalProperties":false,"properties":{"next_steps":{"items":{"type":"string"},"type":["null","array"]},"yaml":{"type":"string"}},"required":["yaml"],"type":"object"}
+{"additionalProperties":false,"properties":{"next_steps":{"items":{"type":"string"},"type":["null","array"]},"truncated":{"type":"boolean"},"yaml":{"type":"string"}},"required":["yaml","truncated"],"type":"object"}
 ```
 
 </details>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1586,7 +1586,7 @@ Annotations: readOnly=false, destructive=true, idempotent=false, openWorld=true
 <details><summary>usage_data_metric_definitions</summary>
 
 ```json
-{"additionalProperties":false,"properties":{"next_steps":{"items":{"type":"string"},"type":["null","array"]},"yaml":{"type":"string"}},"required":["yaml"],"type":"object"}
+{"additionalProperties":false,"properties":{"next_steps":{"items":{"type":"string"},"type":["null","array"]},"truncated":{"type":"boolean"},"yaml":{"type":"string"}},"required":["yaml","truncated"],"type":"object"}
 ```
 
 </details>

--- a/site/src/data/token-footprint.json
+++ b/site/src/data/token-footprint.json
@@ -11,17 +11,17 @@
   "individual": {
     "free": {
       "visible_tools": 854,
-      "tool_schema_tokens": 501753,
+      "tool_schema_tokens": 501763,
       "reduction_factor_vs_dynamic": 334
     },
     "premium": {
       "visible_tools": 1007,
-      "tool_schema_tokens": 600492,
+      "tool_schema_tokens": 600502,
       "reduction_factor_vs_dynamic": 400
     },
     "ultimate": {
       "visible_tools": 1073,
-      "tool_schema_tokens": 629506,
+      "tool_schema_tokens": 629516,
       "reduction_factor_vs_dynamic": 419
     }
   }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -175,7 +175,7 @@ sonar.cpd.exclusions=internal/tools/groupsaml/groupsaml.go,internal/tools/*/acti
 # S3776: "Refactor this method to reduce its Cognitive Complexity"
 # Test helper functions that verify multiple fields of API responses naturally
 # have higher complexity. Splitting them reduces test readability.
-sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7
+sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7,g8
 
 # S1192 — duplicated string literals in tests
 sonar.issue.ignore.multicriteria.t1.ruleKey=go:S1192
@@ -233,4 +233,24 @@ sonar.issue.ignore.multicriteria.g6.resourceKey=**/gitlab/client.go
 
 sonar.issue.ignore.multicriteria.g7.ruleKey=go:S5527
 sonar.issue.ignore.multicriteria.g7.resourceKey=**/gitlab/client.go
+
+# S1192: "Define a constant instead of duplicating this literal"
+# internal/prompts/exclusion.go is promptBackingActions, the map from each
+# prompt name to the catalog actions its handler reads. It is a data table, and
+# the repeated literals are its data: "merge_request.list" appears twelve times
+# because twelve prompts read that action. The table's stated purpose, in its
+# own doc comment, is that a reviewer can see at a glance which tools a prompt
+# duplicates, so replacing the action IDs with Go identifiers would obscure the
+# one thing it exists for.
+#
+# The usual argument for a constant — a typo becomes a compile error instead of
+# a silent bug — does not apply here, because the IDs are not compared against
+# each other but resolved against the live catalog:
+# TestPromptBackingActions_StaysAlignedWithBothSurfaces fails, naming the
+# offending ID, on any string that no action answers to. A
+# constant whose value carries the same typo fails that test identically. So a
+# constant would buy nothing this table does not already have, and cost the
+# readability it was built for.
+sonar.issue.ignore.multicriteria.g8.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.g8.resourceKey=**/prompts/exclusion.go
 


### PR DESCRIPTION
This takes two of the items still open on https://github.com/jmrplens/gitlab-mcp-server/issues/402 and leaves the rest of that list alone, because another branch owns `cmd/server/**`, `internal/oauth/**` and `internal/toolutil/metatool.go` and I did not want a second set of edits landing in those files.

The first item is MTG-02, the tool-level download ceilings, and the first thing to say about it is that the two files the issue names are already fixed. `groupimportexport.go` and `model_registry.go` both bound their reads against an explicit maximum and have done since the September security branch landed, which is what my own audit comment on the issue found as well. What was not done is the rest of the class. Two other actions still handed a remote response body to `io.ReadAll` with nothing bounding it: `project.download_avatar` and `usage_data_metric_definitions`. The avatar one is the one that matters, because `projectReadSpec` registers it read-only, so it sits inside the surface a `read_api` token keeps and any tenant with a token could point it at a large object and make a shared process buffer the whole response and then hold a base64 copy a third larger beside it. That is the exposure MTG-02 describes, in a file the audit did not enumerate.

Both ceilings are expressed against decoded bytes rather than encoded, which is the convention the two existing ones already set, and it is the side a caller can reason about since it is the size GitLab reports for the file and the size the upload action accepts. The cost of a call is a multiple of it: the decoded bytes and the base64 copy are held at the same time and then copied into a JSON-RPC message, so the 1 MiB avatar ceiling bounds a call at roughly 2.3 MiB rather than at 1, and the comment on the constant says so. The metric-definitions document is the exception that proves the rule, since it is returned as text rather than base64, so there is no encoded copy to account for and the two ways of expressing its ceiling are the same number.

The two actions differ in what they do at the ceiling, and deliberately. The issue asks for a `Truncated` flag on both, following the job-trace pattern, and I have followed that only where it is the right answer. An avatar above 1 MiB is refused, not truncated, for the same reason a group export is refused: the prefix of a PNG or a JPEG decodes to no image at all, so a partial answer would be a wrong answer wearing a flag. The 1 MiB itself comes from the endpoint rather than from taste, since GitLab caps an avatar upload at 200 KB and the sibling upload action already tells the caller so, which leaves five times that as room for an avatar stored before the limit existed or imported without it. The metric-definitions document does truncate and does carry a `Truncated` flag, because a prefix of it still reads as the definitions it holds, exactly like a job trace, and its 2 MiB sits above the definition set GitLab actually ships and below the 4 MiB message ceiling both transports apply, which is the real upper bound here since the whole document travels in the JSON response. That endpoint is admin-only, so it is a smaller problem than the avatar rather than a different one, and I bounded it anyway because an unbounded read of a remote response is a ceiling nobody chose.

Each ceiling carries two tests rather than one, and the second is the interesting one. An assertion written against the returned value alone still passes with the `io.LimitReader` deleted, because checking the length after buffering the whole body refuses exactly the same downloads while having already done the thing the ceiling exists to prevent. I verified that rather than assumed it: with the limit reader removed and the length check left in place, all three subtests of the avatar refusal test still pass. So each action also has a test that counts the bytes taken off the stream, which is the only part of the observable behaviour that can tell a real ceiling from a cosmetic one. Those readers are finite on purpose, a few times the ceiling, because an endless one proves the same point by hanging until the test binary's timeout and taking whatever memory `io.ReadAll` claims on the way.

The second item is the prompts registration. `internal/resources` already takes a `RegisterOptions` carrying the excluded actions, so a resource cannot be a way around `--exclude-tools`, and `internal/resources/doc.go` recorded that prompts were the remaining hole. They were: 37 prompts running handler code with the caller's credential, returning the same data a tool returns, taking no options at all. An operator who excluded `gitlab_mr_changes_get` removed it from `tools/list` and from `resources/read` and was still served the identical diffs by asking for the `review_mr` prompt, so the mitigation covered two of the three ways to reach it. `prompts.Register` now takes the same shape: a `RegisterOptions` with the excluded catalog action IDs, a hand-kept `promptBackingActions` table relating each prompt to the actions whose data it reads, and an `excludingRegistrar` wrapping the one `addPrompt` chokepoint every prompt already passes through. A prompt goes when any one of its backing actions was excluded rather than only when all of them were, which is the same conservative reading the resource surface takes, and a prompt missing from the table is kept rather than withheld. Two drift tests hold the table honest in both directions, one failing when a registered prompt has no entry and the other when an entry names an action that is not in the real catalog, and the second is what verified all 37 rows against the live Ultimate catalog rather than against my reading of the handlers. The options are variadic, so every existing call site compiles unchanged and a deployment that excludes nothing still gets all 37.

One consequence worth flagging for whoever picks up the rest of the issue: the wiring for this is now a single line in a file I have deliberately not touched. `registerConfiguredCapabilities` in `cmd/server/main.go` already computes `excludedActions` and already passes it to `resources.Register` on the line above, so giving the prompt surface the same treatment is `prompts.Register(server, client, prompts.RegisterOptions{ExcludedActions: excludedActions})` and nothing else. Until that lands, this PR ships the mechanism and the tests but not the behaviour change in the shipped binary, which is the same state `internal/resources` was in between its own two halves.

The generated artefacts moved because adding the `Truncated` field changes the output schema of `gitlab_get_metric_definitions`, so the individual tool snapshot, the token footprint, the README stats, `llms.txt` and the testing reference are all regenerated here. The snapshot diff is five lines and is the new field and its `required` entry.

I did not touch MTG-03, whose cancellation half already landed in https://github.com/jmrplens/gitlab-mcp-server/pull/453, and the remaining items on the issue stay open.

## Summary by Sourcery

Bound remote download responses and apply configured tool exclusions consistently across the prompt surface.

New Features:
- Propagate configured tool exclusions to MCP prompt registration so prompts backed by excluded actions are no longer exposed or executable.
- Expose truncation status for oversized metric-definition responses while preserving the returned prefix.

Bug Fixes:
- Bound avatar and metric-definition response reads to prevent unbounded remote downloads from consuming excessive memory.
- Refuse oversized avatar downloads instead of returning unusable partial image data.

Enhancements:
- Associate prompts with their backing catalog actions and add drift protection to keep exclusions aligned with the live action catalog.

Documentation:
- Update generated tool schema, token-footprint, testing, and project statistics documentation for the new response field and tests.

Tests:
- Add coverage confirming download ceilings limit bytes consumed, boundary behavior, avatar refusal, metric-definition truncation, and prompt exclusion across listing and retrieval.

Chores:
- Document remaining coverage limitations for prompt and resource rate limiting.
- Add a targeted static-analysis exclusion for the prompt backing-action data table.