### PR TITLE
test: close the harness port race, and take four packages through condition and mutation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,153 |     236,222 |
-| Unit tests (`_test.go`)  |       659 |     391,588 |
+| Unit tests (`_test.go`)  |       659 |     391,615 |
 | End-to-end tests         |       239 |      64,018 |
-| **Total**                | **2,051** | **691,828** |
+| **Total**                | **2,051** | **691,855** |
 
 ### Functions
 
@@ -498,7 +498,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 7,421 |
-| `defer` statements                 | 1,302 |
+| `defer` statements                 | 1,303 |
 | `struct` types defined             | 2,941 |
 | `//nolint` suppressions            |   315 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/README.md
+++ b/README.md
@@ -467,18 +467,18 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,153 |     236,222 |
-| Unit tests (`_test.go`)  |       659 |     391,615 |
-| End-to-end tests         |       239 |      64,018 |
-| **Total**                | **2,051** | **691,855** |
+| Source (`.go`, non-test) |     1,153 |     236,250 |
+| Unit tests (`_test.go`)  |       659 |     391,639 |
+| End-to-end tests         |       239 |      64,079 |
+| **Total**                | **2,051** | **691,968** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,816 |
+| Source functions                |  8,817 |
 | . Exported (public)             |  2,864 |
-| . Unexported (private)          |  5,952 |
+| . Unexported (private)          |  5,953 |
 | Unit test functions (`TestXxx`) | 13,633 |
 | Subtests (`t.Run(...)`)         |  5,277 |
 | End-to-end test functions       |    601 |
@@ -490,15 +490,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~205 lines |
 | Average test file length           |                 ~594 lines |
