### PR TITLE
ci: run the race detector at release and weekly, and fix four timing-dependent wait tests

### DIFF
--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -1,0 +1,116 @@
+# Race detector workflow for gitlab-mcp-server
+#
+# Nothing in this repository ran `go test -race` until this workflow existed:
+# every test job in ci.yml runs the suite without it, and `make test-race`
+# passed no `-timeout`, so it died on the ten-minute default partway through
+# internal/tools (issue 536).
+#
+# Where it runs, and where it deliberately does not. Not on every push: the
+# unit suite takes minutes without the detector and the better part of an hour
+# with it, which is a cost a pull request should not pay for a class of defect
+# that is rare and not introduced by most changes. Instead:
+#
+#   * at release, called by release.yml in parallel with the E2E gate, so a
+#     race cannot reach a tag;
+#   * once a week on main, beside the scheduled E2E run, so a race introduced
+#     this week surfaces this week rather than at the next tag.
+#
+# This is a workflow of its own rather than a job in ci.yml for the same reason
+# e2e.yml is: ci.yml converges on one job, "CI", which is the single check
+# branch protection requires, and a job added there becomes a gate on every
+# pull request. Nothing here reaches that graph, so the required check is
+# unchanged.
+#
+# Reusable, not copied. release.yml calls this file the way it calls e2e.yml,
+# so the commands a maintainer can run by hand from the dispatch menu are the
+# commands the release gate runs.
+
+name: Race Detector
+
+on:
+  schedule:
+    # Mondays, 06:23 UTC: the same day as the scheduled E2E run and after it,
+    # off the hour for the reason recorded in e2e.yml, since GitHub delays runs
+    # that pile up on round times.
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  # The whole unit suite, tooling included, under the detector.
+  #
+  # `go test -timeout` bounds each package's test binary, not the run, so the
+  # number has to cover the worst single package rather than their sum. That is
+  # internal/tools, at about 976 s under the detector against 113 s without it
+  # on a developer machine (issue 536), so roughly 8.6x. Its tests run in
+  # sequence within the package, so what decides its runtime here is per-core
+  # speed rather than the runner's four cores, and 60m leaves better than
+  # double. It still ends a genuine deadlock with every goroutine stack
+  # printed, which a job-level kill does not.
+  #
+  # The job bound is what covers the whole set: go test compiles and runs up to
+  # GOMAXPROCS package binaries at once, so having half the cores roughly
+  # doubles the wall time even where no single package got slower.
+  unit:
+    name: "🏁 Race (unit suite)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+      - run: go mod download
+      - name: Unit suite under the race detector
+        run: go test -race -count=1 -timeout 60m ./cmd/... ./internal/...
+
+  # The two transport modules, which are here because they are the only tests
+  # that drive the shipped binary as a process. `go test -race` instruments the
+  # test binary alone, so on its own it would watch the harness and say nothing
+  # about the server, which is the half worth watching: the harness passes the
+  # detector on to the binary it builds through a build-tag seam
+  # (harness_race_test.go in each module), and sets GORACE=halt_on_error=1 so a
+  # detected race stops the server rather than being printed into a log nobody
+  # reads.
+  #
+  # A race build shares no cache with an ordinary one, so the first build is a
+  # cold build of the whole dependency tree. It is done here rather than inside
+  # the test's five-minute bound.
+  transport:
+    name: "🏁 Race (${{ matrix.name }} transport e2e)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    strategy:
+      # Both modules report. Stopping at the first failure would hide a second,
+      # different one.
+      fail-fast: false
+      matrix:
+        include:
+          - name: HTTP
+            tag: httpe2e
+            dir: ./test/e2e/http/
+          - name: stdio
+            tag: stdioe2e
+            dir: ./test/e2e/stdio/
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+      - run: go mod download
+      - name: Warm the race build cache
+        run: go build -race -o /dev/null ./cmd/server
+      # 45m rather than the 900s these modules carry without the detector.
+      # Every test here starts a server, and an instrumented one takes several
+      # seconds to reach /health where an ordinary one takes under two, so the
+      # module's runtime is dominated by a per-test cost that the detector
+      # multiplies. The bound is here to end a hang with goroutine stacks, not
+      # to express how long the module should take.
+      - name: Transport module under the race detector
+        env:
+          TAG: ${{ matrix.tag }}
+          DIR: ${{ matrix.dir }}
+        run: go test -race -tags "$TAG" -count=1 -timeout 45m "$DIR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 # Release pipeline for gitlab-mcp-server
 #
 # Triggers: tag push matching v*, and a manual dispatch that REHEARSES.
