### PR TITLE
ci: put every test job in the verdict, cache the manifest validator, and regenerate the brand assets in update-all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,20 @@ jobs:
         run: make check-readonly-graphql
       - name: Check the one-click install buttons
         run: make check-install-buttons
+      # The manifest validator is the registry's publisher, a module whose 77
+      # direct dependencies are not this project's, so it is not a go.mod tool.
+      # It is installed once per pinned version into a directory named after
+      # that version and cached by that version, so a push resolves nothing
+      # over the network and a stale binary can never validate with another
+      # release.
+      - name: Read the pinned publisher version
+        id: publisher
+        run: echo "version=$(make -s mcp-publisher-version)" >> "$GITHUB_OUTPUT"
+      - name: Cache the MCP Registry publisher
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/gitlab-mcp-server/mcp-publisher/${{ steps.publisher.outputs.version }}
+          key: mcp-publisher-${{ steps.publisher.outputs.version }}-${{ runner.os }}
       - name: Check MCP Registry manifest
         run: make check-server-json
       # Downloads every declared artifact, so it runs on main only. A pull
@@ -705,6 +719,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
+    # Everything that can fail a change is listed, the test jobs included: the
+    # verdict used to take only the analysis jobs, so a failing unit suite, a
+    # compile error on another platform, or a red Windows leg could sit under
+    # a green required check. The cross-platform summary already tells the
+    # known Go runtime crash on AMX hosts apart from a failing test (issue
+    # 467), so listing it fails the verdict on real failures only.
     needs:
       - generated
       - golangci-lint
@@ -715,6 +735,11 @@ jobs:
       - server-json-schema
       - supply-chain
       - docs-audit
+      - coverage
+      - compile
+      - typecheck
+      - cross_platform_summary
+      - docker-build
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -724,6 +749,9 @@ jobs:
         env:
           RESULTS: ${{ toJSON(needs) }}
           INFORMATIONAL: docs-audit
+          # The image build only runs for a pull request; on a push it is
+          # skipped by design rather than failed.
+          MAY_SKIP: docker-build
         run: bash .github/scripts/needs-verdict.sh
 
   # Every job above runs on Linux, and until this one existed that was the only

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run brand brand-check brand-rasters test test-short test-race test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run brand brand-check brand-rasters ensure-mcp-publisher mcp-publisher-version test test-short test-race test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -22,8 +22,16 @@ BINARY_NAME=gitlab-mcp-server
 CMD_PATH=./cmd/server
 PKGS=./cmd/... ./internal/...
 # Keep in lockstep with MCP_PUBLISHER_VERSION in .github/workflows/release.yml:
-# this one validates the manifest, that one publishes it.
+# this one validates the manifest, that one publishes it. check-server-json
+# refuses to run when the two disagree.
 MCP_PUBLISHER_VERSION=v1.8.1
+# The publisher is installed once per pinned version into a directory named
+# after that version, so a stale binary can never validate with another
+# release, and CI caches that directory by version instead of resolving the
+# module on every push. It is not a go.mod tool on purpose: the registry
+# module carries 77 direct dependencies that are not this project's.
+MCP_PUBLISHER_DIR=$(HOME)/.cache/gitlab-mcp-server/mcp-publisher/$(MCP_PUBLISHER_VERSION)
+MCP_PUBLISHER=$(MCP_PUBLISHER_DIR)/publisher
 GO_ANALYSIS_PKGS=./...
 # Every e2e build tag, and it must stay every one. A tagged file is invisible
 # to go vet and to golangci-lint unless its tag is listed here, so a suite
@@ -748,8 +756,17 @@ check-install-buttons:
 	go run ./cmd/audit_install_buttons/
 
 ## check-server-json: validate server.json with the official MCP Registry publisher.
-check-server-json:
-	go run github.com/modelcontextprotocol/registry/cmd/publisher@$(MCP_PUBLISHER_VERSION) validate server.json
+check-server-json: ensure-mcp-publisher
+	@grep -q 'MCP_PUBLISHER_VERSION: "$(MCP_PUBLISHER_VERSION)"' .github/workflows/release.yml || { echo "MCP_PUBLISHER_VERSION $(MCP_PUBLISHER_VERSION) in the Makefile is not the version .github/workflows/release.yml publishes with; keep the two in lockstep"; exit 1; }
+	$(MCP_PUBLISHER) validate server.json
+
+## mcp-publisher-version: print the pinned MCP Registry publisher version; CI keys its cache on it.
+mcp-publisher-version:
+	@echo $(MCP_PUBLISHER_VERSION)
+
+## ensure-mcp-publisher: install the pinned MCP Registry publisher into its version-named directory when it is not there yet.
+ensure-mcp-publisher:
+	@test -x $(MCP_PUBLISHER) || GOBIN=$(MCP_PUBLISHER_DIR) go install github.com/modelcontextprotocol/registry/cmd/publisher@$(MCP_PUBLISHER_VERSION)
 
 ## check-server-json-packages: verify every package server.json declares is
 ## really published and really installable. Downloads the artifacts, so it needs
