### PR TITLE
docs(agents): hold the Test Expert and the coverage skill to the 100% rule

### DIFF
--- a/.github/agents/test-expert.agent.md
+++ b/.github/agents/test-expert.agent.md
@@ -1,5 +1,5 @@
 ---
-description: "Go test expert for writing, analyzing, improving, and validating tests. Covers new test development, existing test analysis, coverage analysis to 90%+, false-pass detection, edge case identification, mandatory test documentation, and refreshing docs/development/testing/testing.md with cmd/gen_testing_docs at phase completion. Uses Context7 for up-to-date Go testing docs."
+description: "Go test expert for writing, analyzing, improving, and validating tests. Covers new test development, existing test analysis, coverage analysis to 100% per touched package (seams for the branches real input cannot reach), false-pass detection, edge case identification, mandatory test documentation, and refreshing docs/development/testing/testing.md with cmd/gen_testing_docs at phase completion. Uses Context7 for up-to-date Go testing docs."
 name: "Test Expert"
 ---
 
@@ -11,7 +11,7 @@ You are a Go Test Expert specializing in writing, analyzing, improving, and vali
 
 1. **New Test Development** — Write comprehensive tests for untested or new code
 2. **Existing Test Analysis & Improvement** — Review tests for quality, correctness, and completeness
-3. **Coverage Analysis** — Systematically increase coverage to 90%+ per package
+3. **Coverage Analysis** — Drive every touched package to 100% coverage, preexisting code included; name each function that stays below it, with the reason
 4. **False-Pass Detection** — Verify that tests actually validate what they claim and aren't passing vacuously
 5. **Edge Case Identification** — Discover untested boundary conditions, error paths, and corner cases
 6. **Test Documentation** — Every test must be documented explaining what it tests and why
@@ -187,7 +187,7 @@ After writing tests, perform a **mutation check**: mentally (or actually) change
 
    ```text
    Package             Before    After     Target    Status
-   internal/tools/xyz  72%       93%       90%       Done
+   internal/tools/xyz  72%       100%      100%      Done
    ```
 
 7. Validate with race detection: `go test -race -count=1 ./internal/tools/{domain}/`
@@ -427,15 +427,30 @@ When writing or reviewing tests, ensure these categories are covered:
 
 ## Coverage Targets
 
-| Package | Minimum | Stretch |
-|---------|---------|---------|
-| `internal/tools/*` | 90% | 95% |
-| `internal/resources` | 90% | 95% |
-| `internal/prompts` | 90% | 95% |
-| `internal/gitlab` | 90% | 95% |
-| `internal/config` | 90% | 95% |
-| `cmd/server` | 80% | 90% |
-| **Overall** | **90%** | **95%** |
+The house rule: a package touched by a change is driven to **100% statement coverage**, preexisting code included. Every function that stays below 100% is named in the report with the reason, and "defensive branch" is not a reason until a seam has been tried.
+
+| Scope | Target |
+|-------|--------|
+| Every package the change touches | 100% |
+| The repository as a whole (the CI gate) | 90% minimum; a floor, never the goal |
+
+### Reaching the last branches
+
+- **Real inputs first.** A crafted fixture, a specific declaration shape, a file that does not parse, a broken symlink: prefer any of these over a seam.
+- **Seams for what a real input cannot reach.** A package-level function variable defaulting to the standard-library call, overridden in the test and restored with `t.Cleanup`:
+
+  ```go
+  var (
+      walkDir      = filepath.WalkDir
+      formatSource = format.Source
+      writeFile    = os.WriteFile
+  )
+  ```
+
+  Established in `cmd/godoc_tool/docgo.go` and `cmd/gen_stats/main.go`. Each seam carries a short doc comment naming the branch it exists for. Wrap a helper rather than aliasing `os.WriteFile` directly when gosec's taint analysis would otherwise re-home a finding onto a test file.
+- **Tests run as root.** Permission bits make nothing fail. A read that must fail even for root uses a broken symlink (`os.Symlink` to a missing target); a write that must fail goes through a seam.
+- **`main()` is covered, not exempt.** Extract `runMain(args []string, stdout, stderr io.Writer) int`, make `main()` the one line `osExit(runMain(os.Args, os.Stdout, os.Stderr))` with `var osExit = os.Exit`, and assert every exit code and message. Replace `os.Args` in the test so the flag set parses no test flags.
+- **Never lift the number by other means.** No weakened assertions, no `//nolint`, no coverage pragmas, no branches deleted to make the figure. A provably dead branch is removed as a code change with its own justification, or made reachable by extracting it into a function a test can call directly.
 
 ## Interaction With User
 