-| Comment lines in source            |  38,430 (~16.3% of source) |
+| Comment lines in source            |  38,448 (~16.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,421 |
-| `defer` statements                 | 1,303 |
+| `if err != nil` checks             | 7,424 |
+| `defer` statements                 | 1,304 |
 | `struct` types defined             | 2,941 |
 | `//nolint` suppressions            |   315 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -522,7 +522,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,294 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~4,295 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 13,707 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,153 |     236,250 |
-| Unit tests (`_test.go`)  |       659 |     391,639 |
+| Unit tests (`_test.go`)  |       659 |     391,643 |
 | End-to-end tests         |       239 |      64,079 |
-| **Total**                | **2,051** | **691,968** |
+| **Total**                | **2,051** | **691,972** |
 
 ### Functions
 

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,153 |     236,222 |
-| Unit tests (`_test.go`)  |       659 |     391,581 |
+| Unit tests (`_test.go`)  |       659 |     391,588 |
 | End-to-end tests         |       239 |      64,018 |
-| **Total**                | **2,051** | **691,821** |
+| **Total**                | **2,051** | **691,828** |
 
 ### Functions
 
@@ -480,7 +480,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | . Exported (public)             |  2,864 |
 | . Unexported (private)          |  5,952 |
 | Unit test functions (`TestXxx`) | 13,633 |
-| Subtests (`t.Run(...)`)         |  5,274 |
+| Subtests (`t.Run(...)`)         |  5,277 |
 | End-to-end test functions       |    601 |
 
 ### Ratios worth noting

--- a/README.md
+++ b/README.md
@@ -467,40 +467,40 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,153 |     236,134 |
-| Unit tests (`_test.go`)  |       659 |     389,774 |
-| End-to-end tests         |       239 |      63,946 |
-| **Total**                | **2,051** | **689,854** |
+| Source (`.go`, non-test) |     1,153 |     236,222 |
+| Unit tests (`_test.go`)  |       659 |     391,581 |
+| End-to-end tests         |       239 |      64,018 |
+| **Total**                | **2,051** | **691,821** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,810 |
+| Source functions                |  8,816 |
 | . Exported (public)             |  2,864 |
-| . Unexported (private)          |  5,946 |
-| Unit test functions (`TestXxx`) | 13,598 |
-| Subtests (`t.Run(...)`)         |  5,233 |
+| . Unexported (private)          |  5,952 |
+| Unit test functions (`TestXxx`) | 13,633 |
+| Subtests (`t.Run(...)`)         |  5,274 |
 | End-to-end test functions       |    601 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.65× more tests than code |
+| Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~205 lines |
-| Average test file length           |                 ~591 lines |
-| Comment lines in source            |  38,363 (~16.2% of source) |
+| Average test file length           |                 ~594 lines |
+| Comment lines in source            |  38,430 (~16.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,399 |
-| `defer` statements                 | 1,291 |
+| `if err != nil` checks             | 7,421 |
+| `defer` statements                 | 1,302 |
 | `struct` types defined             | 2,941 |
-| `//nolint` suppressions            |   314 |
+| `//nolint` suppressions            |   315 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
@@ -522,8 +522,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,293 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,706 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,294 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,707 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/server/listen.go
+++ b/cmd/server/listen.go
@@ -53,7 +53,16 @@ func isUnixSocketAddr(addr string) bool {
 // address is a path, a TCP port otherwise.
 func listenHTTP(ctx context.Context, addr string, socketMode os.FileMode) (net.Listener, error) {
 	if !isUnixSocketAddr(addr) {
-		return (&net.ListenConfig{}).Listen(ctx, "tcp", addr)
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		// The address that was bound, not the one that was asked for. They
+		// differ whenever the port is 0, which is how a deployment asks the
+		// kernel to choose one, and there is no other way to learn which port
+		// it chose. The unix branch has logged what it bound since it existed.
+		slog.InfoContext(ctx, "listening on tcp", "addr", listener.Addr().String())
+		return listener, nil
 	}
 	return listenUnix(ctx, addr, socketMode)
 }

--- a/cmd/server/probe.go
+++ b/cmd/server/probe.go
@@ -11,6 +11,11 @@
 // --transport and --http from their arguments, derives where /health is served,
 // and asks. A target may also be given outright, for a probe run from outside
 // the container or for a deployment whose process list cannot be read.
+//
+// One listener it cannot discover is one bound to port 0: the command line then
+// says 0 and the port that was actually bound is known only to the kernel and
+// to the server's own log. A deployment that asks the kernel for a port has to
+// give --probe the target, which it knows from that log.
 
 package main
 

--- a/docs/development/testing/README.md
+++ b/docs/development/testing/README.md
@@ -27,6 +27,65 @@ correctly.
 | Schema model evaluation | `cmd/eval_mcp_surfaces --preset schema-enterprise`        | Mock catalog                       | Models can select tools/actions and shape arguments from the MCP schema and descriptions.      |
 | Docker model evaluation | `cmd/eval_mcp_surfaces --preset docker-* --execute-tools` | Docker GitLab CE                   | Models can drive real MCP calls against a populated GitLab instance, including safe mutations. |
 
+## Beyond Statement Coverage
+
+Statement coverage is at or near 100% across `cmd/` and `internal/`, so it no
+longer answers the question it is usually asked. Two tools answer what it
+cannot, and both are run by hand on the package being worked on rather than
+over the tree:
+
+| Tool                                    | Command                                         | What it finds                                                                                           |
+| --------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Condition coverage ([gobco][gobco])     | `make coverage-conditions PKG=./internal/oauth` | An operand of a compound condition that no test ever evaluated both ways: a covered line, half decided. |
+| Mutation testing ([gremlins][gremlins]) | `make coverage-mutants PKG=./internal/oauth`    | A line every test runs and none asserts: the tool flips an operator or a boundary and asks who notices. |
+
+[gobco]: https://github.com/rillig/gobco
+[gremlins]: https://github.com/go-gremlins/gremlins
+
+### What they cost, and why the figures are not generated
+
+Measured on an 8-core machine, September 2026, one package at a time:
+
+| Package                        | Own test time | gobco | gremlins |
+| ------------------------------ | ------------: | ----: | -------: |
+| `internal/config`              |         1.5 s |   4 s |    128 s |
+| `internal/oauth`               |         0.2 s |   6 s |     88 s |
+| `internal/gitlab`              |         8.0 s |  68 s |    229 s |
+| `internal/serverpool`          |         1.0 s |  69 s |    207 s |
+| `internal/tools/actioncatalog` |         0.5 s |  68 s |        — |
+| `internal/subscriptions`       |         1.5 s |  72 s |        — |
+| `internal/tools/dynamic`       |        35.0 s | 231 s |        — |
+| `internal/tools`               |        89.2 s | 283 s |        — |
+
+Four packages therefore cost about eleven minutes of mutation testing and
+another two and a half of condition coverage, against roughly six minutes for
+the whole-tree coverage pass `cmd/gen_testing_docs` runs. Extending either to
+the packages that carry logic would be four to five times the generator's
+current cost, which is why neither figure is a generated column in
+[Testing Reference](testing.md): a number nobody can afford to regenerate goes
+stale in the file while looking current.
+
+**gobco cannot analyse a package with build-constrained files at all.** It
+copies every `.go` file into its work directory ignoring `//go:build`, so
+`internal/toolutil` and `cmd/server` both fail with a redeclaration panic
+(`openLeafNoFollow`, `isConnRefused`). Those two are covered by mutation
+testing only.
+
+### Reading a survivor
+
+Not every survivor is a gap. Three kinds cannot be killed by any test and
+should be recorded rather than chased:
+
+- **A boundary whose two sides agree at the boundary.** Flipping `>` to `>=`
+  where both branches assign the same value at the boundary changes nothing.
+  Six of the retry-clamp mutants in `internal/gitlab` are this shape.
+- **A guard that a second guard makes unobservable.** The negative token
+  cache checks "disabled" in both `RecordKind` and `Lookup`, so removing the
+  second changes no answer.
+- **A tool artifact.** Mutations inside package-level constant initializers
+  and `switch { case … }` expressions are reported as not covered because
+  neither carries a statement counter, not because no test reaches them.
+
 ## When To Use Each Layer
 
 Use unit tests for implementation changes and regression coverage. Use E2E

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,199 |
-| Unit test functions                                   | 13,598 |
+| Total test functions                                  | 14,234 |
+| Unit test functions                                   | 13,633 |
 | E2E test functions                                    |    601 |
 | cmd test functions                                    |  2,507 |
 | Test files (internal/)                                |    508 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,644 | 82.0% |
+| `TestFunc_Scenario` (2-part)           | 11,670 | 82.0% |
 | `TestFunc` (no underscore)             |    967 |  6.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,588 | 11.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,597 | 11.2% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,292 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,327 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,467 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            601 |        233 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,507 |        151 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,199** |    **892** |                                                                                                 |
+| **Total**               |     **14,234** |    **892** |                                                                                                 |
 
 ### Core Packages
 
@@ -62,22 +62,22 @@
 | clientcompat  |        18 |   100.0% | Package clientcompat applies per-client response compatibility profiles to MCP results.                                                                                                                                                                            |
 | cmdutil       |         8 |   100.0% | Package cmdutil provides shared helpers for repository command utilities.                                                                                                                                                                                          |
 | completions   |       101 |   100.0% | Package completions provides a CompletionHandler for GitLab-aware autocomplete of prompt arguments and resource URI template parameters.                                                                                                                           |
-| config        |       107 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                                                                   |
+| config        |       116 |   100.0% | Package config loads, normalizes, and validates runtime configuration for the GitLab MCP server.                                                                                                                                                                   |
 | edition       |         5 |    87.0% | Package edition defines the GitLab licensing tier model used to gate tool availability across the MCP server.                                                                                                                                                      |
 | elicitation   |       129 |    98.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                                                                       |
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
-| gitlab        |        80 |    99.6% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
+| gitlab        |        86 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
-| oauth         |        72 |    98.9% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
+| oauth         |        78 |   100.0% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       280 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
 | resources     |       188 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
-| serverpool    |       102 |    98.9% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
+| serverpool    |       116 |   100.0% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       850 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,292** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,327** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -363,13 +363,13 @@
 | edition       |    87.0% |
 | elicitation   |    98.3% |
 | gatewaycompat |    99.4% |
-| gitlab        |    99.6% |
+| gitlab        |   100.0% |
 | mcpotel       |    99.0% |
-| oauth         |    98.9% |
+| oauth         |   100.0% |
 | progress      |    83.8% |
 | prompts       |   100.0% |
 | resources     |    99.5% |
-| serverpool    |    98.9% |
+| serverpool    |   100.0% |
 | subscriptions |    98.5% |
 | telemetry     |    93.1% |
 | testutil      |    89.6% |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -585,6 +585,72 @@ func TestParseSize_CaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestParseSize_RefusesASizeOfNothing verifies that a size of zero, and a
+// negative one, are refused rather than accepted as a ceiling.
+//
+// A ceiling of zero would refuse every upload and every local file read with
+// "too large", which reads as a broken server rather than as a setting the
+// operator wrote. Only non-numeric input was refused before, so the boundary
+// between "no ceiling was asked for" and "a ceiling of nothing" was never
+// tested at all.
+func TestParseSize_RefusesASizeOfNothing(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		want    int64
+	}{
+		{name: "zero", input: "0", wantErr: true},
+		{name: "zero with a unit", input: "0MB", wantErr: true},
+		{name: "negative", input: "-1", wantErr: true},
+		{name: "one byte is a ceiling, however small", input: "1", want: 1},
+		{name: "empty falls back to the default", input: "", want: 4096},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSize(tt.input, 4096)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseSize(%q) = %d, want a refusal", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSize(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseSize(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidate_RateLimitBurstOfOne_IsAccepted verifies the smallest burst a
+// rate-limited deployment may configure.
+//
+// A burst is a token bucket's depth, so one is the smallest that admits any
+// request at all, and it is the value an operator writes to say "no burst,
+// just the rate". Only zero and the ceiling were asserted, which leaves the
+// bound free to drift onto the one value between them.
+func TestValidate_RateLimitBurstOfOne_IsAccepted(t *testing.T) {
+	cfg := &Config{
+		GitLabURL:      testGitLabURL,
+		GitLabToken:    testGitLabToken,
+		RateLimitRPS:   10,
+		RateLimitBurst: 1,
+		MaxHTTPClients: DefaultMaxHTTPClients,
+	}
+	if err := cfg.validate(); err != nil {
+		t.Errorf("validate() refused a burst of 1 beside a positive RPS: %v", err)
+	}
+
+	cfg.RateLimitBurst = 0
+	if err := cfg.validate(); err == nil {
+		t.Error("validate() accepted a burst of 0 beside a positive RPS, which admits nothing")
+	}
+}
+
 // TestParseInt verifies parseInt handles valid values, defaults, and errors.
 func TestParseInt(t *testing.T) {
 	tests := []struct {
@@ -1525,6 +1591,20 @@ func TestLoad_RevalidateInterval(t *testing.T) {
 		_, err := Load()
 		if err == nil {
 			t.Fatal("expected error for SESSION_REVALIDATE_INTERVAL exceeding maximum")
+		}
+	})
+
+	// The maximum itself is a value the operator may set. Only "over" and
+	// "well under" were asserted, so a bound that had drifted from > to >=
+	// would refuse the documented ceiling and no test would say so.
+	t.Run("the maximum itself is accepted", func(t *testing.T) {
+		t.Setenv("SESSION_REVALIDATE_INTERVAL", MaxRevalidateInterval.String())
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() refused the documented maximum: %v", err)
+		}
+		if cfg.RevalidateInterval != MaxRevalidateInterval {
+			t.Errorf("RevalidateInterval = %v, want %v", cfg.RevalidateInterval, MaxRevalidateInterval)
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1459,9 +1459,11 @@ func TestParseToolSurfaceValue_UnknownIsRefusedByName(t *testing.T) {
 		t.Fatal("parseToolSurfaceValue(typo) = nil error, want a refusal")
 	}
 	for _, want := range []string{"TOOL_SURFACE", "indivdual"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q does not mention %q", err, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not mention %q", err, want)
+			}
+		})
 	}
 	if got := LegacyMetaToolsReplacement("indivdual"); got != "" {
 		t.Errorf("LegacyMetaToolsReplacement(typo) = %q, want no replacement", got)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -370,15 +370,75 @@ func TestLoad_CapabilitySurfaceInvalid(t *testing.T) {
 	}
 }
 
-// TestEffectiveCapabilitySurface verifies that empty capability settings resolve
-// to the full surface while explicit minimal settings are preserved.
+// TestEffectiveCapabilitySurface verifies that an unset or unrecognized
+// capability setting resolves to the default surface while each canonical
+// value is preserved.
+//
+// The full arm is asserted explicitly rather than left to the default: both
+// return the same string, so a switch that had lost the arm would still
+// answer correctly for "full" and wrongly for anything else the arm ever
+// grows to cover.
 func TestEffectiveCapabilitySurface(t *testing.T) {
-	if got := EffectiveCapabilitySurface(""); got != CapabilitySurfaceFull {
-		t.Fatalf("EffectiveCapabilitySurface(empty) = %q, want %q", got, CapabilitySurfaceFull)
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty falls back to the default", input: "", want: DefaultCapabilitySurface},
+		{name: "unrecognized falls back to the default", input: "compact", want: DefaultCapabilitySurface},
+		{name: "the canonical full is preserved", input: CapabilitySurfaceFull, want: CapabilitySurfaceFull},
+		{name: "the canonical minimal is preserved", input: CapabilitySurfaceMinimal, want: CapabilitySurfaceMinimal},
 	}
-	if got := EffectiveCapabilitySurface(CapabilitySurfaceMinimal); got != CapabilitySurfaceMinimal {
-		t.Fatalf("EffectiveCapabilitySurface(minimal) = %q, want %q", got, CapabilitySurfaceMinimal)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveCapabilitySurface(tt.input); got != tt.want {
+				t.Errorf("EffectiveCapabilitySurface(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
+}
+
+// TestValidateSurfaces_AcceptEveryCanonicalValue verifies the two validators
+// a configuration passes through accept each surface they document and refuse
+// anything else by name.
+//
+// Only one arm of each switch was ever taken, so a validator that had lost
+// the individual or the full arm would have refused a documented
+// configuration at startup with the list of values it had just rejected.
+func TestValidateSurfaces_AcceptEveryCanonicalValue(t *testing.T) {
+	t.Run("tool surface", func(t *testing.T) {
+		for _, surface := range []string{"", ToolSurfaceMeta, ToolSurfaceIndividual, ToolSurfaceDynamic} {
+			t.Run(surface, func(t *testing.T) {
+				if err := validateToolSurface(surface); err != nil {
+					t.Errorf("validateToolSurface(%q) = %v, want it accepted", surface, err)
+				}
+			})
+		}
+		err := validateToolSurface("individual-tools")
+		if err == nil {
+			t.Fatal("validateToolSurface(alias) = nil, want a refusal: validation runs on the resolved surface, not the operator's spelling")
+		}
+		if !strings.Contains(err.Error(), "individual-tools") {
+			t.Errorf("error %q does not name the value it refused", err)
+		}
+	})
+
+	t.Run("capability surface", func(t *testing.T) {
+		for _, surface := range []string{"", CapabilitySurfaceFull, CapabilitySurfaceMinimal} {
+			t.Run(surface, func(t *testing.T) {
+				if err := validateCapabilitySurface(surface); err != nil {
+					t.Errorf("validateCapabilitySurface(%q) = %v, want it accepted", surface, err)
+				}
+			})
+		}
+		err := validateCapabilitySurface("minimum")
+		if err == nil {
+			t.Fatal("validateCapabilitySurface(alias) = nil, want a refusal")
+		}
+		if !strings.Contains(err.Error(), "minimum") {
+			t.Errorf("error %q does not name the value it refused", err)
+		}
+	})
 }
 
 // TestLoad_MetaParamSchemaDefault verifies that [Load] defaults
@@ -946,6 +1006,14 @@ func TestLoad_DeprecatedEnterpriseEnv(t *testing.T) {
 	if LegacyEnterpriseEnvInUse("premium", "true") {
 		t.Error("LegacyEnterpriseEnvInUse should be false when GITLAB_MCP_TIER is set")
 	}
+	// Neither set is the ordinary case, and it must not warn: a deprecation
+	// notice about a variable the operator never wrote is noise they cannot act on.
+	if LegacyEnterpriseEnvInUse("", "") {
+		t.Error("LegacyEnterpriseEnvInUse should be false when neither variable is set")
+	}
+	if LegacyEnterpriseEnvInUse("", "   ") {
+		t.Error("LegacyEnterpriseEnvInUse should treat a whitespace-only GITLAB_ENTERPRISE as unset")
+	}
 }
 
 // TestLoad_InvalidReadOnly verifies that Load returns an error when
@@ -1229,6 +1297,12 @@ func TestEffectiveToolSurface(t *testing.T) {
 		{name: "legacy meta", metaTools: true, want: ToolSurfaceMeta},
 		{name: "legacy individual", metaTools: false, want: ToolSurfaceIndividual},
 		{name: "unknown falls back to meta", metaTools: true, toolSurface: "unknown", want: ToolSurfaceMeta},
+		// An explicit surface wins over the legacy boolean in both
+		// directions; only the dynamic arm was exercised, so a switch that
+		// had lost these two would have gone on passing while silently
+		// deriving the surface from META_TOOLS instead.
+		{name: "explicit meta beats a contradicting legacy boolean", metaTools: false, toolSurface: ToolSurfaceMeta, want: ToolSurfaceMeta},
+		{name: "explicit individual beats a contradicting legacy boolean", metaTools: true, toolSurface: ToolSurfaceIndividual, want: ToolSurfaceIndividual},
 	}
 
 	for _, tt := range tests {
@@ -1237,6 +1311,94 @@ func TestEffectiveToolSurface(t *testing.T) {
 				t.Errorf("EffectiveToolSurface() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestParseToolSurfaceValue_EverySpellingAnOperatorMayWrite verifies each
+// accepted spelling of the tool-surface selector resolves to the surface it
+// names, and that an unrecognized one is refused by name.
+//
+// The selector accepts nineteen spellings across three surfaces, and only six
+// of them were ever evaluated: the two booleans and the three canonical names,
+// plus one alias. An arm quietly deleted from any of the three cases would
+// have turned a documented value into a startup error, and nothing here would
+// have noticed. They are cheap to pin because the function is pure, and they
+// are the values operators copy out of the README.
+func TestParseToolSurfaceValue_EverySpellingAnOperatorMayWrite(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "the canonical meta", value: ToolSurfaceMeta, want: ToolSurfaceMeta},
+		{name: "legacy true", value: "true", want: ToolSurfaceMeta},
+		{name: "legacy t", value: "t", want: ToolSurfaceMeta},
+		{name: "legacy 1", value: "1", want: ToolSurfaceMeta},
+		{name: "legacy yes", value: "yes", want: ToolSurfaceMeta},
+		{name: "legacy y", value: "y", want: ToolSurfaceMeta},
+		{name: "meta-tools", value: "meta-tools", want: ToolSurfaceMeta},
+		{name: "metatools", value: "metatools", want: ToolSurfaceMeta},
+
+		{name: "the canonical individual", value: ToolSurfaceIndividual, want: ToolSurfaceIndividual},
+		{name: "legacy false", value: "false", want: ToolSurfaceIndividual},
+		{name: "legacy f", value: "f", want: ToolSurfaceIndividual},
+		{name: "legacy 0", value: "0", want: ToolSurfaceIndividual},
+		{name: "legacy no", value: "no", want: ToolSurfaceIndividual},
+		{name: "legacy n", value: "n", want: ToolSurfaceIndividual},
+		{name: "individual-tools", value: "individual-tools", want: ToolSurfaceIndividual},
+		{name: "tools", value: "tools", want: ToolSurfaceIndividual},
+
+		{name: "the canonical dynamic", value: ToolSurfaceDynamic, want: ToolSurfaceDynamic},
+		{name: "dynamic-tools", value: "dynamic-tools", want: ToolSurfaceDynamic},
+		{name: "low-token", value: "low-token", want: ToolSurfaceDynamic},
+
+		{name: "case and surrounding space are ignored", value: "  META  ", want: ToolSurfaceMeta},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseToolSurfaceValue(tt.value, "TOOL_SURFACE")
+			if err != nil {
+				t.Fatalf("parseToolSurfaceValue(%q) unexpected error: %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseToolSurfaceValue(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+
+			// The same spelling must survive the exported entry point, in
+			// both the TOOL_SURFACE and the legacy META_TOOLS position.
+			mode, metaTools, err := ParseToolSurface(tt.value, "")
+			if err != nil {
+				t.Fatalf("ParseToolSurface(%q, \"\") unexpected error: %v", tt.value, err)
+			}
+			if mode != tt.want {
+				t.Errorf("ParseToolSurface(%q, \"\") = %q, want %q", tt.value, mode, tt.want)
+			}
+			if wantMeta := tt.want != ToolSurfaceIndividual; metaTools != wantMeta {
+				t.Errorf("ParseToolSurface(%q, \"\") metaTools = %v, want %v", tt.value, metaTools, wantMeta)
+			}
+			if replacement := LegacyMetaToolsReplacement(tt.value); replacement != tt.want {
+				t.Errorf("LegacyMetaToolsReplacement(%q) = %q, want %q", tt.value, replacement, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseToolSurfaceValue_UnknownIsRefusedByName verifies the error names
+// the setting and the value, since an operator reading it has only the log to
+// work out which of the two selectors they mistyped.
+func TestParseToolSurfaceValue_UnknownIsRefusedByName(t *testing.T) {
+	_, err := parseToolSurfaceValue("indivdual", "TOOL_SURFACE")
+	if err == nil {
+		t.Fatal("parseToolSurfaceValue(typo) = nil error, want a refusal")
+	}
+	for _, want := range []string{"TOOL_SURFACE", "indivdual"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	if got := LegacyMetaToolsReplacement("indivdual"); got != "" {
+		t.Errorf("LegacyMetaToolsReplacement(typo) = %q, want no replacement", got)
 	}
 }
 
@@ -1252,6 +1414,13 @@ func TestParseCapabilitySurface_Aliases(t *testing.T) {
 		{name: "default alias", input: "default", want: CapabilitySurfaceFull},
 		{name: "low token alias", input: "low-token", want: CapabilitySurfaceMinimal},
 		{name: "invalid", input: "compact", wantErr: true},
+		// The canonical spellings and the remaining alias: only the aliases
+		// were exercised, so the two arms an operator is most likely to
+		// write were the untested ones.
+		{name: "the canonical full", input: CapabilitySurfaceFull, want: CapabilitySurfaceFull},
+		{name: "the canonical minimal", input: CapabilitySurfaceMinimal, want: CapabilitySurfaceMinimal},
+		{name: "minimum alias", input: "minimum", want: CapabilitySurfaceMinimal},
+		{name: "case and surrounding space are ignored", input: "  FULL  ", want: CapabilitySurfaceFull},
 	}
 
 	for _, tt := range tests {
@@ -1795,6 +1964,7 @@ func TestValidateMetadataURL_RejectsWhatTheFlagsPromise(t *testing.T) {
 		{name: "a path with no host", value: "/privacy", wantErr: true},
 		{name: "a scheme that is not http(s)", value: "ftp://example.com/privacy", wantErr: true},
 		{name: "a mailto link", value: "mailto:someone@example.com", wantErr: true},
+		{name: "unparseable", value: "https://[::1/privacy", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -2017,6 +2187,12 @@ func TestValidateOAuthGitLabURL_RequiresHTTPSOffTheMachine(t *testing.T) {
 		{name: "http on loopback", raw: "http://127.0.0.1:8929"},
 		{name: "http elsewhere", raw: "http://gitlab.example.com", wantErr: "cleartext"},
 		{name: "not a url", raw: "gitlab.example.com", wantErr: "not an absolute URL"},
+		{name: "unparseable", raw: "https://[::1", wantErr: "not an absolute URL"},
+		// Neither https nor http: the loopback exemption must not be
+		// reached at all, or a scheme this server cannot speak would be
+		// accepted for any host that happens to be local.
+		{name: "a scheme that is neither http nor https", raw: "ftp://gitlab.example.com", wantErr: "cleartext"},
+		{name: "a foreign scheme on loopback", raw: "ftp://127.0.0.1:8929", wantErr: "cleartext"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2047,6 +2223,11 @@ func TestValidatePublicURL_ExportedPathAndTheNonURL(t *testing.T) {
 		{name: "no host", raw: "mcp.example.com", wantErr: "not an absolute URL"},
 		{name: "unparseable", raw: "https://[::1", wantErr: "not an absolute URL"},
 		{name: "empty", raw: "", wantErr: "requires --public-url"},
+		// A scheme that is neither https nor http short-circuits before the
+		// loopback exemption, so an identifier no client can dereference is
+		// refused wherever it points.
+		{name: "a scheme that is neither http nor https", raw: "ftp://mcp.example.com", wantErr: "must use https"},
+		{name: "a foreign scheme on loopback", raw: "ftp://127.0.0.1:8080", wantErr: "must use https"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/env_file_test.go
+++ b/internal/config/env_file_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -543,6 +544,136 @@ func TestLoadEnvFiles_UnparsableWorkingDirectoryFile_StillReportsIt(t *testing.T
 			t.Errorf("IgnoredKeys = %v, want none from an unparsable file", report.IgnoredKeys)
 		}
 	})
+}
+
+// TestIgnoredWorkingDirEnvFile_OnlyReportsAFileWorthNaming verifies which
+// working-directory entries are reported as an ignored .env at all.
+//
+// The warning exists to explain a file whose settings did not take effect, so
+// it must not fire for something that has no settings to lose: a directory
+// that happens to be named .env, an empty one, or the very file the operator
+// pointed GITLAB_MCP_ENV_FILE at, which was loaded on purpose. Only the last
+// of those had a test; the first two are the shape a `mkdir .env` or a
+// `touch .env` produces, and warning about either sends the operator looking
+// for a precedence bug that is not there.
+func TestIgnoredWorkingDirEnvFile_OnlyReportsAFileWorthNaming(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup prepares the working directory and returns the value of the
+		// explicit path the caller had resolved, if any.
+		setup    func(t *testing.T, work string) string
+		wantPath bool
+		wantKeys []string
+	}{
+		{
+			name: "no working-directory file at all",
+			setup: func(*testing.T, string) string {
+				return ""
+			},
+		},
+		{
+			name: "a directory that happens to be named .env",
+			setup: func(t *testing.T, work string) string {
+				t.Helper()
+				if err := os.Mkdir(filepath.Join(work, ".env"), 0o750); err != nil {
+					t.Fatalf("mkdir .env: %v", err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "an empty .env sets nothing and is not worth a warning",
+			setup: func(t *testing.T, work string) string {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(work, ".env"), nil, 0o600); err != nil {
+					t.Fatalf("write empty .env: %v", err)
+				}
+				return ""
+			},
+		},
+		{
+			name: "the file the operator named is not an ignored file",
+			setup: func(t *testing.T, work string) string {
+				t.Helper()
+				return writeEnvFile(t, work, ".env", "GITLAB_URL=https://named.example.com")
+			},
+		},
+		{
+			name: "a .env beside a differently named explicit file is still ignored",
+			setup: func(t *testing.T, work string) string {
+				t.Helper()
+				writeEnvFile(t, work, ".env", "GITLAB_URL=https://ignored.example.com")
+				return writeEnvFile(t, work, "custom.env", "GITLAB_URL=https://named.example.com")
+			},
+			wantPath: true,
+			wantKeys: []string{"GITLAB_URL"},
+		},
+		{
+			name: "a .env with content and no explicit file is ignored",
+			setup: func(t *testing.T, work string) string {
+				t.Helper()
+				writeEnvFile(t, work, ".env", "GITLAB_TOKEN=glpat-ignored")
+				return ""
+			},
+			wantPath: true,
+			wantKeys: []string{"GITLAB_TOKEN"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			work := t.TempDir()
+			t.Chdir(work)
+			explicit := tt.setup(t, work)
+
+			path, keys := ignoredWorkingDirEnvFile(explicit)
+
+			if tt.wantPath && path == "" {
+				t.Fatal("ignoredWorkingDirEnvFile() named no file, want the working-directory .env")
+			}
+			if !tt.wantPath && path != "" {
+				t.Fatalf("ignoredWorkingDirEnvFile() = %q, want nothing reported", path)
+			}
+			if !slices.Equal(keys, tt.wantKeys) {
+				t.Errorf("keys = %v, want %v", keys, tt.wantKeys)
+			}
+		})
+	}
+}
+
+// TestLoadEnvFiles_NoHomeDirectory_LoadsWhatIsLeft verifies that a process
+// with no resolvable home directory still loads the file it was pointed at.
+//
+// A daemon started by an init system, a container running as a user with no
+// passwd entry, and a cron job all reach os.UserHomeDir with nothing to
+// return. The home file is a convenience; losing it must not take the
+// explicit file with it, and must not be an error the operator sees.
+func TestLoadEnvFiles_NoHomeDirectory_LoadsWhatIsLeft(t *testing.T) {
+	clearEnvFileKeys(t)
+	resetEnvFileAnnouncement(t)
+	work := t.TempDir()
+	t.Chdir(work)
+	named := writeEnvFile(t, work, "custom.env", "GITLAB_URL=https://named.example.com")
+
+	// An empty HOME is what os.UserHomeDir refuses on every platform this
+	// server runs on, and it is the only way to reach that branch without
+	// a real account whose home has been removed.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv(EnvFileVar, named)
+	resetExplicitEnvFile(t)
+
+	report := LoadEnvFiles()
+
+	if report.HomePath != "" {
+		t.Errorf("HomePath = %q, want none when the home directory cannot be resolved", report.HomePath)
+	}
+	if report.ExplicitErr != nil {
+		t.Errorf("ExplicitErr = %v, want the named file loaded regardless", report.ExplicitErr)
+	}
+	if got := os.Getenv("GITLAB_URL"); got != "https://named.example.com" {
+		t.Errorf("GITLAB_URL = %q, want the named file's value", got)
+	}
 }
 
 // TestDotenvKeys_UnreadableFile_ReturnsNoKeys verifies the other half of the

--- a/internal/config/env_file_test.go
+++ b/internal/config/env_file_test.go
@@ -676,6 +676,87 @@ func TestLoadEnvFiles_NoHomeDirectory_LoadsWhatIsLeft(t *testing.T) {
 	}
 }
 
+// TestLoadEnvFiles_HomeWithoutTheFile_NamesNothing verifies that a home
+// directory holding no dotenv leaves HomePath empty.
+//
+// The report is what the startup announcement reads, and naming a file that
+// was never loaded sends an operator to edit a path that does not exist while
+// the setting they are chasing comes from somewhere else. Nothing asserted the
+// empty case, so a load whose success test had been inverted would have
+// announced the home file on every start that did not have one.
+func TestLoadEnvFiles_HomeWithoutTheFile_NamesNothing(t *testing.T) {
+	clearEnvFileKeys(t)
+	resetEnvFileAnnouncement(t)
+	useHomeDir(t, t.TempDir())
+	t.Chdir(t.TempDir())
+
+	report := LoadEnvFiles()
+
+	if report.HomePath != "" {
+		t.Errorf("HomePath = %q, want none: the home directory holds no dotenv", report.HomePath)
+	}
+}
+
+// TestAnnouncedKeys_BoundsWithoutTruncatingWhatFits verifies the two limits
+// on the untrusted key names the ignored-file warning prints.
+//
+// Both are bounds on a log line assembled from a file this server refused to
+// load, so the names in it are attacker-controlled. What the boundary decides
+// is whether a file that sits exactly on a limit is reported intact: a bound
+// off by one truncates a perfectly ordinary ten-key .env and appends an
+// ellipsis to a key that was never too long, which reads as corruption rather
+// than as a limit.
+func TestAnnouncedKeys_BoundsWithoutTruncatingWhatFits(t *testing.T) {
+	t.Parallel()
+
+	keyOf := func(n int) string { return strings.Repeat("K", n) }
+
+	t.Run("exactly the key limit is kept whole", func(t *testing.T) {
+		t.Parallel()
+		keys := make([]string, maxAnnouncedKeys)
+		for i := range keys {
+			keys[i] = "K" + strconv.Itoa(i)
+		}
+		if got := announcedKeys(keys); len(got) != maxAnnouncedKeys {
+			t.Errorf("announcedKeys kept %d of exactly %d keys", len(got), maxAnnouncedKeys)
+		}
+	})
+
+	t.Run("one key over the limit is dropped", func(t *testing.T) {
+		t.Parallel()
+		keys := make([]string, maxAnnouncedKeys+1)
+		for i := range keys {
+			keys[i] = "K" + strconv.Itoa(i)
+		}
+		if got := announcedKeys(keys); len(got) != maxAnnouncedKeys {
+			t.Errorf("announcedKeys kept %d keys, want the list capped at %d", len(got), maxAnnouncedKeys)
+		}
+	})
+
+	t.Run("a key of exactly the rune limit is not shortened", func(t *testing.T) {
+		t.Parallel()
+		key := keyOf(maxAnnouncedKeyRunes)
+		got := announcedKeys([]string{key})
+		if len(got) != 1 || got[0] != key {
+			t.Errorf("announcedKeys(%d runes) = %v, want the name unchanged", maxAnnouncedKeyRunes, got)
+		}
+	})
+
+	t.Run("one rune over the limit is shortened", func(t *testing.T) {
+		t.Parallel()
+		got := announcedKeys([]string{keyOf(maxAnnouncedKeyRunes + 1)})
+		if len(got) != 1 {
+			t.Fatalf("announcedKeys returned %d names, want 1", len(got))
+		}
+		if !strings.HasSuffix(got[0], "...") {
+			t.Errorf("announcedKeys(%d runes) = %q, want it shortened", maxAnnouncedKeyRunes+1, got[0])
+		}
+		if runes := []rune(got[0]); len(runes) != maxAnnouncedKeyRunes+3 {
+			t.Errorf("shortened name is %d runes, want %d plus the ellipsis", len(runes), maxAnnouncedKeyRunes)
+		}
+	})
+}
+
 // TestDotenvKeys_UnreadableFile_ReturnsNoKeys verifies the other half of the
 // same courtesy: a file that vanished between the check and the read, or that
 // this process may not open, costs the warning its key names and nothing else.

--- a/internal/config/env_name.go
+++ b/internal/config/env_name.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -88,7 +89,16 @@ func LegacyEnvName(name string) string {
 // old spelling was the value's source. The warning is emitted once at startup
 // rather than at each read, because several of these are consulted more than
 // once and a per-read warning would say the same thing four times.
-var deprecatedEnvUses sync.Map
+//
+// It is a typed map behind a mutex rather than a [sync.Map] because every key
+// this package stores is a setting name and every value one of two kinds: the
+// any-typed alternative bought nothing here but two assertions whose false
+// branch no input could reach, and the map is written a handful of times at
+// startup, where lock contention is not a consideration.
+var (
+	deprecatedEnvMu   sync.Mutex
+	deprecatedEnvUses = map[string]envUseKind{}
+)
 
 // Getenv reads a setting under its prefixed name, falling back to the
 // unprefixed one and recording that it did.
@@ -109,24 +119,34 @@ func Getenv(name string) string {
 
 	switch {
 	case prefixedSet && legacySet:
-		deprecatedEnvUses.Store(name, bothSet)
+		recordDeprecatedEnvUse(name, bothSet)
 		return prefixed
 	case prefixedSet:
 		return prefixed
 	case legacySet:
-		deprecatedEnvUses.Store(name, legacyOnly)
+		recordDeprecatedEnvUse(name, legacyOnly)
 		return legacy
 	default:
 		return ""
 	}
 }
 
-// How an unprefixed name came to be noticed, which decides what the warning
-// tells the operator to do about it.
+// envUseKind is how an unprefixed name came to be noticed, which decides what
+// the warning tells the operator to do about it.
+type envUseKind int
+
 const (
-	legacyOnly = iota
+	legacyOnly envUseKind = iota
 	bothSet
 )
+
+// recordDeprecatedEnvUse notes that name was read under its unprefixed
+// spelling, in the way kind describes.
+func recordDeprecatedEnvUse(name string, kind envUseKind) {
+	deprecatedEnvMu.Lock()
+	defer deprecatedEnvMu.Unlock()
+	deprecatedEnvUses[name] = kind
+}
 
 // DeprecatedEnvWarnings returns one line per unprefixed variable that was
 // actually read, in a stable order, ready to be logged at startup.
@@ -134,18 +154,15 @@ const (
 // It reports what was read rather than what is set, so an operator is never
 // warned about a variable this deployment ignores anyway.
 func DeprecatedEnvWarnings() []string {
-	var names []string
-	deprecatedEnvUses.Range(func(key, _ any) bool {
-		if name, ok := key.(string); ok {
-			names = append(names, name)
-		}
-		return true
-	})
-	slices.Sort(names)
+	deprecatedEnvMu.Lock()
+	recorded := maps.Clone(deprecatedEnvUses)
+	deprecatedEnvMu.Unlock()
+
+	names := slices.Sorted(maps.Keys(recorded))
 
 	warnings := make([]string, 0, len(names))
 	for _, name := range names {
-		kind, _ := deprecatedEnvUses.Load(name)
+		kind := recorded[name]
 		legacy := LegacyEnvName(name)
 		if kind == bothSet {
 			warnings = append(warnings, "both "+EnvPrefix+name+" and "+legacy+
@@ -167,10 +184,9 @@ func PrefixedEnvNames() []string {
 // the record is process-wide by design: the warning belongs to the process, not
 // to a call.
 func resetDeprecatedEnvUses() {
-	deprecatedEnvUses.Range(func(key, _ any) bool {
-		deprecatedEnvUses.Delete(key)
-		return true
-	})
+	deprecatedEnvMu.Lock()
+	defer deprecatedEnvMu.Unlock()
+	clear(deprecatedEnvUses)
 }
 
 // TrimmedGetenv is [Getenv] with surrounding whitespace removed, which is what

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -1207,6 +1207,154 @@ func TestCredentialRejected_NilContext(t *testing.T) {
 	}
 }
 
+// TestCredentialRejected_OnlyAnExplicitRefusalCountsAsOne verifies the verdict
+// the probe actually returns, for every answer GitLab can give it.
+//
+// The positive half is the point: a 401 or a 403 on /api/v4/user is the
+// instance saying this credential is no longer good, and it is what makes the
+// pool drop the entry. Nothing asserted that half before, so a probe that had
+// been reduced to `return false` would have passed the whole suite while
+// quietly keeping revoked credentials alive for as long as the process ran.
+//
+// The negative half is the fail-open rule: a 404 from a stubbed instance, a
+// 5xx, and an instance that does not answer at all are all "no verdict", and
+// answering true for any of them turns one unreachable GitLab into a mass
+// revocation across every pooled entry.
+func TestCredentialRejected_OnlyAnExplicitRefusalCountsAsOne(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		unreliable bool
+		want       bool
+	}{
+		{name: "401 is the instance refusing the credential", status: http.StatusUnauthorized, want: true},
+		{name: "403 is the instance refusing the credential", status: http.StatusForbidden, want: true},
+		{name: "200 is the credential working", status: http.StatusOK},
+		{name: "404 is a stubbed endpoint, not a verdict", status: http.StatusNotFound},
+		{name: "500 is the instance struggling, not a verdict", status: http.StatusInternalServerError},
+		{name: "an instance that does not answer is not a verdict", unreliable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v4/version" {
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"version": "17.0.0"})
+					return
+				}
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			client, err := NewClient(newTestConfig(srv.URL, testValidToken))
+			if err != nil {
+				t.Fatalf(fmtNewClientErr, err)
+			}
+			if tt.unreliable {
+				// Closing the server first is how a transport error is
+				// produced without waiting on a timeout: the probe's Do
+				// fails to connect at all.
+				srv.Close()
+			}
+
+			if got := client.CredentialRejected(context.Background()); got != tt.want {
+				t.Errorf("CredentialRejected() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPing_NullVersionDocument verifies that a version endpoint answering the
+// JSON literal null is reported as a failed ping rather than dereferenced.
+//
+// client-go decodes into a pointer it leaves nil when the body is null, so
+// this is the one 200 response that reaches [Client.Ping] with no error and
+// no value. Without the nil half of the guard the next line reads
+// v.Version off nothing.
+func TestPing_NullVersionDocument(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("null"))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(newTestConfig(srv.URL, testValidToken))
+	if err != nil {
+		t.Fatalf(fmtNewClientErr, err)
+	}
+
+	version, err := client.Ping(context.Background())
+	if err == nil {
+		t.Fatalf("Ping() = %q, want an error for a null version document", version)
+	}
+}
+
+// TestDetectTier_NullLicenseDocument verifies that a license endpoint
+// answering the JSON literal null falls back to Free rather than being
+// dereferenced, the same shape [TestPing_NullVersionDocument] pins for the
+// version endpoint.
+func TestDetectTier_NullLicenseDocument(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v4/version" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"version": "17.0.0"})
+			return
+		}
+		_, _ = w.Write([]byte("null"))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(newTestConfig(srv.URL, testValidToken))
+	if err != nil {
+		t.Fatalf(fmtNewClientErr, err)
+	}
+
+	if got := client.DetectTier(context.Background()); got != edition.Free {
+		t.Errorf("DetectTier() on a null license document = %v, want free", got)
+	}
+}
+
+// TestNewBaseTransport_ForeignDefault_StillBuildsATransport covers the
+// fallback taken when http.DefaultTransport is not an *http.Transport.
+//
+// A process whose default is an instrumented or mocked RoundTripper has
+// nothing to clone, and this package must build a plain transport rather
+// than dereference what it found. The clone exists to inherit proxy and
+// dial settings, not to make requests work, so the fallback is only about
+// staying alive; what it must not lose is this package's own response
+// header timeout, which is asserted here.
+//
+// The shared transport is realized before the swap so no other test can
+// observe the foreign default through the sync.OnceValue.
+func TestNewBaseTransport_ForeignDefault_StillBuildsATransport(t *testing.T) {
+	_ = buildBaseTransport(false)
+
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = testRoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return original.RoundTrip(r)
+	})
+
+	transport := newBaseTransport(nil)
+	if transport == nil {
+		t.Fatal("newBaseTransport() = nil with a foreign DefaultTransport")
+	}
+	if transport.ResponseHeaderTimeout != responseHeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, responseHeaderTimeout)
+	}
+	if transport.TLSClientConfig != nil {
+		t.Errorf("TLSClientConfig = %+v, want none when no TLS configuration was supplied", transport.TLSClientConfig)
+	}
+}
+
+// testRoundTripperFunc is a RoundTripper that is deliberately not an
+// *http.Transport, which is the condition the fallback above exists for.
+type testRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip delegates to the wrapped function.
+func (f testRoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
 // TestPoolClientConstructors_UseTheirAuthScheme verifies each pool client
 // constructor authenticates every request path — the raw credential probe,
 // the raw version probe, and SDK API calls — with its own scheme: the

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -666,6 +666,18 @@ func TestEnsureInitialized_Recovery(t *testing.T) {
 	if !client.IsInitialized() {
 		t.Error("client should be initialized after successful recovery")
 	}
+	// Recovery must also switch lazy re-initialization off. The check runs
+	// from the transport on every SDK request, so a client that stays in
+	// lazy mode after recovering takes the lock, and once per cooldown a
+	// whole version round-trip, for the rest of the process's life.
+	if client.needsLazyInit.Load() {
+		t.Error("lazy re-initialization is still armed after a successful recovery")
+	}
+	before := client.lastInitAttempt
+	client.EnsureInitialized(context.Background())
+	if client.lastInitAttempt != before {
+		t.Error("a recovered client attempted initialization again")
+	}
 }
 
 // TestEnsureInitialized_Cooldown verifies that [Client.EnsureInitialized]

--- a/internal/gitlab/context_test.go
+++ b/internal/gitlab/context_test.go
@@ -42,6 +42,18 @@ func TestWithClient_BindsTheClientARequestRunsUnder(t *testing.T) {
 			},
 			want: bound,
 		},
+		{
+			// WithClient refuses to store a nil, so only a caller reaching
+			// past it can produce this. The fallback still has to win:
+			// returning the typed nil would hand a handler a client whose
+			// every method call is a nil dereference, which is strictly
+			// worse than the refusal ErrUnboundClient gives.
+			name: "a typed-nil binding falls back to the captured client",
+			ctx: func() context.Context {
+				return context.WithValue(context.Background(), clientContextKey{}, (*Client)(nil))
+			},
+			want: captured,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -108,6 +120,15 @@ func TestClientFrom_SaysWhetherAnythingWasBound(t *testing.T) {
 		{
 			name:    "a nil context",
 			ctx:     func() context.Context { return nil },
+			wantNil: true,
+		},
+		{
+			// "Bound to a nil client" is not "bound": a middleware told
+			// otherwise would install nothing and report that it had.
+			name: "a context carrying a typed-nil client",
+			ctx: func() context.Context {
+				return context.WithValue(context.Background(), clientContextKey{}, (*Client)(nil))
+			},
 			wantNil: true,
 		},
 	}

--- a/internal/gitlab/response_limit_test.go
+++ b/internal/gitlab/response_limit_test.go
@@ -415,6 +415,11 @@ type stubRoundTripper struct {
 	body string
 	// status is the answer's status code; zero means 200.
 	status int
+	// nilResponse answers (nil, nil), and nilBody answers a response whose
+	// Body is nil. Both violate the [http.RoundTripper] contract; they exist
+	// because this transport is the innermost layer and guards against them.
+	nilResponse bool
+	nilBody     bool
 }
 
 // RoundTrip returns the stubbed response or error.
@@ -422,13 +427,99 @@ func (s *stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	if s.fail {
 		return nil, errors.New("stub transport failure")
 	}
+	if s.nilResponse {
+		return nil, nil //nolint:nilnil // a contract-violating transport is what this stub imitates
+	}
 	status := s.status
 	if status == 0 {
 		status = http.StatusOK
 	}
-	return &http.Response{
+	resp := &http.Response{
 		StatusCode: status,
 		Body:       io.NopCloser(strings.NewReader(s.body)),
 		Header:     make(http.Header),
-	}, nil
+	}
+	if s.nilBody {
+		resp.Body = nil
+	}
+	return resp, nil
+}
+
+// TestResponseLimitTransport_ContractViolatingBase_IsPassedThrough verifies
+// that the innermost transport survives a base that breaks the
+// [http.RoundTripper] contract, rather than dereferencing what it was handed.
+//
+// Two shapes are pinned. A base that answers (nil, nil) must not reach the
+// unauthorized hook, since there is no status to judge, and must not be
+// wrapped, since there is no body to bound. A base that answers a response
+// with a nil Body must be returned untouched for the same reason: wrapping
+// nil would turn a malformed answer into a nil dereference in whichever
+// layer above reads it.
+//
+// These are the branches an in-process transport stack can produce and a real
+// GitLab cannot, so nothing else in this package reaches them: net/http's own
+// transport always returns one of the two valid shapes.
+func TestResponseLimitTransport_ContractViolatingBase_IsPassedThrough(t *testing.T) {
+	// roundTrip reports the shape of what came back rather than the response
+	// itself: every case here is about a response with no body to hand on,
+	// and returning one would only be a body nothing can close.
+	roundTrip := func(t *testing.T, base http.RoundTripper) (respWasNil, bodyWasNil bool, fired int) {
+		t.Helper()
+		client := &Client{}
+		client.SetMaxResponseBytes(1 << 20)
+		client.SetOnUnauthorized(func() { fired++ })
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://gitlab.example.com/x", http.NoBody)
+		if err != nil {
+			t.Fatalf("NewRequest unexpected error: %v", err)
+		}
+		resp, err := (&responseLimitTransport{base: base, client: client}).RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip() unexpected error: %v", err)
+		}
+		if resp == nil {
+			return true, true, fired
+		}
+		if resp.Body == nil {
+			return false, true, fired
+		}
+		defer resp.Body.Close()
+		return false, false, fired
+	}
+
+	t.Run("a base that answers nothing at all", func(t *testing.T) {
+		respWasNil, _, fired := roundTrip(t, &stubRoundTripper{nilResponse: true})
+		if !respWasNil {
+			t.Error("RoundTrip() invented a response, want the base's nil passed through")
+		}
+		if fired != 0 {
+			t.Errorf("the unauthorized hook fired %d times for a response that never existed", fired)
+		}
+	})
+
+	t.Run("a base that answers a response with no body", func(t *testing.T) {
+		respWasNil, bodyWasNil, fired := roundTrip(t, &stubRoundTripper{nilBody: true})
+		if respWasNil {
+			t.Fatal("RoundTrip() = nil, want the base's response passed through")
+		}
+		if !bodyWasNil {
+			t.Error("the nil body was replaced, want it passed through unwrapped")
+		}
+		if fired != 0 {
+			t.Errorf("the unauthorized hook fired %d times on a 200", fired)
+		}
+	})
+
+	t.Run("a 401 with no body still fires the hook", func(t *testing.T) {
+		respWasNil, bodyWasNil, fired := roundTrip(t, &stubRoundTripper{nilBody: true, status: http.StatusUnauthorized})
+		if respWasNil {
+			t.Fatal("RoundTrip() = nil, want the base's response passed through")
+		}
+		if !bodyWasNil {
+			t.Error("the nil body was replaced, want it passed through unwrapped")
+		}
+		if fired != 1 {
+			t.Errorf("the unauthorized hook fired %d times on a 401, want once", fired)
+		}
+	})
 }

--- a/internal/gitlab/retry_test.go
+++ b/internal/gitlab/retry_test.go
@@ -106,6 +106,52 @@ func TestClampedBackoff_RespectsTheCallersMinimum(t *testing.T) {
 	}
 }
 
+// TestClampedBackoff_JitterStaysInsideTheCallersWindow verifies the spread
+// added on top of the computed wait is the window client-go asked for, and
+// not some other span.
+//
+// The jitter exists so that a fleet of pooled clients released by one
+// rate-limit reset does not re-send in lockstep, and its width is the
+// caller's own [minWait, maxWait) range. Every other assertion in this file
+// is one-sided — no longer than the ceiling, no shorter than the step — so a
+// jitter computed from the wrong span passed them all: a wider one still sits
+// under the ceiling, and a narrower one still clears the step, while the
+// desynchronisation the jitter was added for quietly changes size.
+//
+// Sampled rather than computed because the value is random by design. With a
+// window of 300ms, a span mutated to 500ms puts four samples in ten above the
+// bound, so a couple of hundred draws settle it beyond any doubt a test needs.
+func TestClampedBackoff_JitterStaysInsideTheCallersWindow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		minWait = 100 * time.Millisecond
+		maxWait = 400 * time.Millisecond
+		samples = 200
+	)
+	// attempt 0 with no response: the wait before jitter is one step, which
+	// is above minWait and well under the ceiling, so neither clamp fires and
+	// what remains is exactly the jitter.
+	base := retryBackoffStep
+
+	var sawSpread bool
+	for range samples {
+		got := clampedBackoff(minWait, maxWait, 0, nil)
+		if got < base {
+			t.Fatalf("clampedBackoff() = %v, want at least the unjittered wait %v", got, base)
+		}
+		if got >= base+(maxWait-minWait) {
+			t.Fatalf("clampedBackoff() = %v, want less than %v: the jitter is wider than the window it was given", got, base+(maxWait-minWait))
+		}
+		if got != base {
+			sawSpread = true
+		}
+	}
+	if !sawSpread {
+		t.Errorf("every one of %d waits was exactly %v; no jitter was added at all", samples, base)
+	}
+}
+
 // TestRateLimitResetWait_ReadsTheHeader verifies how the RateLimit-Reset
 // header is turned into a wait, including every shape that must yield none.
 func TestRateLimitResetWait_ReadsTheHeader(t *testing.T) {
@@ -208,6 +254,8 @@ func countingFailureServer(t *testing.T, failStatus, failures int, rateLimited b
 // magnitude away from both the fixed and the unfixed behavior, so they
 // discriminate without turning CI load into a failure.
 func TestClient_RetryBudget_IsBounded(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		status      int
@@ -224,6 +272,13 @@ func TestClient_RetryBudget_IsBounded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// The three cases spend their time waiting out a real backoff,
+			// which is the point of the assertion and cannot be shortened
+			// without measuring something else. They share nothing — each
+			// builds its own server and its own client — so waiting through
+			// them at the same time costs the longest rather than the sum.
+			t.Parallel()
+
 			srvURL, hits := countingFailureServer(t, tt.status, tt.failures, tt.rateLimited)
 
 			client, err := NewClientWithTokenRetries(srvURL, testValidToken, false, false)

--- a/internal/oauth/cache.go
+++ b/internal/oauth/cache.go
@@ -55,7 +55,8 @@ func (c *TokenCache) Get(gitlabURL, token string) (*auth.TokenInfo, bool) {
 		// would throw that away and send the next request back to GitLab. This
 		// call still reports a miss, which is what it observed.
 		c.mu.Lock()
-		if current, stillThere := c.entries[key]; stillThere && expired(current.expiresAt) {
+		current, stillThere := c.entries[key]
+		if stillStale(current, stillThere) {
 			delete(c.entries, key)
 		}
 		c.mu.Unlock()
@@ -126,6 +127,20 @@ func (c *TokenCache) Cleanup() {
 // code says, which is enough reason to say the other thing.
 func expired(deadline time.Time) bool {
 	return expiredAt(time.Now(), deadline)
+}
+
+// stillStale reports whether an entry re-read under the write lock is still
+// the expired one a read observed under the read lock, and so may be deleted.
+//
+// It is a function of its own because both of its false answers come from a
+// race no test can schedule: between releasing the read lock and taking the
+// write lock, another goroutine may have deleted the entry (present is false)
+// or reverified the token and stored a live one (the deadline has moved into
+// the future). Deleting in either case throws away work and sends the next
+// request back to GitLab, so the rule is worth stating and asserting on its
+// own rather than left as a condition only a lucky interleaving reaches.
+func stillStale(entry cacheEntry, present bool) bool {
+	return present && expired(entry.expiresAt)
 }
 
 // expiredAt is [expired] against a caller-supplied instant, for a sweep that

--- a/internal/oauth/cache_test.go
+++ b/internal/oauth/cache_test.go
@@ -70,6 +70,57 @@ func TestTokenCache_GetExpired(t *testing.T) {
 	}
 }
 
+// TestStillStale_KeepsWhatAnotherGoroutineSaved verifies the rule the lazy
+// eviction re-checks under the write lock.
+//
+// Get releases the read lock before taking the write lock, so both false
+// answers here are races a test cannot schedule: another request may have
+// evicted the entry in the gap, or reverified the same token and stored a
+// live one. Deleting in either case discards a verification that has already
+// happened and sends the next request back to GitLab for an identity this
+// process already holds, which is the whole cost the cache exists to avoid.
+func TestStillStale_KeepsWhatAnotherGoroutineSaved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entry   cacheEntry
+		present bool
+		want    bool
+	}{
+		{
+			name:    "the expired entry is still there",
+			entry:   cacheEntry{expiresAt: time.Now().Add(-time.Minute)},
+			present: true,
+			want:    true,
+		},
+		{
+			name:    "another goroutine evicted it first",
+			present: false,
+		},
+		{
+			name:    "another goroutine reverified the token",
+			entry:   cacheEntry{expiresAt: time.Now().Add(time.Minute)},
+			present: true,
+		},
+		{
+			name:    "an entry expiring exactly now is stale",
+			entry:   cacheEntry{expiresAt: time.Now()},
+			present: true,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stillStale(tt.entry, tt.present); got != tt.want {
+				t.Errorf("stillStale() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestTokenCache_Evict verifies that Evict removes a specific token entry
 // and subsequent Get calls for that token return a miss.
 func TestTokenCache_Evict(t *testing.T) {

--- a/internal/oauth/rejected.go
+++ b/internal/oauth/rejected.go
@@ -158,6 +158,12 @@ func (r *RejectedTokens) evictLocked() {
 	if len(r.entries) < r.max {
 		return
 	}
+	// The map is non-empty here: the early return above fired unless at least
+	// r.max entries survived the expiry sweep, and r.max is positive whenever
+	// this cache is enabled. So the loop always names a key, and guarding the
+	// delete against the empty string would only be a guard against a state
+	// that cannot be reached — and a no-op even if it were, since deleting an
+	// absent key does nothing.
 	var oldestKey string
 	var oldestAt time.Time
 	for key, entry := range r.entries {
@@ -165,9 +171,7 @@ func (r *RejectedTokens) evictLocked() {
 			oldestKey, oldestAt = key, entry.expiresAt
 		}
 	}
-	if oldestKey != "" {
-		delete(r.entries, oldestKey)
-	}
+	delete(r.entries, oldestKey)
 }
 
 // Len returns the number of entries held, expired ones included.

--- a/internal/oauth/rejected_test.go
+++ b/internal/oauth/rejected_test.go
@@ -231,6 +231,51 @@ func TestRejectedTokens_IsScopedToTheInstance(t *testing.T) {
 // as though it knew something, and an entry past its TTL must be dropped on the
 // way out so a token refused an hour ago is verified upstream again rather than
 // refused from memory forever.
+// TestRejectedTokens_Lookup_AnswersWhatItKnows verifies the two answers the
+// negative cache gives on an enabled cache that has not expired: the recorded
+// reason for a token it holds, and "nothing known" for one it does not.
+//
+// Contains answers the same question as a boolean and is what most of this
+// file exercises, so Lookup's own live path and its own miss had never been
+// taken. The kind is the load-bearing half: a refusal recorded because this
+// deployment does not accept the token's application must not come back as
+// GitLab's own verdict, or the caller is told to re-authorize against an
+// instance that was perfectly happy with the credential.
+func TestRejectedTokens_Lookup_AnswersWhatItKnows(t *testing.T) {
+	t.Parallel()
+
+	const instance = "https://gitlab.example.com"
+	cache := NewRejectedTokens(8, time.Hour)
+	cache.RecordKind(instance, "unaccepted-token", RejectionUnaccepted)
+	cache.Record(instance, "invalid-token")
+
+	tests := []struct {
+		name       string
+		token      string
+		wantKind   RejectionKind
+		wantKnown  bool
+		wantLenOne bool
+	}{
+		{name: "a token refused by this deployment", token: "unaccepted-token", wantKind: RejectionUnaccepted, wantKnown: true},
+		{name: "a token GitLab itself refused", token: "invalid-token", wantKind: RejectionInvalid, wantKnown: true},
+		{name: "a token nothing is known about", token: "unseen-token", wantKind: RejectionInvalid},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			kind, known := cache.Lookup(instance, tt.token)
+			if known != tt.wantKnown {
+				t.Errorf("Lookup() known = %v, want %v", known, tt.wantKnown)
+			}
+			if kind != tt.wantKind {
+				t.Errorf("Lookup() kind = %v, want %v", kind, tt.wantKind)
+			}
+		})
+	}
+}
+
 func TestRejectedTokens_Lookup_HonorsDisabledAndExpiry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -1781,8 +1781,11 @@ func TestExpiryFromSeconds_RejectsWhatIsNotADeadline(t *testing.T) {
 		name     string
 		raw      any
 		wantZero bool
+		// wantIn is how far ahead the deadline must land, when it is one.
+		wantIn time.Duration
 	}{
-		{name: "a positive count is a deadline", raw: float64(3600)},
+		{name: "a positive count is a deadline", raw: float64(3600), wantIn: time.Hour},
+		{name: "a single second", raw: float64(1), wantIn: time.Second},
 		{name: "zero says nothing", raw: float64(0), wantZero: true},
 		{name: "a negative count says nothing", raw: float64(-1), wantZero: true},
 		{name: "a missing field", raw: nil, wantZero: true},
@@ -1792,9 +1795,21 @@ func TestExpiryFromSeconds_RejectsWhatIsNotADeadline(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			before := time.Now()
 			got := expiryFromSeconds(tt.raw)
 			if got.IsZero() != tt.wantZero {
-				t.Errorf("expiryFromSeconds(%v) = %v, want zero: %v", tt.raw, got, tt.wantZero)
+				t.Fatalf("expiryFromSeconds(%v) = %v, want zero: %v", tt.raw, got, tt.wantZero)
+			}
+			if tt.wantZero {
+				return
+			}
+			// The count is seconds, and the unit it is multiplied by is what
+			// decides whether an hour-long token is cached for an hour or for
+			// a microsecond. A minute of slack absorbs a slow machine without
+			// admitting a wrong unit.
+			ahead := got.Sub(before)
+			if ahead < tt.wantIn || ahead > tt.wantIn+time.Minute {
+				t.Errorf("expiryFromSeconds(%v) lands %v ahead, want about %v", tt.raw, ahead, tt.wantIn)
 			}
 		})
 	}

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -1521,6 +1521,15 @@ func TestVerificationRedirect_Policy(t *testing.T) {
 		// is nowhere, so it is not the instance, and the policy must say so
 		// rather than let net/http try to dial an empty address.
 		{name: "destination without a host", origin: "https://gitlab.example.com/api/v4/user", dest: "https:///api/v4/user", wantErr: true},
+		// The mirror of the row above: an origin with no host is nowhere
+		// too, and nothing can be a subdomain of it. Without this the
+		// comparison would accept any destination whose name happens to end
+		// in the empty string, which is all of them.
+		{name: "origin without a host", origin: "https:///api/v4/user", dest: "https://gitlab.example.com/api/v4/user", wantErr: true},
+		// The dot boundary lands correctly and the suffix still differs, so
+		// only the suffix test refuses this one. A dot-boundary check on its
+		// own would follow the hop.
+		{name: "a dot boundary over a different parent", origin: "https://gitlab.example.com/api/v4/user", dest: "https://a.xitlab.example.com/api/v4/user", wantErr: true},
 		{name: "ten hops already made", origin: "https://gitlab.example.com/api/v4/user", dest: "https://gitlab.example.com/api/v4/user", hops: 10, wantErr: true},
 	}
 
@@ -1683,5 +1692,137 @@ func TestIntrospectToken_UnreachableInstance_StillAssumesAPI(t *testing.T) {
 	}
 	if got.answered {
 		t.Error("introspectToken() recorded an answer from an instance that never replied")
+	}
+}
+
+// TestSatisfiesMinimum_ApiCoversReadAPI verifies the rule the door depends on
+// when it decides whether a credential meets the deployment's minimum.
+//
+// Only one row of it had ever been evaluated. The rule that api supersedes
+// read_api is the reason this function exists rather than a plain set
+// containment, and it was the untested half: every api-only token would get a
+// 403 for lacking a scope it strictly includes, and nothing here would have
+// said so. The empty minimum is the other unvisited branch, and it is the
+// answer for a caller that demands nothing.
+func TestSatisfiesMinimum_ApiCoversReadAPI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		granted []string
+		minimum string
+		want    bool
+	}{
+		{name: "no minimum admits anything", granted: nil, minimum: "", want: true},
+		{name: "no minimum admits an unknown scope", granted: []string{"read_user"}, minimum: "", want: true},
+		{name: "the minimum is granted outright", granted: []string{ScopeReadAPI}, minimum: ScopeReadAPI, want: true},
+		{name: "api covers a read_api minimum", granted: []string{ScopeAPI}, minimum: ScopeReadAPI, want: true},
+		{name: "read_api does not cover an api minimum", granted: []string{ScopeReadAPI}, minimum: ScopeAPI},
+		{name: "an unrelated scope covers nothing", granted: []string{"read_user"}, minimum: ScopeReadAPI},
+		{name: "no scopes at all", granted: nil, minimum: ScopeReadAPI},
+		// api only supersedes read_api. A minimum this deployment does not
+		// name must not be satisfied by holding something broader in a
+		// different dimension.
+		{name: "api does not cover an unrelated minimum", granted: []string{ScopeAPI}, minimum: "read_registry"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SatisfiesMinimum(tt.granted, tt.minimum); got != tt.want {
+				t.Errorf("SatisfiesMinimum(%v, %q) = %v, want %v", tt.granted, tt.minimum, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpandImpliedScopes_LeavesAnAlreadyCompleteSetAlone verifies the
+// normalization that writes GitLab's implicit grant into the scope list.
+//
+// The row that was missing is a token GitLab already reports both scopes for:
+// appending read_api again would tell the SDK's containment check about a
+// duplicate, and would allocate a copy of the slice on every verification for
+// nothing.
+func TestExpandImpliedScopes_LeavesAnAlreadyCompleteSetAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		scopes []string
+		want   []string
+	}{
+		{name: "api alone gains read_api", scopes: []string{ScopeAPI}, want: []string{ScopeAPI, ScopeReadAPI}},
+		{name: "api and read_api are left alone", scopes: []string{ScopeAPI, ScopeReadAPI}, want: []string{ScopeAPI, ScopeReadAPI}},
+		{name: "read_api alone is left alone", scopes: []string{ScopeReadAPI}, want: []string{ScopeReadAPI}},
+		{name: "no scopes at all", scopes: nil, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := expandImpliedScopes(tt.scopes); !slices.Equal(got, tt.want) {
+				t.Errorf("expandImpliedScopes(%v) = %v, want %v", tt.scopes, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpiryFromSeconds_RejectsWhatIsNotADeadline verifies how an OAuth
+// expires_in is read.
+//
+// A zero or negative count is not a deadline in the past to be honored: it is
+// a field that says nothing, and turning it into a moment already gone would
+// cap every cached identity at the shortest lifetime the cache allows, for
+// every token an instance reports that way.
+func TestExpiryFromSeconds_RejectsWhatIsNotADeadline(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      any
+		wantZero bool
+	}{
+		{name: "a positive count is a deadline", raw: float64(3600)},
+		{name: "zero says nothing", raw: float64(0), wantZero: true},
+		{name: "a negative count says nothing", raw: float64(-1), wantZero: true},
+		{name: "a missing field", raw: nil, wantZero: true},
+		{name: "a field of the wrong type", raw: "3600", wantZero: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := expiryFromSeconds(tt.raw)
+			if got.IsZero() != tt.wantZero {
+				t.Errorf("expiryFromSeconds(%v) = %v, want zero: %v", tt.raw, got, tt.wantZero)
+			}
+		})
+	}
+}
+
+// TestUpstreamError_NamesTheStatusWhenGitLabAnswered verifies the two
+// descriptions the error carries.
+//
+// An operator reading the log has to tell "the instance said no to the
+// request" from "nothing came back at all", because the first is a
+// configuration or rate-limit problem at a known endpoint and the second is a
+// network or DNS one. Only the unreachable wording had a test.
+func TestUpstreamError_NamesTheStatusWhenGitLabAnswered(t *testing.T) {
+	t.Parallel()
+
+	answered := &UpstreamError{Status: http.StatusTooManyRequests, Err: errors.New("slow down")}
+	message := answered.Error()
+	for _, want := range []string{"429", "slow down"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("Error() = %q, want it to mention %q", message, want)
+		}
+	}
+	if strings.Contains(message, "unreachable") {
+		t.Errorf("Error() = %q, want it not to call an answered request unreachable", message)
+	}
+
+	unreachable := &UpstreamError{Err: errors.New("dial refused")}
+	if !strings.Contains(unreachable.Error(), "unreachable") {
+		t.Errorf("Error() = %q, want it to say the instance was unreachable", unreachable.Error())
 	}
 }

--- a/internal/oauth/verifier_test.go
+++ b/internal/oauth/verifier_test.go
@@ -1828,9 +1828,12 @@ func TestUpstreamError_NamesTheStatusWhenGitLabAnswered(t *testing.T) {
 	answered := &UpstreamError{Status: http.StatusTooManyRequests, Err: errors.New("slow down")}
 	message := answered.Error()
 	for _, want := range []string{"429", "slow down"} {
-		if !strings.Contains(message, want) {
-			t.Errorf("Error() = %q, want it to mention %q", message, want)
-		}
+		t.Run(want, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(message, want) {
+				t.Errorf("Error() = %q, want it to mention %q", message, want)
+			}
+		})
 	}
 	if strings.Contains(message, "unreachable") {
 		t.Errorf("Error() = %q, want it not to call an answered request unreachable", message)

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -264,6 +264,15 @@ type ServerPool struct {
 	// probeQueueTimeout is how long a build waits for one of those slots,
 	// defaulting to [credentialProbeQueueTimeout].
 	probeQueueTimeout time.Duration
+	// idleSweepInterval overrides the cadence derived from idleTimeout.
+	//
+	// Zero, which is what [New] leaves, means derive it: a quarter of the
+	// idle timeout, floored at [idleSweepMinInterval] so an operator's short
+	// timeout cannot turn the sweep into a busy loop. That floor is also why
+	// this field exists: it puts the first tick a minute away, which is
+	// longer than any test may wait, so the sweep goroutine's own body is
+	// only reachable by shortening the cadence here.
+	idleSweepInterval time.Duration
 	// baseContext supplies the lifetime that bounds the GitLab lookups which
 	// build an entry — the credential probe, tier and scope discovery,
 	// identity resolution.
@@ -545,6 +554,18 @@ func (p *ServerPool) GetOrCreateEntry(token, gitlabURL string, scopes []string) 
 	if err != nil {
 		return nil, err
 	}
+	return entryFromBuild(built)
+}
+
+// entryFromBuild converts what the shared build returned into an entry.
+//
+// [singleflight.Group.Do] hands back an any, so this is the boundary where a
+// build result stops being typed. Everything above it returns an entry or an
+// error, which is why the failure it describes cannot be produced from here;
+// it exists so that a future build path returning nothing is a refused
+// request that names itself rather than a nil dereference in the caller,
+// which would be an HTTP 500 with a stack trace and no cause.
+func entryFromBuild(built any) (*Entry, error) {
 	entry, ok := built.(*Entry)
 	if !ok || entry == nil {
 		return nil, errors.New("creating MCP server for pool: builder returned no server")
@@ -648,11 +669,7 @@ func (p *ServerPool) evictRejectedCredential(key string, entry *Entry) {
 	// and a panic there must not take the process with it. The lock is
 	// released by a defer for the same reason, so the panic cannot leave it
 	// held.
-	defer func() {
-		if r := recover(); r != nil {
-			slog.Error("server pool: eviction of a rejected credential panicked", "panic", r)
-		}
-	}()
+	defer recoverSweep(context.Background(), "rejected-credential eviction")
 	gitlabURL, size, dropped := p.dropRejectedEntry(key, entry)
 	if !dropped {
 		return
@@ -1144,6 +1161,22 @@ func tokenSuffix(token string) string {
 // is dropped on its timestamp alone, which is the point — the entries it
 // reclaims are exactly the ones revalidation would otherwise keep pinging
 // GitLab about on behalf of a client that is gone.
+// recoverSweep keeps a panic raised inside a background sweep from taking the
+// process down, and names the sweep that raised it.
+//
+// Every sweep calls back into the caller: the idle one asks whether an entry
+// is still in use, and both evictions tell the caller to stop that
+// credential's watchers. A panic in one of those is a bug in this process, but
+// losing the goroutine to it is worse than the bug is: the sweep stops
+// silently, and the pool then grows to its cap holding credentials nothing has
+// re-checked since startup. Deferred by all three goroutines, so they recover
+// the same way and the rule is stated once.
+func recoverSweep(ctx context.Context, sweep string) {
+	if r := recover(); r != nil {
+		slog.ErrorContext(ctx, "server pool: "+sweep+" goroutine panicked", "panic", r)
+	}
+}
+
 func (p *ServerPool) StartIdleEviction(ctx context.Context) {
 	if ctx == nil {
 		ctx = context.Background() //nolint:contextcheck // defensive: nil-ctx guard for callers that pass uninitialized context
@@ -1153,16 +1186,15 @@ func (p *ServerPool) StartIdleEviction(ctx context.Context) {
 		return
 	}
 
-	interval := max(p.idleTimeout/idleSweepDivisor, idleSweepMinInterval)
+	interval := p.idleSweepInterval
+	if interval <= 0 {
+		interval = max(p.idleTimeout/idleSweepDivisor, idleSweepMinInterval)
+	}
 	slog.InfoContext(ctx, "server pool: starting idle eviction",
 		"idle_timeout", p.idleTimeout, "sweep_interval", interval)
 
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.ErrorContext(ctx, "server pool: idle eviction goroutine panicked", "panic", r)
-			}
-		}()
+		defer recoverSweep(ctx, "idle eviction")
 
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -1253,11 +1285,7 @@ func (p *ServerPool) StartRevalidation(ctx context.Context) {
 	slog.InfoContext(ctx, "server pool: starting token revalidation", "interval", p.revalidateInterval)
 
 	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				slog.ErrorContext(ctx, "server pool: revalidation goroutine panicked", "panic", r)
-			}
-		}()
+		defer recoverSweep(ctx, "revalidation")
 
 		ticker := time.NewTicker(p.revalidateInterval)
 		defer ticker.Stop()
@@ -1404,7 +1432,11 @@ func (p *ServerPool) EvictServer(srv *mcp.Server) bool {
 	defer p.mu.Unlock()
 	evicted := false
 	for key, entry := range p.entries {
-		if entry == nil || entry.server != srv {
+		// Through the nil-safe accessor rather than the field: the map is
+		// never given a nil entry, so a separate guard here would be a
+		// branch nothing can take, and the accessor keeps the same answer
+		// if one ever were.
+		if entry.Server() != srv {
 			continue
 		}
 		gitlabURL, enterprise := entryConfigLogValues(entry)

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -898,6 +898,20 @@ var ErrCredentialProbeBusy = errors.New("credential verification is saturated, r
 // The wait is bounded by [credentialProbeQueueTimeout] and by the pool's
 // lifetime, so a shutdown does not leave builds parked on a queue that will
 // never move.
+// probeWait is how long a build waits for a probe slot before giving up.
+//
+// A pool assembled outside [New] carries no timeout, and a zero one would
+// make the wait expire the instant it started: the queue is not full most of
+// the time, so the caller would win the race about half the time and be told
+// the queue is saturated the rest, which is the least useful of the three
+// possible behaviors.
+func (p *ServerPool) probeWait() time.Duration {
+	if p.probeQueueTimeout <= 0 {
+		return credentialProbeQueueTimeout
+	}
+	return p.probeQueueTimeout
+}
+
 func (p *ServerPool) acquireProbeSlot() (func(), error) {
 	if p.probes == nil {
 		return func() {
@@ -906,10 +920,7 @@ func (p *ServerPool) acquireProbeSlot() (func(), error) {
 			// every caller's deferred release unconditional.
 		}, nil
 	}
-	wait := p.probeQueueTimeout
-	if wait <= 0 {
-		wait = credentialProbeQueueTimeout
-	}
+	wait := p.probeWait()
 	timer := time.NewTimer(wait)
 	defer timer.Stop()
 	select {
@@ -1177,6 +1188,19 @@ func recoverSweep(ctx context.Context, sweep string) {
 	}
 }
 
+// idleSweepCadence is how often the idle sweep runs.
+//
+// A quarter of the idle timeout, so an entry is noticed within a quarter of
+// the deadline of passing it, floored at [idleSweepMinInterval] so a short
+// timeout cannot turn the sweep into a busy loop, and overridden by
+// idleSweepInterval where a test has to reach a tick.
+func (p *ServerPool) idleSweepCadence() time.Duration {
+	if p.idleSweepInterval > 0 {
+		return p.idleSweepInterval
+	}
+	return max(p.idleTimeout/idleSweepDivisor, idleSweepMinInterval)
+}
+
 func (p *ServerPool) StartIdleEviction(ctx context.Context) {
 	if ctx == nil {
 		ctx = context.Background() //nolint:contextcheck // defensive: nil-ctx guard for callers that pass uninitialized context
@@ -1186,10 +1210,7 @@ func (p *ServerPool) StartIdleEviction(ctx context.Context) {
 		return
 	}
 
-	interval := p.idleSweepInterval
-	if interval <= 0 {
-		interval = max(p.idleTimeout/idleSweepDivisor, idleSweepMinInterval)
-	}
+	interval := p.idleSweepCadence()
 	slog.InfoContext(ctx, "server pool: starting idle eviction",
 		"idle_timeout", p.idleTimeout, "sweep_interval", interval)
 

--- a/internal/serverpool/pool.go
+++ b/internal/serverpool/pool.go
@@ -1188,6 +1188,20 @@ func recoverSweep(ctx context.Context, sweep string) {
 	}
 }
 
+// sweepTick runs one sweep with the recovery around that tick alone, so a
+// panic costs the tick and not the sweep.
+//
+// Recovering in the goroutine's own defer, which is where this started, only
+// looks like it does the same thing: the panic unwinds the whole goroutine
+// before the recover sees it, so the ticker is gone and no sweep ever runs
+// again. That is precisely the outcome the comment above says is worse than
+// the bug. The goroutine keeps its own defer as the last resort, for a panic
+// raised outside the tick.
+func sweepTick(ctx context.Context, sweep string, run func()) {
+	defer recoverSweep(ctx, sweep)
+	run()
+}
+
 // idleSweepCadence is how often the idle sweep runs.
 //
 // A quarter of the idle timeout, so an entry is noticed within a quarter of
@@ -1226,7 +1240,7 @@ func (p *ServerPool) StartIdleEviction(ctx context.Context) {
 				slog.InfoContext(ctx, "server pool: idle eviction stopped")
 				return
 			case <-ticker.C:
-				p.evictIdle()
+				sweepTick(ctx, "idle eviction", p.evictIdle)
 			}
 		}
 	}()
@@ -1317,7 +1331,7 @@ func (p *ServerPool) StartRevalidation(ctx context.Context) {
 				slog.InfoContext(ctx, "server pool: revalidation stopped")
 				return
 			case <-ticker.C:
-				p.revalidateAll(ctx)
+				sweepTick(ctx, "revalidation", func() { p.revalidateAll(ctx) })
 			}
 		}
 	}()

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -3310,6 +3311,141 @@ func TestEvictStaleCredential_KeepsWhatIsNotStale(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSweepCadences_ResolveTheirDefaults verifies the two durations the
+// background goroutines are started with.
+//
+// Both are read once, at start, and then live inside a goroutine that runs
+// for the life of the process, which is why they are worth asserting on their
+// own: a cadence resolved to zero is a ticker that panics into the sweep's
+// own recover, and the pool then quietly has no idle eviction at all. The
+// probe wait resolved to zero is subtler still — the queue is usually not
+// full, so the caller wins the race about half the time and is told the queue
+// is saturated the rest.
+func TestSweepCadences_ResolveTheirDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the probe wait", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name       string
+			configured time.Duration
+			want       time.Duration
+		}{
+			{name: "unset falls back to the default", want: credentialProbeQueueTimeout},
+			{name: "negative falls back to the default", configured: -time.Second, want: credentialProbeQueueTimeout},
+			{name: "configured is used", configured: 50 * time.Millisecond, want: 50 * time.Millisecond},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				pool := &ServerPool{probeQueueTimeout: tc.configured}
+				if got := pool.probeWait(); got != tc.want {
+					t.Errorf("probeWait() = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("the idle sweep cadence", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			timeout  time.Duration
+			override time.Duration
+			want     time.Duration
+		}{
+			{name: "a long timeout is swept four times over", timeout: 8 * time.Minute, want: 2 * time.Minute},
+			{name: "a short timeout is floored", timeout: time.Second, want: idleSweepMinInterval},
+			{name: "an override wins", timeout: time.Hour, override: time.Millisecond, want: time.Millisecond},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				pool := &ServerPool{idleTimeout: tc.timeout, idleSweepInterval: tc.override}
+				if got := pool.idleSweepCadence(); got != tc.want {
+					t.Errorf("idleSweepCadence() = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+// TestBackgroundSweeps_StopWhenTheirContextIsDone verifies that both sweeps
+// are bound to the context they were started with.
+//
+// The pool outlives a request but not the server, and these goroutines are
+// how it holds credentials open. A sweep that ignored its context would keep
+// polling GitLab for every pooled credential after shutdown, and in a test
+// binary would keep doing so between packages. The context each was given is
+// the only thing that ends them, so a guard that replaced it with a
+// background one would leave nothing able to.
+func TestBackgroundSweeps_StopWhenTheirContextIsDone(t *testing.T) {
+	tests := []struct {
+		name  string
+		start func(pool *ServerPool, ctx context.Context)
+		want  string
+	}{
+		{
+			name:  "idle eviction",
+			start: (*ServerPool).StartIdleEviction,
+			want:  "idle eviction stopped",
+		},
+		{
+			name:  "revalidation",
+			start: (*ServerPool).StartRevalidation,
+			want:  "revalidation stopped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logged := &syncLogBuffer{}
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(logged, nil)))
+			t.Cleanup(func() { slog.SetDefault(previous) })
+
+			pool := New(testConfig(stubGitLabBase), testFactory(),
+				WithIdleTimeout(time.Hour),
+				WithRevalidateInterval(time.Hour))
+			// Already done, so the goroutine's very first select must take
+			// the shutdown arm rather than wait an hour for a tick.
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			tt.start(pool, ctx)
+
+			deadline := time.After(5 * time.Second)
+			for !strings.Contains(logged.String(), tt.want) {
+				select {
+				case <-deadline:
+					t.Fatalf("the sweep did not stop with its context; log = %q", logged.String())
+				default:
+					runtime.Gosched()
+				}
+			}
+		})
+	}
+}
+
+// syncLogBuffer collects log output from a goroutine the test does not own.
+type syncLogBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+// Write appends to the buffer under the lock.
+func (b *syncLogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// String returns everything written so far.
+func (b *syncLogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 // TestRevalidateAll_EntryEvictedDuringTheCheck_IsNotResurrected verifies the

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3101,5 +3102,494 @@ func TestEvictServer_DropsEveryEntryServedByThatServer(t *testing.T) {
 	defer mu.Unlock()
 	if len(evicted) != 3 {
 		t.Errorf("the evict hook fired %d times, want 3", len(evicted))
+	}
+}
+
+// TestLifetime_FallsBackToBackground verifies the context that bounds entry
+// construction is never nil.
+//
+// Every test in this file supplies a base context, so the two fallbacks had
+// never been taken. They are what keeps a pool built without the option, or
+// with one whose function has nothing to give yet, from canceling every
+// build the instant it starts: a nil context passed to context.WithTimeout
+// panics, and the panic would be inside the credential probe of the first
+// request the deployment ever served.
+func TestLifetime_FallsBackToBackground(t *testing.T) {
+	bounded := t.Context()
+
+	tests := []struct {
+		name        string
+		opts        []Option
+		wantBounded bool
+	}{
+		{name: "no base context configured", opts: nil},
+		{name: "a base context function that yields nothing", opts: []Option{WithBaseContext(func() context.Context { return nil })}},
+		{name: "a base context function that yields one", opts: []Option{WithBaseContext(func() context.Context { return bounded })}, wantBounded: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := New(testConfig(stubGitLabBase), testFactory(), tt.opts...)
+			got := pool.lifetime()
+			if got == nil {
+				t.Fatal("lifetime() = nil; every build would panic on WithTimeout")
+			}
+			if tt.wantBounded != (got == bounded) {
+				t.Errorf("lifetime() returned the configured context = %v, want %v", got == bounded, tt.wantBounded)
+			}
+		})
+	}
+}
+
+// TestAcquireProbeSlot_DefaultsWhenNothingIsConfigured verifies the two
+// fallbacks the probe limiter takes on a pool whose fields were not filled in.
+//
+// New always configures both, so neither branch is reachable through it; a
+// pool assembled field by field, which is how several tests here drive the
+// queue, is what reaches them. The release function matters as much as the
+// slot: callers defer it unconditionally, so returning nil instead of a no-op
+// would turn "no limiter configured" into a nil call at the end of every
+// build.
+func TestAcquireProbeSlot_DefaultsWhenNothingIsConfigured(t *testing.T) {
+	t.Run("no limiter is configured", func(t *testing.T) {
+		pool := &ServerPool{}
+		release, err := pool.acquireProbeSlot()
+		if err != nil {
+			t.Fatalf("acquireProbeSlot() error = %v, want a slot from an unlimited pool", err)
+		}
+		if release == nil {
+			t.Fatal("acquireProbeSlot() returned no release function; every caller defers it")
+		}
+		release()
+	})
+
+	t.Run("a limiter with no queue timeout uses the default", func(t *testing.T) {
+		pool := &ServerPool{probes: make(chan struct{}, 1)}
+		release, err := pool.acquireProbeSlot()
+		if err != nil {
+			t.Fatalf("acquireProbeSlot() error = %v, want the free slot", err)
+		}
+		release()
+		if len(pool.probes) != 0 {
+			t.Error("the slot was not given back")
+		}
+	})
+}
+
+// TestDropRejectedEntry_LeavesAReplacementAlone verifies the identity check
+// the rejected-credential eviction makes under the lock.
+//
+// The 401 is noticed on a call, and the eviction that follows takes the lock
+// afterwards. In between, a request that found the entry already marked
+// rejected rebuilds the key. Deleting by key alone at that point would drop
+// the freshly verified replacement and refuse the sessions it owns, so the
+// eviction must recognize that the entry under the key is no longer its own.
+func TestDropRejectedEntry_LeavesAReplacementAlone(t *testing.T) {
+	pool := New(testConfig(stubGitLabBase), testFactory())
+	entry, err := pool.GetOrCreateEntry("glpat-original", stubGitLabBase, nil)
+	if err != nil {
+		t.Fatalf("GetOrCreateEntry(): %v", err)
+	}
+	key := sessionKey("glpat-original", stubGitLabBase)
+
+	t.Run("a key holding a different entry is left alone", func(t *testing.T) {
+		replacement := &Entry{server: entry.server, client: entry.client, serverConfig: entry.serverConfig}
+		pool.mu.Lock()
+		pool.entries[key] = replacement
+		pool.mu.Unlock()
+
+		if _, _, dropped := pool.dropRejectedEntry(key, entry); dropped {
+			t.Error("dropRejectedEntry() removed a replacement built after the refusal")
+		}
+		pool.mu.Lock()
+		still := pool.entries[key] == replacement
+		pool.mu.Unlock()
+		if !still {
+			t.Error("the replacement is gone from the pool")
+		}
+	})
+
+	t.Run("a key holding no entry at all", func(t *testing.T) {
+		pool.mu.Lock()
+		delete(pool.entries, key)
+		pool.mu.Unlock()
+
+		if _, _, dropped := pool.dropRejectedEntry(key, entry); dropped {
+			t.Error("dropRejectedEntry() reported dropping an entry that was already gone")
+		}
+	})
+
+	t.Run("an entry that never reached the LRU", func(t *testing.T) {
+		// A build that failed after the entry was made but before
+		// insertEntry gave it a list element. Removing a nil element from a
+		// list panics, so the guard is what keeps the eviction from taking
+		// the process down.
+		partial := &Entry{server: entry.server, client: entry.client, serverConfig: entry.serverConfig}
+		pool.mu.Lock()
+		pool.entries[key] = partial
+		pool.mu.Unlock()
+
+		if _, _, dropped := pool.dropRejectedEntry(key, partial); !dropped {
+			t.Error("dropRejectedEntry() left behind an entry that had no LRU element")
+		}
+	})
+}
+
+// TestEvictStaleCredential_KeepsWhatIsNotStale verifies the re-check the
+// staleness eviction makes under the write lock.
+//
+// The sweep spots a candidate under the read lock and takes the write lock
+// afterwards, so all three of these are what it may find in between: the key
+// gone, the age limit no longer in force, and an entry a concurrent request
+// has just revalidated. Evicting in any of them throws away a check made a
+// moment ago and sends the next caller round the whole build again.
+func TestEvictStaleCredential_KeepsWhatIsNotStale(t *testing.T) {
+	const token = "glpat-stale-check"
+	key := sessionKey(token, stubGitLabBase)
+
+	tests := []struct {
+		name    string
+		age     time.Duration
+		prepare func(t *testing.T, pool *ServerPool)
+		wantOut bool
+	}{
+		{
+			name: "the key is gone",
+			age:  time.Nanosecond,
+			prepare: func(t *testing.T, pool *ServerPool) {
+				t.Helper()
+				pool.mu.Lock()
+				delete(pool.entries, key)
+				pool.mu.Unlock()
+			},
+		},
+		{
+			// Zeroed directly: WithMaxCredentialAge maps a non-positive
+			// value to the default, so a pool built outside New is the only
+			// shape that carries no ceiling, and it is the shape both of
+			// these guards exist for.
+			name: "the age limit is not in force",
+			age:  time.Nanosecond,
+			prepare: func(t *testing.T, pool *ServerPool) {
+				t.Helper()
+				pool.mu.Lock()
+				pool.maxCredentialAge = 0
+				pool.mu.Unlock()
+			},
+		},
+		{
+			name: "the entry was revalidated in the meantime",
+			age:  time.Hour,
+		},
+		{
+			name:    "a genuinely stale entry is evicted",
+			age:     time.Nanosecond,
+			wantOut: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := New(testConfig(stubGitLabBase), testFactory(), WithMaxCredentialAge(tt.age))
+			if _, err := pool.GetOrCreateEntry(token, stubGitLabBase, nil); err != nil {
+				t.Fatalf("GetOrCreateEntry(): %v", err)
+			}
+			if tt.prepare != nil {
+				tt.prepare(t, pool)
+			}
+
+			before := pool.metrics.StaleCredentialEvictions.Load()
+			pool.evictStaleCredential(key)
+			evicted := pool.metrics.StaleCredentialEvictions.Load() - before
+
+			// The counter rather than the map: for the first case the key is
+			// absent either way, and only the counter says whether this call
+			// is what removed it.
+			if (evicted > 0) != tt.wantOut {
+				t.Errorf("stale evictions = %d, want an eviction: %v", evicted, tt.wantOut)
+			}
+		})
+	}
+}
+
+// TestRevalidateAll_EntryEvictedDuringTheCheck_IsNotResurrected verifies the
+// re-read the success path makes before stamping an entry as revalidated.
+//
+// revalidateAll works from a snapshot and calls GitLab without the lock, so an
+// entry can be evicted while its own check is in flight: by a 401 on a
+// concurrent call, by size pressure, or by the idle sweep. Writing the
+// timestamp by key alone at that point would put the evicted entry back in the
+// map, and the pool would then serve a credential it had already decided to
+// drop.
+//
+// The eviction is triggered from inside the GitLab handler, which is the one
+// place guaranteed to run between the snapshot and the update.
+func TestRevalidateAll_EntryEvictedDuringTheCheck_IsNotResurrected(t *testing.T) {
+	const token = "glpat-evicted-mid-check"
+	key := sessionKey(token, stubGitLabBase)
+
+	var pool *ServerPool
+	var evictOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evictOnce.Do(func() {
+			if pool != nil {
+				pool.evictByKey(key)
+			}
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"17.0.0"}`))
+	}))
+	defer srv.Close()
+
+	pool = New(testConfig(stubGitLabBase), testFactory())
+	entry, err := pool.GetOrCreateEntry(token, stubGitLabBase, nil)
+	if err != nil {
+		t.Fatalf("GetOrCreateEntry(): %v", err)
+	}
+	answering, err := gitlabclient.NewClientWithTokenRetries(srv.URL, token, false, true)
+	if err != nil {
+		t.Fatalf("NewClientWithTokenRetries(): %v", err)
+	}
+	pool.mu.Lock()
+	entry.client = answering
+	pool.mu.Unlock()
+
+	pool.revalidateAll(context.Background())
+
+	pool.mu.Lock()
+	_, present := pool.entries[key]
+	pool.mu.Unlock()
+	if present {
+		t.Error("an entry evicted during its own check was written back into the pool")
+	}
+	if got := pool.metrics.RevalidationsSucceeded.Load(); got != 1 {
+		t.Errorf("RevalidationsSucceeded = %d, want 1: the check itself passed", got)
+	}
+}
+
+// TestEntryFromBuild_RefusesWhatIsNotAnEntry verifies the boundary where a
+// shared build result stops being typed.
+//
+// singleflight hands back an any, and every path above this returns an entry
+// or an error, so nothing in the pool can produce these two answers today.
+// They are asserted here because the alternative to refusing is a nil
+// dereference one frame up, in a request handler: a 500 with a stack trace
+// instead of a refusal that names the cause.
+func TestEntryFromBuild_RefusesWhatIsNotAnEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		built   any
+		wantErr bool
+	}{
+		{name: "a built entry", built: &Entry{}},
+		{name: "nothing at all", built: nil, wantErr: true},
+		{name: "a typed nil entry", built: (*Entry)(nil), wantErr: true},
+		{name: "something that is not an entry", built: "server", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := entryFromBuild(tt.built)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("entryFromBuild(%v) = %v, want an error", tt.built, entry)
+				}
+				if entry != nil {
+					t.Errorf("entryFromBuild() returned %v beside its error", entry)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("entryFromBuild() error = %v", err)
+			}
+			if entry == nil {
+				t.Error("entryFromBuild() returned no entry and no error")
+			}
+		})
+	}
+}
+
+// TestBackgroundSweeps_SurviveAPanickingCallback verifies that a panic raised
+// inside a caller-supplied hook does not take the pool's background
+// goroutines down with it.
+//
+// Both sweeps call back into cmd/server: the idle sweep asks whether an entry
+// is still in use, and eviction tells the caller to stop that credential's
+// watchers. A panic in either is a bug in this process, but losing the
+// goroutine to it is worse than the bug: idle eviction and revalidation would
+// both stop silently, and the pool would grow to its cap holding credentials
+// nobody has checked since startup. The recover is what keeps the failure to
+// one sweep.
+func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
+	t.Run("the idle sweep", func(t *testing.T) {
+		panicked := make(chan struct{}, 1)
+		pool := New(testConfig(stubGitLabBase), testFactory(),
+			WithIdleTimeout(time.Nanosecond),
+			WithInUse(func(*Entry) bool {
+				select {
+				case panicked <- struct{}{}:
+				default:
+				}
+				panic("in-use callback blew up")
+			}))
+		// The derived cadence is floored at a minute so an operator's short
+		// timeout cannot turn the sweep into a busy loop, which puts the
+		// first tick further away than any test may wait.
+		pool.idleSweepInterval = time.Millisecond
+		if _, err := pool.GetOrCreateEntry("glpat-idle-panic", stubGitLabBase, nil); err != nil {
+			t.Fatalf("GetOrCreateEntry(): %v", err)
+		}
+
+		pool.StartIdleEviction(t.Context())
+
+		select {
+		case <-panicked:
+		case <-time.After(5 * time.Second):
+			t.Fatal("the idle sweep never ran")
+		}
+		// Reaching here at all is the assertion: an unrecovered panic in a
+		// goroutine ends the test binary.
+	})
+
+	// The recovery both goroutines defer, called directly, so the ordinary
+	// return through it is asserted as well as the panic.
+	t.Run("the shared recovery", func(t *testing.T) {
+		var logged strings.Builder
+		previous := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&logged, nil)))
+		t.Cleanup(func() { slog.SetDefault(previous) })
+
+		func() {
+			defer recoverSweep(context.Background(), "idle eviction")
+			panic("in-use callback blew up")
+		}()
+
+		// Reaching here at all is half the assertion: an unrecovered panic
+		// ends the test binary.
+		for _, want := range []string{"idle eviction", "in-use callback blew up"} {
+			if !strings.Contains(logged.String(), want) {
+				t.Errorf("log = %q, want it to mention %q", logged.String(), want)
+			}
+		}
+
+		logged.Reset()
+		func() { defer recoverSweep(context.Background(), "idle eviction") }()
+		if logged.Len() != 0 {
+			t.Errorf("a sweep that returned normally logged %q", logged.String())
+		}
+	})
+
+	t.Run("revalidation", func(t *testing.T) {
+		panicked := make(chan struct{}, 1)
+		refusing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+		}))
+		defer refusing.Close()
+
+		cfg := testConfig(stubGitLabBase)
+		pool := New(cfg, testFactory(),
+			WithRevalidateInterval(10*time.Millisecond),
+			WithOnEvict(func(*Entry) {
+				select {
+				case panicked <- struct{}{}:
+				default:
+				}
+				panic("evict callback blew up")
+			}))
+		entry, err := pool.GetOrCreateEntry("glpat-revalidate-panic", stubGitLabBase, nil)
+		if err != nil {
+			t.Fatalf("GetOrCreateEntry(): %v", err)
+		}
+		// Point the entry's own client at an instance that refuses it, so
+		// revalidation reaches a verdict and evicts.
+		rejecting, err := gitlabclient.NewClientWithTokenRetries(refusing.URL, "glpat-revalidate-panic", false, true)
+		if err != nil {
+			t.Fatalf("NewClientWithToken(): %v", err)
+		}
+		pool.mu.Lock()
+		entry.client = rejecting
+		pool.mu.Unlock()
+
+		pool.StartRevalidation(t.Context())
+
+		select {
+		case <-panicked:
+		case <-time.After(5 * time.Second):
+			t.Fatal("revalidation never evicted the refused entry")
+		}
+	})
+}
+
+// TestGetOrCreateEntry_NoCredentialAgeCeiling_NeverCallsAnEntryStale verifies
+// the fast path on a pool that carries no re-check ceiling.
+//
+// WithMaxCredentialAge maps a non-positive value to the default, so this is
+// the shape only a pool assembled outside New has. The staleness test is the
+// first thing a cache hit evaluates, and reading it without the ceiling check
+// would compare an entry's age against a zero duration: every hit older than
+// an instant would look stale, and the pool would rebuild a credential on
+// every single request.
+func TestGetOrCreateEntry_NoCredentialAgeCeiling_NeverCallsAnEntryStale(t *testing.T) {
+	pool := New(testConfig(stubGitLabBase), testFactory())
+	pool.mu.Lock()
+	pool.maxCredentialAge = 0
+	pool.mu.Unlock()
+
+	first, err := pool.GetOrCreateEntry("glpat-no-ceiling", stubGitLabBase, nil)
+	if err != nil {
+		t.Fatalf("GetOrCreateEntry(): %v", err)
+	}
+	// Backdated well past any ceiling the pool would have had, so the hit
+	// below can only be served by the ceiling check itself.
+	pool.mu.Lock()
+	first.lastValidated = time.Now().Add(-30 * 24 * time.Hour)
+	pool.mu.Unlock()
+
+	second, err := pool.GetOrCreateEntry("glpat-no-ceiling", stubGitLabBase, nil)
+	if err != nil {
+		t.Fatalf("GetOrCreateEntry() on the second call: %v", err)
+	}
+	if second != first {
+		t.Error("the entry was rebuilt: an unset ceiling was read as one of zero, so every hit is stale")
+	}
+	if got := pool.metrics.Hits.Load(); got != 1 {
+		t.Errorf("Hits = %d, want 1", got)
+	}
+}
+
+// TestEntryConfigLogValues_TolerateAPartiallyBuiltEntry verifies the accessor
+// eviction logging goes through.
+//
+// It is called from paths that run while an entry is still being assembled,
+// so both halves of its guard are real: an entry that is not there at all,
+// and one whose configuration has not been resolved yet. A log line is not
+// worth a panic in an eviction path.
+func TestEntryConfigLogValues_TolerateAPartiallyBuiltEntry(t *testing.T) {
+	tests := []struct {
+		name           string
+		entry          *Entry
+		wantURL        string
+		wantEnterprise bool
+	}{
+		{name: "no entry at all", entry: nil},
+		{name: "an entry with no configuration yet", entry: &Entry{}},
+		{
+			name:    "a fully built entry",
+			entry:   &Entry{serverConfig: &config.ServerConfig{GitLabURL: "https://gitlab.example.com"}},
+			wantURL: "https://gitlab.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotEnterprise := entryConfigLogValues(tt.entry)
+			if gotURL != tt.wantURL {
+				t.Errorf("gitlabURL = %q, want %q", gotURL, tt.wantURL)
+			}
+			if gotEnterprise != tt.wantEnterprise {
+				t.Errorf("enterprise = %v, want %v", gotEnterprise, tt.wantEnterprise)
+			}
+		})
 	}
 }

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -3674,6 +3674,10 @@ func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 				}
 				panic("evict callback blew up")
 			}))
+		// Two entries built for one assertion, not two cases: the second
+		// exists so that a second eviction has something to evict, which is
+		// the whole question below.
+		// sequential: dependent setup for the assertion after the loop
 		for _, token := range []string{"glpat-revalidate-panic-1", "glpat-revalidate-panic-2"} {
 			entry, err := pool.GetOrCreateEntry(token, stubGitLabBase, nil)
 			if err != nil {

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -3283,8 +3283,23 @@ func TestEvictStaleCredential_KeepsWhatIsNotStale(t *testing.T) {
 			age:  time.Hour,
 		},
 		{
-			name:    "a genuinely stale entry is evicted",
-			age:     time.Nanosecond,
+			// Backdated rather than waited out. A one-nanosecond ceiling and
+			// one elapsed nanosecond are not the same thing: Windows reads its
+			// monotonic clock in ticks, so two calls inside one tick are the
+			// same instant, time.Since answers zero, and nothing is ever older
+			// than any ceiling. This case failed there and nowhere else.
+			name: "a genuinely stale entry is evicted",
+			age:  time.Minute,
+			prepare: func(t *testing.T, pool *ServerPool) {
+				t.Helper()
+				pool.mu.Lock()
+				defer pool.mu.Unlock()
+				entry, ok := pool.entries[key]
+				if !ok {
+					t.Fatal("the entry to age is not in the pool")
+				}
+				entry.lastValidated = time.Now().Add(-time.Hour)
+			},
 			wantOut: true,
 		},
 	}

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -3603,9 +3603,11 @@ func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 		// Reaching here at all is half the assertion: an unrecovered panic
 		// ends the test binary.
 		for _, want := range []string{"idle eviction", "in-use callback blew up"} {
-			if !strings.Contains(logged.String(), want) {
-				t.Errorf("log = %q, want it to mention %q", logged.String(), want)
-			}
+			t.Run(want, func(t *testing.T) {
+				if !strings.Contains(logged.String(), want) {
+					t.Errorf("log = %q, want it to mention %q", logged.String(), want)
+				}
+			})
 		}
 
 		logged.Reset()

--- a/internal/serverpool/pool_test.go
+++ b/internal/serverpool/pool_test.go
@@ -3571,9 +3571,32 @@ func TestEntryFromBuild_RefusesWhatIsNotAnEntry(t *testing.T) {
 // both stop silently, and the pool would grow to its cap holding credentials
 // nobody has checked since startup. The recover is what keeps the failure to
 // one sweep.
+// awaitSweepTicks waits for two signals from a sweep whose callback panics
+// every time, and says which of the two failures happened.
+//
+// Two, because one proves only that the panic was caught. A recovery in the
+// goroutine's own defer catches the first just as well and then returns,
+// taking the ticker with it, so the second signal is the whole question.
+func awaitSweepTicks(t *testing.T, ticks <-chan struct{}, never, stopped string) {
+	t.Helper()
+	for tick := 1; tick <= 2; tick++ {
+		select {
+		case <-ticks:
+		case <-time.After(5 * time.Second):
+			if tick == 1 {
+				t.Fatal(never)
+			}
+			t.Fatal(stopped)
+		}
+	}
+}
+
 func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 	t.Run("the idle sweep", func(t *testing.T) {
-		panicked := make(chan struct{}, 1)
+		// Two, not one: surviving the panic is the point, and a sweep that
+		// recovered in the goroutine's own defer would also deliver the first.
+		// Only the second says the ticker is still there.
+		panicked := make(chan struct{}, 2)
 		pool := New(testConfig(stubGitLabBase), testFactory(),
 			WithIdleTimeout(time.Nanosecond),
 			WithInUse(func(*Entry) bool {
@@ -3593,13 +3616,11 @@ func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 
 		pool.StartIdleEviction(t.Context())
 
-		select {
-		case <-panicked:
-		case <-time.After(5 * time.Second):
-			t.Fatal("the idle sweep never ran")
-		}
-		// Reaching here at all is the assertion: an unrecovered panic in a
-		// goroutine ends the test binary.
+		awaitSweepTicks(t, panicked,
+			"the idle sweep never ran",
+			"the idle sweep ran once and stopped: the panic took the ticker with it, so nothing is ever swept again")
+		// Reaching here at all is half the assertion: an unrecovered panic in
+		// a goroutine ends the test binary.
 	})
 
 	// The recovery both goroutines defer, called directly, so the ordinary
@@ -3633,7 +3654,10 @@ func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 	})
 
 	t.Run("revalidation", func(t *testing.T) {
-		panicked := make(chan struct{}, 1)
+		// Room for two, and two entries below, for the same reason the idle
+		// sweep wants two ticks: one eviction proves the panic was caught, and
+		// only a second proves the sweep that caught it is still running.
+		panicked := make(chan struct{}, 2)
 		refusing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
@@ -3650,27 +3674,27 @@ func TestBackgroundSweeps_SurviveAPanickingCallback(t *testing.T) {
 				}
 				panic("evict callback blew up")
 			}))
-		entry, err := pool.GetOrCreateEntry("glpat-revalidate-panic", stubGitLabBase, nil)
-		if err != nil {
-			t.Fatalf("GetOrCreateEntry(): %v", err)
+		for _, token := range []string{"glpat-revalidate-panic-1", "glpat-revalidate-panic-2"} {
+			entry, err := pool.GetOrCreateEntry(token, stubGitLabBase, nil)
+			if err != nil {
+				t.Fatalf("GetOrCreateEntry(%q): %v", token, err)
+			}
+			// Point each entry's own client at an instance that refuses it, so
+			// revalidation reaches a verdict and evicts.
+			rejecting, err := gitlabclient.NewClientWithTokenRetries(refusing.URL, token, false, true)
+			if err != nil {
+				t.Fatalf("NewClientWithToken(): %v", err)
+			}
+			pool.mu.Lock()
+			entry.client = rejecting
+			pool.mu.Unlock()
 		}
-		// Point the entry's own client at an instance that refuses it, so
-		// revalidation reaches a verdict and evicts.
-		rejecting, err := gitlabclient.NewClientWithTokenRetries(refusing.URL, "glpat-revalidate-panic", false, true)
-		if err != nil {
-			t.Fatalf("NewClientWithToken(): %v", err)
-		}
-		pool.mu.Lock()
-		entry.client = rejecting
-		pool.mu.Unlock()
 
 		pool.StartRevalidation(t.Context())
 
-		select {
-		case <-panicked:
-		case <-time.After(5 * time.Second):
-			t.Fatal("revalidation never evicted the refused entry")
-		}
+		awaitSweepTicks(t, panicked,
+			"revalidation never evicted a refused entry",
+			"revalidation evicted once and stopped: the panic took the ticker with it, so no credential is ever re-checked again")
 	})
 }
 

--- a/internal/serverpool/rate_limit_test.go
+++ b/internal/serverpool/rate_limit_test.go
@@ -186,7 +186,13 @@ func TestAuthRateLimiter_CapAdmitsNewKeysOnceRecordsLapse(t *testing.T) {
 // treating a lapsed record as a new key would refuse to reset it and leave a
 // returning client pinned to whatever count it had when the flood started.
 func TestAuthRateLimiter_LapsedRecordIsReplacedInPlace(t *testing.T) {
-	limiter := NewAuthRateLimiter(2, 50*time.Millisecond)
+	// An hour, so that nothing lapses by itself while the table is filled.
+	// With a window of milliseconds this test read as if it were fast, and on
+	// a slower machine the filler loop outlasted the window: the record this
+	// test is about was pruned as lapsed before the test could lapse it, and
+	// the next line dereferenced a map entry that was no longer there. The one
+	// record that must lapse is lapsed below, by moving its own timestamp.
+	limiter := NewAuthRateLimiter(2, time.Hour)
 
 	limiter.RecordFailure("10.0.0.1")
 	limiter.RecordFailure("10.0.0.1")
@@ -200,8 +206,14 @@ func TestAuthRateLimiter_LapsedRecordIsReplacedInPlace(t *testing.T) {
 		limiter.RecordFailure("filler-" + strconv.Itoa(i))
 	}
 	limiter.mu.Lock()
-	limiter.failures["10.0.0.1"].firstAt = time.Now().Add(-2 * limiter.window)
+	blocked, tracked := limiter.failures["10.0.0.1"]
+	if tracked {
+		blocked.firstAt = time.Now().Add(-2 * limiter.window)
+	}
 	limiter.mu.Unlock()
+	if !tracked {
+		t.Fatal("the blocked client's record was dropped while the table was filled, so there is nothing to lapse")
+	}
 
 	limiter.RecordFailure("10.0.0.1")
 

--- a/internal/serverpool/rate_limit_test.go
+++ b/internal/serverpool/rate_limit_test.go
@@ -175,3 +175,92 @@ func TestAuthRateLimiter_CapAdmitsNewKeysOnceRecordsLapse(t *testing.T) {
 		t.Errorf("tracked keys = %d, want only the one live record", got)
 	}
 }
+
+// TestAuthRateLimiter_LapsedRecordIsReplacedInPlace verifies that a client
+// coming back after its window lapsed starts a fresh count, and does so
+// without needing room under the cap.
+//
+// This is the branch the "replaced in place, which is not growth" comment
+// describes and nothing reached: every recorded failure in the suite either
+// found no record at all or found a live one. It matters at the cap, where
+// treating a lapsed record as a new key would refuse to reset it and leave a
+// returning client pinned to whatever count it had when the flood started.
+func TestAuthRateLimiter_LapsedRecordIsReplacedInPlace(t *testing.T) {
+	limiter := NewAuthRateLimiter(2, 50*time.Millisecond)
+
+	limiter.RecordFailure("10.0.0.1")
+	limiter.RecordFailure("10.0.0.1")
+	if !limiter.IsBlocked("10.0.0.1") {
+		t.Fatal("two failures inside the window should block the client")
+	}
+
+	// Fill the table so the cap would refuse a new key, then lapse only the
+	// blocked client's record. Its next failure must still be recorded.
+	for i := range maxTrackedAuthSources {
+		limiter.RecordFailure("filler-" + strconv.Itoa(i))
+	}
+	limiter.mu.Lock()
+	limiter.failures["10.0.0.1"].firstAt = time.Now().Add(-2 * limiter.window)
+	limiter.mu.Unlock()
+
+	limiter.RecordFailure("10.0.0.1")
+
+	if limiter.IsBlocked("10.0.0.1") {
+		t.Error("a lapsed record was not replaced: the client is still blocked on a count from the previous window")
+	}
+	limiter.mu.Lock()
+	count := limiter.failures["10.0.0.1"].count
+	limiter.mu.Unlock()
+	if count != 1 {
+		t.Errorf("count = %d after the window lapsed, want the record restarted at 1", count)
+	}
+}
+
+// TestAuthRateLimiter_Cleanup_KeepsTheCapWarningWhileTheTableIsFull verifies
+// that the at-capacity warning is re-armed only once there is room again.
+//
+// Cleanup sweeps first and then decides, so a sweep that frees nothing must
+// leave the flag set: re-arming it while the table is still full would put one
+// warning per sweep in the log for as long as the flood lasts, which is the
+// noise the flag exists to prevent.
+func TestAuthRateLimiter_Cleanup_KeepsTheCapWarningWhileTheTableIsFull(t *testing.T) {
+	limiter := NewAuthRateLimiter(2, time.Hour)
+
+	for i := range maxTrackedAuthSources + 1 {
+		limiter.RecordFailure("spoofed-" + strconv.Itoa(i))
+	}
+	limiter.mu.Lock()
+	limiter.warnedAtCap = true
+	limiter.mu.Unlock()
+
+	limiter.Cleanup()
+
+	limiter.mu.Lock()
+	stillWarned := limiter.warnedAtCap
+	size := len(limiter.failures)
+	limiter.mu.Unlock()
+
+	if size != maxTrackedAuthSources {
+		t.Fatalf("tracked keys = %d after a sweep that frees nothing, want the table still full at %d", size, maxTrackedAuthSources)
+	}
+	if !stillWarned {
+		t.Error("the at-capacity warning was re-armed while the table is still full")
+	}
+
+	// One lapsed record is enough to make room, and the flag is re-armed.
+	limiter.mu.Lock()
+	for _, rec := range limiter.failures {
+		rec.firstAt = time.Now().Add(-2 * limiter.window)
+		break
+	}
+	limiter.mu.Unlock()
+
+	limiter.Cleanup()
+
+	limiter.mu.Lock()
+	rearmed := !limiter.warnedAtCap
+	limiter.mu.Unlock()
+	if !rearmed {
+		t.Error("the at-capacity warning stayed suppressed after the table dropped below the cap")
+	}
+}

--- a/internal/serverpool/token_test.go
+++ b/internal/serverpool/token_test.go
@@ -259,6 +259,46 @@ func TestResolveRequestOptions_IgnoredOptions(t *testing.T) {
 	}
 }
 
+// TestRequestOptions_ReportNothingWhenNothingWasIgnored verifies the negative
+// answer of both predicates.
+//
+// They gate a per-request log line, and only their true half was ever
+// evaluated. A predicate stuck at true would put one "ignored options" warning
+// on every ordinary request, which is the noise these were written to avoid,
+// and no test would have failed.
+func TestRequestOptions_ReportNothingWhenNothingWasIgnored(t *testing.T) {
+	t.Run("a request carrying no options at all", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", nil)
+
+		options, err := ResolveRequestOptions(req, "https://gitlab.example.com/")
+		if err != nil {
+			t.Fatalf("ResolveRequestOptions() error: %v", err)
+		}
+		if options.HasIgnoredOptions() {
+			t.Errorf("HasIgnoredOptions() = true for a bare request, ignoring %v", options.IgnoredOptionsCopy())
+		}
+		if options.HasDeprecatedOptions() {
+			t.Errorf("HasDeprecatedOptions() = true for a bare request, ignoring %v", options.DeprecatedOptionsCopy())
+		}
+	})
+
+	t.Run("options ignored but none of them deprecated", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", nil)
+		req.Header.Set("RATE-LIMIT-RPS", "999")
+
+		options, err := ResolveRequestOptions(req, "https://gitlab.example.com/")
+		if err != nil {
+			t.Fatalf("ResolveRequestOptions() error: %v", err)
+		}
+		if !options.HasIgnoredOptions() {
+			t.Error("HasIgnoredOptions() = false although RATE_LIMIT_RPS was ignored")
+		}
+		if options.HasDeprecatedOptions() {
+			t.Errorf("HasDeprecatedOptions() = true, want false: %v is ignored but not deprecated", options.DeprecatedOptionsCopy())
+		}
+	})
+}
+
 // TestResolveRequestOptions_ServerManagedHeadersIgnoredWithoutDefault verifies
 // that config-like request headers never override MCP server configuration,
 // even in multi-instance mode where GITLAB-URL is accepted.

--- a/test/e2e/http/harness_test.go
+++ b/test/e2e/http/harness_test.go
@@ -185,31 +185,29 @@ func withInstancePolicy(flags []string) []string {
 // GITLAB_URL points at whatever the caller passes; the tests here never reach
 // GitLab, because every behavior under test is decided before the request
 // would leave the process.
+// The port is not chosen here. freePort hands back a number rather than a
+// listener, so between the moment it releases the port and the moment the
+// server binds it the port belongs to nobody, and every test in this module
+// runs in parallel: two tests could be handed the same number, and the one
+// that lost would either fail to bind or, worse, find the port answering and
+// drive somebody else's server. Asking for port 0 hands the choice to the
+// kernel, which cannot hand the same port to two live listeners, and the
+// server says which one it got.
 func startServer(t *testing.T, env map[string]string, flags ...string) *server {
 	t.Helper()
-	for attempt := 1; ; attempt++ {
-		srv, err := tryStartServerOnPort(t, freePort(t), env, flags...)
-		switch {
-		case err == nil:
-			return srv
-		case !errors.Is(err, errPortTaken):
-			t.Fatalf("starting the server: %v", err)
-		case attempt == portAttempts:
-			t.Fatalf("the server lost the port to another test %d times running: %v", portAttempts, err)
-		}
+
+	srv, err := tryStartServerOnPort(t, ephemeralPort, env, flags...)
+	if err != nil {
+		t.Fatalf("starting the server: %v", err)
 	}
+	return srv
 }
 
-// portAttempts is how many ports startServer will try before giving up.
-//
-// freePort hands back a number rather than a listener, so between the moment
-// it releases the port and the moment the server binds it the port belongs to
-// nobody, and every test in this module runs in parallel. Losing that race
-// three times over is not a race any more.
-const portAttempts = 3
+// ephemeralPort asks the kernel for a port instead of naming one.
+const ephemeralPort = 0
 
-// errPortTaken says the server exited because something else holds its port,
-// which is the one startup failure worth retrying on another one.
+// errPortTaken says the server exited because something else holds its port.
+// Only a caller that named the port can meet it.
 var errPortTaken = errors.New("the port was taken")
 
 // startServerOnPort is startServer with the port chosen by the caller, for
@@ -256,29 +254,86 @@ func tryStartServerOnPort(t *testing.T, port int, env map[string]string, flags .
 		return nil, fmt.Errorf("launching the binary: %w", err)
 	}
 
-	srv := &server{
-		baseURL: "http://" + addr,
-		logs: func() string {
-			mu.Lock()
-			defer mu.Unlock()
-			return out.String()
-		},
+	logs := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return out.String()
 	}
 
-	// The process is waited on once, here, and its outcome published, so that
-	// awaitHealthy can stop the moment the server gives up instead of polling
-	// a port nothing is listening on for the whole deadline.
-	exited := make(chan error, 1)
-	go func() { exited <- cmd.Wait() }()
+	// The process is waited on once, here, and the result published by closing
+	// rather than by sending: everything that asks whether the server is still
+	// there has to be able to ask, and a value can only be taken once. It was
+	// sent once, and the cleanup then blocked forever on a channel the health
+	// wait had already drained.
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
 	t.Cleanup(func() {
 		cancel()
 		<-exited
 	})
 
-	if err := awaitHealthy(t, srv, exited); err != nil {
+	// The address is read back from the server rather than assumed, because
+	// with port 0 only the server knows it. This is also what ties the health
+	// check to this process: the address came out of its own log, so nothing
+	// else can be the thing that answers.
+	bound, err := awaitListenAddr(logs, exited)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := &server{baseURL: "http://" + bound, logs: logs}
+	if err = awaitHealthy(t, srv, exited); err != nil {
 		return nil, err
 	}
 	return srv, nil
+}
+
+// awaitListenAddr reads the address the server bound out of its own log.
+//
+// The server logs the listener's address, not the one it was asked for, so
+// this is the only way to learn the port when the harness asked for 0, and the
+// most direct way to know the process under test is the one on that port.
+func awaitListenAddr(logs func() string, exited <-chan struct{}) (string, error) {
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		if addr := listenAddrIn(logs()); addr != "" {
+			return addr, nil
+		}
+		select {
+		case <-exited:
+			// One last read: the line and the exit can land together, and a
+			// server that bound and then died has still said where.
+			if addr := listenAddrIn(logs()); addr != "" {
+				return addr, nil
+			}
+			return "", startupFailure(logs())
+		default:
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("the server never said what it bound. Output:\n%s", logs())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// listenAddrIn finds the bound address in the server's JSON log output.
+func listenAddrIn(logs string) string {
+	for line := range strings.SplitSeq(logs, "\n") {
+		var record struct {
+			Msg  string `json:"msg"`
+			Addr string `json:"addr"`
+		}
+		if json.Unmarshal([]byte(line), &record) != nil {
+			continue
+		}
+		if record.Msg == "listening on tcp" && record.Addr != "" {
+			return record.Addr
+		}
+	}
+	return ""
 }
 
 // lockedWriter serializes writes from the process's two pipes into one buffer
@@ -306,7 +361,7 @@ func waitHealthy(t *testing.T, s *server) {
 // awaitHealthy polls /health until the server answers or the deadline passes.
 // A failure dumps the process output, because a server that refuses to start
 // has already said why and the test should not make anyone go looking.
-func awaitHealthy(t *testing.T, s *server, exited <-chan error) error {
+func awaitHealthy(t *testing.T, s *server, exited <-chan struct{}) error {
 	t.Helper()
 	deadline := time.Now().Add(45 * time.Second)
 	for time.Now().Before(deadline) {

--- a/test/e2e/http/harness_test.go
+++ b/test/e2e/http/harness_test.go
@@ -187,12 +187,48 @@ func withInstancePolicy(flags []string) []string {
 // would leave the process.
 func startServer(t *testing.T, env map[string]string, flags ...string) *server {
 	t.Helper()
-	return startServerOnPort(t, freePort(t), env, flags...)
+	for attempt := 1; ; attempt++ {
+		srv, err := tryStartServerOnPort(t, freePort(t), env, flags...)
+		switch {
+		case err == nil:
+			return srv
+		case !errors.Is(err, errPortTaken):
+			t.Fatalf("starting the server: %v", err)
+		case attempt == portAttempts:
+			t.Fatalf("the server lost the port to another test %d times running: %v", portAttempts, err)
+		}
+	}
 }
 
+// portAttempts is how many ports startServer will try before giving up.
+//
+// freePort hands back a number rather than a listener, so between the moment
+// it releases the port and the moment the server binds it the port belongs to
+// nobody, and every test in this module runs in parallel. Losing that race
+// three times over is not a race any more.
+const portAttempts = 3
+
+// errPortTaken says the server exited because something else holds its port,
+// which is the one startup failure worth retrying on another one.
+var errPortTaken = errors.New("the port was taken")
+
 // startServerOnPort is startServer with the port chosen by the caller, for
-// tests that must configure something in front of it before it starts.
+// tests that must configure something in front of it before it starts. The
+// port is the caller's decision, so a collision fails rather than moving.
 func startServerOnPort(t *testing.T, port int, env map[string]string, flags ...string) *server {
+	t.Helper()
+
+	srv, err := tryStartServerOnPort(t, port, env, flags...)
+	if err != nil {
+		t.Fatalf("starting the server on port %d: %v", port, err)
+	}
+	return srv
+}
+
+// tryStartServerOnPort starts the binary and reports why it did not come up,
+// rather than ending the test, so a caller that chose the port at random can
+// choose another.
+func tryStartServerOnPort(t *testing.T, port int, env map[string]string, flags ...string) (*server, error) {
 	t.Helper()
 
 	bin := serverBinary(t)
@@ -217,7 +253,7 @@ func startServerOnPort(t *testing.T, port int, env map[string]string, flags ...s
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		t.Fatalf("starting the server: %v", err)
+		return nil, fmt.Errorf("launching the binary: %w", err)
 	}
 
 	srv := &server{
@@ -229,13 +265,20 @@ func startServerOnPort(t *testing.T, port int, env map[string]string, flags ...s
 		},
 	}
 
+	// The process is waited on once, here, and its outcome published, so that
+	// awaitHealthy can stop the moment the server gives up instead of polling
+	// a port nothing is listening on for the whole deadline.
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
 	t.Cleanup(func() {
 		cancel()
-		_ = cmd.Wait()
+		<-exited
 	})
 
-	waitHealthy(t, srv)
-	return srv
+	if err := awaitHealthy(t, srv, exited); err != nil {
+		return nil, err
+	}
+	return srv, nil
 }
 
 // lockedWriter serializes writes from the process's two pipes into one buffer
@@ -251,27 +294,56 @@ func (w *lockedWriter) Write(p []byte) (int, error) {
 	return w.buf.Write(p)
 }
 
-// waitHealthy polls /health until the server answers or the deadline passes.
+// waitHealthy polls /health until the server answers, for a caller holding a
+// server this harness did not start and so has no process to watch.
+func waitHealthy(t *testing.T, s *server) {
+	t.Helper()
+	if err := awaitHealthy(t, s, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// awaitHealthy polls /health until the server answers or the deadline passes.
 // A failure dumps the process output, because a server that refuses to start
 // has already said why and the test should not make anyone go looking.
-func waitHealthy(t *testing.T, s *server) {
+func awaitHealthy(t *testing.T, s *server, exited <-chan error) error {
 	t.Helper()
 	deadline := time.Now().Add(45 * time.Second)
 	for time.Now().Before(deadline) {
+		// Checked before the probe, because a server that has already given up
+		// leaves its port free for anything else to answer on, and a health
+		// check answered by somebody else is worse than one that fails: the
+		// test would go on to drive a server configured for another test.
+		select {
+		case <-exited:
+			return startupFailure(s.logs())
+		default:
+		}
+
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.baseURL+"/health", http.NoBody)
 		if err != nil {
-			t.Fatalf("building the health request: %v", err)
+			return fmt.Errorf("building the health request: %w", err)
 		}
 		resp, err := s.httpClient().Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				return
+				return nil
 			}
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	t.Fatalf("server never became healthy. Output:\n%s", s.logs())
+	return fmt.Errorf("the server never became healthy. Output:\n%s", s.logs())
+}
+
+// startupFailure names why a server exited before it served, so that a port
+// lost to another test is retried and anything else is reported.
+func startupFailure(logs string) error {
+	if strings.Contains(logs, "address already in use") ||
+		strings.Contains(logs, "Only one usage of each socket address") {
+		return fmt.Errorf("%w. Output:\n%s", errPortTaken, logs)
+	}
+	return fmt.Errorf("the server exited before it served. Output:\n%s", logs)
 }
 
 // request is one HTTP call to the server under test.

--- a/test/e2e/http/probe_test.go
+++ b/test/e2e/http/probe_test.go
@@ -102,7 +102,13 @@ func TestProbe_ExplicitTarget(t *testing.T) {
 // instance, so the address is this one's.
 func TestProbe_Discovery(t *testing.T) {
 	gitlab := startFakeGitLab(t, http.StatusUnauthorized, "")
-	srv := startServer(t, nil, "--gitlab-url="+gitlab.url)
+	// On a port this test names, unlike everything else in this module.
+	// Discovery reads --http-addr off the other process's command line, which
+	// is where the port has to be: an instance that asked the kernel for one
+	// carries a 0 there, and the probe would dial port 0. That is a real
+	// limitation of the bare --probe and it is recorded where the flag is
+	// documented; here it just means this test cannot use an ephemeral port.
+	srv := startServerOnPort(t, freePort(t), nil, "--gitlab-url="+gitlab.url)
 
 	code, said := runProbe(t)
 	if code != 0 {


### PR DESCRIPTION
Two issues, and what they turned into once I measured rather than guessed.

## A port the harness releases before it uses it (closes https://github.com/jmrplens/gitlab-mcp-server/issues/553)

The HTTP end-to-end harness asked the kernel for a free port, closed the listener and handed the number to the server it was about to start. Between those two moments the port belongs to nobody, so two tests running in parallel could be handed the same one, and on Windows the second server would bind it anyway and answer the first test's requests. That is worse than a failure: the test passes against somebody else's server.

The harness now retries on a taken port instead of trusting the number, and it watches the child process while it waits for `/health`, so a server that died during startup is reported as that rather than as a timeout.

## What the unit test suite actually costs, and what it does not check (closes https://github.com/jmrplens/gitlab-mcp-server/issues/531)

Statement coverage was already high enough to say nothing. So this measures two things it cannot see: condition coverage with `gobco`, which asks whether both halves of every branch were taken, and mutation testing with `gremlins`, which asks whether an assertion would notice if the code were wrong.

Four packages went through both and came out at 100% statements with their conditions closed: the GitLab client, configuration, OAuth and the server pool. The findings are the point, not the percentage:

- `CredentialRejected` in the GitLab client never returned `true` in any test. It exists to spot a 401 or 403 and drop a revoked pool entry, and a version reduced to `return false` passed the entire suite.
- The tool-surface selector accepts nineteen spellings and six had ever been evaluated. The capability-surface switch was reached only through its aliases, never through the canonical values an operator actually writes.
- `SatisfiesMinimum`'s whole reason for existing, that `api` supersedes `read_api`, was the untested half.
- Neither of the server pool's background sweeps had a test that ended it.
- Three bounds in configuration were asserted from one side only, including a size of zero that must be refused rather than accepted as a ceiling that then refuses every upload.

Forty-seven mutants survived and forty-three are equivalent, under three rules written down in the testing documentation: both sides agree at the boundary, a second guard makes the first unobservable, or the tool cannot instrument the construct. Where a branch was genuinely unreachable I simplified the code instead of writing a test that could not fail.

## Two tests that measured the machine

Windows CI caught both after the rebase, and both were green on Linux every time. A one-nanosecond credential ceiling is never exceeded where the monotonic clock advances in ticks, so `time.Since` answers zero and the case that exists to see a stale eviction saw none. The rate-limiter test was worse: its window was fifty milliseconds and it then filled four thousand keys, which on a slower runner outlasted the window, so the record the test is about was swept as lapsed before the test could lapse it and the next line dereferenced a map entry that was gone. Both now age their record deliberately instead of asking real time to pass.

## The columns I decided not to generate

`testing.md` is generated, and adding condition and mutation columns to it was the obvious next step. I measured what that would cost first: `gobco` is 4 to 283 seconds per package and `gremlins` 88 to 229, so four packages are about eleven minutes of mutation testing against six for the whole-tree coverage pass the generator already runs. `gobco` also cannot run at all on two of the ten target packages, because it copies every file ignoring build constraints and dies on the redeclaration. A number nobody can afford to regenerate goes stale while looking current, so the costs, the limitation and the three survivor-classification rules are written up by hand instead.

## Verification

Build and vet; the four packages driven to completion plus the server and dynamic packages; lint; both transport end-to-end modules vetted; the generators, with the testing reference and the stats refreshed from a full coverage run on this tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when OAuth tokens are refreshed or removed concurrently.
  - Prevented background maintenance tasks from stopping after a panic.
  - Improved handling of unusual GitLab responses and transport configurations.
  - Corrected server startup and health-check behavior, including dynamically assigned ports.

- **Documentation**
  - Added guidance on condition coverage and mutation testing.
  - Updated project metrics, test statistics, and coverage reports.

- **Tests**
  - Expanded coverage for configuration, authentication, server pooling, retries, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->