### PR TITLE
test(bench): cover the harness's process half with a stand-in server

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,18 +459,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,065 |     226,008 |
-| Unit tests (`_test.go`)  |       634 |     367,592 |
+| Source (`.go`, non-test) |     1,065 |     226,043 |
+| Unit tests (`_test.go`)  |       634 |     367,606 |
 | End-to-end tests         |       223 |      60,661 |
-| **Total**                | **1,922** | **654,261** |
+| **Total**                | **1,922** | **654,310** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,474 |
+| Source functions                |  8,475 |
 | . Exported (public)             |  2,799 |
-| . Unexported (private)          |  5,675 |
+| . Unexported (private)          |  5,676 |
 | Unit test functions (`TestXxx`) | 13,101 |
 | Subtests (`t.Run(...)`)         |  4,867 |
 | End-to-end test functions       |    566 |
@@ -482,15 +482,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~579 lines |
-| Comment lines in source            |  34,275 (~15.2% of source) |
+| Comment lines in source            |  34,282 (~15.2% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,080 |
-| `defer` statements                 | 1,188 |
+| `if err != nil` checks             | 7,082 |
+| `defer` statements                 | 1,190 |
 | `struct` types defined             | 2,880 |
 | `//nolint` suppressions            |   276 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -459,39 +459,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,064 |     225,829 |
-| Unit tests (`_test.go`)  |       634 |     366,943 |
+| Source (`.go`, non-test) |     1,065 |     226,008 |
+| Unit tests (`_test.go`)  |       634 |     367,592 |
 | End-to-end tests         |       223 |      60,661 |
-| **Total**                | **1,921** | **653,433** |
+| **Total**                | **1,922** | **654,261** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,469 |
+| Source functions                |  8,474 |
 | . Exported (public)             |  2,799 |
-| . Unexported (private)          |  5,670 |
-| Unit test functions (`TestXxx`) | 13,082 |
-| Subtests (`t.Run(...)`)         |  4,858 |
+| . Unexported (private)          |  5,675 |
+| Unit test functions (`TestXxx`) | 13,101 |
+| Subtests (`t.Run(...)`)         |  4,867 |
 | End-to-end test functions       |    566 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.62× more tests than code |
+| Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~212 lines |
-| Average test file length           |                 ~578 lines |
-| Comment lines in source            |  34,247 (~15.2% of source) |
+| Average test file length           |                 ~579 lines |
+| Comment lines in source            |  34,275 (~15.2% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,067 |
-| `defer` statements                 | 1,187 |
-| `struct` types defined             | 2,878 |
+| `if err != nil` checks             | 7,080 |
+| `defer` statements                 | 1,188 |
+| `struct` types defined             | 2,880 |
 | `//nolint` suppressions            |   276 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -499,7 +499,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   251 |
+| Go packages                    |   252 |
 | Direct dependencies (`go.mod`) |    31 |
 | Indirect dependencies          |    38 |
 
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,105 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,313 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,109 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,318 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/bench_resources/main_test.go
+++ b/cmd/bench_resources/main_test.go
@@ -282,7 +282,12 @@ func runWithStandin(m *testing.M) int {
 		}
 		defer func() { _ = os.RemoveAll(dir) }()
 		path := filepath.Join(dir, "standin")
-		build := exec.CommandContext(context.Background(), "go", "build", "-o", path, "./testdata/standin")
+		// Bounded like buildServer: the Go test timeout cannot stop a build
+		// started before m.Run, so a stalled one would hold the package until
+		// an outer runner gave up.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		build := exec.CommandContext(ctx, "go", "build", "-o", path, "./testdata/standin")
 		if out, buildErr := build.CombinedOutput(); buildErr != nil {
 			fmt.Fprintf(os.Stderr, "build testdata/standin: %v\n%s", buildErr, out)
 			return 1

--- a/cmd/bench_resources/main_test.go
+++ b/cmd/bench_resources/main_test.go
@@ -4,9 +4,14 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -246,5 +251,214 @@ func TestOptionsValidate_RejectsValuesThatWouldMeasureNothing(t *testing.T) {
 				t.Errorf("validate() = %v, want it to name %s", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// standinPath is the stand-in server under testdata/standin, built once by
+// TestMain for every test that measures a process. Empty on Windows, where
+// those tests skip: the harness samples /proc or ps and asks for a goroutine
+// count with SIGQUIT, and Windows has neither.
+var standinPath string
+
+// TestMain builds the stand-in before the tests and removes it after them.
+//
+// Built here rather than per test because a t.TempDir goes with the test that
+// made it, and built at all because the process-spawning half of this command
+// cannot be exercised against anything in-process: the readiness poll, the
+// pipe wiring, the resident-set sampling and the traceback signal all need a
+// child. Linking the real server for that would cost a minute per run to
+// learn nothing about the harness.
+func TestMain(m *testing.M) {
+	os.Exit(runWithStandin(m))
+}
+
+// runWithStandin builds the stand-in, runs the tests and cleans up after them.
+func runWithStandin(m *testing.M) int {
+	if runtime.GOOS != "windows" {
+		dir, err := os.MkdirTemp("", "bench-standin")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "create a build directory for the stand-in: %v\n", err)
+			return 1
+		}
+		defer func() { _ = os.RemoveAll(dir) }()
+		path := filepath.Join(dir, "standin")
+		build := exec.CommandContext(context.Background(), "go", "build", "-o", path, "./testdata/standin")
+		if out, buildErr := build.CombinedOutput(); buildErr != nil {
+			fmt.Fprintf(os.Stderr, "build testdata/standin: %v\n%s", buildErr, out)
+			return 1
+		}
+		standinPath = path
+	}
+	return m.Run()
+}
+
+// standinBinary returns the stand-in server, skipping where nothing can be
+// measured.
+func standinBinary(t *testing.T) string {
+	t.Helper()
+	if standinPath == "" {
+		t.Skip("the harness samples /proc or ps and signals SIGQUIT, neither of which Windows has")
+	}
+	return standinPath
+}
+
+// quickOptions are the flags of a smoke run against the stand-in: one round, a
+// fast sampler, and a record path of its own so the guard against overwriting
+// the published record lets it through.
+func quickOptions(t *testing.T, root string) options {
+	t.Helper()
+	return options{
+		binary:         standinBinary(t),
+		record:         filepath.Join(root, "record.json"),
+		recordSet:      true,
+		rounds:         1,
+		sampleInterval: 20 * time.Millisecond,
+		quick:          true,
+	}
+}
+
+// TestMeasure_QuickMatrix_ProducesOneScenarioPerPlan runs the smoke matrix
+// against the stand-in and checks the record carries what every downstream
+// artifact reads: a scenario per plan, the build the server reported, and the
+// settings the matrix imposed rather than the ones the flags asked for.
+func TestMeasure_QuickMatrix_ProducesOneScenarioPerPlan(t *testing.T) {
+	root := t.TempDir()
+	opts := quickOptions(t, root)
+	opts.rounds = 7 // the smoke matrix pins one round, and the record must say so
+
+	run, err := measure(opts, root)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	if got, want := len(run.Scenarios), len(quickMatrix()); got != want {
+		t.Fatalf("recorded %d scenarios, want %d", got, want)
+	}
+	if run.Server.Version != "standin" || run.Server.Commit == "" {
+		t.Errorf("server info = %+v, want the build /health reported", run.Server)
+	}
+	if run.Settings.Rounds != 1 || !run.Settings.Quick || run.Settings.SampleIntervalMs != 20 {
+		t.Errorf("settings = %+v, want the smoke matrix's one round, quick, 20 ms", run.Settings)
+	}
+	if run.Schema != resultSchema || run.GeneratedAt == "" || run.Host.OS == "" {
+		t.Errorf("record header incomplete: schema %d, generated %q, host %+v", run.Schema, run.GeneratedAt, run.Host)
+	}
+	for _, scenario := range run.Scenarios {
+		t.Run(scenario.ID, func(t *testing.T) {
+			if len(scenario.Latency) != 3 {
+				t.Errorf("%d latency rows, want one per method", len(scenario.Latency))
+			}
+			if scenario.Goroutines == 0 {
+				t.Errorf("no goroutine count: notes %v", scenario.Notes)
+			}
+		})
+	}
+}
+
+// TestExecute_MeasureRenderCheck_AgreeWithEachOther drives the command the
+// way make does: a measurement that writes the record and every artifact, then
+// -render over the same record, then -check, which must find nothing stale in
+// what the two previous calls wrote.
+func TestExecute_MeasureRenderCheck_AgreeWithEachOther(t *testing.T) {
+	root, tree := renderTree(t)
+	opts := quickOptions(t, root)
+	// execute resolves relative paths against the real module root, so the
+	// temporary tree's paths go in absolute.
+	opts.docCharts = filepath.Join(root, filepath.FromSlash(tree.docCharts))
+	opts.siteCharts = filepath.Join(root, filepath.FromSlash(tree.siteCharts))
+	opts.docPage = filepath.Join(root, filepath.FromSlash(tree.docPage))
+	opts.sitePageEN = filepath.Join(root, filepath.FromSlash(tree.sitePageEN))
+	opts.sitePageES = filepath.Join(root, filepath.FromSlash(tree.sitePageES))
+
+	if err := execute(opts); err != nil {
+		t.Fatalf("execute (measure): %v", err)
+	}
+	run, err := readRun(opts.record)
+	if err != nil {
+		t.Fatalf("the measurement left no readable record: %v", err)
+	}
+	assertChartsWritten(t, root, tree, run)
+
+	redraw := opts
+	redraw.render = true
+	if renderErr := execute(redraw); renderErr != nil {
+		t.Errorf("execute (render): %v", renderErr)
+	}
+	check := opts
+	check.check = true
+	if checkErr := execute(check); checkErr != nil {
+		t.Errorf("execute (check) over what execute just wrote: %v", checkErr)
+	}
+}
+
+// TestExecute_RefusesWhatItCannotRun covers the two ways the command stops
+// before measuring or drawing: flags that would measure nothing, and a record
+// that is not there to redraw from.
+func TestExecute_RefusesWhatItCannotRun(t *testing.T) {
+	t.Run("invalid flags", func(t *testing.T) {
+		err := execute(options{rounds: 0, sampleInterval: time.Millisecond})
+		if err == nil || !strings.Contains(err.Error(), "-rounds") {
+			t.Errorf("execute = %v, want the -rounds refusal", err)
+		}
+	})
+	t.Run("absent record", func(t *testing.T) {
+		absent := filepath.Join(t.TempDir(), "absent.json")
+		err := execute(options{render: true, record: absent})
+		if err == nil || !strings.Contains(err.Error(), absent) {
+			t.Errorf("execute = %v, want it to name %s", err, absent)
+		}
+	})
+}
+
+// writeModuleFile creates one file of the throwaway module below.
+func writeModuleFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("create %s: %v", filepath.Dir(path), err)
+	}
+	//#nosec G703 -- both halves of the path are this test's own: a t.TempDir and a literal
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestBuildServer_CompilesCmdServerUnderTheRoot points buildServer at a
+// throwaway module with a trivial cmd/server, which exercises the real build
+// path in a second rather than the minute the actual server takes to link.
+func TestBuildServer_CompilesCmdServerUnderTheRoot(t *testing.T) {
+	root := t.TempDir()
+	writeModuleFile(t, filepath.Join(root, "go.mod"), "module standin.example/server\n\ngo 1.22\n")
+	writeModuleFile(t, filepath.Join(root, "cmd", "server", "main.go"), "package main\n\nfunc main() {}\n")
+
+	built, err := buildServer(root)
+	if err != nil {
+		t.Fatalf("buildServer: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(built)) })
+	info, statErr := os.Stat(built)
+	if statErr != nil {
+		t.Fatalf("the built binary is not there: %v", statErr)
+	}
+	if info.Size() == 0 {
+		t.Error("the built binary is empty")
+	}
+}
+
+// TestBuildServer_NothingToBuild_ReportsTheCompilerOutput checks a root with
+// no module in it fails with the compiler's own words attached, since that is
+// what somebody running the benchmark from the wrong directory needs to see.
+func TestBuildServer_NothingToBuild_ReportsTheCompilerOutput(t *testing.T) {
+	_, err := buildServer(t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "build ./cmd/server") {
+		t.Errorf("buildServer = %v, want the build failure", err)
+	}
+}
+
+// TestRel_PathThatCannotBeMadeRelative_IsReturnedWhole covers the fallback
+// for a path filepath.Rel refuses, which happens when only one of the two is
+// absolute.
+func TestRel_PathThatCannotBeMadeRelative_IsReturnedWhole(t *testing.T) {
+	absolute := filepath.Join(t.TempDir(), "record.json")
+	if got := rel("relative-root", absolute); got != absolute {
+		t.Errorf("rel = %q, want the path untouched %q", got, absolute)
 	}
 }

--- a/cmd/bench_resources/render_test.go
+++ b/cmd/bench_resources/render_test.go
@@ -458,3 +458,44 @@ func TestWriteFile_UnreadablePath_IsAnErrorNotAChange(t *testing.T) {
 		t.Error("an absent file was not reported as a change")
 	}
 }
+
+// TestShortCommit_TrimsToEightCharacters covers the width the rest of the
+// documentation uses, and a short value left whole.
+func TestShortCommit_TrimsToEightCharacters(t *testing.T) {
+	cases := []struct{ name, commit, want string }{
+		{name: "full sha", commit: "0123456789abcdef", want: "01234567"},
+		{name: "already short", commit: "abc", want: "abc"},
+		{name: "empty", commit: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shortCommit(tc.commit); got != tc.want {
+				t.Errorf("shortCommit(%q) = %q, want %q", tc.commit, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTableCells_ZeroIsNotAvailable checks the two table formatters print n/a
+// for a figure that was not measured rather than a zero a reader would take
+// for a measurement.
+func TestTableCells_ZeroIsNotAvailable(t *testing.T) {
+	cases := []struct {
+		name   string
+		render func(float64) string
+		value  float64
+		want   string
+	}{
+		{name: "mib unmeasured", render: mib, value: 0, want: "n/a"},
+		{name: "mib measured", render: mib, value: 63.4, want: "63"},
+		{name: "ms unmeasured", render: ms, value: 0, want: "n/a"},
+		{name: "ms measured", render: ms, value: 12.6, want: "13"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.render(tc.value); got != tc.want {
+				t.Errorf("%s(%v) = %q, want %q", tc.name, tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/bench_resources/result_test.go
+++ b/cmd/bench_resources/result_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -208,5 +209,29 @@ func sampleRun() *Run {
 			scenario("http-meta", transportHTTP, surfaceMeta, 4),
 			scenario("http-individual", transportHTTP, surfaceIndividual, 4),
 		},
+	}
+}
+
+// TestWriteRun_ReportsWhereItCouldNotWrite covers the two filesystem
+// refusals: a parent that cannot be created because a file is in the way, and
+// a path that is a directory.
+func TestWriteRun_ReportsWhereItCouldNotWrite(t *testing.T) {
+	root := t.TempDir()
+	blocker := filepath.Join(root, "file")
+	//#nosec G703 -- both halves of the path are this test's own: a t.TempDir and a literal
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write the blocking file: %v", err)
+	}
+	cases := []struct{ name, path, wantErr string }{
+		{name: "parent is a file", path: filepath.Join(blocker, "record.json"), wantErr: "create"},
+		{name: "path is a directory", path: root, wantErr: "write"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := writeRun(tc.path, sampleRun())
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("writeRun(%s) = %v, want %q", tc.path, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/cmd/bench_resources/rpc.go
+++ b/cmd/bench_resources/rpc.go
@@ -342,6 +342,9 @@ func commandProcess(cmd *exec.Cmd) (io.WriteCloser, io.Reader, error) {
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		// The command is never started on this path, so nothing else will
+		// close the stdin pipe already wired to it.
+		_ = stdin.Close()
 		return nil, nil, fmt.Errorf("stdout pipe: %w", err)
 	}
 	return stdin, stdout, nil

--- a/cmd/bench_resources/rpc_test.go
+++ b/cmd/bench_resources/rpc_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
@@ -322,3 +323,44 @@ func TestStdioRPC_ContextCancelled_ReturnsPromptly(t *testing.T) {
 
 // itoa renders an id for the fixtures above.
 func itoa(value int64) string { return strconv.FormatInt(value, 10) }
+
+// TestCommandProcess_RefusesPipesAlreadyWired covers the two ways exec.Cmd
+// declines to hand out a pipe: a stream the caller already assigned.
+func TestCommandProcess_RefusesPipesAlreadyWired(t *testing.T) {
+	cases := []struct {
+		name    string
+		prepare func(*exec.Cmd)
+		wantErr string
+	}{
+		{name: "stdin already set", prepare: func(c *exec.Cmd) { c.Stdin = strings.NewReader("") }, wantErr: "stdin pipe"},
+		{name: "stdout already set", prepare: func(c *exec.Cmd) { c.Stdout = io.Discard }, wantErr: "stdout pipe"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.CommandContext(t.Context(), "go", "version")
+			tc.prepare(cmd)
+			_, _, err := commandProcess(cmd)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("commandProcess = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestFirstLine_TrimsForAnErrorMessage checks a body is cut at its first line
+// and at two hundred bytes, since the message it goes into is one line of a
+// note.
+func TestFirstLine_TrimsForAnErrorMessage(t *testing.T) {
+	cases := []struct{ name, body, want string }{
+		{name: "multi-line", body: "  first\nsecond\n", want: "first"},
+		{name: "long", body: strings.Repeat("x", 250), want: strings.Repeat("x", 200)},
+		{name: "blank", body: "\n\n", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstLine([]byte(tc.body)); got != tc.want {
+				t.Errorf("firstLine(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/bench_resources/run_test.go
+++ b/cmd/bench_resources/run_test.go
@@ -365,3 +365,174 @@ func TestDecodeHealth_ReadsTheBuildTheServerReports(t *testing.T) {
 		})
 	}
 }
+
+// standinRunner is a runner over the stand-in: the two stand-in services, a
+// fast sampler and a quiet reporter.
+func standinRunner(t *testing.T) *runner {
+	t.Helper()
+	binary := standinBinary(t)
+	stub := startStubGitLab()
+	t.Cleanup(stub.close)
+	sink := startOTLPSink()
+	t.Cleanup(sink.close)
+	return &runner{
+		binary:         binary,
+		stub:           stub,
+		otlp:           sink,
+		sampleInterval: 20 * time.Millisecond,
+		progress:       progressFunc(false),
+	}
+}
+
+// httpPlan is an HTTP scenario small enough for a test and large enough to
+// have a ramp: two credentials, two requests in flight, the rounds given.
+func httpPlan(rounds int) scenarioPlan {
+	return scenarioPlan{
+		ID: "http-dynamic-telemetry", Transport: transportHTTP, Surface: surfaceDynamic,
+		Telemetry: true, Clients: 2, Parallel: 2, Rounds: rounds,
+	}
+}
+
+// TestRunScenario_HTTP_FillsEveryPublishedFigure measures the stand-in over
+// HTTP with telemetry on and checks every figure the tables and charts read
+// is there: the startup milestones, the idle and per-client resident sets, a
+// ramp point per credential, one distribution per method with every call
+// counted, and the goroutine count that ends the process.
+func TestRunScenario_HTTP_FillsEveryPublishedFigure(t *testing.T) {
+	r := standinRunner(t)
+	plan := httpPlan(2)
+
+	scenario, err := r.runScenario(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("runScenario: %v", err)
+	}
+
+	if scenario.ID != plan.ID || scenario.Clients != 2 || scenario.Parallel != 2 || scenario.Rounds != 2 || !scenario.Telemetry {
+		t.Errorf("scenario header %+v does not describe the plan %+v", scenario, plan)
+	}
+	assertStartupMeasured(t, scenario)
+	assertMemoryMeasured(t, scenario)
+	assertLatencyPerMethod(t, scenario, plan.Clients*plan.Parallel*plan.Rounds)
+	if scenario.Goroutines < 1 {
+		t.Errorf("goroutines = %d, want the traceback counted", scenario.Goroutines)
+	}
+	if len(scenario.Notes) != 0 {
+		t.Errorf("notes %v on a scenario where everything answered", scenario.Notes)
+	}
+	if r.serverInfo.Version != "standin" {
+		t.Errorf("the runner kept server info %+v, want what /health reported", r.serverInfo)
+	}
+}
+
+// assertStartupMeasured checks the three startup milestones and the size of
+// the cold listing were all taken.
+func assertStartupMeasured(t *testing.T, scenario Scenario) {
+	t.Helper()
+	if s := scenario.Startup; s.ProcessReadyMs <= 0 || s.FirstListMs <= 0 || s.WarmListMs <= 0 {
+		t.Errorf("startup milestones %+v, want all three measured", s)
+	}
+	if scenario.ListBytes == 0 {
+		t.Error("the cold tools/list response was not sized")
+	}
+}
+
+// assertMemoryMeasured checks every resident-set figure came from the kernel
+// and the ramp has a point per credential.
+func assertMemoryMeasured(t *testing.T, scenario Scenario) {
+	t.Helper()
+	if m := scenario.Memory; m.IdleMiB <= 0 || m.OneClientMiB <= 0 || m.AllClientsMiB <= 0 || m.PeakMiB <= 0 {
+		t.Errorf("memory figures %+v, want every one read from the kernel", m)
+	}
+	if len(scenario.Ramp) != 2 || scenario.Ramp[1].Client != 2 || scenario.Ramp[1].ColdListMs <= 0 {
+		t.Errorf("ramp %+v, want one point per credential", scenario.Ramp)
+	}
+}
+
+// assertLatencyPerMethod checks each measured method has a distribution over
+// every call the plan issued.
+func assertLatencyPerMethod(t *testing.T, scenario Scenario, wantCount int) {
+	t.Helper()
+	for _, method := range []string{methodResourcesList, methodToolsCall, methodToolsList} {
+		t.Run(method, func(t *testing.T) {
+			latency, ok := scenario.latency(method)
+			if !ok {
+				t.Fatalf("no distribution for %s", method)
+			}
+			if latency.Count != wantCount {
+				t.Errorf("%d samples, want %d (clients x parallel x rounds)", latency.Count, wantCount)
+			}
+			if latency.P50 <= 0 || latency.Max < latency.P50 {
+				t.Errorf("percentiles %+v are not a distribution", latency)
+			}
+		})
+	}
+}
+
+// TestRunScenario_Stdio_TimesTheSpawnAndPublishesNoIdleFigure measures the
+// stand-in over stdio, where the record's shape differs on purpose: readiness
+// is the exec of the first client's process, and there is no idle figure
+// because a stdio process has no idle state to size for.
+func TestRunScenario_Stdio_TimesTheSpawnAndPublishesNoIdleFigure(t *testing.T) {
+	r := standinRunner(t)
+	plan := scenarioPlan{
+		ID: "stdio-dynamic", Transport: transportStdio, Surface: surfaceDynamic, Clients: 2, Parallel: 1, Rounds: 1,
+	}
+
+	scenario, err := r.runScenario(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("runScenario: %v", err)
+	}
+	if scenario.Startup.ProcessReadyMs <= 0 {
+		t.Errorf("ProcessReadyMs = %v, want the first client's exec timed", scenario.Startup.ProcessReadyMs)
+	}
+	if scenario.Memory.IdleMiB != 0 {
+		t.Errorf("IdleMiB = %v on stdio, want none", scenario.Memory.IdleMiB)
+	}
+	if scenario.Memory.AllClientsMiB <= 0 || len(scenario.Ramp) != 2 {
+		t.Errorf("memory %+v ramp %+v, want two processes measured", scenario.Memory, scenario.Ramp)
+	}
+	if scenario.Goroutines < 1 {
+		t.Errorf("goroutines = %d, want the first process's traceback counted", scenario.Goroutines)
+	}
+	if r.serverInfo.Version != "" {
+		t.Errorf("stdio reported server info %+v, want none", r.serverInfo)
+	}
+}
+
+// TestRunScenario_ColdListRefused_FailsTheScenario makes the stand-in refuse
+// tools/list, which is the first thing the ramp asks: a scenario whose
+// surface cannot be listed has nothing to publish and must say so rather than
+// record zeros.
+func TestRunScenario_ColdListRefused_FailsTheScenario(t *testing.T) {
+	t.Setenv("STANDIN_FAIL", methodToolsList)
+	r := standinRunner(t)
+
+	_, err := r.runScenario(t.Context(), httpPlan(1))
+	if err == nil || !strings.Contains(err.Error(), "cold tools/list for client 0") {
+		t.Errorf("runScenario = %v, want the cold tools/list failure", err)
+	}
+}
+
+// TestRunScenario_FailedCalls_AreNotedRatherThanFatal makes the stand-in
+// refuse tools/call: the load phase records how many calls failed and why,
+// keeps the other methods' distributions, and the scenario still completes.
+func TestRunScenario_FailedCalls_AreNotedRatherThanFatal(t *testing.T) {
+	t.Setenv("STANDIN_FAIL", methodToolsCall)
+	r := standinRunner(t)
+	plan := httpPlan(1)
+
+	scenario, err := r.runScenario(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("runScenario: %v", err)
+	}
+	wantNote := strconv.Itoa(plan.Clients*plan.Parallel) + " tools/call calls failed"
+	if len(scenario.Notes) != 1 || !strings.Contains(scenario.Notes[0], wantNote) {
+		t.Errorf("notes %v, want one saying %q", scenario.Notes, wantNote)
+	}
+	if calls, ok := scenario.latency(methodToolsCall); !ok || calls.Count != 0 {
+		t.Errorf("tools/call distribution %+v, want an empty one kept in place", calls)
+	}
+	if list, ok := scenario.latency(methodToolsList); !ok || list.Count != plan.Clients*plan.Parallel {
+		t.Errorf("tools/list distribution %+v, want unaffected", list)
+	}
+}

--- a/cmd/bench_resources/run_test.go
+++ b/cmd/bench_resources/run_test.go
@@ -422,6 +422,12 @@ func TestRunScenario_HTTP_FillsEveryPublishedFigure(t *testing.T) {
 	if r.serverInfo.Version != "standin" {
 		t.Errorf("the runner kept server info %+v, want what /health reported", r.serverInfo)
 	}
+	// Telemetry was on, so the endpoint the harness configured must have
+	// been reached: a plan that says telemetry while nothing is exported
+	// would publish figures for a configuration that was never measured.
+	if got := r.otlp.requests.Load(); got == 0 {
+		t.Error("the OTLP sink received no export from a scenario with telemetry on")
+	}
 }
 
 // assertStartupMeasured checks the three startup milestones and the size of
@@ -534,5 +540,8 @@ func TestRunScenario_FailedCalls_AreNotedRatherThanFatal(t *testing.T) {
 	}
 	if list, ok := scenario.latency(methodToolsList); !ok || list.Count != plan.Clients*plan.Parallel {
 		t.Errorf("tools/list distribution %+v, want unaffected", list)
+	}
+	if resources, ok := scenario.latency(methodResourcesList); !ok || resources.Count != plan.Clients*plan.Parallel {
+		t.Errorf("resources/list distribution %+v, want unaffected", resources)
 	}
 }

--- a/cmd/bench_resources/target_test.go
+++ b/cmd/bench_resources/target_test.go
@@ -13,6 +13,7 @@ package main
 import (
 	"context"
 	"net"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -259,5 +260,160 @@ func TestFreePort_SuccessiveCalls_DoNotCollide(t *testing.T) {
 	}
 	if second == first {
 		t.Errorf("both reservations returned %d while the first was held", first)
+	}
+}
+
+// standinPlan is the plan the process-level tests hand a target: two clients,
+// two in flight, one round, on the surface the stand-in claims to serve.
+func standinPlan(transport string) scenarioPlan {
+	return scenarioPlan{
+		ID: transport + "-dynamic", Transport: transport, Surface: surfaceDynamic,
+		Clients: 2, Parallel: 2, Rounds: 1,
+	}
+}
+
+// assertClientTalks admits one client and checks it gets the surface back.
+func assertClientTalks(t *testing.T, tgt target, index int) *clientConn {
+	t.Helper()
+	conn, _, err := tgt.addClient(t.Context(), index)
+	if err != nil {
+		t.Fatalf("addClient(%d): %v", index, err)
+	}
+	payload, callErr := conn.rpc.call(t.Context(), methodToolsList, nil)
+	if callErr != nil {
+		t.Fatalf("tools/list on client %d: %v", index, callErr)
+	}
+	if !strings.Contains(string(payload), "gitlab_find_action") {
+		t.Errorf("client %d got %q, want the stand-in's surface", index, payload)
+	}
+	return conn
+}
+
+// TestHTTPTarget_OneProcessServesEveryCredential starts the stand-in the way
+// the HTTP scenarios do and walks the target's whole life: readiness through
+// /health, one process however many clients, a client per credential, the
+// traceback that ends it, and a close that finds nothing left to stop.
+func TestHTTPTarget_OneProcessServesEveryCredential(t *testing.T) {
+	stub := startStubGitLab()
+	t.Cleanup(stub.close)
+	tgt := &httpTarget{binary: standinBinary(t), plan: standinPlan(transportHTTP), stubURL: stub.url}
+	t.Cleanup(tgt.close)
+
+	if procs := tgt.processes(); procs != nil {
+		t.Errorf("processes() before start = %v, want none", procs)
+	}
+	if _, err := tgt.goroutines(); err == nil {
+		t.Error("goroutines() before start returned a count")
+	}
+
+	ready, err := tgt.start(t.Context())
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if ready <= 0 {
+		t.Errorf("start reported %s to readiness", ready)
+	}
+	if info := tgt.serverInfo(); info.Version != "standin" || info.Commit == "" {
+		t.Errorf("serverInfo = %+v, want what /health reported", info)
+	}
+	if procs := tgt.processes(); len(procs) != 1 {
+		t.Errorf("%d processes, want the one HTTP server", len(procs))
+	}
+
+	first := assertClientTalks(t, tgt, 0)
+	second := assertClientTalks(t, tgt, 1)
+	if procs := tgt.processes(); len(procs) != 1 {
+		t.Errorf("%d processes after two clients, want still one", len(procs))
+	}
+	first.rpc.close()
+	second.rpc.close()
+
+	count, dumpErr := tgt.goroutines()
+	if dumpErr != nil {
+		t.Fatalf("goroutines: %v", dumpErr)
+	}
+	if count < 1 {
+		t.Errorf("counted %d goroutines in the traceback", count)
+	}
+	tgt.close() // the process is already gone, and closing twice must be harmless
+}
+
+// TestHTTPTarget_ExecFailure_IsReportedAsSuch gives the target a binary that
+// is not there, which must fail at the exec rather than after sixty seconds of
+// polling a port nothing listens on.
+func TestHTTPTarget_ExecFailure_IsReportedAsSuch(t *testing.T) {
+	tgt := &httpTarget{
+		binary: filepath.Join(t.TempDir(), "absent"), plan: standinPlan(transportHTTP), stubURL: "http://127.0.0.1:1",
+	}
+	_, err := tgt.start(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "start server") {
+		t.Errorf("start = %v, want the exec failure", err)
+	}
+}
+
+// TestStdioTarget_EveryClientIsItsOwnProcess spawns two stand-ins the way the
+// stdio scenarios do and checks what the transport's shape implies: nothing
+// exists before a client, each client is a process, the traceback ends only
+// the first, and the second keeps answering until close.
+func TestStdioTarget_EveryClientIsItsOwnProcess(t *testing.T) {
+	stub := startStubGitLab()
+	t.Cleanup(stub.close)
+	tgt := &stdioTarget{binary: standinBinary(t), plan: standinPlan(transportStdio), stubURL: stub.url}
+	t.Cleanup(tgt.close)
+
+	if ready, err := tgt.start(t.Context()); err != nil || ready != 0 {
+		t.Errorf("start = (%s, %v), want the honest zero for a transport with no process yet", ready, err)
+	}
+	if info := tgt.serverInfo(); info != (ServerInfo{}) {
+		t.Errorf("serverInfo = %+v, want empty on stdio", info)
+	}
+	if _, err := tgt.goroutines(); err == nil {
+		t.Error("goroutines() with no process returned a count")
+	}
+
+	conn, spawn, err := tgt.addClient(t.Context(), 0)
+	if err != nil {
+		t.Fatalf("addClient(0): %v", err)
+	}
+	if spawn <= 0 {
+		t.Errorf("the exec took %s", spawn)
+	}
+	if _, callErr := conn.rpc.call(t.Context(), methodToolsList, nil); callErr != nil {
+		t.Fatalf("tools/list on process 0: %v", callErr)
+	}
+	second := assertClientTalks(t, tgt, 1)
+	if procs := tgt.processes(); len(procs) != 2 {
+		t.Fatalf("%d processes, want one per client", len(procs))
+	}
+
+	count, dumpErr := tgt.goroutines()
+	if dumpErr != nil {
+		t.Fatalf("goroutines: %v", dumpErr)
+	}
+	if count < 1 {
+		t.Errorf("counted %d goroutines in the traceback", count)
+	}
+	if _, callErr := second.rpc.call(t.Context(), methodResourcesList, nil); callErr != nil {
+		t.Errorf("the second process stopped answering after the first was dumped: %v", callErr)
+	}
+	if _, callErr := conn.rpc.call(t.Context(), methodResourcesList, nil); callErr == nil {
+		t.Error("the dumped process still answered")
+	}
+	tgt.close()
+}
+
+// TestStdioTarget_ExecFailure_NamesTheClient checks a client whose process
+// cannot start is reported by index, and leaves no process recorded for the
+// sampler to ask about.
+func TestStdioTarget_ExecFailure_NamesTheClient(t *testing.T) {
+	tgt := &stdioTarget{
+		binary: filepath.Join(t.TempDir(), "absent"), plan: standinPlan(transportStdio), stubURL: "http://127.0.0.1:1",
+	}
+	_, _, err := tgt.addClient(t.Context(), 3)
+	if err == nil || !strings.Contains(err.Error(), "start stdio server 3") {
+		t.Errorf("addClient = %v, want the exec failure naming client 3", err)
+	}
+	if procs := tgt.processes(); len(procs) != 0 {
+		t.Errorf("%d processes recorded for a client that never started", len(procs))
 	}
 }

--- a/cmd/bench_resources/testdata/standin/main.go
+++ b/cmd/bench_resources/testdata/standin/main.go
@@ -1,0 +1,179 @@
+// Command standin is the server the benchmark's tests measure instead of the
+// real one.
+//
+// The harness in cmd/bench_resources starts a binary, waits for its health
+// document, drives it over HTTP or over its pipes, samples its resident set and
+// finally sends it a traceback signal and counts what it printed. Every one of
+// those steps is process-level and none of them can be exercised against an
+// in-process fake; and building the real server for every test run would cost
+// a minute of linking to learn nothing about the harness. This program answers
+// the same contract in a few hundred lines: the flags the HTTP target passes,
+// the environment the stdio target sets, a /health document, JSON-RPC over SSE
+// and over newline-delimited pipes, and a runtime that dumps its goroutines on
+// SIGQUIT because nothing here catches it.
+//
+// STANDIN_FAIL names one JSON-RPC method the stand-in refuses with an error
+// result, which is how the tests reach the harness's failure branches without
+// a server that is actually broken.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	failEnv = "STANDIN_FAIL"
+	version = "standin"
+	commit  = "0123456789abcdef0123456789abcdef01234567"
+)
+
+// request is the subset of a JSON-RPC request the stand-in reads.
+type request struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+}
+
+// rpcError is a JSON-RPC error object.
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func main() {
+	httpMode := flag.Bool("http", false, "serve HTTP instead of stdio")
+	addr := flag.String("http-addr", "", "listen address in HTTP mode")
+	flag.String("gitlab-url", "", "accepted and ignored")
+	flag.String("tool-surface", "", "accepted and ignored")
+	flag.Int("rate-limit-rps", 0, "accepted and ignored")
+	flag.Bool("telemetry", false, "accepted and ignored")
+	flag.Parse()
+
+	if *httpMode {
+		if err := serveHTTP(*addr); err != nil {
+			fmt.Fprintln(os.Stderr, "standin:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	// The stdio target configures its process through the environment, so a
+	// stand-in that started without it would hide a harness that stopped
+	// setting it.
+	if os.Getenv("GITLAB_URL") == "" || os.Getenv("GITLAB_TOKEN") == "" {
+		fmt.Fprintln(os.Stderr, "standin: stdio mode needs GITLAB_URL and GITLAB_TOKEN in the environment")
+		os.Exit(1)
+	}
+	serveStdio(os.Stdin, os.Stdout)
+}
+
+// serveHTTP answers /health and /mcp until the process is killed.
+func serveHTTP(addr string) error {
+	if addr == "" {
+		return fmt.Errorf("--http needs --http-addr")
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", addr, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status": "ok", "version": version, "commit": commit,
+		})
+	})
+	mux.HandleFunc("POST /mcp", handleMCP)
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	return server.Serve(listener)
+}
+
+// handleMCP checks the headers a 2026-07-28 client must send and answers in
+// the SSE shape the real server uses by default.
+func handleMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("PRIVATE-TOKEN") == "" {
+		http.Error(w, "missing credential", http.StatusUnauthorized)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "unreadable body", http.StatusBadRequest)
+		return
+	}
+	var req request
+	if unmarshalErr := json.Unmarshal(body, &req); unmarshalErr != nil {
+		http.Error(w, "malformed request", http.StatusBadRequest)
+		return
+	}
+	if r.Header.Get("Mcp-Method") != req.Method {
+		http.Error(w, "Mcp-Method does not name the request's method", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	fmt.Fprintf(w, "event: message\ndata: %s\n\n", respond(req))
+}
+
+// serveStdio answers one newline-delimited request per line until the input
+// closes.
+func serveStdio(in io.Reader, out io.Writer) {
+	var mu sync.Mutex
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var req request
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			continue
+		}
+		mu.Lock()
+		_, _ = out.Write(append(respond(req), '\n'))
+		mu.Unlock()
+	}
+}
+
+// respond builds the response for one request.
+func respond(req request) []byte {
+	var result any
+	var failure *rpcError
+	switch {
+	case os.Getenv(failEnv) == req.Method:
+		failure = &rpcError{Code: -32000, Message: "the stand-in refused " + req.Method}
+	case req.Method == "tools/list":
+		result = map[string]any{"tools": []map[string]any{
+			{"name": "gitlab_find_action", "description": "find"},
+			{"name": "gitlab_execute_action", "description": "execute"},
+		}}
+	case req.Method == "resources/list":
+		result = map[string]any{"resources": []any{}}
+	case req.Method == "tools/call":
+		result = map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+			"isError": false,
+		}
+	default:
+		failure = &rpcError{Code: -32601, Message: "method not found: " + req.Method}
+	}
+
+	envelope := map[string]any{"jsonrpc": "2.0", "id": req.ID}
+	if failure != nil {
+		envelope["error"] = failure
+	} else {
+		envelope["result"] = result
+	}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"encode"}}`)
+	}
+	return payload
+}

--- a/cmd/bench_resources/testdata/standin/main.go
+++ b/cmd/bench_resources/testdata/standin/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -55,8 +56,12 @@ func main() {
 	flag.String("gitlab-url", "", "accepted and ignored")
 	flag.String("tool-surface", "", "accepted and ignored")
 	flag.Int("rate-limit-rps", 0, "accepted and ignored")
-	flag.Bool("telemetry", false, "accepted and ignored")
+	telemetry := flag.Bool("telemetry", false, "send one export to OTEL_EXPORTER_OTLP_ENDPOINT, as the real server's exporters would")
 	flag.Parse()
+
+	if *telemetry {
+		exportTelemetry(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	}
 
 	if *httpMode {
 		if err := serveHTTP(*addr); err != nil {
@@ -76,6 +81,33 @@ func main() {
 }
 
 // serveHTTP answers /health and /mcp until the process is killed.
+// exportTelemetry posts one metrics export to the OTLP endpoint the harness
+// configured, so a run with telemetry on reaches the sink the way the real
+// server's exporters do and a harness that stopped wiring the endpoint is
+// caught. Best effort: the sink's answer changes nothing here, and an
+// unreachable one is reported and otherwise ignored, as an exporter would.
+func exportTelemetry(endpoint string) {
+	if endpoint == "" {
+		fmt.Fprintln(os.Stderr, "standin: --telemetry without OTEL_EXPORTER_OTLP_ENDPOINT, nothing exported")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	body := strings.NewReader(`{"resourceMetrics":[]}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(endpoint, "/")+"/v1/metrics", body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "standin: telemetry export:", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "standin: telemetry export:", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
 func serveHTTP(addr string) error {
 	if addr == "" {
 		return fmt.Errorf("--http needs --http-addr")

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,26 +18,26 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,648 |
-| Unit test functions                                   | 13,082 |
+| Total test functions                                  | 13,667 |
+| Unit test functions                                   | 13,101 |
 | E2E test functions                                    |    566 |
-| cmd test functions                                    |  2,149 |
+| cmd test functions                                    |  2,168 |
 | Test files (internal/)                                |    501 |
 | Test files (cmd/)                                     |    133 |
 | Test files (test/e2e/)                                |    221 |
 | Tool sub-packages tested                              |    176 |
 | Core packages tested                                  |     21 |
-| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.3% |
+| Overall coverage (`go test ./internal/... ./cmd/...`) |  97.7% |
 | Overall coverage (`go test ./internal/...`)           |  98.3% |
-| Average package coverage                              |  98.2% |
+| Average package coverage                              |  98.3% |
 
 ### Naming Convention Stats
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,316 | 82.9% |
+| `TestFunc_Scenario` (2-part)           | 11,325 | 82.9% |
 | `TestFunc` (no underscore)             |    968 |  7.1% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,364 | 10.0% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,374 | 10.1% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            305 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,441 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            566 |        221 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,149 |        133 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,648** |    **855** |                                                                                                 |
+| cmd packages            |          2,168 |        133 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,667** |    **855** |                                                                                                 |
 
 ### Core Packages
 
@@ -327,7 +327,7 @@
 | cmd/audit_test_names                           |    89.4% |
 | cmd/audit_test_subtests                        |    98.1% |
 | cmd/audit_tokens                               |    98.0% |
-| cmd/bench_resources                            |    68.5% |
+| cmd/bench_resources                            |    93.3% |
 | cmd/eval_mcp_surfaces/internal/evalrun         |    88.9% |
 | cmd/eval_mcp_surfaces/internal/evaluator       |    93.6% |
 | cmd/eval_mcp_surfaces/internal/evaluator/cases |    99.6% |
@@ -559,7 +559,6 @@
 Coverage target: **>90%** per package. Packages below the target in the latest generated coverage snapshot:
 
 - **cmd/gen_action_catalog_manifest** (66.7%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
-- **cmd/bench_resources** (68.5%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_1to1** (71.1%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_dynamic_aliases** (77.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **dynamiccatalog** (78.6%) - review this package for missing unit coverage or add an explicit exception if the remaining paths are integration-only.


### PR DESCRIPTION
`cmd/bench_resources` sat at 68% coverage, and Sonar put the new code of the benchmark PR at 72.5%, under the 80% gate. Everything below that line is the half of the harness that starts a process: the readiness poll, the pipe wiring, the resident-set sampler, the ramp, the load rounds and the traceback signal. None of it can be exercised against anything in-process, and linking the real server for it would cost a minute per test run to learn nothing about the harness. I preferred covering it to excluding it.

## The stand-in

`cmd/bench_resources/testdata/standin` is a Go program, standard library only, that answers the harness's contract in two hundred lines: the flags the HTTP target passes, the environment the stdio target sets (it refuses to start without `GITLAB_URL` and `GITLAB_TOKEN`, so a harness that stopped setting them is caught), a `/health` document, JSON-RPC over SSE on `/mcp` with the `Mcp-Method` and `PRIVATE-TOKEN` headers checked, newline-delimited JSON-RPC on stdio, and a runtime that dumps its goroutines on SIGQUIT because nothing in it catches the signal. `STANDIN_FAIL` names one method it refuses with an error result, which is how the tests reach the ramp's fatal path and the load phase's failure notes without a server that is actually broken. It follows `cmd/server/testdata/peer`: built by `TestMain` once per test binary, and outside Sonar's coverage like every `testdata` program.

## What is now tested

- Both targets end to end: readiness through `/health`, one process for every credential on HTTP and one process per client on stdio, the traceback that ends a target and a `close` that finds nothing left to stop, and the exec failure each reports.
- `runScenario` on both transports, including telemetry on: every startup milestone, the idle and per-client resident sets read from the kernel, a ramp point per credential, one distribution per method with every call counted, the goroutine count, and stdio's honest zero for readiness and idle memory.
- The failure branches: a refused cold `tools/list` fails the scenario; refused `tools/call`s are noted and the other distributions survive.
- `measure` over the quick matrix and `execute` measure → render → check over a temporary tree, which is the round trip `make` runs.
- `buildServer` against a throwaway module with a trivial `cmd/server`, so the real build path runs in a second, plus its failure.
- Small leftovers: `commandProcess` refusing pre-wired pipes, `firstLine`, `shortCommit`, the `n/a` table cells, `writeRun`'s two filesystem refusals, `rel` on a path that cannot be made relative.

Coverage goes from 68.5% to 93.1% (Go statements). Sonar's check on this PR reads "0.0% Coverage on New Code" because the PR adds no coverable line: it is tests plus a `testdata` program, which `sonar.exclusions` keeps out as a fixture, like `cmd/server/testdata/peer`. The figure that moved is the package's line coverage in the same analysis, 72.5% on main to 91.1% here, and the project's 97.5%. What remains is the darwin branches of the host probes, the non-Linux branch of the process reader, and the sixty-second health deadline. The process-level tests skip on Windows, where the harness has neither `/proc`, `ps` nor SIGQUIT to work with; the package's whole suite runs in about two seconds, three shuffled runs in five.

## Summary by Sourcery

Raise benchmark harness coverage by testing its process-based execution paths with a lightweight HTTP and stdio stand-in server.

Bug Fixes:
- Ensure command process setup cleans up an already-created stdin pipe when stdout pipe creation fails.

Enhancements:
- Exercise the benchmark harness end to end for HTTP and stdio process targets, including readiness, RPC handling, resource sampling, telemetry, ramping, tracebacks, shutdown, and failure reporting.
- Add a lightweight stand-in server fixture that supports the harness's HTTP and stdio contracts without requiring the real server.
- Cover benchmark measurement, rendering, validation, server building, result writing, formatting, path handling, and command-process error paths.
- Raise cmd/bench_resources coverage above 90% and remove it from the below-target package list.

Build:
- Build the stand-in server once per test binary and validate the real server build path with a temporary Go module.

Documentation:
- Update repository and testing metrics to reflect the added fixture, tests, package count, and improved coverage.

Tests:
- Add process-level integration tests for both benchmark transports and their success and failure branches.
- Add coverage for benchmark command round trips and remaining filesystem, formatting, path, and pipe-handling edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README statistics to reflect the current codebase.
  * Refreshed testing metrics, including test counts and coverage figures.

* **Tests**
  * Expanded benchmark resource testing across HTTP and stdio workflows.
  * Added coverage for process lifecycles, error handling, rendering, measurements, and failure scenarios.
  * Added a standalone test server to support end-to-end benchmark validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->