### PR TITLE
ci: tell a Go runtime crash on Windows from a failing test, and rerun only that

### DIFF
--- a/.github/scripts/go-test-crash-aware.sh
+++ b/.github/scripts/go-test-crash-aware.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# go-test-crash-aware.sh — run a test suite through gotestsum and tell a Go
+# runtime crash apart from a failing test.
+#
+# Usage:
+#   go-test-crash-aware.sh <json-dir> [-flag=value ...] <packages ...>
+#
+# Flags are passed to `go test` as written and must carry their value in the
+# same word (-timeout=30m, not -timeout 30m), because the packages are told
+# from the flags by their first character and run again on their own.
+#
+# The first run is `gotestsum --jsonfile <json-dir>/first.json -- <args>`.
+# Its go test -json stream is then read back. A package whose output carries
+# one of the signatures below is a crashed package; a package with a fail
+# event and no signature is a failing package, whether a test failed, the
+# build broke or TestMain gave up. Failing packages fail the run, as they
+# always did, and are listed with their failing tests. Crashed packages are
+# run once more, alone: one that passes is reported as a runtime crash in
+# the log and in the job summary and does not fail the run, one that crashes
+# or fails again does.
+#
+# Why. The Windows leg of the cross-platform matrix dies inside the Go
+# runtime now and then (issue 467). golang/go#81238 explains it: on hosts with
+# Intel AMX, recovering a hardware exception on a goroutine stack lets Windows
+# write its exception context below the stack into the heap, and the next
+# garbage collection faults. The hosted pool is heterogeneous, so the same
+# commit crashes on one runner and passes on the next. Rerunning the whole job
+# by hand told nobody anything and cost twenty minutes; failing on the crash
+# blocked merges on a bug nobody here can fix; ignoring the leg let a real
+# Windows regression pass as one more flake. This keeps the distinction, and
+# keeps a record of every crash where a reader looks for one.
+#
+# The signatures are the runtime's own words for a corrupted heap or stack,
+# and only those. "panic: runtime error" is not one: an unrecovered nil
+# dereference is a bug in the code under test. Neither is a deadlock nor a
+# concurrent map write, which the runtime also reports as a fatal error and
+# which are bugs too.
+set -uo pipefail
+
+JSON_DIR="${1:?Usage: $0 <json-dir> [-flag=value ...] <packages ...>}"
+shift
+
+CRASH_SIGNATURES='fatal error: (fault|found pointer to free object|found bad pointer in Go heap|unexpected signal|bad pointer in frame)|runtime: marked free object in span|traceback did not unwind completely'
+
+flags=()
+packages=()
+for arg in "$@"; do
+  case "$arg" in
+    -*) flags+=("$arg") ;;
+    *) packages+=("$arg") ;;
+  esac
+done
+if [ "${#packages[@]}" -eq 0 ]; then
+  echo "ERROR: no packages given" >&2
+  exit 2
+fi
+
+mkdir -p "$JSON_DIR"
+
+# crashed_packages lists the packages whose output carries a crash signature.
+crashed_packages() {
+  jq -r --arg re "$CRASH_SIGNATURES" \
+    'select(.Action == "output" and (.Output | test($re))) | .Package' "$1" | sort -u
+}
+
+# failed_packages lists the packages with a package-level fail event.
+failed_packages() {
+  jq -r 'select(.Action == "fail" and .Test == null) | .Package' "$1" | sort -u
+}
+
+# failed_tests lists "package<TAB>test" for every test-level fail event.
+failed_tests() {
+  jq -r 'select(.Action == "fail" and .Test != null) | "\(.Package)\t\(.Test)"' "$1" | sort -u
+}
+
+# crash_lines lists "package<TAB>first signature line" per crashed package.
+crash_lines() {
+  jq -r --arg re "$CRASH_SIGNATURES" \
+    'select(.Action == "output" and (.Output | test($re))) | "\(.Package)\t\(.Output | rtrimstr("\n"))"' "$1" \
+    | sort -u -k1,1
+}
+
+# without prints the lines of $1 whose first field is not listed in $2.
+without() {
+  awk -F'\t' -v list="$2" '
+    BEGIN { n = split(list, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") c[a[i]] = 1 }
+    $1 != "" && !($1 in c)' <<< "$1"
+}
+
+# summary appends to the job summary when there is one, and always to stdout.
+summary() {
+  printf '%s\n' "$@"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$@" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+first="$JSON_DIR/first.json"
+gotestsum --jsonfile "$first" -- "${flags[@]}" "${packages[@]}"
+first_status=$?
+if [ ! -s "$first" ]; then
+  echo "ERROR: gotestsum wrote no JSON stream to $first (exit $first_status)" >&2
+  exit "${first_status:-1}"
+fi
+
+crashed=$(crashed_packages "$first")
+failing=$(without "$(failed_packages "$first")" "$crashed")
+
+if [ -n "$failing" ]; then
+  summary "### Test suite: failing packages" ""
+  while IFS= read -r pkg; do
+    summary "- \`$pkg\`"
+    while IFS=$'\t' read -r p t; do
+      [ "$p" = "$pkg" ] && summary "  - $t"
+    done <<< "$(failed_tests "$first")"
+  done <<< "$failing"
+  if [ -n "$crashed" ]; then
+    summary "" "Also crashed inside the Go runtime, not rerun because the failures above decide the run:"
+    while IFS=$'\t' read -r p line; do summary "- \`$p\`: $line"; done <<< "$(crash_lines "$first")"
+  fi
+  exit 1
+fi
+
+if [ -z "$crashed" ]; then
+  exit "$first_status"
+fi
+
+echo
+echo "The Go runtime crashed in the following package(s); rerunning them alone once (issue 467, golang/go#81238):"
+while IFS=$'\t' read -r p line; do echo "  $p: $line"; done <<< "$(crash_lines "$first")"
+echo
+
+rerun="$JSON_DIR/rerun.json"
+# shellcheck disable=SC2086 # import paths, one per line, never contain spaces
+gotestsum --jsonfile "$rerun" -- "${flags[@]}" $crashed
+rerun_status=$?
+
+crashed_again=$(crashed_packages "$rerun")
+failed_again=$(failed_packages "$rerun")
+
+summary "### Test suite: Go runtime crash" "" \
+  "The first run crashed inside the Go runtime (issue 467, golang/go#81238) and the crashed packages were run once more on their own." "" \
+  "| Package | First run | Rerun |" "| --- | --- | --- |"
+while IFS=$'\t' read -r p line; do
+  outcome="passed"
+  if grep -qxF "$p" <<< "$crashed_again"; then outcome="crashed again"
+  elif grep -qxF "$p" <<< "$failed_again"; then outcome="failed"; fi
+  summary "| \`$p\` | \`$line\` | $outcome |"
+done <<< "$(crash_lines "$first")"
+
+if [ -n "$crashed_again" ] || [ -n "$failed_again" ] || [ "$rerun_status" -ne 0 ]; then
+  summary "" "The rerun did not pass, so the run fails."
+  exit 1
+fi
+echo "::warning title=Go runtime crash::the Go runtime crashed in $(wc -l <<< "$crashed" | tr -d ' ') package(s) and every one passed when rerun alone; see the job summary (issue 467)"
+exit 0

--- a/.github/scripts/go-test-crash-aware.sh
+++ b/.github/scripts/go-test-crash-aware.sh
@@ -30,17 +30,27 @@
 # Windows regression pass as one more flake. This keeps the distinction, and
 # keeps a record of every crash where a reader looks for one.
 #
-# The signatures are the runtime's own words for a corrupted heap or stack,
-# and only those. "panic: runtime error" is not one: an unrecovered nil
-# dereference is a bug in the code under test. Neither is a deadlock nor a
-# concurrent map write, which the runtime also reports as a fatal error and
-# which are bugs too.
+# A crash is a "fatal error:" line from the runtime, minus the messages the
+# runtime uses for a bug in the code under test. The first version of this
+# script named the corruption messages instead (a fault, a pointer to a free
+# object, a bad pointer in the heap) and the third crash seen was none of
+# them: "acquireSudog: found s.elem != nil in cache", the sudog cache's own
+# consistency check tripping over the same corrupted heap. A corrupted heap
+# trips whichever runtime invariant reads it first, so the list can never be
+# complete; the list of things the runtime says about a bug in user code is
+# short and stable, and that is the one kept. "panic: runtime error" is never
+# a crash: an unrecovered nil dereference is a bug in the code under test.
 set -uo pipefail
 
 JSON_DIR="${1:?Usage: $0 <json-dir> [-flag=value ...] <packages ...>}"
 shift
 
-CRASH_SIGNATURES='fatal error: (fault|found pointer to free object|found bad pointer in Go heap|unexpected signal|bad pointer in frame)|runtime: marked free object in span|traceback did not unwind completely'
+CRASH_MARK='^fatal error: '
+# Fatal errors the runtime reports for a bug in the code under test: a
+# deadlock, a concurrent map access, a sync misuse, out of memory, a goroutine
+# stack past its limit, a thread-limit overrun, a checkptr violation, a test
+# calling os.Exit. These fail the run and are not rerun.
+BUG_MARK='^fatal error: (all goroutines are asleep|concurrent map |sync: |runtime: out of memory|out of memory|stack overflow|runtime: program exceeds|checkptr|unexpected call to os\.Exit|too many )'
 
 flags=()
 packages=()
@@ -57,10 +67,10 @@ fi
 
 mkdir -p "$JSON_DIR"
 
-# crashed_packages lists the packages whose output carries a crash signature.
+# crashed_packages lists the packages whose output carries a runtime crash.
 crashed_packages() {
-  jq -r --arg re "$CRASH_SIGNATURES" \
-    'select(.Action == "output" and (.Output | test($re))) | .Package' "$1" | sort -u
+  jq -r --arg crash "$CRASH_MARK" --arg bug "$BUG_MARK" \
+    'select(.Action == "output" and (.Output | test($crash)) and (.Output | test($bug) | not)) | .Package' "$1" | sort -u
 }
 
 # failed_packages lists the packages with a package-level fail event.
@@ -73,10 +83,10 @@ failed_tests() {
   jq -r 'select(.Action == "fail" and .Test != null) | "\(.Package)\t\(.Test)"' "$1" | sort -u
 }
 
-# crash_lines lists "package<TAB>first signature line" per crashed package.
+# crash_lines lists "package<TAB>first crash line" per crashed package.
 crash_lines() {
-  jq -r --arg re "$CRASH_SIGNATURES" \
-    'select(.Action == "output" and (.Output | test($re))) | "\(.Package)\t\(.Output | rtrimstr("\n"))"' "$1" \
+  jq -r --arg crash "$CRASH_MARK" --arg bug "$BUG_MARK" \
+    'select(.Action == "output" and (.Output | test($crash)) and (.Output | test($bug) | not)) | "\(.Package)\t\(.Output | rtrimstr("\n"))"' "$1" \
     | sort -u -k1,1
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,8 +784,19 @@ jobs:
       # The bound is raised from the 10 minute default because cmd/server
       # exceeded it on Windows, where the suite runs roughly three times slower
       # than on Linux.
+      #
+      # Through the crash-aware runner rather than a bare go test: the Windows
+      # leg dies inside the Go runtime now and then, for a reason recorded in
+      # the script and in issue 467, and the runner tells that crash apart
+      # from a failing test, reruns only the crashed package, and puts the
+      # outcome in the job summary. A failing test fails the leg as before.
+      # Flags carry their value in the same word, which is how the runner
+      # tells them from packages.
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum
       - name: Unit suite
-        run: go test -count=1 -timeout 30m ./cmd/server/... ./internal/...
+        shell: bash
+        run: bash .github/scripts/go-test-crash-aware.sh test-results/unit-suite -count=1 -timeout=30m ./cmd/server/... ./internal/...
       # The two transport modules need neither GitLab nor a credential, and
       # they are why this is not a build-only check: they start the real binary
       # and drive it the way a client does, over pipes and sockets, which is
@@ -847,8 +858,12 @@ jobs:
   # standalone jobs through "checks". One result is read but does not decide,
   # for a reason recorded where the job is defined: the platform matrix has a
   # Windows leg that crashes inside the Go runtime now and then, tracked in
-  # https://github.com/jmrplens/gitlab-mcp-server/issues/467. It is printed so
-  # a red one is seen, and cannot block a merge until that changes.
+  # https://github.com/jmrplens/gitlab-mcp-server/issues/467. Its unit suite
+  # runs through .github/scripts/go-test-crash-aware.sh, which reruns a
+  # crashed package alone and records the crash in the job summary, so a red
+  # leg now means a failing test or a package that crashed twice. It is
+  # printed so a red one is seen; it becomes a deciding result once a run of
+  # weeks shows it red for those reasons only.
   #
   # "skipped" passes only for the Docker summary, which skips itself on pushes
   # to main along with the matrix it summarizes. For every other job a skip


### PR DESCRIPTION
The Windows leg of the cross-platform matrix dies inside the Go runtime now and then. This finds out why, shows the runner image is not the variable, and makes the leg say what happened instead of going red.

## The cause

Issue 467 cites golang/go#76614, which is closed: its reporter traced the crashes to a nil pointer in their own code. The defect is [golang/go#81238](https://github.com/golang/go/issues/81238), open since 2026-08-31. On windows/amd64, when a hardware exception is recovered on a goroutine stack, Windows writes its exception CONTEXT below the stack's low bound; on hosts with Intel AMX that record is 11 567 bytes against the 4 096 the Go 1.27 runtime reserves, and the overflow lands in the adjacent heap span. The next garbage collection reports what it finds, which is the `sync.poolCleanup` fault in the issue: `os.RemoveAll` allocated, the allocation started a GC, and `clearpools` walked memory the exception had overwritten. The Go maintainers say the runtime cannot reserve stack for contexts that size; the fix is moving from VEH to SEH (golang/go#47576), with no date.

## The runner image is not the variable

I ran the upstream reproducer four times per image on this repository's runners ([run 33869090230](https://github.com/jmrplens/gitlab-mcp-server/actions/runs/33869090230), from a throwaway branch since deleted). Every AMD EPYC host was clean on both images. The one attempt that landed on an Intel Xeon Platinum 8573C corrupted the heap on `windows-2022` (build 10.0.20348) exactly as the issue describes for 2025. The fault follows the CPU, and the hosted pool mixes them.

## What changes

The matrix's unit suite runs through `.github/scripts/go-test-crash-aware.sh`. It runs the packages under gotestsum, reads the `go test -json` stream back, and sorts packages into two kinds: a package whose output carries one of the runtime's own corruption signatures is a crashed package; a package that failed without one is a failing package, whether a test failed, the build broke or `TestMain` gave up. Failing packages fail the leg, as they always did, and are listed with their failing tests. Crashed packages are run once more, alone: one that passes is recorded in the job summary as a runtime crash and does not fail the leg, one that crashes or fails again does.

A crash is a `fatal error:` line from the runtime, minus the messages the runtime uses for a bug in the code under test: a deadlock, a concurrent map access, a `sync` misuse, out of memory, a goroutine stack past its limit, a thread-limit overrun, a checkptr violation, a test calling `os.Exit`. Those fail the leg and are not rerun, and so does `panic: runtime error`, which is an unrecovered nil dereference in the code under test. The first version of this listed the corruption messages instead (a fault, a pointer to a free object, a bad pointer in the heap), and the third crash seen the same day was none of them: `acquireSudog: found s.elem != nil in cache`, on PR 476's Windows leg, the sudog cache's own consistency check tripping over the same corrupted heap. A corrupted heap trips whichever invariant reads it first, so that list can never be complete; the list of what the runtime says about user bugs is short and stable, and that is the one kept.

The script is exercised locally by a harness with a fake gotestsum over prepared streams: all pass; a failing test; a crash that passes on rerun (exit 0, summary table); a crash that crashes again (exit 1); a crash beside a real failure elsewhere (exit 1, no rerun); a build failure; an unrecovered nil dereference; a deadlock; the sudog and a `semacquire` invariant as crashes; concurrent map writes, a negative WaitGroup counter, a stack overflow and an `os.Exit` in a test as bugs. All fourteen behave as stated.

## What does not change yet

`Cross-platform` stays informational for the final verdict. Once a run of weeks shows the leg red only for a failing test or a package that crashed twice, it becomes a deciding result, and that is when 467 closes.
