### PR TITLE
docs(go): keep file comments out of the package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,10 +459,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,072 |     227,236 |
+| Source (`.go`, non-test) |     1,072 |     227,290 |
 | Unit tests (`_test.go`)  |       639 |     369,320 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **657,746** |
+| **Total**                | **1,937** | **657,800** |
 
 ### Functions
 
@@ -479,10 +479,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.63× more tests than code |
-| Average source file length         |                 ~211 lines |
+| Test lines vs source lines         | 1.62× more tests than code |
+| Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~577 lines |
-| Comment lines in source            |  34,787 (~15.3% of source) |
+| Comment lines in source            |  34,795 (~15.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -514,8 +514,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,131 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,408 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,132 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,409 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_1to1/doc_validate.go
+++ b/cmd/audit_1to1/doc_validate.go
@@ -4,6 +4,7 @@
 // doc is the 1:1 ground truth, so a citation pointing at a doc that no longer
 // exists (renamed/removed upstream) silently invalidates an adjudication — this
 // gate surfaces it.
+
 package main
 
 import (

--- a/cmd/audit_doc_coverage/catalog_walker.go
+++ b/cmd/audit_doc_coverage/catalog_walker.go
@@ -5,6 +5,7 @@
 // self-managed-enterprise tier, then snapshots every action's
 // IndividualTool.Name, owning group, tier, and destructive flag into a
 // flat lookup table for the auditor's main comparison loop.
+
 package main
 
 import (

--- a/cmd/audit_doc_coverage/doc_parser.go
+++ b/cmd/audit_doc_coverage/doc_parser.go
@@ -15,6 +15,7 @@
 // in any of these positions within the file. Tier badge parsing is
 // best-effort and looks for the canonical "Premium"/"Ultimate" tokens
 // near each heading.
+
 package main
 
 import (

--- a/cmd/audit_doc_coverage/main.go
+++ b/cmd/audit_doc_coverage/main.go
@@ -1,6 +1,4 @@
-// Package main implements the audit_doc_coverage command.
-//
-// audit_doc_coverage reports per-doc-file gaps between
+// Command audit_doc_coverage reports per-doc-file gaps between
 // docs/reference/tools/<doc>.md and the canonical action catalog. It produces
 // plan/docs-tools-backlog.json (gitignored) listing, per file:
 //

--- a/cmd/audit_doc_coverage/mapping.go
+++ b/cmd/audit_doc_coverage/mapping.go
@@ -6,6 +6,7 @@
 // that must be split off their owning group. Both cases are
 // enumerated explicitly here so the auditor's main logic stays
 // table-driven and the special cases are reviewable in one place.
+
 package main
 
 import (

--- a/cmd/audit_metrics/site_stats.go
+++ b/cmd/audit_metrics/site_stats.go
@@ -14,6 +14,7 @@
 //   - catalog_groups.*  catalog group count per tier (IncludeMCP)
 //   - resources/prompts registered MCP resource and prompt counts
 //   - tool_packages     Go package directories under internal/tools
+
 package main
 
 import (

--- a/cmd/audit_surface_quality/metadata_audit.go
+++ b/cmd/audit_surface_quality/metadata_audit.go
@@ -1,4 +1,5 @@
 // Metadata-quality audit functions (formerly audit_tools).
+
 package main
 
 import (

--- a/cmd/audit_surface_quality/output_audit.go
+++ b/cmd/audit_surface_quality/output_audit.go
@@ -1,4 +1,5 @@
 // Output-quality audit functions (formerly audit_output).
+
 package main
 
 import (

--- a/cmd/audit_test_names/files.go
+++ b/cmd/audit_test_names/files.go
@@ -21,6 +21,7 @@
 //
 // test/e2e is exempt as a tree: its files have no source modules to be named
 // after.
+
 package main
 
 import (

--- a/cmd/audit_tokens/model_facing.go
+++ b/cmd/audit_tokens/model_facing.go
@@ -7,6 +7,7 @@
 // them overstated the figure the footprint exists to report, and by a lot: 16%
 // of the individual tool surface, 12% of the dynamic one, and 53% of the
 // shared resource and prompt surface.
+
 package main
 
 import (

--- a/cmd/bench_resources/chart.go
+++ b/cmd/bench_resources/chart.go
@@ -7,6 +7,7 @@
 // trusted; the palette has to be the site's own; and a log axis, a threshold
 // rule and value labels on the bars are all things a general-purpose library
 // makes harder than two hundred lines of arithmetic does.
+
 package main
 
 import (

--- a/cmd/bench_resources/figures.go
+++ b/cmd/bench_resources/figures.go
@@ -6,6 +6,7 @@
 // number of clients: the first two. What does a client wait for, and where
 // does that wait actually live: the third. What does a request cost once
 // everything is warm: the fourth.
+
 package main
 
 import (

--- a/cmd/bench_resources/host.go
+++ b/cmd/bench_resources/host.go
@@ -5,6 +5,7 @@
 // What must never happen is a number published with no machine attached, which
 // is why the fields are gathered here rather than typed into the documentation
 // by hand.
+
 package main
 
 import (

--- a/cmd/bench_resources/matrix.go
+++ b/cmd/bench_resources/matrix.go
@@ -6,6 +6,7 @@
 // another about a thousand; telemetry, because exporting is work the server
 // would not otherwise do; and concurrency, in both of its meanings, since
 // clients and in-flight requests cost different things.
+
 package main
 
 import (

--- a/cmd/bench_resources/proc_sample.go
+++ b/cmd/bench_resources/proc_sample.go
@@ -8,6 +8,7 @@
 // the stacks, the binary's mapped text and everything the scavenger has not
 // returned yet. Those numbers differ by a factor of two or more, and only one
 // of them gets a process OOM-killed.
+
 package main
 
 import (

--- a/cmd/bench_resources/render.go
+++ b/cmd/bench_resources/render.go
@@ -6,6 +6,7 @@
 // re-renders from the committed record and compares, which turns "the chart
 // matches the numbers" from a promise into a gate; -render redraws after a
 // change to the figures without spending minutes re-measuring.
+
 package main
 
 import (

--- a/cmd/bench_resources/result.go
+++ b/cmd/bench_resources/result.go
@@ -5,6 +5,7 @@
 // the site page are all rendered from it, and nothing re-measures to draw a
 // picture. That is what makes a chart re-renderable on a machine that never
 // ran the benchmark, and what makes -check possible at all.
+
 package main
 
 import (
@@ -158,6 +159,10 @@ const (
 	methodToolsList     = "tools/list"
 )
 
+// MethodLatency is the latency distribution of one MCP method over a run:
+// the percentiles and maximum, in milliseconds, of Count timed calls. Detail
+// distinguishes calls to the same method that are not comparable, such as a
+// tool call that reaches GitLab from one answered locally.
 type MethodLatency struct {
 	Method string  `json:"method"`
 	Detail string  `json:"detail,omitempty"`

--- a/cmd/bench_resources/rpc.go
+++ b/cmd/bench_resources/rpc.go
@@ -11,6 +11,7 @@
 // What an operator sizes for is the work the server does. So this client sends
 // the request every time, and the documentation says plainly that a caching
 // client pays it less often than these figures suggest.
+
 package main
 
 import (

--- a/cmd/bench_resources/run.go
+++ b/cmd/bench_resources/run.go
@@ -6,6 +6,7 @@
 // parallel. Collapsing those phases would produce one resident-set number that
 // answers none of the three questions an operator asks: what does it cost
 // idle, what does one more client cost, and what does it peak at.
+
 package main
 
 import (

--- a/cmd/bench_resources/stubs.go
+++ b/cmd/bench_resources/stubs.go
@@ -7,6 +7,7 @@
 // latency, its rate limits and its network into every figure, and two people
 // re-measuring would compare their GitLab installations rather than this
 // server.
+
 package main
 
 import (

--- a/cmd/bench_resources/target.go
+++ b/cmd/bench_resources/target.go
@@ -10,6 +10,7 @@
 // On stdio every client is its own process with its own catalog, so N clients
 // are N processes. On HTTP one process serves everyone and the pool holds one
 // entry per credential, so N clients are N tokens against one process.
+
 package main
 
 import (

--- a/cmd/bench_resources/theme.go
+++ b/cmd/bench_resources/theme.go
@@ -9,6 +9,7 @@
 // Two colors are not in the stylesheet and are stated here, each with the
 // reason it has to be: the palette carries one accent and one indicator, and a
 // three-series chart needs a third hue that is neither.
+
 package main
 
 import (

--- a/cmd/server/bearer_guard.go
+++ b/cmd/server/bearer_guard.go
@@ -14,6 +14,7 @@
 // through reaches the SDK middleware, whose own verification is a hit on the
 // cache this guard just populated, so the upstream cost is one call either
 // way.
+
 package main
 
 import (

--- a/cmd/server/client_ip.go
+++ b/cmd/server/client_ip.go
@@ -7,6 +7,7 @@
 // other peer it is caller-supplied text, and a caller who can choose the
 // address their failures are charged to can choose somebody else's, or a fresh
 // one per request. The two flags are therefore required together.
+
 package main
 
 import (

--- a/cmd/server/conn_refused_unix.go
+++ b/cmd/server/conn_refused_unix.go
@@ -2,6 +2,7 @@
 
 // conn_refused_unix.go answers "did the kernel say nothing is listening?" on the
 // platforms where that answer is ECONNREFUSED and nothing else.
+
 package main
 
 import (

--- a/cmd/server/conn_refused_windows.go
+++ b/cmd/server/conn_refused_windows.go
@@ -3,6 +3,7 @@
 // conn_refused_windows.go answers "did the kernel say nothing is listening?" on
 // Windows, where the answer arrives as a Winsock code that shares neither the
 // value nor the identity of the POSIX errno of the same name.
+
 package main
 
 import (

--- a/cmd/server/env_overlay.go
+++ b/cmd/server/env_overlay.go
@@ -10,6 +10,7 @@
 // and, when --gitlab-url was omitted, the GITLAB-URL header are
 // client-controlled. Nothing here is reachable per request, so a client cannot
 // influence any of it for itself or for anyone else.
+
 package main
 
 import (

--- a/cmd/server/health.go
+++ b/cmd/server/health.go
@@ -7,6 +7,7 @@
 // "which one is it", and none of them holds a GitLab token to ask with. What
 // it answers is therefore chosen to give away nothing a caller could use: no
 // counters, no configuration, no GitLab round-trip.
+
 package main
 
 import (

--- a/cmd/server/instructions.go
+++ b/cmd/server/instructions.go
@@ -3,6 +3,7 @@
 // differently on each tool surface, the guidance is assembled per surface
 // rather than written once: a single hardcoded text would name individual-mode
 // tools to a dynamic-mode model that cannot see any of them.
+
 package main
 
 import (

--- a/cmd/server/listen.go
+++ b/cmd/server/listen.go
@@ -7,6 +7,7 @@
 // in the first place, no bridge, no docker-proxy hop, and no certificate to
 // issue or rotate. The socket is the cheaper answer where it applies, so
 // --http-addr accepts a filesystem path as well as host:port.
+
 package main
 
 import (

--- a/cmd/server/probe.go
+++ b/cmd/server/probe.go
@@ -11,6 +11,7 @@
 // --transport and --http from their arguments, derives where /health is served,
 // and asks. A target may also be given outright, for a probe run from outside
 // the container or for a deployment whose process list cannot be read.
+
 package main
 
 import (

--- a/cmd/server/readiness.go
+++ b/cmd/server/readiness.go
@@ -20,6 +20,7 @@
 // Waiting, not answering early. A client that receives an empty tools/list and
 // does not act on notifications/tools/list_changed concludes the server has no
 // tools, which is a worse failure than a short wait and far harder to diagnose.
+
 package main
 
 import (

--- a/cmd/server/refusal_log.go
+++ b/cmd/server/refusal_log.go
@@ -8,6 +8,7 @@
 // themselves are already counted, by the failure budget and the metrics; the
 // line is what needs holding back, one per message per window, with how many
 // it stands for on the next one that does get written.
+
 package main
 
 import (

--- a/cmd/server/socket_mode_unix.go
+++ b/cmd/server/socket_mode_unix.go
@@ -43,6 +43,7 @@
 // unlink-on-close would remove that name rather than the published one. It is
 // switched off and the published path is removed on Close instead, and only
 // when it is still the same inode this process created.
+
 package main
 
 import (

--- a/cmd/server/socket_mode_windows.go
+++ b/cmd/server/socket_mode_windows.go
@@ -7,6 +7,7 @@
 // and there is no umask and no fchmod to apply. Saying so out loud is the
 // honest behaviour — quietly accepting the flag would let an operator believe
 // a restriction is in force that the platform never applied.
+
 package main
 
 import (

--- a/internal/config/env_file.go
+++ b/internal/config/env_file.go
@@ -22,6 +22,7 @@
 // decision anyone made. Git's safe.directory ownership check, direnv's
 // per-directory "direnv allow" and VS Code Workspace Trust are three
 // independent tools that reached the same conclusion.
+
 package config
 
 import (

--- a/internal/config/http_overlay.go
+++ b/internal/config/http_overlay.go
@@ -12,6 +12,7 @@
 // absent variables, which would make "exported the default" indistinguishable
 // from "exported nothing" and let the overlay overwrite a flag default with an
 // identical value for the wrong reason.
+
 package config
 
 import (

--- a/internal/elicitation/flow.go
+++ b/internal/elicitation/flow.go
@@ -1,4 +1,4 @@
-// Package elicitation: flow.go implements the multi round-trip request
+// flow.go implements the multi round-trip request
 // (MRTR, SEP-2322) elicitation flow required by MCP protocol version
 // 2026-07-28, where server-initiated elicitation/create requests are
 // forbidden while serving a tool call. A Flow transparently selects the
@@ -11,6 +11,7 @@
 //     opaque RequestState so multi-step flows survive handler re-invocation.
 //   - Older sessions fall back to the synchronous [Client] path, which
 //     issues elicitation/create requests directly.
+
 package elicitation
 
 import (

--- a/internal/elicitation/schemas.go
+++ b/internal/elicitation/schemas.go
@@ -1,7 +1,8 @@
-// Package elicitation: schemas.go holds the JSON Schema builders and
+// schemas.go holds the JSON Schema builders and
 // response-content parsers shared by the synchronous [Client] path and the
 // multi round-trip [Flow] path, so both mechanisms request and validate
 // identical shapes.
+
 package elicitation
 
 import (

--- a/internal/elicitation/state.go
+++ b/internal/elicitation/state.go
@@ -1,5 +1,6 @@
-// Package elicitation: state.go signs and binds the opaque RequestState that
+// state.go signs and binds the opaque RequestState that
 // carries a multi round-trip flow's accumulated answers between rounds.
+
 package elicitation
 
 import (

--- a/internal/serverpool/token.go
+++ b/internal/serverpool/token.go
@@ -306,6 +306,8 @@ type UnnamedInstanceError struct {
 	Allowed []string
 }
 
+// Error implements the [error] interface. The message names no instance, for
+// the reason given on the type.
 func (e *UnnamedInstanceError) Error() string {
 	return "this deployment serves several GitLab instances, so the " +
 		RequestOptionGitLabURL + " header must name the one this request is for"
@@ -325,6 +327,8 @@ type DisallowedGitLabURLError struct {
 	Allowed []string
 }
 
+// Error implements the [error] interface. It lists the published instances
+// and never the rejected value, which is caller-controlled text.
 func (e *DisallowedGitLabURLError) Error() string {
 	return "the GITLAB-URL header names an instance this deployment does not serve; allowed: " +
 		strings.Join(e.Allowed, ", ")

--- a/internal/subscriptions/kind.go
+++ b/internal/subscriptions/kind.go
@@ -124,8 +124,6 @@ func (k Kind) String() string {
 	return "unknown"
 }
 
-// Template returns the URI template this kind's resource is registered
-// under, or "" for [KindUnknown].
 // Templates returns the URI template of every subscribable kind, sorted,
 // for surfaces that advertise what can be watched (the gitlab://tools
 // manifest). Deriving the list here rather than copying it means the

--- a/internal/subscriptions/manager.go
+++ b/internal/subscriptions/manager.go
@@ -712,6 +712,16 @@ func (m *Manager[S]) Renew(uri string) bool {
 	return ok
 }
 
+// Lease returns how long a subscription is polled at full speed before it slows
+// down.
+//
+// Callers that hold a subscription open by some means other than request
+// traffic need this to renew it in time; guessing an interval would either
+// waste work or miss the deadline after the option is changed.
+func (m *Manager[S]) Lease() time.Duration {
+	return m.opts.Lease
+}
+
 // RenewAll extends the lease on every watch one subscriber holds, and
 // reports how many of them that revived from a demoted state.
 //
@@ -723,17 +733,6 @@ func (m *Manager[S]) Renew(uri string) bool {
 // during exactly the wait its subscriber cared about. Renewing every watch
 // on the manager would be wrong in the other direction: one busy session
 // would keep another session's abandoned watches at full speed forever.
-
-// Lease returns how long a subscription is polled at full speed before it slows
-// down.
-//
-// Callers that hold a subscription open by some means other than request
-// traffic need this to renew it in time; guessing an interval would either
-// waste work or miss the deadline after the option is changed.
-func (m *Manager[S]) Lease() time.Duration {
-	return m.opts.Lease
-}
-
 func (m *Manager[S]) RenewAll(subscriber S) int {
 	m.mu.Lock()
 	revived := make([]*watcher[S], 0, len(m.watchers))

--- a/internal/testutil/legacy_client.go
+++ b/internal/testutil/legacy_client.go
@@ -1,4 +1,4 @@
-// Package testutil: legacy_client.go provides a minimal hand-rolled MCP
+// legacy_client.go provides a minimal hand-rolled MCP
 // client that performs the legacy initialize handshake at protocol version
 // 2025-11-25 and serves server-initiated elicitation/create requests.
 //
@@ -8,6 +8,7 @@
 // (SEP-2322 forbids server-initiated requests from that version on). Tests
 // that exercise the synchronous path deterministically connect this fake
 // client instead of a real one.
+
 package testutil
 
 import (

--- a/internal/testutil/temp_dir.go
+++ b/internal/testutil/temp_dir.go
@@ -1,5 +1,6 @@
 // temp_dir.go isolates the process temporary directory for a test, on every
 // platform rather than only on the one the test was written on.
+
 package testutil
 
 import (

--- a/internal/tools/catalog_filter.go
+++ b/internal/tools/catalog_filter.go
@@ -9,6 +9,7 @@
 // withheld write with "unknown action" while the shipped binary answered
 // "exists but is not available". A test that builds its own copy of the thing
 // under test is testing the copy; both now call this.
+
 package tools
 
 import (

--- a/internal/tools/workitems/clear_guard.go
+++ b/internal/tools/workitems/clear_guard.go
@@ -1,6 +1,7 @@
 // clear_guard.go guards the work item update paths that silently discard data:
 // an explicit empty assignee or CRM contact list replaces the current one with
 // nothing.
+
 package workitems
 
 import (

--- a/internal/toolutil/file_utils_other.go
+++ b/internal/toolutil/file_utils_other.go
@@ -3,6 +3,7 @@
 // file_utils_other.go carries the leaf-open primitives for platforms with no
 // O_NOFOLLOW, where the surrounding Lstat and post-open Stat checks in
 // file_utils.go are all the containment there is.
+
 package toolutil
 
 import "os"

--- a/internal/toolutil/file_utils_unix.go
+++ b/internal/toolutil/file_utils_unix.go
@@ -3,6 +3,7 @@
 // file_utils_unix.go opens caller-supplied local paths without following a
 // symlink at the leaf, which is the containment the surrounding checks in
 // file_utils.go describe but cannot enforce on their own.
+
 package toolutil
 
 import (

--- a/internal/toolutil/meta_tool.go
+++ b/internal/toolutil/meta_tool.go
@@ -2522,11 +2522,6 @@ var (
 	metaParamSchemaMode = MetaParamSchemaOpaque
 )
 
-// SetMetaParamSchemaMode selects the meta-tool input schema strategy used by
-// [MetaToolSchema]. Accepts "opaque" (default), "compact", or "full". Any
-// other value is coerced to opaque so that misconfiguration cannot break the
-// tools/list payload. Must be called before meta-tools are registered; later
-// calls only affect schemas built after the call returns.
 // MetaParamSchemaMode reports the meta-tool input schema strategy currently
 // selected by [SetMetaParamSchemaMode]: "opaque", "compact" or "full".
 // Callers that memoize a registered surface must key on it, because the
@@ -2535,6 +2530,11 @@ func MetaParamSchemaMode() string {
 	return currentMetaParamSchemaMode()
 }
 
+// SetMetaParamSchemaMode selects the meta-tool input schema strategy used by
+// [MetaToolSchema]. Accepts "opaque" (default), "compact", or "full". Any
+// other value is coerced to opaque so that misconfiguration cannot break the
+// tools/list payload. Must be called before meta-tools are registered; later
+// calls only affect schemas built after the call returns.
 func SetMetaParamSchemaMode(mode string) {
 	metaParamSchemaMu.Lock()
 	defer metaParamSchemaMu.Unlock()

--- a/internal/toolutil/rpc_code.go
+++ b/internal/toolutil/rpc_code.go
@@ -1,5 +1,6 @@
 // rpc_code.go classifies errors with the JSON-RPC codes the MCP specification
 // names, so a client can tell what it is expected to do about a failure.
+
 package toolutil
 
 import (
@@ -25,8 +26,12 @@ type CodedError struct {
 	code  int64
 }
 
+// Error renders the cause alone: the code is for the transport, not the
+// reader.
 func (e *CodedError) Error() string { return e.cause.Error() }
 
+// Unwrap exposes the cause first and the code second, in the order the type
+// documentation explains.
 func (e *CodedError) Unwrap() []error {
 	return []error{e.cause, &jsonrpc.Error{Code: e.code}}
 }

--- a/internal/toolutil/safe_mode.go
+++ b/internal/toolutil/safe_mode.go
@@ -1,6 +1,7 @@
 // safe_mode.go carries the shared Safe Mode preview contract used by every
 // tool surface: individual tool wrapping, meta-tool dispatch, and the dynamic
 // execute tool.
+
 package toolutil
 
 import (


### PR DESCRIPTION
Split out of the schema-enums PR above it so that each half fits the reviewers' 100-file limit. This half is comments only, plus one moved method.

Part of https://github.com/jmrplens/gitlab-mcp-server/issues/362

`go run ./cmd/godoc_tool/ audit` found package documentation that nobody had written as such. A file comment that sits directly above the package clause is the package comment as far as go/doc is concerned, so a header describing one file was being served as the description of the whole package wherever the two touched; a blank line now separates them. Grouped constants carry their documentation on the declaration group, which is where go/doc reads it, and a method that had drifted away from its comment sits next to it again. The auditor reports nothing now.

## Verification

- `go run ./cmd/godoc_tool/ audit`: 0 findings.
- `go build ./...` and the tests of the one package with a moved method, `internal/subscriptions`.
