### PR TITLE
build(deps): update client-go to v2.63.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/shirou/gopsutil/v4 v4.26.7
 	github.com/tiktoken-go/tokenizer v0.8.1
-	gitlab.com/gitlab-org/api/client-go/v2 v2.62.0
+	gitlab.com/gitlab-org/api/client-go/v2 v2.63.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.20.1
 	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-gitlab.com/gitlab-org/api/client-go/v2 v2.62.0 h1:FOSaRwz5feHGhJDo4Yk+TLqF4e6cO3Qm4R929hQqUII=
-gitlab.com/gitlab-org/api/client-go/v2 v2.62.0/go.mod h1:LEVRH0wDbXtvsM7WAGlOgR10HCHCol1rZyjWoSeicuY=
+gitlab.com/gitlab-org/api/client-go/v2 v2.63.0 h1:lPZsGn8oISRd/ReeTI4OuHXWO1UXg9fPkLz5/JxK4lA=
+gitlab.com/gitlab-org/api/client-go/v2 v2.63.0/go.mod h1:a8PSqY/h53boJ6FvWTJZH888tdpcj+n2hVUo2NsOi/E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/bridges/otelslog v0.20.1 h1:5sHc4ToTFjfSZCtGAAM6jPunICAmJX73htv372T4ipc=


### PR DESCRIPTION
client-go published v2.63.0; this moves the server onto it. A client-go bump here is followed by the 1:1 parity audit, since the rule is that every service, action and field the SDK exposes is exposed by this server; this time the audit came back empty.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/513

## What changes

- `go.mod` and `go.sum` move to v2.63.0. The release's one feature registers every API route as a named constant and exposes them through `Routes` and `MatchRoute`, which is why almost every service file in the module changed without a signature moving; the rest is its own dependency bumps.
- Nothing else. `make audit-1to1` against 2.63.0 reports 168 SDK services, 157 wrapped and 11 declared, none undeclared, every GraphQL operation adjudicated, and zero gaps across input fields, output fields, actions and discovery metadata. The Dependency Firewall service still has one method, `EvaluatePackage`, served as `project.dependency_firewall_evaluate`, so the question left open after 2.61 is settled: nothing there is pending.

## Tests

`go build ./...`, `go vet -tags e2e ./...`, and the whole `internal/...` unit suite against the new module; the generators are unchanged because no count moved.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated gitlab.com/gitlab-org/api/client-go/v2 dependency from v2.62.0 to v2.63.0.</li>
</ul></div>