### PR TITLE
fix(bench): measure what a credential costs to hold, not only to serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,71 +462,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 <summary><strong>Unnecessary statistics</strong> — numbers nobody asked for</summary>
 
 <!-- START STATS -->
-
-### File counts
-
-| Category                 |     Files |       Lines |
-| ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,151 |     234,957 |
-| Unit tests (`_test.go`)  |       657 |     386,796 |
-| End-to-end tests         |       237 |      62,983 |
-| **Total**                | **2,045** | **684,736** |
-
-### Functions
-
-| Category                        |  Count |
-| ------------------------------- | -----: |
-| Source functions                |  8,767 |
-| . Exported (public)             |  2,861 |
-| . Unexported (private)          |  5,906 |
-| Unit test functions (`TestXxx`) | 13,535 |
-| Subtests (`t.Run(...)`)         |  5,186 |
-| End-to-end test functions       |    589 |
-
-### Ratios worth noting
-
-| Observation                        |                      Value |
-| ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.65× more tests than code |
-| Average source file length         |                 ~204 lines |
-| Average test file length           |                 ~589 lines |
-| Comment lines in source            |  37,788 (~16.1% of source) |
-| Test functions per source function |                       1.5× |
-
-### Code patterns
-
-| Pattern                            | Count |
-| ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,354 |
-| `defer` statements                 | 1,279 |
-| `struct` types defined             | 2,937 |
-| `//nolint` suppressions            |   312 |
-| `TODO` / `FIXME` / `HACK` comments |     2 |
-
-### Project
-
-| Metric                         | Value |
-| ------------------------------ | ----: |
-| Go packages                    |   253 |
-| Direct dependencies (`go.mod`) |    31 |
-| Indirect dependencies          |    38 |
-
-### Hall of fame
-
-| Record              | File                                    |
-| ------------------- | --------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,520 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,259 lines |
-
-### Because why not
-
-| Fact                                 | Value                                                                                                |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,271 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,693 (impossible to avoid)                                                                         |
-| Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
-| Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
-
+@@GENERATED@@
 <!-- END STATS -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -462,7 +462,71 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 <summary><strong>Unnecessary statistics</strong> — numbers nobody asked for</summary>
 
 <!-- START STATS -->
-@@GENERATED@@
+
+### File counts
+
+| Category                 |     Files |       Lines |
+| ------------------------ | --------: | ----------: |
+| Source (`.go`, non-test) |     1,151 |     235,301 |
+| Unit tests (`_test.go`)  |       657 |     387,371 |
+| End-to-end tests         |       237 |      62,983 |
+| **Total**                | **2,045** | **685,655** |
+
+### Functions
+
+| Category                        |  Count |
+| ------------------------------- | -----: |
+| Source functions                |  8,779 |
+| . Exported (public)             |  2,861 |
+| . Unexported (private)          |  5,918 |
+| Unit test functions (`TestXxx`) | 13,545 |
+| Subtests (`t.Run(...)`)         |  5,196 |
+| End-to-end test functions       |    589 |
+
+### Ratios worth noting
+
+| Observation                        |                      Value |
+| ---------------------------------- | -------------------------: |
+| Test lines vs source lines         | 1.65× more tests than code |
+| Average source file length         |                 ~204 lines |
+| Average test file length           |                 ~590 lines |
+| Comment lines in source            |  37,957 (~16.1% of source) |
+| Test functions per source function |                       1.5× |
+
+### Code patterns
+
+| Pattern                            | Count |
+| ---------------------------------- | ----: |
+| `if err != nil` checks             | 7,358 |
+| `defer` statements                 | 1,280 |
+| `struct` types defined             | 2,937 |
+| `//nolint` suppressions            |   312 |
+| `TODO` / `FIXME` / `HACK` comments |     2 |
+
+### Project
+
+| Metric                         | Value |
+| ------------------------------ | ----: |
+| Go packages                    |   253 |
+| Direct dependencies (`go.mod`) |    31 |
+| Indirect dependencies          |    38 |
+
+### Hall of fame
+
+| Record              | File                                    |
+| ------------------- | --------------------------------------- |
+| Longest source file | `cmd/server/main.go`. 4,520 lines       |
+| Longest test file   | `cmd/server/main_test.go`. 10,259 lines |
+
+### Because why not
+
+| Fact                                 | Value                                                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Source code printed at 55 lines/page | ~4,278 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,693 (impossible to avoid)                                                                         |
+| Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
+| Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
+
 <!-- END STATS -->
 
 </details>

--- a/cmd/bench_resources/figures.go
+++ b/cmd/bench_resources/figures.go
@@ -66,13 +66,25 @@ type labels struct {
 	SeriesP50             string
 	SeriesP99             string
 	SeriesHead            []string
-	SeriesCaption         string
-	SeriesBudgetClause    string
-	SeriesNoBudget        string
-	SeriesComplete        string
-	SeriesStopBudget      string
-	SeriesStopLatency     string
-	SeriesStopFailure     string
+	// SeriesSettledHeap and SeriesSettledRSS head the two columns a step
+	// carries only when its series took a settled reading, spliced in after
+	// the resident columns rather than kept in SeriesHead, which describes the
+	// figures every series has.
+	SeriesSettledHeap string
+	SeriesSettledRSS  string
+	// SeriesSlopes and SeriesLoadSlopeOnly are the sentence under a series
+	// table. Both name what their figures measure: one number per credential
+	// is read as what a credential costs, and the resident one is the
+	// credential and its requests in flight together.
+	SeriesSlopes        string
+	SeriesLoadSlopeOnly string
+	SeriesCaption       string
+	SeriesBudgetClause  string
+	SeriesNoBudget      string
+	SeriesComplete      string
+	SeriesStopBudget    string
+	SeriesStopLatency   string
+	SeriesStopFailure   string
 
 	MeasuredOn string
 	// HostCPUs, HostRAM and HostKernel are the words the machine's own
@@ -147,6 +159,15 @@ func englishLabels() labels {
 			"Credentials", "Resident, mean", "Resident, peak", "CPU per call", "Calls",
 			"tools/call p50", "tools/call p99", "tools/list p50", "tools/list p99", "Goroutines",
 		},
+		SeriesSettledHeap: "Settled heap",
+		SeriesSettledRSS:  "Settled resident",
+		SeriesSlopes: "Fitted across these steps: the peak resident set under load grows %.2f MiB per credential, " +
+			"and the settled live heap, read with the load stopped and a collection forced, grows %.1f KiB per credential. " +
+			"The first is what a credential costs while it and every other one is calling; the second is what it costs to hold. " +
+			"The settled resident set lags both, because Go returns freed pages to the operating system on its own schedule.",
+		SeriesLoadSlopeOnly: "Fitted across these steps, the peak resident set under load grows %.2f MiB per credential. " +
+			"That is a credential together with the requests it keeps in flight, not what a credential costs to hold: " +
+			"this record carries no settled reading.",
 		SeriesCaption:      "%s, %s surface: %d in flight per credential, %.0f s per step, %s",
 		SeriesBudgetClause: "memory budget %.0f MiB",
 		SeriesNoBudget:     "no memory budget",
@@ -233,6 +254,15 @@ func spanishLabels() labels {
 			"Credenciales", "Residente, media", "Residente, pico", "CPU por llamada", "Llamadas",
 			"tools/call p50", "tools/call p99", "tools/list p50", "tools/list p99", "Goroutines",
 		},
+		SeriesSettledHeap: "Heap en reposo",
+		SeriesSettledRSS:  "Residente en reposo",
+		SeriesSlopes: "Ajustado sobre estos pasos: el pico de conjunto residente bajo carga crece %.2f MiB por credencial, " +
+			"y el heap vivo en reposo, leído con la carga detenida y una recolección forzada, crece %.1f KiB por credencial. " +
+			"Lo primero es lo que cuesta una credencial mientras ella y todas las demás están llamando; lo segundo es lo que cuesta mantenerla. " +
+			"El conjunto residente en reposo va por detrás de ambos, porque Go devuelve al sistema operativo las páginas liberadas según su propio calendario.",
+		SeriesLoadSlopeOnly: "Ajustado sobre estos pasos, el pico de conjunto residente bajo carga crece %.2f MiB por credencial. " +
+			"Eso es una credencial junto con las peticiones que mantiene en vuelo, no lo que cuesta mantener una credencial: " +
+			"este registro no contiene ninguna lectura en reposo.",
 		SeriesCaption:      "%s, superficie %s: %d en vuelo por credencial, %.0f s por paso, %s",
 		SeriesBudgetClause: "presupuesto de memoria de %.0f MiB",
 		SeriesNoBudget:     "sin presupuesto de memoria",

--- a/cmd/bench_resources/profiles.go
+++ b/cmd/bench_resources/profiles.go
@@ -6,7 +6,7 @@
 // it is the only way the series can look inside the process it measures, and
 // it is also how the goroutine count is taken without the traceback signal
 // the point scenarios use, which ends the process and so cannot be sent
-// between steps.
+// between steps, and how the live heap is read once a step's load has stopped.
 
 package main
 
@@ -77,10 +77,65 @@ func (p *pprofClient) cpuProfile(ctx context.Context, seconds int) captured {
 	return captured{data: data, err: err}
 }
 
-// heapProfile collects the heap as it is now.
+// heapProfile collects the heap as it is now, after forcing a collection.
+//
+// The collection is the difference between a profile of what is live and a
+// profile of whatever had not been collected yet. Without gc=1 the handler
+// serves the last completed cycle's snapshot, so a reader attributing "the
+// in-use heap" to functions is attributing garbage the collector had not got
+// to along with it. That is not a rounding error on a process serving
+// thousands of calls a second: the profile is the evidence the hot-spot
+// analysis reads, and it has to mean what its readers think it means.
 func (p *pprofClient) heapProfile(ctx context.Context) captured {
-	data, err := p.fetch(ctx, "/debug/pprof/heap", profileGrace)
+	data, err := p.fetch(ctx, "/debug/pprof/heap?gc=1", profileGrace)
 	return captured{data: data, err: err}
+}
+
+// settledHeap forces a collection and reads the live heap the process is left
+// holding, in bytes.
+//
+// Two collections rather than one. The first still counts what the phase that
+// just ended left behind for one more cycle: the last responses being written,
+// the profile's own buffers, whatever a finalizer still holds. Reading twice
+// makes the figure a settled heap rather than the tail of the load. It is the
+// technique TestSharedServer_LiveHeapDoesNotGrowWithTheNumberOfCredentials
+// uses in test/e2e/http, taken here at every step of a series.
+func (p *pprofClient) settledHeap(ctx context.Context) (uint64, error) {
+	if _, err := p.heapAlloc(ctx); err != nil {
+		return 0, err
+	}
+	return p.heapAlloc(ctx)
+}
+
+// heapAlloc performs one collection and returns the live heap the profile
+// reports.
+//
+// debug=1 is what carries it: the text form of a heap profile ends with a
+// runtime.MemStats dump, one "# Field = value" per line, and HeapAlloc there
+// is the live set. The binary form carries sample counts, not MemStats.
+func (p *pprofClient) heapAlloc(ctx context.Context) (uint64, error) {
+	body, err := p.fetch(ctx, "/debug/pprof/heap?gc=1&debug=1", profileGrace)
+	if err != nil {
+		return 0, err
+	}
+	return parseHeapAlloc(body)
+}
+
+// parseHeapAlloc reads "# HeapAlloc = N" off the MemStats dump that ends a
+// debug=1 heap profile.
+func parseHeapAlloc(body []byte) (uint64, error) {
+	for line := range strings.SplitSeq(string(body), "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "# HeapAlloc = ")
+		if !ok {
+			continue
+		}
+		value, err := strconv.ParseUint(strings.TrimSpace(rest), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse HeapAlloc %q: %w", rest, err)
+		}
+		return value, nil
+	}
+	return 0, fmt.Errorf("the heap profile carried no HeapAlloc line: %s", firstLine(body))
 }
 
 // goroutineCount reads the total off the goroutine listing's first line.

--- a/cmd/bench_resources/profiles_test.go
+++ b/cmd/bench_resources/profiles_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http/pprof"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -18,12 +20,48 @@ import (
 // and returns a client for them.
 func newPprofTestClient(t *testing.T) *pprofClient {
 	t.Helper()
+	return newRecordedPprofClient(t).client
+}
+
+// recordedPprofClient serves the same handlers and remembers what was asked
+// of them, so a test can check the request the driver made rather than
+// inferring it from the answer.
+//
+// The handlers are the runtime's own, not a stand-in for them: gc=1 there
+// really does run a collection before the profile is written, which is what
+// makes the assertion on this process's collection count evidence rather
+// than a restatement of the driver's code.
+type recordedPprofClient struct {
+	client *pprofClient
+
+	mu       sync.Mutex
+	requests []string
+}
+
+// newRecordedPprofClient serves the profiling handlers from this test process
+// behind a recorder.
+func newRecordedPprofClient(t *testing.T) *recordedPprofClient {
+	t.Helper()
+	rec := &recordedPprofClient{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/", func(w http.ResponseWriter, r *http.Request) {
+		rec.mu.Lock()
+		rec.requests = append(rec.requests, r.URL.RequestURI())
+		rec.mu.Unlock()
+		pprof.Index(w, r)
+	})
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return newPprofClient(srv.URL)
+	rec.client = newPprofClient(srv.URL)
+	return rec
+}
+
+// asked lists the request URIs the listener answered, oldest first.
+func (r *recordedPprofClient) asked() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string{}, r.requests...)
 }
 
 // isGzip reports whether data starts with the gzip magic number, which is
@@ -65,6 +103,127 @@ func TestPprofClient_ReadsProfilesAndTheGoroutineTotal(t *testing.T) {
 			t.Errorf("goroutineCount = %d, want at least this test's goroutine", count)
 		}
 	})
