### PR TITLE
fix(oauth): conform to the three authorization sub-pages, and keep the raw token out of the identity cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,21 +467,21 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,140 |     229,724 |
-| Unit tests (`_test.go`)  |       646 |     375,291 |
-| End-to-end tests         |       235 |      61,624 |
-| **Total**                | **2,021** | **666,639** |
+| Source (`.go`, non-test) |     1,140 |     229,775 |
+| Unit tests (`_test.go`)  |       646 |     375,471 |
+| End-to-end tests         |       235 |      61,898 |
+| **Total**                | **2,021** | **667,144** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,580 |
-| . Exported (public)             |  2,816 |
+| Source functions                |  8,581 |
+| . Exported (public)             |  2,817 |
 | . Unexported (private)          |  5,764 |
-| Unit test functions (`TestXxx`) | 13,287 |
-| Subtests (`t.Run(...)`)         |  4,982 |
-| End-to-end test functions       |    579 |
+| Unit test functions (`TestXxx`) | 13,291 |
+| Subtests (`t.Run(...)`)         |  4,990 |
+| End-to-end test functions       |    582 |
 
 ### Ratios worth noting
 
@@ -490,15 +490,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~202 lines |
 | Average test file length           |                 ~581 lines |
-| Comment lines in source            |  35,502 (~15.5% of source) |
+| Comment lines in source            |  35,547 (~15.5% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,225 |
-| `defer` statements                 | 1,221 |
+| `if err != nil` checks             | 7,226 |
+| `defer` statements                 | 1,222 |
 | `struct` types defined             | 2,902 |
 | `//nolint` suppressions            |   295 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -515,15 +515,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,441 lines       |
+| Longest source file | `cmd/server/main.go`. 4,446 lines       |
 | Longest test file   | `cmd/server/main_test.go`. 10,314 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,176 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,554 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,177 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,555 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/bearer_guard.go
+++ b/cmd/server/bearer_guard.go
@@ -82,6 +82,12 @@ type bearerGuard struct {
 	// metadataURL is the RFC 9728 protected-resource metadata URL every
 	// challenge points at.
 	metadataURL string
+	// documentationURL is the page the metadata document publishes as
+	// resource_documentation, named again as the RFC 6750 error_uri of the
+	// one refusal whose remedy is on that page rather than in the protocol:
+	// a token from an OAuth application this deployment does not admit.
+	// Empty emits no error_uri.
+	documentationURL string
 	// resolveInstance reports which published GitLab instance a request
 	// selected, or an error when it named one this deployment does not
 	// serve. Nil means "one fixed instance", the single-instance case.
@@ -365,15 +371,30 @@ func (g *bearerGuard) classify(err error, ip, source, instance, token string) *g
 // Nothing else does: GitLab rejected nothing, so a description claiming the
 // token is expired or revoked would send its holder to reauthorize and come
 // back with the same credential.
+//
+// This is the one challenge that carries error_uri, RFC 6750's "URI identifying
+// a human-readable web page with information about the error". Every other
+// refusal has an in-band remedy (authorize, reauthorize, ask for the named
+// scope, wait); this one's remedy is to obtain a token from the application the
+// operator published, which is what the resource documentation describes and
+// what RFC 9728 offers no field for beyond that page. The message used to say
+// "see the resource documentation named in the WWW-Authenticate challenge"
+// while the challenge named only resource_metadata, a document the holder had
+// to fetch to find the page; now the challenge names the page itself, and it is
+// the same page the metadata document publishes.
 func (g *bearerGuard) unacceptedRecipientFailure() *gateFailure {
+	params := []string{
+		"error", "invalid_token",
+		"error_description", "the token was not issued to an OAuth application this deployment admits",
+	}
+	if g.documentationURL != "" {
+		params = append(params, "error_uri", g.documentationURL)
+	}
 	return &gateFailure{
 		status:  http.StatusUnauthorized,
 		code:    errCodeUnauthorized,
-		message: "This token is valid for the GitLab instance, but it was not issued to an OAuth application this deployment admits. Obtain a token from the application the operator published; see the resource documentation named in the WWW-Authenticate challenge.",
-		header: newHeader(headerWWWAuthenticate, g.challenge(
-			"error", "invalid_token",
-			"error_description", "the token was not issued to an OAuth application this deployment admits",
-		)),
+		message: "This token is valid for the GitLab instance, but it was not issued to an OAuth application this deployment admits. Obtain a token from the application the operator published; see the resource documentation, named as error_uri in the WWW-Authenticate challenge and as resource_documentation in the protected-resource metadata.",
+		header:  newHeader(headerWWWAuthenticate, g.challenge(params...)),
 	}
 }
 

--- a/cmd/server/bearer_guard_test.go
+++ b/cmd/server/bearer_guard_test.go
@@ -557,6 +557,87 @@ func TestBearerGuard_RecipientRefusals(t *testing.T) {
 	}
 }
 
+// TestBearerGuard_UnacceptedRecipient_NamesTheDocumentationPage pins the RFC
+// 6750 error_uri on the one refusal whose remedy lives on a web page.
+//
+// The message tells the holder to obtain a token from the application the
+// operator published and to read the resource documentation for which one. It
+// used to say the documentation was "named in the WWW-Authenticate challenge",
+// which named only resource_metadata: a document the holder had to fetch to
+// find the page. error_uri is RFC 6750's parameter for exactly this, "a URI
+// identifying a human-readable web page with information about the error".
+//
+// Three properties are checked. The fresh refusal carries it; the refusal
+// answered from the rejected-token cache carries it too, since the second
+// request is the one a person retrying actually reads; and a guard given no
+// page emits no error_uri rather than an empty one.
+func TestBearerGuard_UnacceptedRecipient_NamesTheDocumentationPage(t *testing.T) {
+	// Not parallel: the two attempts below are one sequence, and the second
+	// only means something after the first has populated the cache.
+	const page = "https://ops.example.com/our-oauth-app"
+	var calls atomic.Int32
+	g := newTestGuard(func(context.Context, string, *http.Request) (*auth.TokenInfo, error) {
+		calls.Add(1)
+		return nil, refusedRecipient()
+	})
+	g.documentationURL = page
+
+	// sequential: the second attempt is only meaningful after the first has
+	// populated the rejected-token cache.
+	for _, attempt := range []string{"fresh", "answered from the rejected-token cache"} {
+		t.Run(attempt, func(t *testing.T) {
+			assertRecipientRefusalNamesPage(t, g.check(guardRequest(t, "gloas-other-app")), page)
+		})
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("verifier called %d times for two attempts; the second must be answered from the rejected-token cache", got)
+	}
+}
+
+// TestBearerGuard_UnacceptedRecipient_WithoutAPageEmitsNoErrorURI is the other
+// half: a guard given no documentation page emits no error_uri rather than an
+// empty one, which a client would try to open.
+func TestBearerGuard_UnacceptedRecipient_WithoutAPageEmitsNoErrorURI(t *testing.T) {
+	t.Parallel()
+
+	g := newTestGuard(func(context.Context, string, *http.Request) (*auth.TokenInfo, error) {
+		return nil, refusedRecipient()
+	})
+	failure := g.check(guardRequest(t, "gloas-other-app"))
+	if failure == nil || failure.status != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %+v", failure)
+	}
+	if challenge := failure.header.Get(headerWWWAuthenticate); strings.Contains(challenge, "error_uri") {
+		t.Errorf("challenge %q carries an error_uri with no page to point at", challenge)
+	}
+}
+
+// refusedRecipient is the verifier error for a token minted for an application
+// the deployment does not admit.
+func refusedRecipient() error {
+	return fmt.Errorf("token was issued to another OAuth application: %w", oauth.ErrUnacceptedRecipient)
+}
+
+// assertRecipientRefusalNamesPage checks the shape of the unaccepted-recipient
+// 401: the RFC 6750 error code, the error_uri naming page, and a message that
+// says where the page is named.
+func assertRecipientRefusalNamesPage(t *testing.T, failure *gateFailure, page string) {
+	t.Helper()
+	if failure == nil || failure.status != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %+v", failure)
+	}
+	challenge := failure.header.Get(headerWWWAuthenticate)
+	if !strings.Contains(challenge, `error_uri="`+page+`"`) {
+		t.Errorf("challenge %q does not name the documentation page as error_uri", challenge)
+	}
+	if !strings.Contains(challenge, `error="invalid_token"`) {
+		t.Errorf("challenge %q lost the RFC 6750 error code", challenge)
+	}
+	if !strings.Contains(failure.message, "error_uri") {
+		t.Errorf("message %q does not tell the holder where the page is named", failure.message)
+	}
+}
+
 // assertRefusalWording checks that a refusal says what is true of it and does
 // not say what is true of a different one.
 func assertRefusalWording(t *testing.T, failure *gateFailure, want, unwanted string) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3109,6 +3109,14 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		slog.InfoContext(ctx, "admitting only tokens issued to the pinned OAuth applications; personal access tokens are refused",
 			"applications", len(cfg.OAuthClientUIDs))
 	}
