### PR TITLE
chore: drop the bench_resources binary committed by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 # Local CLI binaries from cmd/* (built by `go build ./cmd/<name>`)
 /audit_metrics
 /audit_output
+/bench_resources
 /audit_test_names
 /audit_tokens
 /audit_tools


### PR DESCRIPTION
`bench_resources` at the repository root is a compiled Linux binary of `cmd/bench_resources`, committed by accident in #463 along with the benchmark harness. It is 37 MB of x86-64 ELF that nothing references; the harness builds its own copy, and the root-level names the other tools produce (`/audit_metrics`, `/gen_stats`, …) are ignored one by one in `.gitignore`, which this one was not.

Removed, and `/bench_resources` added to `.gitignore` beside the others so a local build cannot come back the same way.

Found by the rename in #482: the only place `git grep` still found the old file names after the rewrite was inside this binary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/gitlab-mcp-server/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

