### PR TITLE
test(server): assert the stream renewal itself, not the clock around it

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,18 +467,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,140 |     229,712 |
-| Unit tests (`_test.go`)  |       646 |     375,273 |
+| Source (`.go`, non-test) |     1,140 |     229,724 |
+| Unit tests (`_test.go`)  |       646 |     375,291 |
 | End-to-end tests         |       235 |      61,624 |
-| **Total**                | **2,021** | **666,609** |
+| **Total**                | **2,021** | **666,639** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,579 |
+| Source functions                |  8,580 |
 | . Exported (public)             |  2,816 |
-| . Unexported (private)          |  5,763 |
+| . Unexported (private)          |  5,764 |
 | Unit test functions (`TestXxx`) | 13,287 |
 | Subtests (`t.Run(...)`)         |  4,982 |
 | End-to-end test functions       |    579 |
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~202 lines |
 | Average test file length           |                 ~581 lines |
-| Comment lines in source            |  35,496 (~15.5% of source) |
+| Comment lines in source            |  35,502 (~15.5% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/cmd/server/subscriptions.go
+++ b/cmd/server/subscriptions.go
@@ -158,6 +158,11 @@ type sessionBridge struct {
 	// number of open listen streams holding their own watches, which is worth
 	// being able to read directly rather than inferring from goroutine counts.
 	liveRenewals atomic.Int64
+	// renewals counts the renewals those tickers have performed. A test that
+	// wants "the stream keeps its watch at full speed" can wait for this to
+	// move instead of sleeping across a lease and reading the clock, which is
+	// the shape that failed on a loaded runner.
+	renewals atomic.Int64
 }
 
 // watchHold identifies one watch as the manager counts it: by session and URI.
@@ -238,6 +243,7 @@ func (b *sessionBridge) renewWhileStreaming(ctx context.Context, session *mcp.Se
 				return
 			case <-ticker.C:
 				b.manager.RenewAll(session)
+				b.renewals.Add(1)
 			}
 		}
 	}()
@@ -311,6 +317,12 @@ func (b *sessionBridge) startRenewing(stream *listenStream) bool {
 // activeRenewals reports how many renewal tickers are running.
 func (b *sessionBridge) activeRenewals() int64 {
 	return b.liveRenewals.Load()
+}
+
+// streamRenewals reports how many times an open listen stream has renewed the
+// watches of its session so far.
+func (b *sessionBridge) streamRenewals() int64 {
+	return b.renewals.Load()
 }
 
 // forgetStream drops the bookkeeping for a stream that is going away.

--- a/cmd/server/subscriptions_test.go
+++ b/cmd/server/subscriptions_test.go
@@ -1643,12 +1643,21 @@ func TestSessionBridge_LegacySubscribeIsStillSessionScoped(t *testing.T) {
 // why it is fixed alongside: the feature would otherwise have shipped and
 // quietly degraded by a factor of forty after thirty minutes.
 //
-// A short lease is injected so the renewal has to actually happen rather than
-// the test passing because nothing had time to expire.
+// The renewal is observed rather than the clock. This test used to sleep for
+// several short leases and then assert that no watch had been demoted, which
+// failed on a loaded macOS runner: with a 150 ms lease, the renewal goroutine
+// only had to be starved for 100 ms for the watch to slow down, and the test
+// reported a defect that was not there. Now the lease is long enough that only
+// a real failure to renew could demote the watch, and the assertion waits for
+// the bridge's own renewal count to move, so what is checked is that the open
+// stream renews and that the renewals keep the watch at full speed.
 func TestSessionBridge_AnOpenListenKeepsItsWatchAtFullSpeed(t *testing.T) {
 	_, gitlab := newPipelineBackend(t, "running")
 	opts := fastOptions()
-	opts.Lease = 150 * time.Millisecond
+	// The stream renews every Lease/3; a lease of three seconds gives a
+	// renewal every second and two seconds of slack before demotion, which no
+	// scheduler starvation a runner produces gets near.
+	opts.Lease = 3 * time.Second
 	runtime := newSubscriptionRuntime(subscriptionGitLabClient(t, gitlab.URL),
 		subscriptionCfg(config.CapabilitySurfaceFull), opts)
 	t.Cleanup(runtime.manager.Close)
@@ -1666,15 +1675,24 @@ func TestSessionBridge_AnOpenListenKeepsItsWatchAtFullSpeed(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	// Several leases' worth of silence. With no renewal the watch is demoted
-	// well before this elapses.
-	time.Sleep(700 * time.Millisecond)
+	// Two renewals prove the ticker is running and renewing; with the lease
+	// above they take about two seconds, and the deadline is generous because
+	// a slow renewal is exactly what must not fail this test.
+	const wantRenewals = 2
+	deadline := time.Now().Add(20 * time.Second)
+	for bridge.streamRenewals() < wantRenewals {
+		if time.Now().After(deadline) {
+			t.Fatalf("the listen stream renewed %d time(s) in 20 s, want at least %d; the renewal ticker is not running",
+				bridge.streamRenewals(), wantRenewals)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 
 	if runtime.manager.Len() != 1 {
 		t.Fatalf("the watch is gone entirely; this test can no longer see what it checks")
 	}
 	if demoted := runtime.manager.DemotedCount(); demoted != 0 {
-		t.Errorf("%d watch(es) demoted while the listen stream was open and being read", demoted)
+		t.Errorf("%d watch(es) demoted while the listen stream was open and renewing", demoted)
 	}
 }
 


### PR DESCRIPTION
`TestSessionBridge_AnOpenListenKeepsItsWatchAtFullSpeed` failed once on the macOS leg of https://github.com/jmrplens/gitlab-mcp-server/pull/508 and passed on the rerun; nothing in that change touched subscriptions. The test was a sleep-then-assert: a 150 ms lease, a 700 ms sleep, then the assertion that the watch had not been demoted. With that lease the renewal goroutine only had to be starved for 100 ms for the watch to slow down, which a loaded runner does, and the test then reported a defect that was not there.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/522

## What changes

The test now asserts the mechanism instead of the clock. The bridge counts the renewals its stream tickers perform (`sessionBridge.renewals`, read through `streamRenewals`), and the test waits for that count to reach two with a lease of three seconds: the stream renews every second, so two renewals take about two seconds and prove the ticker is running, and demotion would need two full seconds of starvation, which nothing a runner does gets near. Only then does it check that no watch was demoted. The deadline for the two renewals is twenty seconds, generous on purpose, since a slow renewal is exactly what must not fail this test.

The counter is one atomic increment per tick beside the existing `liveRenewals`, with no other behavioural change.

## Tests

The reworked test, together with its two siblings on the lease, ran twenty times under `-race` with sixteen busy loops competing for the CPU on a sixteen-thread host, and passed every time. `cmd/server` stays at 100% statement coverage; lint and the subtest gate pass.