@@ -455,8 +470,11 @@ Before declaring any test work complete:
 - [ ] No race conditions (`go test -race ./...`)
 - [ ] Every test function has a doc comment explaining what it tests
 - [ ] False-pass verification completed (checklist above)
-- [ ] Coverage target met for the package
+- [ ] Coverage at 100% for the package, or every function below it named with its reason
 - [ ] `golangci-lint` passes on changed packages
+- [ ] `make check-test-subtests` passes: every case loop runs its cases under `t.Run`
+- [ ] `make check-test-goroutines` passes: no `t.Fatal`/`FailNow` off the test goroutine
+- [ ] `make check-test-file-names` passes: every `_test.go` is named after the module it tests
 - [ ] `docs/development/testing/testing.md` refreshed with `go run ./cmd/gen_testing_docs/` at the end of the test phase when tests or coverage changed
 - [ ] `go run ./cmd/gen_testing_docs/ --check` passes
 

--- a/.github/agents/test-expert.agent.md
+++ b/.github/agents/test-expert.agent.md
@@ -452,6 +452,17 @@ The house rule: a package touched by a change is driven to **100% statement cove
 - **`main()` is covered, not exempt.** Extract `runMain(args []string, stdout, stderr io.Writer) int`, make `main()` the one line `osExit(runMain(os.Args, os.Stdout, os.Stderr))` with `var osExit = os.Exit`, and assert every exit code and message. Replace `os.Args` in the test so the flag set parses no test flags.
 - **Never lift the number by other means.** No weakened assertions, no `//nolint`, no coverage pragmas, no branches deleted to make the figure. A provably dead branch is removed as a code change with its own justification, or made reachable by extracting it into a function a test can call directly.
 
+### Case completeness, not only line coverage
+
+Statement coverage says a line ran, not that a decision was taken both ways or that a test would notice it changing; `cmd/gen_stats` at 100% still had ten single-valued conditions and five unreached mutants. For every decision in the changed code derive the case table first: true and false for each condition with the boundary and its neighbours, the MC/DC minimal set (N+1 cases) for `&&`/`||`/`!` compounds so each operand flips the outcome on its own, one failing case per `if err != nil`, one case per switch arm and the default, zero/one/many for loops with each early exit, and the empty, boundary, nil and cancelled inputs. Then measure and prove it:
+
+```bash
+make coverage-conditions PKG=./internal/foo   # gobco: nothing reported is the target
+make coverage-mutants PKG=./internal/foo      # gremlins: Lived 0 and Not covered 0 is the gate
+```
+
+A lived mutant is fixed by strengthening the assertion, never by excluding it. The `increase-test-coverage` skill carries the full method and the tools' limits.
+
 ## Interaction With User
 
 - **Always present the plan before implementing** — show per-package targets and test cases

--- a/.github/skills/increase-test-coverage/SKILL.md
+++ b/.github/skills/increase-test-coverage/SKILL.md
@@ -393,6 +393,48 @@ The house rule: a package touched by a change is driven to **100% statement cove
 - **`main()` is covered, not exempt.** Extract `runMain(args []string, stdout, stderr io.Writer) int`, make `main()` the one line `osExit(runMain(os.Args, os.Stdout, os.Stderr))` with `var osExit = os.Exit`, and assert every exit code and message. Replace `os.Args` in the test so the flag set parses no test flags.
 - **Never lift the number by other means.** No weakened assertions, no `//nolint`, no coverage pragmas, no branches deleted to make the figure. A provably dead branch is removed as a code change with its own justification, or made reachable by extracting it into a function a test can call directly.
 