@@ -910,9 +927,17 @@ publish-lobehub: check-lhm-manifest
 ## gen-readme: regenerate all managed README.md sections (token footprint + stats).
 gen-readme: gen-footprint gen-stats
 
-## update-all: run every generator and doc updater in one pass.
-## Generates: token footprint, repo stats, site stats, llms.txt, testing docs, action catalog manifest, markdown table formatting.
-update-all: gen-footprint gen-stats gen-site-stats gen-llms gen-lhm-manifest gen-testing-docs gen-action-catalog-manifest
+## update-all: run every generator, the brand assets included, then the table formatter.
+## Generates: brand vectors, token footprint, repo stats, site stats, llms.txt, LobeHub manifest, testing docs, action catalog manifest, markdown table formatting.
+# One generator at a time, in the recipe rather than as prerequisites: brand
+# rewrites internal/toolutil/brandmark_gen.go, which the generators after it
+# compile, and gen-footprint and gen-stats both rewrite README.md, so make -j
+# would interleave them. brand-rasters stays out: it needs rsvg-convert and
+# cwebp, which only the maintainer's machine has.
+update-all:
+	@for target in brand gen-footprint gen-stats gen-site-stats gen-llms gen-lhm-manifest gen-testing-docs gen-action-catalog-manifest; do \
+		$(MAKE) --no-print-directory $$target || exit 1; \
+	done
 	go run ./cmd/format_md_tables/
 	@echo "All generators and formatters complete."
 

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -1061,9 +1061,9 @@ Rewrites the seven assets in place, or (with `--check`) names each stale one and
 
 #### Make targets
 
-- `make brand`
+- `make brand` — also the first generator `make update-all` runs, so a geometry change cannot leave the committed assets stale.
 - `make brand-check` — CI gate.
-- `make brand-rasters` — renders the raster derivatives (README banner WebP, OG and social PNGs, marketplace icons) from those vectors; maintainer-only, needs `rsvg-convert` and `cwebp`.
+- `make brand-rasters` — renders the raster derivatives (README banner WebP, OG and social PNGs, marketplace icons) from those vectors; maintainer-only, needs `rsvg-convert` and `cwebp`, and therefore stays out of `update-all`.
 
 ### gen_icon_webp
 


### PR DESCRIPTION
Three gaps in the release chain, all in CI rather than in the server, recorded during the 2.8.0 sweep.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/510

## What changes

- **The verdict takes every job that can fail a change.** The `✅ CI` check the ruleset requires was decided by the analysis jobs alone (`generated`, lint, `govulncheck`, markdown, site lint, hadolint, the manifest schema, supply chain), so a failing unit suite, a compile error on another platform, a red cross-platform leg or a broken image build all sat under a green required check; https://github.com/jmrplens/gitlab-mcp-server/pull/508 showed the Windows case. `coverage`, `compile`, `typecheck`, `cross_platform_summary` and `docker-build` are in the verdict now. The image build is allowed to be skipped (`MAY_SKIP`), since it only runs for a pull request; the cross-platform summary already runs the Windows leg through the crash-aware runner that tells the known Go runtime crash on AMX hosts (https://github.com/jmrplens/gitlab-mcp-server/issues/467) apart from a failing test, so listing it fails the verdict on real failures only.
- **The manifest validator is installed once per version and cached.** `check-server-json` ran `go run github.com/modelcontextprotocol/registry/cmd/publisher@<version>`, a module download on every push that no cache held because the module is not in `go.sum`. It is not made a `go.mod` tool: the registry module carries 77 direct dependencies (Azure and GCP SDKs, pgx, huma, prometheus, otel) that are not this project's. It is installed with `GOBIN` into `~/.cache/gitlab-mcp-server/mcp-publisher/<version>/`, a directory named after the pinned version so a stale binary can never validate with another release, and CI caches that directory by version (`make mcp-publisher-version` is the key). First run 5.4 s, then 0.6 s. The target also refuses to run when the Makefile's `MCP_PUBLISHER_VERSION` and the one `release.yml` publishes with disagree, which turns the "keep in lockstep" comment into a check. What remains is the validator's own round-trip to the registry's schema: `mcp-publisher validate` takes no offline option, so that call is the tool's, not ours.
- **`update-all` regenerates the brand assets, and runs its generators one at a time.** `brand` is now the first generator it runs, so a geometry change in `cmd/gen_brand` cannot leave the committed assets stale until `brand-check` fails elsewhere. The generators run from the recipe in sequence rather than as prerequisites: `brand` rewrites `internal/toolutil/brandmark_gen.go`, which the generators after it compile, and `gen-footprint` and `gen-stats` both rewrite `README.md`, so `make -j` could interleave them. `brand-rasters` stays a separate target, since it needs `rsvg-convert` and `cwebp`.

## Tests

`make check-server-json` twice (install, then the cached binary), `make -n update-all`, `make check-supply-chain` on the workflow edit (every action stays SHA-pinned), and the verdict script unchanged: it already handles `MAY_SKIP`.
