### PR TITLE
test(server): wait for the condition instead of sleeping and counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,072 |     227,229 |
-| Unit tests (`_test.go`)  |       639 |     369,151 |
+| Unit tests (`_test.go`)  |       639 |     369,208 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **657,570** |
+| **Total**                | **1,937** | **657,627** |
 
 ### Functions
 

--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,072 |     227,229 |
-| Unit tests (`_test.go`)  |       639 |     369,208 |
+| Unit tests (`_test.go`)  |       639 |     369,214 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **657,627** |
+| **Total**                | **1,937** | **657,633** |
 
 ### Functions
 
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 7,141 |
-| `defer` statements                 | 1,205 |
+| `defer` statements                 | 1,206 |
 | `struct` types defined             | 2,888 |
 | `//nolint` suppressions            |   280 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -570,9 +570,11 @@ func TestSubscribe_IdleSession_KeepsWatchingWhileItsStreamIsOpen(t *testing.T) {
 	}
 	waitForPolls(t, backend, 3)
 
-	// Several leases of silence on a session that sends nothing else.
+	// Several leases of silence on a session that sends nothing else. The
+	// baseline counts reads of the watched pipeline only, the same counter
+	// the wait below watches, so nothing but polling can move it.
 	time.Sleep(lease + slow/4)
-	afterLease := backend.calls()
+	afterLease := backend.hits.Load()
 
 	// Three more reads at the base period arrive within milliseconds; a
 	// watch demoted to the slow interval would need three of those, seconds
@@ -633,17 +635,20 @@ func TestSubscribe_ActiveSession_WatcherStaysFast(t *testing.T) {
 		}
 	}
 	busy(8) // four lease periods
-	stillActive := backend.calls()
+	stillActive := backend.hits.Load()
 
-	// Keep the session busy while waiting for three more reads. At the base
-	// period they arrive within milliseconds; a watch demoted to the slow
-	// interval would need seconds, so the deadline is the assertion and the
-	// machine's speed is not.
+	// Keep the session busy while waiting for three more reads of the
+	// watched pipeline. At the base period they arrive within milliseconds;
+	// a watch demoted to the slow interval would need seconds, so the
+	// deadline is the assertion and the machine's speed is not. Only reads
+	// of the pipeline count: the busy traffic itself reaches GitLab, and
+	// counting it would let the renewal calls stand in for the polling they
+	// are supposed to keep alive.
 	deadline := time.Now().Add(slow / 2)
