### PR TITLE
test(stdio): wait for the stderr line an assertion is about instead of reading the buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,069 |     226,675 |
 | Unit tests (`_test.go`)  |       636 |     368,386 |
-| End-to-end tests         |       224 |      60,871 |
-| **Total**                | **1,929** | **655,932** |
+| End-to-end tests         |       224 |      60,906 |
+| **Total**                | **1,929** | **655,967** |
 
 ### Functions
 

--- a/test/e2e/stdio/envfile_test.go
+++ b/test/e2e/stdio/envfile_test.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 const (
@@ -241,13 +242,15 @@ func TestWorkingDirEnvFile_IgnoredFileIsAnnouncedByAbsolutePath(t *testing.T) {
 		"HOME":      envFileHome(t, genuine.URL),
 		"LOG_LEVEL": "info",
 	})
-	// One completed exchange, so the startup logging has certainly been written
-	// by the time stderr is read.
+	// One completed exchange, so the startup logging has certainly been
+	// written by the time stderr is read; not necessarily copied into the
+	// harness's buffer, though, which is on a goroutine of its own, so the
+	// line the assertions are about is waited for.
 	if got := s.call(t, request(1, "tools/list", "")); got["error"] != nil {
 		t.Fatalf("tools/list failed: %v", got["error"])
 	}
 
-	logs := s.stderrText()
+	logs := s.waitForStderr(t, "ignoring the .env file in the working directory", 5*time.Second)
 	// The path this test computes and the path the server prints are resolved
 	// separately, and on macOS one of them goes through /private. Comparing the
 	// resolved form keeps the assertion about the path and not about symlinks.

--- a/test/e2e/stdio/gatewaycompat_test.go
+++ b/test/e2e/stdio/gatewaycompat_test.go
@@ -106,7 +106,7 @@ func TestDescriptionSubstitutions_MalformedValueRefusesToStart(t *testing.T) {
 	if code == 0 {
 		t.Errorf("the server exited 0 on a configuration error\nstderr: %s", s.stderrText())
 	}
-	if logs := s.stderrText(); !strings.Contains(logs, "GITLAB_MCP_DESCRIPTION_SUBSTITUTIONS") {
-		t.Errorf("stderr does not name the variable the operator must fix:\n%s", logs)
-	}
+	// Waited for rather than read: the process has exited, but the harness
+	// copies stderr on its own goroutine and may still be draining the pipe.
+	s.waitForStderr(t, "GITLAB_MCP_DESCRIPTION_SUBSTITUTIONS", 5*time.Second)
 }

--- a/test/e2e/stdio/harness_test.go
+++ b/test/e2e/stdio/harness_test.go
@@ -328,6 +328,33 @@ func (s *session) stderrText() string {
 	return s.stderr.String()
 }
 
