### PR TITLE
fix(serverpool): refuse an unnamed instance in the resolver, not only at the server's gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,17 +459,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,069 |     226,675 |
-| Unit tests (`_test.go`)  |       636 |     368,386 |
+| Source (`.go`, non-test) |     1,069 |     226,701 |
+| Unit tests (`_test.go`)  |       636 |     368,424 |
 | End-to-end tests         |       224 |      60,906 |
-| **Total**                | **1,929** | **655,967** |
+| **Total**                | **1,929** | **656,031** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,497 |
-| . Exported (public)             |  2,800 |
+| Source functions                |  8,498 |
+| . Exported (public)             |  2,801 |
 | . Unexported (private)          |  5,697 |
 | Unit test functions (`TestXxx`) | 13,119 |
 | Subtests (`t.Run(...)`)         |  4,885 |
@@ -482,7 +482,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~579 lines |
-| Comment lines in source            |  34,417 (~15.2% of source) |
+| Comment lines in source            |  34,434 (~15.2% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -491,7 +491,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 7,112 |
 | `defer` statements                 | 1,195 |
-| `struct` types defined             | 2,885 |
+| `struct` types defined             | 2,886 |
 | `//nolint` suppressions            |   280 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -515,7 +515,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~4,121 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,318 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 13,320 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/authgate.go
+++ b/cmd/server/authgate.go
@@ -648,9 +648,13 @@ var errMissingGitLabURL = errors.New("no GitLab instance was selected")
 // requireExplicitInstance refuses to choose an instance on the caller's
 // behalf when the deployment publishes more than one.
 //
-// The resolver's older answer was the first published instance, on the
-// reasoning that a client which does not care keeps working. That holds for a
-// client which does not care, and not for one that cares and failed to say so:
+// The resolver refuses the same request (serverpool.UnnamedInstanceError), so
+// this is not the only place the decision is made; it is the place it is made
+// before the credential is judged, and the place that knows which wording the
+// auth mode allows, since the published set is public in oauth mode and not in
+// legacy mode. The resolver's older answer was the first published instance,
+// on the reasoning that a client which does not care keeps working. That holds
+// for a client which does not care, and not for one that cares and failed to say so:
 // a proxy stripped the header, a client library cannot set custom headers, or
 // the configuration was copied wrong. The credential is then transmitted in
 // full to an instance its holder never named. In oauth mode this is worse

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3050,10 +3050,10 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		if r == nil {
 			return cfg.GitLabURL, nil
 		}
-		// Ahead of the resolver, because the resolver's answer for an absent
-		// header on a multi-instance deployment is the first published
-		// instance — and this is the code path that then POSTs the bearer to
-		// it. See requireExplicitInstance.
+		// Ahead of the resolver for the message, not for the decision: the
+		// resolver refuses an absent header on a multi-instance deployment
+		// too, and this gate turns the same refusal into the wording each
+		// auth mode may use. See requireExplicitInstance.
 		if err := requireExplicitInstance(r, cfg.InstanceURLs()); err != nil {
 			return "", err
 		}

--- a/internal/serverpool/token.go
+++ b/internal/serverpool/token.go
@@ -184,10 +184,13 @@ func ResolveRequestOptionsFor(r *http.Request, allowed []string) (RequestOptions
 
 	if len(normalizedAllowed) > 1 {
 		if header == "" {
-			// The first published instance is the deployment's default, so a
-			// client that does not care which instance it reaches keeps
-			// working unchanged.
-			return RequestOptions{GitLabURL: normalizedAllowed[0], IgnoredOptions: ignoredOptions, DeprecatedOptions: deprecatedOptions}, nil
+			// Refused rather than defaulted to the first published instance,
+			// which is what this did until the server's gate started refusing
+			// the same request ahead of it: choosing on the caller's behalf
+			// transmits their credential in full to a host they never named.
+			// The refusal lives here so it holds for every caller of the
+			// resolver, gate or no gate.
+			return RequestOptions{}, &UnnamedInstanceError{Allowed: normalizedAllowed}
 		}
 		normalizedHeader, headerErr := normalizeGitLabURL(header)
 		if headerErr != nil {
@@ -288,6 +291,25 @@ func NormalizeGitLabURLs(raw []string) ([]string, error) {
 // their credential in full to a host they never named.
 var ErrMissingGitLabURL = errors.New("this deployment publishes no GitLab instance, so the " +
 	RequestOptionGitLabURL + " header must name the one this request is for")
+
+// UnnamedInstanceError reports a request that named no GitLab instance on a
+// deployment that publishes several.
+//
+// There is no in-band way for a client to say which of the published instances
+// it authenticated against, and in oauth mode the verifier POSTs the bearer to
+// whichever instance is resolved, so a default here would deliver the
+// credential to an instance the caller never chose. The message names no
+// instance: whether the published set may be echoed depends on the auth mode,
+// which the caller knows and this package does not. Allowed carries the set
+// for a caller that may.
+type UnnamedInstanceError struct {
+	Allowed []string
+}
+
+func (e *UnnamedInstanceError) Error() string {
+	return "this deployment serves several GitLab instances, so the " +
+		RequestOptionGitLabURL + " header must name the one this request is for"
+}
 
 // DisallowedGitLabURLError reports a GITLAB-URL header naming an instance the
 // deployment does not publish.

--- a/internal/serverpool/token_test.go
+++ b/internal/serverpool/token_test.go
@@ -355,6 +355,48 @@ func TestExtractBearerToken_IgnoresPrivateToken(t *testing.T) {
 // The last case is the point: an unlisted instance is REFUSED, not quietly
 // replaced by the default. Serving the default would answer a question the
 // client did not ask, with another instance's data.
+// assertUnnamedInstanceRefusal checks a request that named no instance on a
+// multi-instance deployment was refused by the resolver itself.
+//
+// The resolver used to answer it with the first published instance while the
+// server's gate refused it, so a caller reaching the resolver without the gate
+// was served an instance the request never named. The refusal is the
+// resolver's now; the set travels on the error for a caller that may echo it,
+// and the message names nobody, since whether the set is public depends on
+// the auth mode.
+func assertUnnamedInstanceRefusal(t *testing.T, err error, allowed []string) {
+	t.Helper()
+	var unnamed *UnnamedInstanceError
+	if !errors.As(err, &unnamed) {
+		t.Fatalf("error = %v, want an *UnnamedInstanceError", err)
+	}
+	if !slices.Equal(unnamed.Allowed, allowed) {
+		t.Errorf("Allowed = %v, want the published set %v", unnamed.Allowed, allowed)
+	}
+	for _, instance := range allowed {
+		if strings.Contains(unnamed.Error(), instance) {
+			t.Errorf("the message names %s, which is the caller's decision to make: %q", instance, unnamed.Error())
+		}
+	}
+}
+
+// assertDisallowedInstanceRefusal checks a header naming an unpublished
+// instance was refused with the published set named and the caller's value
+// not echoed.
+func assertDisallowedInstanceRefusal(t *testing.T, err error, published string) {
+	t.Helper()
+	var disallowed *DisallowedGitLabURLError
+	if !errors.As(err, &disallowed) {
+		t.Fatalf("error = %v, want a *DisallowedGitLabURLError", err)
+	}
+	if !strings.Contains(disallowed.Error(), published) {
+		t.Errorf("error %q does not name the allowed instances", disallowed)
+	}
+	if strings.Contains(disallowed.Error(), "evil.example.com") {
+		t.Error("the rejected value is caller-controlled and must not be echoed back")
+	}
+}
+
 func TestResolveRequestOptionsFor_MultipleInstances(t *testing.T) {
 	const (
 		primary   = "https://gitlab.com"
@@ -363,13 +405,14 @@ func TestResolveRequestOptionsFor_MultipleInstances(t *testing.T) {
 	allowed := []string{primary, secondary}
 
 	tests := []struct {
-		name    string
-		header  string
-		want    string
-		wantErr bool
+		name        string
+		header      string
+		want        string
+		wantErr     bool
+		wantUnnamed bool
 	}{
-		{name: "no header selects the first published instance", want: primary},
-		{name: "header selects the default explicitly", header: primary, want: primary},
+		{name: "no header is refused rather than served the first published instance", wantUnnamed: true},
+		{name: "header selects the first published instance explicitly", header: primary, want: primary},
 		{name: "header selects another published instance", header: secondary, want: secondary},
 		{name: "header selects a trailing-slash spelling of one", header: secondary + "/", want: secondary},
 		{name: "header naming an unpublished instance is refused", header: "https://evil.example.com", wantErr: true},
@@ -382,17 +425,12 @@ func TestResolveRequestOptionsFor_MultipleInstances(t *testing.T) {
 			}
 
 			options, err := ResolveRequestOptionsFor(req, allowed)
+			if tt.wantUnnamed {
+				assertUnnamedInstanceRefusal(t, err, allowed)
+				return
+			}
 			if tt.wantErr {
-				var disallowed *DisallowedGitLabURLError
-				if !errors.As(err, &disallowed) {
-					t.Fatalf("error = %v, want a *DisallowedGitLabURLError", err)
-				}
-				if !strings.Contains(disallowed.Error(), primary) {
-					t.Errorf("error %q does not name the allowed instances", disallowed)
-				}
-				if strings.Contains(disallowed.Error(), "evil.example.com") {
-					t.Error("the rejected value is caller-controlled and must not be echoed back")
-				}
+				assertDisallowedInstanceRefusal(t, err, primary)
 				return
 			}
 			if err != nil {


### PR DESCRIPTION
`serverpool.ResolveRequestOptionsFor` answered a request carrying no `GITLAB-URL` on a deployment that publishes several instances with the first one, and said so in a comment, while `cmd/server`'s gate refused the same request before the credential was judged. Issue 462 put the choice plainly: move the refusal into the resolver so it holds for every caller, or keep the resolver permissive and say so. This does the first.

## What changes

The resolver returns `*serverpool.UnnamedInstanceError` for that request. The error carries the published set for a caller that may name it, and its message names nobody: whether the set may be echoed depends on the auth mode (public in oauth mode through RFC 9728 metadata, not in legacy mode, where echoing it would let any non-empty token enumerate the operator's hostnames), and the package does not know the mode. The gate keeps doing what only it can: refusing before verification and choosing the wording per mode. Its comment, and the one on the oauth verifier's instance resolution, now say that the resolver refuses too and why the gate still stands in front.

The resolver's test asked for the default and now asks for the refusal, with the set on the error and no instance in the message. The `DisallowedGitLabURLError` assertions moved into a helper beside it.

## Verification

`internal/serverpool` and `cmd/server` unit tests, the HTTP transport e2e module (which drives the multi-instance refusals on the wire and checks neither instance is reached), and golangci-lint on both packages.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/462

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Make multi-instance resolution reject requests without an explicitly named GitLab instance across all resolver callers.

Bug Fixes:
- Refuse unnamed instance requests in the serverpool resolver instead of routing them to the first published GitLab instance.
- Prevent credentials from being sent to an instance the request did not explicitly select.

Enhancements:
- Introduce a resolver error that carries the published instances without exposing them in its message, allowing callers to apply authentication-mode-specific wording.
- Align server gate comments and behavior documentation with resolver-level refusal handling.

Tests:
- Update serverpool tests to verify unnamed requests return the new refusal error and preserve the published instance set.
- Extract shared assertions for unnamed and disallowed instance errors.

Chores:
- Refresh README codebase statistics.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Changed the resolver to refuse requests that do not specify a GitLab instance on multi-instance deployments, instead of defaulting to the first published instance.</li>
<li>Introduced a new UnnamedInstanceError type to handle and report these refused requests.</li>
<li>Updated the server's auth gate logic to reflect that the resolver now handles this refusal, ensuring consistent behavior across all callers.</li>
<li>Updated unit tests to verify the new refusal behavior and added helper functions for asserting refusal errors.</li>
</ul></div>