+	// Resolved once and handed to both the metadata document and the guard, so
+	// the page the document publishes as resource_documentation and the page
+	// the recipient refusal names as error_uri cannot be two different pages.
+	links := oauth.ResourceLinks{
+		Documentation:  cfg.ResourceDocumentation,
+		Policy:         cfg.ResourcePolicyURI,
+		TermsOfService: cfg.ResourceTermsURI,
+	}
 	guard := &bearerGuard{
 		verify:             verifier,
 		resolveInstance:    resolveInstance,
@@ -3119,6 +3127,7 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		trustedProxyHeader: cfg.TrustedProxyHeader,
 		trustedProxies:     trustedProxiesOf(cfg.TrustedProxies),
 		metadataURL:        resourceMetadataURL,
+		documentationURL:   links.DocumentationURL(),
 		// The door asks only for what every action needs. Whether a
 		// particular action may write is settled per action, against the
 		// surface the pool built for this token's real authority.
@@ -3126,11 +3135,7 @@ func registerOAuthMCPHandlers(ctx context.Context, cfg *config.Config, _ string,
 		advertisedScope: requiredScope,
 	}
 	authMiddleware := auth.RequireBearerToken(verifier, &auth.RequireBearerTokenOptions{ResourceMetadataURL: resourceMetadataURL, Scopes: []string{oauth.MinimumScope}})
-	prm := oauth.NewProtectedResourceHandler(resourceID, cfg.InstanceURLs(), oauth.SupportedScopes(cfg.ReadOnly, cfg.SafeMode), oauth.ResourceLinks{
-		Documentation:  cfg.ResourceDocumentation,
-		Policy:         cfg.ResourcePolicyURI,
-		TermsOfService: cfg.ResourceTermsURI,
-	})
+	prm := oauth.NewProtectedResourceHandler(resourceID, cfg.InstanceURLs(), oauth.SupportedScopes(cfg.ReadOnly, cfg.SafeMode), links)
 	// One path, the one RFC 9728 §3 derives from this deployment's resource
 	// identifier and the one the challenge above advertises, so the document
 	// answers where a client looks for it and nowhere else. What was here

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -85,6 +85,59 @@ the pin. The full reasoning, with the live evidence that GitLab publishes no
 `resource_indicators_supported`, is
 [ADR-0019](../development/adr/adr-0019-audience-binding-unavailable-at-the-authorization-server.md).
 
+### What the authorization sub-pages ask of a resource server (verified 2026-09-05)
+
+The three sub-pages of the 2026-07-28 authorization specification
+(authorization-server discovery, client registration, security considerations)
+were read clause by clause against this server on that date, after the main
+authorization page and the Streamable HTTP transport had been. Of their
+normative sentences, the ones that bind a **resource server** are these, and
+this is where each is met:
+
+- RFC 9728 protected-resource metadata with at least one `authorization_servers`
+  entry: served at the path §3 derives from `--public-url`; a deployment with no
+  instance to publish (`--allow-any-gitlab-url`) refuses to start in oauth mode
+  rather than publish an empty list. The published value is the canonical form
+  of the instance URL (lowercase host, no default port, no trailing slash, any
+  relative root kept), because a client builds the authorization-server
+  metadata URL from it and must find an `issuer` identical to it.
+- One of the two discovery mechanisms: both are served, `resource_metadata` in
+  every `401` challenge and the well-known document, with `scope` in the
+  challenge as the discovery page permits.
+- OAuth 2.1 §5.2 validation of every inbound token before the request is
+  processed: verified against the instance the request selected, expiry taken
+  from the token itself, scope checked at the door and per action, and every
+  method that can reach a session authenticated, stateful `GET` and `DELETE`
+  included.
+- Audience binding and the passthrough prohibition: the documented deviation
+  above, with `--oauth-client-uid` as the specification's "otherwise verify"
+  alternative.
+- Secure token handling: the identity cache was found to hold the raw bearer
+  beside its digest key, unread by anything, and no longer does. Tokens reach
+  logs as their last four characters only, and the only accepted transmission
+  method is the `Authorization` header, which `bearer_methods_supported` states.
+
+Everything else on those pages binds the client (PKCE with `S256`, the
+`resource` parameter, `state`, the `iss` check, registration state kept per
+authorization server, registered redirect URIs) or the authorization server
+(client ID metadata documents, dynamic registration, exact redirect URI
+validation, refresh-token rotation, short-lived tokens). This server registers
+no clients, issues no tokens and forwards nothing to a third-party
+authorization server, so the confused-deputy clause on proxy servers holding a
+static client ID does not apply to it.
+
+GitLab.com's authorization-server metadata on that date: `code_challenge_methods_supported`
+(`plain`, `S256`) is published in both the OAuth and the OpenID documents, so
+the PKCE gate every MCP client must apply passes; `registration_endpoint` is
+published; `resource_indicators_supported`,
+`client_id_metadata_document_supported`,
+`authorization_response_iss_parameter_supported` and every DPoP field are
+absent. That absence is also why the RFC 9728 fields for DPoP-bound tokens,
+mutual-TLS-bound tokens, authorization details and signed metadata are not
+published in this server's document: each would state a capability the
+authorization server does not offer, and an omitted optional field is the
+truthful value for all of them.
+
 ## Cross-Origin Protection
 
 Every non-safe request (`POST`, `DELETE`) that a **browser** makes from another origin is rejected with `403` before authentication or MCP dispatch:
@@ -252,7 +305,7 @@ When running with `--http`:
 When running with `--auth-mode=oauth`, the server validates every request's Bearer token against the GitLab `/api/v4/user` endpoint before processing:
 
 - **Token verification** — Each token is validated by calling GitLab's user API. Invalid or expired tokens receive HTTP 401
-- **Identity caching** — Verified token identities are cached in-memory using SHA-256 hashed keys (raw tokens are never stored). Cache TTL is configurable via `--oauth-cache-ttl` (default 15m, range 1m–2h)
+- **Identity caching** — Verified token identities are cached in-memory under a SHA-256 digest of instance and token; the cached identity holds the user id, username, scopes and expiry, and no token material. Cache TTL is configurable via `--oauth-cache-ttl` (default 15m, range 1m–2h), and never outlives the token's own expiry when the instance reports one
 - **Bearer only** — only the standard `Authorization: Bearer` scheme is accepted; the legacy `PRIVATE-TOKEN` header is rejected with HTTP 401 in this mode (it remains accepted in legacy mode)
 - **[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) metadata** — The `/.well-known/oauth-protected-resource` endpoint advertises the GitLab authorization server URL, enabling compliant OAuth clients to discover the token issuer
 - **PKCE** — The OAuth 2.1 flow uses Proof Key for Code Exchange (PKCE) to protect against authorization code interception attacks. MCP clients generate a code verifier/challenge pair for each authorization request
@@ -275,25 +328,28 @@ Neither cache records an upstream failure. A timeout, a `5xx`, or a `429` from G
 
 The [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750) error code in `WWW-Authenticate` is the difference between a client reauthorizing, asking for more scope, or simply retrying:
 
-| Condition                       | Status | Challenge                                            |
-| ------------------------------- | ------ | ---------------------------------------------------- |
-| No credential at all            | `401`  | no `error` code (RFC 6750 §3.1), `resource_metadata` |
-| GitLab rejected the token       | `401`  | `error="invalid_token"` with a description           |
-| Token lacks the required scope  | `403`  | `error="insufficient_scope"`, `scope="<required>"`   |
-| Address over the failure budget | `429`  | none; `Retry-After`                                  |
-| GitLab throttled or unreachable | `503`  | **none**; `Retry-After`                              |
+| Condition                                                                      | Status | Challenge                                                              |
+| ------------------------------------------------------------------------------ | ------ | ---------------------------------------------------------------------- |
+| No credential at all                                                           | `401`  | no `error` code (RFC 6750 §3.1), `resource_metadata`                   |
+| GitLab rejected the token                                                      | `401`  | `error="invalid_token"` with a description                             |
+| Token lacks the required scope                                                 | `403`  | `error="insufficient_scope"`, `scope="<required>"`                     |
+| Token from an application the deployment does not admit (`--oauth-client-uid`) | `401`  | `error="invalid_token"`, `error_uri` naming the resource documentation |
+| Address over the failure budget                                                | `429`  | none; `Retry-After`                                                    |
+| GitLab throttled or unreachable                                                | `503`  | **none**; `Retry-After`                                                |
 
 The last row matters more than it looks. Reporting a throttled GitLab as `invalid_token` makes a well-behaved MCP client discard a good credential and start a fresh authorization flow — generating more upstream traffic at exactly the moment the instance asked for less, and asking the user to re-approve an application that was never the problem. A `503` carries no challenge, propagates GitLab's own `Retry-After` when it sent one, and says plainly that the token has not been rejected.
 
+The recipient-pin row is the one refusal whose remedy is not in the protocol: obtaining a token from the application the operator published, which is what the page named as `resource_documentation` describes. Its challenge therefore also carries RFC 6750's `error_uri`, set to that same page, so the holder is not sent to fetch the metadata document to find it. It is kept off the failure budget and cached as its own kind of refusal, because GitLab rejected nothing and reauthorizing returns the same token.
+
 See [HTTP Server Mode — OAuth Mode](../guides/http-server-mode.md#oauth-mode) for the full architecture and flow diagram, and [OAuth App Setup](../guides/oauth-app-setup.md) for creating GitLab OAuth applications.
 
-| Threat                 | Mitigation                                                                                                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Token replay           | TTL-based expiration; tokens re-verified after cache expires                                                                                    |
-| Cache key leakage      | SHA-256 hashing of raw tokens; original tokens never stored                                                                                     |
-| Brute force            | Per-address failure budget (10/minute) plus a rejected-token cache, so repeated attempts never reach GitLab                                     |
-| Upstream amplification | A repeated token is answered from memory, and the failure budget caps the rest: at most ten distinct-token verifications per address per window |
-| Memory dump            | Only SHA-256 hashes and user metadata stored; no raw tokens in cache                                                                            |
+| Threat                 | Mitigation                                                                                                                                                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Token replay           | TTL-based expiration; tokens re-verified after cache expires                                                                                                                                                          |
+| Cache key leakage      | Keys are SHA-256 digests of instance and token, and the cached identity carries no token material                                                                                                                     |
+| Brute force            | Per-address failure budget (10/minute) plus a rejected-token cache, so repeated attempts never reach GitLab                                                                                                           |
+| Upstream amplification | A repeated token is answered from memory, and the failure budget caps the rest: at most ten distinct-token verifications per address per window                                                                       |
+| Memory dump            | The identity and rejection caches hold digests and user metadata only; the pooled GitLab client holds its credential for the entry's lifetime, since it cannot call GitLab without it, and nothing is written to disk |
 
 ## PAT Scope-Based Tool Filtering
 

--- a/docs/development/adr/adr-0019-audience-binding-unavailable-at-the-authorization-server.md
+++ b/docs/development/adr/adr-0019-audience-binding-unavailable-at-the-authorization-server.md
@@ -175,14 +175,33 @@ sets `--oauth-client-uid`.
   defines no field for a recipient pin, so a client cannot discover the
   requirement in advance and learns about it from the `401`. That answer now
   names the cause and points at `resource_documentation`, which is as close to
-  discovery as the RFC allows.
+  discovery as the RFC allows. [Since 2026-09-05 the `401` names that page
+  directly, as the RFC 6750 `error_uri` of its challenge, resolved from the
+  same value the metadata document publishes as `resource_documentation`.
+  Before that the message said the page was named in the challenge while the
+  challenge named only `resource_metadata`, a document the holder had to fetch
+  to find it.]
 
 ### Neutral
 
 - NEU-001: If GitLab adds `resource_indicators_supported`, decisions 1 and 2
   are superseded: the `resource` parameter becomes the mechanism and the
   application pin becomes redundant. That is the revisit trigger: watch the
-  authorization-server metadata document, not a release note.
+  authorization-server metadata document, not a release note. [Re-checked
+  2026-09-05 against the same URL: the same eighteen keys, still no
+  `resource_indicators_supported`. The same document is the trigger for three
+  neighbouring decisions taken while reading the authorization sub-pages
+  clause by clause: `client_id_metadata_document_supported` is absent (the
+  client-registration page's preferred mechanism; a resource server neither
+  publishes nor consumes it, so nothing changes here when it appears),
+  `authorization_response_iss_parameter_supported` is absent (the mix-up
+  mitigation is the client's `iss` check, and RFC 9728 gives a resource server
+  no field for it), and `dpop_signing_alg_values_supported` is absent (the RFC
+  9728 DPoP, mutual-TLS and authorization-details fields are left out of the
+  protected-resource document because each would state a capability GitLab
+  does not offer, and would go in the day it does). `code_challenge_methods_supported`
+  is present in both the OAuth and the OpenID documents, so the PKCE gate
+  every MCP client must apply passes against GitLab.]
 
 ## Alternatives Considered
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 13,866 |
-| Unit test functions                                   | 13,287 |
-| E2E test functions                                    |    579 |
-| cmd test functions                                    |  2,327 |
+| Total test functions                                  | 13,873 |
+| Unit test functions                                   | 13,291 |
+| E2E test functions                                    |    582 |
+| cmd test functions                                    |  2,329 |
 | Test files (internal/)                                |    503 |
 | Test files (cmd/)                                     |    143 |
 | Test files (test/e2e/)                                |    229 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,420 | 82.4% |
+| `TestFunc_Scenario` (2-part)           | 11,424 | 82.3% |
 | `TestFunc` (no underscore)             |    968 |  7.0% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,478 | 10.7% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,481 | 10.7% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,207 |        134 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,209 |        134 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            308 |         14 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,445 |        355 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            579 |        229 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,327 |        143 | server entry point and developer command utilities                                              |
-| **Total**               |     **13,866** |    **875** |                                                                                                 |
+| E2E integration         |            582 |        229 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          2,329 |        143 | server entry point and developer command utilities                                              |
+| **Total**               |     **13,873** |    **875** |                                                                                                 |
 
 ### Core Packages
 
@@ -68,7 +68,7 @@
 | gatewaycompat |        19 |      n/a | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        73 |      n/a | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |      n/a | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        70 |      n/a | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        72 |      n/a | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |      n/a | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       275 |      n/a | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       180 |      n/a | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
@@ -77,7 +77,7 @@
 | telemetry     |       102 |      n/a | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |      n/a | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       807 |      n/a | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,207** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,209** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/docs/guides/http-server-mode.md
+++ b/docs/guides/http-server-mode.md
@@ -292,10 +292,10 @@ graph TD
 
 The pool key is `SHA-256(token + "\x00" + gitlabURL)`, never the raw values. This means:
 
-- Raw tokens and URLs are never stored in memory beyond the initial request
+- No lookup structure holds a raw token: the pool map and the OAuth identity and rejection caches are keyed by digest, so a scan of those structures yields no credential
+- The entry's GitLab client necessarily holds the credential it authenticates with, for as long as the entry lives (bounded by `--pool-idle-timeout`, the credential age limit and LRU eviction), because it cannot call GitLab without it. Nothing is written to disk
 - The same token against different GitLab instances produces different pool entries
 - Log messages show only the last 4 characters of the token (e.g., `...a1b2`) for debugging
-- Even if the pool's internal state were somehow exposed, tokens remain protected
 
 ## Client Authentication
 
@@ -550,7 +550,7 @@ curl http://localhost:8080/.well-known/oauth-protected-resource/gitlab
 
 **Token caching:**
 
-- Cache key: SHA-256 hash of the token (raw token never stored)
+- Cache key: SHA-256 digest of instance and token; the cached identity holds the user id, username, scopes and expiry, and no token material
 - Default TTL: 15 minutes (configurable via `--oauth-cache-ttl`)
 - Bounds: minimum 1 minute, maximum 2 hours
 - Expired entries are evicted on the next lookup, and a background sweep at a quarter of `--oauth-cache-ttl` (30-second floor) removes the ones that are never looked up again

--- a/docs/guides/oauth-app-setup.md
+++ b/docs/guides/oauth-app-setup.md
@@ -309,7 +309,34 @@ A personal access token used as Bearer has none of this: it lives until its own 
 | Token revoked on GitLab          | Next request after cache expiry returns 401                 |
 | Background cleanup               | Expired cache entries evicted periodically                  |
 
-The cache stores only successful verifications, keyed by a SHA-256 hash — raw tokens are never stored. `--oauth-cache-ttl` (default 15m, range 1m–2h) bounds how long a revoked token keeps working.
+The cache stores only successful verifications, keyed by a SHA-256 digest of instance and token, and the cached identity holds no token material. `--oauth-cache-ttl` (default 15m, range 1m–2h) bounds how long a revoked token keeps working, and the token's own expiry shortens it further when the instance reports one.
+
+---
+
+## Admitting only your own application
+
+By default the server admits any credential the instance accepts: a token from
+your application, a token from any other OAuth application on the same GitLab,
+or a personal access token. GitLab's authorization server publishes no
+`resource_indicators_supported`, so RFC 8707 audience restriction is not
+available and the server cannot tell from the token alone which application it
+was issued to; the reasoning is
+[ADR-0019](../development/adr/adr-0019-audience-binding-unavailable-at-the-authorization-server.md).
+
+`--oauth-client-uid` (env `GITLAB_MCP_OAUTH_CLIENT_UID`) turns on the check the
+specification allows instead. Its value is the **Application ID** from Step 1,
+the same string clients configure as `clientId`: GitLab reports it as
+`application.uid` when the server introspects a token, and only tokens naming
+one of the listed applications are admitted. List several, comma-separated,
+when `--gitlab-url` publishes several instances, since each has its own
+application.
+
+Turning it on refuses personal access tokens, which belong to no application,
+so it is not a default. A refused token is answered `401` with
+`error="invalid_token"` and an `error_uri` naming the page published as
+`resource_documentation`, which is where a person finding that response should
+be told which application to use: point `--resource-documentation` at your own
+page when you pin.
 
 ---
 
@@ -349,4 +376,4 @@ The cache stores only successful verifications, keyed by a SHA-256 hash — raw 
 - [GitLab: Configure GitLab as an OAuth 2.0 provider](https://docs.gitlab.com/ee/integration/oauth_provider.html) — official GitLab OAuth Application docs
 - [RFC 9728: OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) — the specification implemented by `--auth-mode=oauth`
 - [OAuth 2.1 Authorization Framework (draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12) — the latest OAuth specification (mandates PKCE)
-- [MCP Specification: Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) — MCP protocol authorization requirements
+- [MCP Specification: Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization) — MCP protocol authorization requirements, with the [authorization-server discovery](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/authorization-server-discovery), [client registration](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration) and [security considerations](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/security-considerations) sub-pages this server was verified against

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -48,6 +48,23 @@ type ResourceLinks struct {
 	TermsOfService string
 }
 
+// DocumentationURL is the page the metadata document publishes as
+// resource_documentation: the operator's own when one was named, and
+// [DefaultResourceDocumentation] otherwise.
+//
+// It is a method rather than a line inside [NewProtectedResourceHandler]
+// because the same page is named a second time, as the RFC 6750 error_uri of
+// the refusal a pinned deployment gives a token from another application. That
+// refusal tells the holder to read the resource documentation; two call sites
+// resolving the default separately is how the challenge and the document would
+// come to name different pages.
+func (l ResourceLinks) DocumentationURL() string {
+	if l.Documentation == "" {
+		return DefaultResourceDocumentation
+	}
+	return l.Documentation
+}
+
 // NewProtectedResourceHandler returns an http.Handler that serves RFC 9728
 // Protected Resource Metadata. MCP clients use this endpoint to discover the
 // GitLab authorization server associated with this resource.
@@ -68,10 +85,6 @@ type ResourceLinks struct {
 // The handler is registered at the single path [MetadataPathFor] derives from
 // the resource identifier.
 func NewProtectedResourceHandler(resourceURL string, gitlabURLs, supportedScopes []string, links ResourceLinks) http.Handler {
-	documentationURL := links.Documentation
-	if documentationURL == "" {
-		documentationURL = DefaultResourceDocumentation
-	}
 	metadata := &oauthex.ProtectedResourceMetadata{
 		Resource: resourceURL,
 		// RFC 9728 defines authorization_servers as an array, so a
@@ -86,7 +99,7 @@ func NewProtectedResourceHandler(resourceURL string, gitlabURLs, supportedScopes
 		// directory or consent screen label this resource instead of
 		// showing only its URL.
 		ResourceName:          "GitLab MCP Server",
-		ResourceDocumentation: documentationURL,
+		ResourceDocumentation: links.DocumentationURL(),
 		// Both are omitempty, and both stay empty unless an operator names a
 		// page. A field pointing at a document that does not exist is worse
 		// than an absent optional field: a consent screen would render a dead

--- a/internal/oauth/metadata_test.go
+++ b/internal/oauth/metadata_test.go
@@ -183,6 +183,54 @@ func TestNewProtectedResourceHandler_ResourceDocumentationIsConfigurable(t *test
 	}
 }
 
+// TestResourceLinks_DocumentationURL_IsWhatTheDocumentPublishes pins the one
+// resolution of resource_documentation that both the metadata document and the
+// recipient refusal's error_uri read from.
+//
+// The two used to be able to disagree: the handler resolved the default inline,
+// and a second caller wanting the same page would have had to repeat that. A
+// refusal that says "see the resource documentation" while naming a different
+// page than the document does is worse than naming none.
+func TestResourceLinks_DocumentationURL_IsWhatTheDocumentPublishes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		links ResourceLinks
+		want  string
+	}{
+		{name: "empty resolves to the project page", links: ResourceLinks{}, want: DefaultResourceDocumentation},
+		{name: "an operator page is returned verbatim", links: ResourceLinks{Documentation: "https://ops.example.com/our-oauth-app"}, want: "https://ops.example.com/our-oauth-app"},
+		{name: "the other links do not affect it", links: ResourceLinks{Policy: "https://ops.example.com/privacy", TermsOfService: "https://ops.example.com/terms"}, want: DefaultResourceDocumentation},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.links.DocumentationURL(); got != tt.want {
+				t.Errorf("DocumentationURL() = %q, want %q", got, tt.want)
+			}
+
+			// The document must publish the same value, or the accessor is
+			// not the single resolution it claims to be.
+			handler := NewProtectedResourceHandler("https://mcp.example.com/mcp",
+				[]string{"https://gitlab.example.com"}, []string{ScopeAPI}, tt.links)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+			var document struct {
+				ResourceDocumentation string `json:"resource_documentation"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&document); err != nil {
+				t.Fatalf("decode metadata: %v", err)
+			}
+			if document.ResourceDocumentation != tt.want {
+				t.Errorf("resource_documentation = %q, want %q: the document and the accessor disagree", document.ResourceDocumentation, tt.want)
+			}
+		})
+	}
+}
+
 // TestProtectedResourceHandler_OptionalLinksAreOmittedUnlessNamed pins how the
 // two optional RFC 9728 URL fields behave.
 //

--- a/internal/oauth/rejected.go
+++ b/internal/oauth/rejected.go
@@ -110,12 +110,13 @@ func (r *RejectedTokens) RecordKind(gitlabURL, token string, kind RejectionKind)
 	if len(r.entries) >= r.max {
 		r.evictLocked()
 	}
-	// Still full after evicting means every entry is live. Skipping the
-	// insert is the safe direction: the rate limiter is the layer that
-	// actually bounds a flood, and this cache only saves it upstream calls.
-	if len(r.entries) >= r.max {
-		return
-	}
+	// evictLocked frees a slot on every full map: it drops what has expired
+	// and, when nothing has, the live entry nearest expiry, so the insert
+	// never grows the map past max. A second "still full" check used to sit
+	// here, unreachable for that reason, with a rationale ("every entry is
+	// live, skip the insert") describing a case the eviction had already
+	// handled. The bound it seemed to add is the one
+	// TestRejectedTokens_AtCapacity_StaysBounded pins.
 	r.entries[key] = rejection{expiresAt: time.Now().Add(r.ttl), kind: kind}
 }
 

--- a/internal/oauth/verifier.go
+++ b/internal/oauth/verifier.go
@@ -312,8 +312,18 @@ func sameVerificationHost(origin, dest *url.URL) bool {
 // The returned verifier populates [auth.TokenInfo] with:
 //   - UserID: the GitLab user's numeric ID (as string)
 //   - Extra["username"]: the GitLab user's login name
-//   - Extra["token"]: the raw token (for downstream GitLab client creation)
-//   - Expiration: now + cacheTTL (so the SDK middleware honors TTL)
+//   - Expiration: now + cacheTTL, shortened to the token's own expiry when the
+//     instance reports one (so the SDK middleware honors both)
+//
+// The raw token is deliberately not carried in Extra. It used to be, "for
+// downstream GitLab client creation", but nothing downstream ever read it: the
+// pool takes the credential from the request header, and the SDK reads only
+// UserID, Scopes and Expiration. What carrying it did do was put every verified
+// bearer, in the clear, into the [TokenCache] for the length of the TTL, while
+// this package's own documentation promised the cache held no raw token
+// material. The MCP security considerations name "tokens cached or logged on
+// the server" as the theft surface; the cache is keyed by digest so that a
+// memory dump yields no credential, and the value has to keep that promise too.
 func NewGitLabVerifier(gitlabURL string, skipTLS bool, cacheTTL time.Duration, cache *TokenCache, clientUIDs ...string) auth.TokenVerifier {
 	return NewGitLabVerifierFor(
 		func(*http.Request) (string, error) { return gitlabURL, nil },
@@ -454,9 +464,10 @@ func admitToken(cache *TokenCache, gitlabURL, token string, cacheTTL time.Durati
 		UserID:     strconv.Itoa(user.ID),
 		Scopes:     result.scopes,
 		Expiration: time.Now().Add(ttl),
+		// The username only. The raw token stays out on purpose; see the
+		// doc comment on [NewGitLabVerifier].
 		Extra: map[string]any{
 			"username": user.Username,
-			"token":    token,
 		},
 	}
 

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -50,11 +50,58 @@ func TestNewGitLabVerifier_ValidToken(t *testing.T) {
 	if got, ok := info.Extra["username"].(string); !ok || got != "testuser" {
 		t.Errorf("Extra[username] = %v, want %q", info.Extra["username"], "testuser")
 	}
-	if got, ok := info.Extra["token"].(string); !ok || got != "valid-token" {
-		t.Errorf("Extra[token] = %v, want %q", info.Extra["token"], "valid-token")
-	}
 	if info.Expiration.Before(time.Now()) {
 		t.Error("Expiration should be in the future")
+	}
+}
+
+// TestNewGitLabVerifier_AdmissionCarriesNoRawToken pins that the identity a
+// verifier returns, and therefore the value the [TokenCache] holds for the
+// TTL, contains the token nowhere.
+//
+// It did until this test existed: Extra["token"] carried the bearer in the
+// clear "for downstream GitLab client creation", which nothing downstream ever
+// read, while the package documentation promised the cache stored no raw token
+// material. A digest key is worth nothing if the value beside it is the
+// credential. The check walks every Extra value rather than one key, so the
+// token cannot come back under another name.
+func TestNewGitLabVerifier_AdmissionCarriesNoRawToken(t *testing.T) {
+	t.Parallel()
+
+	const token = "gloas-secret-material"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/user" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gitlabUserResponse{ID: 42, Username: "testuser"})
+	}))
+	t.Cleanup(srv.Close)
+
+	cache := NewTokenCache()
+	verifier := NewGitLabVerifier(srv.URL, false, 15*time.Minute, cache)
+	info, err := verifier(t.Context(), token, nil)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	cached, ok := cache.Get(srv.URL, token)
+	if !ok {
+		t.Fatal("the admission was not cached")
+	}
+	for name, subject := range map[string]*auth.TokenInfo{"returned": info, "cached": cached} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, present := subject.Extra["token"]; present {
+				t.Error("Extra carries a \"token\" entry; the identity must not hold the credential it was verified with")
+			}
+			for key, value := range subject.Extra {
+				if text, isString := value.(string); isString && strings.Contains(text, token) {
+					t.Errorf("Extra[%q] = %q carries the raw token", key, text)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -1517,6 +1517,10 @@ func TestVerificationRedirect_Policy(t *testing.T) {
 		{name: "ipv6 zone literal spelled as a subdomain", origin: "https://gitlab.example.com/api/v4/user", dest: "https://[::1%25.gitlab.example.com]/api/v4/user", wantErr: true},
 		{name: "ipv6 zone literal on a plain http instance", origin: "http://gitlab.internal/api/v4/user", dest: "http://[::1%25.gitlab.internal]:9102/api/v4/user", wantErr: true},
 		{name: "the instance is itself an ipv6 literal", origin: "https://[2001:db8::1]/api/v4/user", dest: "https://[2001:db8::1]/api/v4/user/"},
+		// A Location of "https:///x" parses to a URL with no host at all. It
+		// is nowhere, so it is not the instance, and the policy must say so
+		// rather than let net/http try to dial an empty address.
+		{name: "destination without a host", origin: "https://gitlab.example.com/api/v4/user", dest: "https:///api/v4/user", wantErr: true},
 		{name: "ten hops already made", origin: "https://gitlab.example.com/api/v4/user", dest: "https://gitlab.example.com/api/v4/user", hops: 10, wantErr: true},
 	}
 

--- a/site/src/content/docs/es/operations/http-server.mdx
+++ b/site/src/content/docs/es/operations/http-server.mdx
@@ -8,7 +8,7 @@ faq:
   - q: "¿Cómo se autentican los clientes en el modo HTTP?"
     a: "Los clientes envían su Token de Acceso Personal de GitLab en cada petición usando la cabecera `PRIVATE-TOKEN` (recomendada) o una cabecera `Authorization: Bearer`; si ambas están presentes en modo legacy, `PRIVATE-TOKEN` tiene precedencia (el modo OAuth solo lee el token Bearer). Un servidor arrancado con `--allow-any-gitlab-url` y sin instancia toma la instancia destino de la cabecera `GITLAB-URL`, y uno que publica varias exige esa cabecera para elegir entre ellas. Para producción, `--auth-mode=oauth` habilita OAuth 2.1 con PKCE compatible con RFC 9728, de modo que los clientes descubren el servidor de autorización y autorizan en el navegador en lugar de copiar tokens."
   - q: "¿Los clientes del modo HTTP comparten estado o contexto?"
-    a: "No. El modo HTTP usa un **pool LRU limitado** de instancias de servidor MCP indexado por el hash SHA-256 del token **y** la URL de GitLab de cada cliente. Los clientes con el mismo token y la misma URL comparten una instancia, mientras que tokens distintos o URLs distintas obtienen instancias completamente aisladas. Los tokens sin procesar nunca se almacenan —solo los hashes SHA-256— y cuando el pool alcanza `--max-http-clients` se desaloja la entrada menos usada recientemente."
+    a: "No. El modo HTTP usa un **pool LRU limitado** de instancias de servidor MCP indexado por el hash SHA-256 del token **y** la URL de GitLab de cada cliente. Los clientes con el mismo token y la misma URL comparten una instancia, mientras que tokens distintos o URLs distintas obtienen instancias completamente aisladas. Las búsquedas en el pool usan solo los hashes SHA-256, el cliente de GitLab de cada entrada conserva la credencial con la que se autentica mientras la entrada vive, y cuando el pool alcanza `--max-http-clients` se desaloja la entrada menos usada recientemente."
   - q: "¿Por qué se caen mis sesiones MCP o se cortan los streams?"
     a: "Dos capas independientes gobiernan la vida útil: el timeout de inactividad de la **sesión MCP** (`--session-timeout`, por defecto `30m`) y el timeout de **conexión HTTP inactiva** (`--http-idle-timeout`, por defecto `0` = desactivado). Como `--http-idle-timeout` vale `0` por defecto, la capa HTTP no cierra conexiones inactivas, así que `--session-timeout` es la vida efectiva de inactividad. Si las sesiones caen pronto, un `--http-idle-timeout` bajo o un timeout de lectura/inactividad del proxy inverso suele cerrar los streams SSE de larga duración; aumenta el timeout del proxy para streams MCP largos."
 ---
@@ -332,7 +332,7 @@ graph TD
 
 - Los clientes con el **mismo token y la misma URL de GitLab** comparten la misma instancia del servidor MCP
 - Los clientes con **diferentes tokens** o **diferentes URLs de GitLab** obtienen instancias completamente aisladas
-- Los tokens sin procesar **nunca se almacenan** — solo se mantienen hashes SHA-256 de token+URL en memoria
+- Las búsquedas en el pool usan **solo hashes SHA-256** de token+URL; el cliente de GitLab de cada entrada conserva la credencial con la que se autentica mientras la entrada vive, porque no puede llamar a GitLab sin ella, y nada se escribe en disco
 - Cuando el pool alcanza `--max-http-clients`, la entrada menos usada recientemente es desalojada
 
 ### Ciclo de vida de la sesión

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -8,7 +8,7 @@ faq:
   - q: "How do clients authenticate in HTTP mode?"
     a: "Clients send their GitLab Personal Access Token on every request using the `PRIVATE-TOKEN` header (recommended) or an `Authorization: Bearer` header; if both are present in legacy mode, `PRIVATE-TOKEN` wins (OAuth mode reads only the Bearer token). A server started with `--allow-any-gitlab-url` and no instance takes the target instance from a `GITLAB-URL` header, and one publishing several requires that header to choose among them. For production, `--auth-mode=oauth` enables RFC 9728–compliant OAuth 2.1 with PKCE, so clients discover the authorization server and authorize in the browser instead of copying tokens."
   - q: "Do HTTP mode clients share state or context?"
-    a: "No. HTTP mode uses a **bounded LRU pool** of MCP server instances keyed by the SHA-256 hash of each client's token **and** GitLab URL. Clients with the same token and same GitLab URL share one instance, while different tokens or different URLs get completely isolated instances. Raw tokens are never stored — only the SHA-256 hashes — and when the pool reaches `--max-http-clients` the least recently used entry is evicted."
+    a: "No. HTTP mode uses a **bounded LRU pool** of MCP server instances keyed by the SHA-256 hash of each client's token **and** GitLab URL. Clients with the same token and same GitLab URL share one instance, while different tokens or different URLs get completely isolated instances. Pool lookups use only the SHA-256 hashes, each entry's GitLab client keeps the credential it authenticates with while the entry lives, and when the pool reaches `--max-http-clients` the least recently used entry is evicted."
   - q: "Why do my MCP sessions drop or streams get cut off?"
     a: "Two independent layers govern lifetime: the **MCP session** idle timeout (`--session-timeout`, default `30m`) and the **HTTP idle connection** timeout (`--http-idle-timeout`, default `0` = disabled). Because `--http-idle-timeout` defaults to `0`, the HTTP layer does not close idle connections, so `--session-timeout` is the effective idle lifetime. If sessions drop early, a low `--http-idle-timeout` or a reverse-proxy read/idle timeout is usually closing long-lived SSE streams; raise the proxy timeout for long-running MCP streams."
 ---
@@ -332,7 +332,7 @@ graph TD
 
 - Clients with the **same token and same GitLab URL** share the same MCP server instance
 - Clients with **different tokens** or **different GitLab URLs** get completely isolated instances
-- Raw tokens are **never stored** — only SHA-256 hashes of token+URL are kept in memory
+- Pool lookups use **only SHA-256 hashes** of token+URL; the entry's GitLab client keeps the credential it authenticates with for as long as the entry lives, since it cannot call GitLab without it, and nothing is written to disk
 - When the pool reaches `--max-http-clients`, the least recently used entry is evicted
 
 ### Session lifecycle

--- a/test/e2e/http/oauth_test.go
+++ b/test/e2e/http/oauth_test.go
@@ -13,12 +13,14 @@ package httpe2e
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -1005,6 +1007,278 @@ func TestOAuth_ResourceDocumentationIsOperatorConfigurable(t *testing.T) {
 			t.Errorf("an unset flag published the test's value: %s", got.body)
 		}
 	})
+}
+
+// startApplicationFakeGitLab serves a GitLab whose /oauth/token/info names the
+// OAuth application each bearer was minted for, which is the only recipient
+// signal the instance offers: GitLab publishes no resource_indicators_supported,
+// so the "or otherwise verify that they are the intended recipient" alternative
+// the specification allows is a comparison against that uid (ADR-0019).
+//
+// The PAT endpoint answers 404 on purpose. A PAT answer ends introspection
+// before the OAuth endpoint is asked, and the OAuth endpoint is the one that
+// names the application. A token the map does not know is refused everywhere.
+func startApplicationFakeGitLab(t *testing.T, applicationFor map[string]string) *fakeGitLab {
+	t.Helper()
+
+	var mu sync.Mutex
+	calls := 0
+
+	bearer := func(r *http.Request) string {
+		token, _ := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		return token
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0","revision":"abcdef"}`))
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		if _, known := applicationFor[bearer(r)]; !known {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"username":"pinned"}`))
+	})
+	mux.HandleFunc("/api/v4/personal_access_tokens/self", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/oauth/token/info", func(w http.ResponseWriter, r *http.Request) {
+		uid, known := applicationFor[bearer(r)]
+		if !known {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"scope":["api"],"expires_in":7200,"application":{"uid":%q}}`, uid)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &fakeGitLab{
+		url: srv.URL,
+		calls: func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return calls
+		},
+	}
+}
+
+// TestOAuth_RecipientRefusalNamesTheDocumentationPage pins the refusal a pinned
+// deployment gives a token from another OAuth application, on the wire.
+//
+// It is the one refusal whose remedy is not in the protocol. A missing
+// credential says authorize, an invalid token says reauthorize, a missing scope
+// names the scope; this one says "obtain a token from the application the
+// operator published", and which application that is lives on the page the
+// metadata document publishes as resource_documentation. RFC 6750's error_uri
+// is the parameter for exactly that, and the challenge now carries it, so the
+// holder is not sent to fetch a document to find a page.
+//
+// The page in the challenge is read out of the document rather than written
+// down here: the two are the same page or the challenge is a lie, and that is
+// the property under test. The refusal must also stay repeatable, because a
+// refusal that charged the address would let one misconfigured client lock a
+// shared address out for everybody holding a credential this deployment does
+// admit.
+func TestOAuth_RecipientRefusalNamesTheDocumentationPage(t *testing.T) {
+	const ours, theirs = "5a4f1c0e-ours", "9b8e7d6c-theirs"
+	gitlab := startApplicationFakeGitLab(t, map[string]string{
+		"gloas-ours":   ours,
+		"gloas-theirs": theirs,
+	})
+
+	deployments := []struct {
+		name string
+		// page is what the operator named, or "" for the project default.
+		page string
+	}{
+		{name: "the operator's own page", page: "https://example.com/our-oauth-app"},
+		{name: "the project page when none is named", page: ""},
+	}
+
+	for _, deployment := range deployments {
+		t.Run(deployment.name, func(t *testing.T) {
+			flags := []string{"--oauth-client-uid=" + ours}
+			if deployment.page != "" {
+				flags = append(flags, "--resource-documentation="+deployment.page)
+			}
+			srv := oauthServer(t, gitlab.url, flags...)
+
+			page := publishedResourceDocumentation(t, srv)
+			if deployment.page != "" && page != deployment.page {
+				t.Fatalf("resource_documentation = %q, want the operator's %q", page, deployment.page)
+			}
+
+			t.Run("a token from another application is refused with the page", func(t *testing.T) {
+				assertRecipientRefusal(t, srv, "gloas-theirs", page)
+			})
+			t.Run("a token from the pinned application is admitted", func(t *testing.T) {
+				assertTokenAdmitted(t, srv, "gloas-ours")
+			})
+			t.Run("the refusal costs the address nothing", func(t *testing.T) {
+				assertRefusalIsFree(t, srv, "gloas-theirs")
+			})
+		})
+	}
+}
+
+// publishedResourceDocumentation reads the page the metadata document names,
+// which is the page a recipient refusal must name too.
+func publishedResourceDocumentation(t *testing.T, srv *server) string {
+	t.Helper()
+
+	got := srv.do(t, request{method: http.MethodGet, path: metadataBasePath})
+	if got.status != http.StatusOK {
+		t.Fatalf("metadata status = %d, want 200: %s", got.status, got.body)
+	}
+	var document struct {
+		ResourceDocumentation string `json:"resource_documentation"`
+	}
+	if err := json.Unmarshal([]byte(got.body), &document); err != nil {
+		t.Fatalf("metadata is not JSON: %v", err)
+	}
+	if document.ResourceDocumentation == "" {
+		t.Fatal("the document publishes no resource_documentation, so there is no page for the challenge to name")
+	}
+	return document.ResourceDocumentation
+}
+
+// assertRecipientRefusal checks the 401 a pinned deployment gives a token from
+// another application: the RFC 6750 code, the error_uri naming page, and a
+// message that says what is true rather than that GitLab rejected the token.
+func assertRecipientRefusal(t *testing.T, srv *server, token, page string) {
+	t.Helper()
+
+	got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer " + token}))
+	if got.status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", got.status, got.body)
+	}
+	challenge := got.header.Get("WWW-Authenticate")
+	if !strings.Contains(challenge, `error="invalid_token"`) {
+		t.Errorf("challenge %q lacks the RFC 6750 error code", challenge)
+	}
+	if !strings.Contains(challenge, `error_uri="`+page+`"`) {
+		t.Errorf("challenge %q does not name the page the document publishes, %q", challenge, page)
+	}
+	if !strings.Contains(got.body, "not issued to an OAuth application") {
+		t.Errorf("the refusal must say what is actually wrong; got: %s", got.body)
+	}
+	if strings.Contains(got.body, "expired") || strings.Contains(challenge, "expired") {
+		t.Error("the refusal claims GitLab rejected the token; it did not, and reauthorizing returns the same one")
+	}
+}
+
+// assertTokenAdmitted checks that a token reaches tools/list, which is what
+// admission means: not merely that the door opened.
+func assertTokenAdmitted(t *testing.T, srv *server, token string) {
+	t.Helper()
+
+	got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer " + token}))
+	if got.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", got.status, got.body)
+	}
+	if !strings.Contains(got.body, `"tools"`) {
+		t.Errorf("an admitted token must reach tools/list; body: %s", truncate(got.body))
+	}
+}
+
+// assertRefusalIsFree repeats a refusal past the authentication-failure budget
+// and fails if the address is ever locked out. A refusal that charged the
+// budget would let one misconfigured client lock a shared address out for
+// everybody holding a credential the deployment does admit.
+func assertRefusalIsFree(t *testing.T, srv *server, token string) {
+	t.Helper()
+
+	for attempt := range 12 {
+		got := srv.do(t, mcpPOST(map[string]string{"Authorization": "Bearer " + token}))
+		if got.status == http.StatusTooManyRequests {
+			t.Fatalf("attempt %d was rate limited: a genuine token from another application was charged against the address", attempt+1)
+		}
+		if got.status != http.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401", attempt+1, got.status)
+		}
+	}
+}
+
+// TestOAuth_PublishedAuthorizationServerIsTheCanonicalIssuer pins the string
+// clients read out of authorization_servers.
+//
+// A client builds the authorization-server metadata URL from that value and
+// then, per the discovery page, checks that the document's issuer "MUST be
+// identical to the issuer identifier used to construct the well-known URL",
+// discarding the metadata otherwise. GitLab's issuer is the canonical form of
+// the instance URL: lowercase host, no default port, no trailing slash, the
+// relative root kept. Whatever spelling the operator typed, that is what has
+// to be published, or every client's discovery fails against a document that
+// is perfectly correct.
+func TestOAuth_PublishedAuthorizationServerIsTheCanonicalIssuer(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		want       string
+	}{
+		{name: "case, default port and trailing slash are canonicalized", configured: "https://GitLab.Example.com:443/", want: "https://gitlab.example.com"},
+		{name: "a relative URL root is kept, since it is part of the issuer", configured: "https://gitlab.example.com/gitlab/", want: "https://gitlab.example.com/gitlab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := startServer(t, nil,
+				"--auth-mode=oauth",
+				"--gitlab-url="+tt.configured,
+				"--public-url="+publicURL,
+			)
+
+			got := srv.do(t, request{method: http.MethodGet, path: metadataBasePath})
+			if got.status != http.StatusOK {
+				t.Fatalf("metadata status = %d, want 200: %s", got.status, got.body)
+			}
+			var document struct {
+				AuthorizationServers []string `json:"authorization_servers"`
+			}
+			if err := json.Unmarshal([]byte(got.body), &document); err != nil {
+				t.Fatalf("metadata is not JSON: %v", err)
+			}
+			if !slices.Equal(document.AuthorizationServers, []string{tt.want}) {
+				t.Errorf("authorization_servers = %v, want [%q]: a client compares this against the issuer GitLab publishes", document.AuthorizationServers, tt.want)
+			}
+		})
+	}
+}
+
+// TestOAuth_RefusesToStartWithNoAuthorizationServerToPublish pins the
+// discovery page's requirement that the metadata document "MUST include the
+// authorization_servers field containing at least one authorization server".
+//
+// --allow-any-gitlab-url publishes no instance, which in legacy mode is a
+// choice about who selects the instance. In oauth mode it would be a document
+// naming nowhere to authorize, so the combination is refused before anything
+// listens rather than served as an empty list.
+func TestOAuth_RefusesToStartWithNoAuthorizationServerToPublish(t *testing.T) {
+	out, err := runServerExpectingExit(t, serverBinary(t),
+		"--http", "--http-addr=127.0.0.1:"+itoa(freePort(t)),
+		"--auth-mode=oauth",
+		"--allow-any-gitlab-url",
+		"--public-url="+publicURL,
+	)
+
+	if err == nil {
+		t.Fatalf("oauth mode started with no authorization server to publish; output:\n%s", out)
+	}
+	if !strings.Contains(out, "--gitlab-url") {
+		t.Errorf("the startup error should say what is missing; got:\n%s", out)
+	}
 }
 
 // TestOAuth_SkipTLSVerifyScope verifies where oauth mode will and will not