-	for backend.calls()-stillActive < 3 {
+	for backend.hits.Load()-stillActive < 3 {
 		if time.Now().After(deadline) {
-			t.Fatalf("GitLab was called %d more times in %v after the lease would have run out; "+
-				"activity on the session did not renew the watch", backend.calls()-stillActive, slow/2)
+			t.Fatalf("the pipeline was read %d more times in %v after the lease would have run out; "+
+				"activity on the session did not renew the watch", backend.hits.Load()-stillActive, slow/2)
 		}
 		busy(1)
 	}

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -133,13 +133,48 @@ func leasedPolling(lease, slow time.Duration) serverOption {
 // long they take.
 func waitForPolls(t *testing.T, b *pipelineBackend, n int64) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	waitForPollsWithin(t, b, n, 5*time.Second)
+}
+
+// waitForPollsWithin is waitForPolls with the deadline chosen by the test,
+// for the cases where the deadline is the assertion: a watch still at its
+// base period reaches n within milliseconds, and one demoted to the slow
+// interval cannot reach it before a deadline of a few seconds, so the
+// deadline separates the two outcomes without measuring how fast the machine
+// is. A count that a fixed sleep was supposed to reach did measure it, and
+// on a slow runner two reads landed where three were expected.
+func waitForPollsWithin(t *testing.T, b *pipelineBackend, n int64, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
 	for b.hits.Load() < n {
 		if time.Now().After(deadline) {
-			t.Fatalf("GitLab was polled %d times in 5s, want at least %d", b.hits.Load(), n)
+			t.Fatalf("GitLab was polled %d times in %v, want at least %d", b.hits.Load(), within, n)
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
+}
+
+// settledCount returns a backend counter once it has not moved for a full
+// quiet span, so a read already in flight when a watcher was stopped has
+// landed before the test starts counting, rather than a moment after the
+// sample was taken. The counter is passed in because the backend keeps two,
+// every request and the reads it answered, and a test must settle the one it
+// then compares. A count that keeps moving until the deadline is a watcher
+// that never stopped, and is reported as that.
+func settledCount(t *testing.T, count func() int64, quiet time.Duration) int64 {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	last, since := count(), time.Now()
+	for time.Since(since) < quiet {
+		if time.Now().After(deadline) {
+			t.Fatalf("GitLab requests kept arriving for 5s (%d so far); the watcher never stopped", count())
+		}
+		time.Sleep(2 * time.Millisecond)
+		if now := count(); now != last {
+			last, since = now, time.Now()
+		}
+	}
+	return last
 }
 
 // TestCreateServer_SubscribeCapability_FollowsCapabilitySurface verifies
@@ -224,9 +259,11 @@ func TestSubscribe_UnreadableURI_StartsNoWatcher(t *testing.T) {
 		t.Errorf("watchers = %d after a refused subscribe, want 0", manager.Len())
 	}
 
-	// The refusal cost one read; what must not happen is a second one.
-	settled := backend.calls()
-	time.Sleep(200 * time.Millisecond)
+	// The refusal cost one read; what must not happen is a second one. The
+	// count is sampled once it has stopped moving, so the read the refusal
+	// itself made cannot land between the sample and the check.
+	settled := settledCount(t, backend.calls, 100*time.Millisecond)
+	time.Sleep(200 * time.Millisecond) // ten or more poll periods
 	if got := backend.calls(); got != settled {
 		t.Errorf("GitLab calls went %d -> %d after a refused subscribe; a watcher outlived the refusal", settled, got)
 	}
@@ -325,9 +362,8 @@ func TestSubscribe_Unsubscribe_StopsPolling(t *testing.T) {
 		t.Fatalf("Unsubscribe: %v", err)
 	}
 	// A read already in flight when the watcher was cancelled may still
-	// land, so let things settle before sampling the count.
-	time.Sleep(50 * time.Millisecond)
-	before := backend.hits.Load()
+	// land, so the count is sampled once it has stopped moving.
+	before := settledCount(t, backend.hits.Load, 100*time.Millisecond)
 	time.Sleep(200 * time.Millisecond) // ten or more poll periods
 
 	if after := backend.hits.Load(); after != before {
@@ -361,9 +397,9 @@ func TestSubscribe_SessionEnds_WatcherStops(t *testing.T) {
 	if closeErr := session.Close(); closeErr != nil {
 		t.Fatalf("session close: %v", closeErr)
 	}
-	// A read already in flight may still land after the session ends.
-	time.Sleep(50 * time.Millisecond)
-	before := backend.calls()
+	// A read already in flight may still land after the session ends, so
+	// the count is sampled once it has stopped moving.
+	before := settledCount(t, backend.calls, 100*time.Millisecond)
 	time.Sleep(200 * time.Millisecond) // ten or more poll periods
 
 	if after := backend.calls(); after != before {
@@ -537,11 +573,12 @@ func TestSubscribe_IdleSession_KeepsWatchingWhileItsStreamIsOpen(t *testing.T) {
 	// Several leases of silence on a session that sends nothing else.
 	time.Sleep(lease + slow/4)
 	afterLease := backend.calls()
-	time.Sleep(300 * time.Millisecond)
 
-	if grew := backend.calls() - afterLease; grew < 3 {
-		t.Errorf("GitLab was called %d more times while the stream was open, want the watch still at full speed", grew)
-	}
+	// Three more reads at the base period arrive within milliseconds; a
+	// watch demoted to the slow interval would need three of those, seconds
+	// apart, so the deadline separates the two outcomes without measuring
+	// how fast the machine is.
+	waitForPollsWithin(t, backend, afterLease+3, slow/2)
 }
 
 // TestSubscribe_ActiveSession_WatcherStaysFast verifies any traffic on the
@@ -597,11 +634,18 @@ func TestSubscribe_ActiveSession_WatcherStaysFast(t *testing.T) {
 	}
 	busy(8) // four lease periods
 	stillActive := backend.calls()
-	busy(8)
 
-	if grew := backend.calls() - stillActive; grew < 3 {
-		t.Errorf("GitLab was called %d more times %v after the lease would have run out; "+
-			"activity on the session did not renew the watch", grew, 4*lease)
+	// Keep the session busy while waiting for three more reads. At the base
+	// period they arrive within milliseconds; a watch demoted to the slow
+	// interval would need seconds, so the deadline is the assertion and the
+	// machine's speed is not.
+	deadline := time.Now().Add(slow / 2)
+	for backend.calls()-stillActive < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("GitLab was called %d more times in %v after the lease would have run out; "+
+				"activity on the session did not renew the watch", backend.calls()-stillActive, slow/2)
+		}
+		busy(1)
 	}
 }
 
@@ -1652,10 +1696,14 @@ func TestSessionBridge_ALegacySubscribeStillFollowsTheLease(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	time.Sleep(600 * time.Millisecond)
-
-	if demoted := runtime.manager.DemotedCount(); demoted == 0 {
-		t.Error("a silent legacy subscription was never demoted; the lease no longer applies to anything")
+	// A silent lease of 100ms runs out well inside the budget; a watch that
+	// is never demoted is what the deadline reports.
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.manager.DemotedCount() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("a silent legacy subscription was never demoted; the lease no longer applies to anything")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -1192,10 +1192,16 @@ func TestStartRevalidation_TriggersRevalidation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	pool.StartRevalidation(ctx)
 
-	// Wait for at least one tick to complete.
-	time.Sleep(150 * time.Millisecond)
+	// Wait for the first tick to complete, rather than for a span the sweep
+	// is expected to fit in.
+	deadline := time.Now().Add(5 * time.Second)
+	for pool.Stats().RevalidationsSucceeded < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("no revalidation completed within 5s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	cancel()
-	time.Sleep(100 * time.Millisecond)
 
 	s := pool.Stats()
 	if s.RevalidationsSucceeded < 1 {
@@ -2108,12 +2114,15 @@ func TestStartRevalidation_PanickingEvictionCallback_DoesNotKillTheProcess(t *te
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	// The panic unwinds after the entry leaves the map, so a moment here is
-	// what separates "recovered" from "about to crash the binary".
-	time.Sleep(50 * time.Millisecond)
-
-	if pool.Stats().RevalidationsFailed == 0 {
-		t.Error("the failed revalidation was not counted")
+	// The panic unwinds after the entry leaves the map and the failure is
+	// counted after that, so waiting for the count is what separates
+	// "recovered" from "about to crash the binary".
+	deadline = time.Now().Add(5 * time.Second)
+	for pool.Stats().RevalidationsFailed == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the failed revalidation was not counted")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -1190,6 +1190,7 @@ func TestStartRevalidation_TriggersRevalidation(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // the wait below can end the test early, and the sweep must not outlive it
 	pool.StartRevalidation(ctx)
 
 	// Wait for the first tick to complete, rather than for a span the sweep


### PR DESCRIPTION
Closes https://github.com/jmrplens/gitlab-mcp-server/issues/484.

`TestSubscribe_IdleSession_KeepsWatchingWhileItsStreamIsOpen` failed on a macOS leg of a pull request that changed nothing near it: two polls landed in a 300 ms window built for three, and a rerun passed. The subscription wiring tests drive a real `httptest` backend, so `synctest` is out, and what they did instead was sleep a fixed span and assert a count, which is a bet on how fast the machine is. The bet fails in both directions: a minimum-growth assertion fails on a slow runner, and an equality-after-settling assertion fails when a read still in flight lands a line after the settled count was sampled.

## What lands

- **"This keeps happening" waits for the count.** Where a test pins that a watch is still at its base period, it now waits for three more reads within a deadline a demoted watch cannot meet: at 20 ms they arrive within milliseconds, and a watch on the 2-second slow interval needs seconds, so the deadline separates the two outcomes without measuring the runner. `TestSubscribe_ActiveSession_WatcherStaysFast` keeps the session busy while it waits, since the lease is what it is exercising.
- **"This stopped" samples once it has stopped.** Where a test pins that polling ended, the count is taken only once it has not moved for a full quiet span, and the counter settled is the one compared; the backend keeps two, requests and answered reads, and my first version settled the wrong one. A count that never settles fails as a watcher that never stopped, which is the defect, rather than as a miscount later.
- **The pool's revalidation tests wait for the first result** of the sweep instead of for a span it was expected to fit in, including the one that pins a panicking eviction callback being recovered.
- **The other real-time waits stay.** The rest sleep past a TTL or a window they set themselves, which is deterministic; hand a process a moment before cancelling it without asserting a count; or are the poll interval of a wait loop.

Nothing pinned changed. A lease that stops demoting, a demoted watch that keeps polling at the base period, and a watcher that outlives its subscriber still fail, by deadline rather than by miscount.

## Tests

The subscription and session-bridge tests three times in a row, the same for the pool's revalidation tests, the full `cmd/server` package, and the subscription tests once more under `GOMAXPROCS=1` to stand in for a starved runner.
