### PR TITLE
ci: run the E2E suite weekly on main, so it meets a real GitLab between releases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,15 +3,24 @@
 # Runs the e2e suite against an ephemeral Docker-based GitLab CE instance.
 # Duration: ~15-20 min (GitLab boot ~5 min + tests ~5-10 min).
 #
-# Two ways in. Manually, from the "Use workflow from" dropdown, optionally with
-# a custom ref such as a fork pull request's merge SHA. And as a reusable
+# Three ways in. Manually, from the "Use workflow from" dropdown, optionally
+# with a custom ref such as a fork pull request's merge SHA. As a reusable
 # workflow, which is how the release pipeline runs its E2E gate: the job used
 # to be copied into release.yml line for line, so a fix to the harness landed
-# in one place and not the other.
+# in one place and not the other. And once a week on main, against the
+# current gitlab-ce:latest, because nothing else runs this suite between
+# releases: the first release rehearsal found three tests that had been
+# broken on main for weeks, one of them green on a copy of the server it was
+# meant to test (issue 474). The weekly run is not a required check; it is
+# the one place the suite meets a real GitLab while nobody is tagging.
 
 name: E2E Tests
 
 on:
+  schedule:
+    # Mondays, 05:17 UTC: off the hour, since GitHub delays runs that pile up
+    # on round times, and before the week's first pushes.
+    - cron: "17 5 * * 1"
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
The E2E suite runs on a tag push and by hand, and nothing else. The first release rehearsal on the current tree ([run 33868328479](https://github.com/jmrplens/gitlab-mcp-server/actions/runs/33868328479)) found three tests that had been broken on `main` for weeks, one of them green on a copy of the server it was meant to test, and no check had shown any of it because no check runs this suite between releases. Those three are fixed in PR 475; this adds the run that would have shown them.

`e2e.yml` gains a `schedule` trigger: Mondays at 05:17 UTC, on `main`, against the current `gitlab-ce:latest`. Off the hour because GitHub delays runs that pile up on round times. The existing defaults carry it: `inputs.gitlab_image` is empty on a schedule and falls back to `gitlab/gitlab-ce:latest`, and the checkout falls back to `github.ref`, which is `main`. One runner for about twenty minutes a week, not a required check, visible on the Actions page.

A push-triggered run is deliberately not proposed: twenty minutes on every merge to `main` is the wrong price for a suite whose failures are, on this evidence, weeks apart.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/474


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