### PR DESCRIPTION
The three authorization sub-pages of the MCP specification, revision 2026-07-28 (authorization-server-discovery, client-registration, security-considerations), read clause by clause against this server as an OAuth resource server. This is batch A of the conformance queue; batches B, C and D landed on 2026-09-01. The two questions were: do we violate anything, and is there anything the RECOMMENDED and OPTIONAL items would add. The findings table follows, one row per normative sentence.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/511

## What changes

- **The identity cache no longer holds the raw bearer.** `admitToken` stored the token in `TokenInfo.Extra["token"]` beside its SHA-256 key, while `doc.go`, `cache.go` and four documentation pages said no raw token was stored. Nothing read it (the pool takes the credential from the request header; the SDK reads the user id, scopes and expiration), so removing it changes no behaviour, and `TestNewGitLabVerifier_AdmissionCarriesNoRawToken` walks every `Extra` value of both the returned and the cached identity. The documentation now says what is true: the pooled GitLab client necessarily holds its credential for the entry's lifetime, nothing on disk.
- **The recipient refusal names the documentation page.** The 401 for a token issued to an application the deployment does not admit said "see the resource documentation named in the challenge" while the challenge named only `resource_metadata`. It now carries RFC 6750 `error_uri`, set to the page the metadata document publishes as `resource_documentation`, resolved once so the two cannot diverge.
- **Three wire tests** in `test/e2e/http/oauth_test.go` for clauses that had none: the recipient refusal names the page the document publishes; the published `authorization_servers` value is the canonical issuer (`https://GitLab.Example.com:443/` is published as `https://gitlab.example.com`); oauth mode refuses to start with `--allow-any-gitlab-url`, rather than serve an empty `authorization_servers`.
- **Docs**: the setup guide gains "Admitting only your own application" (`--oauth-client-uid`, the Application ID clients configure as `clientId`) and points at the 2026-07-28 revision; `docs/concepts/security.md` and ADR-0019 record the verification, the live check of GitLab.com's metadata on 2026-09-05, and the eleven declines with their reasons.
- `internal/oauth` and `cmd/server` stay at 100% statement coverage; an unreachable branch of `RecordKind` is gone.