+// waitForStderr returns the server's stderr once it contains needle, and fails
+// the test if it does not within the window.
+//
+// stderr is copied into the buffer by a goroutine of this harness, so a line
+// the server wrote before answering on stdout can still be in the pipe when
+// the test reads the buffer: the stdout reply and the stderr copy are two
+// goroutines with no ordering between them. A test that asserted on
+// stderrText right after a call therefore found it empty now and then,
+// including for the OTEL_SDK_DISABLED veto, which the server logs before it
+// serves anything. Waiting for the line the assertion is about removes the
+// race without loosening the assertion; an absence assertion that follows
+// should anchor on a line the server always writes after the one it denies.
+func (s *session) waitForStderr(t *testing.T, needle string, within time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		text := s.stderrText()
+		if strings.Contains(text, needle) {
+			return text
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stderr did not carry %q within %s\nstderr: %s", needle, within, text)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // request builds a JSON-RPC request carrying the per-request _meta a
 // 2026-07-28 client sends.
 func request(id int, method, params string) string {

--- a/test/e2e/stdio/telemetry_test.go
+++ b/test/e2e/stdio/telemetry_test.go
@@ -77,10 +77,7 @@ func TestTelemetry_EnabledWithAnUnreachableCollectorKeepsStdoutClean(t *testing.
 	// The failures must be visible, on stderr. A telemetry stack that fails
 	// silently is worse than one that fails loudly: an operator would see an
 	// empty dashboard and no reason for it.
-	stderr := session.stderrText()
-	if !strings.Contains(stderr, "telemetry") {
-		t.Errorf("stderr never mentions telemetry, so an operator has no way to know it was enabled\nstderr: %s", stderr)
-	}
+	session.waitForStderr(t, "telemetry", 5*time.Second)
 }
 
 // TestTelemetry_DisabledByDefault asserts that a server nobody asked to
@@ -104,7 +101,11 @@ func TestTelemetry_DisabledByDefault(t *testing.T) {
 	session.send(t, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
 	session.call(t, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
 
-	if stderr := session.stderrText(); strings.Contains(stderr, "telemetry enabled") {
+	// Anchored on a line the server writes after its telemetry decision, so
+	// the absence asserted below is an absence in what was logged rather than
+	// in what the harness had copied so far.
+	stderr := session.waitForStderr(t, "starting MCP server", 5*time.Second)
+	if strings.Contains(stderr, "telemetry enabled") {
 		t.Errorf("telemetry started without being asked for\nstderr: %s", stderr)
 	}
 	session.terminate(t, 10*time.Second)
@@ -131,12 +132,13 @@ func TestTelemetry_SDKDisabledVetoesTheSwitch(t *testing.T) {
 	session := startSession(t, env)
 	session.call(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"stdio-e2e","version":"0"}}}`)
 
-	stderr := session.stderrText()
+	// The veto is logged before the server serves anything, so it is on its
+	// way by the time initialize is answered; waited for rather than read,
+	// because the harness copies stderr on a goroutine of its own and the
+	// buffer can trail the pipe by the very line this asserts on.
+	stderr := session.waitForStderr(t, "OTEL_SDK_DISABLED", 5*time.Second)
 	if strings.Contains(stderr, "telemetry enabled") {
 		t.Errorf("OTEL_SDK_DISABLED=true did not veto an explicitly requested start\nstderr: %s", stderr)
-	}
-	if !strings.Contains(stderr, "OTEL_SDK_DISABLED") {
-		t.Errorf("the veto fired without saying so; an operator would see telemetry missing and no reason\nstderr: %s", stderr)
 	}
 	session.terminate(t, 10*time.Second)
 }

--- a/test/e2e/stdio/transport_test.go
+++ b/test/e2e/stdio/transport_test.go
@@ -49,9 +49,10 @@ func TestStdout_CarriesNothingButJSONRPC(t *testing.T) {
 		})
 	}
 
-	if logs := s.stderrText(); logs == "" {
-		t.Error("nothing was logged to stderr at LOG_LEVEL=info; either logging is off or it went somewhere else")
-	}
+	// The startup line is written before the server answers anything, so its
+	// absence here would mean logging is off or went somewhere else; waited
+	// for, because the harness copies stderr on a goroutine of its own.
+	s.waitForStderr(t, "starting MCP server", 5*time.Second)
 }
 
 // TestStderr_TakesTheLogsAndStdoutDoesNot checks the other half of the same
@@ -68,11 +69,10 @@ func TestStderr_TakesTheLogsAndStdoutDoesNot(t *testing.T) {
 	}
 
 	// Debug logging produces a lot; none of it may appear on stdout, and
-	// readMessage would have failed above if it had.
-	logs := s.stderrText()
-	if !strings.Contains(logs, "level=DEBUG") && !strings.Contains(logs, "DEBUG") {
-		t.Errorf("LOG_LEVEL=debug produced no debug lines on stderr:\n%s", logs)
-	}
+	// readMessage would have failed above if it had. The debug lines are
+	// waited for rather than read, since the harness copies stderr on a
+	// goroutine of its own.
+	s.waitForStderr(t, "DEBUG", 5*time.Second)
 }
 
 // TestStderr_DefaultLevelIsNotAllSessionChatter pins what an operator actually
@@ -100,7 +100,10 @@ func TestStderr_DefaultLevelIsNotAllSessionChatter(t *testing.T) {
 		}
 	}
 
-	logs := s.stderrText()
+	// Anchored on a line the server writes after the session is up, so the
+	// absences asserted below are absences in what was logged rather than in
+	// what the harness had copied so far.
+	logs := s.waitForStderr(t, "starting MCP server", 5*time.Second)
 	for _, chatter := range []string{
 		"server session connected",
 		"server session disconnected",


### PR DESCRIPTION
`TestTelemetry_SDKDisabledVetoesTheSwitch` read stderr right after `initialize` answered and found it empty now and then. Issue 458 named two candidate causes, a silent veto or a test reading before the server had flushed, and asked for the cause to be named before the fix. It is neither, quite.

## The cause

The server logs the veto inside `telemetry.Start`, which `main` runs before the transport serves anything, so by the time the `initialize` reply is on stdout the veto line has been written to stderr. What races is the harness: `startSessionIn` copies stderr into the session's buffer on a goroutine of its own, and `readMessage` reads stdout on another, with no ordering between the two. A test that reads the buffer the moment a reply arrives can see a buffer that trails the pipe by exactly the line it is about to assert on. The veto is not silent, and the server is not late; the test was reading a copy that had not caught up. Locally the test passes six times in six, which is what a scheduling race looks like on an idle machine.

## The fix

`session.waitForStderr(t, needle, within)` polls the buffer until it contains the line the assertion is about, and fails naming what it waited for. The veto test waits for `OTEL_SDK_DISABLED` and then asserts, on that text, that telemetry did not start. The same read-then-assert shape existed in five sibling tests (the debug-level and info-level transport tests, the SDK chatter test, the env-file warning and the gateway-substitution refusal), one of them with a comment stating the very assumption that is false; they use the helper too. Absence assertions anchor on a line the server always writes after the one they deny (`starting MCP server`), so an absence means absent from the log rather than not yet copied. Nothing asserted is loosened.

Verified: the three telemetry tests three times each, then the whole stdio suite once (173 s) and golangci-lint on the package.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/458

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a `waitForStderr` helper method in the test harness to reliably wait for specific log lines, addressing race conditions where stderr output was read before being fully copied by the harness's goroutine.</li>
<li>Refactored multiple end-to-end tests to use `waitForStderr` instead of directly reading `stderrText()`, ensuring assertions are anchored on expected log output.</li>
<li>Updated README statistics to reflect minor changes in test code size.</li>
</ul></div>

## Summary by Sourcery

Make stdio end-to-end log assertions wait for the relevant stderr output before evaluating them.

Bug Fixes:
- Eliminate flaky stdio end-to-end assertions caused by reading the stderr buffer before the harness had copied the server output.

Enhancements:
- Add a stderr wait helper and update telemetry, transport, environment-file, and gateway compatibility tests to synchronize assertions with expected log lines, including reliable absence checks.

Tests:
- Stabilize stderr-dependent stdio end-to-end tests by waiting for expected log output within a timeout.

Chores:
- Refresh README test statistics.