### PR TITLE
test(server): cover cmd/server to the last block

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,40 +463,40 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,137 |     228,390 |
-| Unit tests (`_test.go`)  |       642 |     371,094 |
+| Source (`.go`, non-test) |     1,137 |     228,461 |
+| Unit tests (`_test.go`)  |       644 |     373,670 |
 | End-to-end tests         |       235 |      61,624 |
-| **Total**                | **2,014** | **661,108** |
+| **Total**                | **2,016** | **663,755** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,536 |
+| Source functions                |  8,537 |
 | . Exported (public)             |  2,810 |
-| . Unexported (private)          |  5,726 |
-| Unit test functions (`TestXxx`) | 13,187 |
-| Subtests (`t.Run(...)`)         |  4,933 |
+| . Unexported (private)          |  5,727 |
+| Unit test functions (`TestXxx`) | 13,251 |
+| Subtests (`t.Run(...)`)         |  4,955 |
 | End-to-end test functions       |    579 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.62× more tests than code |
+| Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~201 lines |
-| Average test file length           |                 ~578 lines |
-| Comment lines in source            |  35,090 (~15.4% of source) |
-| Test functions per source function |                       1.5× |
+| Average test file length           |                 ~580 lines |
+| Comment lines in source            |  35,141 (~15.4% of source) |
+| Test functions per source function |                       1.6× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,170 |
-| `defer` statements                 | 1,206 |
+| `if err != nil` checks             | 7,203 |
+| `defer` statements                 | 1,220 |
 | `struct` types defined             | 2,889 |
-| `//nolint` suppressions            |   281 |
+| `//nolint` suppressions            |   294 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
@@ -509,17 +509,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 ### Hall of fame
 
-| Record              | File                                   |
-| ------------------- | -------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,396 lines      |
-| Longest test file   | `cmd/server/main_test.go`. 8,824 lines |
+| Record              | File                                    |
+| ------------------- | --------------------------------------- |
+| Longest source file | `cmd/server/main.go`. 4,441 lines       |
+| Longest test file   | `cmd/server/main_test.go`. 10,314 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,152 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,527 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,153 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,529 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -464,9 +464,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,137 |     228,461 |
-| Unit tests (`_test.go`)  |       644 |     373,670 |
+| Unit tests (`_test.go`)  |       644 |     373,674 |
 | End-to-end tests         |       235 |      61,624 |
-| **Total**                | **2,016** | **663,755** |
+| **Total**                | **2,016** | **663,759** |
 
 ### Functions
 

--- a/cmd/server/auth_gate_test.go
+++ b/cmd/server/auth_gate_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/serverpool"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -1077,5 +1079,110 @@ func TestTransportSource(t *testing.T) {
 				t.Errorf("transportSource(%q) = %q, want %q", tc.remote, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestGateFailure_Write_LogsARefusalTheClientNeverReceived covers the write
+// failing under the refusal: the status is already committed, so nothing can
+// be resent, and the log line is the only trace that a rejection was lost.
+// The writer is the same broken connection the SSE heartbeat tests use.
+func TestGateFailure_Write_LogsARefusalTheClientNeverReceived(t *testing.T) {
+	logged := testutil.CaptureSlog(t)
+	failure := &gateFailure{status: http.StatusUnauthorized, code: errCodeUnauthorized, message: "no token"}
+	recorder := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", strings.NewReader(`{"id":7}`))
+
+	failure.write(brokenResponseWriter{recorder}, r)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d committed before the body failed", recorder.Code, http.StatusUnauthorized)
+	}
+	if !strings.Contains(logged.String(), "failed to write gate error response") {
+		t.Errorf("log = %q, want the lost refusal reported", logged.String())
+	}
+}
+
+// TestMcpServerGate_Middleware_RefusesASessionMintedForAnotherCredential
+// drives the ownership check through the middleware rather than calling it
+// directly, so the refusal is asserted the way a client sees it: a 404 with a
+// JSON-RPC body, and the handler behind the gate never reached.
+func TestMcpServerGate_Middleware_RefusesASessionMintedForAnotherCredential(t *testing.T) {
+	gate := newGate(t, okFactory)
+	// A tag map that knows nothing about the server the credential resolves
+	// to: whatever session ID arrives was minted for somebody else.
+	gate.sessionTags = &sync.Map{}
+
+	var reached atomic.Bool
+	handler := gate.middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		reached.Store(true)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	req.Header.Set("PRIVATE-TOKEN", gateTestToken)
+	req.Header.Set(mcpSessionIDHeader, "somebody-else"+sessionTagSeparator+"abc")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d for a session that belongs to another credential: %s", recorder.Code, http.StatusNotFound, recorder.Body.String())
+	}
+	if reached.Load() {
+		t.Error("the MCP handler ran on a session the credential does not own")
+	}
+	if decoded := decodeJSONRPCError(t, recorder.Body.String(), "1"); !strings.Contains(decoded.Error.Message, "does not belong") {
+		t.Errorf("message = %q, want it to say the session belongs to somebody else", decoded.Error.Message)
+	}
+}
+
+// TestNewTransportBudget_WithoutALimiter_IsAbsent pins that no limiter means
+// no budget at all rather than a budget that panics on first use: the nil
+// budget is the documented shape of a deployment without a trusted proxy
+// header, and every method already tolerates it.
+func TestNewTransportBudget_WithoutALimiter_IsAbsent(t *testing.T) {
+	t.Parallel()
+	if budget := newTransportBudget(nil); budget != nil {
+		t.Errorf("newTransportBudget(nil) = %+v, want nil", budget)
+	}
+	limiter := serverpool.NewAuthRateLimiter(2, authFailureWindow)
+	if got := newTransportBudget(limiter).rateLimiter(); got != limiter {
+		t.Error("rateLimiter() did not hand back the limiter the budget wraps")
+	}
+}
+
+// TestTransportBudget_Cleanup_ForgetsLapsedPairsOnly covers the sweep the
+// periodic cleanup runs: a pair whose window has passed is dropped, so the
+// same key charges the source again on its next failure, and a pair still
+// inside its window is kept, so it does not.
+func TestTransportBudget_Cleanup_ForgetsLapsedPairsOnly(t *testing.T) {
+	t.Parallel()
+
+	budget := newTransportBudget(serverpool.NewAuthRateLimiter(3, authFailureWindow))
+	const source = "203.0.113.7"
+	budget.charge(source, "198.51.100.1")
+	budget.charge(source, "198.51.100.2")
+
+	budget.mu.Lock()
+	budget.charged[source+"\x00"+"198.51.100.1"] = time.Now().Add(-2 * authFailureWindow)
+	budget.mu.Unlock()
+
+	budget.cleanup()
+
+	budget.mu.Lock()
+	remaining := len(budget.charged)
+	budget.mu.Unlock()
+	if remaining != 1 {
+		t.Fatalf("cleanup left %d pair(s), want 1: the lapsed pair forgotten and the live one kept", remaining)
+	}
+
+	// The kept pair is still counted, so charging it again costs nothing.
+	budget.charge(source, "198.51.100.2")
+	if budget.blocked(source) {
+		t.Fatal("a key still inside its window was charged a second time")
+	}
+	// The forgotten pair is a fresh key again, and it is the third one.
+	budget.charge(source, "198.51.100.1")
+	if !budget.blocked(source) {
+		t.Error("a key whose window lapsed did not charge the source again after cleanup")
 	}
 }

--- a/cmd/server/bearer_guard_test.go
+++ b/cmd/server/bearer_guard_test.go
@@ -798,3 +798,75 @@ func TestBearerGuard_BlockedByTheFleetBudget_NamesTheTransportSource(t *testing.
 		t.Errorf("the 429 line does not name the transport source that spent the budget: %s", line)
 	}
 }
+
+// TestBearerGuard_MultiInstanceWithoutASelection_IsRefusedBeforeVerification
+// covers a deployment publishing several instances and a request naming none.
+//
+// The refusal is answered before the verifier runs, on purpose: verifying
+// would put this bearer on the wire to an instance the caller never chose. It
+// is a 400 that names the published set, which oauth mode may do because the
+// RFC 9728 metadata serves the same list unauthenticated, and it is not
+// charged to the limiter, since nothing was learned about the credential.
+func TestBearerGuard_MultiInstanceWithoutASelection_IsRefusedBeforeVerification(t *testing.T) {
+	t.Parallel()
+
+	var verified atomic.Int64
+	g := newTestGuard(func(context.Context, string, *http.Request) (*auth.TokenInfo, error) {
+		verified.Add(1)
+		return nil, errors.New("must not be reached")
+	})
+	g.instances = []string{"https://gitlab.com", "https://gitlab.example.com"}
+	g.resolveInstance = func(*http.Request) (string, error) { return "", errMissingGitLabURL }
+
+	failure := g.check(guardRequest(t, "gloas-valid"))
+
+	if failure == nil || failure.status != http.StatusBadRequest {
+		t.Fatalf("failure = %+v, want a 400 asking for the GITLAB-URL header", failure)
+	}
+	for _, instance := range g.instances {
+		if !strings.Contains(failure.message, instance) {
+			t.Errorf("message = %q, want it to publish %s", failure.message, instance)
+		}
+	}
+	if verified.Load() != 0 {
+		t.Error("the verifier ran for a request that named no instance; the bearer went on the wire")
+	}
+	assertSpendsNoBudget(t, g)
+}
+
+// TestDescribeScopeShortfall_NamesWhatTheTokenHolds pins the wording of the
+// scope refusal for each shape a token's scope list can take, because the
+// reader is somebody who believes they granted the right thing and has to be
+// told what they actually hold.
+func TestDescribeScopeShortfall_NamesWhatTheTokenHolds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		granted []string
+		want    []string
+		unwant  []string
+	}{
+		{name: "no scope at all", granted: nil, want: []string{"no GitLab API scope"}},
+		{name: "one scope", granted: []string{"read_user"}, want: []string{"the read_user scope,"}},
+		{name: "several scopes", granted: []string{"read_user", "profile"}, want: []string{"the read_user, profile scopes"}},
+		{name: "GitLab's own mcp scope is explained", granted: []string{"mcp"}, want: []string{"the mcp scope", "GitLab's mcp scope is for its own MCP server"}},
+		{name: "the orbit variant is explained too", granted: []string{"mcp_orbit", "profile"}, want: []string{"GitLab's mcp scope is for its own MCP server"}},
+		{name: "an unrelated scope gets no mcp aside", granted: []string{"profile"}, unwant: []string{"GitLab's mcp scope"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := describeScopeShortfall(tc.granted, oauth.MinimumScope, oauth.ScopeAPI)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("describeScopeShortfall(%v) = %q, want it to carry %q", tc.granted, got, want)
+				}
+			}
+			for _, unwanted := range tc.unwant {
+				if strings.Contains(got, unwanted) {
+					t.Errorf("describeScopeShortfall(%v) = %q, must not carry %q", tc.granted, got, unwanted)
+				}
+			}
+		})
+	}
+}

--- a/cmd/server/client_ip_test.go
+++ b/cmd/server/client_ip_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"net/http"
 	"net/netip"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -252,5 +253,28 @@ func TestTrustedProxiesOf_UnparseableList_TrustsNobody(t *testing.T) {
 	}
 	if trustedProxiesOf([]string{"127.0.0.1"}).empty() {
 		t.Error("a valid list produced an empty trusted set")
+	}
+}
+
+// TestClientIP_HeaderWithNoHops_ChargesThePeer covers a header that is present
+// and carries only separators and whitespace: there is no hop to believe, so
+// the trusted peer itself is charged, exactly as if the header were absent.
+func TestClientIP_HeaderWithNoHops_ChargesThePeer(t *testing.T) {
+	t.Parallel()
+	proxies, err := parseTrustedProxies([]string{"127.0.0.1"})
+	if err != nil {
+		t.Fatalf("parseTrustedProxies: %v", err)
+	}
+	for _, value := range []string{" , ", ",", " ,, "} {
+		t.Run(strconv.Quote(value), func(t *testing.T) {
+			t.Parallel()
+			r := &http.Request{
+				RemoteAddr: "127.0.0.1:12345",
+				Header:     http.Header{"X-Forwarded-For": {value}},
+			}
+			if got := clientIP(r, "X-Forwarded-For", proxies); got != "127.0.0.1" {
+				t.Errorf("clientIP(%q) = %q, want the peer 127.0.0.1", value, got)
+			}
+		})
 	}
 }

--- a/cmd/server/first_run.go
+++ b/cmd/server/first_run.go
@@ -73,13 +73,18 @@ Press Enter to close.
 	_, _ = bufio.NewReader(in).ReadString('\n')
 }
 
+// osExecutable resolves the running binary's path. A variable because the
+// lookup cannot be made to fail from outside the process, and the fallback
+// name below is otherwise never printed by any test.
+var osExecutable = os.Executable //nolint:gochecknoglobals // test seam
+
 // executableName is how to spell this program on the reader's command line.
 //
 // Taken from the running binary rather than hardcoded, so the line can be
 // copied as it appears: someone who renamed the download, or who reached this
 // through a launcher, is told the name that will actually work.
 func executableName() string {
-	path, err := os.Executable()
+	path, err := osExecutable()
 	if err != nil || path == "" {
 		return "gitlab-mcp-server"
 	}

--- a/cmd/server/first_run_test.go
+++ b/cmd/server/first_run_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -147,5 +148,31 @@ func TestIsInteractiveTerminal_IsFalseForAFile(t *testing.T) {
 func TestExecutableName_FallsBackToTheProjectName(t *testing.T) {
 	if got := executableName(); got == "" {
 		t.Error("executableName returned an empty string; the --help line would be unusable")
+	}
+}
+
+// TestExecutableName_WhenTheLookupFails_NamesTheProject covers the fallback
+// itself, which the happy path above cannot reach on any platform where the
+// test binary knows its own path. Both ways the lookup can come back empty
+// yield the documented name rather than an empty command the reader cannot
+// type.
+func TestExecutableName_WhenTheLookupFails_NamesTheProject(t *testing.T) {
+	original := osExecutable
+	t.Cleanup(func() { osExecutable = original })
+
+	cases := []struct {
+		name   string
+		lookup func() (string, error)
+	}{
+		{name: "the lookup errors", lookup: func() (string, error) { return "", errors.New("procfs is not mounted") }},
+		{name: "the lookup answers an empty path", lookup: func() (string, error) { return "", nil }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			osExecutable = tc.lookup
+			if got := executableName(); got != "gitlab-mcp-server" {
+				t.Errorf("executableName() = %q, want the project name as the fallback", got)
+			}
+		})
 	}
 }

--- a/cmd/server/health_test.go
+++ b/cmd/server/health_test.go
@@ -177,3 +177,35 @@ func TestNewHealthResponse_CarriesTheDrainingStatus(t *testing.T) {
 		t.Errorf("config_digest = %q, want d1", got.ConfigDigest)
 	}
 }
+
+// TestAnnounceDraining_FlipsTheFlagAndHoldsForTheDelay covers both shapes of
+// the announcement: with no delay the flag flips and the caller closes the
+// listener at once, and with one the flag is already draining while the
+// listener is held open for the whole delay, which is the window a balancer
+// polling /health needs to see the 503 before the close.
+func TestAnnounceDraining_FlipsTheFlagAndHoldsForTheDelay(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		delay time.Duration
+	}{
+		{name: "no delay closes at once", delay: 0},
+		{name: "a delay holds the listener open", delay: 30 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var draining atomic.Bool
+			started := time.Now()
+			announceDraining(t.Context(), &draining, tc.delay)
+			elapsed := time.Since(started)
+
+			if !draining.Load() {
+				t.Error("the draining flag was not set; /health would keep answering 200 through the close")
+			}
+			if elapsed < tc.delay {
+				t.Errorf("announceDraining returned after %s, want at least the %s delay", elapsed, tc.delay)
+			}
+		})
+	}
+}

--- a/cmd/server/listen.go
+++ b/cmd/server/listen.go
@@ -130,12 +130,18 @@ func clearStaleSocket(ctx context.Context, path string) error {
 			path, dialErr,
 		)
 	}
-	if removeErr := os.Remove(path); removeErr != nil {
+	if removeErr := removeStaleSocket(path); removeErr != nil {
 		return fmt.Errorf("removing stale socket %q: %w", path, removeErr)
 	}
 	slog.WarnContext(ctx, "removed a stale unix socket left by an earlier run", "path", path)
 	return nil
 }
+
+// removeStaleSocket unlinks a socket the probe above proved dead. A variable
+// because the tests run with every permission, so nothing on disk can make
+// the unlink fail, and the branch reporting that failure is otherwise never
+// run.
+var removeStaleSocket = os.Remove //nolint:gochecknoglobals // test seam
 
 // repeatedFlag is a flag that may be given more than once, and whose single
 // occurrence may itself be a comma-separated list.

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -182,8 +183,11 @@ func TestClearStaleSocket_ADeadSocketThatCannotBeRemoved_IsReported(t *testing.T
 	if err == nil {
 		t.Fatal("clearStaleSocket() reported success for a socket it could not remove")
 	}
-	if !strings.Contains(err.Error(), "removing stale socket") || !strings.Contains(err.Error(), path) {
-		t.Errorf("error = %q, want the unlink failure naming %s", err, path)
+	// The path is rendered with %q, which escapes the backslashes of a
+	// Windows path, so the expectation is the quoted form rather than the
+	// raw one.
+	if !strings.Contains(err.Error(), "removing stale socket") || !strings.Contains(err.Error(), strconv.Quote(path)) {
+		t.Errorf("error = %q, want the unlink failure naming %s", err, strconv.Quote(path))
 	}
 }
 

--- a/cmd/server/listen_test.go
+++ b/cmd/server/listen_test.go
@@ -159,6 +159,34 @@ func TestClearStaleSocket_DeadSocketIsRemoved(t *testing.T) {
 	}
 }
 