-# Pipeline: Preflight → E2E (the reusable e2e.yml) → Docker → GoReleaser →
+# Pipeline: Preflight → E2E (e2e.yml) + Race (race.yml) → Docker → GoReleaser →
 #           per-publisher jobs → Winget
-# If E2E tests fail, nothing is released.
+# If either gate fails, nothing is released.
 #
 # Rehearsal. Every publisher job below was added after 2.7.5 shipped, so none
 # of them had run for real, and the first real run would have been the next
@@ -147,11 +147,28 @@ jobs:
     permissions:
       contents: read
 
+  # Beside the E2E gate rather than behind it: neither consumes anything the
+  # other produces, and the detector is the longer of the two, so running them
+  # in series would add its whole runtime to every release.
+  #
+  # It gates because a data race is exactly the defect that reaches a tag
+  # otherwise. Nothing in ci.yml runs the detector, by decision (issue 536): the
+  # unit suite takes the better part of an hour under it, which no pull request
+  # should pay, so a release is the first moment the question is asked at all.
+  # The gate sits in front of `docker` for the same reason the E2E gate does,
+  # that being the first job that publishes anything.
+  race:
+    name: "🏁 Race gate"
+    needs: [preflight]
+    uses: ./.github/workflows/race.yml
+    permissions:
+      contents: read
+
   docker:
     name: "🐳 Docker"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [preflight, e2e]
+    needs: [preflight, e2e, race]
     env:
       RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
     # No `environment:` — this job never ran under one, and adding it would

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,15 @@ test-short:
 	go test -count=1 $(PKGS)
 
 ## test-race: run all unit tests with race detector enabled
+# The timeout is explicit because go test's default is ten minutes per package
+# binary and internal/tools alone takes about 976 s under the detector, against
+# 113 s without it, so this target could never finish and reported a timeout
+# rather than a race (issue 536). 60m is the same bound the Race Detector
+# workflow carries, and it is a bound rather than an expectation: it exists to
+# end a deadlock with every goroutine stack printed.
+RACE_TIMEOUT ?= 60m
 test-race:
-	go test -v -race -coverprofile=coverage.out $(PKGS)
+	go test -v -race -timeout $(RACE_TIMEOUT) -coverprofile=coverage.out $(PKGS)
 
 ## test-pkg: run tests for a specific package domain (usage: make test-pkg PKG=branches)
 test-pkg:

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,153 |     236,250 |
-| Unit tests (`_test.go`)  |       659 |     391,643 |
-| End-to-end tests         |       239 |      64,079 |
-| **Total**                | **2,051** | **691,972** |
+| Unit tests (`_test.go`)  |       659 |     391,720 |
+| End-to-end tests         |       243 |      64,277 |
+| **Total**                | **2,055** | **692,247** |
 
 ### Functions
 

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -229,7 +229,7 @@ Unit tests live alongside the code in each sub-package. They use `net/http/httpt
 
 ```bash
 make test            # Standard tests with coverage
-make test-race       # Tests with race detector
+make test-race       # Tests with race detector (RACE_TIMEOUT=60m per package; the suite takes the better part of an hour)
 make coverage-conditions PKG=./internal/foo   # gobco: boolean conditions never evaluated both ways (each is a missing case)
 make coverage-mutants PKG=./internal/foo      # gremlins: mutation testing; Lived 0 and Not covered 0 is the gate on a changed package
 go test ./internal/... -count=1      # Run all unit tests (199 packages)

--- a/docs/development/static-analysis.md
+++ b/docs/development/static-analysis.md
@@ -256,6 +256,21 @@ GitHub Actions uses the same separation as Make:
 
 Separate jobs for `goimports`, `gofmt`, `go vet`, `modernize`, `gosec`, and `staticcheck` are intentionally omitted because `golangci-lint` already covers them with the repository configuration.
 
