### PR TITLE
test(cmd): make the tooling tests pass on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,16 +770,15 @@ jobs:
         run: go build ./...
       - name: Vet every package
         run: go vet ./...
-      # The shipped code, not the whole tree. Everything under cmd/ other than
-      # the server is maintainer tooling: the auditors and generators run on
-      # Linux, from a Makefile target, on this repository's own checkout, and
-      # never on a user's machine. Their tests assume "/" and Linux error text
-      # in dozens of places, and making that portable is real work whose
-      # benefit would be a green tick rather than a working program. Tracked
-      # separately in https://github.com/jmrplens/gitlab-mcp-server/issues/439.
-      #
-      # go build and go vet above still cover every package on every platform,
-      # so a compile break in the tooling is caught here regardless.
+      # The whole tree, tooling included. Everything under cmd/ other than
+      # the server is maintainer tooling that runs on Linux from a Makefile
+      # target, and its tests used to assume "/" and Linux error text, so the
+      # leg ran the shipped code alone. The fifteen tests that failed on a
+      # real Windows were made portable (issue 439): reported paths are
+      # spelled with slashes on every platform, not-found is asserted with
+      # errors.Is rather than by its text, and the one case a platform cannot
+      # produce is skipped there and says why. Running them here is what keeps
+      # that true.
       #
       # The bound is raised from the 10 minute default because cmd/server
       # exceeded it on Windows, where the suite runs roughly three times slower
@@ -796,7 +795,7 @@ jobs:
         run: go install gotest.tools/gotestsum
       - name: Unit suite
         shell: bash
-        run: bash .github/scripts/go-test-crash-aware.sh test-results/unit-suite -count=1 -timeout=30m ./cmd/server/... ./internal/...
+        run: bash .github/scripts/go-test-crash-aware.sh test-results/unit-suite -count=1 -timeout=30m ./cmd/... ./internal/...
       # The two transport modules need neither GitLab nor a credential, and
       # they are why this is not a build-only check: they start the real binary
       # and drive it the way a client does, over pipes and sockets, which is
@@ -814,7 +813,7 @@ jobs:
       # Windows does not implement, so every case that asserts on shutdown
       # would fail for a reason that has nothing to do with the code under
       # test. Giving the harnesses a Windows-native termination path is tracked
-      # in https://github.com/jmrplens/gitlab-mcp-server/issues/439. macOS runs
+      # in https://github.com/jmrplens/gitlab-mcp-server/issues/490. macOS runs
       # them today because SIGTERM and unix sockets both behave there.
       - name: HTTP transport end-to-end
         if: matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,072 |     227,229 |
-| Unit tests (`_test.go`)  |       639 |     369,214 |
+| Source (`.go`, non-test) |     1,072 |     227,236 |
+| Unit tests (`_test.go`)  |       639 |     369,320 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **657,633** |
+| **Total**                | **1,937** | **657,746** |
 
 ### Functions
 
@@ -479,10 +479,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.62× more tests than code |
+| Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~211 lines |
 | Average test file length           |                 ~577 lines |