+// TestClearStaleSocket_ADeadSocketThatCannotBeRemoved_IsReported covers the
+// unlink failing after the probe proved the socket dead. The tests hold every
+// permission, so the unlink is failed through its seam; what is asserted is
+// that the failure names the path and reaches the operator instead of the
+// bind failing a moment later on a file the log never mentioned.
+func TestClearStaleSocket_ADeadSocketThatCannotBeRemoved_IsReported(t *testing.T) {
+	path := filepath.Join(socketDir(t), "stuck.sock")
+	listener := listenUnixForTest(t, path)
+	if unix, ok := listener.(*net.UnixListener); ok {
+		unix.SetUnlinkOnClose(false)
+	} else {
+		t.Fatalf("listener type = %T, want *net.UnixListener", listener)
+	}
+	_ = listener.Close()
+
+	original := removeStaleSocket
+	t.Cleanup(func() { removeStaleSocket = original })
+	removeStaleSocket = func(string) error { return errors.New("operation not permitted") }
+
+	err := clearStaleSocket(t.Context(), path)
+	if err == nil {
+		t.Fatal("clearStaleSocket() reported success for a socket it could not remove")
+	}
+	if !strings.Contains(err.Error(), "removing stale socket") || !strings.Contains(err.Error(), path) {
+		t.Errorf("error = %q, want the unlink failure naming %s", err, path)
+	}
+}
+
 // TestClearStaleSocket_LiveSocketIsRefused is the counterweight: an
 // unconditional remove would let a second instance hijack the socket a
 // running server is still serving, leaving it holding a listener nobody can

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1231,7 +1231,7 @@ func runStdio(ctx context.Context) error {
 	toolutil.SetActionTimeout(cfg.ActionTimeout)
 	toolutil.EnableEmbeddedResources(cfg.EmbeddedResources)
 
-	client, err := gitlabclient.NewClient(cfg)
+	client, err := newGitLabClient(cfg)
 	if err != nil {
 		return fmt.Errorf("creating gitlab client: %w", err)
 	}
@@ -1297,7 +1297,28 @@ func runStdio(ctx context.Context) error {
 // work that is still in flight. It is a backstop against a request that never
 // returns, not a budget: the wait begins by canceling that work, so anything
 // honoring its context is already on its way out.
-const stdioStartupDrainTimeout = 5 * time.Second
+//
+// A var only so a test can shorten it below the time a catalog takes to
+// build, which is the one piece of startup work no cancellation cuts short;
+// nothing at runtime writes it.
+var stdioStartupDrainTimeout = 5 * time.Second //nolint:gochecknoglobals // test seam
+
+// Catalog construction hooks, replaceable in tests.
+//
+// None of these can be made to fail from any input the server takes: the
+// action specs are compiled in and validated by their own tests, the scope
+// filter has no failing path, and the GitLab client refuses only a URL the
+// configuration already refused. The branches that report their failure
+// exist for the day one of those facts changes, and would otherwise never
+// run.
+var (
+	newGitLabClient      = gitlabclient.NewClient            //nolint:gochecknoglobals // test seam
+	buildDynamicCatalog  = dynamiccatalog.Build              //nolint:gochecknoglobals // test seam
+	buildActionCatalog   = gitlabtools.BuildActionCatalog    //nolint:gochecknoglobals // test seam
+	filterActionCatalog  = gitlabtools.FilterActionCatalog   //nolint:gochecknoglobals // test seam
+	registerAllMeta      = gitlabtools.RegisterAllMeta       //nolint:gochecknoglobals // test seam
+	addStandaloneCatalog = dynamictools.AddStandaloneCatalog //nolint:gochecknoglobals // test seam
+)
 
 // prepareStdioCatalog runs everything stdio startup needs GitLab for, registers
 // the tool catalog, and opens the readiness gate.
@@ -1976,7 +1997,7 @@ func registerConfiguredToolSurfaceWithCatalog(server *mcp.Server, client *gitlab
 		var withheld gitlabtools.WithheldActions
 		if actionCatalog == nil {
 			var catalogErr error
-			actionCatalog, withheld, catalogErr = dynamiccatalog.Build(client, cfg)
+			actionCatalog, withheld, catalogErr = buildDynamicCatalog(client, cfg)
 			if catalogErr != nil {
 				return serverSurfaceRegistration{}, fmt.Errorf("build dynamic action catalog: %w", catalogErr)
 			}
@@ -1992,13 +2013,13 @@ func registerConfiguredToolSurfaceWithCatalog(server *mcp.Server, client *gitlab
 		var metaWithheld gitlabtools.WithheldActions
 		filteredCatalog := prebuiltCatalog
 		if filteredCatalog == nil {
-			actionCatalog, catalogErr := gitlabtools.BuildActionCatalog(client, gitlabtools.ActionCatalogOptions{Tier: cfg.Tier, IncludeMCP: true})
+			actionCatalog, catalogErr := buildActionCatalog(client, gitlabtools.ActionCatalogOptions{Tier: cfg.Tier, IncludeMCP: true})
 			if catalogErr != nil {
 				slog.Warn("failed to build meta action catalog", "error", catalogErr)
 				actionCatalog = actioncatalog.NewCatalog()
 			}
 			var filterErr error
-			filteredCatalog, metaWithheld, filterErr = gitlabtools.FilterActionCatalog(actionCatalog, cfg)
+			filteredCatalog, metaWithheld, filterErr = filterActionCatalog(actionCatalog, cfg)
 			if filterErr != nil {
 				return serverSurfaceRegistration{}, fmt.Errorf("filter meta action catalog: %w", filterErr)
 			}
@@ -2020,7 +2041,7 @@ func registerConfiguredToolSurfaceWithCatalog(server *mcp.Server, client *gitlab
 		// catalog can no longer map the operator's entries to anything.
 		var individualExcluded []string
 		if individualCatalog == nil {
-			built, catalogErr := gitlabtools.BuildActionCatalog(client, gitlabtools.ActionCatalogOptions{Tier: cfg.Tier, IncludeMCP: true})
+			built, catalogErr := buildActionCatalog(client, gitlabtools.ActionCatalogOptions{Tier: cfg.Tier, IncludeMCP: true})
 			if catalogErr != nil {
 				return serverSurfaceRegistration{}, fmt.Errorf("build individual action catalog: %w", catalogErr)
 			}
@@ -3899,27 +3920,27 @@ func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 		return nil, fmt.Errorf("creating server-card MCP server: %w", err)
 	}
 
-	st, ct := mcp.NewInMemoryTransports()
+	st, ct := newInspectionTransports()
 	// The 30-second ceiling derives from the server's lifecycle context, so
 	// a shutdown that begins while the card is still being built cancels
 	// the build instead of waiting behind it.
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	serverSession, err := srv.Connect(ctx, st, nil)
+	serverSession, err := connectInspectionServer(srv, ctx, st)
 	if err != nil {
 		return nil, fmt.Errorf("server connect: %w", err)
 	}
 	defer serverSession.Close()
 
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "server-card-builder", Version: "0"}, nil)
-	session, err := mcpClient.Connect(ctx, ct, nil)
+	session, err := connectInspectionClient(mcpClient, ctx, ct)
 	if err != nil {
 		return nil, fmt.Errorf("client connect: %w", err)
 	}
 	defer session.Close()
 
-	toolsResult, err := session.ListTools(ctx, nil)
+	toolsResult, err := listInspectionTools(session, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
@@ -3961,7 +3982,7 @@ func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 		Icons       []mcp.Icon       `json:"icons,omitempty"`
 	}
 
-	resourcesResult, err := session.ListResources(ctx, nil)
+	resourcesResult, err := listInspectionResources(session, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list resources: %w", err)
 	}
@@ -3993,7 +4014,7 @@ func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 		Meta mcp.Meta `json:"_meta,omitempty"`
 	}
 
-	templatesResult, err := session.ListResourceTemplates(ctx, nil)
+	templatesResult, err := listInspectionResourceTemplates(session, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list resource templates: %w", err)
 	}
@@ -4027,7 +4048,7 @@ func buildServerCard(ctx context.Context, cfg *config.Config) ([]byte, error) {
 
 	cardPrompts := []serverCardPrompt{}
 	if config.EffectiveCapabilitySurface(cfg.CapabilitySurface) == config.CapabilitySurfaceFull {
-		promptsResult, promptsErr := session.ListPrompts(ctx, nil)
+		promptsResult, promptsErr := listInspectionPrompts(session, ctx)
 		if promptsErr != nil {
 			return nil, fmt.Errorf("list prompts: %w", promptsErr)
 		}
@@ -4150,6 +4171,19 @@ var (
 	listInspectionTools = func(session *mcp.ClientSession, ctx context.Context) (*mcp.ListToolsResult, error) {
 		return session.ListTools(ctx, nil)
 	}
+	// The three listings the server card reads after the tools, hooked the
+	// same way and for the same reason: an in-memory session does not fail
+	// on its own, so the branches reporting one that did are otherwise
+	// never run.
+	listInspectionResources = func(session *mcp.ClientSession, ctx context.Context) (*mcp.ListResourcesResult, error) {
+		return session.ListResources(ctx, nil)
+	}
+	listInspectionResourceTemplates = func(session *mcp.ClientSession, ctx context.Context) (*mcp.ListResourceTemplatesResult, error) {
+		return session.ListResourceTemplates(ctx, nil)
+	}
+	listInspectionPrompts = func(session *mcp.ClientSession, ctx context.Context) (*mcp.ListPromptsResult, error) {
+		return session.ListPrompts(ctx, nil)
+	}
 )
 
 // listRegisteredTools connects an in-memory MCP client to server and returns
@@ -4222,9 +4256,9 @@ func removeExcludedTools(ctx context.Context, server *mcp.Server, exclude []stri
 		excludeSet[name] = struct{}{}
 	}
 
-	st, ct := mcp.NewInMemoryTransports()
+	st, ct := newInspectionTransports()
 
-	serverSession, err := server.Connect(ctx, st, nil)
+	serverSession, err := connectInspectionServer(server, ctx, st)
 	if err != nil {
 		slog.ErrorContext(ctx, "removeExcludedTools: server connect failed", "error", err)
 		return 0
@@ -4232,14 +4266,14 @@ func removeExcludedTools(ctx context.Context, server *mcp.Server, exclude []stri
 	defer serverSession.Close()
 
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "exclude-filter", Version: "0"}, nil)
-	session, err := mcpClient.Connect(ctx, ct, nil)
+	session, err := connectInspectionClient(mcpClient, ctx, ct)
 	if err != nil {
 		slog.ErrorContext(ctx, "removeExcludedTools: client connect failed", "error", err)
 		return 0
 	}
 	defer session.Close()
 
-	result, err := session.ListTools(ctx, nil)
+	result, err := listInspectionTools(session, ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "removeExcludedTools: list tools failed", "error", err)
 		return 0
@@ -4290,7 +4324,7 @@ func doToolSearch(query, toolSurface string, tier edition.Tier) error {
 	// fourth case to refuse.
 	switch config.EffectiveToolSurface(true, toolSurface) {
 	case config.ToolSurfaceMeta:
-		if err := gitlabtools.RegisterAllMeta(server, nil, tier); err != nil {
+		if err := registerAllMeta(server, nil, tier); err != nil {
 			return err
 		}
 	case config.ToolSurfaceIndividual:
@@ -4303,23 +4337,23 @@ func doToolSearch(query, toolSurface string, tier edition.Tier) error {
 		dynamictools.RegisterCatalogFindExecuteTools(server, catalog)
 	}
 
-	st, ct := mcp.NewInMemoryTransports()
+	st, ct := newInspectionTransports()
 	ctx := context.Background()
 
-	serverSession, err := server.Connect(ctx, st, nil)
+	serverSession, err := connectInspectionServer(server, ctx, st)
 	if err != nil {
 		return fmt.Errorf("connect error: %w", err)
 	}
 	defer serverSession.Close()
 
 	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "search-client", Version: "0"}, nil)
-	session, err := mcpClient.Connect(ctx, ct, nil)
+	session, err := connectInspectionClient(mcpClient, ctx, ct)
 	if err != nil {
 		return fmt.Errorf("connect error: %w", err)
 	}
 	defer session.Close()
 
-	result, err := session.ListTools(ctx, nil)
+	result, err := listInspectionTools(session, ctx)
 	if err != nil {
 		return fmt.Errorf("list tools error: %w", err)
 	}
@@ -4358,14 +4392,14 @@ func doToolSearch(query, toolSurface string, tier edition.Tier) error {
 }
 
 func buildToolSearchCatalog(tier edition.Tier) (*actioncatalog.Catalog, error) {
-	catalog, err := gitlabtools.BuildActionCatalog(nil, gitlabtools.ActionCatalogOptions{
+	catalog, err := buildActionCatalog(nil, gitlabtools.ActionCatalogOptions{
 		Tier:       tier,
 		IncludeMCP: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build action catalog: %w", err)
 	}
-	withStandalone, standaloneErr := dynamictools.AddStandaloneCatalog(catalog, nil, dynamictools.StandaloneOptions{})
+	withStandalone, standaloneErr := addStandaloneCatalog(catalog, nil, dynamictools.StandaloneOptions{})
 	if standaloneErr != nil {
 		return nil, fmt.Errorf("add standalone dynamic actions: %w", standaloneErr)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -332,7 +332,8 @@ func main() {
 	transportChoice, transportErr := resolveTransport(transport, useHTTP, flagWasSet("http"))
 	if transportErr != nil {
 		fmt.Fprintln(os.Stderr, transportErr)
-		os.Exit(2)
+		exitProcess(2)
+		return
 	}
 	useHTTP = transportChoice.HTTP
 
@@ -359,12 +360,14 @@ func main() {
 	}
 
 	if shutdownPeers {
-		os.Exit(runShutdown())
+		exitProcess(runShutdown())
+		return
 	}
 
 	if probeHealth {
 		deps := probeDeps{peers: livePeers, stdinIsNull: peerStdinIsNull}
-		os.Exit(runProbe(context.Background(), flag.Args(), hcfg.tlsCert, deps, os.Stderr))
+		exitProcess(runProbe(context.Background(), flag.Args(), hcfg.tlsCert, deps, os.Stderr))
+		return
 	}
 
 	if toolSearch != "" {
@@ -431,7 +434,8 @@ func main() {
 
 	if err := run(hcfgPtr); err != nil {
 		slog.Error("server exited with error", "error", err)
-		os.Exit(1)
+		exitProcess(1)
+		return
 	}
 }
 
@@ -4302,8 +4306,12 @@ func runToolSearch(query, toolSurface string, tier edition.Tier) {
 	}
 }
 
-// Tool search hooks are replaceable in tests so runToolSearch can be verified
-// without terminating the test process through os.Exit.
+// exitProcess is every exit main takes, so a test can drive main through
+// each of its process-level modes and read the status code back instead of
+// having the test binary end. main returns after calling it for the same
+// reason: os.Exit never returns, and a test's replacement does.
+// toolSearchRunner lets the same tests run --tool-search without building
+// a catalog.
 var (
 	toolSearchRunner = doToolSearch
 	exitProcess      = os.Exit

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2129,12 +2129,12 @@ func shutdownHTTPServer(ctx context.Context, httpServer *http.Server) error {
 	slog.WarnContext(ctx,
 		"HTTP drain budget exhausted, closing the connections that did not finish",
 		"budget", budget)
-	// Shutdown has already closed the listeners, so Close finds them closed
-	// and says so. That is expected here and says nothing about the
-	// connections, which are what this call is for.
-	if closeErr := httpServer.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
-		return fmt.Errorf("http server close after drain budget: %w", closeErr)
-	}
+	// Close has no error left to report: its only error source is closing
+	// the tracked listeners, and Shutdown waited for every Serve loop to
+	// return before it came back, which is where each loop untracks its
+	// listener. What remains is the connections, and closing those reports
+	// nothing.
+	_ = httpServer.Close()
 	return nil
 }
 
@@ -3066,9 +3066,6 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 	// handed the bearer token — which is what made a free-form GITLAB-URL
 	// header unacceptable in oauth mode in the first place.
 	resolveInstance := func(r *http.Request) (string, error) {
-		if r == nil {
-			return cfg.GitLabURL, nil
-		}
 		// Ahead of the resolver for the message, not for the decision: the
 		// resolver refuses an absent header on a multi-instance deployment
 		// too, and this gate turns the same refusal into the wording each
@@ -3185,9 +3182,15 @@ func registerLegacyMCPHandlers(ctx context.Context, cfg *config.Config, pool *se
 	mountMCPEndpoint(cfg, mux, gate.middleware(mcpHandler))
 }
 
+// periodicCleanupInterval is how often the expiring caches (token identities,
+// rejected tokens, failure budgets) are swept. A var only so a test can make
+// the tick arrive; nothing at runtime writes it.
+var periodicCleanupInterval = 5 * time.Minute //nolint:gochecknoglobals // test seam
+
+// startPeriodicCleanup runs cleanup on every tick until ctx ends.
 func startPeriodicCleanup(ctx context.Context, cleanup func()) {
 	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
+		ticker := time.NewTicker(periodicCleanupInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -4283,6 +4286,8 @@ func doToolSearch(query, toolSurface string, tier edition.Tier) error {
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "search", Version: version}, &mcp.ServerOptions{PageSize: 2000, Capabilities: &mcp.ServerCapabilities{}})
 
+	// EffectiveToolSurface answers one of exactly these three, so there is no
+	// fourth case to refuse.
 	switch config.EffectiveToolSurface(true, toolSurface) {
 	case config.ToolSurfaceMeta:
 		if err := gitlabtools.RegisterAllMeta(server, nil, tier); err != nil {
@@ -4296,8 +4301,6 @@ func doToolSearch(query, toolSurface string, tier edition.Tier) error {
 			return err
 		}
 		dynamictools.RegisterCatalogFindExecuteTools(server, catalog)
-	default:
-		return fmt.Errorf("unsupported tool surface for search: %q", toolSurface)
 	}
 
 	st, ct := mcp.NewInMemoryTransports()

--- a/cmd/server/main_linux_test.go
+++ b/cmd/server/main_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+)
+
+// openPTY allocates a pseudo-terminal pair and returns both ends, the slave
+// being what a person's shell would hand a program as its standard input.
+func openPTY(t *testing.T) (master, slave *os.File) {
+	t.Helper()
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("no pseudo-terminal multiplexer here: %v", err)
+	}
+	t.Cleanup(func() { _ = master.Close() })
+	if unlockErr := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); unlockErr != nil {
+		t.Fatalf("unlocking the pty: %v", unlockErr)
+	}
+	number, err := unix.IoctlGetUint32(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		t.Fatalf("reading the pty number: %v", err)
+	}
+	name := "/dev/pts/" + strconv.FormatUint(uint64(number), 10)
+	slave, err = os.OpenFile(name, os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Skipf("the pty slave %s cannot be opened here: %v", name, err)
+	}
+	t.Cleanup(func() { _ = slave.Close() })
+	return master, slave
+}
+
+// TestMain_StartedByHandWithoutCredentials_ExplainsAndWaits covers the screen
+// shown to somebody who double-clicked the binary: stdin is a terminal and no
+// credentials are configured, so main prints what the program is and what it
+// needs on stderr, waits for a line, and returns without starting a server.
+//
+// A pseudo-terminal is the only honest stdin for this, since the guard is a
+// terminal check and a pipe is exactly what it must not match. The message
+// goes to stderr because stdout is the protocol stream, so stderr is what is
+// captured.
+func TestMain_StartedByHandWithoutCredentials_ExplainsAndWaits(t *testing.T) {
+	withFreshFlagSet(t)
+	t.Setenv("GITLAB_URL", "")
+	t.Setenv("GITLAB_TOKEN", "")
+	t.Setenv(config.EnvFileVar, "")
+
+	master, slave := openPTY(t)
+	originalStdin, originalArgs, originalLogger := os.Stdin, os.Args, slog.Default()
+	os.Stdin = slave
+	os.Args = []string{"gitlab-mcp-server"}
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		os.Args = originalArgs
+		slog.SetDefault(originalLogger)
+	})
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	var stderr bytes.Buffer
+	var drained sync.WaitGroup
+	drained.Go(func() { _, _ = io.Copy(&stderr, reader) })
+	originalStderr := os.Stderr
+	os.Stderr = writer
+	t.Cleanup(func() { os.Stderr = originalStderr })
+
+	var exits []int
+	originalExit := exitProcess
+	exitProcess = func(code int) { exits = append(exits, code) }
+	t.Cleanup(func() { exitProcess = originalExit })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		main()
+	}()
+
+	// The line the screen waits for. Written to the terminal's master side,
+	// where a person's Enter would come from; the tty buffers it if main has
+	// not reached the read yet.
+	if _, writeErr := master.WriteString("\n"); writeErr != nil {
+		t.Fatalf("pressing Enter: %v", writeErr)
+	}
+	select {
+	case <-done:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("main did not return after Enter was pressed on the guidance screen")
+	}
+	os.Stderr = originalStderr
+	_ = writer.Close()
+	drained.Wait()
+
+	if len(exits) != 0 {
+		t.Errorf("exit codes = %v, want none: the screen returns rather than failing", exits)
+	}
+	for _, want := range []string{"GITLAB_URL", "GITLAB_TOKEN", "Press Enter to close."} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(stderr.String(), want) {
+				t.Errorf("stderr = %q, want it to carry %q", stderr.String(), want)
+			}
+		})
+	}
+}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2381,6 +2381,517 @@ func TestListRegisteredTools_ErrorPaths(t *testing.T) {
 	})
 }
 
+// failDynamicCatalog makes the dynamic catalog build fail for the test's
+// duration and returns the error it fails with.
+func failDynamicCatalog(t *testing.T, builds *atomic.Int64) error {
+	t.Helper()
+	forced := errors.New("forced catalog failure")
+	original := buildDynamicCatalog
+	t.Cleanup(func() { buildDynamicCatalog = original })
+	buildDynamicCatalog = func(*gitlabclient.Client, *config.ServerConfig) (*actioncatalog.Catalog, tools.WithheldActions, error) {
+		if builds != nil {
+			builds.Add(1)
+		}
+		return nil, tools.WithheldActions{}, forced
+	}
+	return forced
+}
+
+// heldOpenStdin points os.Stdin at a pipe whose write end stays open, so the
+// SDK never reads EOF and only the server's own decisions can end a session.
+func heldOpenStdin(t *testing.T) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	original := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = original
+		_ = writer.Close()
+		_ = reader.Close()
+	})
+}
+
+// TestRunStdio_ClientAndShellFailures_AreReportedBeforeServing covers the two
+// startup failures stdio mode reports before it ever answers a handshake: a
+// GitLab client that cannot be built, and a server shell refused over a
+// malformed description substitution. The first is forced through its seam,
+// because the configuration already refuses every URL the client would; the
+// second is the real parser refusing a real value.
+func TestRunStdio_ClientAndShellFailures_AreReportedBeforeServing(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	cases := []struct {
+		name    string
+		arrange func(t *testing.T)
+		want    string
+	}{
+		{
+			name: "the client cannot be built",
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := newGitLabClient
+				t.Cleanup(func() { newGitLabClient = original })
+				newGitLabClient = func(*config.Config) (*gitlabclient.Client, error) {
+					return nil, errors.New("forced client failure")
+				}
+			},
+			want: "creating gitlab client: forced client failure",
+		},
+		{
+			name:    "the shell refuses a malformed substitution",
+			arrange: func(t *testing.T) { t.Helper(); t.Setenv(gatewaycompat.EnvVar, "=x") },
+			want:    "creating MCP server",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITLAB_URL", gitlab.URL)
+			t.Setenv("GITLAB_TOKEN", testToken)
+			t.Setenv("TOOL_SURFACE", config.ToolSurfaceDynamic)
+			tc.arrange(t)
+
+			err := runStdio(t.Context())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("runStdio() = %v, want an error carrying %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunStdio_ACatalogThatCannotBeBuilt_StopsTheServer covers what happens
+// to a stdio session whose catalog fails to build while the handshake is
+// already being answered: serving is cancelled rather than left holding every
+// other method forever, and the startup error, not the shutdown it caused, is
+// what runStdio returns. The client's pipe is held open so nothing but that
+// decision can end the session.
+func TestRunStdio_ACatalogThatCannotBeBuilt_StopsTheServer(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	t.Setenv("GITLAB_URL", gitlab.URL)
+	t.Setenv("GITLAB_TOKEN", testToken)
+	t.Setenv("TOOL_SURFACE", config.ToolSurfaceDynamic)
+	forced := failDynamicCatalog(t, nil)
+	heldOpenStdin(t)
+
+	done := make(chan error, 1)
+	go func() { done <- runStdio(context.Background()) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, forced) || !strings.Contains(err.Error(), "registering the tool catalog") {
+			t.Errorf("runStdio() = %v, want the catalog failure wrapped as the startup error", err)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("runStdio kept serving after its catalog failed to build")
+	}
+}
+
+// TestRunStdio_StartupOutlivingTheClient_IsCutOffAtTheDrain covers the bound
+// on the wait for startup work: a client that leaves while the catalog is
+// still being built is not held for the whole build, only for the drain,
+// which is shortened here below the build's own duration. The catalog build
+// is the one piece of startup no cancellation cuts short, so the test then
+// waits for that goroutine itself, so it cannot write into a later test's
+// logger.
+func TestRunStdio_StartupOutlivingTheClient_IsCutOffAtTheDrain(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	t.Setenv("GITLAB_URL", gitlab.URL)
+	t.Setenv("GITLAB_TOKEN", testToken)
+	t.Setenv("TOOL_SURFACE", config.ToolSurfaceDynamic)
+	restoreDrain := stdioStartupDrainTimeout
+	stdioStartupDrainTimeout = time.Millisecond
+	t.Cleanup(func() { stdioStartupDrainTimeout = restoreDrain })
+
+	var mu sync.Mutex
+	var messages []string
+	capture := levelCapturingHandler{threshold: slog.LevelDebug, mu: &mu, messages: &messages}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	logged := func(message string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Contains(messages, message)
+	}
+
+	// A closed pipe: EOF at once, so serving ends while the build is running.
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	_ = writer.Close()
+	original := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = original
+		_ = reader.Close()
+	})
+
+	if runErr := runStdio(context.Background()); runErr != nil {
+		t.Fatalf("runStdio() = %v, want a clean stop when the client leaves", runErr)
+	}
+	if !logged("startup work had not finished when serving ended") {
+		t.Error("runStdio returned without noting that startup was still running")
+	}
+
+	deadline := time.Now().Add(testHTTPLivenessTimeout)
+	for !logged("tool catalog ready") {
+		if time.Now().After(deadline) {
+			t.Fatal("the startup goroutine never finished its catalog build")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestStartPooledRegistration_AFailedBuild_FailsTheGateAndEvicts covers the
+// failure the post-insert hook exists for: a catalog that cannot be built
+// for a pooled credential fails the requests parked on its gate and evicts
+// the entry, so the next request for that credential rebuilds instead of
+// being handed a server with no tools.
+func TestStartPooledRegistration_AFailedBuild_FailsTheGateAndEvicts(t *testing.T) {
+	forced := failDynamicCatalog(t, nil)
+	client := newMockGitLabClient(t)
+	shell, err := newServerShell(t.Context(), client, &config.ServerConfig{ToolSurface: config.ToolSurfaceDynamic})
+	if err != nil {
+		t.Fatalf("newServerShell: %v", err)
+	}
+	var pending sync.Map
+	pending.Store(shell.server, shell)
+	evicted := make(chan struct{})
+
+	startPooledRegistration(t.Context(), &pending, shell.server, func() { close(evicted) })
+
+	select {
+	case <-evicted:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("the entry was not evicted after its catalog failed to build")
+	}
+	if cause := shell.gate.failed(); !errors.Is(cause, forced) {
+		t.Errorf("gate failure = %v, want the build's own error", cause)
+	}
+}
+
+// TestServeHTTP_APooledCatalogThatCannotBeBuilt_IsEvicted covers the same
+// failure on the wire: the request that triggered the build is answered with
+// the retry-able refusal rather than an empty catalog, and the next request
+// for the same credential builds again instead of finding the poisoned entry
+// cached.
+func TestServeHTTP_APooledCatalogThatCannotBeBuilt_IsEvicted(t *testing.T) {
+	var builds atomic.Int64
+	failDynamicCatalog(t, &builds)
+	gitlab := newMockGitLabServer(t)
+	addr, shutdown := startStatelessServeHTTP(t, statelessTestConfig(gitlab.URL, true))
+	defer shutdown()
+
+	for attempt := range 2 {
+		resp := postStatelessJSONRPC(t, addr, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+		body := readAndCloseBody(t, resp)
+		if !strings.Contains(body, "retry it") {
+			t.Errorf("request %d = %d %q, want the catalog refusal asking for a retry", attempt, resp.StatusCode, body)
+		}
+	}
+	if builds.Load() != 2 {
+		t.Errorf("the catalog was built %d time(s) for two requests, want 2: a failed entry must be evicted, not cached", builds.Load())
+	}
+}
+
+// TestCreateServer_ARegistrationFailure_IsReturned covers the two callers
+// that want a finished server and get a failure instead: createServer itself,
+// and the server card built on top of it.
+func TestCreateServer_ARegistrationFailure_IsReturned(t *testing.T) {
+	forced := failDynamicCatalog(t, nil)
+	client := newMockGitLabClient(t)
+
+	if _, err := createServer(t.Context(), client, &config.ServerConfig{ToolSurface: config.ToolSurfaceDynamic}); !errors.Is(err, forced) {
+		t.Errorf("createServer() error = %v, want the registration failure", err)
+	}
+
+	gitlab := newMockGitLabServer(t)
+	_, cardErr := buildServerCard(t.Context(), &config.Config{GitLabURL: gitlab.URL, ToolSurface: config.ToolSurfaceDynamic})
+	if !errors.Is(cardErr, forced) || !strings.Contains(cardErr.Error(), "creating server-card MCP server") {
+		t.Errorf("buildServerCard() error = %v, want the registration failure named as the card server's", cardErr)
+	}
+}
+
+// TestRegisterConfiguredToolSurfaceWithCatalog_BuildFailures_AreReported
+// covers each surface's answer to a catalog it cannot build. The dynamic and
+// individual surfaces refuse outright; the meta surface warns and registers
+// an empty catalog, so a build failure there is only fatal when the filter
+// that follows fails as well.
+func TestRegisterConfiguredToolSurfaceWithCatalog_BuildFailures_AreReported(t *testing.T) {
+	forced := errors.New("forced catalog failure")
+	client := newMockGitLabClient(t)
+	cases := []struct {
+		name    string
+		surface string
+		arrange func(t *testing.T)
+		wantErr string
+		wantLog string
+	}{
+		{
+			name:    "dynamic refuses",
+			surface: config.ToolSurfaceDynamic,
+			arrange: func(t *testing.T) { t.Helper(); failDynamicCatalog(t, nil) },
+			wantErr: "build dynamic action catalog",
+		},
+		{
+			name:    "individual refuses",
+			surface: config.ToolSurfaceIndividual,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := buildActionCatalog
+				t.Cleanup(func() { buildActionCatalog = original })
+				buildActionCatalog = func(*gitlabclient.Client, tools.ActionCatalogOptions) (*actioncatalog.Catalog, error) {
+					return nil, forced
+				}
+			},
+			wantErr: "build individual action catalog",
+		},
+		{
+			name:    "meta warns and carries on with an empty catalog",
+			surface: config.ToolSurfaceMeta,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := buildActionCatalog
+				t.Cleanup(func() { buildActionCatalog = original })
+				buildActionCatalog = func(*gitlabclient.Client, tools.ActionCatalogOptions) (*actioncatalog.Catalog, error) {
+					return nil, forced
+				}
+			},
+			wantLog: "failed to build meta action catalog",
+		},
+		{
+			name:    "meta refuses when the filter fails too",
+			surface: config.ToolSurfaceMeta,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := filterActionCatalog
+				t.Cleanup(func() { filterActionCatalog = original })
+				filterActionCatalog = func(*actioncatalog.Catalog, *config.ServerConfig) (*actioncatalog.Catalog, tools.WithheldActions, error) {
+					return nil, tools.WithheldActions{}, forced
+				}
+			},
+			wantErr: "filter meta action catalog",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := testutil.CaptureSlog(t)
+			tc.arrange(t)
+			server := mcp.NewServer(&mcp.Implementation{Name: "surface", Version: "0"}, nil)
+			cfg := &config.ServerConfig{ToolSurface: tc.surface}
+
+			_, err := registerConfiguredToolSurfaceWithCatalog(server, client, cfg, tc.surface, nil)
+
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Errorf("error = %v, want it to carry %q", err, tc.wantErr)
+			}
+			if tc.wantErr == "" && err != nil {
+				t.Errorf("error = %v, want the surface to carry on", err)
+			}
+			if tc.wantLog != "" && !strings.Contains(logged.String(), tc.wantLog) {
+				t.Errorf("log = %q, want it to carry %q", logged.String(), tc.wantLog)
+			}
+		})
+	}
+}
+
+// TestDoToolSearch_ACatalogThatCannotBeBuilt_IsReported covers the search
+// refusing over a catalog it cannot assemble, on the two surfaces that build
+// one: the meta registration failing, and the dynamic catalog failing at
+// either of its two steps.
+func TestDoToolSearch_ACatalogThatCannotBeBuilt_IsReported(t *testing.T) {
+	forced := errors.New("forced catalog failure")
+	cases := []struct {
+		name    string
+		surface string
+		arrange func(t *testing.T)
+		want    string
+	}{
+		{
+			name:    "meta registration fails",
+			surface: config.ToolSurfaceMeta,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := registerAllMeta
+				t.Cleanup(func() { registerAllMeta = original })
+				registerAllMeta = func(*mcp.Server, *gitlabclient.Client, edition.Tier) error { return forced }
+			},
+			want: "forced catalog failure",
+		},
+		{
+			name:    "the dynamic catalog fails to build",
+			surface: config.ToolSurfaceDynamic,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := buildActionCatalog
+				t.Cleanup(func() { buildActionCatalog = original })
+				buildActionCatalog = func(*gitlabclient.Client, tools.ActionCatalogOptions) (*actioncatalog.Catalog, error) {
+					return nil, forced
+				}
+			},
+			want: "build action catalog",
+		},
+		{
+			name:    "the standalone actions fail to join it",
+			surface: config.ToolSurfaceDynamic,
+			arrange: func(t *testing.T) {
+				t.Helper()
+				original := addStandaloneCatalog
+				t.Cleanup(func() { addStandaloneCatalog = original })
+				addStandaloneCatalog = func(*actioncatalog.Catalog, *gitlabclient.Client, dynamictools.StandaloneOptions) (*actioncatalog.Catalog, error) {
+					return nil, forced
+				}
+			},
+			want: "add standalone dynamic actions",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.arrange(t)
+			err := doToolSearch("issue", tc.surface, edition.Free)
+			if !errors.Is(err, forced) || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("doToolSearch() = %v, want %q wrapping the forced failure", err, tc.want)
+			}
+		})
+	}
+}
+
+// inspectionFailures are the three in-memory steps every catalog inspection
+// takes, each made to fail through its seam, with the wording the caller
+// under test must attach.
+func inspectionFailures(t *testing.T, forced error) []struct {
+	name    string
+	arrange func(t *testing.T)
+} {
+	t.Helper()
+	return []struct {
+		name    string
+		arrange func(t *testing.T)
+	}{
+		{name: "server connect", arrange: func(t *testing.T) {
+			t.Helper()
+			original := connectInspectionServer
+			t.Cleanup(func() { connectInspectionServer = original })
+			connectInspectionServer = func(*mcp.Server, context.Context, mcp.Transport) (*mcp.ServerSession, error) {
+				return nil, forced
+			}
+		}},
+		{name: "client connect", arrange: func(t *testing.T) {
+			t.Helper()
+			original := connectInspectionClient
+			t.Cleanup(func() { connectInspectionClient = original })
+			connectInspectionClient = func(*mcp.Client, context.Context, mcp.Transport) (*mcp.ClientSession, error) {
+				return nil, forced
+			}
+		}},
+		{name: "list tools", arrange: func(t *testing.T) {
+			t.Helper()
+			original := listInspectionTools
+			t.Cleanup(func() { listInspectionTools = original })
+			listInspectionTools = func(*mcp.ClientSession, context.Context) (*mcp.ListToolsResult, error) {
+				return nil, forced
+			}
+		}},
+	}
+}
+
+// TestDoToolSearch_InMemoryFailures_AreWrapped covers the search's own
+// in-memory session failing at each step, which no input reaches and which
+// the search reports rather than printing an empty listing over.
+func TestDoToolSearch_InMemoryFailures_AreWrapped(t *testing.T) {
+	forced := errors.New("forced inspection failure")
+	for _, tc := range inspectionFailures(t, forced) {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.arrange(t)
+			err := doToolSearch("issue", config.ToolSurfaceMeta, edition.Free)
+			if !errors.Is(err, forced) || !strings.Contains(err.Error(), "error") {
+				t.Errorf("doToolSearch() = %v, want the %s failure wrapped", err, tc.name)
+			}
+		})
+	}
+}
+
+// TestRemoveExcludedTools_InMemoryFailures_RemoveNothing covers the
+// exclusion pass unable to list the server's tools: it removes nothing and
+// says why, because guessing at names to remove would be worse than
+// leaving an exclusion unapplied and reported.
+func TestRemoveExcludedTools_InMemoryFailures_RemoveNothing(t *testing.T) {
+	forced := errors.New("forced inspection failure")
+	for _, tc := range inspectionFailures(t, forced) {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := testutil.CaptureSlog(t)
+			tc.arrange(t)
+			server := mcp.NewServer(&mcp.Implementation{Name: "exclusions", Version: "0"}, nil)
+
+			removed := removeExcludedTools(t.Context(), server, []string{"gitlab_issue_list"})
+
+			if removed != 0 {
+				t.Errorf("removeExcludedTools() = %d, want 0 when the listing failed", removed)
+			}
+			if !strings.Contains(logged.String(), "removeExcludedTools: "+tc.name+" failed") {
+				t.Errorf("log = %q, want the %s failure reported", logged.String(), tc.name)
+			}
+		})
+	}
+}
+
+// TestBuildServerCard_InMemoryFailures_AreWrapped covers the card builder's
+// session failing at each of its six steps, each named in the error so the
+// 503 the endpoint answers with can be traced to the listing that failed.
+func TestBuildServerCard_InMemoryFailures_AreWrapped(t *testing.T) {
+	forced := errors.New("forced inspection failure")
+	gitlab := newMockGitLabServer(t)
+	cfg := &config.Config{GitLabURL: gitlab.URL, ToolSurface: config.ToolSurfaceDynamic, CapabilitySurface: config.CapabilitySurfaceFull}
+
+	cases := inspectionFailures(t, forced)
+	cases = append(cases,
+		struct {
+			name    string
+			arrange func(t *testing.T)
+		}{name: "list resources", arrange: func(t *testing.T) {
+			t.Helper()
+			original := listInspectionResources
+			t.Cleanup(func() { listInspectionResources = original })
+			listInspectionResources = func(*mcp.ClientSession, context.Context) (*mcp.ListResourcesResult, error) {
+				return nil, forced
+			}
+		}},
+		struct {
+			name    string
+			arrange func(t *testing.T)
+		}{name: "list resource templates", arrange: func(t *testing.T) {
+			t.Helper()
+			original := listInspectionResourceTemplates
+			t.Cleanup(func() { listInspectionResourceTemplates = original })
+			listInspectionResourceTemplates = func(*mcp.ClientSession, context.Context) (*mcp.ListResourceTemplatesResult, error) {
+				return nil, forced
+			}
+		}},
+		struct {
+			name    string
+			arrange func(t *testing.T)
+		}{name: "list prompts", arrange: func(t *testing.T) {
+			t.Helper()
+			original := listInspectionPrompts
+			t.Cleanup(func() { listInspectionPrompts = original })
+			listInspectionPrompts = func(*mcp.ClientSession, context.Context) (*mcp.ListPromptsResult, error) {
+				return nil, forced
+			}
+		}},
+	)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.arrange(t)
+			_, err := buildServerCard(t.Context(), cfg)
+			if !errors.Is(err, forced) || !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("buildServerCard() = %v, want the %s failure named", err, tc.name)
+			}
+		})
+	}
+}
+
 // TestNewDepthLimitedBody_ADisabledLimit_PassesTheBodyThrough pins that a
 // zero or negative ceiling means no wrapper at all rather than a wrapper that
 // refuses everything, and that a body already refused keeps refusing on every

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -10,11 +10,19 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"io"
 	"log/slog"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +30,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -35,11 +44,13 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/gatewaycompat"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/mcpotel"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/oauth"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/resources"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/serverpool"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/telemetry"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