## Findings

Revision 2026-07-28, pages fetched in full on 2026-09-05 from
`https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/{authorization-server-discovery,client-registration,security-considerations}.md`
(saved beside this file under `spec/`). Branch `spec-batch-a-authorization`, on top of `de07060d`.
Tracker: https://github.com/jmrplens/gitlab-mcp-server/issues/511. Predecessor: https://github.com/jmrplens/gitlab-mcp-server/pull/328.

## Summary

72 normative sentences across the three pages: **authorization-server-discovery 12**, **client-registration 26**, **security-considerations 34**.
By level: MUST 46, MUST NOT 3, SHOULD 16, MAY 6, informative pointer 1.
By bound party: **resource server 14** (ten on security-considerations, four on discovery; four of the fourteen bind every party, and one, the proxy-server consent clause, does not apply to a server that holds no client ID), **client only 35**, **authorization server only 19**, **client and authorization server 4**.

Of the fourteen resource-server clauses: **10 satisfied** (9 by this repository, 1 by the go-sdk's bearer middleware acting as a second check behind the guard), **1 gap, fixed** (SC-5: the identity cache held the raw bearer beside its digest key while every document said it did not), **2 documented deviations, unchanged and re-verified** (SC-4/SC-32 audience binding with the pin off by default; SC-33 passthrough; ADR-0019 still holds and GitLab.com's metadata still lacks `resource_indicators_supported` on 2026-09-05), **1 not applicable** (SC-29).
Adopt/decline over the RECOMMENDED and OPTIONAL items: **1 adoption** (RFC 6750 `error_uri` on the recipient-pin refusal, the one challenge parameter this server omitted), **11 declines** with reasons (six RFC 9728 fields, one RFC 6750 error code, consuming authorization-server metadata, CIMD, DCR advertising, `resource_name` internationalization).
Three wire tests added in `test/e2e/http/oauth_test.go` (the recipient refusal names the page the document publishes; the published `authorization_servers` value is the canonical issuer; oauth mode refuses to start with no instance to publish); two unit tests added; one unit assertion inverted.
The thirteen PR 328 findings were re-checked where a clause here depends on them and all hold; each is cited in the rows below by file and line.