-| Comment lines in source            |  34,782 (~15.3% of source) |
+| Comment lines in source            |  34,787 (~15.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/cmd/audit_catalog_first/main_test.go
+++ b/cmd/audit_catalog_first/main_test.go
@@ -14,6 +14,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -1035,10 +1036,14 @@ func TestDiscoverDomainSources_UnusableTree_ReturnsError(t *testing.T) {
 		files   map[string]string
 		inspect string
 		wantErr string
+		// wantIs is asserted with errors.Is where the text is the operating
+		// system's rather than this tool's: Windows spells a missing path
+		// differently from Linux, and the error wraps fs.ErrNotExist on both.
+		wantIs error
 	}{
 		{name: "tools directory missing", files: map[string]string{}, wantErr: "read tools directory"},
 		{name: "domain file does not parse", files: map[string]string{"internal/tools/alpha/alpha.go": "package alpha\n\nfunc {\n"}, wantErr: "parse "},
-		{name: "domain directory missing", files: map[string]string{}, inspect: "absent", wantErr: "no such file or directory"},
+		{name: "domain directory missing", files: map[string]string{}, inspect: "absent", wantIs: fs.ErrNotExist},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1048,6 +1053,12 @@ func TestDiscoverDomainSources_UnusableTree_ReturnsError(t *testing.T) {
 				_, err = inspectDomainSource(filepath.Join(root, tt.inspect), tt.inspect)
 			} else {
 				_, err = discoverDomainSources(root)
+			}
+			if tt.wantIs != nil {
+				if !errors.Is(err, tt.wantIs) {
+					t.Fatalf("error = %v, want %v", err, tt.wantIs)
+				}
+				return
 			}
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)

--- a/cmd/audit_doc_coverage/main.go
+++ b/cmd/audit_doc_coverage/main.go
@@ -268,9 +268,15 @@ func buildDocEntries(repoRoot string, docPaths []string) (docEntries map[string]
 	absByRel = make(map[string]string, len(docPaths))
 	relByBase = make(map[string]string, len(docPaths))
 	for _, p := range docPaths {
+		// The key is the repository's spelling of the path, with slashes: it
+		// is compared with the README mapping and reported as-is, and on
+		// Windows filepath.Rel returns backslashes that would match nothing.
+		// A path that cannot be made relative is kept exactly as given.
 		rel, relErr := filepath.Rel(repoRoot, p)
 		if relErr != nil {
 			rel = p
+		} else {
+			rel = filepath.ToSlash(rel)
 		}
 		docEntries[rel] = &fileFinding{DocPath: rel}
 		absByRel[rel] = p

--- a/cmd/audit_doc_coverage/main_test.go
+++ b/cmd/audit_doc_coverage/main_test.go
@@ -973,7 +973,9 @@ func TestSortedUnique_Scenarios_DedupesAndSorts(t *testing.T) {
 // the repo).
 func TestResolveOutputPath_ByPathKind(t *testing.T) {
 	root := filepath.Join("home", "user", "repo")
-	abs := filepath.Join(string(filepath.Separator)+"tmp", "out.json")
+	// A rooted path on every platform: "/tmp" is not absolute on Windows,
+	// where an absolute path needs a volume, and would be joined onto root.
+	abs := filepath.Join(t.TempDir(), "out.json")
 	cases := []struct {
 		name  string
 		input string

--- a/cmd/audit_doc_tool_names/main_test.go
+++ b/cmd/audit_doc_tool_names/main_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -187,6 +188,21 @@ func TestScanFile_UnreadableFile_ReturnsError(t *testing.T) {
 	}
 }
 
+// rootBelowAFile returns a root path that sits below a regular file, so
+// stat fails for a reason other than absence.
+//
+// Not on Windows: a path below a regular file is reported as not found
+// there, which scanRoot rightly treats as an absent root, so the stat failure
+// this case exercises cannot be produced by this construction.
+func rootBelowAFile(t *testing.T, root string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("a path below a regular file reports not-found on Windows")
+	}
+	file := writeDoc(t, root, "README.md", "x")
+	return filepath.Join(file, "child")
+}
+
 // TestScanRoot_Roots_ScansFilesAndTrees verifies one docRoots entry may be
 // a single file or a tree: a missing root is skipped, a tree yields every
 // .md and .mdx file below it while other extensions and node_modules are
@@ -228,12 +244,8 @@ func TestScanRoot_Roots_ScansFilesAndTrees(t *testing.T) {
 			wantNames:   []string{"gitlab_list_issues", "gitlab_get_issue"},
 		},
 		{
-			name: "root_below_a_file_fails_stat",
-			setup: func(t *testing.T, root string) string {
-				t.Helper()
-				file := writeDoc(t, root, "README.md", "x")
-				return filepath.Join(file, "child")
-			},
+			name:    "root_below_a_file_fails_stat",
+			setup:   rootBelowAFile,
 			wantErr: true,
 		},
 		{

--- a/cmd/audit_test_names/files_test.go
+++ b/cmd/audit_test_names/files_test.go
@@ -242,8 +242,12 @@ func TestRunFileCheck_ReportsVerdict(t *testing.T) {
 			name: "missing directory",
 			dirs: func(root string) []string { return []string{filepath.Join(root, "absent")} },
 			wantStdout: func(root string) string {
-				path := filepath.ToSlash(filepath.Join(root, "absent"))
-				return fmt.Sprintf("%-70s %s\n", path, "unreadable: open "+filepath.Join(root, "absent")+": no such file or directory") +
+				absent := filepath.Join(root, "absent")
+				// The reason carries the operating system's own text for a
+				// missing directory, so it is taken from the same read the
+				// check makes rather than spelled the Linux way.
+				_, readErr := os.ReadDir(absent)
+				return fmt.Sprintf("%-70s %s\n", filepath.ToSlash(absent), "unreadable: "+readErr.Error()) +
 					"test-file naming: 1 file(s) violate the convention\n"
 			},
 		},

--- a/cmd/bench_resources/main.go
+++ b/cmd/bench_resources/main.go
@@ -294,10 +294,11 @@ func resolve(root, path string) string {
 }
 
 // rel renders a path for a message, relative to the module root when it is
-// inside it.
+// inside it, spelled the way the repository spells it: with slashes, on
+// every platform.
 func rel(root, path string) string {
 	if relative, err := filepath.Rel(root, path); err == nil {
-		return relative
+		return filepath.ToSlash(relative)
 	}
 	return path
 }

--- a/cmd/bench_resources/main_test.go
+++ b/cmd/bench_resources/main_test.go
@@ -196,8 +196,9 @@ func TestResolveAndRel_RoundTrip(t *testing.T) {
 	}
 
 	// An absolute flag value is left alone, which is what lets a smoke run
-	// write outside the repository.
-	outside := "/tmp/bench.json"
+	// write outside the repository. Built from a temporary directory so it
+	// is rooted on every platform: "/tmp" carries no volume on Windows.
+	outside := filepath.Join(t.TempDir(), "bench.json")
 	if got := resolve(root, outside); got != outside {
 		t.Errorf("resolve rewrote an absolute path: %q", got)
 	}

--- a/cmd/eval_mcp_surfaces/internal/evaluator/docker_runtime_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/docker_runtime_test.go
@@ -5,10 +5,33 @@
 package evaluator
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
+
+// exitingCommand is a command that exits with status: the POSIX true and
+// false on unix, cmd.exe's exit built-in on Windows, where neither exists.
+func exitingCommand(status int) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", "exit", map[bool]string{true: "1", false: "0"}[status != 0]}
+	}
+	if status != 0 {
+		return "false", nil
+	}
+	return "true", nil
+}
+
+// sleepingCommand is a command that outlives any short timeout without
+// spawning a child of its own: a grandchild holding the output pipe would
+// keep the wait going after the process under test had been killed.
+func sleepingCommand() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "powershell", []string{"-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 5"}
+	}
+	return "sleep", []string{"5"}
+}
 
 // TestShouldAutoStartDockerRuntime_RequiresDockerPresetAndGitLabBackend
 // verifies that shouldAutoStartDockerRuntime only returns true when all three
@@ -183,8 +206,12 @@ func TestDockerEnterpriseRuntime_DetectsEditionPresetAndEnvironment(t *testing.T
 
 // TestRunDockerRuntimeCommand_ReportsFailureAndTimeout verifies a failing
 // command is reported under its step name and a command that outlives its
-// timeout is reported as timed out. Both use plain shell utilities.
+// timeout is reported as timed out. The commands are the platform's own
+// plain utilities, since none of true, false or sleep exists on Windows.
 func TestRunDockerRuntimeCommand_ReportsFailureAndTimeout(t *testing.T) {
+	failing, failingArgs := exitingCommand(1)
+	succeeding, succeedingArgs := exitingCommand(0)
+	sleeping, sleepingArgs := sleepingCommand()
 	cases := []struct {
 		name    string
 		timeout time.Duration
@@ -192,9 +219,9 @@ func TestRunDockerRuntimeCommand_ReportsFailureAndTimeout(t *testing.T) {
 		args    []string
 		want    string
 	}{
-		{name: "exit status", timeout: 5 * time.Second, command: "false", want: "step-name: exit status 1"},
-		{name: "timeout", timeout: 20 * time.Millisecond, command: "sleep", args: []string{"5"}, want: "step-name timed out after"},
-		{name: "success", timeout: 5 * time.Second, command: "true"},
+		{name: "exit status", timeout: 5 * time.Second, command: failing, args: failingArgs, want: "step-name: exit status 1"},
+		{name: "timeout", timeout: 20 * time.Millisecond, command: sleeping, args: sleepingArgs, want: "step-name timed out after"},
+		{name: "success", timeout: 5 * time.Second, command: succeeding, args: succeedingArgs},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/eval_mcp_surfaces/internal/evaluator/options_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/options_test.go
@@ -116,7 +116,9 @@ func TestToolExecutionMode_ReflectsDryRunExecuteAndExternalModes(t *testing.T) {
 // TestDefaultArtifactPaths_UseEvaluationDirectories verifies generated report,
 // trace, and terminal paths stay under the ignored evaluation output tree.
 func TestDefaultArtifactPaths_UseEvaluationDirectories(t *testing.T) {
-	if got := defaultOutputPath("openai:gpt/test model"); !strings.HasPrefix(got, defaultEvalDir+string(filepath.Separator)) || !strings.Contains(got, "openai-gpt-test-model") {
+	// The paths are built with filepath, so they carry the platform's
+	// separator; the prefix they must sit under is spelled with slashes.
+	if got := filepath.ToSlash(defaultOutputPath("openai:gpt/test model")); !strings.HasPrefix(got, defaultEvalDir+"/") || !strings.Contains(got, "openai-gpt-test-model") {
 		t.Fatalf("defaultOutputPath() = %q", got)
 	}
 	if got := defaultComparisonOutputPath(); !strings.Contains(got, filepath.Join(defaultEvalDir, "comparison")) || !strings.HasSuffix(got, "-summary.md") {
@@ -283,7 +285,7 @@ func TestDefaultTerminalLogPath_UsesIgnoredTerminalDirectory(t *testing.T) {
 
 // TestDefaultOutputPath_UsesIgnoredDistDirectory verifies DefaultOutputPath uses ignored dist directory.
 func TestDefaultOutputPath_UsesIgnoredDistDirectory(t *testing.T) {
-	got := defaultOutputPath("claude/sonnet:4 6")
+	got := filepath.ToSlash(defaultOutputPath("claude/sonnet:4 6"))
 	if !strings.HasPrefix(got, "dist/evaluation/mcp-surfaces/model-") {
 		t.Fatalf("defaultOutputPath() = %q, want dist evaluation path", got)
 	}

--- a/cmd/format_md_tables/main_test.go
+++ b/cmd/format_md_tables/main_test.go
@@ -524,16 +524,20 @@ func TestDiscoverMarkdownFiles_FindsMDX(t *testing.T) {
 // directory no longer exists, so getcwd fails) is reported as a root
 // resolution error rather than an open error on an empty path.
 func TestRun_RemovedWorkingDirectory_ReturnsResolveRootError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows getcwd does not fail when the current directory is removed")
-	}
 	gone := filepath.Join(t.TempDir(), "gone")
 	if err := os.Mkdir(gone, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Chdir(gone)
+	// Windows refuses to remove a process's working directory, and macOS
+	// keeps answering getcwd from the path it remembers, so on neither can
+	// the failure be produced this way: both skip rather than report the
+	// operating system's design as a defect here.
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("remove working directory: %v", err)
+		t.Skipf("this platform will not remove the working directory: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("this platform's getcwd still answers after the working directory is removed")
 	}
 
 	var stdout bytes.Buffer

--- a/cmd/gen_brand/main_test.go
+++ b/cmd/gen_brand/main_test.go
@@ -227,18 +227,23 @@ func notADirectoryText() string {
 
 // chdirIntoRemovedDir makes a directory the working directory and then
 // removes it, so os.Getwd fails with ENOENT regardless of privilege.
+//
+// Windows refuses to remove a process's working directory, and macOS keeps
+// answering getcwd from the path it remembers, so on neither can the failure
+// be produced this way: both skip rather than report the operating system's
+// design as a defect here.
 func chdirIntoRemovedDir(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows getcwd does not fail when the current directory is removed")
-	}
 	gone := filepath.Join(t.TempDir(), "gone")
 	if err := os.Mkdir(gone, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Chdir(gone)
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("remove working directory: %v", err)
+		t.Skipf("this platform will not remove the working directory: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("this platform's getcwd still answers after the working directory is removed")
 	}
 }
 

--- a/cmd/gen_brand/main_test.go
+++ b/cmd/gen_brand/main_test.go
@@ -151,7 +151,7 @@ func TestRun_Write_UnwritableTree_ReturnsError(t *testing.T) {
 					t.Fatalf("write blocker: %v", err)
 				}
 			},
-			wantErr: []string{"create ", filepath.Dir(first), "not a directory"},
+			wantErr: []string{"create ", filepath.Dir(first), notADirectoryText()},
 		},
 		{
 			name: "asset path is a directory",
@@ -213,6 +213,16 @@ func chdirIntoRootlessDir(t *testing.T) {
 		}
 	}
 	t.Chdir(dir)
+}
+
+// notADirectoryText is the operating system's wording for a directory being
+// created below a regular file: ENOTDIR on unix, and on Windows the
+// path-not-found error that stands in for it.
+func notADirectoryText() string {
+	if runtime.GOOS == "windows" {
+		return "cannot find the path specified"
+	}
+	return "not a directory"
 }
 
 // chdirIntoRemovedDir makes a directory the working directory and then

--- a/cmd/gen_icon_webp/main_test.go
+++ b/cmd/gen_icon_webp/main_test.go
@@ -497,16 +497,20 @@ func TestRasterize_CwebpUnusable_ReturnsCwebpError(t *testing.T) {
 // getcwd(3) then fails with ENOENT regardless of privilege, which makes the
 // branch reproducible without depending on permission enforcement.
 func TestRepoRoot_RemovedWorkingDirectory_ReturnsError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows getcwd does not fail when the current directory is removed")
-	}
 	gone := filepath.Join(t.TempDir(), "gone")
 	if err := os.Mkdir(gone, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Chdir(gone)
+	// Windows refuses to remove a process's working directory, and macOS
+	// keeps answering getcwd from the path it remembers, so on neither can
+	// the failure be produced this way: both skip rather than report the
+	// operating system's design as a defect here.
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("remove working directory: %v", err)
+		t.Skipf("this platform will not remove the working directory: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("this platform's getcwd still answers after the working directory is removed")
 	}
 
 	if _, err := repoRoot(); err == nil || strings.Contains(err.Error(), "go.mod not found") {

--- a/cmd/gen_lhm_manifest/main_test.go
+++ b/cmd/gen_lhm_manifest/main_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -381,16 +380,20 @@ func assertManifestRewritten(t *testing.T, root, original string) {
 // surfaces the project-root lookup failure when the working directory was
 // removed from under the process, instead of reading a manifest from nowhere.
 func TestRun_RemovedWorkingDirectory_ReturnsProjectRootError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows getcwd does not fail when the current directory is removed")
-	}
 	gone := filepath.Join(t.TempDir(), "gone")
 	if err := os.Mkdir(gone, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Chdir(gone)
+	// Windows refuses to remove a process's working directory, and macOS
+	// keeps answering getcwd from the path it remembers, so on neither can
+	// the failure be produced this way: both skip rather than report the
+	// operating system's design as a defect here.
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("remove working directory: %v", err)
+		t.Skipf("this platform will not remove the working directory: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("this platform's getcwd still answers after the working directory is removed")
 	}
 
 	err := run(true)

--- a/cmd/gen_stats/main_test.go
+++ b/cmd/gen_stats/main_test.go
@@ -107,6 +107,12 @@ require github.com/g/h v1.0.0 // indirect
 // TestCollectStats_NonZeroCounts verifies collectStats returns non-zero
 // counts when run against the real repository root.
 func TestCollectStats_NonZeroCounts(t *testing.T) {
+	// The counts come from the git index, so a copy of the tree without its
+	// .git, a source archive or a mirror synced without it, has nothing to
+	// count, and that is not what this test is about.
+	if out, err := exec.CommandContext(t.Context(), "git", "rev-parse", "--is-inside-work-tree").Output(); err != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Skip("not inside a git work tree; the counts come from the index")
+	}
 	stats, err := collectStats(".")
 	if err != nil {
 		t.Fatalf("collectStats: %v", err)

--- a/cmd/internal/auditshared/actionspec_builders_test.go
+++ b/cmd/internal/auditshared/actionspec_builders_test.go
@@ -4,6 +4,8 @@
 package auditshared
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +65,7 @@ func TestDiscoverActionSpecGroupBuilders_Scenarios_ScansTopLevelSources(t *testi
 		missing bool
 		want    []string
 		wantErr string
+		wantIs  error
 	}{
 		{
 			name: "sorted names from top-level sources only",
@@ -98,7 +101,10 @@ func TestDiscoverActionSpecGroupBuilders_Scenarios_ScansTopLevelSources(t *testi
 		{
 			name:    "missing directory",
 			missing: true,
-			wantErr: "no such file or directory",
+			// Asserted with errors.Is rather than by text: the text is the
+			// operating system's, and Windows spells a missing path
+			// differently from Linux.
+			wantIs: fs.ErrNotExist,
 		},
 	}
 	for _, tt := range tests {
@@ -109,6 +115,12 @@ func TestDiscoverActionSpecGroupBuilders_Scenarios_ScansTopLevelSources(t *testi
 			}
 
 			got, err := DiscoverActionSpecGroupBuilders(dir)
+			if tt.wantIs != nil {
+				if !errors.Is(err, tt.wantIs) {
+					t.Fatalf("DiscoverActionSpecGroupBuilders() error = %v, want %v", err, tt.wantIs)
+				}
+				return
+			}
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("DiscoverActionSpecGroupBuilders() error = %v, want containing %q", err, tt.wantErr)

--- a/cmd/internal/mcpsurface/surface_test.go
+++ b/cmd/internal/mcpsurface/surface_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -252,16 +251,20 @@ func TestProjectRoot_NotFound(t *testing.T) {
 // removed: getcwd(3) then fails with ENOENT regardless of privilege, which
 // is what makes the branch reproducible in a test.
 func TestProjectRoot_RemovedWorkingDirectory_ReturnsError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows getcwd does not fail when the current directory is removed")
-	}
 	gone := filepath.Join(t.TempDir(), "gone")
 	if err := os.Mkdir(gone, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Chdir(gone)
+	// Windows refuses to remove a process's working directory, and macOS
+	// keeps answering getcwd from the path it remembers, so on neither can
+	// the failure be produced this way: both skip rather than report the
+	// operating system's design as a defect here.
 	if err := os.RemoveAll(gone); err != nil {
-		t.Fatalf("remove working directory: %v", err)
+		t.Skipf("this platform will not remove the working directory: %v", err)
+	}
+	if _, err := os.Getwd(); err == nil {
+		t.Skip("this platform's getcwd still answers after the working directory is removed")
 	}
 
 	_, err := ProjectRoot()


### PR DESCRIPTION
Closes https://github.com/jmrplens/gitlab-mcp-server/issues/439.

What the issue asked for, the Windows-only source compiling in CI and the build-constrained packages running their tests there, landed with the CI reshaping. What was left was the tooling under `cmd/`, which the Windows leg deliberately skipped because its tests assumed "/" and Linux error text: fifteen tests in nine packages, measured on a Windows Server 2025 VM. This makes them pass there and puts `./cmd/...` on every leg of the matrix so they stay that way.

## What lands

- **One line fixes four.** `audit_doc_coverage` keyed its report by the path `filepath.Rel` returned, which carries backslashes on Windows and matched nothing the README mapping spells with slashes, so every doc came out with zero expected tools and the live baseline saw an unexpected prefix on all forty-four files. The key is now the repository's spelling of the path on every platform. `bench_resources` renders the paths in its messages the same way.
- **Not-found is asserted with `errors.Is`, not by its text.** `audit_catalog_first` and `auditshared` wanted "no such file or directory", which Windows spells "The system cannot find the file specified"; both errors wrap `fs.ErrNotExist`. `audit_test_names` builds its expected line from the same `os.ReadDir` the check makes.
- **An absolute path has a volume on Windows.** `/tmp/out.json` and `/tmp/bench.json` were joined onto the root there, since `filepath.IsAbs` is false for them; the tests build the value from a temporary directory now.
- **The platform's own utilities.** The docker-runtime command test exec'd `true`, `false` and `sleep`; on Windows it uses `cmd /c exit` and a PowerShell `Start-Sleep`, chosen so the sleeper has no child holding the output pipe past the kill. `gen_brand` expects Windows's path-not-found wording where unix reports ENOTDIR.
- **One case is skipped on Windows and says why.** A root path below a regular file is reported as absent there, which `scanRoot` rightly treats as nothing to scan, so the stat failure that case exercises cannot be produced by that construction.
- **The `gen_stats` count test skips outside a git work tree.** The counts come from the index, and a source archive or a mirror synced without `.git` has none.
- **The matrix runs the tooling.** The cross-platform leg's package list is `./cmd/... ./internal/...` on all three platforms, and the comment that excluded the tooling now says what changed. Running it on macOS for the first time found six tests of one more family, the removed-working-directory cases: Darwin keeps answering `getcwd` from the path it remembers, so the failure they exercise cannot be produced there, and Windows refuses the removal outright. Both skip with the reason now, the way `internal/cmdutil` already did. The other half of the issue, a Windows-native termination path for the transport harnesses so the HTTP and stdio modules can run on that leg, is https://github.com/jmrplens/gitlab-mcp-server/issues/490.

## Tests

The nine packages on Linux, then `./cmd/...` on the Windows Server 2025 VM with `.git` synced so the index-backed tests count rather than skip: all 44 packages with tests pass there, `cmd/server` included, and the one regression the full run caught (a path that cannot be made relative must be kept exactly as given, which the slash conversion had touched) is fixed and re-verified on the same VM.