@@ -699,6 +710,145 @@ func TestServeStdio_ContextCancelled(t *testing.T) {
 	// stdio mode with canceled context should return an error or nil
 	// (either is acceptable — we just verify it doesn't hang)
 	_ = err
+}
+
+// acceptFailingListener is a bound listener whose accept loop fails outright,
+// standing in for a socket the kernel stopped serving under the process.
+type acceptFailingListener struct {
+	net.Listener
+	err error
+}
+
+func (l *acceptFailingListener) Accept() (net.Conn, error) { return nil, l.err }
+
+// TestServeHTTPOn_TheServeLoopFails_IsReportedAsAServerError covers the other
+// way serving ends: not a shutdown but the accept loop returning an error of
+// its own, which is a failure the process must exit non-zero over rather than
+// a stop it should describe as clean.
+func TestServeHTTPOn_TheServeLoopFails_IsReportedAsAServerError(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	bound, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	listener := &acceptFailingListener{Listener: bound, err: errors.New("accept: socket is not connected")}
+
+	serveErr := serveHTTPOn(t.Context(), statelessTestConfig(gitlab.URL, false), bound.Addr().String(), listener, defaultHTTPIdleTimeout)
+
+	if serveErr == nil || !errors.Is(serveErr, listener.err) || !strings.Contains(serveErr.Error(), "mcp server error (http)") {
+		t.Errorf("serveHTTPOn() = %v, want the accept failure wrapped as a server error", serveErr)
+	}
+}
+
+// selfSignedTLSPair mints a certificate for the loopback address and writes
+// it and its key as the PEM pair --tls-cert and --tls-key expect, returning
+// both paths and the parsed certificate so a client can trust exactly it.
+func selfSignedTLSPair(t *testing.T) (certPath, keyPath string, cert *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "gitlab-mcp-server test"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err = x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if writeErr := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if writeErr := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	return certPath, keyPath, cert
+}
+
+// TestServeHTTPOn_WithATLSPair_ServesHTTPS covers the listener terminating
+// TLS itself: the pair the operator configured is what the server presents,
+// under the floor the code states, and the plain-HTTP path is not taken.
+func TestServeHTTPOn_WithATLSPair_ServesHTTPS(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	certPath, keyPath, cert := selfSignedTLSPair(t)
+	cfg := statelessTestConfig(gitlab.URL, false)
+	cfg.TLSCertFile, cfg.TLSKeyFile = certPath, keyPath
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveHTTPOn(ctx, cfg, addr, listener, defaultHTTPIdleTimeout)
+	}()
+
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+	client := &http.Client{
+		Timeout:   testHTTPLivenessTimeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}},
+	}
+	t.Cleanup(client.CloseIdleConnections)
+
+	var resp *http.Response
+	deadline := time.Now().Add(testHTTPLivenessTimeout)
+	for {
+		select {
+		case serveErr := <-errCh:
+			t.Fatalf("serveHTTPOn exited before answering: %v", serveErr)
+		default:
+		}
+		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+addr+"/health", nil)
+		if reqErr != nil {
+			t.Fatalf("build request: %v", reqErr)
+		}
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the TLS listener never answered: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	readAndCloseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/health over TLS = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if resp.TLS == nil || resp.TLS.Version < tls.VersionTLS12 {
+		t.Errorf("response TLS state = %+v, want a handshake at TLS 1.2 or above", resp.TLS)
+	}
+
+	cancel()
+	select {
+	case serveErr := <-errCh:
+		if serveErr != nil {
+			t.Fatalf("serveHTTPOn() = %v, want a clean stop", serveErr)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("the TLS server did not shut down in time")
+	}
 }
 
 // TestServeHTTP_PortConflict verifies that [serveHTTP] returns an error