Line numbers refer to the branch as reviewed; the rebase onto main moved nothing they point at. Wire tests are in `test/e2e/http/` and drive the real binary with `--auth-mode=oauth` against the module's fake GitLab.

## Legend

- **RS**: this server as OAuth resource server. **C**: MCP client. **AS**: authorization server (GitLab). **All**: every implementer.
- Status: `sat/us` satisfied by this repository, `sat/sdk` satisfied by the go-sdk, `n/a`, `gap` (fixed on this branch), `deviation` (accepted and recorded in ADR-0019).

## authorization-server-discovery

| ID | Sentence (verbatim) | Level | Binds | Status | Evidence |
| --- | --- | --- | --- | --- | --- |
| ASD-1 | "MCP servers **MUST** implement the OAuth 2.0 Protected Resource Metadata (RFC9728) specification to indicate the locations of authorization servers." | MUST | RS | sat/us | `internal/oauth/metadata.go:87` `NewProtectedResourceHandler` builds the document; served by the SDK's `auth.ProtectedResourceMetadataHandler` (`auth.go:188`); mounted at `cmd/server/main.go:3153` on the one path `MetadataPathFor` derives (`metadata.go:162`). Wire: `TestOAuth_DirectoryReadableMetadata`, `TestProtectedResourceMetadata_BehavesLikeAnHTTPDocument` (GET, HEAD, 405 with Allow, cacheable, CORS). |
| ASD-2 | "The Protected Resource Metadata document returned by the MCP server **MUST** include the `authorization_servers` field containing at least one authorization server." | MUST | RS | sat/us | `metadata.go:95` publishes `cfg.InstanceURLs()`; `main.go:1096` refuses to start oauth mode with no instance (`--allow-any-gitlab-url` publishes none). The value is canonical (`serverpool/token.go:340` `normalizeGitLabURL`, applied at `main.go:879`), which ASD-12 needs. Wire: `TestOAuth_MultiInstanceAllowList` ("the metadata publishes every instance"); **new** `TestOAuth_RefusesToStartWithNoAuthorizationServerToPublish`; **new** `TestOAuth_PublishedAuthorizationServerIsTheCanonicalIssuer`. |
| ASD-3 | "Clients **MUST** maintain separate registration state (client credentials, tokens) per authorization server" | MUST | C | n/a | RS-side counterpart, not required by this sentence: both caches key on instance and token (`internal/oauth/cache.go:168` `tokenKey`, `rejected.go:203` `rejectedKey`), so a credential verified against one published instance is never identity on another (PR 328 finding, holds). |
| ASD-4 | "and **MUST NOT** assume that credentials valid for one authorization server will be accepted by another." | MUST NOT | C | n/a | Same counterpart as ASD-3; the verifier verifies against the instance the request selected (`verifier.go:353` `NewGitLabVerifierFor`). Wire: `TestOAuth_MultiInstanceAllowList`. |
| ASD-5 | "MCP servers **MUST** implement one of the following discovery mechanisms to provide authorization server location information to MCP clients: 1. WWW-Authenticate Header ... 2. Well-Known URI ..." | MUST | RS | sat/us | Both. Every 401 carries `resource_metadata` (`cmd/server/bearer_guard.go:498` `oauthChallenge`; the gate's copy at `auth_gate.go`), and the well-known document is served at the RFC 9728 §3 path (`metadata.go:162`, `main.go:3153`). The spec's two well-known forms: the path form when `--public-url` carries a path, the root form when it does not, and nothing else (PR 328 finding, holds). Wire: `TestOAuth_SatisfiesRemoteDirectoryAuthProbe`, `TestOAuth_MetadataAnswersOnlyItsOwnDerivedPath`, `TestOAuth_PathCarryingPublicURLIsSelfConsistent`, `TestOAuth_ChallengeIsReadableCrossOrigin` (`WWW-Authenticate` exposed to browsers, `main.go:3566`). |
| ASD-6 | "MCP clients **MUST** support both discovery mechanisms and use the resource metadata URL from the parsed `WWW-Authenticate` headers when present; otherwise, they **MUST** fall back to constructing and requesting the well-known URIs in the order listed above." | MUST | C | n/a | The RS side is ASD-5. |
| ASD-7 | "MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses from the MCP server." | MUST | C | n/a | The challenge is a well-formed RFC 9110 quoted-string list (`bearer_guard.go:498`, `quotedStringEscape`), so a conforming parser reads it. Wire: every `TestOAuth_*` that reads `resource_metadata` out of the header (`metadataPathFromChallenge`). |
| ASD-8 | "Servers can also include a `scope` parameter in the `WWW-Authenticate` challenge to indicate the scopes required for accessing the resource; the scope semantics and the associated client behavior are defined in the Scope Selection Strategy section." | permissive ("can"; the main page says SHOULD) | RS | sat/us | Every oauth-mode challenge carries `scope` (`bearer_guard.go:498`, appended from `advertisedScope`), naming the scope that buys the full surface; the `insufficient_scope` 403 names the minimum instead (`bearer_guard.go:253`, RFC 6750 §3.1). PR 328 finding, holds. Wire: `TestOAuth_MissingCredentialChallengeHasNoErrorCode` asserts `scope="api"`. |
| ASD-9 | "MCP clients **MUST** attempt multiple well-known endpoints when discovering authorization server metadata." | MUST | C | n/a | Not consumed by the RS (see decline D-8). |
| ASD-10 | "For issuer URLs with path components (e.g., `https://auth.example.com/tenant1`), clients **MUST** try endpoints in the following priority order: ..." | MUST | C | n/a | RS-adjacent: a relative-URL-root GitLab is published with its path kept (`token.go:360` trims only the trailing slash), so the client's path-insertion form is right. Wire: **new** `TestOAuth_PublishedAuthorizationServerIsTheCanonicalIssuer` ("a relative URL root is kept"). |
| ASD-11 | "For issuer URLs without path components (e.g., `https://auth.example.com`), clients **MUST** try: ..." | MUST | C | n/a | Same. |
| ASD-12 | "After retrieving a metadata document, MCP clients **MUST** validate it as required by RFC8414 Section 3.3 or OpenID Connect Discovery Section 4.3: the `issuer` value in the document **MUST** be identical to the issuer identifier used to construct the well-known URL. If they differ, the client **MUST NOT** use the metadata." | MUST, MUST NOT | C | n/a | RS-adjacent and load-bearing: the string this server publishes is the one the client compares "identical" against GitLab's `issuer`. Verified live 2026-09-05: GitLab.com's `issuer` is `https://gitlab.com`, the canonical form `normalizeGitLabURL` produces (`token.go:340`: lowercase host `canonicalHost` `token.go:378`, default port dropped, trailing slash trimmed, path kept). Whatever the operator typed (`https://GitLab.com:443/`), the canonical form is published. Wire: **new** `TestOAuth_PublishedAuthorizationServerIsTheCanonicalIssuer`. |

## client-registration

No sentence on this page binds a resource server. Three are RS-adjacent (what a resource server publishes so the client can do what the sentence asks); those rows say what is published.

| ID | Sentence (verbatim) | Level | Binds | Status | Evidence |
| --- | --- | --- | --- | --- | --- |
| CR-1 | "Clients supporting all options **SHOULD** use the following priority order: 1. Use pre-registered client information ... 2. Use Client ID Metadata Documents ... 3. Use Dynamic Client Registration ... 4. Prompt the user ..." | SHOULD | C | n/a | RS-adjacent: this server supports option 1 by publishing where the pre-registered application is described (`resource_documentation`, CR-16) and diagnoses the option-3 trap on GitLab (CR-17). |
| CR-2 | "MCP clients and authorization servers **SHOULD** support OAuth Client ID Metadata Documents ... for client registration." | SHOULD | C, AS | n/a | GitLab.com publishes no `client_id_metadata_document_supported` (live, 2026-09-05; tracked upstream, cited in `docs/guides/oauth-app-setup.md`). A resource server has nothing to publish or consume for CIMD (decline D-9). |
| CR-3 | "MCP implementations supporting Client ID Metadata Documents **MUST** follow the requirements specified in OAuth Client ID Metadata Document." | MUST | C, AS (implementations supporting CIMD) | n/a | This server does not implement CIMD; the sentence conditions on doing so. |
| CR-4 | "Clients **MUST** host their metadata document at an HTTPS URL following RFC requirements" | MUST | C | n/a | |
| CR-5 | "The `client_id` URL **MUST** use the "https" scheme and contain a path component, e.g. `https://example.com/client.json`" | MUST | C | n/a | |
| CR-6 | "The metadata document **MUST** include at least the following properties: `client_id`, `client_name`, `redirect_uris`" | MUST | C | n/a | |
| CR-7 | "Clients **MUST** ensure the `client_id` value in the metadata matches the document URL exactly" | MUST | C | n/a | |
| CR-8 | "Clients **MAY** use `private_key_jwt` for client authentication (e.g., for requests to the token endpoint) with appropriate JWKS configuration ..." | MAY | C | n/a | |
| CR-9 | "[Authorization Servers] **SHOULD** fetch metadata documents when encountering URL-formatted client_ids" | SHOULD | AS | n/a | |
| CR-10 | "[Authorization Servers] **MUST** validate that the fetched document's `client_id` matches the URL exactly" | MUST | AS | n/a | |
| CR-11 | "[Authorization Servers] **SHOULD** cache metadata respecting HTTP cache headers" | SHOULD | AS | n/a | |
| CR-12 | "[Authorization Servers] **MUST** validate redirect URIs presented in an authorization request against those in the metadata document" | MUST | AS | n/a | |
| CR-13 | "[Authorization Servers] **MUST** validate the document structure is valid JSON and contains required fields" | MUST | AS | n/a | |
| CR-14 | "[Authorization Servers] **SHOULD** follow the security considerations in Section 6 of Client ID Metadata Document and in Client ID Metadata Document Security" | SHOULD | AS | n/a | |
| CR-15 | "MCP clients **SHOULD** check for this capability and **MAY** fall back to Dynamic Client Registration or pre-registration if unavailable." | SHOULD, MAY | C | n/a | |
| CR-16 | "MCP clients **SHOULD** support an option for static client credentials such as those supplied by a pre-registration flow. This could be: 1. Hardcode a client ID ... or 2. Present a UI to users that allows them to enter these details, after registering an OAuth client themselves (e.g., through a configuration interface hosted by the server)." | SHOULD | C | n/a | RS-adjacent, satisfied: the only RFC 9728 field that can lead a client to a pre-registered client ID is `resource_documentation`, published by default and operator-configurable (`--resource-documentation`, `metadata.go:61` `DocumentationURL`; PR 328 finding, holds), pointing at `docs/guides/oauth-app-setup.md`, which walks through registering the application and lists the redirect URI per client. Wire: `TestOAuth_ResourceDocumentationIsOperatorConfigurable`. |
| CR-17 | "MCP clients and authorization servers **MAY** support the OAuth 2.0 Dynamic Client Registration Protocol RFC7591 to allow MCP clients to obtain OAuth client IDs without user interaction." | MAY | C, AS | n/a | GitLab.com does (`registration_endpoint`, live 2026-09-05), and forces such clients to the `mcp` scope. RS-adjacent, satisfied: a token carrying `mcp` and no API scope is answered 403 `insufficient_scope` with a message naming exactly that (`bearer_guard.go:473` `describeScopeShortfall`; unit `TestDescribeScopeShortfall_NamesWhatTheTokenHolds`), and the guide's "Dynamic Client Registration and the `mcp` scope" section explains it. |
| CR-18 | "MCP clients **MUST** specify an appropriate `application_type` during Dynamic Client Registration." | MUST | C | n/a | |
| CR-19 | "Native applications ... **SHOULD** use `application_type: "native"`" | SHOULD | C | n/a | |
| CR-20 | "Web applications ... **SHOULD** use `application_type: "web"`" | SHOULD | C | n/a | |
| CR-21 | "MCP clients **MUST** be prepared to handle registration failures due to redirect URI constraints when authorization servers implement OIDC." | MUST | C | n/a | |
| CR-22 | "When a registration request is rejected, clients **SHOULD** surface a meaningful error to the user or developer." | SHOULD | C | n/a | |
| CR-23 | "Clients **MAY** retry registration with an adjusted `application_type` or with redirect URIs that conform to the authorization server's requirements for the given application type." | MAY | C | n/a | |
| CR-24 | "Clients that use pre-registered credentials, or persist client credentials obtained via Dynamic Client Registration, **MUST** associate those credentials with the specific authorization server that issued them, keyed by the authorization server's `issuer` identifier." | MUST | C | n/a | RS-adjacent: the key the client uses is the value this server publishes, so it must be stable across restarts and spellings; it is the canonical form (ASD-12). |
| CR-25 | "When the authorization server changes (detected via updated protected resource metadata), clients **MUST NOT** reuse client credentials from a different authorization server and **MUST** re-register with the new authorization server." | MUST NOT, MUST | C | n/a | RS-adjacent: a change to `--gitlab-url` is visible to the client through `authorization_servers`, which is exactly the detection the sentence names. Nothing further for the RS to do. |
| CR-26 | "If the authorization server indicated by protected resource metadata no longer matches the one the credentials were registered with, clients **SHOULD** surface an error rather than silently attempting to use mismatched credentials." | SHOULD | C | n/a | |

## security-considerations

| ID | Sentence (verbatim) | Level | Binds | Status | Evidence |
| --- | --- | --- | --- | --- | --- |
| SC-1 | "This document outlines security requirements that implementers **MUST** consider when building MCP clients and servers." | MUST | All | sat/us | This table. |
| SC-2 | "Additionally, implementors **MUST** follow OAuth 2.1 security best practices as outlined in OAuth 2.1 Section 7. "Security Considerations"." | MUST | All | sat/us | The §7 items that bind a resource server, against draft-ietf-oauth-v2-1-13: §7.1.3.2 "The client MUST validate the TLS certificate chain when making requests to protected resources" (this server is that client on the upstream leg: `main.go:1122` refuses `--skip-tls-verify` for a non-loopback instance in oauth mode; wire `TestOAuth_SkipTLSVerifyScope`); §7.1.3.3 always TLS (`config.go:1052` `ValidateOAuthGitLabURL`, `main.go:1129`; wire `TestOAuth_PlaintextInstanceIsRefusedAtStartup`); §7.1.3.7 "Bearer tokens MUST NOT be passed in page URLs" (the only accepted method is the `Authorization` header, `token.go:101` `bearerCredential`, and `bearer_methods_supported: ["header"]` says so, `metadata.go:96`); §7.7 credentials-guessing (per-address failure budget `auth_gate.go:24`, rejected-token cache `rejected.go:101`; wire `TestGate_RepeatedFailuresBlockTheAddress`, `TestOAuth_RejectedTokenIsNotRelayedUpstreamEveryTime`); §7.1.1.2 token disclosure (tokens reach logs as their last four characters, `main.go:3314` `safeTokenSuffix`; and see SC-5). |
| SC-3 | "MCP clients **MUST** include the `resource` parameter in authorization and token requests as specified in the Resource Parameter Implementation section" | MUST | C | n/a | GitLab ignores it (no `resource_indicators_supported`); the client must still send it. Nothing for the RS. |
| SC-4 | "MCP servers **MUST** validate that tokens presented to them were specifically issued for their use" | MUST | RS | deviation (ADR-0019, re-verified) | The named mechanism is unavailable: GitLab.com's authorization-server metadata on 2026-09-05 carries the same eighteen keys ADR-0019 recorded and no `resource_indicators_supported`. The "otherwise verify" alternative (SC-32) is implemented opt-in: `--oauth-client-uid` compares the application a token was minted for (`verifier.go:594` `acceptedRecipient`, checked before anything is cached at `verifier.go:455`). With the pin off (the default) the deviation stands as ADR-0019 decision 4 records it; the trade-off (a pin refuses personal access tokens) is unchanged. ADR-0019 NEU-001 now carries the re-check date. Wire: **new** `TestOAuth_RecipientRefusalNamesTheDocumentationPage` (pinned application admitted, another refused). |
| SC-5 | "Clients and servers **MUST** implement secure token storage and follow OAuth best practices, as outlined in OAuth 2.1, Section 7.1." | MUST | C, RS | **gap, fixed** | The identity cache is keyed by SHA-256 of instance and token (`cache.go:168`) and every document said no raw token was stored, but the cached value, `auth.TokenInfo`, carried the bearer in `Extra["token"]` "for downstream GitLab client creation" (old `verifier.go:459`). Nothing read it: the pool takes the credential from the request header (`auth_gate.go:495`) and the SDK reads only `UserID`, `Scopes` and `Expiration`. Fix: `admitToken` no longer stores it (`verifier.go:470` region), doc comment on `NewGitLabVerifier` says why; unit `TestNewGitLabVerifier_AdmissionCarriesNoRawToken` walks every `Extra` value of both the returned and the cached identity. Documentation corrected where it overstated: `docs/concepts/security.md` (identity caching bullet, threat table), `docs/guides/http-server-mode.md` (session key isolation, token caching), `docs/guides/oauth-app-setup.md` (server-side cache), site EN/ES HTTP page (pool bullet and FAQ), now stating that the pooled GitLab client necessarily holds its credential for the entry's lifetime and nothing is written to disk. Commit `fix(oauth): keep the raw token out of the identity cache`. |
| SC-6 | "Authorization servers **SHOULD** issue short-lived access tokens to reduce the impact of leaked tokens." | SHOULD | AS | n/a | RS-adjacent (PR 328 finding, holds): the cached admission never outlives the token, `verifier.go:491` `effectiveCacheTTL` reads `expires_in`/`expires_at`; unit `TestGitLabVerifier_CacheNeverOutlivesTheToken`. GitLab.com issues 2-hour OAuth tokens. |
| SC-7 | "For public clients, authorization servers **MUST** rotate refresh tokens as described in OAuth 2.1 Section 4.3.1 "Token Endpoint Extension"." | MUST | AS | n/a | Refresh tokens never reach this server. |
| SC-8 | "Implementations **MUST** follow OAuth 2.1 Section 1.5 "Communication Security"." | MUST | All | sat/us | `--public-url` must be https (`config.go:1100` `validatePublicURL`, loopback http tolerated for development); every published instance must be https (`config.go:1052`, `main.go:1129`); `--skip-tls-verify` refused for a non-loopback instance (`main.go:1122`); the listener can terminate TLS itself (`--tls-cert`/`--tls-key`). Wire: `TestOAuth_RequiresPublicURL`, `TestOAuth_PlaintextInstanceIsRefusedAtStartup`, `TestOAuth_SkipTLSVerifyScope`. |
| SC-9 | "All authorization server endpoints **MUST** be served over HTTPS." | MUST | AS | n/a | RS-adjacent: only https instances are published as `authorization_servers` (SC-8), so this server never points a client at a plaintext authorization server. |
| SC-10 | "All redirect URIs **MUST** be either `localhost` or use HTTPS." | MUST | C, AS | n/a | The redirect URI table in `docs/guides/oauth-app-setup.md` lists only loopback and https callbacks. |
| SC-11 | "To mitigate this, MCP clients **MUST** implement PKCE according to OAuth 2.1 Section 7.5.2 and **MUST** verify PKCE support before proceeding with authorization." | MUST | C | n/a | |
| SC-12 | "MCP clients **MUST** use the `S256` code challenge method when technically capable, as required by OAuth 2.1 Section 4.1.1." | MUST | C | n/a | |
| SC-13 | "MCP clients **MUST** rely on authorization server metadata to verify this capability" | MUST | C | n/a | GitLab.com publishes `code_challenge_methods_supported: ["plain","S256"]` (live 2026-09-05), so the gate passes for the authorization server this deployment publishes. |
| SC-14 | "**OAuth 2.0 Authorization Server Metadata**: If `code_challenge_methods_supported` is absent, the authorization server does not support PKCE and MCP clients **MUST** refuse to proceed." | MUST | C | n/a | Present at GitLab.com (SC-13). |
| SC-15 | "**OpenID Connect Discovery 1.0**: ... MCP clients **MUST** verify the presence of `code_challenge_methods_supported` in the provider metadata response. If the field is absent, MCP clients **MUST** refuse to proceed." | MUST | C | n/a | Present in GitLab.com's `/.well-known/openid-configuration` too (live 2026-09-05), so a client that falls through to OIDC discovery does not refuse. |
| SC-16 | "Authorization servers providing OpenID Connect Discovery 1.0 **MUST** include `code_challenge_methods_supported` in their metadata to ensure MCP compatibility." | MUST | AS | n/a | GitLab.com complies (SC-15). |
| SC-17 | "An attacker that controls one of the authorization servers an MCP client interacts with may attempt to have the client send it an authorization code or token issued by a different, honest authorization server (a mix-up attack ...). Authorization Response Validation specifies the required mitigation." | informative pointer | C (the MUSTs live on the main page) | n/a | RS-adjacent because a deployment publishing several `authorization_servers` is the multi-AS setting the attack needs: the mitigation is the client's `iss` comparison, GitLab.com publishes no `authorization_response_iss_parameter_supported` (live 2026-09-05), and RFC 9728 gives a resource server no field to help with. What this server does control: it never sends a client's bearer to an instance the client did not name (`auth_gate.go:675` `requireExplicitInstance`; wire `TestGate_PublishedInstances_HeaderCannotRedirectTheCredential`, `TestOAuth_MultiInstanceAllowList`), and the verifier refuses a verification redirect that leaves the instance (`verifier.go:252` `verificationRedirect`; unit `TestNewGitLabVerifier_CrossHostRedirect_IsRefused`). Recorded in ADR-0019 NEU-001. |
| SC-18 | "MCP clients **MUST** have redirect URIs registered with the authorization server." | MUST | C | n/a | The setup guide's per-client redirect URI table is where an operator registers them. |
| SC-19 | "Authorization servers **MUST** validate exact redirect URIs against pre-registered values to prevent redirection attacks." | MUST | AS | n/a | GitLab (Doorkeeper) does; the guide's `localhost` versus `127.0.0.1` note documents its exact-match rule. |
| SC-20 | "MCP clients **SHOULD** use and verify state parameters in the authorization code flow and discard any results that do not include or have a mismatch with the original state." | SHOULD | C | n/a | |
| SC-21 | "Authorization servers **MUST** take precautions to prevent redirecting user agents to untrusted URI's, following suggestions laid out in OAuth 2.1 Section 7.12.2" | MUST | AS | n/a | |
| SC-22 | "Authorization servers **SHOULD** only automatically redirect the user agent if it trusts the redirection URI. If the URI is not trusted, the authorization server MAY inform the user and rely on the user to make the correct decision." | SHOULD, MAY | AS | n/a | |
| SC-23 | "When implementing Client ID Metadata Documents, authorization servers **MUST** consider the security implications detailed in OAuth Client ID Metadata Document, Section 6." | MUST | AS | n/a | |
| SC-24 | "Authorization servers fetching metadata documents **SHOULD** consider Server-Side Request Forgery (SSRF) risks" | SHOULD | AS | n/a | |
| SC-25 | "Authorization servers: **SHOULD** display additional warnings for `localhost`-only redirect URIs" | SHOULD | AS | n/a | |
| SC-26 | "**MAY** require additional attestation mechanisms for enhanced security" | MAY | AS | n/a | |
| SC-27 | "**MUST** clearly display the redirect URI hostname during authorization" | MUST | AS | n/a | |
| SC-28 | "Authorization servers **MAY** implement domain-based trust policies for accepting Client ID Metadata Documents" | MAY | AS | n/a | |
| SC-29 | "MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically registered client before forwarding to third-party authorization servers (which may require additional consent)." | MUST | RS acting as an OAuth proxy with a static client ID | n/a | This server holds no client ID, registers no clients, serves no `/authorize` or `/token`, and forwards nothing to a third-party authorization server: the client authorizes with GitLab directly and this server only verifies the result. Every path other than the MCP endpoint, the metadata document, `/health` and the server card is an unauthenticated 404 (`main.go:2724` `mountMCPEndpoint`; wire `TestOAuth_UnknownPathIs404NotAChallenge`). |
| SC-30 | "MCP servers **MUST** validate access tokens before processing the request, ensuring the access token is issued specifically for the MCP server, and take all necessary steps to ensure no data is returned to unauthorized parties." | MUST | RS | sat/us (first and third conjuncts); the second is SC-4 | Before processing: the guard is the outermost layer of the MCP endpoint chain (`main.go:3162`: guard, SDK bearer middleware, pool gate, handler), runs on every method except a CORS preflight (`bearer_guard.go:139`), and the SDK middleware behind it is a second check (`auth.go:97`). No data to unauthorized parties: `tools/list` and `server/discover` stay authenticated (ADR-0018 paragraph quotes this exact sentence; holds), stateful `GET`/`DELETE` are gated (`auth_gate.go:340`; wire `TestGate_StatefulGETAndDELETEAreAuthenticated`), a session is bound to the credential that minted it (`auth_gate.go:401`; wire `TestGate_SessionIsBoundToTheCredentialThatMintedIt`; PR 328 finding, holds), and an untrusted `Origin` is refused on every method (`main.go:2759`; wire `TestCrossOrigin_MCPEndpointRefusesUntrustedOriginOnEveryMethod`; PR 328 finding, holds). Wire for "before processing": `TestOAuth_SatisfiesRemoteDirectoryAuthProbe` (a `tools/call` naming a nonexistent tool is 401, never dispatched). |
| SC-31 | "A MCP server **MUST** follow the guidelines in OAuth 2.1 - Section 5.2 to validate inbound tokens." | MUST | RS | sat/us, with the SDK as second check | §5.2: "the resource server MUST check that the access token is not yet expired, is authorized to access the requested resource, was issued with the appropriate scope, and meets other policy requirements". Validity: verified against the issuing instance's `/api/v4/user` (`verifier.go:383`) and the pool's own probe (`pool.go:807`); a reference token checked by "querying the authorization server", the form §5.2 names. Not expired: the token's own expiry caps the cache (`verifier.go:491`), and the SDK middleware refuses an expired `TokenInfo` (`auth.go:171`). Scope: `MinimumScope` at the door (`bearer_guard.go:233`, `verifier.go:67` `SatisfiesMinimum`), the SDK's containment check behind it (`auth.go:155`), and per action through the surface narrowed to the token's real authority (`pool.go:871` `applyScopeReadOnly`; ADR-0018; wire `TestOAuth_ReadAPITokenGetsAReadOnlySurface`). Policy: the recipient pin (SC-4). Wire: `TestOAuth_RejectedTokenSaysInvalidToken`, `TestOAuth_UnderScopedTokenIsForbiddenNotInvalid`, `TestOAuth_ReadAPITokenIsAdmitted`. Step-up on the tool-call path itself (403 `insufficient_scope` on the mutating call) remains the open half recorded in ADR-0018 NEG-003; it belongs to the main page's Scope Challenge Handling, not to these three. |
| SC-32 | "MCP servers **MUST** only accept tokens specifically intended for themselves and **MUST** reject tokens that do not include them in the audience claim or otherwise verify that they are the intended recipient of the token." | MUST | RS | deviation (ADR-0019, re-verified) | No audience claim exists to check (SC-4). "Otherwise verify" is `--oauth-client-uid` (`verifier.go:594`), opt-in. Unchanged; the refusal it produces now names the remedy page (A-1). |
| SC-33 | "If the MCP server makes requests to upstream APIs, it may act as an OAuth client to them. The access token used at the upstream API is a separate token, issued by the upstream authorization server. The MCP server **MUST NOT** pass through the token it received from the MCP client." | MUST NOT | RS | deviation (ADR-0019 decision 3, unchanged) | The token is forwarded, to the GitLab that issued it, as the same user, with no scope added; the sentence's own framing ("a separate token, issued by the upstream authorization server") describes a third party this deployment does not have. ADR-0019 concedes the letter and states why the deviation does not generalize; `docs/concepts/security.md` says the same in operator terms, and the two still agree. Not re-argued here. |
| SC-34 | "MCP clients **MUST** implement and use the `resource` parameter as defined in RFC 8707 ... to explicitly specify the target resource for which the token is being requested." | MUST | C | n/a | RS-adjacent: the value a client sends is the RFC 9728 `resource` this server publishes, `--public-url` verbatim (`metadata.go`, `Resource: resourceURL`); wire `TestOAuth_PathCarryingPublicURLIsSelfConsistent`. |

## Question 2: what is RECOMMENDED or OPTIONAL and omitted, adopt or decline

### RFC 9728 §2 protected-resource metadata fields, one by one

| Field | RFC level | Published | Decision |
| --- | --- | --- | --- |
| `resource` | REQUIRED | yes, `--public-url` verbatim | present |
| `authorization_servers` | OPTIONAL in the RFC, MUST here (ASD-2) | yes, canonical instance URLs | present |
| `scopes_supported` | RECOMMENDED | yes: `api`, `read_api` for a writing deployment; `read_api` alone under `--read-only`/`--safe-mode` (`verifier.go:85`) | present |
| `bearer_methods_supported` | OPTIONAL | yes: `["header"]`, and true (only the header is read) | present |
| `resource_name` | RECOMMENDED | yes: `GitLab MCP Server` (`metadata.go:101`) | present. **D-1 declined**: the RFC's `resource_name#<lang>` internationalization; the value is a product name, identical in every language the docs ship. |
| `resource_documentation` | OPTIONAL | yes, default or `--resource-documentation` | present (PR 328) |
| `resource_policy_uri` | OPTIONAL | when `--resource-policy-uri` is set | present (PR 328); omitted by default on purpose (a dead link on a consent screen) |
| `resource_tos_uri` | OPTIONAL | when `--resource-tos-uri` is set | present (PR 328) |
| `jwks_uri` | OPTIONAL | no | **D-2 declined**: for a resource server that signs or encrypts its responses; this one signs nothing, so there is no key to publish. |
| `resource_signing_alg_values_supported` | OPTIONAL | no | **D-3 declined**: same reason as `jwks_uri`. |
| `tls_client_certificate_bound_access_tokens` | OPTIONAL, default `false` | no | **D-4 declined**: GitLab issues no certificate-bound tokens; omitting the field states `false`, which is the truth. Publishing `true` would tell a client to bind what cannot be bound. |
| `authorization_details_types_supported` | OPTIONAL | no | **D-5 declined**: RFC 9396 rich authorization requests; GitLab's metadata lists no `authorization_details_types_supported` (live 2026-09-05), so no type could be honored. |
| `dpop_signing_alg_values_supported`, `dpop_bound_access_tokens_required` | OPTIONAL | no | **D-6 declined**: GitLab publishes no `dpop_signing_alg_values_supported` (live 2026-09-05), so no DPoP-bound token can be issued for this resource; requiring one would refuse every client. Revisit trigger recorded in ADR-0019 NEU-001. |
| `signed_metadata` | OPTIONAL | no | **D-7 declined**: needs a signing key and a client that verifies it; no MCP client does, and the SDK's `oauthex.ProtectedResourceMetadata` (v1.7.0) has no field for it. |

### RFC 6750 §3 `WWW-Authenticate` challenge parameters, one by one

| Parameter | Level | Emitted | Decision |
| --- | --- | --- | --- |
| auth-scheme `Bearer` | MUST | yes, every challenge (`bearer_guard.go:500`) | present |
| `realm` | OPTIONAL | yes, `gitlab-mcp-server` | present |
| `scope` | OPTIONAL (SHOULD on the main page) | yes, every challenge; the minimum on `insufficient_scope` | present (PR 328) |
| `error` | OPTIONAL; omitted on a request that carried no credential (§3.1) | `invalid_token` on a rejected or unaccepted token, `insufficient_scope` on an under-scoped one, none on a missing credential | present; wire `TestOAuth_MissingCredentialChallengeHasNoErrorCode`, `TestOAuth_RejectedTokenSaysInvalidToken`, `TestOAuth_UnderScopedTokenIsForbiddenNotInvalid` |
| `error` = `invalid_request` | OPTIONAL | no | **D-8a declined**: no request shape reaches it. Only one token method is read, so "more than one method" cannot occur; a foreign scheme (`Basic`) or an empty `Bearer` is answered as a request carrying no bearer, with the plain challenge, which is what RFC 9110 §11.6.1 prescribes for a scheme the resource does not accept. |
| `error_description` | OPTIONAL | yes, on every `error` | present |
| `error_uri` | OPTIONAL | **now yes**, on the unaccepted-recipient 401 | **A-1 adopted**. It is the one refusal whose remedy is a web page rather than a protocol step (obtain a token from the application the operator published), and the message already told the holder to read "the resource documentation named in the WWW-Authenticate challenge" while the challenge named only `resource_metadata`. The page is resolved once (`metadata.go:61` `ResourceLinks.DocumentationURL`) and handed to both the document and the guard (`main.go:3115`, `main.go:3130`), so the two cannot name different pages. `bearer_guard.go:385`. Unit: `TestBearerGuard_UnacceptedRecipient_NamesTheDocumentationPage` (fresh and cached refusals), `TestBearerGuard_UnacceptedRecipient_WithoutAPageEmitsNoErrorURI`, `TestResourceLinks_DocumentationURL_IsWhatTheDocumentPublishes`. Wire: `TestOAuth_RecipientRefusalNamesTheDocumentationPage`, which reads the page out of the served document and requires the challenge to name that same page, for an operator page and for the default. Commit `feat(oauth): name the documentation page in the recipient refusal`. |
| `resource_metadata` (RFC 9728 §5.1) | the discovery mechanism | yes, every oauth-mode challenge | present |

### Authorization-server metadata this server consumes

| Item | Decision |
| --- | --- |
| Fetching `/.well-known/oauth-authorization-server` (or the OIDC document) of each published instance, at startup or on demand | **D-8 declined**, on purpose. RFC 9728 and the discovery page place authorization-server discovery and its validation on the client (ASD-9 to ASD-12); a resource server has no protocol role in it and nothing it could publish from the result. A startup probe would make a deployment's start depend on reaching the instance, and a client re-validates the document anyway, so a wrong answer would be caught by the party the specification charges with catching it. What the resource server does owe the client is a published value that makes that validation succeed: the canonical issuer form (ASD-12, wire-tested). The revisit trigger for ADR-0019 (`resource_indicators_supported` appearing) stays a maintainer watch of that document; the same watch now covers CIMD, `iss` and DPoP (ADR-0019 NEU-001). |

### Client-registration mechanisms, as they affect what a resource server publishes or expects

| Mechanism | What a resource server can publish or expect | Decision |
| --- | --- | --- |
| Client ID Metadata Documents | Nothing: the capability flag is the authorization server's (`client_id_metadata_document_supported`), the document is the client's, and a resource server neither fetches nor validates either. GitLab.com does not advertise it (live 2026-09-05). | **D-9 declined** as not applicable. The guide's statement that GitLab has not shipped CIMD stays accurate. |
| Pre-registration | `resource_documentation` is the RFC 9728 field that leads a client to a pre-registered client ID, and the guide it points at registers the application and lists redirect URIs per client. The `--oauth-client-uid` pin is the resource server's side of "expect": only tokens of the published application. | present; the guide now also has an "Admitting only your own application" section (the ADR cited the guide for where a uid is found, and the guide never said). |
| Dynamic Client Registration | Nothing to publish. What a resource server can do is diagnose the outcome: on GitLab a dynamically registered client is forced to the `mcp` scope, and the 403 names that (`describeScopeShortfall`). | present. **D-10 declined**: advertising a registration endpoint or DCR support in the protected-resource document; RFC 9728 defines no such field, and GitLab's own metadata already carries `registration_endpoint`. |

### Security-considerations mitigations for a resource server, one by one

| Mitigation | Status |
| --- | --- |
| Audience binding (RFC 8707) | unavailable at GitLab; opt-in recipient pin instead (ADR-0019). Deviation with the pin off. |
| Token passthrough prohibition | deviation, ADR-0019 decision 3, unchanged. |
| Secure token storage | fixed (SC-5): digest keys, no token material in the cached identity, last four characters in logs, nothing on disk; the pooled client holds its credential for the entry's lifetime, bounded by idle timeout, credential age and LRU eviction. |
| Short-lived tokens honored | the cache never outlives the token (SC-6). |
| Communication security | https enforced for identifier and instances; certificate verification cannot be disabled for a remote instance in oauth mode (SC-8). |
| Credentials guessing | per-address failure budget, transport-source budget behind a trusted proxy header, rejected-token cache (SC-2). |
| Session binding | a session ID is bound to the credential that minted it (SC-30; PR 328 finding, holds). |
| Open redirection, PKCE, `state`, mix-up | client's and authorization server's. This server's verification client refuses a cross-host redirect of its own (SC-17). |
| Confused deputy (proxy with a static client ID) | not applicable (SC-29). |
| Access token privilege restriction | validated before processing; minimum scope at the door, authority per action (SC-30, SC-31). |

**D-11 declined**: consuming `Retry-After` from GitLab's authorization endpoints or `revocation_endpoint` for proactive revocation. A revoked token is detected on the first data call GitLab refuses (`pool.go` `SetOnUnauthorized`) and within the cache TTL; introspecting `/oauth/token/info` on every request would double the upstream cost this batch's predecessors reduced.

## Ambiguities, read conservatively

- SC-33 is read as binding this server despite the framing about a separate upstream token, because the prohibition sentence itself carries no condition (ADR-0019 already took this reading; it is kept).
- ASD-5's "at the path of the server's MCP endpoint" is read as the RFC 9728 §3 derivation from the published resource identifier (`--public-url`), not from every path the handler happens to answer; the alternative (serving the document under `/mcp` too) was rejected in PR 328 as claiming an identity the deployment did not publish.
- OAuth 2.1 §5.2's "issued with the appropriate scope" is read as satisfied by the per-action narrowing rather than by a per-call 403; a per-call `insufficient_scope` step-up is a stricter reading and remains ADR-0018 NEG-003's open item on the main page, outside these three.
