### PR TITLE
docs(eval): give the CE meta-tools results a block to publish into

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,19 +463,19 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,072 |     227,763 |
-| Unit tests (`_test.go`)  |       639 |     369,521 |
+| Source (`.go`, non-test) |     1,072 |     227,788 |
+| Unit tests (`_test.go`)  |       639 |     369,591 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **658,474** |
+| **Total**                | **1,937** | **658,569** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,520 |
+| Source functions                |  8,522 |
 | . Exported (public)             |  2,804 |
-| . Unexported (private)          |  5,716 |
-| Unit test functions (`TestXxx`) | 13,140 |
+| . Unexported (private)          |  5,718 |
+| Unit test functions (`TestXxx`) | 13,143 |
 | Subtests (`t.Run(...)`)         |  4,899 |
 | End-to-end test functions       |    577 |
 
@@ -486,7 +486,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.62× more tests than code |
 | Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~578 lines |
-| Comment lines in source            |  34,939 (~15.3% of source) |
+| Comment lines in source            |  34,949 (~15.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -496,7 +496,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | `if err != nil` checks             | 7,143 |
 | `defer` statements                 | 1,206 |
 | `struct` types defined             | 2,888 |
-| `//nolint` suppressions            |   280 |
+| `//nolint` suppressions            |   281 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project

--- a/README.md
+++ b/README.md
@@ -315,7 +315,11 @@ The published model-evaluation set covers 596 task attempts and 2220 expected MC
 <!-- END MODEL EVAL DYNAMIC SUMMARY -->
 
 <details>
-<summary>Enterprise meta &amp; dynamic evaluation results</summary>
+<summary>Meta-tools and Enterprise evaluation results</summary>
+
+<!-- START MODEL EVAL META SUMMARY -->
+No CE meta-tools run has been published yet: `make eval-surfaces-docker SURFACE=meta` followed by `--publish-docs` fills this block.
+<!-- END MODEL EVAL META SUMMARY -->
 
 <!-- START MODEL EVAL ENTERPRISE META SUMMARY -->
 Current published result: **Docker Enterprise meta 20260527**.
@@ -460,9 +464,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,072 |     227,759 |
-| Unit tests (`_test.go`)  |       639 |     369,458 |
+| Unit tests (`_test.go`)  |       639 |     369,490 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **658,407** |
+| **Total**                | **1,937** | **658,439** |
 
 ### Functions
 
@@ -471,8 +475,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  8,519 |
 | . Exported (public)             |  2,804 |
 | . Unexported (private)          |  5,715 |
-| Unit test functions (`TestXxx`) | 13,138 |
-| Subtests (`t.Run(...)`)         |  4,897 |
+| Unit test functions (`TestXxx`) | 13,139 |
+| Subtests (`t.Run(...)`)         |  4,898 |
 | End-to-end test functions       |    577 |
 
 ### Ratios worth noting
@@ -489,7 +493,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,141 |
+| `if err != nil` checks             | 7,143 |
 | `defer` statements                 | 1,206 |
 | `struct` types defined             | 2,888 |
 | `//nolint` suppressions            |   280 |

--- a/README.md
+++ b/README.md
@@ -463,20 +463,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,072 |     227,759 |
-| Unit tests (`_test.go`)  |       639 |     369,490 |
+| Source (`.go`, non-test) |     1,072 |     227,763 |
+| Unit tests (`_test.go`)  |       639 |     369,521 |
 | End-to-end tests         |       226 |      61,190 |
-| **Total**                | **1,937** | **658,439** |
+| **Total**                | **1,937** | **658,474** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,519 |
+| Source functions                |  8,520 |
 | . Exported (public)             |  2,804 |
-| . Unexported (private)          |  5,715 |
-| Unit test functions (`TestXxx`) | 13,139 |
-| Subtests (`t.Run(...)`)         |  4,898 |
+| . Unexported (private)          |  5,716 |
+| Unit test functions (`TestXxx`) | 13,140 |
+| Subtests (`t.Run(...)`)         |  4,899 |
 | End-to-end test functions       |    577 |
 
 ### Ratios worth noting
@@ -486,7 +486,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.62× more tests than code |
 | Average source file length         |                 ~212 lines |
 | Average test file length           |                 ~578 lines |
-| Comment lines in source            |  34,936 (~15.3% of source) |
+| Comment lines in source            |  34,939 (~15.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
@@ -1347,6 +1347,12 @@ func TestPublishDocSections_HaveAHomeInTheCommittedDocuments(t *testing.T) {
 	for _, key := range []string{publishSectionMeta, publishSectionDynamic, publishSectionEnterpriseMeta, publishSectionEnterpriseDynamic} {
 		t.Run(key, func(t *testing.T) {
 			section := publishDocSectionForKey(key)
+			// The unknown section carries empty markers, and an empty string
+			// is contained in every document, so a key the lookup does not
+			// know would pass the checks below without validating anything.
+			if section.Key != key {
+				t.Fatalf("publishDocSectionForKey(%q) returned the %q section", key, section.Key)
+			}
 			for _, marker := range []string{section.ResultsStartMarker, section.ResultsEndMarker} {
 				if !strings.Contains(string(results), marker) {
 					t.Errorf("%s has no %s marker for the %q section", defaultPublishResultsDoc, marker, key)

--- a/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/publish_docs_test.go
@@ -1328,3 +1328,35 @@ func TestFirstPositive_ReturnsFirstPositiveOrZero(t *testing.T) {
 		t.Fatalf("firstPositive(non-positive) = %d, want 0", got)
 	}
 }
+
+// TestPublishDocSections_HaveAHomeInTheCommittedDocuments pins that every
+// section the publisher knows has both of its marker pairs in the committed
+// documents. A CE meta-tools run used to reach applyManagedBlock after a
+// two-hour evaluation only to find no block to publish into; a section with
+// no home now fails here in a second instead.
+func TestPublishDocSections_HaveAHomeInTheCommittedDocuments(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "..")
+	results, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(defaultPublishResultsDoc))) // #nosec G304 -- fixed in-repo path
+	if err != nil {
+		t.Fatalf("read %s: %v", defaultPublishResultsDoc, err)
+	}
+	readme, err := os.ReadFile(filepath.Join(root, defaultPublishReadme)) // #nosec G304 -- fixed in-repo path
+	if err != nil {
+		t.Fatalf("read %s: %v", defaultPublishReadme, err)
+	}
+	for _, key := range []string{publishSectionMeta, publishSectionDynamic, publishSectionEnterpriseMeta, publishSectionEnterpriseDynamic} {
+		t.Run(key, func(t *testing.T) {
+			section := publishDocSectionForKey(key)
+			for _, marker := range []string{section.ResultsStartMarker, section.ResultsEndMarker} {
+				if !strings.Contains(string(results), marker) {
+					t.Errorf("%s has no %s marker for the %q section", defaultPublishResultsDoc, marker, key)
+				}
+			}
+			for _, marker := range []string{section.SummaryStartMarker, section.SummaryEndMarker} {
+				if !strings.Contains(string(readme), marker) {
+					t.Errorf("%s has no %s marker for the %q section", defaultPublishReadme, marker, key)
+				}
+			}
+		})
+	}
+}

--- a/cmd/gen_stats/main.go
+++ b/cmd/gen_stats/main.go
@@ -48,15 +48,32 @@ const (
 	scannerBufSize = 512 * 1024
 )
 
+// Seams over os.Exit and run, so a test can observe the exit code runMain
+// returns and drive both of its branches without regenerating the real README
+// or ending the test process.
+var (
+	osExit   = os.Exit
+	runStats = run
+)
+
 // main regenerates the README stats section and exits non-zero on failure.
 // With --check it verifies the section is current without writing.
 func main() {
-	check := flag.Bool("check", false, "verify README stats section is current without writing")
-	flag.Parse()
-	if err := run(*check); err != nil {
+	osExit(runMain(os.Args))
+}
+
+// runMain parses the flags and dispatches to run, returning the process exit
+// code. It takes its arguments explicitly, the way run takes its options, so a
+// test can drive every exit path.
+func runMain(args []string) int {
+	fs := flag.NewFlagSet(args[0], flag.ExitOnError)
+	check := fs.Bool("check", false, "verify README stats section is current without writing")
+	fs.Parse(args[1:]) //nolint:errcheck // ExitOnError handles parse failures
+	if err := runStats(*check); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // run collects repository statistics and replaces the README stats section.
@@ -356,17 +373,25 @@ func scanGoDecls(path string, isE2E, isTest bool, s *repoStats) error {
 				continue
 			}
 			for _, spec := range d.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok {
-					continue
-				}
-				if _, isStruct := ts.Type.(*ast.StructType); isStruct {
-					s.StructTypes++
-				}
+				countStructType(spec, s)
 			}
 		}
 	}
 	return nil
+}
+
+// countStructType increments the struct counter when spec declares a struct
+// type. The specs of a type declaration are always TypeSpecs, so the assertion
+// is a guard rather than a filter; it is a function of its own only so a test
+// can drive that guard with a spec that is not one.
+func countStructType(spec ast.Spec, s *repoStats) {
+	ts, ok := spec.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+	if _, isStruct := ts.Type.(*ast.StructType); isStruct {
+		s.StructTypes++
+	}
 }
 
 func updateFunctionStats(name string, isE2E, isTest bool, s *repoStats) {

--- a/cmd/gen_stats/main.go
+++ b/cmd/gen_stats/main.go
@@ -469,6 +469,16 @@ func classifyDep(line string, direct, indirect *int) {
 	}
 }
 
+// roundedAverage is lines per file rounded to the nearest whole line, and 0
+// when there are no files. Integer division would truncate, and the README
+// presents the figure as an approximation, so 577.96 has to read ~578.
+func roundedAverage(lines, files int) int {
+	if files <= 0 {
+		return 0
+	}
+	return (lines + files/2) / files
+}
+
 // renderStats builds the Markdown tables for the <!-- START STATS --> section.
 func renderStats(s *repoStats) string {
 	totalFiles := s.SourceFiles + s.UnitTestFiles + s.E2ETestFiles
@@ -483,14 +493,8 @@ func renderStats(s *repoStats) string {
 	if srcFuncs > 0 {
 		testPerFunc = float64(s.TestFuncs) / float64(srcFuncs)
 	}
-	avgSrc := 0
-	if s.SourceFiles > 0 {
-		avgSrc = s.SourceLines / s.SourceFiles
-	}
-	avgTest := 0
-	if s.UnitTestFiles > 0 {
-		avgTest = s.UnitTestLines / s.UnitTestFiles
-	}
+	avgSrc := roundedAverage(s.SourceLines, s.SourceFiles)
+	avgTest := roundedAverage(s.UnitTestLines, s.UnitTestFiles)
 	commentPct := 0.0
 	if s.SourceLines > 0 {
 		commentPct = float64(s.CommentLines) / float64(s.SourceLines) * 100

--- a/cmd/gen_stats/main_test.go
+++ b/cmd/gen_stats/main_test.go
@@ -8,6 +8,8 @@
 package main
 
 import (
+	"errors"
+	"go/ast"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -891,4 +893,72 @@ func splitTableRow(line string) []string {
 		cells = append(cells, strings.TrimSpace(part))
 	}
 	return cells
+}
+
+// TestRunMain_ReturnsTheExitCodeForRunsOutcome verifies the dispatch: a run
+// that succeeds exits 0, and one that fails exits 1 after reporting the error.
+func TestRunMain_ReturnsTheExitCodeForRunsOutcome(t *testing.T) {
+	tests := []struct {
+		name   string
+		runErr error
+		want   int
+	}{
+		{name: "a successful run exits zero", runErr: nil, want: 0},
+		{name: "a failing run exits one", runErr: errors.New("boom"), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runStats = func(bool) error { return tt.runErr }
+			t.Cleanup(func() { runStats = run })
+			if got := runMain([]string{"gen_stats", "--check"}); got != tt.want {
+				t.Errorf("runMain() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMain_HandsTheExitCodeToOsExit verifies main wires runMain's result to the
+// exit seam. os.Args is replaced so the flag set parses no test flags.
+func TestMain_HandsTheExitCodeToOsExit(t *testing.T) {
+	runStats = func(bool) error { return nil }
+	t.Cleanup(func() { runStats = run })
+	oldArgs := os.Args
+	os.Args = []string{"gen_stats"}
+	t.Cleanup(func() { os.Args = oldArgs })
+	var got int
+	osExit = func(code int) { got = code }
+	t.Cleanup(func() { osExit = os.Exit })
+
+	main()
+
+	if got != 0 {
+		t.Errorf("main() exited %d, want 0", got)
+	}
+}
+
+// TestCountStructType_CountsOnlyStructTypeSpecs verifies the struct counter and
+// its guard: a struct type declaration is counted, a non-struct type is not,
+// and a spec that is not a type declaration at all is passed over.
+func TestCountStructType_CountsOnlyStructTypeSpecs(t *testing.T) {
+	t.Run("a struct type is counted", func(t *testing.T) {
+		var s repoStats
+		countStructType(&ast.TypeSpec{Name: ast.NewIdent("T"), Type: &ast.StructType{Fields: &ast.FieldList{}}}, &s)
+		if s.StructTypes != 1 {
+			t.Errorf("StructTypes = %d, want 1", s.StructTypes)
+		}
+	})
+	t.Run("a non-struct type is not counted", func(t *testing.T) {
+		var s repoStats
+		countStructType(&ast.TypeSpec{Name: ast.NewIdent("T"), Type: ast.NewIdent("int")}, &s)
+		if s.StructTypes != 0 {
+			t.Errorf("StructTypes = %d, want 0", s.StructTypes)
+		}
+	})
+	t.Run("a spec that is not a type declaration is skipped", func(t *testing.T) {
+		var s repoStats
+		countStructType(&ast.ValueSpec{Names: []*ast.Ident{ast.NewIdent("x")}}, &s)
+		if s.StructTypes != 0 {
+			t.Errorf("StructTypes = %d, want 0", s.StructTypes)
+		}
+	})
 }

--- a/cmd/gen_stats/main_test.go
+++ b/cmd/gen_stats/main_test.go
@@ -597,6 +597,31 @@ func TestRenderStats_ZeroStats_GuardsDivisions(t *testing.T) {
 	}
 }
 
+// TestRoundedAverage_RoundsToNearestLine pins that the per-file averages
+// round rather than truncate: 369,897 lines over 640 files is 577.96, which
+// the README used to print as ~577.
+func TestRoundedAverage_RoundsToNearestLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines int
+		files int
+		want  int
+	}{
+		{name: "exact division", lines: 1000, files: 10, want: 100},
+		{name: "fraction above a half rounds up", lines: 369897, files: 640, want: 578},
+		{name: "fraction below a half rounds down", lines: 2309, files: 4, want: 577},
+		{name: "exactly a half rounds up", lines: 3, files: 2, want: 2},
+		{name: "no files is zero, not a division by zero", lines: 500, files: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := roundedAverage(tt.lines, tt.files); got != tt.want {
+				t.Errorf("roundedAverage(%d, %d) = %d, want %d", tt.lines, tt.files, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestFmtInt_AddsThousandsSeparators verifies the integer formatter inserts
 // comma separators at the expected positions.
 func TestFmtInt_AddsThousandsSeparators(t *testing.T) {

--- a/docs/development/testing/model-results.md
+++ b/docs/development/testing/model-results.md
@@ -2,10 +2,9 @@
 
 This document publishes the current model-evaluation results selected with
 `cmd/eval_mcp_surfaces --publish-docs`. Each surface and edition has its own
-managed section (CE dynamic, Enterprise/Premium meta-tools, Enterprise/Premium
-dynamic), so publishing one does not replace the others. A CE meta-tools block
-is not present at the moment, so a CE meta run has nowhere to publish here
-until one is added. Raw reports and traces are not committed.
+managed section (CE dynamic, CE meta-tools, Enterprise/Premium meta-tools,
+Enterprise/Premium dynamic), so publishing one does not replace the others.
+Raw reports and traces are not committed.
 
 ## Dynamic Results
 
@@ -38,6 +37,13 @@ until one is added. Raw reports and traces are not committed.
 
 Published with `cmd/eval_mcp_surfaces --publish-docs` from reviewed Markdown reports. Raw traces and JSON artifacts are not included here.
 <!-- END MODEL EVAL DYNAMIC RESULTS -->
+
+## Meta-Tools Results
+
+`make eval-surfaces-docker SURFACE=meta` followed by `cmd/eval_mcp_surfaces --publish-docs` publishes a CE meta-tools run between the markers below, newest first.
+
+<!-- START MODEL EVAL META RESULTS -->
+<!-- END MODEL EVAL META RESULTS -->
 
 ## Enterprise Meta-Tools Results
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,717 |
-| Unit test functions                                   | 13,140 |
+| Total test functions                                  | 13,720 |
+| Unit test functions                                   | 13,143 |
 | E2E test functions                                    |    577 |
-| cmd test functions                                    |  2,194 |
+| cmd test functions                                    |  2,197 |
 | Test files (internal/)                                |    502 |
 | Test files (cmd/)                                     |    137 |
 | Test files (test/e2e/)                                |    224 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,366 | 82.9% |
+| `TestFunc_Scenario` (2-part)           | 11,369 | 82.9% |
 | `TestFunc` (no underscore)             |    968 |  7.1% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,383 | 10.1% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            305 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,444 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            577 |        224 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,194 |        137 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,717** |    **863** |                                                                                                 |
+| cmd packages            |          2,197 |        137 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,720** |    **863** |                                                                                                 |
 
 ### Core Packages
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,715 |
-| Unit test functions                                   | 13,138 |
+| Total test functions                                  | 13,716 |
+| Unit test functions                                   | 13,139 |
 | E2E test functions                                    |    577 |
-| cmd test functions                                    |  2,192 |
+| cmd test functions                                    |  2,193 |
 | Test files (internal/)                                |    502 |
 | Test files (cmd/)                                     |    137 |
 | Test files (test/e2e/)                                |    224 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,364 | 82.9% |
+| `TestFunc_Scenario` (2-part)           | 11,365 | 82.9% |
 | `TestFunc` (no underscore)             |    968 |  7.1% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,383 | 10.1% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            305 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,444 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            577 |        224 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,192 |        137 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,715** |    **863** |                                                                                                 |
+| cmd packages            |          2,193 |        137 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,716** |    **863** |                                                                                                 |
 
 ### Core Packages
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,716 |
-| Unit test functions                                   | 13,139 |
+| Total test functions                                  | 13,717 |
+| Unit test functions                                   | 13,140 |
 | E2E test functions                                    |    577 |
-| cmd test functions                                    |  2,193 |
+| cmd test functions                                    |  2,194 |
 | Test files (internal/)                                |    502 |
 | Test files (cmd/)                                     |    137 |
 | Test files (test/e2e/)                                |    224 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,365 | 82.9% |
+| `TestFunc_Scenario` (2-part)           | 11,366 | 82.9% |
 | `TestFunc` (no underscore)             |    968 |  7.1% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,383 | 10.1% |
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            305 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,444 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            577 |        224 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,193 |        137 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,716** |    **863** |                                                                                                 |
+| cmd packages            |          2,194 |        137 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,717** |    **863** |                                                                                                 |
 
 ### Core Packages
 


### PR DESCRIPTION
The evaluator's publisher knows four sections (CE dynamic, CE meta-tools, Enterprise meta-tools, Enterprise dynamic) and the two documents it writes carried blocks for three of them. A CE meta-tools run reached `applyManagedBlock` after a two-hour evaluation only to find no marker to publish into.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/497

## What changes

- `docs/development/testing/model-results.md` gains a **Meta-Tools Results** section with the `MODEL EVAL META RESULTS` markers, empty until the first CE meta run is published, and its intro no longer describes the gap.
- The README's collapsed evaluation panel gains the `MODEL EVAL META SUMMARY` block (the publisher replaces its content on every run) and is titled for what it now holds.
- `TestPublishDocSections_HaveAHomeInTheCommittedDocuments` reads both committed documents and checks that every section the publisher knows has both of its marker pairs, so the next section without a home fails in a second rather than at the end of a run.

The blocks stay empty in this PR: filling them takes `make eval-surfaces-docker SURFACE=meta` against a Docker GitLab with the four model providers, which is a run of its own.

## Verification

- `go test ./cmd/eval_mcp_surfaces/internal/evaluator/` and `golangci-lint` on the package.
- `markdownlint-cli2` on both documents; `format_md_tables --check`.