@@ -2231,6 +2381,291 @@ func TestListRegisteredTools_ErrorPaths(t *testing.T) {
 	})
 }
 
+// TestNewDepthLimitedBody_ADisabledLimit_PassesTheBodyThrough pins that a
+// zero or negative ceiling means no wrapper at all rather than a wrapper that
+// refuses everything, and that a body already refused keeps refusing on every
+// later read instead of handing the decoder the rest of a document it was
+// told not to have.
+func TestNewDepthLimitedBody_ADisabledLimit_PassesTheBodyThrough(t *testing.T) {
+	t.Parallel()
+
+	body := io.NopCloser(strings.NewReader(`{"a":[[[1]]]}`))
+	for _, limit := range []int{0, -1} {
+		t.Run(strconv.Itoa(limit), func(t *testing.T) {
+			t.Parallel()
+			if got := newDepthLimitedBody(body, limit); got != body {
+				t.Errorf("newDepthLimitedBody(limit=%d) wrapped the body, want it returned unchanged", limit)
+			}
+		})
+	}
+
+	limited := newDepthLimitedBody(io.NopCloser(strings.NewReader(`[[[[1]]]]`)), 2)
+	buf := make([]byte, 64)
+	if _, err := limited.Read(buf); err == nil {
+		t.Fatal("a body nested past the ceiling was read without a refusal")
+	}
+	if _, err := limited.Read(buf); err == nil || !strings.Contains(err.Error(), "deeper than 2 levels") {
+		t.Errorf("a second read after the refusal returned %v, want the same refusal", err)
+	}
+	if closeErr := limited.Close(); closeErr != nil {
+		t.Errorf("Close() = %v, want nil", closeErr)
+	}
+}
+
+// TestTransportFailureBudget_ExistsOnlyWithATrustedHeader pins the shape the
+// gates rely on: without a trusted proxy header the primary key is already the
+// transport source, so a second budget over the same string would only halve
+// it, and nil is what "no second budget" looks like.
+func TestTransportFailureBudget_ExistsOnlyWithATrustedHeader(t *testing.T) {
+	t.Parallel()
+	if budget := transportFailureBudget("  "); budget != nil {
+		t.Errorf("transportFailureBudget(blank) = %+v, want nil", budget)
+	}
+	budget := transportFailureBudget("X-Forwarded-For")
+	if budget == nil || budget.rateLimiter() == nil {
+		t.Fatal("transportFailureBudget(header) = nil, want a budget with a limiter behind it")
+	}
+}
+
+// TestWriteUnsupportedProtocolVersion_LogsAResponseTheClientNeverReceived
+// covers the write failing under the refusal, where the status is already on
+// the wire and the log line is the only trace of what was lost.
+func TestWriteUnsupportedProtocolVersion_LogsAResponseTheClientNeverReceived(t *testing.T) {
+	logged := testutil.CaptureSlog(t)
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", strings.NewReader(`{"id":3}`))
+
+	writeUnsupportedProtocolVersion(brokenResponseWriter{rec}, r, []string{"2025-11-25"}, "1999-01-01")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d committed before the body failed", rec.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(logged.String(), "failed to write unsupported-protocol-version response") {
+		t.Errorf("log = %q, want the lost response reported", logged.String())
+	}
+}
+
+// TestStartPeriodicCleanup_RunsOnEveryTickUntilTheContextEnds covers the
+// sweep loop itself, which at its production interval of five minutes no test
+// would ever see tick: the cleanup runs on each tick and stops running once
+// the context ends.
+func TestStartPeriodicCleanup_RunsOnEveryTickUntilTheContextEnds(t *testing.T) {
+	restore := periodicCleanupInterval
+	periodicCleanupInterval = time.Millisecond
+	t.Cleanup(func() { periodicCleanupInterval = restore })
+
+	var ticks atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	startPeriodicCleanup(ctx, func() { ticks.Add(1) })
+
+	deadline := time.Now().Add(testHTTPLivenessTimeout)
+	for ticks.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("cleanup ran %d time(s) at a 1ms interval, want at least 3", ticks.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+
+	// Once the loop has noticed the cancellation the count stops moving.
+	var settled int64
+	for range 50 {
+		settled = ticks.Load()
+		time.Sleep(5 * time.Millisecond)
+		if ticks.Load() == settled {
+			return
+		}
+	}
+	t.Error("cleanup kept running after its context ended")
+}
+
+// TestStartPooledRegistration_WithNothingPending_StartsNothing covers the two
+// ways the post-insert hook finds no work: a server nobody recorded a shell
+// for, which is what a second hook call for the same server sees, and a
+// recorded value that is not a shell at all. Neither may start a goroutine
+// or evict anything.
+func TestStartPooledRegistration_WithNothingPending_StartsNothing(t *testing.T) {
+	t.Parallel()
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "pooled", Version: "0"}, nil)
+	var pending sync.Map
+	var evicted atomic.Int64
+	evict := func() { evicted.Add(1) }
+
+	startPooledRegistration(t.Context(), &pending, srv, evict)
+
+	pending.Store(srv, "not a shell")
+	startPooledRegistration(t.Context(), &pending, srv, evict)
+	if _, still := pending.Load(srv); still {
+		t.Error("an entry that is not a shell was left in the map; the next hook would find it again")
+	}
+	if evicted.Load() != 0 {
+		t.Errorf("evict ran %d time(s) with nothing to register", evicted.Load())
+	}
+}
+
+// TestPrepareStdioCatalog_ResolvesWhatStartupNeedsBeforeOpeningTheGate covers
+// the stdio startup work against a reachable GitLab, which the main-level test
+// cannot see because its client closes the pipe before the first request
+// returns: the identity is published, the tier is detected rather than
+// pinned, and the gate opens only once the catalog is registered. The second
+// case is an instance that answers the version and refuses the user lookup,
+// which still verifies the connection and starts without an identity.
+func TestPrepareStdioCatalog_ResolvesWhatStartupNeedsBeforeOpeningTheGate(t *testing.T) {
+	cases := []struct {
+		name         string
+		userStatus   int
+		wantIdentity bool
+	}{
+		{name: "the user is resolved", userStatus: http.StatusOK, wantIdentity: true},
+		{name: "the user lookup fails", userStatus: http.StatusInternalServerError, wantIdentity: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gitlab := stdioStartupGitLab(t, tc.userStatus)
+			cfg := &config.Config{
+				GitLabURL:      gitlab.URL,
+				GitLabToken:    testToken,
+				ToolSurface:    config.ToolSurfaceDynamic,
+				DisableRetries: true,
+			}
+			client, err := gitlabclient.NewClient(cfg)
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			serverCfg := cfg.ServerConfig()
+			shell, err := newServerShell(t.Context(), client, serverCfg, withTransport(mcpotel.TransportPipe))
+			if err != nil {
+				t.Fatalf("newServerShell: %v", err)
+			}
+			identity := &deferredIdentity{}
+
+			if prepErr := prepareStdioCatalog(t.Context(), client, cfg, serverCfg, shell, identity); prepErr != nil {
+				t.Fatalf("prepareStdioCatalog: %v", prepErr)
+			}
+
+			if !shell.gate.isReady() {
+				t.Error("the readiness gate is still shut after the catalog was registered")
+			}
+			if serverCfg.Tier != edition.Free {
+				t.Errorf("tier = %s, want free detected from an instance with no license endpoint", serverCfg.Tier)
+			}
+			assertStartupIdentity(t, identity.resolved.Load(), tc.wantIdentity)
+		})
+	}
+}
+
+// stdioStartupGitLab answers the two requests stdio startup makes, with the
+// user lookup answering the given status.
+func stdioStartupGitLab(t *testing.T, userStatus int) *httptest.Server {
+	t.Helper()
+	gitlab := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v4/version":
+			testutil.RespondJSON(w, http.StatusOK, `{"version":"17.0.0","revision":"abc"}`)
+		case "/api/v4/user":
+			if userStatus != http.StatusOK {
+				http.Error(w, `{"message":"boom"}`, userStatus)
+				return
+			}
+			testutil.RespondJSON(w, http.StatusOK, `{"id":42,"username":"testuser"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(gitlab.Close)
+	return gitlab
+}
+
+// assertStartupIdentity checks what stdio startup published about the caller.
+func assertStartupIdentity(t *testing.T, resolved *toolutil.UserIdentity, want bool) {
+	t.Helper()
+	if want && (resolved == nil || resolved.UserID != "42" || resolved.Username != "testuser") {
+		t.Errorf("identity = %+v, want user 42 testuser", resolved)
+	}
+	if !want && resolved != nil {
+		t.Errorf("identity = %+v, want none when the user lookup failed", resolved)
+	}
+}
+
+// TestNewServerShell_RateLimitAndProgressNotifications covers two pieces of
+// the shell the ordinary tests leave alone: the tools/call rate limit, which
+// is attached only when a positive rate is configured and says so, and the
+// handler for a client's own progress notifications, which this server only
+// logs, because nothing a client reports about its progress changes what the
+// server does.
+func TestNewServerShell_RateLimitAndProgressNotifications(t *testing.T) {
+	logged := testutil.CaptureSlog(t)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(logged, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	client := newMockGitLabClient(t)
+	shell, err := newServerShell(t.Context(), client, &config.ServerConfig{
+		ToolSurface:    config.ToolSurfaceDynamic,
+		RateLimitRPS:   5,
+		RateLimitBurst: 1,
+	})
+	if err != nil {
+		t.Fatalf("newServerShell: %v", err)
+	}
+	if !strings.Contains(logged.String(), "tools/call rate limit enabled") {
+		t.Errorf("log = %q, want the rate limit announced", logged.String())
+	}
+
+	session := newInMemorySession(t, shell.server)
+	if notifyErr := session.NotifyProgress(t.Context(), &mcp.ProgressNotificationParams{ProgressToken: "upload-1", Progress: 0.5, Message: "halfway"}); notifyErr != nil {
+		t.Fatalf("NotifyProgress: %v", notifyErr)
+	}
+	deadline := time.Now().Add(testHTTPLivenessTimeout)
+	for !strings.Contains(logged.String(), "received progress notification from client") {
+		if time.Now().After(deadline) {
+			t.Fatalf("log = %q, want the client's progress notification recorded", logged.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestRegisterConfiguredToolSurfaceWithCatalog_IndividualPrebuilt_ReportsExclusions
+// covers the individual surface handed a catalog it did not build, which is
+// how the tests reach it: the exclusions are resolved against that catalog,
+// since it is the only one available, and reported the same way the other
+// two surfaces report theirs.
+func TestRegisterConfiguredToolSurfaceWithCatalog_IndividualPrebuilt_ReportsExclusions(t *testing.T) {
+	client := newMockGitLabClient(t)
+	cfg := &config.ServerConfig{ToolSurface: config.ToolSurfaceIndividual, ExcludeTools: []string{"issue.list"}}
+	prebuilt, err := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Tier: edition.Free, IncludeMCP: true})
+	if err != nil {
+		t.Fatalf("BuildActionCatalog: %v", err)
+	}
+	server := mcp.NewServer(&mcp.Implementation{Name: "individual", Version: "0"}, nil)
+
+	registration, err := registerConfiguredToolSurfaceWithCatalog(server, client, cfg, config.ToolSurfaceIndividual, prebuilt)
+	if err != nil {
+		t.Fatalf("registerConfiguredToolSurfaceWithCatalog: %v", err)
+	}
+	if registration.surfaceCatalog != prebuilt {
+		t.Error("the registration did not keep the catalog it was handed")
+	}
+	if !slices.Contains(registration.excludedActions, "issue.list") {
+		t.Errorf("excludedActions = %v, want issue.list resolved against the supplied catalog", registration.excludedActions)
+	}
+}
+
+// TestDoToolSearch_NoMatches_SaysSo covers the search answering nothing: a
+// script grepping the output has to be able to tell "no tool matches" from an
+// empty listing, so the answer is a sentence naming the query rather than
+// silence.
+func TestDoToolSearch_NoMatches_SaysSo(t *testing.T) {
+	stdout := captureStdout(t)
+
+	if err := doToolSearch("zzzz-nothing-is-called-this", config.ToolSurfaceDynamic, edition.Free); err != nil {
+		t.Fatalf("doToolSearch: %v", err)
+	}
+
+	if out := stdout(); !strings.Contains(out, `No tools found matching "zzzz-nothing-is-called-this"`) {
+		t.Errorf("stdout = %q, want the no-match sentence naming the query", out)
+	}
+}
+
 // TestRunStdio_PingSucceeds verifies the success path for Ping in runStdio,
 // where the GitLab mock returns a valid version response.
 func TestRunStdio_PingSucceeds(t *testing.T) {
@@ -3246,6 +3681,146 @@ func TestServeHTTP_OAuthMode_MetadataEndpoint(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_OAuthMode_SeveralInstances_TheHeaderChooses covers the
+// resolver oauth mode verifies against when more than one instance is
+// published: a request naming none is refused before the bearer goes
+// anywhere, one naming an instance outside the list is refused as
+// misaddressed, and one naming a published instance is verified against it
+// and served.
+func TestServeHTTP_OAuthMode_SeveralInstances_TheHeaderChooses(t *testing.T) {
+	first := newMockGitLabServerWithUser(t)
+	second := newMockGitLabServerWithUser(t)
+	cfg := &config.Config{
+		GitLabURL:      first.URL,
+		GitLabURLs:     []string{first.URL, second.URL},
+		MaxHTTPClients: config.DefaultMaxHTTPClients,
+		SessionTimeout: config.DefaultSessionTimeout,
+		ToolSurface:    config.ToolSurfaceDynamic,
+		AuthMode:       config.AuthModeOAuth,
+		PublicURL:      "https://mcp.example.com",
+		OAuthCacheTTL:  config.DefaultOAuthCacheTTL,
+		Stateless:      true,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, errCh := oauthAddr(t, ctx, cfg)
+
+	cases := []struct {
+		name       string
+		instance   string
+		wantStatus int
+		wantBody   string
+	}{
+		{name: "no instance selected", instance: "", wantStatus: http.StatusBadRequest, wantBody: second.URL},
+		{name: "an unpublished instance", instance: "https://unpublished.example.com", wantStatus: http.StatusForbidden, wantBody: "does not serve"},
+		{name: "the second published instance", instance: second.URL, wantStatus: http.StatusOK, wantBody: "protocolVersion"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://"+addr+"/mcp", strings.NewReader(body))
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			req.Header.Set(hdrContentType, mimeJSON)
+			req.Header.Set("Accept", mimeJSONSSE)
+			req.Header.Set("Authorization", "Bearer "+testToken)
+			if tc.instance != "" {
+				req.Header.Set(serverpool.RequestOptionGitLabURL, tc.instance)
+			}
+			resp, err := testHTTPClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			got := readAndCloseBody(t, resp)
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d: %s", resp.StatusCode, tc.wantStatus, got)
+			}
+			if !strings.Contains(got, tc.wantBody) {
+				t.Errorf("body = %q, want it to carry %q", got, tc.wantBody)
+			}
+		})
+	}
+
+	cancel()
+	select {
+	case srvErr := <-errCh:
+		if srvErr != nil {
+			t.Fatalf("serveHTTP error: %v", srvErr)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("shutdown timeout")
+	}
+}
+
+// TestServeHTTP_PinnedApplicationsAndTrustedProxy_AreWiredInBothAuthModes
+// covers the two registrations that depend on configuration nothing else in
+// this file sets: a pinned OAuth application, which oauth mode announces at
+// startup because it turns every personal access token away, and a trusted
+// proxy header, which gives both auth modes a transport budget with its own
+// periodic sweep. What is asserted is the startup line and that the server
+// comes up and serves /health with the extra machinery in place.
+func TestServeHTTP_PinnedApplicationsAndTrustedProxy_AreWiredInBothAuthModes(t *testing.T) {
+	cases := []struct {
+		name     string
+		authMode string
+		wantLog  string
+	}{
+		{name: "oauth mode", authMode: config.AuthModeOAuth, wantLog: "admitting only tokens issued to the pinned OAuth applications"},
+		{name: "legacy mode", authMode: config.AuthModeLegacy, wantLog: "starting MCP server in HTTP mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logged := testutil.CaptureSlog(t)
+			gitlab := newMockGitLabServerWithUser(t)
+			cfg := &config.Config{
+				GitLabURL:          gitlab.URL,
+				MaxHTTPClients:     config.DefaultMaxHTTPClients,
+				SessionTimeout:     config.DefaultSessionTimeout,
+				ToolSurface:        config.ToolSurfaceDynamic,
+				AuthMode:           tc.authMode,
+				PublicURL:          "https://mcp.example.com",
+				OAuthCacheTTL:      config.DefaultOAuthCacheTTL,
+				OAuthClientUIDs:    []string{"0123456789abcdef"},
+				TrustedProxyHeader: "X-Forwarded-For",
+				TrustedProxies:     []string{"127.0.0.1"},
+				Stateless:          true,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			addr, errCh := oauthAddr(t, ctx, cfg)
+
+			if !strings.Contains(logged.String(), tc.wantLog) {
+				t.Errorf("startup log = %q, want it to carry %q", logged.String(), tc.wantLog)
+			}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			resp, err := testHTTPClient.Do(req)
+			if err != nil {
+				t.Fatalf("health request: %v", err)
+			}
+			readAndCloseBody(t, resp)
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("/health = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+
+			cancel()
+			select {
+			case srvErr := <-errCh:
+				if srvErr != nil {
+					t.Fatalf("serveHTTP error: %v", srvErr)
+				}
+			case <-time.After(testHTTPLivenessTimeout):
+				t.Fatal("shutdown timeout")
+			}
+		})
+	}
+}
+
 // TestServeHTTP_OAuthMode_RejectsUnauthenticated verifies that OAuth mode
 // rejects requests without a Bearer token with 401.
 func TestServeHTTP_OAuthMode_RejectsUnauthenticated(t *testing.T) {
@@ -4199,6 +4774,122 @@ func TestServeHTTP_ShutdownDuringServerCardBuild_DrainsCleanly(t *testing.T) {
 	// Release the gated builder only after the assertions: its goroutine
 	// outlives serveHTTPOn by design, and must not touch the restored seam.
 	close(releaseBuild)
+}
+
+// TestServeHTTP_ServerCardBuildFails_AnswersUnavailableAndStaysUp covers a
+// card that cannot be built: the endpoint answers 503 rather than a broken
+// document, the failure is cached the way a success would be so the build is
+// not retried on every fetch, and the rest of the server is unaffected.
+//
+// Deliberately not parallel: the builder seam is a package global.
+func TestServeHTTP_ServerCardBuildFails_AnswersUnavailableAndStaysUp(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	var builds atomic.Int64
+	origBuild := buildServerCardFn
+	buildServerCardFn = func(context.Context, *config.Config) ([]byte, error) {
+		builds.Add(1)
+		return nil, errors.New("the catalog would not marshal")
+	}
+	t.Cleanup(func() { buildServerCardFn = origBuild })
+
+	addr, shutdown := startStatelessServeHTTP(t, statelessTestConfig(gitlab.URL, false))
+	defer shutdown()
+
+	for attempt := range 2 {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+serverCardPath, nil)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		resp, err := testHTTPClient.Do(req)
+		if err != nil {
+			t.Fatalf("card request %d: %v", attempt, err)
+		}
+		body := readAndCloseBody(t, resp)
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("card request %d = %d, want %d: %s", attempt, resp.StatusCode, http.StatusServiceUnavailable, body)
+		}
+	}
+	if builds.Load() != 1 {
+		t.Errorf("the card was built %d time(s), want once: a failed build is cached like a successful one", builds.Load())
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := testHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("health request: %v", err)
+	}
+	readAndCloseBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/health = %d after a failed card build, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// TestServeHTTP_ServerCardRequestAbandonedMidBuild_DoesNotPoisonTheCard covers
+// a fetcher that gives up while the first build is still running: its handler
+// is released at once rather than left waiting for a build it will never read,
+// and the build itself carries on, so the next fetcher gets the finished card.
+//
+// Deliberately not parallel: the builder seam is a package global.
+func TestServeHTTP_ServerCardRequestAbandonedMidBuild_DoesNotPoisonTheCard(t *testing.T) {
+	gitlab := newMockGitLabServer(t)
+	buildStarted := make(chan struct{})
+	releaseBuild := make(chan struct{})
+	origBuild := buildServerCardFn
+	buildServerCardFn = func(context.Context, *config.Config) ([]byte, error) {
+		close(buildStarted)
+		<-releaseBuild
+		return []byte(`{"name":"card"}`), nil
+	}
+	t.Cleanup(func() { buildServerCardFn = origBuild })
+
+	addr, shutdown := startStatelessServeHTTP(t, statelessTestConfig(gitlab.URL, false))
+	defer shutdown()
+
+	// The first fetcher, which abandons its request once the build is in
+	// flight. Its own outcome is a transport error and is not asserted on:
+	// what matters is what the next fetcher sees.
+	abandonCtx, abandon := context.WithCancel(t.Context())
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		req, reqErr := http.NewRequestWithContext(abandonCtx, http.MethodGet, "http://"+addr+serverCardPath, nil)
+		if reqErr != nil {
+			t.Errorf("build card request: %v", reqErr)
+			return
+		}
+		if resp, doErr := testHTTPClient.Do(req); doErr == nil {
+			resp.Body.Close()
+		}
+	}()
+	select {
+	case <-buildStarted:
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("card build never started")
+	}
+	abandon()
+	<-firstDone
+	// The handler learns of the disconnect from the connection's background
+	// read, which is asynchronous to the client returning; the build is held a
+	// little longer so the release does not race that read, since a handler
+	// that sees both the finished build and the gone client picks either.
+	time.Sleep(100 * time.Millisecond)
+
+	close(releaseBuild)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+serverCardPath, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := testHTTPClient.Do(req)
+	if err != nil {
+		t.Fatalf("second card request: %v", err)
+	}
+	body := readAndCloseBody(t, resp)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(body, `"card"`) {
+		t.Errorf("second card request = %d %q, want the finished card", resp.StatusCode, body)
+	}
 }
 
 // TestBuildServerCard_MinimalCapabilitySurface verifies that server-card
@@ -7999,6 +8690,50 @@ func TestSSEAwareWriter_ABrokenStream_EndsItsHeartbeat(t *testing.T) {
 	writer.stopKeepAlive()
 }
 
+// TestSSEAwareWriter_AClientThatWentAway_EndsItsHeartbeat covers the third
+// way the heartbeat goroutine exits: the request context ending because the
+// client disconnected, as opposed to the handler returning or a write failing.
+//
+// A stream whose reader is gone has nobody to keep alive, and a goroutine
+// ticking every twenty-five seconds for the rest of the process would be the
+// leak this exit prevents. The interval is left at its default on purpose:
+// the exit must come from the disconnect signal alone, before any tick.
+func TestSSEAwareWriter_AClientThatWentAway_EndsItsHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set(hdrContentType, "text/event-stream")
+	disconnected := make(chan struct{})
+	writer := &sseAwareWriter{ResponseWriter: rec, disconnected: disconnected}
+
+	writer.WriteHeader(http.StatusOK)
+	if writer.done == nil {
+		t.Fatal("no heartbeat was started for a response that committed to text/event-stream")
+	}
+
+	close(disconnected)
+	select {
+	case <-writer.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the heartbeat is still running for a client that disconnected")
+	}
+	writer.stopKeepAlive()
+}
+
+// TestSSEAwareWriter_Unwrap_ExposesTheConnection pins the method
+// http.NewResponseController relies on: the SDK sets write deadlines through
+// the controller, and a wrapper that did not unwrap would stop it at a type
+// that has no deadline to set, silently leaving every stream on the default.
+func TestSSEAwareWriter_Unwrap_ExposesTheConnection(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	writer := &sseAwareWriter{ResponseWriter: rec}
+	if got := writer.Unwrap(); got != http.ResponseWriter(rec) {
+		t.Errorf("Unwrap() = %T, want the wrapped recorder", got)
+	}
+}
+
 // TestServeStdio_TheTwoDocumentedShutdowns_ExitCleanly pins the exit status of
 // the two ways an stdio session is meant to end.
 //
@@ -8719,6 +9454,67 @@ func TestShutdownHTTPServer_NothingInFlight_ReturnsWithoutSpendingTheBudget(t *t
 	}
 }
 
+// closeFailingListener is a listener whose socket the kernel will not
+// release: Close closes the underlying socket, so the serve loop ends the way
+// it always does, and still reports an error.
+type closeFailingListener struct {
+	net.Listener
+	closeErr error
+}
+
+func (l *closeFailingListener) Close() error {
+	_ = l.Listener.Close()
+	return l.closeErr
+}
+
+// TestShutdownHTTPServer_AListenerThatWillNotClose_IsReported covers the one
+// error the drain still reports after an exhausted budget stopped being one.
+//
+// A listener whose close fails is a real failure rather than a late
+// connection: nothing was drained badly, the socket itself could not be
+// released, and the process is about to exit believing it was. Shutdown
+// carries that error out once the server is idle, and it must not be
+// mistaken for the budget running out, which is answered with a forced close
+// and no error at all.
+func TestShutdownHTTPServer_AListenerThatWillNotClose_IsReported(t *testing.T) {
+	bound, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	listener := &closeFailingListener{Listener: bound, closeErr: errors.New("socket held by the kernel")}
+	httpServer := newHTTPServer("", http.NotFoundHandler(), defaultHTTPIdleTimeout)
+	served := make(chan error, 1)
+	go func() { served <- httpServer.Serve(listener) }()
+	// One answered request proves Serve is tracking the listener, so the
+	// drain has a listener to close rather than racing the serve loop's start.
+	req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+bound.Addr().String()+"/", nil)
+	if reqErr != nil {
+		t.Fatalf("build request: %v", reqErr)
+	}
+	resp, doErr := testHTTPClient.Do(req)
+	if doErr != nil {
+		t.Fatalf("request: %v", doErr)
+	}
+	readAndCloseBody(t, resp)
+	testHTTPClient.CloseIdleConnections()
+
+	shutdownErr := shutdownHTTPServer(t.Context(), httpServer)
+	if shutdownErr == nil {
+		t.Fatal("shutdownHTTPServer() = nil, want the listener's close failure reported")
+	}
+	if !strings.Contains(shutdownErr.Error(), "http server shutdown") || !errors.Is(shutdownErr, listener.closeErr) {
+		t.Errorf("shutdownHTTPServer() = %q, want the drain's wrapping of the listener's error", shutdownErr)
+	}
+	select {
+	case serveErr := <-served:
+		if !errors.Is(serveErr, http.ErrServerClosed) {
+			t.Errorf("Serve() = %v, want ErrServerClosed: the socket itself was closed", serveErr)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("Serve did not return after the listener was closed")
+	}
+}
+
 // TestHTTPShutdownBudget_TakesTheSmallerOfTheDefaultAndTheCallersDeadline
 // verifies the arithmetic on its own, with no server to drain.
 //
@@ -8782,6 +9578,18 @@ func cancelledDeadlineContext(t *testing.T, in time.Duration) context.Context {
 func blockedHTTPServer(t *testing.T) *http.Server {
 	t.Helper()
 
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return blockedHTTPServerOn(t, listener)
+}
+
+// blockedHTTPServerOn is [blockedHTTPServer] serving on a listener the caller
+// supplies, for the tests that need to see what the server does with it.
+func blockedHTTPServerOn(t *testing.T, listener net.Listener) *http.Server {
+	t.Helper()
+
 	var enteredOnce sync.Once
 	entered := make(chan struct{})
 	release := make(chan struct{})
@@ -8790,10 +9598,6 @@ func blockedHTTPServer(t *testing.T) *http.Server {
 		<-release
 	}), defaultHTTPIdleTimeout)
 
-	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
 	go func() { _ = httpServer.Serve(listener) }()
 
 	callDone := make(chan struct{})

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2487,6 +2487,26 @@ func TestRunStdio_ACatalogThatCannotBeBuilt_StopsTheServer(t *testing.T) {
 	}
 }
 
+// captureLogMessages installs a default logger that records every message at
+// DEBUG and above, and returns a function reporting whether any recorded
+// message contains the given text. The record is guarded by a mutex, so it
+// is safe to consult while goroutines the test started are still logging,
+// which a plain buffer is not.
+func captureLogMessages(t *testing.T) func(substring string) bool {
+	t.Helper()
+	var mu sync.Mutex
+	var messages []string
+	capture := levelCapturingHandler{threshold: slog.LevelDebug, mu: &mu, messages: &messages}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return func(substring string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.ContainsFunc(messages, func(message string) bool { return strings.Contains(message, substring) })
+	}
+}
+
 // TestRunStdio_StartupOutlivingTheClient_IsCutOffAtTheDrain covers the bound
 // on the wait for startup work: a client that leaves while the catalog is
 // still being built is not held for the whole build, only for the drain,
@@ -2502,18 +2522,7 @@ func TestRunStdio_StartupOutlivingTheClient_IsCutOffAtTheDrain(t *testing.T) {
 	restoreDrain := stdioStartupDrainTimeout
 	stdioStartupDrainTimeout = time.Millisecond
 	t.Cleanup(func() { stdioStartupDrainTimeout = restoreDrain })
-
-	var mu sync.Mutex
-	var messages []string
-	capture := levelCapturingHandler{threshold: slog.LevelDebug, mu: &mu, messages: &messages}
-	previous := slog.Default()
-	slog.SetDefault(slog.New(capture))
-	t.Cleanup(func() { slog.SetDefault(previous) })
-	logged := func(message string) bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return slices.Contains(messages, message)
-	}
+	logged := captureLogMessages(t)
 
 	// A closed pipe: EOF at once, so serving ends while the build is running.
 	reader, writer, err := os.Pipe()
@@ -3128,8 +3137,7 @@ func assertStartupIdentity(t *testing.T, resolved *toolutil.UserIdentity, want b
 // logs, because nothing a client reports about its progress changes what the
 // server does.
 func TestNewServerShell_RateLimitAndProgressNotifications(t *testing.T) {
-	logged := testutil.CaptureSlog(t)
-	slog.SetDefault(slog.New(slog.NewJSONHandler(logged, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	logged := captureLogMessages(t)
 
 	client := newMockGitLabClient(t)
 	shell, err := newServerShell(t.Context(), client, &config.ServerConfig{
@@ -3140,8 +3148,8 @@ func TestNewServerShell_RateLimitAndProgressNotifications(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newServerShell: %v", err)
 	}
-	if !strings.Contains(logged.String(), "tools/call rate limit enabled") {
-		t.Errorf("log = %q, want the rate limit announced", logged.String())
+	if !logged("tools/call rate limit enabled") {
+		t.Error("the rate limit was attached without being announced")
 	}
 
 	session := newInMemorySession(t, shell.server)
@@ -3149,9 +3157,9 @@ func TestNewServerShell_RateLimitAndProgressNotifications(t *testing.T) {
 		t.Fatalf("NotifyProgress: %v", notifyErr)
 	}
 	deadline := time.Now().Add(testHTTPLivenessTimeout)
-	for !strings.Contains(logged.String(), "received progress notification from client") {
+	for !logged("received progress notification from client") {
 		if time.Now().After(deadline) {
-			t.Fatalf("log = %q, want the client's progress notification recorded", logged.String())
+			t.Fatal("the client's progress notification was never recorded")
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -4305,7 +4313,7 @@ func TestServeHTTP_PinnedApplicationsAndTrustedProxy_AreWiredInBothAuthModes(t *
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logged := testutil.CaptureSlog(t)
+			logged := captureLogMessages(t)
 			gitlab := newMockGitLabServerWithUser(t)
 			cfg := &config.Config{
 				GitLabURL:          gitlab.URL,
@@ -4325,8 +4333,8 @@ func TestServeHTTP_PinnedApplicationsAndTrustedProxy_AreWiredInBothAuthModes(t *
 			defer cancel()
 			addr, errCh := oauthAddr(t, ctx, cfg)
 
-			if !strings.Contains(logged.String(), tc.wantLog) {
-				t.Errorf("startup log = %q, want it to carry %q", logged.String(), tc.wantLog)
+			if !logged(tc.wantLog) {
+				t.Errorf("startup log lacks %q", tc.wantLog)
 			}
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+addr+"/health", nil)
 			if err != nil {
@@ -9440,13 +9448,35 @@ func TestServeStdio_TheTwoDocumentedShutdowns_ExitCleanly(t *testing.T) {
 // failure and exits non-zero, which is what a supervisor's restart policy
 // acts on. A context deadline is the reachable stand-in here, since it ends
 // the run without the client closing its pipe and without a cancellation.
+//
+// The SDK's Run cannot return while its read loop is parked on stdin, and
+// nothing in the stdio binding interrupts that read, so once the deadline
+// has passed the pipe's read end is closed from here: that ends the loop
+// with an error that is not EOF, which is not a client hanging up, and Run
+// then reports the deadline it had already chosen.
 func TestServeStdio_AnyOtherEnd_IsReportedAsAFailure(t *testing.T) {
-	heldOpenStdin(t)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	original := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = original
+		_ = writer.Close()
+		_ = reader.Close()
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	done := make(chan error, 1)
 	go func() { done <- serveStdio(ctx, newTestMCPServer(t)) }()
+
+	<-ctx.Done()
+	// Long enough for Run to have taken the deadline's branch, where it waits
+	// on the session, before the session is made to end.
+	time.Sleep(500 * time.Millisecond)
+	_ = reader.Close()
 
 	select {
 	case serveErr := <-done:
@@ -9454,7 +9484,7 @@ func TestServeStdio_AnyOtherEnd_IsReportedAsAFailure(t *testing.T) {
 			t.Errorf("serveStdio() = %v, want the deadline reported as a server error", serveErr)
 		}
 	case <-time.After(testHTTPLivenessTimeout):
-		t.Fatal("serveStdio did not return after its context expired")
+		t.Fatal("serveStdio did not return after its context expired and its input ended")
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2596,6 +2596,28 @@ func TestServeHTTP_APooledCatalogThatCannotBeBuilt_IsEvicted(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_AShellThatCannotBeBuilt_IsAnsweredUnavailable covers the
+// pool factory refusing to build a shell at all, which a malformed
+// description substitution does when the listener was brought up without
+// runHTTP's startup validation in front of it. The request is answered as an
+// upstream failure rather than served from nothing, and the reason stays
+// out of the response.
+func TestServeHTTP_AShellThatCannotBeBuilt_IsAnsweredUnavailable(t *testing.T) {
+	t.Setenv(gatewaycompat.EnvVar, "=x")
+	gitlab := newMockGitLabServer(t)
+	addr, shutdown := startStatelessServeHTTP(t, statelessTestConfig(gitlab.URL, true))
+	defer shutdown()
+
+	resp := postStatelessJSONRPC(t, addr, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	body := readAndCloseBody(t, resp)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d: %s", resp.StatusCode, http.StatusServiceUnavailable, body)
+	}
+	if strings.Contains(body, gatewaycompat.EnvVar) {
+		t.Errorf("body = %q leaks the deployment's configuration to the client", body)
+	}
+}
+
 // TestCreateServer_ARegistrationFailure_IsReturned covers the two callers
 // that want a finished server and get a failure instead: createServer itself,
 // and the server card built on top of it.
@@ -9410,6 +9432,29 @@ func TestServeStdio_TheTwoDocumentedShutdowns_ExitCleanly(t *testing.T) {
 				t.Fatal("serveStdio did not return")
 			}
 		})
+	}
+}
+
+// TestServeStdio_AnyOtherEnd_IsReportedAsAFailure is the counterweight to the
+// two documented shutdowns: a session that ends for any other reason is a
+// failure and exits non-zero, which is what a supervisor's restart policy
+// acts on. A context deadline is the reachable stand-in here, since it ends
+// the run without the client closing its pipe and without a cancellation.
+func TestServeStdio_AnyOtherEnd_IsReportedAsAFailure(t *testing.T) {
+	heldOpenStdin(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- serveStdio(ctx, newTestMCPServer(t)) }()
+
+	select {
+	case serveErr := <-done:
+		if !errors.Is(serveErr, context.DeadlineExceeded) || !strings.Contains(serveErr.Error(), "mcp server error") {
+			t.Errorf("serveStdio() = %v, want the deadline reported as a server error", serveErr)
+		}
+	case <-time.After(testHTTPLivenessTimeout):
+		t.Fatal("serveStdio did not return after its context expired")
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8798,6 +8798,106 @@ func TestMain_VersionAndToolSearch_ExitBeforeAnythingIsStarted(t *testing.T) {
 	}
 }
 
+// TestMain_ProcessLevelModes_ExitThroughTheSeam covers the argument forms
+// that end the process with a status code, every one of which now leaves
+// through exitProcess so the code can be read back here: a transport nobody
+// recognizes, --shutdown with nothing to stop, --probe of a listener that
+// answers, and an HTTP deployment that names no instance. The first case is
+// --version again, carrying the two flags main handles before it prints:
+// --env-file, which has to reach the environment before anything reads it,
+// and --meta-tools, which is recorded as explicitly set.
+//
+// --shutdown runs under a private process name, because with the real one it
+// would find, and stop, any server the machine running this test is serving.
+func TestMain_ProcessLevelModes_ExitThroughTheSeam(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "server.env")
+	health := httptest.NewServer(healthMux(http.StatusOK))
+	t.Cleanup(health.Close)
+
+	cases := []struct {
+		name       string
+		args       []string
+		wantExit   []int
+		wantStdout string
+		// verify runs after main returned, for what the mode leaves behind.
+		verify func(t *testing.T)
+	}{
+		{
+			name:       "--version carrying --env-file and --meta-tools",
+			args:       []string{"gitlab-mcp-server", "-version", "-env-file", envFile, "-meta-tools"},
+			wantStdout: version,
+			verify: func(t *testing.T) {
+				t.Helper()
+				if got := os.Getenv(config.EnvFileVar); got != envFile {
+					t.Errorf("%s = %q after --env-file, want %q", config.EnvFileVar, got, envFile)
+				}
+			},
+		},
+		{
+			name:     "a transport nobody recognizes exits 2",
+			args:     []string{"gitlab-mcp-server", "-transport", "carrier-pigeon"},
+			wantExit: []int{2},
+		},
+		{
+			name:     "--shutdown with no instance running exits 0",
+			args:     []string{filepath.Join(t.TempDir(), peerName(t)), "-shutdown"},
+			wantExit: []int{0},
+		},
+		{
+			name:     "--probe of a listener that answers exits 0",
+			args:     []string{"gitlab-mcp-server", "-probe", health.URL + "/health"},
+			wantExit: []int{0},
+		},
+		{
+			name:     "--http naming no instance exits 1",
+			args:     []string{"gitlab-mcp-server", "-http"},
+			wantExit: []int{1},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			withFreshFlagSet(t)
+			// Claimed through t.Setenv so what main writes reverts with the
+			// test, and cleared so no instance from the environment turns the
+			// HTTP case into a working server.
+			t.Setenv(config.EnvFileVar, "")
+			t.Setenv("GITLAB_URL", "")
+			t.Setenv("GITLAB_TOKEN", "")
+			t.Setenv("GITLAB_MCP_TELEMETRY", "")
+
+			var exits []int
+			originalExit := exitProcess
+			exitProcess = func(code int) { exits = append(exits, code) }
+			originalArgs, originalLogger, originalBase := os.Args, slog.Default(), baseLogHandler
+			os.Args = tt.args
+			t.Cleanup(func() {
+				exitProcess = originalExit
+				os.Args = originalArgs
+				slog.SetDefault(originalLogger)
+				baseLogHandler = originalBase
+				// The HTTP case switches the filesystem policy for the
+				// process; every other test here runs as stdio.
+				toolutil.SetLocalFilesystemAccess(true)
+			})
+			stdout := captureStdout(t)
+
+			main()
+
+			printed := stdout()
+			if tt.wantStdout != "" && !strings.Contains(printed, tt.wantStdout) {
+				t.Errorf("stdout = %q, want it to carry %q", printed, tt.wantStdout)
+			}
+			if !slices.Equal(exits, tt.wantExit) {
+				t.Errorf("exit codes = %v, want %v", exits, tt.wantExit)
+			}
+			if tt.verify != nil {
+				tt.verify(t)
+			}
+		})
+	}
+}
+
 // TestMain_StdioMode_StartsAndStopsWithTheClient covers the ordinary path all
 // the way through main: no flags, credentials from the environment, and a
 // client that closes its pipe.

--- a/cmd/server/probe_linux_test.go
+++ b/cmd/server/probe_linux_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestPeerStdinIsNull_ReadsTheProcessFileDescriptor covers the procfs read
+// behind a discovered --transport auto instance, against real children
+// rather than a fabricated tree: the null device is what a container started
+// without -i gives, and a pipe is what every MCP client gives.
+//
+// A child with no Stdin set is the null-device case, because that is what
+// os/exec connects file descriptor 0 to when nothing is supplied.
+func TestPeerStdinIsNull_ReadsTheProcessFileDescriptor(t *testing.T) {
+	t.Parallel()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	cases := []struct {
+		name  string
+		stdin *os.File
+		want  bool
+	}{
+		{name: "a child reading the null device", stdin: nil, want: true},
+		{name: "a child reading a pipe", stdin: reader, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			child := exec.CommandContext(t.Context(), "/bin/sleep", "30")
+			if tc.stdin != nil {
+				child.Stdin = tc.stdin
+			}
+			if startErr := child.Start(); startErr != nil {
+				t.Skipf("cannot start a child process: %v", startErr)
+			}
+			t.Cleanup(func() {
+				_ = child.Process.Kill()
+				_ = child.Wait()
+			})
+
+			got, readErr := peerStdinIsNull(pid32(t, child.Process.Pid))
+			if readErr != nil {
+				t.Fatalf("peerStdinIsNull: %v", readErr)
+			}
+			if got != tc.want {
+				t.Errorf("peerStdinIsNull = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/server/probe_test.go
+++ b/cmd/server/probe_test.go
@@ -18,11 +18,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/shirou/gopsutil/v4/process"
 )
 
 // TestParseListenerFlags_ReadsEverySpelling covers the flag spellings the flag
@@ -566,5 +569,115 @@ func TestLivePeers_ExcludesThisProcess(t *testing.T) {
 		if len(p.args) == 0 {
 			t.Errorf("livePeers returned pid %d with no command line", p.pid)
 		}
+	}
+}
+
+// TestLivePeers_ListsRunningPeersAndSkipsOnesWithoutACommandLine covers what
+// the probe reads off the process table: a running instance with its command
+// line, and nothing for a process that has no command line to read.
+//
+// The second is a real shape rather than a defensive one. A process that has
+// exited but not yet been reaped is still listed under its name, so
+// discovery finds it, and its command line is empty, so there is no listener
+// to derive from it. Listing it would send the probe to the default port on
+// behalf of a process that serves nothing.
+func TestLivePeers_ListsRunningPeersAndSkipsOnesWithoutACommandLine(t *testing.T) {
+	binary := buildPeer(t, filepath.Join(t.TempDir(), peerName(t)))
+	withArgv0(t, binary)
+	running := startPeer(t, binary, nil)
+
+	// Started and killed but deliberately not reaped until the test ends, so
+	// it stays in the table as a zombie for the duration of the assertions.
+	zombie := exec.CommandContext(t.Context(), binary)
+	if err := zombie.Start(); err != nil {
+		t.Fatalf("starting the peer that will become a zombie: %v", err)
+	}
+	t.Cleanup(func() { _ = zombie.Wait() })
+	if err := zombie.Process.Kill(); err != nil {
+		t.Fatalf("killing the peer: %v", err)
+	}
+
+	runningPID := pid32(t, running.cmd.Process.Pid)
+	zombiePID := pid32(t, zombie.Process.Pid)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		peers, err := livePeers()
+		if err != nil {
+			t.Fatalf("livePeers: %v", err)
+		}
+		var sawRunning, sawZombie bool
+		for _, p := range peers {
+			switch p.pid {
+			case runningPID:
+				sawRunning = true
+				if len(p.args) == 0 || p.args[0] != binary {
+					t.Errorf("pid %d listed with args %q, want its command line starting with %q", p.pid, p.args, binary)
+				}
+			case zombiePID:
+				sawZombie = true
+			}
+		}
+		if sawRunning && !sawZombie {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("after 10s: running peer listed=%v, zombie listed=%v; want the running one and not the zombie", sawRunning, sawZombie)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestLivePeers_ProcessListingFails_ReturnsTheError pins that discovery
+// reports an unreadable process table rather than answering "no instances",
+// which --probe would turn into an unhealthy verdict with the wrong cause.
+func TestLivePeers_ProcessListingFails_ReturnsTheError(t *testing.T) {
+	original := listProcesses
+	t.Cleanup(func() { listProcesses = original })
+	listProcesses = func() ([]*process.Process, error) {
+		return nil, errors.New("procfs is not mounted")
+	}
+
+	peers, err := livePeers()
+	if err == nil || !strings.Contains(err.Error(), "procfs is not mounted") {
+		t.Fatalf("livePeers() = %v, %v; want the listing's error", peers, err)
+	}
+}
+
+// TestRunProbe_ATargetThatCannotBecomeARequest_IsUnhealthy covers a host:port
+// that splits cleanly and still cannot be asked: net.SplitHostPort accepts any
+// host text, and the URL built from it is what refuses the space.
+func TestRunProbe_ATargetThatCannotBecomeARequest_IsUnhealthy(t *testing.T) {
+	t.Parallel()
+	var said bytes.Buffer
+	code := runProbe(t.Context(), []string{"a b:80"}, "", probeDeps{}, &said)
+	if code != probeUnhealthy {
+		t.Errorf("runProbe(%q) = %d, want %d: %s", "a b:80", code, probeUnhealthy, said.String())
+	}
+	if !strings.Contains(said.String(), "invalid character") {
+		t.Errorf("runProbe said %q, want the URL parser's complaint about the host", said.String())
+	}
+}
+
+// TestCertificateName_PrefersDNSThenIPThenCommonName pins the name the probe
+// asks a pinned listener to answer to, in the order the certificate's own
+// contents decide it.
+func TestCertificateName_PrefersDNSThenIPThenCommonName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cert *x509.Certificate
+		want string
+	}{
+		{name: "a DNS name wins", cert: &x509.Certificate{DNSNames: []string{"mcp.example"}, IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)}, Subject: pkix.Name{CommonName: "cn"}}, want: "mcp.example"},
+		{name: "an IP address without DNS names", cert: &x509.Certificate{IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)}, Subject: pkix.Name{CommonName: "cn"}}, want: "127.0.0.1"},
+		{name: "the common name is the last resort", cert: &x509.Certificate{Subject: pkix.Name{CommonName: "cn"}}, want: "cn"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := certificateName(tc.cert); got != tc.want {
+				t.Errorf("certificateName() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/server/shutdown.go
+++ b/cmd/server/shutdown.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,11 @@ import (
 // shutdownGracePeriod is the maximum time runShutdown waits after graceful
 // termination before force-killing remaining peer processes.
 const shutdownGracePeriod = 5 * time.Second
+
+// listProcesses enumerates every process on the machine. A variable because
+// the listing fails only when procfs itself is unreadable, which no input to
+// this binary produces, and the branch that reports it is otherwise never run.
+var listProcesses = process.Processes //nolint:gochecknoglobals // test seam
 
 // runShutdown finds all running instances of this binary (excluding self),
 // sends SIGTERM (Unix) / TerminateProcess (Windows), waits up to 5 seconds
@@ -52,6 +58,17 @@ func runShutdown() int {
 	}
 
 forceKill:
+	forceKillPeers(peers, os.Stderr)
+	return 0
+}
+
+// forceKillPeers kills every peer still running once the grace period has
+// lapsed, and reports the outcome on stderr.
+//
+// Zero kills is a possible outcome rather than a contradiction: a peer can
+// exit between the last poll and the deadline, and then there is nothing left
+// to kill and nothing to complain about.
+func forceKillPeers(peers []*process.Process, stderr io.Writer) {
 	var killed int
 	for _, p := range peers {
 		running, _ := p.IsRunning()
@@ -61,11 +78,10 @@ forceKill:
 		}
 	}
 	if killed > 0 {
-		fmt.Fprintf(os.Stderr, "shutdown: force-killed %d instance(s)\n", killed)
-	} else {
-		fmt.Fprintf(os.Stderr, "shutdown: all instances terminated\n")
+		fmt.Fprintf(stderr, "shutdown: force-killed %d instance(s)\n", killed)
+		return
 	}
-	return 0
+	fmt.Fprintf(stderr, "shutdown: all instances terminated\n")
 }
 
 // findPeers returns all running processes matching this binary's base name,
@@ -76,7 +92,7 @@ func findPeers() ([]*process.Process, error) {
 	self := os.Getpid()
 	baseName := canonicalBinaryName(filepath.Base(os.Args[0]))
 
-	all, err := process.Processes()
+	all, err := listProcesses()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/server/shutdown_test.go
+++ b/cmd/server/shutdown_test.go
@@ -11,12 +11,15 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -192,6 +195,100 @@ func TestRunShutdown_RunningPeers_AreStoppedBeforeItReturns(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRunShutdown_ProcessListingFails_ReportsAndExitsNonZero covers the one
+// error --shutdown can meet before it has done anything: the process table
+// could not be read.
+//
+// An updater acts on the exit status, and this is the case where "found
+// nothing" would be a lie: nothing was looked at. The listing is replaced
+// through its seam because procfs cannot be made unreadable from a test.
+func TestRunShutdown_ProcessListingFails_ReportsAndExitsNonZero(t *testing.T) {
+	original := listProcesses
+	t.Cleanup(func() { listProcesses = original })
+	listProcesses = func() ([]*process.Process, error) {
+		return nil, errors.New("procfs is not mounted")
+	}
+
+	if got := runShutdown(); got != 1 {
+		t.Errorf("runShutdown() = %d when the process table is unreadable, want 1", got)
+	}
+
+	_, err := findPeers()
+	if err == nil || !strings.Contains(err.Error(), "procfs is not mounted") {
+		t.Errorf("findPeers() error = %v, want the listing's own error passed through", err)
+	}
+}
+
+// TestFindPeers_AProcessThatVanishedAfterTheListing_IsSkipped covers the gap
+// between enumerating the table and reading a name from it: a process that
+// exited in between has no name to read and must be passed over rather than
+// fail the whole lookup, which would abort a --shutdown over a process that is
+// already gone.
+//
+// The listing is injected because the gap is otherwise a race against the
+// machine's own process churn: on a busy host it was hit by luck and on a
+// quiet one never.
+func TestFindPeers_AProcessThatVanishedAfterTheListing_IsSkipped(t *testing.T) {
+	withArgv0(t, filepath.Join(t.TempDir(), peerName(t)))
+	gone := &process.Process{Pid: pid32(t, exitedPID(t))}
+	original := listProcesses
+	t.Cleanup(func() { listProcesses = original })
+	listProcesses = func() ([]*process.Process, error) {
+		return []*process.Process{gone}, nil
+	}
+
+	peers, err := findPeers()
+	if err != nil {
+		t.Fatalf("findPeers() error = %v, want nil: a vanished process is not a failure", err)
+	}
+	if len(peers) != 0 {
+		t.Errorf("findPeers() = %d peer(s), want none: the only listed process has no name to match", len(peers))
+	}
+}
+
+// TestForceKillPeers_ReportsWhatItDid covers the phase after the grace period,
+// in both of its outcomes.
+//
+// The second outcome is the one runShutdown cannot be made to reach on
+// purpose: a peer that stops between the last poll and the deadline is gone by
+// the time the kill runs, and then there is nothing to kill and nothing to
+// complain about. Reaching it through runShutdown would mean racing a
+// process exit against a five-second timer, so the phase is exercised
+// directly with a pid that has already exited and been reaped.
+func TestForceKillPeers_ReportsWhatItDid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the peer cannot decline TerminateProcess, so there is no wedged peer to kill")
+	}
+
+	binary := buildPeer(t, filepath.Join(t.TempDir(), peerName(t)))
+	wedged := startPeer(t, binary, []string{peerIgnoreTermEnv + "=1"})
+	alive := &process.Process{Pid: pid32(t, wedged.cmd.Process.Pid)}
+	gone := &process.Process{Pid: pid32(t, exitedPID(t))}
+
+	tests := []struct {
+		name  string
+		peers []*process.Process
+		want  string
+	}{
+		{name: "nothing left to kill", peers: []*process.Process{gone}, want: "shutdown: all instances terminated\n"},
+		{name: "a wedged peer is killed", peers: []*process.Process{gone, alive}, want: "shutdown: force-killed 1 instance(s)\n"},
+	}
+
+	// Order matters: the second case kills the peer the first leaves alone.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var said bytes.Buffer
+			forceKillPeers(tt.peers, &said)
+			if said.String() != tt.want {
+				t.Errorf("forceKillPeers said %q, want %q", said.String(), tt.want)
+			}
+		})
+	}
+	if !wedged.exited(t) {
+		t.Error("the peer that ignores SIGTERM survived the kill")
 	}
 }
 

--- a/cmd/server/socket_mode_unix.go
+++ b/cmd/server/socket_mode_unix.go
@@ -167,6 +167,12 @@ var (
 	lstatStagedSocket = os.Lstat        //nolint:gochecknoglobals // test seam
 	mkdirStagingDir   = os.Mkdir        //nolint:gochecknoglobals // test seam
 	readRandomName    = cryptorand.Read //nolint:gochecknoglobals // test seam
+	// The two descriptor calls restrictDirToOwner makes on the staging
+	// directory it just opened. fchmod cannot fail for the owner of a fresh
+	// directory, and fstat on an open descriptor cannot fail at all, so the
+	// branches refusing a mode that did not apply exist only through these.
+	fchmodStagingDir = (*os.File).Chmod //nolint:gochecknoglobals // test seam
+	fstatStagingDir  = (*os.File).Stat  //nolint:gochecknoglobals // test seam
 )
 
 // confirmReachable connects to path and hangs up.
@@ -300,10 +306,10 @@ func restrictDirToOwner(dir string) error {
 	}
 	defer func() { _ = file.Close() }()
 
-	if chmodErr := file.Chmod(stagingDirMode); chmodErr != nil {
+	if chmodErr := fchmodStagingDir(file, stagingDirMode); chmodErr != nil {
 		return fmt.Errorf("restricting the staging directory %q: %w", dir, chmodErr)
 	}
-	info, err := file.Stat()
+	info, err := fstatStagingDir(file)
 	if err != nil {
 		return fmt.Errorf("checking the staging directory %q: %w", dir, err)
 	}

--- a/cmd/server/socket_mode_unix_test.go
+++ b/cmd/server/socket_mode_unix_test.go
@@ -582,6 +582,161 @@ func TestRestrictDirToOwner_ASymlink_IsRefused(t *testing.T) {
 	}
 }
 
+// TestRestrictDirToOwner_ADescriptorCallThatFails_IsReported covers the two
+// descriptor calls that guard the staging directory's mode, and the verdict
+// on a mode that was applied and did not take.
+//
+// None of the three can be provoked through the filesystem: a fresh directory
+// accepts its owner's fchmod, fstat on an open descriptor does not fail, and
+// a filesystem that silently ignores a chmod is not one the tests run on. So
+// each is driven through its seam, and what is asserted is that the check
+// refuses rather than serving a socket in a directory it could not confirm.
+func TestRestrictDirToOwner_ADescriptorCallThatFails_IsReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	originalChmod, originalStat := fchmodStagingDir, fstatStagingDir
+	t.Cleanup(func() {
+		fchmodStagingDir = originalChmod
+		fstatStagingDir = originalStat
+	})
+
+	cases := []struct {
+		name  string
+		chmod func(*os.File, os.FileMode) error
+		stat  func(*os.File) (os.FileInfo, error)
+		want  string
+	}{
+		{
+			name:  "the chmod fails",
+			chmod: func(*os.File, os.FileMode) error { return errors.New("read-only file system") },
+			stat:  originalStat,
+			want:  "restricting the staging directory",
+		},
+		{
+			name:  "the stat fails",
+			chmod: originalChmod,
+			stat:  func(*os.File) (os.FileInfo, error) { return nil, errors.New("stale file handle") },
+			want:  "checking the staging directory",
+		},
+		{
+			name:  "the mode did not apply",
+			chmod: originalChmod,
+			stat: func(f *os.File) (os.FileInfo, error) {
+				info, err := f.Stat()
+				if err != nil {
+					return nil, err
+				}
+				return wrongModeInfo{FileInfo: info}, nil
+			},
+			want: "refusing to build a socket in it",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fchmodStagingDir, fstatStagingDir = tc.chmod, tc.stat
+			dir := filepath.Join(t.TempDir(), "staging")
+			if err := os.Mkdir(dir, stagingDirMode); err != nil {
+				t.Fatalf("creating the directory: %v", err)
+			}
+
+			err := restrictDirToOwner(dir)
+			if err == nil {
+				t.Fatal("restrictDirToOwner() accepted a directory whose mode it could not confirm")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to say %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewStagingDir_ADirectoryItCannotRestrict_IsRemovedAndReported covers the
+// reservation succeeding and the restriction failing: the name must not be
+// left behind, since a staging directory nobody will remove is a socket path
+// nobody can reach.
+//
+// The reservation is made to hand back a symlink to a real directory, which is
+// the shape O_NOFOLLOW exists to refuse.
+func TestNewStagingDir_ADirectoryItCannotRestrict_IsRemovedAndReported(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	parent := t.TempDir()
+	target := filepath.Join(parent, "real")
+	if err := os.Mkdir(target, stagingDirMode); err != nil {
+		t.Fatalf("creating the target directory: %v", err)
+	}
+	original := mkdirStagingDir
+	t.Cleanup(func() { mkdirStagingDir = original })
+	var reserved string
+	mkdirStagingDir = func(name string, _ os.FileMode) error {
+		reserved = name
+		return os.Symlink(target, name)
+	}
+
+	_, err := newStagingDir(parent)
+	if err == nil {
+		t.Fatal("newStagingDir() handed out a directory it could not restrict")
+	}
+	if !strings.Contains(err.Error(), "opening the staging directory") {
+		t.Errorf("error = %q, want the restriction failure", err)
+	}
+	if _, statErr := os.Lstat(reserved); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("the reserved name %s was left behind: %v", reserved, statErr)
+	}
+}
+
+// TestBindUnixSocket_AStagingFailure_IsReportedWithThePath covers the two ways
+// the bind can fail before a socket exists: no staging directory could be
+// reserved, and the staged name was already occupied. Both name the operator's
+// path, since that is the one they typed, and neither leaves a staging
+// directory behind.
+func TestBindUnixSocket_AStagingFailure_IsReportedWithThePath(t *testing.T) {
+	// Deliberately not parallel: see the note on the binding tests.
+	original := mkdirStagingDir
+	t.Cleanup(func() { mkdirStagingDir = original })
+
+	cases := []struct {
+		name  string
+		mkdir func(string, os.FileMode) error
+		want  string
+	}{
+		{
+			name:  "no staging directory could be reserved",
+			mkdir: func(string, os.FileMode) error { return errors.New("no space left on device") },
+			want:  "preparing to bind unix socket",
+		},
+		{
+			// The reservation succeeds, and a directory already stands where
+			// the socket was to be created, so the bind itself is refused.
+			name: "the staged name is already occupied",
+			mkdir: func(name string, mode os.FileMode) error {
+				if err := os.Mkdir(name, mode); err != nil {
+					return err
+				}
+				return os.Mkdir(filepath.Join(name, stagedSocketName), mode)
+			},
+			want: "listening on unix socket",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mkdirStagingDir = tc.mkdir
+			dir := socketDir(t)
+			path := filepath.Join(dir, "s.sock")
+
+			listener, err := bindUnixSocket(t.Context(), path, 0o660)
+			if err == nil {
+				_ = listener.Close()
+				t.Fatal("bindUnixSocket() served on a socket its staging could not produce")
+			}
+			if !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), path) {
+				t.Errorf("error = %q, want it to say %q and name %s", err, tc.want, path)
+			}
+			if leftovers := stagingLeftovers(t, dir); len(leftovers) != 0 {
+				t.Errorf("staging directories left behind: %v", leftovers)
+			}
+		})
+	}
+}
+
 // TestConfirmReachable_APathNothingIsServing_IsReported covers the check that
 // turns an unverifiable assumption into a startup failure.
 //

--- a/cmd/server/stdio_test.go
+++ b/cmd/server/stdio_test.go
@@ -483,3 +483,34 @@ func assertJSONRPCRefusal(t *testing.T, raw []byte, wantCode int, detail string)
 		t.Errorf("message = %q, want it to name %s", answer.Error.Message, detail)
 	}
 }
+
+// TestSanitizedInput_MaxLineBytes_DefaultsWhenUnconfigured pins the ceiling a
+// reader built without limits enforces: the default, not zero, since a zero
+// ceiling would refuse every line.
+func TestSanitizedInput_MaxLineBytes_DefaultsWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+	reader, _ := resilientStdioWith(strings.NewReader(""), &bytes.Buffer{}, stdioLimits{})
+	if got := reader.maxLineBytes(); got != defaultMaxStdioLineBytes {
+		t.Errorf("maxLineBytes() = %d with no limit configured, want the default %d", got, defaultMaxStdioLineBytes)
+	}
+	configured, _ := resilientStdioWith(strings.NewReader(""), &bytes.Buffer{}, stdioLimits{maxLineBytes: 512})
+	if got := configured.maxLineBytes(); got != 512 {
+		t.Errorf("maxLineBytes() = %d, want the configured 512", got)
+	}
+}
+
+// TestErrorLine_AnIDThatIsNotJSON_WritesNothing covers the one way the answer
+// can fail to marshal: a raw id that is not valid JSON, which the encoder
+// refuses rather than copying through. Every caller passes an id scalarID
+// has already vetted, so the case is a contract check on the only fallback:
+// silence, since a half-formed line on the protocol stream would be worse
+// than no answer.
+func TestErrorLine_AnIDThatIsNotJSON_WritesNothing(t *testing.T) {
+	t.Parallel()
+	if got := errorLine(json.RawMessage("{"), -32600, "refused"); got != nil {
+		t.Errorf("errorLine with an unmarshalable id wrote %q, want nothing", got)
+	}
+	if got := errorLine(json.RawMessage(`7`), -32600, "refused"); !strings.HasSuffix(string(got), "\n") || !strings.Contains(string(got), `"id":7`) {
+		t.Errorf("errorLine with a valid id wrote %q, want a newline-terminated answer carrying the id", got)
+	}
+}

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -2112,3 +2112,101 @@ func resourceTemplateURIs(t *testing.T, server *mcp.Server) map[string]bool {
 	}
 	return uris
 }
+
+// TestResourceReader_WithoutAnIndex_AnswersNotReadyInsteadOfPanicking covers
+// the reader before registration has published an index. The runtime seeds
+// one, so nothing built through it gets here; the point is that a reader that
+// somehow does answers with the retryable "not ready" rather than
+// dereferencing nil inside a watcher.
+func TestResourceReader_WithoutAnIndex_AnswersNotReadyInsteadOfPanicking(t *testing.T) {
+	t.Parallel()
+	reader := &resourceReader{}
+	_, err := reader.Read(context.Background(), "gitlab://project/42/pipeline/99")
+	if !errors.Is(err, errCatalogNotReady) {
+		t.Errorf("Read() error = %v, want %v", err, errCatalogNotReady)
+	}
+}
+
+// TestSessionBridge_ForgetStream_IgnoresANilStream pins the nil guard on the
+// bookkeeping a renewal ticker drops when it ends: a legacy subscribe has no
+// stream, and forgetting nothing must be a no-op rather than a map write
+// under a nil key.
+func TestSessionBridge_ForgetStream_IgnoresANilStream(t *testing.T) {
+	t.Parallel()
+	bridge := newSessionBridge(nil)
+	bridge.renewing[&listenStream{cancel: func() {}}] = struct{}{}
+
+	bridge.forgetStream(nil)
+
+	if len(bridge.renewing) != 1 {
+		t.Errorf("forgetStream(nil) changed the renewal set to %d entries, want the one stream left alone", len(bridge.renewing))
+	}
+}
+
+// TestSessionBridge_ALeaseTooShortToRenew_StartsNoTicker covers the renewal
+// interval collapsing to zero: a lease of a couple of nanoseconds leaves
+// nothing to divide into thirds, and a ticker cannot be built on a zero
+// interval, so the stream holds its watch without one rather than panicking
+// in time.NewTicker.
+func TestSessionBridge_ALeaseTooShortToRenew_StartsNoTicker(t *testing.T) {
+	_, gitlab := newPipelineBackend(t, "running")
+	opts := fastOptions()
+	opts.Lease = 2 * time.Nanosecond
+	runtime := newSubscriptionRuntime(subscriptionGitLabClient(t, gitlab.URL),
+		subscriptionCfg(config.CapabilitySurfaceFull), opts)
+	t.Cleanup(runtime.manager.Close)
+	bridge := newSessionBridge(runtime.manager)
+	session, _ := connectedSessions(t)
+
+	streamCtx, endStream := context.WithCancel(t.Context())
+	defer endStream()
+	ctx := withListenStream(streamCtx, &listenStream{cancel: func() {}})
+	if err := bridge.Subscribe(ctx, &mcp.SubscribeRequest{
+		Session: session,
+		Params:  &mcp.SubscribeParams{URI: "gitlab://project/42/pipeline/99"},
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if runtime.manager.Len() != 1 {
+		t.Fatalf("watchers = %d, want 1: the watch itself is unaffected by the missing ticker", runtime.manager.Len())
+	}
+	if got := bridge.activeRenewals(); got != 0 {
+		t.Errorf("activeRenewals() = %d, want 0 when the lease leaves no interval to renew on", got)
+	}
+}
+
+// TestSessionBridge_SubscribeUnlessStateless_TellsTheListenPathFromTheLegacyOne
+// pins the one distinction the stateless handler draws. The SDK routes both
+// resources/subscribe and every URI of a subscriptions/listen through it, and
+// only the first is undeliverable on a sessionless transport, so the mark on
+// the context is what decides between a real watch and the refusal.
+func TestSessionBridge_SubscribeUnlessStateless_TellsTheListenPathFromTheLegacyOne(t *testing.T) {
+	_, gitlab := newPipelineBackend(t, "running")
+	runtime := newSubscriptionRuntime(subscriptionGitLabClient(t, gitlab.URL),
+		subscriptionCfg(config.CapabilitySurfaceFull), fastOptions())
+	t.Cleanup(runtime.manager.Close)
+	bridge := newSessionBridge(runtime.manager)
+	session, _ := connectedSessions(t)
+	req := &mcp.SubscribeRequest{
+		Session: session,
+		Params:  &mcp.SubscribeParams{URI: "gitlab://project/42/pipeline/99"},
+	}
+
+	if err := bridge.subscribeUnlessStateless(t.Context(), req); !errors.Is(err, errStatelessSubscribe) {
+		t.Fatalf("a legacy subscribe on a stateless transport returned %v, want %v", err, errStatelessSubscribe)
+	}
+	if runtime.manager.Len() != 0 {
+		t.Fatalf("watchers = %d after the refusal, want none started", runtime.manager.Len())
+	}
+
+	streamCtx, endStream := context.WithCancel(t.Context())
+	defer endStream()
+	listen := withListenStream(streamCtx, &listenStream{cancel: func() {}})
+	if err := bridge.subscribeUnlessStateless(listen, req); err != nil {
+		t.Fatalf("a listen-path subscribe was refused: %v", err)
+	}
+	if runtime.manager.Len() != 1 {
+		t.Errorf("watchers = %d after the listen-path subscribe, want 1", runtime.manager.Len())
+	}
+}

--- a/cmd/server/telemetry.go
+++ b/cmd/server/telemetry.go
@@ -191,12 +191,9 @@ func installSlogBridge() (restore func()) {
 	}
 
 	previous := slog.Default()
+	// Non-nil by construction: NewSlogHandler declines only a nil base, which
+	// the check above already turned away.
 	bridged := telemetry.NewSlogHandler(baseLogHandler, telemetry.DefaultLogSeverity, identityRedactor())
-	if bridged == nil {
-		return func() {
-			// Same as above: no bridge, nothing to put back.
-		}
-	}
 	slog.SetDefault(slog.New(bridged))
 	return func() { slog.SetDefault(previous) }
 }

--- a/cmd/server/telemetry_identity.go
+++ b/cmd/server/telemetry_identity.go
@@ -261,13 +261,7 @@ func identityRedactor() *telemetry.Redactor {
 		if policy == telemetry.IdentityNone {
 			return
 		}
-		redactor, err := telemetry.NewRedactor(policy, identityKeyring())
-		if err != nil {
-			slog.Error("telemetry identity redactor could not be built; recording nothing about callers",
-				"component", "telemetry", "error", err)
-			return
-		}
-		identityRedactorVal = redactor
+		identityRedactorVal = telemetry.NewRedactor(policy, identityKeyring())
 	})
 	return identityRedactorVal
 }

--- a/cmd/server/telemetry_identity_test.go
+++ b/cmd/server/telemetry_identity_test.go
@@ -391,3 +391,89 @@ func TestTelemetryResources_AnUnusablePolicy_RecordsNothing(t *testing.T) {
 		t.Errorf("telemetryResources() = %#v, want nil so nothing about a resource is recorded", got)
 	}
 }
+
+// TestLogIdentityPolicy_SpeaksOnlyForANonDefaultPolicy pins the one line an
+// operator skimming a log for surprises needs, and its absence for the default:
+// "we are recording nobody" on every startup would be noise, "we are recording
+// usernames" is the line that has to be there.
+func TestLogIdentityPolicy_SpeaksOnlyForANonDefaultPolicy(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy telemetry.IdentityPolicy
+		want   string
+	}{
+		{name: "the default says nothing", policy: telemetry.DefaultIdentityPolicy, want: ""},
+		{name: "full names what is exported", policy: telemetry.IdentityFull, want: "telemetry records caller identity"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { slog.SetDefault(previous) })
+
+			logIdentityPolicy(tc.policy)
+
+			if tc.want == "" && buf.Len() != 0 {
+				t.Errorf("the default policy logged %q, want silence", buf.String())
+			}
+			if tc.want != "" && !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("log = %q, want it to carry %q", buf.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestTelemetryIdentityPolicy_TheFlagBeatsTheEnvironment covers the precedence
+// for the policy the same way the rotation test does for its flag: what the
+// operator typed wins over what the environment happened to carry.
+func TestTelemetryIdentityPolicy_TheFlagBeatsTheEnvironment(t *testing.T) {
+	withFreshFlagSet(t)
+	t.Setenv(telemetry.EnvIdentityName, string(telemetry.IdentityNone))
+
+	previous := telemetryIdentityFlag
+	t.Cleanup(func() { telemetryIdentityFlag = previous })
+	telemetryIdentityFlag = flag.String("telemetry-identity", string(telemetry.DefaultIdentityPolicy), "")
+	if err := flag.CommandLine.Parse([]string{"-telemetry-identity=full"}); err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+
+	policy, err := telemetryIdentityPolicy()
+	if err != nil {
+		t.Fatalf("telemetryIdentityPolicy: %v", err)
+	}
+	if policy != telemetry.IdentityFull {
+		t.Errorf("policy = %q, want the flag's full rather than the environment's none", policy)
+	}
+}
+
+// TestIdentityKeyring_ARotationOutOfRange_RecordsNothingAndAnnouncesNothing
+// covers a rotation that parses but that the keyring refuses: longer than the
+// thirty days a generated key may live. The keyring is then absent, which
+// every consumer reads as "record nothing", and the startup announcement says
+// nothing either, because announcing that identity is recorded and then
+// failing to build the thing that records it would be the announcement lying.
+func TestIdentityKeyring_ARotationOutOfRange_RecordsNothingAndAnnouncesNothing(t *testing.T) {
+	t.Setenv(telemetry.EnvIdentityName, string(telemetry.IdentityPseudonymous))
+	t.Setenv(telemetry.EnvIdentityKeyName, "")
+	t.Setenv(telemetry.EnvIdentityRotationName, (telemetry.MaxKeyRotation + time.Hour).String())
+	resetIdentityKeyring(t)
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	if ring := identityKeyring(); ring != nil {
+		t.Fatalf("identityKeyring() = %v, want nil for a rotation past the maximum", ring)
+	}
+	if !strings.Contains(buf.String(), "keyring could not be built") {
+		t.Errorf("log = %q, want the keyring failure reported", buf.String())
+	}
+
+	buf.Reset()
+	announceIdentityChoice()
+	if strings.Contains(buf.String(), "telemetry records caller identity") {
+		t.Errorf("startup log %q announces identity recording for a keyring that could not be built", buf.String())
+	}
+}

--- a/cmd/server/telemetry_test.go
+++ b/cmd/server/telemetry_test.go
@@ -449,3 +449,48 @@ func TestStartTelemetry_TheEnabledAnnouncement_SurvivesAWarnLogLevel(t *testing.
 		t.Errorf("the startup announcement was suppressed at LOG_LEVEL=warn; captured %v", messages)
 	}
 }
+
+// TestStartTelemetry_WarnsWhenACredentialCrossesTheNetworkInTheClear covers
+// the one configuration mistake this server refuses to keep quiet about: a
+// collector header configured beside a plaintext endpoint on another host.
+//
+// The endpoint is a name under the reserved .invalid domain, so it is remote
+// by any reading and resolves to nothing at once rather than hanging the
+// shutdown flush on a connection attempt. The warning is read off the base
+// handler because it is emitted after the bridge is installed, which is where
+// it has to be for the collector to receive it too.
+func TestStartTelemetry_WarnsWhenACredentialCrossesTheNetworkInTheClear(t *testing.T) {
+	restore := telemetryFlag
+	t.Cleanup(func() { telemetryFlag = restore })
+	telemetryFlag = nil
+
+	t.Setenv("GITLAB_MCP_TELEMETRY", "true")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector.invalid:4318")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer%20secret")
+	t.Setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "200")
+	t.Setenv("OTEL_BSP_EXPORT_TIMEOUT", "200")
+
+	var mu sync.Mutex
+	var messages []string
+	capture := levelCapturingHandler{threshold: slog.LevelWarn, mu: &mu, messages: &messages}
+	previous, previousBase := slog.Default(), baseLogHandler
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+		baseLogHandler = previousBase
+	})
+	baseLogHandler = capture
+	slog.SetDefault(slog.New(capture))
+
+	provider, stop := startTelemetry(t.Context(), "2.7.6", config.ToolSurfaceDynamic)
+	t.Cleanup(func() { stop(boundedShutdown(t)) })
+	if !provider.Enabled() {
+		t.Fatal("telemetry did not start, so there was no export to warn about")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	const warning = "a collector credential is configured against a plaintext endpoint on another host; it crosses the network in the clear on every export"
+	if !slices.Contains(messages, warning) {
+		t.Errorf("the plaintext-credential warning was not logged; captured %v", messages)
+	}
+}

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,12 +18,12 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,766 |
-| Unit test functions                                   | 13,187 |
+| Total test functions                                  | 13,830 |
+| Unit test functions                                   | 13,251 |
 | E2E test functions                                    |    579 |
-| cmd test functions                                    |  2,228 |
+| cmd test functions                                    |  2,292 |
 | Test files (internal/)                                |    503 |
-| Test files (cmd/)                                     |    139 |
+| Test files (cmd/)                                     |    141 |
 | Test files (test/e2e/)                                |    229 |
 | Tool sub-packages tested                              |    176 |
 | Core packages tested                                  |     21 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,408 | 82.9% |
+| `TestFunc_Scenario` (2-part)           | 11,422 | 82.6% |
 | `TestFunc` (no underscore)             |    968 |  7.0% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,390 | 10.1% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,440 | 10.4% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            308 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,444 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            579 |        229 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,228 |        139 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,766** |    **871** |                                                                                                 |
+| cmd packages            |          2,292 |        141 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,830** |    **873** |                                                                                                 |
 
 ### Core Packages
 

--- a/internal/telemetry/identity.go
+++ b/internal/telemetry/identity.go
@@ -139,9 +139,11 @@ type Redactor struct {
 //
 // A nil keyring is accepted and yields no digest, which is the same answer the
 // zero value gives: a caller that never wired one records nothing rather than
-// emitting something that looks like a pseudonym and is not.
-func NewRedactor(policy IdentityPolicy, keys *Keyring) (*Redactor, error) {
-	return &Redactor{policy: policy, keys: keys}, nil
+// emitting something that looks like a pseudonym and is not. Nothing here can
+// fail: the policy was validated where it was parsed, and the keyring is
+// whatever the caller built, nil included.
+func NewRedactor(policy IdentityPolicy, keys *Keyring) *Redactor {
+	return &Redactor{policy: policy, keys: keys}
 }
 
 // Policy reports what this redactor was built for.

--- a/internal/telemetry/identity_test.go
+++ b/internal/telemetry/identity_test.go
@@ -17,14 +17,10 @@ func attrMap(t *testing.T, attrs []attribute.KeyValue) map[string]string {
 	return out
 }
 
-// newRedactor builds one or fails the test.
+// newRedactor builds one over the test keyring.
 func newRedactor(t *testing.T, policy IdentityPolicy) *Redactor {
 	t.Helper()
-	redactor, err := NewRedactor(policy, testKeyring(t))
-	if err != nil {
-		t.Fatalf("NewRedactor(%q, testKeyring(t)): %v", policy, err)
-	}
-	return redactor
+	return NewRedactor(policy, testKeyring(t))
 }
 
 // TestRedactor_DefaultExportsNothing pins the default, which is the only value
@@ -298,10 +294,7 @@ func TestPolicyDescription_SaysWhatEachPolicyExports(t *testing.T) {
 func TestRedactor_ABrokenKeyringYieldsNoIdentityAtAll(t *testing.T) {
 	t.Parallel()
 
-	redactor, err := NewRedactor(IdentityPseudonymous, nil)
-	if err != nil {
-		t.Fatalf("NewRedactor: %v", err)
-	}
+	redactor := NewRedactor(IdentityPseudonymous, nil)
 
 	if attrs := redactor.Attributes("42", "jane"); len(attrs) != 0 {
 		t.Errorf("a redactor with no keyring produced %v; an empty digest is not a pseudonym", attrs)


### PR DESCRIPTION
`cmd/server` goes from 95.7% to 100.0% statement coverage (`go tool cover -func`, whole package, `-count=1`), with no function left below 100% and every new test passing under `-race`. It is the package the house rule was hardest on: most of what was uncovered were failure branches that no input to a test process can reach, so the work is mostly seams and, where a branch turned out to be unreachable by anything, removing it.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/509

## Seams

All in the shape the package already used (`var x = call //nolint:gochecknoglobals // test seam`, restored with `t.Cleanup`):

- `shutdown.go`: `listProcesses = process.Processes`. procfs cannot be made unreadable from a test, and the seam also feeds `findPeers` a pid that vanished between the listing and the name read, a branch that used to be covered only by whatever the machine's processes happened to do.
- `first_run.go`: `osExecutable = os.Executable`. The binary lookup fails on no platform the tests run on.
- `listen.go`: `removeStaleSocket = os.Remove`. As root no on-disk state makes an unlink fail.
- `socket_mode_unix.go`: `fchmodStagingDir = (*os.File).Chmod` and `fstatStagingDir = (*os.File).Stat`, beside the seams the file already had. The owner's fchmod on a directory it just created does not fail, fstat on an open descriptor does not either, and "the mode was applied and did not stick" needs a filesystem that ignores chmod.
- `main.go`: `periodicCleanupInterval` (was a five-minute literal) and `stdioStartupDrainTimeout` (was a `const`) become variables so the tick and the drain are observable. `newGitLabClient`, `buildDynamicCatalog`, `buildActionCatalog`, `filterActionCatalog`, `registerAllMeta` and `addStandaloneCatalog` get seams because no input to the server can make them fail (the specs are compiled and validated by their own tests, the scope filter has no error branch, the client only rejects URLs the configuration already rejected); they cover the whole "the catalog could not be built" chain in stdio, in the HTTP pool with eviction, in `createServer`, in the server card and in the tool search. `listInspectionResources`, `listInspectionResourceTemplates` and `listInspectionPrompts` follow the shape `listInspectionTools` had, and `removeExcludedTools`, `doToolSearch` and `buildServerCard` read through the inspection hooks `listRegisteredTools` already used. The remaining `os.Exit` calls in `main()` (invalid transport, `--shutdown`, `--probe`, a failing `run`) go through the existing `exitProcess` seam, with a `return` after each.

## Branches that could not be reached, removed or extracted

- `internal/telemetry/identity.go`: `NewRedactor` could not fail; it no longer returns an error (three call sites adjusted).
- `cmd/server/telemetry.go`: the `bridged == nil` check after `NewSlogHandler`, which only returns nil for a nil base that the line above already refuses.
- `cmd/server/main.go`: the error of `httpServer.Close()` after the drain budget is spent (`Shutdown` waits for every `Serve` to return and unregister its listener before returning, so `Close` has no listener left to close and no error to return); the `r == nil` guard in the OAuth instance resolver, which neither the guard nor the verifier can reach; the `default` of the `doToolSearch` switch, since `EffectiveToolSurface` returns exactly one of three values.
- `cmd/server/shutdown.go`: the force-kill phase is extracted into `forceKillPeers(peers, stderr)` so "every peer exited between the last poll and the deadline" can be exercised without racing a five-second timer.

Two branches are covered in a way that depends on scheduling, though the assertion is deterministic in both: the server-card fetcher that abandons its request mid-build (`TestServeHTTP_ServerCardRequestAbandonedMidBuild…`, which waits 100 ms before releasing the build) and the stdio failure by deadline (`TestServeStdio_AnyOtherEnd…`, 500 ms past the deadline before closing the pipe). Under an extreme scheduler the SDK's `select` could pick another branch; the test would still pass, or fail visibly, never pass falsely.

## New test files

`cmd/server/probe_linux_test.go` and `cmd/server/main_linux_test.go`; the second drives the first-run screen through a real pseudo-terminal on stdin.

## Tests

`go test ./cmd/server/ -coverprofile -count=1` (389 s, 100.0%), the new tests under `-race`, and on every batch `gofmt`, `golangci-lint`, `audit_test_subtests -check`, `check-test-goroutines`, `check-test-file-names`; at the end `go build ./...`, `make gen-stats`, `gen_testing_docs -skip-coverage` with its `--check`, and markdownlint on the two regenerated Markdown files.