+## Case Completeness: Conditions and Mutants
+
+Statement coverage says a line ran. It does not say a decision was taken both ways, and it does not say a test would notice the decision changing. Measured on this repository: `cmd/gen_stats` at 100% statement coverage still had ten conditions that were only ever true or only ever false, and five mutants no test reached. Go's own coverage cannot see either, because a compound `if a && b` is one block to it. Three steps close the gap, and a changed package passes all three before the work is done.
+
+### 1. Derive the cases before writing them
+
+For every decision in the changed code, write the case table first, then the tests that fill it:
+
+- **A simple condition** (`if n > 0`): one case true, one false, and for a comparison the boundary itself and both neighbours (`0`, `1`, `-1`).
+- **A compound condition** (`a && b`, `a || b`, `!a`, and their nestings): the MC/DC minimal set, N+1 cases for N conditions, each condition flipping the outcome on its own while the others hold. For `a && b`: (T,T) is the true case, (F,T) and (T,F) each falsify it through one condition. For `a || b`: (F,F) is the false case, (T,F) and (F,T) each satisfy it through one condition. Longer chains compose the same way, and short-circuit order decides which operand is even evaluated.
+- **Every `if err != nil`**: one case where the error happens, driven by a real failure (a fixture that does not parse, a broken symlink, a refused connection, a cancelled context) or by a seam.
+- **Every `switch` and type switch**: one case per arm and one for the default, including an arm no real input reaches, which is extracted into a function a test can call directly.
+- **Loops**: zero iterations, one, several; and each `continue`, `break` and early `return` inside.
+- **Inputs**: empty, whitespace, the boundary length, unicode, the maximum, nil and the zero value; first, middle, last and empty pages; the context cancelled before and during the call.
+
+### 2. Measure the conditions with gobco
+
+[gobco](https://github.com/rillig/gobco) instruments every boolean condition, `&&`, `||` and `!` operands included, and reports the ones never evaluated both ways:
+
+```bash
+make coverage-conditions PKG=./cmd/gen_stats
+# Condition coverage: 156/166
+# main.go:177:7: condition "lines > s.LargestTestLines" was 9 times true but never false
+# main.go:355:17: condition "isE2E" was 29 times false but never true
+```
+
+Every reported line is a missing case from the table in step 1. The target is nothing reported. A condition that genuinely cannot take the other value is dead code: remove it as a code change, or extract it so a test can reach it; do not leave it as an accepted exception. gobco does not report a function never called at all (statement coverage does) and does not instrument `select`.
+
+### 3. Prove the cases with mutation testing
+
+A case can execute a decision and still not check it. [gremlins](https://github.com/go-gremlins/gremlins) rewrites one operator at a time (`>` to `>=`, `==` to `!=`, `&&` to `||`, `+` to `-`, `-x` to `x`, `i++` to `i--`) and reruns the tests; a mutant that survives is a decision no assertion pins:
+
+```bash
+make coverage-mutants PKG=./cmd/gen_stats
+# Killed: 108, Lived: 0, Not covered: 12
+# Test efficacy: 100.00%   Mutator coverage: 90.00%
+```
+
+The gate on a changed package is **Lived: 0 and Not covered: 0**. A lived mutant is fixed by strengthening the assertion that should have caught it, never by excluding the mutant. The not-covered mutants sit on the same lines gobco reports, so step 2 usually clears them. The target turns on `INVERT_LOGICAL` (`&&` to `||`, off by gremlins' default), which is the operator that proves each operand of a compound condition matters on its own; `GREMLINS_FLAGS` passes anything else, such as `-S l` to print only the lived mutants or `-E` to exclude generated files.
+
+Both tools run through `go run` with the version pinned in the Makefile; `go install github.com/rillig/gobco@v1.3.4` and `go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0` keep them on the path for repeated use. Neither runs in CI: they are the last two steps of the coverage work on a package, and their results go in the pull request beside the coverage figure.
+
 ---
 
 ## Troubleshooting

--- a/.github/skills/increase-test-coverage/SKILL.md
+++ b/.github/skills/increase-test-coverage/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: increase-test-coverage
-description: 'Increase Go test coverage to 90%+ using a Research → Plan → Implement pipeline. Analyzes coverage gaps, generates table-driven tests with httptest mocks, and validates results with go test -coverprofile. Designed for Go MCP server projects using the official go-sdk and gitlab.com/gitlab-org/api/client-go/v2.'
+description: 'Increase Go test coverage to 100% per touched package using a Research → Plan → Implement pipeline, with seams for the branches real input cannot reach. Analyzes coverage gaps, generates table-driven tests with httptest mocks, and validates results with go test -coverprofile. Designed for Go MCP server projects using the official go-sdk and gitlab.com/gitlab-org/api/client-go/v2.'
 ---
 
 # Increase Test Coverage
 
 ## Primary Directive
 
-Systematically increase Go test coverage to **90%+ per package** using a structured Research → Plan → Implement pipeline. Generate comprehensive, buildable, passing tests that follow project conventions and use proper mocks for external dependencies.
+Systematically increase Go test coverage to **100% per touched package**, preexisting code included, using a structured Research → Plan → Implement pipeline; every function that stays below 100% is named in the report with its reason. Generate comprehensive, buildable, passing tests that follow project conventions and use proper mocks for external dependencies.
 
 All tests must:
 
@@ -74,7 +74,7 @@ Review the HTML report to visually identify uncovered code blocks.
 For each package, analyze:
 
 1. **Uncovered functions** — Functions with 0% coverage (highest priority)
-2. **Partially covered functions** — Functions below 90% (error paths, edge cases)
+2. **Partially covered functions** — Functions below 100% (error paths, edge cases, defensive branches)
 3. **Untested branches** — Conditional logic where only one branch is covered
 4. **Error handling paths** — `if err != nil` blocks that are never tested
 5. **Edge cases** — Boundary conditions, nil inputs, empty slices, zero values
@@ -115,23 +115,23 @@ Rank packages by coverage gap impact:
 
 | Priority | Criteria |
 |----------|----------|
-| P0 — Critical | Core business logic with 0% coverage |
+| P0 — Critical | Core business logic with 0% coverage, `main()` included |
 | P1 — High | Tool handlers, resource handlers below 80% |
-| P2 — Medium | Helper functions, config loading below 90% |
-| P3 — Low | Already above 90%, minor edge cases |
+| P2 — Medium | Helper functions, config loading below 100%: error paths and edge cases |
+| P3 — Last | The remaining defensive branches: real inputs where one exists, seams where none does |
 
 ### Step 2: Group into Phases
 
 Divide work into **2-5 phases**, each targeting a specific package or functional area:
 
 ```text
-Phase 1: [package] — Current: X% → Target: 90%+
+Phase 1: [package] — Current: X% → Target: 100%
   - TestFunctionA_HappyPath
   - TestFunctionA_ErrorCase
   - TestFunctionA_EdgeCase_EmptyInput
   ...
 
-Phase 2: [package] — Current: X% → Target: 90%+
+Phase 2: [package] — Current: X% → Target: 100%
   ...
 ```
 
@@ -308,11 +308,11 @@ After each phase, update progress:
 
 ```text
 Package             Before    After     Target    Status
-internal/tools      72%       91%       90%       ✅ Done
-internal/gitlab     65%       —         90%       🔄 In Progress
-internal/config     80%       —         90%       ⏳ Pending
-internal/resources  70%       —         90%       ⏳ Pending
-internal/prompts    68%       —         90%       ⏳ Pending
+internal/tools      72%       100%      100%      ✅ Done
+internal/gitlab     65%       —         100%      🔄 In Progress
+internal/config     80%       —         100%      ⏳ Pending
+internal/resources  70%       —         100%      ⏳ Pending
+internal/prompts    68%       —         100%      ⏳ Pending
 ```
 
 ### Step 5: Final Validation
@@ -321,8 +321,8 @@ After all phases complete:
 
 1. Run full test suite: `go test -race -coverprofile=coverage.out ./...`
 2. Generate final coverage report: `go tool cover -func=coverage.out`
-3. Verify every package meets 90%+ target
-4. Run quality checks: `make golangci-lint`
+3. Verify every touched package is at 100%, or name each function below it with its reason
+4. Run quality checks: `make golangci-lint`, `make check-test-subtests`, `make check-test-goroutines`, `make check-test-file-names`
 5. Refresh `docs/development/testing/testing.md`: `go run ./cmd/gen_testing_docs/`
 6. Verify the generated testing reference: `go run ./cmd/gen_testing_docs/ --check`
 7. Lint the generated testing reference: `npx markdownlint-cli2 docs/development/testing/testing.md`
@@ -368,15 +368,30 @@ After all phases complete:
 
 ## Coverage Targets
 
-| Package | Minimum Target | Stretch Goal |
-|---------|---------------|-------------|
-| `internal/tools` | 90% | 95% |
-| `internal/resources` | 90% | 95% |
-| `internal/prompts` | 90% | 95% |
-| `internal/gitlab` | 90% | 95% |
-| `internal/config` | 90% | 95% |
-| `cmd/server` | 80% | 90% |
-| **Overall** | **90%** | **95%** |
+The house rule: a package touched by a change is driven to **100% statement coverage**, preexisting code included. Every function that stays below 100% is named in the report with the reason, and "defensive branch" is not a reason until a seam has been tried.
+
+| Scope | Target |
+|-------|--------|
+| Every package the change touches | 100% |
+| The repository as a whole (the CI gate) | 90% minimum; a floor, never the goal |
+
+### Reaching the last branches
+
+- **Real inputs first.** A crafted fixture, a specific declaration shape, a file that does not parse, a broken symlink: prefer any of these over a seam.
+- **Seams for what a real input cannot reach.** A package-level function variable defaulting to the standard-library call, overridden in the test and restored with `t.Cleanup`:
+
+  ```go
+  var (
+      walkDir      = filepath.WalkDir
+      formatSource = format.Source
+      writeFile    = os.WriteFile
+  )
+  ```
+
+  Established in `cmd/godoc_tool/docgo.go` and `cmd/gen_stats/main.go`. Each seam carries a short doc comment naming the branch it exists for. Wrap a helper rather than aliasing `os.WriteFile` directly when gosec's taint analysis would otherwise re-home a finding onto a test file.
+- **Tests run as root.** Permission bits make nothing fail. A read that must fail even for root uses a broken symlink (`os.Symlink` to a missing target); a write that must fail goes through a seam.
+- **`main()` is covered, not exempt.** Extract `runMain(args []string, stdout, stderr io.Writer) int`, make `main()` the one line `osExit(runMain(os.Args, os.Stdout, os.Stderr))` with `var osExit = os.Exit`, and assert every exit code and message. Replace `os.Args` in the test so the flag set parses no test flags.
+- **Never lift the number by other means.** No weakened assertions, no `//nolint`, no coverage pragmas, no branches deleted to make the figure. A provably dead branch is removed as a code change with its own justification, or made reachable by extracting it into a function a test can call directly.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run brand brand-check brand-rasters ensure-mcp-publisher mcp-publisher-version test test-short test-race test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run brand brand-check brand-rasters ensure-mcp-publisher mcp-publisher-version test test-short test-race coverage-conditions coverage-mutants test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -461,6 +461,16 @@ eval-surfaces-docker-enterprise-all-fixtures:
 	else \
 		EVAL_SURFACE_ENTERPRISE=true EVAL_SURFACE_CASE_SET=all EVAL_SURFACE_FIXTURE_SMOKE=true ./scripts/eval-surfaces-docker.sh "$(SURFACE)"; \
 	fi
+
+## coverage-conditions: report the boolean conditions of PKG never evaluated both ways (gobco). A line reported is a missing test case; `&&`, `||` and `!` operands count separately.
+coverage-conditions:
+	@test -n "$(PKG)" || { echo "usage: make coverage-conditions PKG=./cmd/gen_stats"; exit 2; }
+	cd $(PKG) && go run github.com/rillig/gobco@v1.3.4
+
+## coverage-mutants: mutation-test PKG with gremlins, INVERT_LOGICAL on so `&&`/`||` independence is checked. The gate on a changed package is Lived 0 and Not covered 0.
+coverage-mutants:
+	@test -n "$(PKG)" || { echo "usage: make coverage-mutants PKG=./cmd/gen_stats"; exit 2; }
+	go run github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0 unleash --invert-logical --workers 4 $(GREMLINS_FLAGS) $(PKG)
 
 ## coverage: run tests and generate HTML coverage report
 coverage: test

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -230,6 +230,8 @@ Unit tests live alongside the code in each sub-package. They use `net/http/httpt
 ```bash
 make test            # Standard tests with coverage
 make test-race       # Tests with race detector
+make coverage-conditions PKG=./internal/foo   # gobco: boolean conditions never evaluated both ways (each is a missing case)
+make coverage-mutants PKG=./internal/foo      # gremlins: mutation testing; Lived 0 and Not covered 0 is the gate on a changed package
 go test ./internal/... -count=1      # Run all unit tests (199 packages)
 go test ./internal/tools/branches/ -count=1 -v  # Run one domain verbose
 go test ./internal/tools/ -run TestBranch -count=1    # Run specific tests


### PR DESCRIPTION
The Test Expert agent and the `increase-test-coverage` skill both targeted 90% per package, which is the CI floor and not the standard the repository works to. They now state the house rule: a package a change touches is driven to 100%, preexisting code included, and every function that stays below is named with its reason.

Refs https://github.com/jmrplens/gitlab-mcp-server/issues/509

## What changes

- **The target.** Every "90%+" becomes 100% per touched package; the whole-repository 90% stays as what it is, the CI floor.
- **How the last branches are reached**, written into both files so it outlives this issue: real inputs first; a seam (a package-level function variable defaulting to the standard-library call, restored with `t.Cleanup`) for the branches no input reaches, as `cmd/godoc_tool/docgo.go` and `cmd/gen_stats/main.go` already do; a broken symlink where a permission bit does nothing because the tests run as root; `main()` covered through an `osExit` seam and a `runMain(args, streams) int` extraction; and never lifting the figure by weakening an assertion, adding `//nolint`, or deleting a branch.
- **The gates.** The quality checklist gains `check-test-subtests`, `check-test-goroutines` and `check-test-file-names`, which CI already runs.

## Tests

Documentation only; `markdownlint-cli2` on both files.

## Case completeness, beyond the line count

A second commit adds what the maintainer asked for after the first: 100% of statements is not 100% of cases. Measured on `cmd/gen_stats`, a package at 100% statement coverage, gobco still found ten conditions that were only ever true or only ever false, and gremlins five mutants no test reached; Go's own coverage cannot see either, since `if a && b` is one block to it.

- **The method.** Derive the case table before the tests: both values of every condition with the boundary and its neighbours, the MC/DC minimal set (N+1 cases) for `&&`/`||`/`!` compounds so each operand flips the outcome on its own, a failing case per `if err != nil`, every switch arm and the default, zero/one/many for loops with each early exit, and the empty, boundary, nil and cancelled inputs.
- **Measure conditions with gobco** (`make coverage-conditions PKG=…`): every boolean condition, operands of `&&`, `||` and `!` included, reported when never evaluated both ways. Nothing reported is the target.
- **Prove the cases with gremlins** (`make coverage-mutants PKG=…`): operators rewritten one at a time and the tests rerun, `INVERT_LOGICAL` on so the independence of each operand is checked. The gate on a changed package is Lived 0 and Not covered 0; a lived mutant is fixed by strengthening the assertion, never by excluding it.
- Both tools run through `go run` with their versions pinned in the Makefile (gobco 1.3.4, gremlins 0.6.0); neither runs in CI. `docs/development/development.md` lists the two targets beside the other test targets.

The outputs quoted in the skill are the ones the targets printed on this repository.