+### The race detector
+
+The race detector is a gate of its own, in `.github/workflows/race.yml`, and it deliberately does not run on a pull request. The unit suite takes minutes without it and the better part of an hour with it, which no push should pay for a class of defect that most changes cannot introduce. It runs in two places instead:
+
+| When            | How                                                                                                   | What it covers                                    |
+| --------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Every release   | `release.yml` calls `race.yml` beside the E2E gate, in front of the first job that publishes anything | so a race cannot reach a tag                      |
+| Mondays, weekly | the workflow's own `schedule`, beside the scheduled E2E run                                           | so a race introduced this week surfaces this week |
+
+Three jobs run there: the whole unit suite (`go test -race ./cmd/... ./internal/...`), and the two transport end-to-end modules, which are the only tests that drive the shipped binary as a process. `go test -race` instruments the test binary alone, so each transport harness passes the flag on to the server it builds through a build-tag seam (`harness_race_test.go` beside `harness_norace_test.go` in `test/e2e/http` and `test/e2e/stdio`) and starts it with `GORACE=halt_on_error=1`, or a detected race would be printed to a log and the run would stay green.
+
+Every one of those runs carries an explicit `-timeout`, and so does `make test-race`. Go's default is ten minutes **per package binary**, and `internal/tools` alone takes about 976 s under the detector against 113 s without it, so before the timeouts existed the target could not finish and reported a timeout rather than a race. `RACE_TIMEOUT` in the Makefile is that bound; it is a bound and not an expectation, there to end a deadlock with every goroutine stack printed.
+
+Nothing here reaches the `CI` workflow's graph, so the single required check is unchanged.
+
 ## GitLab CI Example
 
 ```yaml

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -24,7 +24,7 @@
 | cmd test functions                                    |  2,507 |
 | Test files (internal/)                                |    508 |
 | Test files (cmd/)                                     |    151 |
-| Test files (test/e2e/)                                |    233 |
+| Test files (test/e2e/)                                |    237 |
 | Tool sub-packages tested                              |    176 |
 | Core packages tested                                  |     21 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  98.2% |
@@ -48,9 +48,9 @@
 | Core packages           |          2,327 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,467 |        355 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            601 |        233 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| E2E integration         |            601 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,507 |        151 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,234** |    **892** |                                                                                                 |
+| **Total**               |     **14,234** |    **896** |                                                                                                 |
 
 ### Core Packages
 

--- a/docs/reference/tools/ci-cd.md
+++ b/docs/reference/tools/ci-cd.md
@@ -260,7 +260,9 @@ Delete all artifacts across an entire project. This is a destructive operation.
 
 ### `gitlab_job_wait`
 
-Wait for a CI/CD job to reach a terminal state (success, failed, canceled, skipped, manual). Polls the job status at a configurable interval and sends progress notifications. Returns the final job details when done or when the timeout is reached.
+Wait for a CI/CD job to reach a terminal state (success, failed, canceled, skipped, manual). Polls the job status at a configurable interval and sends progress notifications. Returns the final job details when done, and on a timeout the last details it managed to read, with `timed_out` set.
+
+`timeout_seconds` bounds the whole call, the poll in flight included, so a timeout shorter than one round trip to the instance returns `timed_out` with an empty `final_status`: the wait ended before any status had been read, and reporting one would be reporting a status nobody looked at. Give the wait at least as long as a `gitlab_job_get` takes against your instance.
 
 | Parameter          | Required | Default | Description                                |
 | ------------------ | -------- | ------- | ------------------------------------------ |

--- a/internal/tools/jobs/wait_test.go
+++ b/internal/tools/jobs/wait_test.go
@@ -15,10 +15,38 @@ import (
 
 const pathWaitJob = "/api/v4/projects/42/jobs/100"
 
+// useFastJobPollDuration scales every polling duration from seconds to
+// milliseconds, the timeout included, so a twenty-second wait takes twenty
+// milliseconds.
+//
+// Only a test about the timeout itself wants this. It makes the whole wait
+// shorter than one round trip to the httptest server on a loaded machine, so
+// the first poll can be cut off by the deadline before it answers and Wait can
+// time out having read nothing at all.
 func useFastJobPollDuration(t *testing.T) {
 	t.Helper()
 	original := pollDuration
 	pollDuration = func(seconds int) time.Duration { return time.Duration(seconds) * time.Millisecond }
+	t.Cleanup(func() { pollDuration = original })
+}
+
+// useFastJobPollInterval scales only the polling interval to milliseconds and
+// leaves every other duration, the timeout included, in real seconds. A test
+// about polling is then never ended by a clock it is not about, however slow
+// the machine running it.
+//
+// The interval is passed in rather than read back because pollDuration is
+// handed the value after [toolutil.ClampPollInterval] has applied the 5..60
+// bounds, so a caller asking for 1 would see 10 here.
+func useFastJobPollInterval(t *testing.T, intervalSeconds int) {
+	t.Helper()
+	original := pollDuration
+	pollDuration = func(seconds int) time.Duration {
+		if seconds == intervalSeconds {
+			return time.Millisecond
+		}
+		return original(seconds)
+	}
 	t.Cleanup(func() { pollDuration = original })
 }
 
@@ -128,6 +156,22 @@ func TestJobWait_FailedJob_NoFailOnError(t *testing.T) {
 
 // TestJobWait_Timeout verifies that Wait returns TimedOut=true when the
 // job stays in a running state and the timeout expires.
+//
+// It is about the timeout and nothing else. The scaled clock makes the whole
+// wait twenty milliseconds, which on a loaded runner is shorter than one round
+// trip to the httptest server: the deadline then cuts the first poll off before
+// it answers and Wait times out having read no status, so FinalStatus is empty.
+// That is the documented behavior, pinned without any I/O by waitpoll's
+// TestPoll_PollReceivesTimeoutContext, and asserting "running" unconditionally
+// here is what went red on slow Windows runners (issue 548).
+//
+// PollCount is what makes the status assertion exact rather than merely
+// weakened. The loop increments it before each poll and only reaches a second
+// iteration once the first poll has returned a non-terminal status, so a count
+// of two or more means a status was really read, and Wait must report it. A
+// count the fake kept of the requests it answered would be weaker: the server
+// can answer a request whose response the deadline stops the client from
+// reading.
 func TestJobWait_Timeout(t *testing.T) {
 	useFastJobPollDuration(t)
 
@@ -151,15 +195,25 @@ func TestJobWait_Timeout(t *testing.T) {
 	if !out.TimedOut {
 		t.Error("TimedOut should be true")
 	}
-	if out.FinalStatus != "running" {
-		t.Errorf("FinalStatus = %q, want %q", out.FinalStatus, "running")
+	if out.FinalStatus != "" && out.FinalStatus != "running" {
+		t.Errorf("FinalStatus = %q, want %q or empty", out.FinalStatus, "running")
+	}
+	if out.PollCount >= 2 && out.FinalStatus != "running" {
+		t.Errorf("FinalStatus = %q after %d polls, want %q once a poll has answered",
+			out.FinalStatus, out.PollCount, "running")
 	}
 }
 
 // TestJobWait_PollingTransition verifies that Wait polls multiple times
 // before the job transitions from running to success.
+//
+// Only the interval is scaled. Scaling the timeout as well left the whole
+// transition sixty milliseconds in which to make two round trips to the
+// httptest server, which is the same clock this file's timeout test is about
+// (issue 548), and losing that race here would have failed on a status Wait
+// never got to read rather than on the polling this test is for.
 func TestJobWait_PollingTransition(t *testing.T) {
-	useFastJobPollDuration(t)
+	useFastJobPollInterval(t, 5)
 
 	var callCount atomic.Int32
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -335,8 +389,13 @@ func TestJobWait_ManualJob(t *testing.T) {
 // cancellation that occurs during the polling loop (not before entry).
 // Uses a short-lived context that expires after the first poll but before
 // the ticker (5 s min), ensuring the select picks ctx.Done deterministically.
+//
+// Only the interval is scaled, so the caller's two-millisecond context is the
+// only clock that can end this wait. With the timeout scaled too it was three
+// hundred milliseconds away, near enough that a stalled machine could time out
+// instead of canceling and return no error at all.
 func TestJobWait_ContextCanceledDuringPoll(t *testing.T) {
-	useFastJobPollDuration(t)
+	useFastJobPollInterval(t, 5)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Millisecond)
 	defer cancel()

--- a/internal/tools/jobs/wait_test.go
+++ b/internal/tools/jobs/wait_test.go
@@ -36,8 +36,10 @@ func useFastJobPollDuration(t *testing.T) {
 // the machine running it.
 //
 // The interval is passed in rather than read back because pollDuration is
-// handed the value after [toolutil.ClampPollInterval] has applied the 5..60
-// bounds, so a caller asking for 1 would see 10 here.
+// handed the value after [toolutil.ClampPollInterval] has been applied, and
+// that is not a clamp to the nearer bound: a value under the minimum of 5
+// becomes the default of 10, not 5, while one over 60 becomes 60. A caller
+// asking for 1 would therefore see 10 here.
 func useFastJobPollInterval(t *testing.T, intervalSeconds int) {
 	t.Helper()
 	original := pollDuration

--- a/internal/tools/waitpoll/wait_poll_test.go
+++ b/internal/tools/waitpoll/wait_poll_test.go
@@ -173,10 +173,26 @@ func TestPoll_TickerContinuesUntilTerminal(t *testing.T) {
 
 // TestPoll_TimeoutReturnsLastItem verifies timeout returns the last observed
 // non-terminal item and TimedOut=true.
+//
+// This is where the property jobs.TestJobWait_Timeout cannot pin deterministically
+// is pinned instead: the poll callback here ignores its context and returns at
+// once, so a status is always read before the deadline, with no I/O to lose the
+// race to.
+//
+// The durations are keyed on the seconds value rather than left to
+// fastDuration, which returns a millisecond for both and so left the ticker and
+// the deadline racing: whenever the ticker won, a second poll ran and Value was
+// 2. Making the interval an hour is what the assertion on Value = 1 means.
 func TestPoll_TimeoutReturnsLastItem(t *testing.T) {
 	opts, _ := pollOptions("running")
 	opts.IntervalSeconds = 60
 	opts.TimeoutSeconds = 1
+	opts.PollDuration = func(seconds int) time.Duration {
+		if seconds == opts.TimeoutSeconds {
+			return time.Millisecond
+		}
+		return time.Hour
+	}
 
 	result, err := Poll(context.Background(), opts)
 	if err != nil {

--- a/test/e2e/http/harness_norace_test.go
+++ b/test/e2e/http/harness_norace_test.go
@@ -1,0 +1,22 @@
+//go:build httpe2e && !race
+
+// harness_norace_test.go is the ordinary half of the harness build seam, used
+// by every run that is not `go test -race`. See harness_race_test.go for the
+// other half and for why the seam exists.
+package httpe2e
+
+import "time"
+
+// serverBuildArgs returns the `go build` arguments for the server under test.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build.
+const serverBuildTimeout = 5 * time.Minute
+
+// raceEnviron adds nothing to the server's environment when the detector is
+// not in play.
+func raceEnviron() []string {
+	return nil
+}

--- a/test/e2e/http/harness_race_test.go
+++ b/test/e2e/http/harness_race_test.go
@@ -1,0 +1,39 @@
+//go:build httpe2e && race
+
+// harness_race_test.go is the race-detector half of the harness build seam. The
+// go tool sets the `race` build tag when -race is used, so this file is what is
+// compiled by `go test -race -tags httpe2e ./test/e2e/http/` and
+// harness_norace_test.go is what is compiled otherwise.
+package httpe2e
+
+import "time"
+
+// serverBuildArgs returns the `go build` arguments for the server under test,
+// with the detector on.
+//
+// This seam exists because `go test -race` instruments the test binary and
+// nothing else. The server is a separate process built by the harness, so
+// without passing the flag on, a race run would watch the harness's own
+// goroutines and say nothing about the server's, which are the ones this module
+// exists to reach: the handler chain lives in package main and can only be
+// driven as a process.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-race", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build. A race build shares no object cache
+// with an ordinary one, so it is a cold build of the whole dependency tree even
+// on a machine that has just compiled these tests.
+const serverBuildTimeout = 15 * time.Minute
+
+// raceEnviron is the extra environment an instrumented server is started with.
+//
+// Without halt_on_error the race runtime prints its report to stderr and lets
+// the process continue, setting the exit status only at a clean exit. A server
+// that is killed at the end of a test, which is most of them here, would then
+// take the report to the log with it and the run would stay green. Halting
+// fails whichever test was talking to it, with the report in the captured
+// output.
+func raceEnviron() []string {
+	return []string{"GORACE=halt_on_error=1"}
+}

--- a/test/e2e/http/harness_test.go
+++ b/test/e2e/http/harness_test.go
@@ -84,9 +84,12 @@ func serverBinary(t *testing.T) string {
 			// go build -o writes exactly the name it is given.
 			out += ".exe"
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		// The build arguments and the bound come from the race seam, so a
+		// `go test -race` run builds an instrumented server rather than
+		// driving an uninstrumented one (harness_race_test.go).
+		ctx, cancel := context.WithTimeout(context.Background(), serverBuildTimeout)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/server")
+		cmd := exec.CommandContext(ctx, "go", serverBuildArgs(out)...) //#nosec G204 -- every argument is a constant chosen by a build tag, plus a path this function got from os.MkdirTemp; nothing here comes from outside the test.
 		cmd.Dir = repoRoot()
 		if output, runErr := cmd.CombinedOutput(); runErr != nil {
 			errBuild = fmt.Errorf("building cmd/server: %w\n%s", runErr, output)
@@ -240,6 +243,9 @@ func tryStartServerOnPort(t *testing.T, port int, env map[string]string, flags .
 		"LOG_LEVEL=info",
 		"TOOL_SURFACE=dynamic",
 	)
+	// Before the caller's own entries, so a test that needs to say something
+	// else about GORACE still can.
+	cmd.Env = append(cmd.Env, raceEnviron()...)
 	for k, v := range env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/test/e2e/http/harness_test.go
+++ b/test/e2e/http/harness_test.go
@@ -270,13 +270,28 @@ func tryStartServerOnPort(t *testing.T, port int, env map[string]string, flags .
 	// rather than by sending: everything that asks whether the server is still
 	// there has to be able to ask, and a value can only be taken once. It was
 	// sent once, and the cleanup then blocked forever on a channel the health
-	// wait had already drained.
+	// wait had already drained. The wait's own error is recorded beside it,
+	// which is safe to read once the close has been observed.
+	//
+	// The cleanup asks, before it asks the process to stop, whether it is
+	// already gone. An exit nobody asked for is what a race report looks like
+	// under GORACE=halt_on_error=1, and it can land after the request that
+	// tripped it was already answered: no assertion fails, the report goes to
+	// the captured output of a test that passed, and the exit status is the
+	// only thing left saying anything happened.
+	var waitErr error
 	exited := make(chan struct{})
 	go func() {
-		_ = cmd.Wait()
+		waitErr = cmd.Wait()
 		close(exited)
 	}()
 	t.Cleanup(func() {
+		select {
+		case <-exited:
+			t.Errorf("the server exited on its own during the test (%s), which no test here asks it to do:\n%s",
+				describeExit(waitErr, cmd), logs())
+		default:
+		}
 		cancel()
 		<-exited
 	})
@@ -340,6 +355,23 @@ func listenAddrIn(logs string) string {
 		}
 	}
 	return ""
+}
+
+// describeExit names how the process ended: its recorded status when there is
+// one, and the error from the wait otherwise.
+//
+// The status is what to report. A server that handles its termination signal
+// exits 0, so the wait error alone says "<nil>" about a process that is
+// certainly gone, which is the least useful thing a message about an exit
+// could say.
+func describeExit(waitErr error, cmd *exec.Cmd) string {
+	if state := cmd.ProcessState; state != nil {
+		return state.String()
+	}
+	if waitErr != nil {
+		return waitErr.Error()
+	}
+	return "exit status not recorded"
 }
 
 // lockedWriter serializes writes from the process's two pipes into one buffer

--- a/test/e2e/stdio/harness_norace_test.go
+++ b/test/e2e/stdio/harness_norace_test.go
@@ -1,0 +1,22 @@
+//go:build stdioe2e && !race
+
+// harness_norace_test.go is the ordinary half of the harness build seam, used
+// by every run that is not `go test -race`. See harness_race_test.go for the
+// other half and for why the seam exists.
+package stdioe2e
+
+import "time"
+
+// serverBuildArgs returns the `go build` arguments for the server under test.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build.
+const serverBuildTimeout = 5 * time.Minute
+
+// raceEnviron adds nothing to the server's environment when the detector is
+// not in play.
+func raceEnviron() []string {
+	return nil
+}

--- a/test/e2e/stdio/harness_race_test.go
+++ b/test/e2e/stdio/harness_race_test.go
@@ -1,0 +1,39 @@
+//go:build stdioe2e && race
+
+// harness_race_test.go is the race-detector half of the harness build seam. The
+// go tool sets the `race` build tag when -race is used, so this file is what is
+// compiled by `go test -race -tags stdioe2e ./test/e2e/stdio/` and
+// harness_norace_test.go is what is compiled otherwise.
+package stdioe2e
+
+import "time"
+
+// serverBuildArgs returns the `go build` arguments for the server under test,
+// with the detector on.
+//
+// This seam exists because `go test -race` instruments the test binary and
+// nothing else. The server is a separate process built by the harness, so
+// without passing the flag on, a race run would watch the harness's own
+// goroutines and say nothing about the server's, which are the ones this module
+// exists to reach: what is under test is the process, its pipes and its
+// streams.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-race", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build. A race build shares no object cache
+// with an ordinary one, so it is a cold build of the whole dependency tree even
+// on a machine that has just compiled these tests.
+const serverBuildTimeout = 15 * time.Minute
+
+// raceEnviron is the extra environment an instrumented server is started with.
+//
+// Without halt_on_error the race runtime prints its report to stderr and lets
+// the process continue, setting the exit status only at a clean exit. A server
+// that is terminated at the end of a test, which is most of them here, would
+// then take the report to the log with it and the run would stay green.
+// Halting fails whichever test was talking to it, with the report in the
+// captured stderr.
+func raceEnviron() []string {
+	return []string{"GORACE=halt_on_error=1"}
+}

--- a/test/e2e/stdio/harness_test.go
+++ b/test/e2e/stdio/harness_test.go
@@ -136,6 +136,10 @@ type session struct {
 	exited chan struct{}
 	// state is what the reaper found, for the callers that report an exit code.
 	state atomic.Pointer[os.ProcessState]
+	// expectedExit is set by [session.waitExit], which every helper that asks
+	// the server to stop goes through. Without it the cleanup cannot tell an
+	// exit a test was about from one the server took by itself.
+	expectedExit atomic.Bool
 
 	mu     sync.Mutex
 	stderr strings.Builder
@@ -264,6 +268,20 @@ func startSessionIn(t *testing.T, dir string, env map[string]string, args ...str
 	}()
 
 	t.Cleanup(func() {
+		// Asked before stdin is closed, because closing it is how this harness
+		// asks the server to stop and an exit after that says nothing. A
+		// process already gone at this point went on its own, which under
+		// GORACE=halt_on_error=1 is what a race report looks like: the report
+		// lands in the captured stderr of a test that made its last assertion
+		// and passed, and nothing else would ever mention it.
+		if !s.expectedExit.Load() {
+			select {
+			case <-s.exited:
+				t.Errorf("the server exited on its own during the test (%s), which no test here asks it to do\nstderr: %s",
+					s.exitStatus(), s.stderrText())
+			default:
+			}
+		}
 		_ = stdin.Close()
 		cancel()
 		// Not Cmd.Wait: the reaper above already collected the child, so this
@@ -391,6 +409,15 @@ func (s *session) alive() bool {
 	default:
 		return true
 	}
+}
+
+// exitStatus describes how the process ended, in a form that makes sense
+// whether or not the reaper had recorded it by the time it was asked.
+func (s *session) exitStatus() string {
+	if state := s.state.Load(); state != nil {
+		return state.String()
+	}
+	return "exit status not recorded"
 }
 
 // stderrText returns everything the server has logged so far.
@@ -606,6 +633,11 @@ func (s *session) closeStdinAndWait(t *testing.T, within time.Duration) (code in
 // its own when the process does.
 func (s *session) waitExit(t *testing.T, within time.Duration) (code int, exited bool) {
 	t.Helper()
+
+	// Every helper that asks the server to stop arrives here, so this is the
+	// one place that has to record that the exit about to happen is the test's
+	// own doing and not a finding.
+	s.expectedExit.Store(true)
 
 	done := make(chan *os.ProcessState, 1)
 	go func() {

--- a/test/e2e/stdio/harness_test.go
+++ b/test/e2e/stdio/harness_test.go
@@ -85,9 +85,12 @@ func serverBinary(t *testing.T) string {
 			// go build -o writes exactly the name it is given.
 			out += ".exe"
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		// The build arguments and the bound come from the race seam, so a
+		// `go test -race` run builds an instrumented server rather than
+		// driving an uninstrumented one (harness_race_test.go).
+		ctx, cancel := context.WithTimeout(context.Background(), serverBuildTimeout)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/server")
+		cmd := exec.CommandContext(ctx, "go", serverBuildArgs(out)...) //#nosec G204 -- every argument is a constant chosen by a build tag, plus a path this function got from os.MkdirTemp; nothing here comes from outside the test.
 		cmd.Dir = repoRoot()
 		if output, runErr := cmd.CombinedOutput(); runErr != nil {
 			errBuild = fmt.Errorf("building cmd/server: %w\n%s", runErr, output)
@@ -192,6 +195,9 @@ func startSessionIn(t *testing.T, dir string, env map[string]string, args ...str
 	cmd.Dir = dir
 
 	environ := []string{"PATH=" + os.Getenv("PATH"), "HOME=" + t.TempDir()}
+	// Before the caller's own entries, so a test that needs to say something
+	// else about GORACE still can.
+	environ = append(environ, raceEnviron()...)
 	for k, v := range env {
 		environ = append(environ, k+"="+v)
 	}


### PR DESCRIPTION
Two changes that were their own issues.

## The race detector runs where it was decided it should (closes https://github.com/jmrplens/gitlab-mcp-server/issues/536)

No job ran `go test -race`, and `make test-race` carried no timeout, so it could not even finish the largest package. A new reusable workflow runs the unit suite and both transport end-to-end modules under the detector, with explicit timeouts sized for the detector's overhead on a runner: sixty minutes for the unit suite, whose largest package takes about sixteen minutes under the detector on a developer machine, and forty-five for each transport module, where every test starts an instrumented server.

It runs in two places and not on every push. At release, in parallel with the end-to-end gate, and the first job that publishes anything now waits on both, so a race cannot reach a tag. And weekly, beside the scheduled end-to-end run, so a race introduced this week surfaces this week rather than with twenty other changes on top of it. The single required check on pull requests is unchanged.

The transport modules needed more than a flag. They build the server binary themselves, so an instrumented test binary would have watched the harness and said nothing about the server. Each module now carries a compile-time seam, selected by the `race` build tag, that builds the server with the detector and runs it with `GORACE=halt_on_error=1`, because a detector report printed by a server that is then killed at the end of a test leaves the run green. Verified by building and driving instrumented servers through both modules. The non-race path is byte-identical to before.

## Four timing-dependent tests, fixed rather than loosened (closes https://github.com/jmrplens/gitlab-mcp-server/issues/548)

`TestJobWait_Timeout` scaled its timeout down to a few milliseconds, shorter than one round trip on a slow runner, so the wait timed out before its first poll had answered and the final status was empty. I did not change `Wait`: the poller bounds each poll by the wait deadline on purpose, so that a timeout means the whole call, and an unread status is already pinned as the right answer for a poll that was cut short. The test now asserts the status only once the poll count proves one was read, which is exact rather than weaker. Three neighbours with the same window are fixed with it, because the weekly race run is exactly where a millisecond window becomes a coin toss. A throwaway reproduction with a slow handler forced the Windows state deterministically; the old assertions fail on it and the new ones hold.

The reference page gains the one sentence that was missing about what a timeout shorter than a round trip returns.

## Gates

Build, vet, the two packages twenty and fifty times over, lint on them and on both transport modules, the subtests, goroutine and test-file-name audits, the supply-chain audit for the release workflow change, the generators, and markdownlint. Coverage on the touched packages is unchanged at 100 and 99.2 percent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stdio request handling so responses received during shutdown or cancellation are returned reliably instead of being lost.
  - Clarified job-wait timeout behavior, including the latest available job details and final status.

- **Quality Improvements**
  - Added scheduled and release-time race detection for unit and end-to-end tests.
  - Added coverage for race conditions affecting HTTP and stdio transports.
  - Added configurable time limits for race-enabled test runs.

- **Documentation**
  - Updated testing, static-analysis, CI/CD, and repository statistics documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->