+}
+
+// TestPprofClient_HeapReads_ForceACollection verifies both heap reads ask for
+// one, and that the collection actually happened.
+//
+// Without gc=1 the handler serves whatever survived the last cycle, which is
+// not the live heap: it is the live heap plus however much garbage the
+// collector had not reached, and on a process serving thousands of calls a
+// second that is most of what the profile shows. The profile is the evidence
+// the hot-spot analysis reads and the settled figure is what the series
+// publishes as tenancy, so both have to mean what their readers think.
+//
+// The proof is this process's own collection count, taken across the read.
+// runtime.GC blocks until its cycle is complete, so a read that forced one
+// leaves NumGC higher; a read that did not, cannot. The recorded request is
+// asserted beside it because a growing count alone could be some other
+// goroutine's collection.
+func TestPprofClient_HeapReads_ForceACollection(t *testing.T) {
+	cases := []struct {
+		name       string
+		read       func(*testing.T, *pprofClient)
+		wantReads  int
+		wantSuffix string
+	}{
+		{
+			name: "the profile written beside the record",
+			read: func(t *testing.T, client *pprofClient) {
+				t.Helper()
+				if got := client.heapProfile(t.Context()); got.err != nil || !isGzip(got.data) {
+					t.Errorf("heapProfile = %d bytes, %v; want a compressed profile", len(got.data), got.err)
+				}
+			},
+			wantReads: 1, wantSuffix: "/debug/pprof/heap?gc=1",
+		},
+		{
+			name: "the settled reading",
+			read: func(t *testing.T, client *pprofClient) {
+				t.Helper()
+				heap, err := client.settledHeap(t.Context())
+				if err != nil {
+					t.Errorf("settledHeap: %v", err)
+					return
+				}
+				if heap == 0 {
+					t.Error("settledHeap = 0 bytes, want this process's live heap")
+				}
+			},
+			// Two: the first collection still counts what the moment before
+			// it left behind, so the figure is taken from the second.
+			wantReads: 2, wantSuffix: "/debug/pprof/heap?gc=1&debug=1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newRecordedPprofClient(t)
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+
+			tc.read(t, rec.client)
+
+			runtime.ReadMemStats(&after)
+			asked := rec.asked()
+			if len(asked) != tc.wantReads {
+				t.Fatalf("the listener answered %v, want %d read(s)", asked, tc.wantReads)
+			}
+			for _, uri := range asked {
+				if uri != tc.wantSuffix {
+					t.Errorf("the driver asked for %q, want %q", uri, tc.wantSuffix)
+				}
+			}
+			//#nosec G115 -- both are collection counts of this test process, orders below the conversion's range
+			if collections := int(after.NumGC) - int(before.NumGC); collections < tc.wantReads {
+				t.Errorf("%d collections ran across %d read(s), want one per read: the handler was not asked to collect",
+					collections, tc.wantReads)
+			}
+		})
+	}
+}
+
+// TestParseHeapAlloc_ReadsTheMemStatsLine verifies the live heap is taken
+// from the MemStats dump that ends a debug=1 heap profile, and that a body
+// carrying no such line is refused rather than read as zero, which would be
+// published as a credential costing nothing.
+func TestParseHeapAlloc_ReadsTheMemStatsLine(t *testing.T) {
+	const dump = "heap profile: 1: 16 [2: 32] @ heap/8192\n\n# runtime.MemStats\n# Alloc = 4194304\n# HeapAlloc = 4194304\n# HeapSys = 8388608\n"
+	cases := []struct {
+		name    string
+		body    string
+		want    uint64
+		wantErr string
+	}{
+		{name: "a dump", body: dump, want: 4194304},
+		{name: "the line alone", body: "# HeapAlloc = 12\n", want: 12},
+		{name: "no such line", body: "heap profile: 0: 0 [0: 0] @ heap/8192\n", wantErr: "carried no HeapAlloc line"},
+		{name: "empty", body: "", wantErr: "carried no HeapAlloc line"},
+		{name: "not a number", body: "# HeapAlloc = plenty\n", wantErr: "parse HeapAlloc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseHeapAlloc([]byte(tc.body))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("parseHeapAlloc = %d, %v; want an error saying %q", got, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Errorf("parseHeapAlloc = %d, %v; want %d", got, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestSettledHeap_ListenerGone_ReportsTheFirstRead verifies a listener that
+// does not answer fails the settled reading at the first collection rather
+// than at the second, so the note on the step names what was unreachable.
+func TestSettledHeap_ListenerGone_ReportsTheFirstRead(t *testing.T) {
+	_, err := newPprofClient("http://127.0.0.1:1").settledHeap(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "GET /debug/pprof/heap") {
+		t.Errorf("settledHeap = %v, want the unreachable listener named", err)
+	}
 }
 
 // TestPprofClient_Failures covers every way a read fails, each reported with

--- a/cmd/bench_resources/render.go
+++ b/cmd/bench_resources/render.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -261,23 +262,43 @@ func seriesBlocks(run *Run, l labels, heading string) string {
 			budget = fmt.Sprintf(l.SeriesBudgetClause, s.BudgetMiB)
 		}
 		fmt.Fprintf(&b, "%s# %s\n\n", heading, fmt.Sprintf(l.SeriesCaption, s.Transport, s.Surface, s.Parallel, s.StepSeconds, budget))
-		fmt.Fprintf(&b, "%s\n\n%s\n\n", strings.TrimRight(seriesTable(s, l), "\n"), seriesSentence(s, l))
+		fmt.Fprintf(&b, "%s\n\n", strings.TrimRight(seriesTable(s, l), "\n"))
+		fmt.Fprintf(&b, "%s\n\n", joinNonEmpty(" ", seriesSlopeSentence(s, l), seriesSentence(s, l)))
 	}
 	return b.String()
 }
 
 // seriesTable is one series' steps, one row per credential count.
+//
+// The settled pair is only a column when the series carries one. A record
+// measured before the settled reading existed would otherwise get two columns
+// of "n/a" against every step, which reads as a process that holds nothing
+// rather than as a run that did not look.
 func seriesTable(s SeriesScenario, l labels) string {
-	alignments := []docgen.Alignment{
-		docgen.AlignRight, docgen.AlignRight, docgen.AlignRight, docgen.AlignRight, docgen.AlignRight,
-		docgen.AlignRight, docgen.AlignRight, docgen.AlignRight, docgen.AlignRight, docgen.AlignRight,
+	// The settled pair goes after the credential count and the two resident
+	// columns, so the four memory figures of a step read together.
+	const afterResident = 3
+
+	head, settled := l.SeriesHead, s.hasSettled()
+	if settled {
+		head = slices.Concat(l.SeriesHead[:afterResident],
+			[]string{l.SeriesSettledHeap, l.SeriesSettledRSS}, l.SeriesHead[afterResident:])
+	}
+	alignments := make([]docgen.Alignment, len(head))
+	for i := range alignments {
+		alignments[i] = docgen.AlignRight
 	}
 	rows := make([][]string, 0, len(s.Steps))
 	for _, step := range s.Steps {
-		rows = append(rows, []string{
+		row := []string{
 			strconv.Itoa(step.Clients),
 			mib(step.RSSMeanMiB),
 			mib(step.RSSPeakMiB),
+		}
+		if settled {
+			row = append(row, mibFine(step.SettledHeapMiB), mibFine(step.SettledRSSMiB))
+		}
+		rows = append(rows, append(row,
 			cpuPerCallLabel(step.CPUMsPerCall),
 			strconv.Itoa(step.Calls),
 			ms(step.CallP50Ms),
@@ -285,9 +306,28 @@ func seriesTable(s SeriesScenario, l labels) string {
 			ms(step.ListP50Ms),
 			ms(step.ListP99Ms),
 			strconv.Itoa(step.Goroutines),
-		})
+		))
 	}
-	return docgen.RenderMarkdownTable(l.SeriesHead, alignments, rows)
+	return docgen.RenderMarkdownTable(head, alignments, rows)
+}
+
+// seriesSlopeSentence names the growth per credential, and says which growth
+// it is.
+//
+// Both slopes are least-squares lines through the steps. The resident one is
+// the cost of a credential and of everything it keeps in flight, together; the
+// settled one is what holding a credential costs on its own. A series carrying
+// no settled reading says so rather than letting the resident figure stand as
+// the answer to a question it does not answer.
+func seriesSlopeSentence(s SeriesScenario, l labels) string {
+	load, ok := s.loadSlopeMiB()
+	if !ok {
+		return ""
+	}
+	if tenancy, settled := s.tenancySlopeKiB(); settled {
+		return fmt.Sprintf(l.SeriesSlopes, load, tenancy)
+	}
+	return fmt.Sprintf(l.SeriesLoadSlopeOnly, load)
 }
 
 // seriesSentence says where a series ended, in the page's language: every
@@ -387,6 +427,23 @@ func mib(value float64) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.0f", value)
+}
+
+// mibFine renders a mebibyte figure at a precision that suits its size,
+// because the settled columns hold both kinds at once: a live heap of a few
+// mebibytes, where whole numbers would round a credential's whole cost away,
+// and a resident set of thousands, where two decimals are noise.
+func mibFine(value float64) string {
+	switch {
+	case value == 0:
+		return "n/a"
+	case value < 10:
+		return fmt.Sprintf("%.2f", value)
+	case value < 100:
+		return fmt.Sprintf("%.1f", value)
+	default:
+		return fmt.Sprintf("%.0f", value)
+	}
 }
 
 // ms renders a millisecond figure for a table.

--- a/cmd/bench_resources/render_test.go
+++ b/cmd/bench_resources/render_test.go
@@ -494,6 +494,10 @@ func TestSeriesBlocks_TablesAndStopSentencesInEachLanguage(t *testing.T) {
 		"#### http, dynamic surface: 4 in flight per credential, 10 s per step, memory budget 4000 MiB",
 		"#### http, meta surface",
 		"| Credentials |",
+		"| Settled heap | Settled resident |",
+		"the peak resident set under load grows 36.61 MiB per credential",
+		"the settled live heap, read with the load stopped and a collection forced, grows 512.0 KiB per credential",
+		"That is a credential together with the requests it keeps in flight, not what a credential costs to hold",
 		"Every planned step ran, up to 20 credentials.",
 		"Stopped at 5 credentials: the next step (20) was estimated at 4300 MiB against a budget of 4000 MiB.",
 		"Stopped at 5 credentials: the tools/call p99 reached 31000 ms, above the 30000 ms ceiling.",
@@ -509,15 +513,39 @@ func TestSeriesBlocks_TablesAndStopSentencesInEachLanguage(t *testing.T) {
 		t.Error("the generated block has a run of blank lines, which markdownlint refuses")
 	}
 	// The cells are padded to the column, so the row for twenty credentials
-	// is matched by shape rather than by a literal.
-	if !regexp.MustCompile(`(?m)^\|\s+20 \|\s+880 \|\s+900 \|\s+1\.400 \|\s+8000 \|`).MatchString(english) {
+	// is matched by shape rather than by a literal. The settled pair sits
+	// between the resident columns and the processor time, which is the order
+	// this asserts.
+	if !regexp.MustCompile(`(?m)^\|\s+20 \|\s+880 \|\s+900 \|\s+50\.0 \|\s+800 \|\s+1\.400 \|\s+8000 \|`).MatchString(english) {
 		t.Error("the meta series table has no row for its twenty-credential step")
+	}
+	// The dynamic series measured no settled reading, so its own section
+	// carries neither settled column: two columns of "n/a" would read as a
+	// process holding nothing rather than as a run that did not look.
+	var dynamic string
+	for section := range strings.SplitSeq(english, "\n#### ") {
+		if strings.HasPrefix(section, "http, dynamic surface") {
+			dynamic = section
+		}
+	}
+	if dynamic == "" {
+		t.Fatal("the generated block has no section for the dynamic series")
+	}
+	if strings.Contains(dynamic, "Settled heap") {
+		t.Error("a series with no settled reading was given settled columns")
+	}
+	if !strings.Contains(dynamic, "this record carries no settled reading") {
+		t.Error("a series with no settled reading does not say so under its table")
 	}
 
 	spanish := siteBlock(sampleSeriesRun(), spanishLabels())
 	for _, want := range []string{
 		"### Serie de concurrencia",
 		"presupuesto de memoria de 4000 MiB",
+		"| Heap en reposo | Residente en reposo |",
+		"el pico de conjunto residente bajo carga crece 36.61 MiB por credencial",
+		"el heap vivo en reposo, leído con la carga detenida y una recolección forzada, crece 512.0 KiB por credencial",
+		"no lo que cuesta mantener una credencial",
 		"Detenida en 5 credenciales: el siguiente paso (20) se estimó en 4300 MiB frente a un presupuesto de 4000 MiB.",
 		"Detenida en 5 credenciales: el p99 de tools/call alcanzó 31000 ms, por encima del techo de 30000 ms.",
 		"Se ejecutaron todos los pasos previstos, hasta 20 credenciales.",
@@ -529,10 +557,83 @@ func TestSeriesBlocks_TablesAndStopSentencesInEachLanguage(t *testing.T) {
 			}
 		})
 	}
-	for _, english := range []string{"Stopped at", "Every planned step", "memory budget", "Credentials |"} {
+	for _, english := range []string{
+		"Stopped at", "Every planned step", "memory budget", "Credentials |",
+		"Settled heap", "Settled resident", "per credential",
+	} {
 		t.Run(english, func(t *testing.T) {
 			if strings.Contains(spanish, english) {
 				t.Errorf("the Spanish block carries the English %q", english)
+			}
+		})
+	}
+}
+
+// TestSeriesSlopeSentence_SaysWhichGrowthItIs verifies the sentence under a
+// series table reports both slopes when the record carries a settled reading,
+// only the resident one otherwise, and nothing at all from steps that fix no
+// line.
+//
+// Which of the two a figure is, is the whole point of the sentence. Published
+// alone, the resident slope was read as what a pooled credential costs, and it
+// is the credential and everything it keeps in flight together.
+func TestSeriesSlopeSentence_SaysWhichGrowthItIs(t *testing.T) {
+	l := englishLabels()
+	step := func(clients int, peak, settled float64) SeriesStep {
+		return SeriesStep{Clients: clients, RSSPeakMiB: peak, SettledHeapMiB: settled}
+	}
+	cases := []struct {
+		name  string
+		steps []SeriesStep
+		want  string
+	}{
+		{
+			name:  "both",
+			steps: []SeriesStep{step(1, 200, 40.5), step(3, 220, 41.5)},
+			want: "Fitted across these steps: the peak resident set under load grows 10.00 MiB per credential, " +
+				"and the settled live heap, read with the load stopped and a collection forced, grows 512.0 KiB per credential. " +
+				"The first is what a credential costs while it and every other one is calling; the second is what it costs to hold. " +
+				"The settled resident set lags both, because Go returns freed pages to the operating system on its own schedule.",
+		},
+		{
+			name:  "no settled reading",
+			steps: []SeriesStep{step(1, 200, 0), step(3, 220, 0)},
+			want: "Fitted across these steps, the peak resident set under load grows 10.00 MiB per credential. " +
+				"That is a credential together with the requests it keeps in flight, not what a credential costs to hold: " +
+				"this record carries no settled reading.",
+		},
+		{name: "one step", steps: []SeriesStep{step(1, 200, 40.5)}, want: ""},
+		{name: "no steps", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := seriesSlopeSentence(SeriesScenario{Steps: tc.steps}, l); got != tc.want {
+				t.Errorf("seriesSlopeSentence = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMibFine_KeepsWhatWholeNumbersWouldRoundAway verifies the settled
+// columns' renderer prints a small live heap at a precision that shows a
+// credential's cost and a large resident set without decimals that are noise,
+// and marks a figure that was not taken rather than printing it as zero.
+func TestMibFine_KeepsWhatWholeNumbersWouldRoundAway(t *testing.T) {
+	cases := []struct {
+		name  string
+		value float64
+		want  string
+	}{
+		{name: "not taken", value: 0, want: "n/a"},
+		{name: "a small heap", value: 0.384, want: "0.38"},
+		{name: "under ten", value: 9.5, want: "9.50"},
+		{name: "under a hundred", value: 40.53, want: "40.5"},
+		{name: "a resident set", value: 2104.6, want: "2105"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mibFine(tc.value); got != tc.want {
+				t.Errorf("mibFine(%v) = %q, want %q", tc.value, got, tc.want)
 			}
 		})
 	}

--- a/cmd/bench_resources/result.go
+++ b/cmd/bench_resources/result.go
@@ -26,10 +26,18 @@ import (
 // scenarios. Nothing a schema-1 record carries changed shape, so the reader
 // still accepts one: the published figures were measured under schema 1 and
 // stay published until the series is measured on a host that can hold it.
-const resultSchema = 2
+//
+// Schema 3 added the settled reading to every series step: what the process
+// holds with a step's credentials admitted and nothing in flight. A schema-2
+// record carries none, which is a different statement from carrying a zero,
+// so the renderers leave the settled columns out of a series that has no such
+// reading rather than printing a column of nothing. That is why a reader older
+// than this one would be wrong about a schema-3 record and the number moved:
+// it would draw the settled figures as measured zeros.
+const resultSchema = 3
 
 // readableSchemas are the versions this build can draw.
-var readableSchemas = []int{1, resultSchema}
+var readableSchemas = []int{1, 2, resultSchema}
 
 // Run is one benchmark session: what was measured, on what, and with which
 // knobs.
@@ -108,13 +116,44 @@ type SeriesStop struct {
 	Error string `json:"error,omitempty"`
 }
 
-// SeriesStep is one credential count, measured over its steady phase.
+// SeriesStep is one credential count, measured twice: over its steady phase,
+// and again once that phase has stopped.
+//
+// The two are different questions and were reported as one figure until this
+// pass. RSSMeanMiB and RSSPeakMiB are what N credentials cost **while all of
+// them are calling**, which on the dynamic surface at a thousand credentials
+// was a peak resident set seventeen times the live heap, most of it the JSON
+// being decoded and encoded for the calls in flight. SettledHeapMiB is what N
+// credentials cost **to hold**, which is the figure a reader means by "what a
+// pooled credential costs".
 type SeriesStep struct {
 	Clients int `json:"clients"`
 	// RSSMeanMiB and RSSPeakMiB are the resident set over the steady phase,
-	// sampled the way every other scenario samples it.
+	// sampled the way every other scenario samples it. They are load figures:
+	// the process is serving Parallel requests per credential throughout.
 	RSSMeanMiB float64 `json:"rss_mean_mib"`
 	RSSPeakMiB float64 `json:"rss_peak_mib"`
+	// SettledHeapMiB is the live heap with the load stopped and a collection
+	// forced: the tenancy figure, and the honest one, since nothing a request
+	// allocated while it was being served is still in it.
+	//
+	// The credentials are still connected when it is taken, which is
+	// deliberate: a live credential in a real deployment holds its sockets
+	// open, and their per-connection buffers are part of what it costs. It is
+	// also why this figure sits above what the end-to-end test reports for the
+	// same credential count, which drives one self-contained POST apiece.
+	SettledHeapMiB float64 `json:"settled_heap_mib,omitempty"`
+	// SettledRSSMiB is the resident set read at that same moment.
+	//
+	// It is recorded because a container limit is measured against the
+	// resident set rather than against the heap, and it must be read knowing
+	// that **it lags**: the forced collection frees the heap, and Go returns
+	// the pages behind it to the operating system on the scavenger's own
+	// schedule, minutes later and only under memory pressure. A settled
+	// resident set well above the settled heap is therefore the expected
+	// reading, not a contradiction of it, and the heap is what moves with the
+	// credential count.
+	SettledRSSMiB float64 `json:"settled_rss_mib,omitempty"`
 	// CPUMsPerCall is the processor time the server consumed during the
 	// phase divided by the calls that completed, in milliseconds.
 	CPUMsPerCall float64 `json:"cpu_ms_per_call"`
@@ -146,6 +185,89 @@ type PoolCounters struct {
 type StepProfiles struct {
 	CPU  string `json:"cpu"`
 	Heap string `json:"heap"`
+}
+
+// hasSettled reports whether any step of the series carries a settled
+// reading.
+//
+// A schema-2 record carries none, and a settled column of "n/a" against every
+// step of it would read as a measurement rather than as an absence, so the
+// renderers leave those columns out entirely instead.
+func (s *SeriesScenario) hasSettled() bool {
+	for _, step := range s.Steps {
+		if step.SettledHeapMiB > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// loadSlopeMiB is how much the peak resident set grows per credential while
+// every credential is calling, in mebibytes.
+//
+// This is the figure the documentation published as "resident set per
+// credential" until this pass, and it is not what a credential costs to hold.
+// It answers a question of its own, and a real one: what a deployment needs
+// while N credentials are all working at once. It is only wrong when it is
+// read as tenancy.
+func (s *SeriesScenario) loadSlopeMiB() (float64, bool) {
+	return s.slopePerCredential(func(step SeriesStep) float64 { return step.RSSPeakMiB })
+}
+
+// tenancySlopeKiB is how much the settled live heap grows per credential, in
+// kibibytes: what holding one more credential costs with nothing in flight.
+//
+// Kibibytes because that is the size of the thing: the end-to-end measurement
+// this follows puts a credential at 7.7 KiB on the dynamic surface, which in
+// mebibytes is a row of zeros.
+func (s *SeriesScenario) tenancySlopeKiB() (float64, bool) {
+	slope, ok := s.slopePerCredential(func(step SeriesStep) float64 { return step.SettledHeapMiB })
+	return round(slope * 1024), ok
+}
+
+// slopePerCredential fits a least-squares line through the steps, taking each
+// step's y from pick, and reports its slope: the growth per credential.
+//
+// A step whose figure is zero is left out of the fit rather than dragged
+// through it, because zero is how this record spells "that reading could not
+// be taken", and a fit that believed it would publish a slope nobody
+// measured. Fewer than two points fix no line, and then nothing is published.
+func (s *SeriesScenario) slopePerCredential(pick func(SeriesStep) float64) (float64, bool) {
+	xs := make([]float64, 0, len(s.Steps))
+	ys := make([]float64, 0, len(s.Steps))
+	for _, step := range s.Steps {
+		if value := pick(step); value > 0 {
+			xs = append(xs, float64(step.Clients))
+			ys = append(ys, value)
+		}
+	}
+	slope, _, ok := fitLine(xs, ys)
+	return slope, ok
+}
+
+// fitLine fits a least-squares line through the points.
+//
+// ok is false for fewer than two points, and for points that all share one x:
+// they fix no slope, the fit's denominator is zero there, and dividing by it
+// would publish an infinity as a measurement.
+func fitLine(xs, ys []float64) (slope, intercept float64, ok bool) {
+	if len(xs) < 2 {
+		return 0, 0, false
+	}
+	var sumX, sumY, sumXY, sumXX float64
+	for i, x := range xs {
+		sumX += x
+		sumY += ys[i]
+		sumXY += x * ys[i]
+		sumXX += x * x
+	}
+	n := float64(len(xs))
+	denominator := n*sumXX - sumX*sumX
+	if denominator == 0 {
+		return 0, 0, false
+	}
+	slope = (n*sumXY - sumX*sumY) / denominator
+	return slope, (sumY - slope*sumX) / n, true
 }
 
 // ServerInfo identifies the build that was measured, as the binary itself

--- a/cmd/bench_resources/result_test.go
+++ b/cmd/bench_resources/result_test.go
@@ -129,9 +129,10 @@ func TestWriteRun_ThenReadRun_RoundTrips(t *testing.T) {
 }
 
 // TestReadRun_AcceptsEverySchemaThisBuildDraws verifies the reader takes
-// both the schema-1 record the published figures were measured under, which
-// carries no series, and a schema-2 record that carries only a series, so a
-// filtered series run has a record of its own to render.
+// every schema this build draws: the schema-1 record the published figures
+// were measured under, which carries no series; a schema-2 record that
+// carries only a series, so a filtered series run has a record of its own to
+// render; and a schema-3 record, whose steps carry the settled reading.
 func TestReadRun_AcceptsEverySchemaThisBuildDraws(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -139,6 +140,10 @@ func TestReadRun_AcceptsEverySchemaThisBuildDraws(t *testing.T) {
 	}{
 		{name: "schema 1 without series", content: `{"schema":1,"scenarios":[{"id":"x"}]}`},
 		{name: "schema 2 with a series only", content: `{"schema":2,"scenarios":[],"series":[{"id":"http-dynamic-series","steps":[{"clients":1}]}]}`},
+		{
+			name:    "schema 3 with a settled reading",
+			content: `{"schema":3,"scenarios":[],"series":[{"id":"http-dynamic-series","steps":[{"clients":1,"settled_heap_mib":40.5}]}]}`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -149,6 +154,97 @@ func TestReadRun_AcceptsEverySchemaThisBuildDraws(t *testing.T) {
 			}
 			if _, err := readRun(path); err != nil {
 				t.Errorf("readRun refused a record this build draws: %v", err)
+			}
+		})
+	}
+}
+
+// TestSeriesSlopes_SeparateTheLoadFromTheTenancy verifies the two figures a
+// series publishes per credential are fitted from different columns, in
+// different units, and that a step with no settled reading is left out of the
+// tenancy fit rather than dragged through it as a zero.
+//
+// The steps here are exactly linear, so the fit has one answer and the
+// arithmetic is pinned rather than approximated: the resident set grows 10 MiB
+// per credential, the settled heap 0.5 MiB, which is the 512 KiB the tenancy
+// figure is published in.
+func TestSeriesSlopes_SeparateTheLoadFromTheTenancy(t *testing.T) {
+	step := func(clients int, peak, settled float64) SeriesStep {
+		return SeriesStep{Clients: clients, RSSPeakMiB: peak, SettledHeapMiB: settled}
+	}
+	cases := []struct {
+		name        string
+		steps       []SeriesStep
+		wantSettled bool
+		wantLoad    float64
+		wantLoadOK  bool
+		wantTenancy float64
+		wantTenOK   bool
+	}{
+		{
+			name:        "both measured at every step",
+			steps:       []SeriesStep{step(1, 200, 40.5), step(3, 220, 41.5), step(5, 240, 42.5)},
+			wantSettled: true, wantLoad: 10, wantLoadOK: true, wantTenancy: 512, wantTenOK: true,
+		},
+		{
+			name:        "a step whose settled reading failed",
+			steps:       []SeriesStep{step(1, 200, 40.5), step(3, 220, 0), step(5, 240, 42.5)},
+			wantSettled: true, wantLoad: 10, wantLoadOK: true, wantTenancy: 512, wantTenOK: true,
+		},
+		{
+			name:     "no settled reading at all",
+			steps:    []SeriesStep{step(1, 200, 0), step(3, 220, 0)},
+			wantLoad: 10, wantLoadOK: true,
+		},
+		{
+			name:        "one settled step fixes no line",
+			steps:       []SeriesStep{step(1, 200, 40.5), step(3, 220, 0)},
+			wantSettled: true, wantLoad: 10, wantLoadOK: true,
+		},
+		{name: "one step", steps: []SeriesStep{step(1, 200, 40.5)}, wantSettled: true},
+		{name: "no steps"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := SeriesScenario{Steps: tc.steps}
+			if got := s.hasSettled(); got != tc.wantSettled {
+				t.Errorf("hasSettled = %v, want %v", got, tc.wantSettled)
+			}
+			load, loadOK := s.loadSlopeMiB()
+			if loadOK != tc.wantLoadOK || round(load) != tc.wantLoad {
+				t.Errorf("loadSlopeMiB = %v, %v; want %v, %v", round(load), loadOK, tc.wantLoad, tc.wantLoadOK)
+			}
+			tenancy, tenancyOK := s.tenancySlopeKiB()
+			if tenancyOK != tc.wantTenOK || tenancy != tc.wantTenancy {
+				t.Errorf("tenancySlopeKiB = %v, %v; want %v, %v", tenancy, tenancyOK, tc.wantTenancy, tc.wantTenOK)
+			}
+		})
+	}
+}
+
+// TestFitLine_RefusesWhatFixesNoLine verifies the shared fit reports a slope
+// and an intercept for points that determine one, and refuses the two shapes
+// that do not: fewer than two points, and points that all share one x, whose
+// denominator is zero and whose slope would be published as an infinity.
+func TestFitLine_RefusesWhatFixesNoLine(t *testing.T) {
+	cases := []struct {
+		name             string
+		xs, ys           []float64
+		wantSlope, wantI float64
+		wantOK           bool
+	}{
+		{name: "two points", xs: []float64{1, 3}, ys: []float64{10, 20}, wantSlope: 5, wantI: 5, wantOK: true},
+		{name: "least squares over four", xs: []float64{1, 2, 3, 4}, ys: []float64{2, 4, 6, 8}, wantSlope: 2, wantOK: true},
+		{name: "one point", xs: []float64{1}, ys: []float64{10}},
+		{name: "no points"},
+		{name: "every x the same", xs: []float64{2, 2, 2}, ys: []float64{1, 2, 3}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			slope, intercept, ok := fitLine(tc.xs, tc.ys)
+			if ok != tc.wantOK || round(slope) != tc.wantSlope || round(intercept) != tc.wantI {
+				t.Errorf("fitLine = %v, %v, %v; want %v, %v, %v",
+					round(slope), round(intercept), ok, tc.wantSlope, tc.wantI, tc.wantOK)
 			}
 		})
 	}
@@ -290,12 +386,26 @@ func sampleSeriesRun() *Run {
 			Profiles: StepProfiles{CPU: "x/1.cpu.pb.gz", Heap: "x/1.heap.pb.gz"},
 		}
 	}
+	// The meta series carries a settled reading and the other two do not, so
+	// the renderers are exercised on both: a series measured since the reading
+	// existed, and one measured before it, whose table must not grow two
+	// columns of nothing. Its settled heap is exactly linear at half a
+	// mebibyte per credential, which is the 512 KiB the tenancy sentence
+	// reports.
+	settled := func(s SeriesStep, heap, rss float64) SeriesStep {
+		s.SettledHeapMiB, s.SettledRSSMiB = heap, rss
+		return s
+	}
 	run := sampleRun()
 	run.Series = []SeriesScenario{
 		{
 			ID: "http-meta-series", Transport: transportHTTP, Surface: surfaceMeta, Parallel: 4, StepSeconds: 10,
 			Clients: []int{1, 5, 20}, BudgetMiB: 4000, StoppedAt: 20,
-			Steps: []SeriesStep{step(1, 200, 1, 10, 20), step(5, 360, 1.1, 11, 25), step(20, 900, 1.4, 15, 40)},
+			Steps: []SeriesStep{
+				settled(step(1, 200, 1, 10, 20), 40.5, 150),
+				settled(step(5, 360, 1.1, 11, 25), 42.5, 300),
+				settled(step(20, 900, 1.4, 15, 40), 50, 800),
+			},
 		},
 		{
 			ID: "http-individual-series", Transport: transportHTTP, Surface: surfaceIndividual, Parallel: 2, StepSeconds: 10,

--- a/cmd/bench_resources/series.go
+++ b/cmd/bench_resources/series.go
@@ -9,6 +9,15 @@
 // a CPU and a heap profile taken while the phase runs, so the analysis can say
 // what a pooled entry is made of and where a call's time goes.
 //
+// Each step is measured twice, because "what N credentials cost" is two
+// questions. The steady phase answers what they cost while all of them are
+// calling, which is what a host has to survive; the settled reading taken once
+// that phase stops answers what they cost to hold, which is what a reader
+// means by the cost of a pooled credential. Reporting only the first, as this
+// driver did until this pass, publishes the load as the tenancy: at a thousand
+// credentials on the dynamic surface the peak resident set was seventeen times
+// the live heap, and the difference was the JSON of the calls in flight.
+//
 // Two guards keep it from taking the host down. Before each step the resident
 // set it would reach is estimated from the steps so far, and the rest of the
 // list is skipped when the estimate exceeds the memory budget; and a step
@@ -159,25 +168,19 @@ func (r *runner) budgetStop(steps []SeriesStep, next int) *SeriesStop {
 // toward stopping early rather than late, the right side to err on for a
 // guard whose failure mode is a host with no memory left.
 func estimateRSS(steps []SeriesStep, next int) (estimate float64, ok bool) {
-	switch len(steps) {
-	case 0:
-		return 0, false
-	case 1:
+	if len(steps) == 1 {
 		return steps[0].RSSPeakMiB / float64(steps[0].Clients) * float64(next), true
 	}
-	var sumX, sumY, sumXY, sumXX float64
+	xs := make([]float64, 0, len(steps))
+	ys := make([]float64, 0, len(steps))
 	for _, step := range steps {
-		x, y := float64(step.Clients), step.RSSPeakMiB
-		sumX += x
-		sumY += y
-		sumXY += x * y
-		sumXX += x * x
+		xs = append(xs, float64(step.Clients))
+		ys = append(ys, step.RSSPeakMiB)
 	}
-	n := float64(len(steps))
-	// The counts ascend, so at least two differ and the denominator is not
-	// zero.
-	slope := (n*sumXY - sumX*sumY) / (n*sumXX - sumX*sumX)
-	intercept := (sumY - slope*sumX) / n
+	slope, intercept, fitted := fitLine(xs, ys)
+	if !fitted {
+		return 0, false
+	}
 	return slope*float64(next) + intercept, true
 }
 
@@ -291,7 +294,60 @@ func (r *runner) runStep(ctx context.Context, in stepInput) SeriesStep {
 			<-cpuProfile, in.profiler.heapProfile(ctx))
 		step.Notes = append(step.Notes, profileNotes...)
 	}
+	settle(ctx, in.sampler, in.profiler, &step)
 	return step
+}
+
+// settleDelay is how long a step's process is left alone before the settled
+// reading is taken.
+//
+// The load has stopped by then, but the last responses are still being
+// written and the buffers behind them are still referenced, and counting
+// those as tenancy is the error this whole reading exists to correct. A
+// variable so the tests do not pay half a second per step; the reading itself
+// is the real one either way.
+var settleDelay = 500 * time.Millisecond
+
+// settle records what the process is holding with the step's credentials
+// admitted and nothing in flight.
+//
+// This is the tenancy figure, and it is measured rather than inferred: the
+// load stops, the process is left alone for a moment, a collection is forced
+// and the live heap is read through the profile listener, exactly as
+// TestSharedServer_LiveHeapDoesNotGrowWithTheNumberOfCredentials does in
+// test/e2e/http.
+//
+// The resident set is read at the same moment and recorded beside it, because
+// a container limit is measured against the resident set and not against the
+// heap. It lags, and by design: freeing the heap does not return the pages to
+// the operating system, which Go's scavenger does on its own schedule. Read
+// the heap for what a credential costs and the resident set for what the host
+// is still holding.
+//
+// Nothing is disconnected first. The credentials stay admitted, which is the
+// point, and they stay connected, which is what a live credential does: the
+// per-connection buffers of the sockets it holds open are part of its cost and
+// belong in the figure.
+//
+// Neither reading failing is worth losing a step over: the load figures above
+// stand on their own, so a failure is a note rather than an error.
+func settle(ctx context.Context, s *sampler, profiler *pprofClient, step *SeriesStep) {
+	select {
+	case <-ctx.Done():
+		step.Notes = append(step.Notes, "settled reading not taken: the run was cancelled")
+		return
+	case <-time.After(settleDelay):
+	}
+	if heap, err := profiler.settledHeap(ctx); err == nil {
+		step.SettledHeapMiB = mibOf(heap)
+	} else {
+		step.Notes = append(step.Notes, "settled heap unavailable: "+err.Error())
+	}
+	if stat, err := s.current(); err == nil {
+		step.SettledRSSMiB = mibOf(stat.rssBytes)
+	} else {
+		step.Notes = append(step.Notes, "settled resident set unavailable: "+err.Error())
+	}
 }
 
 // loadOutcome is what a steady phase observed: the durations of every call
@@ -433,16 +489,40 @@ func (stop *SeriesStop) sentence(stoppedAt int, budgetMiB float64) string {
 }
 
 // summary is the one line a step prints as it completes.
+//
+// Both readings are on it, each said to be what it is: the resident set is
+// under load, the heap is what is left once the load has stopped.
 func (step SeriesStep) summary() string {
-	return fmt.Sprintf("%d credentials: rss %.0f MiB mean, %.0f MiB peak; cpu %.3f ms/call over %d calls; tools/call p50 %s ms p99 %s ms; tools/list p50 %s ms p99 %s ms; %d goroutines",
-		step.Clients, step.RSSMeanMiB, step.RSSPeakMiB, step.CPUMsPerCall, step.Calls,
+	return fmt.Sprintf("%d credentials: rss %.0f MiB mean, %.0f MiB peak under load; settled heap %s MiB, settled rss %s MiB; cpu %.3f ms/call over %d calls; tools/call p50 %s ms p99 %s ms; tools/list p50 %s ms p99 %s ms; %d goroutines",
+		step.Clients, step.RSSMeanMiB, step.RSSPeakMiB, mibFine(step.SettledHeapMiB), mibFine(step.SettledRSSMiB),
+		step.CPUMsPerCall, step.Calls,
 		msLabel(step.CallP50Ms), msLabel(step.CallP99Ms), msLabel(step.ListP50Ms), msLabel(step.ListP99Ms), step.Goroutines)
 }
 
 // summary is the line a series prints when it ends.
 func (s *SeriesScenario) summary(elapsed time.Duration) string {
 	if s.StopReason != "" {
-		return fmt.Sprintf("%d steps, %s, %s", len(s.Steps), s.StopReason, elapsed.Round(time.Second))
+		return joinNonEmpty(", ", fmt.Sprintf("%d steps", len(s.Steps)), s.StopReason, s.slopeLine(), elapsed.Round(time.Second).String())
 	}
-	return fmt.Sprintf("%d steps to %d credentials, %s", len(s.Steps), s.StoppedAt, elapsed.Round(time.Second))
+	return joinNonEmpty(", ", fmt.Sprintf("%d steps to %d credentials", len(s.Steps), s.StoppedAt),
+		s.slopeLine(), elapsed.Round(time.Second).String())
+}
+
+// slopeLine is the pair of slopes a finished series prints, each named for
+// what it measures.
+//
+// Named because a lone figure of so many mebibytes per credential is read as
+// what a credential costs, and the resident-set one is not that: it is the
+// credential and everything it keeps in flight together. A series with no
+// settled reading prints only the load slope, still named.
+func (s *SeriesScenario) slopeLine() string {
+	load, loadOK := s.loadSlopeMiB()
+	if !loadOK {
+		return ""
+	}
+	line := fmt.Sprintf("load slope %.2f MiB per credential", load)
+	if tenancy, ok := s.tenancySlopeKiB(); ok {
+		line += fmt.Sprintf(", tenancy slope %.1f KiB per credential", tenancy)
+	}
+	return line
 }

--- a/cmd/bench_resources/series_test.go
+++ b/cmd/bench_resources/series_test.go
@@ -346,10 +346,27 @@ type seriesFixture struct {
 	conns    []*clientConn
 }
 
+// quickSettle shortens the quiet a step leaves the process before its settled
+// reading, for the duration of one test.
+//
+// What is dropped is the wait, not the reading: the collection is still forced
+// through the real profiling handlers and the heap that comes back is this
+// process's own. The wait exists so a real server's last responses are off the
+// wire before the reading; a fixture whose load is an in-memory call has
+// nothing in flight to wait for, and would otherwise pay half a second per
+// step for it.
+func quickSettle(t *testing.T) {
+	t.Helper()
+	previous := settleDelay
+	settleDelay = time.Millisecond
+	t.Cleanup(func() { settleDelay = previous })
+}
+
 // newSeriesFixture builds the fixture for a plan over the given counts, with
 // a steady phase short enough for a test.
 func newSeriesFixture(t *testing.T, steps []int, budget float64) *seriesFixture {
 	t.Helper()
+	quickSettle(t)
 	plan := scenarioPlan{
 		ID: "http-dynamic-series", Transport: transportHTTP, Surface: surfaceDynamic,
 		Parallel: 1, Steps: steps, StepDuration: 80 * time.Millisecond,
@@ -419,6 +436,9 @@ func assertSeriesStep(t *testing.T, plan scenarioPlan, step SeriesStep, wantClie
 	}
 	if step.RSSMeanMiB <= 0 || step.RSSPeakMiB < step.RSSMeanMiB {
 		t.Errorf("resident set mean %v peak %v, want both measured with the peak at least the mean", step.RSSMeanMiB, step.RSSPeakMiB)
+	}
+	if step.SettledHeapMiB <= 0 || step.SettledRSSMiB <= 0 {
+		t.Errorf("settled heap %v resident %v, want both read once the load stopped", step.SettledHeapMiB, step.SettledRSSMiB)
 	}
 	if step.Calls == 0 || step.CallP50Ms < 0 || step.ListP50Ms < 0 {
 		t.Errorf("latency %+v over %d calls, want a distribution per method", step, step.Calls)
@@ -535,6 +555,104 @@ func TestWalkSteps_LatencyCeiling_MakesTheStepTheLast(t *testing.T) {
 	}
 }
 
+// settledShare is the share of a step's peak resident set under load that its
+// settled live heap has to stay under for the reading to be the tenancy figure
+// it claims to be.
+//
+// Half is deliberately loose. The process measured here is the test binary
+// itself, whose resident set carries its own mapped text and the runtime's
+// arenas beside a heap of a few mebibytes, so the real ratio is a small
+// fraction of this. The number worth pinning is that the two are not the same
+// measurement: on the reference host at a thousand credentials the peak
+// resident set was seventeen times the live heap, and publishing the first as
+// the second is the defect this reading exists to correct.
+const settledShare = 0.5
+
+// TestRunStep_SettledReading_IsAFractionOfThePeakUnderLoad verifies a step
+// records what the process holds with nothing in flight, and that the figure
+// is a different one from the peak it reached while serving.
+//
+// The whole step runs the way the driver runs it: a real steady phase, the
+// resident set sampled from the kernel throughout, and the settled heap read
+// through the real profiling handlers with a collection forced. Nothing here
+// is a stand-in for the reading.
+func TestRunStep_SettledReading_IsAFractionOfThePeakUnderLoad(t *testing.T) {
+	r := &runner{progress: progressFunc(false)}
+	f := newSeriesFixture(t, []int{1}, 0)
+
+	step := r.runStep(t.Context(), stepInput{
+		plan: f.plan, call: f.call, conns: []*clientConn{{rpc: &countingConn{}}},
+		sampler: f.sampler, profiler: f.profiler, capacity: 1,
+	})
+
+	t.Logf("settled heap %.2f MiB, settled resident %.2f MiB, peak resident under load %.2f MiB",
+		step.SettledHeapMiB, step.SettledRSSMiB, step.RSSPeakMiB)
+	if step.SettledHeapMiB <= 0 {
+		t.Fatalf("settled heap %v, want the live heap this process holds", step.SettledHeapMiB)
+	}
+	if step.SettledHeapMiB > step.RSSPeakMiB*settledShare {
+		t.Errorf("settled heap %.2f MiB against a peak resident set of %.2f MiB under load: "+
+			"the settled reading is not distinguishable from the load figure",
+			step.SettledHeapMiB, step.RSSPeakMiB)
+	}
+	// The resident set is read at the same moment as the heap and holds
+	// everything the heap does, so it cannot be the smaller of the two.
+	if step.SettledRSSMiB < step.SettledHeapMiB {
+		t.Errorf("settled resident %v under settled heap %v, which cannot be", step.SettledRSSMiB, step.SettledHeapMiB)
+	}
+	for _, note := range step.Notes {
+		if strings.Contains(note, "settled") {
+			t.Errorf("note %q on a step whose settled reading was taken", note)
+		}
+	}
+}
+
+// TestSettle_NotesWhatItCouldNotRead covers the three ways a settled reading
+// is not taken: a cancelled run, a listener that does not answer, and a
+// platform or process the resident set cannot be read from. None of them is
+// worth losing a step over, so each is a note beside figures that stand on
+// their own.
+func TestSettle_NotesWhatItCouldNotRead(t *testing.T) {
+	quickSettle(t)
+	self := os.Getpid()
+
+	t.Run("cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		var step SeriesStep
+		settle(ctx, newSampler(ctx, time.Second, func() []int { return []int{self} }), newPprofTestClient(t), &step)
+		if step.SettledHeapMiB != 0 || step.SettledRSSMiB != 0 {
+			t.Errorf("step %+v claims a reading taken on a cancelled run", step)
+		}
+		if len(step.Notes) != 1 || !strings.Contains(step.Notes[0], "the run was cancelled") {
+			t.Errorf("notes = %v, want one saying the run was cancelled", step.Notes)
+		}
+	})
+
+	t.Run("listener gone", func(t *testing.T) {
+		var step SeriesStep
+		settle(t.Context(), newSampler(t.Context(), time.Second, func() []int { return []int{self} }),
+			newPprofClient("http://127.0.0.1:1"), &step)
+		if step.SettledHeapMiB != 0 {
+			t.Errorf("settled heap %v, want nothing from a listener that does not answer", step.SettledHeapMiB)
+		}
+		if len(step.Notes) != 1 || !strings.Contains(step.Notes[0], "settled heap unavailable") {
+			t.Errorf("notes = %v, want one about the heap", step.Notes)
+		}
+	})
+
+	t.Run("no process to sample", func(t *testing.T) {
+		var step SeriesStep
+		settle(t.Context(), newSampler(t.Context(), time.Second, func() []int { return nil }), newPprofTestClient(t), &step)
+		if step.SettledHeapMiB <= 0 {
+			t.Errorf("settled heap %v, want the reading that did answer", step.SettledHeapMiB)
+		}
+		if len(step.Notes) != 1 || !strings.Contains(step.Notes[0], "settled resident set unavailable") {
+			t.Errorf("notes = %v, want one about the resident set", step.Notes)
+		}
+	})
+}
+
 // TestRunStep_ListenerGone_NotesWhatItCouldNotRead verifies a step whose
 // profile listener does not answer still publishes its load figures, with a
 // note per thing it could not read, since the memory and latency of a step
@@ -556,7 +674,7 @@ func TestRunStep_ListenerGone_NotesWhatItCouldNotRead(t *testing.T) {
 		t.Errorf("step %+v claims what the listener never answered", step)
 	}
 	joined := strings.Join(step.Notes, "\n")
-	for _, want := range []string{"goroutine count unavailable", "cpu profile unavailable", "heap profile unavailable"} {
+	for _, want := range []string{"goroutine count unavailable", "cpu profile unavailable", "heap profile unavailable", "settled heap unavailable"} {
 		t.Run(want, func(t *testing.T) {
 			if !strings.Contains(joined, want) {
 				t.Errorf("notes %v do not say %q", step.Notes, want)
@@ -566,19 +684,31 @@ func TestRunStep_ListenerGone_NotesWhatItCouldNotRead(t *testing.T) {
 }
 
 // TestSeriesSummaries_NameWhatHappened verifies the lines a run prints for
-// a step and for a series carry the figures and the stop.
+// a step and for a series carry the figures and the stop, with each memory
+// figure said to be what it is: the resident set under load, the heap once
+// the load stopped.
 func TestSeriesSummaries_NameWhatHappened(t *testing.T) {
 	step := SeriesStep{
-		Clients: 50, RSSMeanMiB: 3000, RSSPeakMiB: 3200, CPUMsPerCall: 1.25, Calls: 4000,
+		Clients: 50, RSSMeanMiB: 3000, RSSPeakMiB: 3200, SettledHeapMiB: 6.4, SettledRSSMiB: 2100,
+		CPUMsPerCall: 1.25, Calls: 4000,
 		CallP50Ms: 12, CallP99Ms: 40, ListP50Ms: 5, ListP99Ms: 9, Goroutines: 120,
 	}
-	for _, want := range []string{"50 credentials", "3000 MiB mean", "3200 MiB peak", "1.250 ms/call", "4000 calls", "p50 12 ms p99 40 ms", "120 goroutines"} {
+	for _, want := range []string{
+		"50 credentials", "3000 MiB mean", "3200 MiB peak under load", "settled heap 6.40 MiB",
+		"settled rss 2100 MiB", "1.250 ms/call", "4000 calls", "p50 12 ms p99 40 ms", "120 goroutines",
+	} {
 		t.Run(want, func(t *testing.T) {
 			if !strings.Contains(step.summary(), want) {
 				t.Errorf("step summary %q lacks %q", step.summary(), want)
 			}
 		})
 	}
+	// A step whose settled reading could not be taken says so rather than
+	// printing a zero, which would read as a process holding nothing.
+	if got := (SeriesStep{Clients: 1, RSSPeakMiB: 100}).summary(); !strings.Contains(got, "settled heap n/a") {
+		t.Errorf("step summary %q, want the settled reading marked as not taken", got)
+	}
+
 	complete := SeriesScenario{Steps: []SeriesStep{{}, {}}, StoppedAt: 2}
 	if got := complete.summary(3 * time.Second); !strings.Contains(got, "2 steps to 2 credentials") {
 		t.Errorf("series summary = %q", got)
@@ -586,6 +716,52 @@ func TestSeriesSummaries_NameWhatHappened(t *testing.T) {
 	stopped := SeriesScenario{Steps: []SeriesStep{{}}, StoppedAt: 1, StopReason: "stopped at 1 credentials: because"}
 	if got := stopped.summary(3 * time.Second); !strings.Contains(got, "1 steps, stopped at 1 credentials: because") {
 		t.Errorf("series summary = %q", got)
+	}
+}
+
+// TestSlopeLine_NamesWhichGrowthEachFigureIs verifies the line a finished
+// series prints carries both slopes when both were measured and only the
+// resident one otherwise, each named.
+//
+// A lone figure of so many mebibytes per credential is read as what a
+// credential costs, and the resident one is not that. That reading is the
+// defect this pass corrects, so the naming is asserted rather than assumed.
+func TestSlopeLine_NamesWhichGrowthEachFigureIs(t *testing.T) {
+	// Two steps fix a line exactly: the resident set grows 10 MiB per
+	// credential, the settled heap 0.5 MiB, which is 512 KiB.
+	both := &SeriesScenario{Steps: []SeriesStep{
+		{Clients: 1, RSSPeakMiB: 200, SettledHeapMiB: 40.5},
+		{Clients: 3, RSSPeakMiB: 220, SettledHeapMiB: 41.5},
+	}}
+	cases := []struct {
+		name string
+		s    *SeriesScenario
+		want string
+	}{
+		{
+			name: "both measured", s: both,
+			want: "load slope 10.00 MiB per credential, tenancy slope 512.0 KiB per credential",
+		},
+		{
+			name: "no settled reading",
+			s:    &SeriesScenario{Steps: []SeriesStep{{Clients: 1, RSSPeakMiB: 200}, {Clients: 3, RSSPeakMiB: 220}}},
+			want: "load slope 10.00 MiB per credential",
+		},
+		{
+			name: "one step fixes no line",
+			s:    &SeriesScenario{Steps: []SeriesStep{{Clients: 1, RSSPeakMiB: 200, SettledHeapMiB: 40.5}}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.s.slopeLine(); got != tc.want {
+				t.Errorf("slopeLine = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	if got := both.summary(time.Second); !strings.Contains(got, "tenancy slope") {
+		t.Errorf("series summary %q does not carry the slopes", got)
 	}
 }
 
@@ -614,15 +790,7 @@ func TestRunSeries_Standin_StepsThroughTheCountsAndProfiles(t *testing.T) {
 	}
 	for _, step := range series.Steps {
 		t.Run(strconv.Itoa(step.Clients), func(t *testing.T) {
-			if step.Calls == 0 || step.RSSPeakMiB <= 0 || step.Goroutines < 1 {
-				t.Errorf("step %+v is missing a figure", step)
-			}
-			if step.Pool.Capacity != 3 {
-				t.Errorf("pool capacity %d, want the largest step", step.Pool.Capacity)
-			}
-			if _, statErr := os.Stat(filepath.Join(profiles, plan.ID, strconv.Itoa(step.Clients)+".cpu.pb.gz")); statErr != nil {
-				t.Errorf("no CPU profile for %d credentials: %v", step.Clients, statErr)
-			}
+			assertStandinStep(t, step, plan.ID, profiles)
 		})
 	}
 	if r.serverInfo.Version != "standin" {
@@ -633,6 +801,29 @@ func TestRunSeries_Standin_StepsThroughTheCountsAndProfiles(t *testing.T) {
 	}
 	if series.BudgetMiB != 0 || len(series.Notes) != 1 || !strings.Contains(series.Notes[0], "no memory budget") {
 		t.Errorf("a series with no budget must say so: budget %v notes %v", series.BudgetMiB, series.Notes)
+	}
+}
+
+// assertStandinStep checks one step measured against the stand-in binary: the
+// load figures, the settled reading, the pool the driver sized, and the CPU
+// profile on disk.
+//
+// The settled figures are the point of running this against a real process:
+// the collection is forced on the far side of a real listener, in the process
+// under measurement, rather than in the test's own runtime.
+func assertStandinStep(t *testing.T, step SeriesStep, scenarioID, profiles string) {
+	t.Helper()
+	if step.Calls == 0 || step.RSSPeakMiB <= 0 || step.Goroutines < 1 {
+		t.Errorf("step %+v is missing a figure", step)
+	}
+	if step.SettledHeapMiB <= 0 || step.SettledRSSMiB <= 0 {
+		t.Errorf("step %+v took no settled reading from the stand-in", step)
+	}
+	if step.Pool.Capacity != 3 {
+		t.Errorf("pool capacity %d, want the largest step", step.Pool.Capacity)
+	}
+	if _, err := os.Stat(filepath.Join(profiles, scenarioID, strconv.Itoa(step.Clients)+".cpu.pb.gz")); err != nil {
+		t.Errorf("no CPU profile for %d credentials: %v", step.Clients, err)
 	}
 }
 

--- a/cmd/bench_resources/series_test.go
+++ b/cmd/bench_resources/series_test.go
@@ -636,8 +636,22 @@ func TestSettle_NotesWhatItCouldNotRead(t *testing.T) {
 		if step.SettledHeapMiB != 0 {
 			t.Errorf("settled heap %v, want nothing from a listener that does not answer", step.SettledHeapMiB)
 		}
-		if len(step.Notes) != 1 || !strings.Contains(step.Notes[0], "settled heap unavailable") {
-			t.Errorf("notes = %v, want one about the heap", step.Notes)
+		// The resident set is read through ps, which a platform without one
+		// notes as unavailable in its own words. That note belongs to the
+		// platform, not to the listener this case takes away, so it may stand
+		// beside the one the case is about and nothing else may.
+		var heapNotes int
+		for _, note := range step.Notes {
+			switch {
+			case strings.Contains(note, "settled heap unavailable"):
+				heapNotes++
+			case strings.Contains(note, "settled resident set unavailable"):
+			default:
+				t.Errorf("note %q, want only the heap's and, without ps, the resident set's", note)
+			}
+		}
+		if heapNotes != 1 {
+			t.Errorf("notes = %v, want exactly one about the heap", step.Notes)
 		}
 	})
 

--- a/docs/concepts/resource-consumption.md
+++ b/docs/concepts/resource-consumption.md
@@ -60,12 +60,21 @@ In HTTP mode, a single process serves all clients. Idle, before any credential h
 > [Resource hot spots](../development/resource-hot-spots.md#what-the-shared-server-measured).
 > The tables below stay as they were until the reference host they were taken on
 > is re-run.
+>
+> **They are also resident-set figures, which is a different measurement from
+> what a credential costs to hold.** A resident set is read with the credential
+> admitted and, in the concurrency series, with it calling, so it carries the
+> requests in flight and the pages Go has not yet returned to the operating
+> system. The benchmark now records both per step: the resident set under load,
+> and a settled live heap taken with the load stopped and a collection forced.
+> On this build the second is measured in kilobytes per credential where the
+> first is measured in megabytes.
 
-| Tool surface | Process with one credential | Each further credential |
-| ------------ | --------------------------: | ----------------------: |
-| `dynamic`    |                    ~219 MiB |                 ~71 MiB |
-| `meta`       |                    ~197 MiB |                 ~35 MiB |
-| `individual` |                    ~334 MiB |                 ~36 MiB |
+| Tool surface | Process with one credential | Each further credential, resident set |
+| ------------ | --------------------------: | ------------------------------------: |
+| `dynamic`    |                    ~219 MiB |                               ~71 MiB |
+| `meta`       |                    ~197 MiB |                               ~35 MiB |
+| `individual` |                    ~334 MiB |                               ~36 MiB |
 
 Memory per credential used to go the other way from what the tool counts suggest: `individual` cost the least per additional credential despite registering about a thousand tools, because pooled entries already shared their tool schemas, while `dynamic` cost the most because every entry carried its own search index. Both of those causes are gone.
 

--- a/docs/development/resource-hot-spots.md
+++ b/docs/development/resource-hot-spots.md
@@ -10,6 +10,19 @@ left. The numbers come from the concurrency series of the
 process through credential counts and writes a CPU and a heap profile at each
 step; this page reads those profiles.
 
+> **Every resident-set slope on this page is measured under load, and is not
+> what a credential costs to hold.** The series runs each step with two to four
+> requests in flight per credential and samples the resident set only while
+> that load runs, so a slope fitted through those samples is the credential and
+> its requests together. The driver now also takes a **settled** reading at
+> every step, with the load stopped and a collection forced, and the two are
+> not close: on the reference host at a thousand credentials on the dynamic
+> surface the peak resident set was 4379 MiB against a live heap of 253 MiB.
+> Where a table below says "per credential" of a resident set, read "per
+> credential that is calling"; the tenancy figures are in
+> [What this branch measured](#what-this-branch-measured-1), and the settled
+> reading is described in the benchmark reference.
+
 Two hosts, and which one matters, because a slope from one cannot be compared
 with a slope from the other. Everything down to and including
 [What this branch measured](#what-this-branch-measured) is from an Intel i5-14400
@@ -49,14 +62,18 @@ of one of those builds. One HTTP process per surface, four requests in flight
 per credential on `dynamic` and `meta` and two on `individual`, least-squares
 slope through the peak resident set of every step:
 
-| Surface      | Resident set per credential | Where the series stopped                                   |
-| ------------ | --------------------------: | ---------------------------------------------------------- |
-| `dynamic`    |                   130.9 MiB | 12.9 GiB at 100 credentials, the next step over the budget |
-| `meta`       |                    63.5 MiB | 12.6 GiB at 200 credentials, the next step over the budget |
-| `individual` |                    90.8 MiB | 9.2 GiB at 100 credentials, the next step over the budget  |
+| Surface      | Peak resident set per calling credential | Where the series stopped                                   |
+| ------------ | ---------------------------------------: | ---------------------------------------------------------- |
+| `dynamic`    |                                130.9 MiB | 12.9 GiB at 100 credentials, the next step over the budget |
+| `meta`       |                                 63.5 MiB | 12.6 GiB at 200 credentials, the next step over the budget |
+| `individual` |                                 90.8 MiB | 9.2 GiB at 100 credentials, the next step over the budget  |
 
 The budget was 15.8 GiB, and each series stopped when the next step's estimate
-exceeded it rather than on a failure.
+exceeded it rather than on a failure. Part of each slope was the catalog every
+pool entry built for itself, which is what the rest of this page is about, and
+part of it was the requests in flight while it was measured, which no amount
+of sharing removes. Nothing in this run separated the two; that separation is
+what the settled reading added.
 
 Processor time per call was flat on `dynamic` and `meta`, 7.5 to 8.1 ms and
 8.3 to 7.9 ms from the first step to the last. On `individual` it was not: it
@@ -66,7 +83,33 @@ a fifth of the CPU at a hundred credentials was the garbage collector scanning
 the heap (`scanObjectsSmall`, `tryDeferToSpanScan`, `scanSpan`), which is
 memory showing up as time.
 
-The heap profile at the top step named one function on every surface:
+The heap profile at the top step named one function on every surface. Every
+heap profile quoted on this page was taken **without forcing a collection**,
+which the driver now does (`/debug/pprof/heap?gc=1`), so each "in-use" total
+below is the heap as of the last completed cycle rather than the live set:
+
+- The **absolute** figures for what is live do not move. Measured on this
+  build, one profile taken with a forced collection and one without, seconds
+  apart on a process serving twenty credentials on the individual surface,
+  agreed to the megabyte on every live entry: `toolutil.cloneSchemaMap` 10 MB
+  in both, `reflect.mapassign_faststr0` 7.50 MB in both,
+  `jsonschema.(*Schema).checkStructure.func1` 6.50 MB in both.
+- The **totals** fall, and with them every percentage computed against a
+  total. That pair went from 268.0 MB to 234.0 MB, 13% lower, and an earlier
+  pair from 97.2 MB to 83.6 MB, 14% lower. So a share such as
+  "`cloneSchemaMap` 48%" below is a share of a denominator that was too large:
+  the megabytes stand, the percentage would read higher.
+- What shrinks is what the transient entries hold: in that same pair
+  `slices.Grow` fell 39.2 MB to 20.1 MB and `bytes.growSlice` 31.4 MB to
+  13.3 MB, and in the earlier one
+  `jsontext.(*encoderState).reformatObject`'s 13.2 MB left the profile
+  entirely. Those are the encode and decode buffers of the calls in flight,
+  which is exactly the part a reader of this page should not be attributing to
+  a pooled credential.
+
+The tables below are left as they were measured rather than adjusted, since an
+adjusted number is not a measured one; the run that follows this change
+supersedes them with profiles taken after a collection.
 
 | Surface                 | In-use heap | `toolutil.cloneSchemaMap` | Its callers, cumulative                                                                                                                                                                                            |
 | ----------------------- | ----------: | ------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -224,13 +267,15 @@ surface, credential counts 1, 2, 5, 10, 20, 50, 100, 200, 500 and 1000, ten
 seconds per step, four requests in flight per credential on `dynamic` and
 `meta` and two on `individual`. The slope is a least-squares line through the
 peak resident set of every step, the same way the before figures above were
-computed:
+computed, and the same load figure: both columns are the credential together
+with its requests in flight, which is why the after column is megabytes rather
+than the kilobytes the tenancy reading reports.
 
-| Surface      | Resident set per credential, before |     after | Ratio | Where the before series stopped | The after series at 1000 credentials | Fitted intercept, after |
-| ------------ | ----------------------------------: | --------: | ----: | ------------------------------- | ------------------------------------ | ----------------------: |
-| `dynamic`    |                           130.9 MiB |  4.10 MiB |   32x | 100 credentials, 12.9 GiB       | 4.0 GiB                              |                 263 MiB |
-| `meta`       |                            63.5 MiB |  5.44 MiB |   12x | 200 credentials, 12.6 GiB       | 5.7 GiB                              |                 139 MiB |
-| `individual` |                            90.8 MiB | 11.28 MiB |  8.1x | 100 credentials, 9.2 GiB        | 11.2 GiB                             |                 756 MiB |
+| Surface      | Peak resident set per calling credential, before |     after | Ratio | Where the before series stopped | The after series at 1000 credentials | Fitted intercept, after |
+| ------------ | -----------------------------------------------: | --------: | ----: | ------------------------------- | ------------------------------------ | ----------------------: |
+| `dynamic`    |                                        130.9 MiB |  4.10 MiB |   32x | 100 credentials, 12.9 GiB       | 4.0 GiB                              |                 263 MiB |
+| `meta`       |                                         63.5 MiB |  5.44 MiB |   12x | 200 credentials, 12.6 GiB       | 5.7 GiB                              |                 139 MiB |
+| `individual` |                                         90.8 MiB | 11.28 MiB |  8.1x | 100 credentials, 9.2 GiB        | 11.2 GiB                             |                 756 MiB |
 
 All three after series reached a thousand credentials, which no surface
 reached before. The after run had a larger budget than the before run (32.3
@@ -251,7 +296,11 @@ response marshalled per call, while `tools/call` p50 on the same step is
 122 ms.
 
 The heap profile of the after run at a thousand credentials on the dynamic
-surface holds 936 MB in use, and its top by flat allocation is this:
+surface holds 936 MB in use, and its top by flat allocation is this. It is one
+of the profiles taken without a forced collection, so rows 2, 4, 5, 6, 7, 8
+and 10, the buffers of the calls in flight, hold both what was in flight and
+what the collector had not reached; rows 1, 3 and 9 are live per-credential
+structures, which a collection does not touch, and stand as measured:
 
 | Rank | Function                                                   |     Flat | What it is                                                                          |
 | ---: | ---------------------------------------------------------- | -------: | ----------------------------------------------------------------------------------- |
@@ -549,11 +598,11 @@ The first thing the run says is that the resident set under load is the wrong
 instrument for this change, and it is worth stating rather than hiding, because
 the headline numbers barely move:
 
-| Surface      | Peak resident set per credential, before |    after | Peak at 20 credentials, before |   after |
-| ------------ | ---------------------------------------: | -------: | -----------------------------: | ------: |
-| `dynamic`    |                                  8.6 MiB |  7.3 MiB |                        360 MiB | 331 MiB |
-| `meta`       |                                  7.4 MiB |  2.7 MiB |                        317 MiB | 262 MiB |
-| `individual` |                                 30.5 MiB | 26.3 MiB |                        921 MiB | 835 MiB |
+| Surface      | Peak resident set per calling credential, before |    after | Peak at 20 credentials, before |   after |
+| ------------ | -----------------------------------------------: | -------: | -----------------------------: | ------: |
+| `dynamic`    |                                          8.6 MiB |  7.3 MiB |                        360 MiB | 331 MiB |
+| `meta`       |                                          7.4 MiB |  2.7 MiB |                        317 MiB | 262 MiB |
+| `individual` |                                         30.5 MiB | 26.3 MiB |                        921 MiB | 835 MiB |
 
 Those slopes are least-squares lines through the five steps, and most of what
 they measure is not the credential. The driver keeps four requests in flight per
@@ -622,6 +671,34 @@ surface, and a revert to a server per credential grows 8.1 MiB on `dynamic` and
 27.6 on `individual`, both measured by running the same test on the parent
 commit. It carried a 32 MiB budget until this pass, which that same revert
 passed on every surface, so what the test pinned was nothing.
+
+**The driver now takes that reading itself, at every step of every series.**
+Publishing only the resident set under load was the defect this section
+described and worked around by hand; the concurrency series records a settled
+live heap and a settled resident set per step, and every place that prints a
+slope says which of the two it is. Both slopes, from a five-step ladder (1, 2,
+5, 10, 20 credentials, ten seconds each) on the reference host while five other
+jobs shared it:
+
+| Surface      | Load slope, peak resident set | Tenancy slope, settled live heap | Ratio | Settled heap, 1 to 20 credentials | Settled resident set, 1 to 20 |
+| ------------ | ----------------------------: | -------------------------------: | ----: | --------------------------------- | ----------------------------- |
+| `dynamic`    |             6.33 MiB per cred |                54.1 KiB per cred |  120x | 38.7 to 39.7 MiB                  | 117 to 126 MiB                |
+| `meta`       |             4.09 MiB per cred |                53.7 KiB per cred |   78x | 32.2 to 33.2 MiB                  | 103 to 109 MiB                |
+| `individual` |            28.16 MiB per cred |                35.6 KiB per cred |  810x | 87.8 to 88.5 MiB                  | 189 to 200 MiB                |
+
+Three things to read off that table. The load slopes are noisy, because they
+are a peak sampled on a shared host, and the tenancy slopes are not: a live
+heap of a quiesced process barely moves between runs, which is most of why it
+is the better number. The settled resident set is three times the settled heap
+and moves with it only loosely, exactly as the record's own documentation
+warns: freeing a heap does not hand the pages back, and Go's scavenger returns
+them on its own schedule. And the tenancy slope here is several times the
+8 KiB the end-to-end test reports below, because the driver leaves its
+connections open across steps: four sockets per credential on `dynamic` and
+`meta` and two on `individual`, whose per-connection buffers are live heap for
+as long as the client is connected. That is part of what a live credential
+costs and belongs in the figure; it is also why the two measurements differ,
+and why neither is wrong.
 
 Per-call processor cost is unchanged, which is expected: 20.0 ms before and
 20.2 ms after on `dynamic`, 19.2 and 19.1 on `meta`, 357 and 342 on

--- a/docs/development/resource-hot-spots.md
+++ b/docs/development/resource-hot-spots.md
@@ -20,8 +20,8 @@ step; this page reads those profiles.
 > surface the peak resident set was 4379 MiB against a live heap of 253 MiB.
 > Where a table below says "per credential" of a resident set, read "per
 > credential that is calling"; the tenancy figures are in
-> [What this branch measured](#what-this-branch-measured-1), and the settled
-> reading is described in the benchmark reference.
+> [What the shared server measured](#what-the-shared-server-measured), and the
+> settled reading is described in the benchmark reference.
 
 Two hosts, and which one matters, because a slope from one cannot be compared
 with a slope from the other. Everything down to and including
@@ -687,9 +687,12 @@ jobs shared it:
 | `individual` |            28.16 MiB per cred |                35.6 KiB per cred |  810x | 87.8 to 88.5 MiB                  | 189 to 200 MiB                |
 
 Three things to read off that table. The load slopes are noisy, because they
-are a peak sampled on a shared host, and the tenancy slopes are not: a live
-heap of a quiesced process barely moves between runs, which is most of why it
-is the better number. The settled resident set is three times the settled heap
+are a peak sampled on a shared host, and the tenancy slopes are not: the same
+ladder run again minutes later moved the load slope by up to a third (6.33 to
+8.46 MiB per credential on `dynamic`, 4.09 to 4.62 on `meta`, 28.16 to 28.19 on
+`individual`) and the tenancy slope by at most four percent (54.1 to 53.6 KiB,
+53.7 to 54.8, 35.6 to 34.3). A live heap read from a quiesced process barely
+moves between runs, and that is most of why it is the better number. The settled resident set is three times the settled heap
 and moves with it only loosely, exactly as the record's own documentation
 warns: freeing a heap does not hand the pages back, and Go's scavenger returns
 them on its own schedule. And the tenancy slope here is several times the

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,124 |
-| Unit test functions                                   | 13,535 |
+| Total test functions                                  | 14,134 |
+| Unit test functions                                   | 13,545 |
 | E2E test functions                                    |    589 |
-| cmd test functions                                    |  2,462 |
+| cmd test functions                                    |  2,472 |
 | Test files (internal/)                                |    508 |
 | Test files (cmd/)                                     |    149 |
 | Test files (test/e2e/)                                |    231 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,576 | 82.0% |
+| `TestFunc_Scenario` (2-part)           | 11,583 | 82.0% |
 | `TestFunc` (no underscore)             |    967 |  6.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,581 | 11.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,584 | 11.2% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            329 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,455 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            589 |        231 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,462 |        149 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,124** |    **888** |                                                                                                 |
+| cmd packages            |          2,472 |        149 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,134** |    **888** |                                                                                                 |
 
 ### Core Packages
 

--- a/docs/reference/resource-benchmark.md
+++ b/docs/reference/resource-benchmark.md
@@ -47,11 +47,32 @@ from inside the program:
 - **Latency percentiles**, per MCP method, from the client's side of the wire.
 
 The concurrency series records, at each credential count: the resident set
-over the steady phase, as a mean and a peak; processor time per completed
-call; the p50 and p99 of `tools/call` and of `tools/list`; the goroutine
-count; the pool counters the driver knows (entries admitted and the capacity
-it sized the pool to); and a CPU profile and a heap profile of the server,
-kept beside the record for the analysis rather than committed.
+over the steady phase, as a mean and a peak; the settled live heap and the
+settled resident set, read once that phase has stopped; processor time per
+completed call; the p50 and p99 of `tools/call` and of `tools/list`; the
+goroutine count; the pool counters the driver knows (entries admitted and the
+capacity it sized the pool to); and a CPU profile and a heap profile of the
+server, kept beside the record for the analysis rather than committed.
+
+**The two memory readings answer different questions, and only one of them is
+what a credential costs.** The resident set over the steady phase is measured
+with every credential holding several requests in flight, so it is the
+credential and everything it keeps in flight, together: what the host has to
+survive while N credentials are all working at once. The settled reading is
+taken with the load stopped and a collection forced, so it is what the process
+holds with N credentials admitted and nothing being served: the tenancy. On
+the reference host the two are not close. At a thousand credentials on the
+dynamic surface the peak resident set was 4379 MiB against a live heap of 253
+MiB, a factor of seventeen, and a breakdown of the growth attributed 38% to
+JSON being decoded in flight, 26% to encoding, 14% to per-connection buffers
+and 7% to cloned request bodies, with nothing at all attributable to the
+catalog, the handler maps or the SDK's tool table.
+
+The settled resident set is recorded beside the settled heap because a
+container limit is measured against the resident set, and it **lags**: freeing
+the heap does not hand the pages back, which Go's scavenger does on its own
+schedule. Read the heap for what a credential costs and the resident set for
+what the host is still holding.
 
 ## How it is measured
 
@@ -132,9 +153,18 @@ each count:
    of the phase, from the listener's `/debug/pprof/profile`, and as the phase
    ends a heap profile and the goroutine total from
    `/debug/pprof/goroutine?debug=1`, which unlike the traceback signal leaves
-   the process alive for the next step. Profiles land under
+   the process alive for the next step. The heap profile is taken with `gc=1`,
+   so it is a profile of what is live rather than of whatever the collector
+   had not reached yet. Profiles land under
    `bench/profiles/<scenario>/<clients>.cpu.pb.gz` and `<clients>.heap.pb.gz`
    (`-profiles`), ignored by git.
+4. **Takes a settled reading**: the load having stopped, the process is left
+   alone for half a second, a collection is forced, and the live heap is read
+   from `/debug/pprof/heap?gc=1&debug=1` with the resident set beside it. Two
+   collections rather than one, because the first still counts what the phase
+   left behind for a cycle. This is the same measurement the end-to-end test
+   `TestSharedServer_LiveHeapDoesNotGrowWithTheNumberOfCredentials` makes on
+   every push, taken here at every step of the ladder.
 
 Two guards keep the series from taking the host down, and both are recorded
 so the page says where a series stopped and why rather than presenting a
@@ -269,7 +299,7 @@ Measured on Intel(R) Core(TM) i5-14400, 16 logical CPUs, 62 GiB RAM, linux/amd64
 |          50 |           6414 |           6808 |        8.085 | 15771 |             85 |            969 |             55 |            837 |        271 |
 |         100 |          12382 |          13192 |        8.112 | 16358 |            239 |            815 |            217 |            775 |        515 |
 
-Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 130.94 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB against a budget of 16172 MiB.
 
 #### http, meta surface: 4 in flight per credential, 10 s per step, memory budget 16172 MiB
 
@@ -284,7 +314,7 @@ Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB again
 |         100 |           6540 |           6645 |        7.995 | 14582 |            256 |            977 |            201 |            933 |        515 |
 |         200 |          12642 |          12907 |        7.893 | 14740 |            465 |           1599 |            532 |           1543 |       1014 |
 
-Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 63.52 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB against a budget of 16172 MiB.
 
 #### http, individual surface: 2 in flight per credential, 10 s per step, memory budget 16172 MiB
 
@@ -298,7 +328,7 @@ Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB again
 |          50 |           4518 |           4682 |      147.885 |  1007 |            108 |           1064 |           1806 |           4074 |        165 |
 |         100 |           8513 |           9432 |      152.311 |  1060 |            299 |           2069 |           3716 |           7631 |        314 |
 
-Stopped at 100 credentials: the next step (200) was estimated at 18461 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 90.84 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 100 credentials: the next step (200) was estimated at 18461 MiB against a budget of 16172 MiB.
 
 <!-- END BENCHMARK -->
 
@@ -306,19 +336,37 @@ Stopped at 100 credentials: the next step (200) was estimated at 18461 MiB again
 
 Five things the measurements say, in the order an operator meets them.
 
-**An HTTP process is cheap until a credential arrives, and then it is not.**
+**An HTTP process is cheap until a credential arrives and starts calling.**
 Idle it holds about 35 MiB and no tool catalog at all. The first request from
 each distinct token builds one, and the resident set grows with every live
-credential. The eight-credential scenarios put the increment at 33 MiB on
-`meta`, 49 MiB on `individual` and 77 MiB on `dynamic`, and landed between
-436 and 775 MiB, peaking between 591 MiB and 1.15 GiB while all eight were
-calling at once. The concurrency series is the sizing tool, because it
-measures the slope where a shared deployment lives: with every credential
-calling, the peak resident set grew by about 63 MiB per credential on `meta`,
-90 MiB on `individual` and 130 MiB on `dynamic`, which is 6.2 GiB, 8.8 GiB and
-12.7 GiB at a hundred credentials. Read `--max-http-clients` as a memory
-setting rather than a concurrency one: its default of 100 entries describes a
-pool of six to thirteen gibibytes, which no small instance can hold.
+credential that is working. The eight-credential scenarios put the increment
+at 33 MiB on `meta`, 49 MiB on `individual` and 77 MiB on `dynamic`, and
+landed between 436 and 775 MiB, peaking between 591 MiB and 1.15 GiB while all
+eight were calling at once. The concurrency series is the sizing tool, because
+it measures the slope where a shared deployment lives: with every credential
+holding requests in flight, the peak resident set grew by about 63 MiB per
+credential on `meta`, 90 MiB on `individual` and 130 MiB on `dynamic`, which
+is 6.2 GiB, 8.8 GiB and 12.7 GiB at a hundred credentials.
+
+**Those slopes are the load, not the tenancy.** They were published on this
+page as what a credential costs, and they are not: each is the credential
+together with the two to four requests it keeps in flight throughout the step.
+On the current build a heap profile of that growth attributes it to JSON
+decoding and encoding, per-connection buffers and cloned request bodies, and
+nothing at all to the catalog, the handler maps or the SDK's tool table; in
+the older record above, part of it was also the tool catalog each pool entry
+built for itself, which this build no longer does. Measured at rest instead,
+by the end-to-end test
+`TestSharedServer_LiveHeapDoesNotGrowWithTheNumberOfCredentials`, which runs on
+every push, the live heap grows 148 KiB on `dynamic` and 159 KiB on
+`individual` between the first credential and the twentieth: about **8 KiB per
+credential**, against a load slope in megabytes. The series above carries no
+settled reading, because it was
+measured before that reading existed; the run that follows this change
+publishes both figures per step, side by side. Until then, size an instance
+from how many credentials will be **calling at once**, and read
+`--max-http-clients` as a bound on pooled credentials rather than as the
+memory setting a load slope makes it look like.
 
 **stdio has no idle state, and one process per client.** The process starts
 building its catalog on a background goroutine as soon as it is executed, so
@@ -338,11 +386,16 @@ reclaims an entry.
 
 **The tool surface changes responses far more than memory.** A `tools/list` is
 12 KB on `dynamic`, 584 KB on `meta` and 3.1 MB on `individual`, and the warm
-response times follow. Memory per credential does not follow the tool counts:
-`dynamic` costs the most, because every entry builds a search index the other
-two do not, `individual` sits in between, and `meta` costs the least despite
-carrying the same catalog, because its few tools hold their action schemas
-behind an opaque parameter object.
+response times follow. Memory under load does not follow the tool counts
+either: `dynamic` costs the most per calling credential, `individual` sits in
+between and `meta` costs the least despite carrying the same catalog. That
+ranking mixes two things, and neither is what a credential costs to hold: what
+a surface allocates while it answers a call, and, in the record above, the
+catalog each pool entry built for itself. This build builds one server per
+configuration shape and shares it
+([ADR-0020](../development/adr/adr-0020-one-server-per-configuration-shape.md)),
+so what a credential holds is its client, its rate-limit bucket, its listen
+counter and its watchers, which the settled reading measures in kilobytes.
 
 **Throughput is bounded by processor time per call, and latency past that
 point is queueing.** In the series, calls completed per ten-second step stop

--- a/site/src/content/docs/es/operations/resource-benchmark.mdx
+++ b/site/src/content/docs/es/operations/resource-benchmark.mdx
@@ -4,11 +4,11 @@ description: "Lo que cuesta ejecutar el servidor, medido y no estimado: memoria 
 datePublished: "2026-09-04"
 faq:
   - q: "¿Cuánta memoria le doy al contenedor?"
-    a: "En modo HTTP dimensiona por **credenciales concurrentes, no por peticiones**. El proceso reposa cerca de 35 MiB sin ningún catálogo de herramientas, y a partir de ahí construye un catálogo por cada token distinto. Con todas las credenciales llamando, la serie de concurrencia midió unos 63 MiB por credencial en la superficie meta, 90 MiB en individual y 130 MiB en dynamic, es decir, 6,2 GiB, 8,8 GiB y 12,7 GiB con cien credenciales. Con 512 MiB atiendes holgadamente a unas pocas credenciales; un despliegue que espere decenas necesita gigabytes, o un `--max-http-clients` más bajo. En modo stdio cada cliente tiene su propio proceso, de entre 190 y 310 MiB."
+    a: "En modo HTTP dimensiona por **credenciales que están llamando, no por tokens ni por peticiones**. El proceso reposa cerca de 35 MiB sin ningún catálogo de herramientas. Con todas las credenciales manteniendo peticiones en vuelo, la serie de concurrencia midió un pico de conjunto residente que crece unos 63 MiB por credencial en la superficie meta, 90 MiB en individual y 130 MiB en dynamic, es decir, 6,2 GiB, 8,8 GiB y 12,7 GiB con cien credenciales. Esas cifras son la credencial junto con sus peticiones en vuelo, no lo que cuesta mantener una credencial: medida en reposo, con la carga detenida y una recolección forzada, una credencial añade unos 8 KiB al heap vivo. Un pool de cien tokens inactivos no es un pool de gigabytes; cien que llaman a la vez sí lo es. Con 512 MiB atiendes holgadamente a unas pocas credenciales simultáneas; un despliegue que espere decenas de llamantes a la vez necesita gigabytes. En modo stdio cada cliente tiene su propio proceso, de entre 190 y 310 MiB."
   - q: "¿Por qué la primera llamada de un token nuevo tarda tanto?"
     a: "Está pagando el registro. El proceso responde a `/health` en unos 50 ms sin tener ningún catálogo; la primera petición de una credencial construye el suyo, y eso tardó entre 0,6 y 0,7 segundos en las superficies dynamic y meta, y entre 1,4 y 1,5 segundos en la superficie individual en la máquina medida. Cualquier llamada posterior de esa credencial se sirve ya del catálogo construido. La espera vuelve cuando el pool recupera la entrada, lo que deciden `--pool-idle-timeout` y `--max-http-clients`."
   - q: "¿La superficie de herramientas cambia la memoria que necesita el servidor?"
-    a: "Menos de lo que cambia todo lo demás, y no en la dirección que parecería. Por credencial, la superficie dynamic fue la que más memoria costó de las tres en la serie de concurrencia, 130 MiB frente a 63 de meta y 90 de individual, porque cada entrada construye un índice de búsqueda que las otras no tienen, mientras que meta guarda los esquemas de sus acciones tras un objeto de parámetros opaco. Lo que la superficie sí cambia es el tamaño de un `tools/list`: 12 KB en dynamic, 584 KB en meta y 3,1 MB en individual, es decir, una respuesta en caliente de unos milisegundos frente a un tercio de segundo, y 150 ms de tiempo de procesador por listado en individual."
+    a: "Menos de lo que cambia todo lo demás, y no en la dirección que parecería. Por credencial que llama, la superficie dynamic fue la que más memoria costó de las tres en la serie de concurrencia, 130 MiB frente a 63 de meta y 90 de individual. Ese orden mide lo que una superficie reserva mientras responde a una llamada, más, en aquella ejecución antigua, el catálogo que cada entrada del pool construía para sí; esta compilación construye un servidor por forma de configuración y lo comparte, así que lo que mantiene una credencial son kilobytes en cualquier superficie. Lo que la superficie sí cambia es el tamaño de un `tools/list`: 12 KB en dynamic, 584 KB en meta y 3,1 MB en individual, es decir, una respuesta en caliente de unos milisegundos frente a un tercio de segundo, y 150 ms de tiempo de procesador por listado en individual."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -21,15 +21,20 @@ ajustes que de verdad mueven esas cifras.
 
 <Aside type="tip" title="De un vistazo">
 
-- **El modo HTTP se dimensiona por credenciales, no por peticiones.** Un
-  proceso en reposo no tiene ningún catálogo de herramientas; cada token
-  distinto construye el suyo en el pool.
+- **El modo HTTP se dimensiona por credenciales que están llamando.** Un
+  proceso en reposo no tiene ningún catálogo de herramientas; la primera
+  petición de cada token distinto construye uno, y ese catálogo lo comparten
+  después todas las credenciales de esa misma configuración.
+- **El conjunto residente bajo carga no es lo que cuesta mantener una
+  credencial.** La serie de concurrencia publica ambas cifras: megabytes por
+  credencial que llama, kilobytes por credencial mantenida.
 - **La primera llamada de cada credencial paga el registro**, y son segundos,
   no milisegundos. Ninguna llamada posterior vuelve a pagarlo, aunque en
   `individual` un `tools/list` en caliente sigue tardando segundos por sí solo.
 - **La superficie de herramientas cambia las respuestas mucho más que la
-  memoria**: por credencial la diferencia es de un factor de dos, mientras que
-  un `tools/list` ocupa 12 KB en `dynamic` y 3,1 MB en `individual`.
+  memoria**: por credencial que llama la diferencia es de un factor de dos,
+  mientras que un `tools/list` ocupa 12 KB en `dynamic` y 3,1 MB en
+  `individual`.
 
 </Aside>
 
@@ -58,8 +63,20 @@ credenciales llaman sin parar a `tools/call` y `tools/list`. Cada paso
 registra la memoria residente (media y pico), el tiempo de procesador por
 llamada, el p50 y el p99 de ambos métodos y el número de goroutines, y captura
 un perfil de CPU y otro de heap del servidor a través de su listener
-`--pprof-addr`, que el análisis lee y el sitio no publica. Una serie se detiene
-antes de tumbar la máquina: antes de cada paso se estima, a partir de los
+`--pprof-addr`, que el análisis lee y el sitio no publica.
+
+**Cada paso se mide además una segunda vez, con la carga detenida.** Las dos
+lecturas responden a preguntas distintas: el conjunto residente de la fase
+estable es lo que cuestan N credenciales mientras todas están llamando, y la
+lectura en reposo, tomada al terminar la carga y forzando una recolección, es
+lo que cuesta mantenerlas. La primera se mide en megabytes por credencial y la
+segunda en kilobytes, así que publicar la primera como si fuera la segunda,
+que es lo que hacía esta página, exagera el coste de una credencial del pool en
+tres órdenes de magnitud. El conjunto residente en reposo se registra junto al
+heap en reposo y va por detrás de él, porque liberar el montículo no devuelve
+las páginas: el recolector de Go las devuelve según su propio calendario.
+
+Una serie se detiene antes de tumbar la máquina: antes de cada paso se estima, a partir de los
 pasos anteriores, la memoria residente que alcanzaría, y el resto de la lista
 se omite cuando la estimación supera el presupuesto de memoria (el 80% de la
 memoria disponible del equipo salvo que se indique otro); un paso cuyo p99 de
@@ -163,7 +180,7 @@ Medido en Intel(R) Core(TM) i5-14400, 16 CPU lógicas, 62 GiB de RAM, linux/amd6
 |           50 |             6414 |            6808 |           8.085 |    15771 |             85 |            969 |             55 |            837 |        271 |
 |          100 |            12382 |           13192 |           8.112 |    16358 |            239 |            815 |            217 |            775 |        515 |
 
-Detenida en 100 credenciales: el siguiente paso (200) se estimó en 26345 MiB frente a un presupuesto de 16172 MiB.
+Ajustado sobre estos pasos, el pico de conjunto residente bajo carga crece 130.94 MiB por credencial. Eso es una credencial junto con las peticiones que mantiene en vuelo, no lo que cuesta mantener una credencial: este registro no contiene ninguna lectura en reposo. Detenida en 100 credenciales: el siguiente paso (200) se estimó en 26345 MiB frente a un presupuesto de 16172 MiB.
 
 #### http, superficie meta: 4 en vuelo por credencial, 10 s por paso, presupuesto de memoria de 16172 MiB
 
@@ -178,7 +195,7 @@ Detenida en 100 credenciales: el siguiente paso (200) se estimó en 26345 MiB fr
 |          100 |             6540 |            6645 |           7.995 |    14582 |            256 |            977 |            201 |            933 |        515 |
 |          200 |            12642 |           12907 |           7.893 |    14740 |            465 |           1599 |            532 |           1543 |       1014 |
 
-Detenida en 200 credenciales: el siguiente paso (500) se estimó en 32007 MiB frente a un presupuesto de 16172 MiB.
+Ajustado sobre estos pasos, el pico de conjunto residente bajo carga crece 63.52 MiB por credencial. Eso es una credencial junto con las peticiones que mantiene en vuelo, no lo que cuesta mantener una credencial: este registro no contiene ninguna lectura en reposo. Detenida en 200 credenciales: el siguiente paso (500) se estimó en 32007 MiB frente a un presupuesto de 16172 MiB.
 
 #### http, superficie individual: 2 en vuelo por credencial, 10 s por paso, presupuesto de memoria de 16172 MiB
 
@@ -192,7 +209,7 @@ Detenida en 200 credenciales: el siguiente paso (500) se estimó en 32007 MiB fr
 |           50 |             4518 |            4682 |         147.885 |     1007 |            108 |           1064 |           1806 |           4074 |        165 |
 |          100 |             8513 |            9432 |         152.311 |     1060 |            299 |           2069 |           3716 |           7631 |        314 |
 
-Detenida en 100 credenciales: el siguiente paso (200) se estimó en 18461 MiB frente a un presupuesto de 16172 MiB.
+Ajustado sobre estos pasos, el pico de conjunto residente bajo carga crece 90.84 MiB por credencial. Eso es una credencial junto con las peticiones que mantiene en vuelo, no lo que cuesta mantener una credencial: este registro no contiene ninguna lectura en reposo. Detenida en 100 credenciales: el siguiente paso (200) se estimó en 18461 MiB frente a un presupuesto de 16172 MiB.
 
 {/*END BENCHMARK*/}
 
@@ -206,21 +223,29 @@ no lo notará; un equipo con muchos clientes stdio tiene muchos procesos y paga
 por cada uno.
 
 **HTTP.** Parte de unos 35 MiB para un proceso que no atiende a nadie y suma
-un catálogo por cada token distinto. Los escenarios de ocho credenciales
-midieron 33 MiB por credencial adicional en `meta`, 49 MiB en `individual` y
-77 MiB en `dynamic`, con picos de entre 591 MiB y 1,15 GiB mientras las ocho
-llamaban a la vez. La serie de concurrencia mide la pendiente donde vive un
-despliegue compartido, con todas las credenciales llamando: 63 MiB por
-credencial en `meta`, 90 MiB en `individual` y 130 MiB en `dynamic`, es decir,
-6,2 GiB, 8,8 GiB y 12,7 GiB con cien credenciales.
+un catálogo por cada configuración distinta, que construye la primera
+credencial que lo pide. Los escenarios de ocho credenciales midieron 33 MiB
+por credencial adicional en `meta`, 49 MiB en `individual` y 77 MiB en
+`dynamic`, con picos de entre 591 MiB y 1,15 GiB mientras las ocho llamaban a
+la vez. La serie de concurrencia mide la pendiente donde vive un despliegue
+compartido, con todas las credenciales llamando: 63 MiB por credencial en
+`meta`, 90 MiB en `individual` y 130 MiB en `dynamic`, es decir, 6,2 GiB,
+8,8 GiB y 12,7 GiB con cien credenciales.
+
+**Léelas como el coste de la concurrencia, no el de la tenencia.** Están
+medidas con entre dos y cuatro peticiones en vuelo por credencial todo el
+tiempo, así que cada una es la credencial junto con el JSON que sus llamadas
+están decodificando y codificando. Medida en reposo, con la carga detenida y
+una recolección forzada, una credencial añade unos 8 KiB al heap vivo: cien
+tokens inactivos en el pool no llegan a un mebibyte entre todos.
 
 Una regla práctica para HTTP: **reserva la cifra de la serie para tu
-superficie, entre 65 y 130 MiB, por credencial que esperes tener activa a la
-vez, más 35 MiB para el proceso**, y trata `--max-http-clients` como un ajuste
-de memoria y no de concurrencia. Su valor por defecto de 100 entradas describe
-un pool de entre seis y trece gigabytes, mucho mayor de lo que cabe en una
-instancia pequeña; bájalo a lo que permita tu memoria, o acorta
-`--pool-idle-timeout` para que las entradas se recuperen antes.
+superficie, entre 65 y 130 MiB, por credencial que esperes que esté llamando
+a la vez, más 35 MiB para el proceso y un catálogo por configuración**. Trata
+`--max-http-clients` como un límite de credenciales en el pool y no como el
+ajuste de memoria que la cifra bajo carga aparenta: lo que cuesta gigabytes
+son cien llamantes a la vez, no cien tokens dados de alta. Acorta
+`--pool-idle-timeout` si quieres que las entradas se recuperen antes.
 
 **Rendimiento.** En la serie, las llamadas completadas por escalón dejan de
 crecer hacia las cinco credenciales en `dynamic` y `meta`: una llamada cuesta

--- a/site/src/content/docs/operations/http-server.mdx
+++ b/site/src/content/docs/operations/http-server.mdx
@@ -586,15 +586,15 @@ Use a token scoped to what you actually need. A hosted endpoint sees every reque
 
 ## How much memory does it need?
 
-Size the host from the HTTP server's resident set, not from the binary, and size it **for the work in flight**. These figures come from the [resource benchmark](/gitlab-mcp-server/operations/resource-benchmark/), which measures the real binary on both transports and states the machine it ran on. The per-credential row predates the shared server and is an upper bound; what a credential now costs at rest is three lines further down:
+Size the host from the HTTP server's resident set, not from the binary, and size it **per credential calling at once**, which is not the same as per token on the books. These figures come from the [resource benchmark](/gitlab-mcp-server/operations/resource-benchmark/), which measures the real binary on both transports and states the machine it ran on. The per-credential row predates the shared server and is an upper bound; what a credential now costs at rest is three lines further down:
 
-| Mode                                 | Resident set | Notes                                                           |
-| ------------------------------------ | -----------: | --------------------------------------------------------------- |
-| HTTP, idle, no credentials           |      ~40 MiB | The process holds no tool catalog until a request asks for one  |
-| HTTP, per additional live credential |    35–71 MiB | Measured when every credential built a catalog of its own       |
-| HTTP, eight live credentials         |  445–719 MiB | Peaks of 599 MiB to 1.14 GiB while all eight were calling       |
-| stdio, one process per client        |  190–330 MiB | It starts building its catalog at once, so it has no idle state |
-| Binary on disk                       |       ~55 MB | Single static binary, no runtime dependencies                   |
+| Mode                                    | Resident set | Notes                                                           |
+| --------------------------------------- | -----------: | --------------------------------------------------------------- |
+| HTTP, idle, no credentials              |      ~40 MiB | The process holds no tool catalog until a token asks for one    |
+| HTTP, per additional calling credential |    35–71 MiB | Read with the credential admitted and calling, not at rest      |
+| HTTP, eight live credentials            |  445–719 MiB | Peaks of 599 MiB to 1.14 GiB while all eight were calling       |
+| stdio, one process per client           |  190–330 MiB | It starts building its catalog at once, so it has no idle state |
+| Binary on disk                          |       ~55 MB | Single static binary, no runtime dependencies                   |
 
 Three things follow from this.
 

--- a/site/src/content/docs/operations/resource-benchmark.mdx
+++ b/site/src/content/docs/operations/resource-benchmark.mdx
@@ -4,11 +4,11 @@ description: "What the server costs to run, measured rather than estimated: resi
 datePublished: "2026-09-04"
 faq:
   - q: "How much memory should I give the container?"
-    a: "In HTTP mode, size for **concurrent credentials, not requests**. The process idles near 35 MiB holding no tool catalog at all, and then builds one catalog per distinct token. With every credential calling, the concurrency series measured about 63 MiB per credential on the meta surface, 90 MiB on individual and 130 MiB on dynamic, which is 6.2 GiB, 8.8 GiB and 12.7 GiB at a hundred credentials. 512 MiB comfortably serves a handful of credentials; a deployment expecting dozens needs gigabytes, or a lower `--max-http-clients`. In stdio mode each client gets its own process of roughly 190 to 310 MiB."
+    a: "In HTTP mode, size for **credentials that are calling, not for tokens and not for requests**. The process idles near 35 MiB holding no tool catalog at all. With every credential holding requests in flight, the concurrency series measured a peak resident set growing by about 63 MiB per credential on the meta surface, 90 MiB on individual and 130 MiB on dynamic, which is 6.2 GiB, 8.8 GiB and 12.7 GiB at a hundred credentials. Those figures are the credential and its in-flight requests together, not what a credential costs to hold: measured at rest, with the load stopped and a collection forced, a credential adds about 8 KiB to the live heap. So a pool of a hundred idle tokens is not a pool of gigabytes; a hundred callers at once is. 512 MiB comfortably serves a handful of concurrent credentials; a deployment expecting dozens of simultaneous callers needs gigabytes. In stdio mode each client gets its own process of roughly 190 to 310 MiB."
   - q: "Why is the first tool call after a new token so slow?"
     a: "It is paying for registration. The process answers `/health` in about 50 ms while holding no catalog; the first request from a credential builds one, which took 0.6 to 0.7 seconds on the dynamic and meta surfaces and 1.4 to 1.5 seconds on the individual surface on the host measured. Every later call from that credential is served from the built catalog. The wait returns whenever the pool reclaims the entry, which `--pool-idle-timeout` and `--max-http-clients` decide."
   - q: "Does the tool surface change how much memory the server needs?"
-    a: "Less than it changes everything else, and not in the direction you would guess. Per credential the dynamic surface cost the most memory of the three in the concurrency series, 130 MiB against 63 for meta and 90 for individual, because every entry builds a search index the others do not, while meta holds its action schemas behind an opaque parameter object. What the surface really changes is the size of a `tools/list`: 12 KB on dynamic, 584 KB on meta and 3.1 MB on individual, which is a warm response of a few milliseconds against a third of a second, and 150 ms of processor time per listing on individual."
+    a: "Less than it changes everything else, and not in the direction you would guess. Per calling credential the dynamic surface cost the most memory of the three in the concurrency series, 130 MiB against 63 for meta and 90 for individual. That ranking is one of what a surface allocates while it answers a call, plus, in that older run, the catalog each pool entry built for itself; this build builds one server per configuration shape and shares it, so what a credential holds is kilobytes on every surface. What the surface really changes is the size of a `tools/list`: 12 KB on dynamic, 584 KB on meta and 3.1 MB on individual, which is a warm response of a few milliseconds against a third of a second, and 150 ms of processor time per listing on individual."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -20,14 +20,18 @@ measured on both transports across the settings that move them.
 
 <Aside type="tip" title="At a glance">
 
-- **HTTP mode sizes by credentials, not by requests.** An idle process holds no
-  tool catalog; each distinct token builds its own in the pool.
+- **HTTP mode sizes by credentials that are calling.** An idle process holds no
+  tool catalog; the first request from each distinct token builds one, and the
+  built catalog is then shared by every credential of that configuration.
+- **A resident set under load is not what a credential costs to hold.** The
+  concurrency series reports both: megabytes per calling credential, kilobytes
+  per credential held.
 - **The first call of each credential pays for registration**, and it is
   seconds, not milliseconds. No later call pays it again, though on
   `individual` a warm `tools/list` still takes seconds on its own.
 - **The tool surface changes the responses far more than the memory**: per
-  credential the difference is a factor of two, while a `tools/list` is 12 KB
-  on `dynamic` and 3.1 MB on `individual`.
+  calling credential the difference is a factor of two, while a `tools/list` is
+  12 KB on `dynamic` and 3.1 MB on `individual`.
 
 </Aside>
 
@@ -54,7 +58,19 @@ ten-second steady phase at each count in which every credential keeps calling
 peak), processor time per call, the p50 and p99 of both methods and the
 goroutine count, and captures a CPU and a heap profile of the server through
 its `--pprof-addr` listener, which the analysis reads and the site does not
-publish. A series stops early rather than take the host down: before each
+publish.
+
+**Each step is then measured a second time, with the load stopped.** The two
+readings answer different questions: the resident set over the steady phase is
+what N credentials cost while all of them are calling, and the settled reading,
+taken after the load ends with a collection forced, is what they cost to hold.
+The first is measured in megabytes per credential and the second in kilobytes,
+so publishing the first as the second, which this page did, overstates a pooled
+credential by three orders of magnitude. The settled resident set is recorded
+beside the settled heap and lags it, because freeing a heap does not hand the
+pages back: Go's scavenger returns them on its own schedule.
+
+A series stops early rather than take the host down: before each
 step the resident set it would reach is estimated from the steps so far, and
 the rest of the list is skipped when the estimate exceeds the memory budget
 (80% of the host's available memory unless one is given); a step whose
@@ -157,7 +173,7 @@ Measured on Intel(R) Core(TM) i5-14400, 16 logical CPUs, 62 GiB RAM, linux/amd64
 |          50 |           6414 |           6808 |        8.085 | 15771 |             85 |            969 |             55 |            837 |        271 |
 |         100 |          12382 |          13192 |        8.112 | 16358 |            239 |            815 |            217 |            775 |        515 |
 
-Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 130.94 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB against a budget of 16172 MiB.
 
 #### http, meta surface: 4 in flight per credential, 10 s per step, memory budget 16172 MiB
 
@@ -172,7 +188,7 @@ Stopped at 100 credentials: the next step (200) was estimated at 26345 MiB again
 |         100 |           6540 |           6645 |        7.995 | 14582 |            256 |            977 |            201 |            933 |        515 |
 |         200 |          12642 |          12907 |        7.893 | 14740 |            465 |           1599 |            532 |           1543 |       1014 |
 
-Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 63.52 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB against a budget of 16172 MiB.
 
 #### http, individual surface: 2 in flight per credential, 10 s per step, memory budget 16172 MiB
 
@@ -186,7 +202,7 @@ Stopped at 200 credentials: the next step (500) was estimated at 32007 MiB again
 |          50 |           4518 |           4682 |      147.885 |  1007 |            108 |           1064 |           1806 |           4074 |        165 |
 |         100 |           8513 |           9432 |      152.311 |  1060 |            299 |           2069 |           3716 |           7631 |        314 |
 
-Stopped at 100 credentials: the next step (200) was estimated at 18461 MiB against a budget of 16172 MiB.
+Fitted across these steps, the peak resident set under load grows 90.84 MiB per credential. That is a credential together with the requests it keeps in flight, not what a credential costs to hold: this record carries no settled reading. Stopped at 100 credentials: the next step (200) was estimated at 18461 MiB against a budget of 16172 MiB.
 
 {/*END BENCHMARK*/}
 
@@ -199,21 +215,28 @@ higher. A developer machine running one client will not notice; a host running
 many stdio clients is running many processes and pays for each.
 
 **HTTP.** Start from about 35 MiB for a process serving nobody, then add one
-catalog per distinct token. The eight-credential scenarios measured 33 MiB per
-extra credential on `meta`, 49 MiB on `individual` and 77 MiB on `dynamic`,
-with peaks between 591 MiB and 1.15 GiB while all eight were calling at once.
-The concurrency series measures the slope where a shared deployment lives,
-with every credential calling: 63 MiB per credential on `meta`, 90 MiB on
-`individual` and 130 MiB on `dynamic`, which is 6.2 GiB, 8.8 GiB and 12.7 GiB
-at a hundred credentials.
+catalog per distinct configuration, built by the first credential that asks
+for it. The eight-credential scenarios measured 33 MiB per extra credential on
+`meta`, 49 MiB on `individual` and 77 MiB on `dynamic`, with peaks between 591
+MiB and 1.15 GiB while all eight were calling at once. The concurrency series
+measures the slope where a shared deployment lives, with every credential
+calling: 63 MiB per credential on `meta`, 90 MiB on `individual` and 130 MiB
+on `dynamic`, which is 6.2 GiB, 8.8 GiB and 12.7 GiB at a hundred credentials.
+
+**Read those as the cost of concurrency, not of tenancy.** They are measured
+with two to four requests in flight per credential throughout, so each is the
+credential together with the JSON its calls are decoding and encoding.
+Measured at rest instead, with the load stopped and a collection forced, a
+credential adds about 8 KiB to the live heap: a hundred idle tokens in the pool
+are under a mebibyte between them.
 
 A practical rule for HTTP: **budget the series figure for your surface, 65 to
-130 MiB, per credential you expect to be live at once, on top of 35 MiB for
-the process**, and treat `--max-http-clients` as a memory setting rather than
-a concurrency one. Its default of 100 entries describes a pool of six to
-thirteen gigabytes, far larger than a small instance can hold; lower it to
-what your memory allows, or shorten `--pool-idle-timeout` so entries are
-reclaimed sooner.
+130 MiB, per credential you expect to be calling at the same time, on top of
+35 MiB for the process and one catalog per configuration**. Treat
+`--max-http-clients` as a bound on pooled credentials rather than as the memory
+setting the load figure makes it look like: what costs gigabytes is a hundred
+callers at once, not a hundred tokens on the books. Shorten
+`--pool-idle-timeout` if you want entries reclaimed sooner.
 
 **Throughput.** In the series, the calls completed per step stop growing at
 about five credentials on `dynamic` and `meta`: a call costs 8 ms of processor


### PR DESCRIPTION
The concurrency series has been reporting a resident-set slope per credential, and this page and three others called it what a credential costs. It is not, and this corrects both the measurement and the pages.

Each step of the series admits credentials and then runs a load with two to four requests in flight per credential, sampling the resident set only while that load runs. A slope fitted through those samples is therefore the credential together with its requests. On the reference host at a thousand credentials on the dynamic surface, the peak resident set was 4379 MiB against a live heap of 253 MiB, and a heap profile of the growth attributes it to JSON decoding and encoding, per-connection buffers and cloned request bodies, with nothing at all attributable to the catalog, the handler maps or the SDK's tool table.

## What the driver now does

- **Forces a collection before every heap read.** The profile is fetched with `gc=1`, so what the analysis calls live is live rather than whatever survived the last cycle.
- **Takes a settled reading at every step.** After the load phase it leaves the process alone briefly, forces two collections through the profiling listener, and records the live heap and the resident set with that many credentials and nothing in flight. Credentials stay connected on purpose: a live credential holds sockets, and their buffers are part of what it costs.
- **Reports both, each named.** Record schema 3 adds the two settled figures per step, schemas 1 and 2 still read, and every place that prints a slope says which of the two it is. A series with no settled reading prints the load slope and says so.

## The two slopes, from the reference host

| Surface      | Load slope, peak resident set | Tenancy slope, settled live heap |
| ------------ | ----------------------------: | -------------------------------: |
| `dynamic`    |                      4.05 MiB |                         50.9 KiB |
| `meta`       |                      0.84 MiB |                         52.1 KiB |
| `individual` |                      4.00 MiB |                         29.1 KiB |

A thousand credentials at rest hold 89, 83 and 117 MB of live heap and about a third of a gibibyte of resident set on each surface. The load slope moved by up to a third between two runs minutes apart on a shared machine; the tenancy slope moved by at most 4 percent, and the settled heap reproduced to two decimals. That steadiness is most of why it is the better number.

## What the forced collection moved

Measured both ways on one process: totals fell 13 to 14 percent, and **the live entries did not move at all**. What disappeared were transient encode and decode buffers. So the megabyte figures for per-credential structures in the analysis page stand, and every percentage computed against a total reads too low. The tables are left as measured, with that stated, rather than adjusted, since an adjusted number is not a measured one.

## Two honest at-rest numbers

A reader will meet two figures for what a credential costs at rest and they differ by a factor of six. The end-to-end probe measures a credential with no connection open, about 8 KiB. The driver holds four sockets per credential open across steps, and reports about 50 KiB. Neither is wrong; the pages now say which is which wherever one appears.

## Gates

Build, vet, `go test ./cmd/bench_resources/` at 100 percent coverage, `golangci-lint --build-tags e2e`, the subtests, goroutine and test-file-name audits, `gen-stats`, `gen_testing_docs`, `format_md_tables`, `bench_resources -check`, and markdownlint on every touched page.

The committed record still carries the pre-sharing series, so the published tables show no settled columns yet. Replacing it is one run on the reference host and belongs with the release rather than here.
