### PR TITLE
refactor: clear the SonarCloud findings and reuse the resource read helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,153 |     236,250 |
-| Unit tests (`_test.go`)  |       659 |     391,720 |
+| Source (`.go`, non-test) |     1,153 |     236,254 |
+| Unit tests (`_test.go`)  |       659 |     391,826 |
 | End-to-end tests         |       243 |      64,277 |
-| **Total**                | **2,055** | **692,247** |
+| **Total**                | **2,055** | **692,357** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,817 |
+| Source functions                |  8,820 |
 | . Exported (public)             |  2,864 |
-| . Unexported (private)          |  5,953 |
-| Unit test functions (`TestXxx`) | 13,633 |
-| Subtests (`t.Run(...)`)         |  5,277 |
+| . Unexported (private)          |  5,956 |
+| Unit test functions (`TestXxx`) | 13,635 |
+| Subtests (`t.Run(...)`)         |  5,278 |
 | End-to-end test functions       |    601 |
 
 ### Ratios worth noting
@@ -489,17 +489,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.66× more tests than code |
 | Average source file length         |                 ~205 lines |
-| Average test file length           |                 ~594 lines |
-| Comment lines in source            |  38,448 (~16.3% of source) |
+| Average test file length           |                 ~595 lines |
+| Comment lines in source            |  38,485 (~16.3% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,424 |
+| `if err != nil` checks             | 7,418 |
 | `defer` statements                 | 1,304 |
-| `struct` types defined             | 2,941 |
+| `struct` types defined             | 2,942 |
 | `//nolint` suppressions            |   315 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -523,7 +523,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~4,295 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,707 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 13,710 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/audit_1to1/internal/enums/exemptions.go
+++ b/cmd/audit_1to1/internal/enums/exemptions.go
@@ -14,6 +14,10 @@ const (
 	// back with, not one the add and edit endpoints grant; the handlers treat
 	// 0 as the field left unset and refuse the request before it leaves.
 	membershipNoAccessGrant = "0 (No access) is read back on a membership but never granted: doc/api/members.md lists it under valid access levels while the add and edit handlers (members.go, group_members.go) treat 0 as access_level left unset and refuse the call"
+	// memberRoleBaseLevels: a custom role is based on a role a member can
+	// hold, which leaves out both ends of AccessLevelValue and the minimal
+	// access level in between.
+	memberRoleBaseLevels = "doc/api/member_roles.md#add-a-member-role-to-an-instance lists 10 (Guest) through 50 (Owner) as the valid base access levels"
 	// broadcastTargetLevels: the roles a banner can target are the membership
 	// roles proper, without the two ends of AccessLevelValue.
 	broadcastTargetLevels = "doc/api/broadcast_messages.md lists target_access_levels as 10 (Guest), 15 (Planner), 20 (Reporter), 25 (Security Manager), 30 (Developer), 40 (Maintainer) and 50 (Owner); 5 (Minimal access) and 60 (Admin) are AccessLevelValue constants outside that set"
@@ -73,9 +77,9 @@ func buildAcceptedEnumGaps() map[string]string {
 		"groupldap.AddInput.group_access=60":                 "doc/api/group_ldap_links.md#add-an-ldap-group-link lists 0 (No access) through 50 (Owner); " + membershipNoAdmin,
 		"groupsaml.AddInput.access_level=60":                 "doc/api/saml.md#add-a-saml-group-link lists 0 (No access) through 50 (Owner); " + membershipNoAdmin,
 
-		"memberroles.CreateInstanceInput.base_access_level=0":  "doc/api/member_roles.md#add-a-member-role-to-an-instance lists 10 (Guest) through 50 (Owner) as the valid base access levels",
-		"memberroles.CreateInstanceInput.base_access_level=5":  "doc/api/member_roles.md#add-a-member-role-to-an-instance lists 10 (Guest) through 50 (Owner) as the valid base access levels",
-		"memberroles.CreateInstanceInput.base_access_level=60": "doc/api/member_roles.md#add-a-member-role-to-an-instance lists 10 (Guest) through 50 (Owner) as the valid base access levels",
+		"memberroles.CreateInstanceInput.base_access_level=0":  memberRoleBaseLevels,
+		"memberroles.CreateInstanceInput.base_access_level=5":  memberRoleBaseLevels,
+		"memberroles.CreateInstanceInput.base_access_level=60": memberRoleBaseLevels,
 
 		"broadcastmessages.CreateInput.target_access_levels=0":  broadcastTargetLevels,
 		"broadcastmessages.CreateInput.target_access_levels=5":  broadcastTargetLevels,

--- a/cmd/bench_resources/render_test.go
+++ b/cmd/bench_resources/render_test.go
@@ -788,7 +788,7 @@ func TestWriteSection_ChangedUnderCheck_ReportsWithoutWriting(t *testing.T) {
 	if err != nil || !changed {
 		t.Errorf("writeSection -check = (%v, %v), want a reported change", changed, err)
 	}
-	if got := readFileForTest(t, path); got != original {
+	if readFileForTest(t, path) != original {
 		t.Error("-check rewrote the page")
 	}
 

--- a/cmd/bench_resources/run_test.go
+++ b/cmd/bench_resources/run_test.go
@@ -430,7 +430,7 @@ func TestRunScenario_HTTP_FillsEveryPublishedFigure(t *testing.T) {
 	// Telemetry was on, so the endpoint the harness configured must have
 	// been reached: a plan that says telemetry while nothing is exported
 	// would publish figures for a configuration that was never measured.
-	if got := r.otlp.requests.Load(); got == 0 {
+	if r.otlp.requests.Load() == 0 {
 		t.Error("the OTLP sink received no export from a scenario with telemetry on")
 	}
 }

--- a/cmd/bench_resources/series.go
+++ b/cmd/bench_resources/series.go
@@ -93,7 +93,9 @@ func (r *runner) runSeries(ctx context.Context, plan scenarioPlan) (SeriesScenar
 
 	var conns []*clientConn
 	defer func() { closeConns(conns) }()
-	r.walkSteps(ctx, plan, tgt, newPprofClient("http://"+tgt.pprofAddr), s, call, &result, &conns)
+	r.walkSteps(ctx, seriesInput{
+		plan: plan, tgt: tgt, profiler: newPprofClient("http://" + tgt.pprofAddr), sampler: s, call: call,
+	}, &result, &conns)
 
 	if len(result.Steps) == 0 {
 		return SeriesScenario{}, fmt.Errorf("no step completed: %s", result.StopReason)
@@ -104,26 +106,41 @@ func (r *runner) runSeries(ctx context.Context, plan scenarioPlan) (SeriesScenar
 	return result, nil
 }
 
+// seriesInput is everything one series is walked with that does not change
+// between its steps: the plan being followed, the server process it is
+// followed against, and the instruments trained on that process for the
+// length of the run.
+//
+// These five travel together because the walk holds them all fixed while the
+// result and the connection list it accumulates into are the only things that
+// move, and a signature that listed all seven side by side read as seven
+// interchangeable arguments.
+type seriesInput struct {
+	plan     scenarioPlan
+	tgt      target
+	profiler *pprofClient
+	sampler  *sampler
+	call     toolCall
+}
+
 // walkSteps runs the planned counts in order until one of the guards stops
 // the series, admitting credentials into conns as it goes so the caller can
 // close them whatever happened.
-func (r *runner) walkSteps(ctx context.Context, plan scenarioPlan, tgt target, profiler *pprofClient,
-	s *sampler, call toolCall, result *SeriesScenario, conns *[]*clientConn,
-) {
-	for i, count := range plan.Steps {
+func (r *runner) walkSteps(ctx context.Context, in seriesInput, result *SeriesScenario, conns *[]*clientConn) {
+	for i, count := range in.plan.Steps {
 		if stop := r.budgetStop(result.Steps, count); stop != nil {
 			result.stopBefore(i, stop)
 			return
 		}
-		admitted, admitErr := r.admit(ctx, tgt, len(*conns), count)
+		admitted, admitErr := r.admit(ctx, in.tgt, len(*conns), count)
 		*conns = append(*conns, admitted...)
 		if admitErr != nil {
 			result.stopBefore(i, &SeriesStop{Kind: stopFailure, NextClients: count, Error: admitErr.Error()})
 			return
 		}
 		step := r.runStep(ctx, stepInput{
-			plan: plan, call: call, conns: *conns, sampler: s, profiler: profiler,
-			capacity: slices.Max(plan.Steps),
+			plan: in.plan, call: in.call, conns: *conns, sampler: in.sampler, profiler: in.profiler,
+			capacity: slices.Max(in.plan.Steps),
 		})
 		result.Steps = append(result.Steps, step)
 		result.StoppedAt = step.Clients

--- a/cmd/bench_resources/series_test.go
+++ b/cmd/bench_resources/series_test.go
@@ -394,7 +394,9 @@ func newSeriesFixture(t *testing.T, steps []int, budget float64) *seriesFixture 
 // walk runs the steps against a target and returns the result.
 func (f *seriesFixture) walk(t *testing.T, r *runner, tgt target) SeriesScenario {
 	t.Helper()
-	r.walkSteps(t.Context(), f.plan, tgt, f.profiler, f.sampler, f.call, &f.result, &f.conns)
+	r.walkSteps(t.Context(), seriesInput{
+		plan: f.plan, tgt: tgt, profiler: f.profiler, sampler: f.sampler, call: f.call,
+	}, &f.result, &f.conns)
 	t.Cleanup(func() { closeConns(f.conns) })
 	return f.result
 }

--- a/cmd/server/auth_gate_test.go
+++ b/cmd/server/auth_gate_test.go
@@ -1240,7 +1240,7 @@ func TestNewTransportBudget_WithoutALimiter_IsAbsent(t *testing.T) {
 		t.Errorf("newTransportBudget(nil) = %+v, want nil", budget)
 	}
 	limiter := serverpool.NewAuthRateLimiter(2, authFailureWindow)
-	if got := newTransportBudget(limiter).rateLimiter(); got != limiter {
+	if newTransportBudget(limiter).rateLimiter() != limiter {
 		t.Error("rateLimiter() did not hand back the limiter the budget wraps")
 	}
 }

--- a/cmd/server/first_run_test.go
+++ b/cmd/server/first_run_test.go
@@ -146,7 +146,7 @@ func TestIsInteractiveTerminal_IsFalseForAFile(t *testing.T) {
 // The name is printed for the reader to type, so an empty string would leave
 // the line unusable.
 func TestExecutableName_FallsBackToTheProjectName(t *testing.T) {
-	if got := executableName(); got == "" {
+	if executableName() == "" {
 		t.Error("executableName returned an empty string; the --help line would be unusable")
 	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1015,7 +1015,14 @@ func TestRunWithContext_SuccessHTTPMetaTools(t *testing.T) {
 }
 
 // TestRunWithContext_SuccessStdio verifies that [runWithContext] in stdio mode
-// returns promptly when the context is already canceled.
+// returns promptly, and reports no error, when the context is already canceled.
+//
+// Both halves are the assertion. A cancelled context is how a signal reaches
+// this call, and [serveStdio] maps it to a clean return precisely so a
+// shutdown the operator asked for does not exit nonzero; returning at all is
+// the other half, because the startup goroutine outlives the transport and a
+// stdio shutdown that waited on it would hang the process a client has
+// already let go of.
 func TestRunWithContext_SuccessStdio(t *testing.T) {
 	srv := newMockGitLabServer(t)
 	t.Setenv("GITLAB_URL", srv.URL)
@@ -1025,9 +1032,17 @@ func TestRunWithContext_SuccessStdio(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately so stdio exits immediately
 
-	err := runWithContext(ctx, nil)
-	// With a canceled context, stdio server returns immediately (error or nil)
-	_ = err
+	errCh := make(chan error, 1)
+	go func() { errCh <- runWithContext(ctx, nil) }()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("runWithContext() = %v, want nil: a cancelled context is an ordinary shutdown", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runWithContext() did not return after its context was cancelled")
+	}
 }
 
 // TestRunWithContext_InvalidConfig verifies that [runWithContext] returns an
@@ -2883,7 +2898,7 @@ func TestNewDepthLimitedBody_ADisabledLimit_PassesTheBodyThrough(t *testing.T) {
 	for _, limit := range []int{0, -1} {
 		t.Run(strconv.Itoa(limit), func(t *testing.T) {
 			t.Parallel()
-			if got := newDepthLimitedBody(body, limit); got != body {
+			if newDepthLimitedBody(body, limit) != body {
 				t.Errorf("newDepthLimitedBody(limit=%d) wrapped the body, want it returned unchanged", limit)
 			}
 		})
@@ -3128,21 +3143,6 @@ func TestDoToolSearch_NoMatches_SaysSo(t *testing.T) {
 	if out := stdout(); !strings.Contains(out, `No actions found matching "zzzz-nothing-is-called-this"`) {
 		t.Errorf("stdout = %q, want the no-match sentence naming the query", out)
 	}
-}
-
-// TestRunStdio_PingSucceeds verifies the success path for Ping in runStdio,
-// where the GitLab mock returns a valid version response.
-func TestRunStdio_PingSucceeds(t *testing.T) {
-	srv := newMockGitLabServer(t)
-	t.Setenv("GITLAB_URL", srv.URL)
-	t.Setenv("GITLAB_TOKEN", testToken)
-	t.Setenv("META_TOOLS", "false")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := runWithContext(ctx, nil)
-	_ = err
 }
 
 // TestServeHTTP_RequestWithToken verifies that the HTTP handler processes
@@ -3613,7 +3613,7 @@ func TestServeHTTP_MissingToken(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d: %s", resp.StatusCode, http.StatusUnauthorized, respBody)
 	}
-	if challenge := resp.Header.Get("WWW-Authenticate"); challenge == "" {
+	if resp.Header.Get("WWW-Authenticate") == "" {
 		t.Error("401 without WWW-Authenticate violates RFC 9110")
 	}
 	if !strings.Contains(respBody, "\"jsonrpc\"") {
@@ -4801,7 +4801,7 @@ func TestServeHTTP_LegacyMode_NoMetadataEndpoint(t *testing.T) {
 	// but not with a valid OAuth metadata JSON.
 	if resp.StatusCode == http.StatusOK {
 		var meta map[string]any
-		if decErr := json.NewDecoder(resp.Body).Decode(&meta); decErr == nil {
+		if json.NewDecoder(resp.Body).Decode(&meta) == nil {
 			if _, hasServers := meta["authorization_servers"]; hasServers {
 				t.Error("legacy mode should NOT serve OAuth metadata, but found authorization_servers")
 			}
@@ -6818,7 +6818,7 @@ func TestCorsMiddleware_TrustedOriginPreflight_IsAnswered(t *testing.T) {
 	}
 	// The origin is echoed, never "*": these requests carry Authorization,
 	// and a browser rejects the wildcard on a credentialed request.
-	if got := rec.Header().Get("Access-Control-Allow-Origin"); got == "*" {
+	if rec.Header().Get("Access-Control-Allow-Origin") == "*" {
 		t.Error("a credentialed endpoint must echo the origin, not answer with *")
 	}
 	if !slices.Contains(rec.Header().Values("Vary"), "Origin") {
@@ -6920,7 +6920,7 @@ func TestCorsMiddleware_ActualRequest_ExposesTransportHeaders(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Expose-Headers"); got != corsExposeHeaders {
 		t.Errorf("Access-Control-Expose-Headers = %q, want %q", got, corsExposeHeaders)
 	}
-	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "" {
+	if rec.Header().Get("Access-Control-Allow-Methods") != "" {
 		t.Error("Access-Control-Allow-Methods belongs to a preflight response only")
 	}
 }

--- a/cmd/server/sdk_log_test.go
+++ b/cmd/server/sdk_log_test.go
@@ -224,7 +224,7 @@ func TestSDKLogHandler_WithAttrsKeepsTheHandlerWrapping(t *testing.T) {
 	if got := records[0]["msg"]; got != "resource subscribed" {
 		t.Errorf("the surviving record is %q, want the one that is not session chatter", got)
 	}
-	if got := records[0]["component"]; got != "sdk" {
+	if records[0]["component"] != "sdk" {
 		t.Errorf("the attached attribute was lost: %v", records[0])
 	}
 }
@@ -262,7 +262,7 @@ func TestSDKLogHandler_GroupedAttributesAreLeftAlone(t *testing.T) {
 	if !ok {
 		t.Fatalf("the group is missing: %v", records[0])
 	}
-	if got := group["level"]; got != "info" {
+	if group["level"] != "info" {
 		t.Errorf("grouped attribute renamed to something else: %v", group)
 	}
 	if got := records[0]["level"]; got != "INFO" {

--- a/cmd/server/telemetry_identity_test.go
+++ b/cmd/server/telemetry_identity_test.go
@@ -42,7 +42,7 @@ func TestIdentityRedactor_OneInstanceServesEverySignal(t *testing.T) {
 	if first != second {
 		t.Error("two calls produced two redactors; the same user would get two different digests")
 	}
-	if users := telemetryUsers(); users == nil {
+	if telemetryUsers() == nil {
 		t.Error("the middleware was given no attributer while the policy names callers")
 	}
 }
@@ -59,7 +59,7 @@ func TestIdentityRedactor_NoneBuildsNothing(t *testing.T) {
 	if got := identityRedactor(); got != nil {
 		t.Errorf("policy none built a redactor (%v); nothing should name a caller", got)
 	}
-	if users := telemetryUsers(); users != nil {
+	if telemetryUsers() != nil {
 		t.Error("policy none gave the middleware an attributer")
 	}
 }

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,234 |
-| Unit test functions                                   | 13,633 |
+| Total test functions                                  | 14,236 |
+| Unit test functions                                   | 13,635 |
 | E2E test functions                                    |    601 |
-| cmd test functions                                    |  2,507 |
+| cmd test functions                                    |  2,506 |
 | Test files (internal/)                                |    508 |
 | Test files (cmd/)                                     |    151 |
 | Test files (test/e2e/)                                |    237 |
@@ -37,7 +37,7 @@
 | -------------------------------------- | -----: | ----: |
 | `TestFunc_Scenario` (2-part)           | 11,670 | 82.0% |
 | `TestFunc` (no underscore)             |    967 |  6.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,597 | 11.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,599 | 11.2% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,327 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,330 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (176) |          8,467 |        355 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            601 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,507 |        151 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,234** |    **896** |                                                                                                 |
+| cmd packages            |          2,506 |        151 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,236** |    **896** |                                                                                                 |
 
 ### Core Packages
 
@@ -71,13 +71,13 @@
 | oauth         |        78 |   100.0% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
 | prompts       |       280 |   100.0% | Package prompts registers MCP prompt templates that generate AI-optimized summaries, reviews, reports, and assessments from GitLab project, group, and cross-project data.                                                                                         |
-| resources     |       188 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
+| resources     |       191 |    99.5% | Package resources registers read-only MCP resources for GitLab and server metadata.                                                                                                                                                                                |
 | serverpool    |       116 |   100.0% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       850 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,327** |          |                                                                                                                                                                                                                                                                    |
+| **Subtotal**  | **2,330** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 

--- a/internal/prompts/exclusion.go
+++ b/internal/prompts/exclusion.go
@@ -10,14 +10,20 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
-// registrar is the subset of *mcp.Server that prompt registration uses.
+// promptAdder is the subset of *mcp.Server that prompt registration uses.
 //
 // The registration helpers take this interface rather than the concrete server
 // so a wrapper can decide, per prompt, whether the call reaches the server at
 // all. That is the only place the decision fits: every prompt in this package
 // is registered through [addPrompt], and a filter there covers all 37 without
 // any of them knowing it exists.
-type registrar interface {
+//
+// Named for its one method, as Go names a one-method interface, while the
+// concrete types satisfying it are named for what they are: an
+// [excludingRegistrar] is a registrar, and adding prompts is what it can do.
+// The sibling in internal/resources keeps the plain name because it carries
+// two methods and so has no method to be named after.
+type promptAdder interface {
 	AddPrompt(prompt *mcp.Prompt, handler mcp.PromptHandler)
 }
 
@@ -137,7 +143,7 @@ var promptBackingActions = map[string][]string{
 // calls stay a flat list of what this server offers, and the narrowing stays
 // one decision in one place.
 type excludingRegistrar struct {
-	inner    registrar
+	inner    promptAdder
 	excluded map[string]struct{}
 }
 
@@ -151,7 +157,7 @@ func (r *excludingRegistrar) AddPrompt(prompt *mcp.Prompt, handler mcp.PromptHan
 // registrarFor returns the registrar the registration calls should be given
 // for these options: the plain one when nothing is excluded, and a filtering
 // wrapper otherwise.
-func registrarFor(inner registrar, opts []RegisterOptions) registrar {
+func registrarFor(inner promptAdder, opts []RegisterOptions) promptAdder {
 	excluded := excludedPromptNames(opts)
 	if len(excluded) == 0 {
 		return inner
@@ -209,7 +215,7 @@ func excludedPromptNames(opts []RegisterOptions) map[string]struct{} {
 // once for all 37, including the ones that read several endpoints and would
 // otherwise fail differently depending on which read came first.
 type attributedRegistrar struct {
-	inner registrar
+	inner promptAdder
 	base  *gitlabclient.Client
 }
 
@@ -224,6 +230,6 @@ func (r *attributedRegistrar) AddPrompt(prompt *mcp.Prompt, handler mcp.PromptHa
 
 // attributed wraps inner so every prompt registered through it refuses an
 // unattributed request. See [attributedRegistrar].
-func attributed(inner registrar, base *gitlabclient.Client) registrar {
+func attributed(inner promptAdder, base *gitlabclient.Client) promptAdder {
 	return &attributedRegistrar{inner: inner, base: base}
 }

--- a/internal/prompts/prompt_analytics.go
+++ b/internal/prompts/prompt_analytics.go
@@ -26,7 +26,7 @@ import (
 //   - release_cadence: time-between-releases analysis with a release history table.
 //   - weekly_team_recap: group-level weekly recap combining merged MRs, open
 //     MRs, and open issues.
-func registerAnalyticsPrompts(server registrar, client *gitlabclient.Client) {
+func registerAnalyticsPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerMergeVelocityPrompt(server, client)
 	registerReleaseReadinessPrompt(server, client)
 	registerReleaseCadencePrompt(server, client)
@@ -34,7 +34,7 @@ func registerAnalyticsPrompts(server registrar, client *gitlabclient.Client) {
 }
 
 // registerMergeVelocityPrompt registers the merge_velocity prompt.
-func registerMergeVelocityPrompt(server registrar, client *gitlabclient.Client) {
+func registerMergeVelocityPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "merge_velocity",
 		Title:       toolutil.TitleFromName("merge_velocity"),
@@ -141,7 +141,7 @@ func writeDailyMergeChart(b *strings.Builder, mrs []*gl.BasicMergeRequest) {
 }
 
 // registerReleaseReadinessPrompt registers the release_readiness prompt.
-func registerReleaseReadinessPrompt(server registrar, client *gitlabclient.Client) {
+func registerReleaseReadinessPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "release_readiness",
 		Title:       toolutil.TitleFromName("release_readiness"),
@@ -246,7 +246,7 @@ func readinessLabel(blockers int) string {
 }
 
 // registerReleaseCadencePrompt registers the release_cadence prompt.
-func registerReleaseCadencePrompt(server registrar, client *gitlabclient.Client) {
+func registerReleaseCadencePrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "release_cadence",
 		Title:       toolutil.TitleFromName("release_cadence"),
@@ -362,7 +362,7 @@ func releaseDate(r *gl.Release) time.Time {
 }
 
 // registerWeeklyTeamRecapPrompt registers the weekly_team_recap prompt.
-func registerWeeklyTeamRecapPrompt(server registrar, client *gitlabclient.Client) {
+func registerWeeklyTeamRecapPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "weekly_team_recap",
 		Title:       toolutil.TitleFromName("weekly_team_recap"),

--- a/internal/prompts/prompt_audit.go
+++ b/internal/prompts/prompt_audit.go
@@ -58,7 +58,7 @@ func isDefaultBranchProtected(branches []*gl.ProtectedBranch, defaultBranch stri
 //   - audit_project_full: a comprehensive audit covering settings, branch
 //     protection, access, labels, milestones, templates, webhooks, and
 //     push rules.
-func registerAuditPrompts(server registrar, client *gitlabclient.Client) {
+func registerAuditPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerAuditProjectWorkflowPrompt(server, client)
 	registerAuditProjectFullPrompt(server, client)
 }
@@ -387,7 +387,7 @@ func writeMemberTable(b *strings.Builder, members []*gl.ProjectMember) {
 // audit_project_workflow.
 
 // registerAuditProjectWorkflowPrompt registers the audit_project_workflow prompt.
-func registerAuditProjectWorkflowPrompt(server registrar, client *gitlabclient.Client) {
+func registerAuditProjectWorkflowPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:  "audit_project_workflow",
 		Title: toolutil.TitleFromName("audit_project_workflow"),
@@ -544,7 +544,7 @@ func writeTemplatesAudit(b *strings.Builder, issueTPL, mrTPL []*gl.ProjectTempla
 // audit_project_full.
 
 // registerAuditProjectFullPrompt registers the audit_project_full prompt.
-func registerAuditProjectFullPrompt(server registrar, client *gitlabclient.Client) {
+func registerAuditProjectFullPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:  "audit_project_full",
 		Title: toolutil.TitleFromName("audit_project_full"),

--- a/internal/prompts/prompt_cross_project.go
+++ b/internal/prompts/prompt_cross_project.go
@@ -15,7 +15,7 @@ import (
 )
 
 // registerMyOpenMRsPrompt registers the my_open_mrs prompt.
-func registerMyOpenMRsPrompt(server registrar, client *gitlabclient.Client) {
+func registerMyOpenMRsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_open_mrs",
 		Title:       toolutil.TitleFromName("my_open_mrs"),
@@ -108,7 +108,7 @@ func handleMyOpenMRs(ctx context.Context, client *gitlabclient.Client, req *mcp.
 }
 
 // registerMyPendingReviewsPrompt registers the my_pending_reviews prompt.
-func registerMyPendingReviewsPrompt(server registrar, client *gitlabclient.Client) {
+func registerMyPendingReviewsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_pending_reviews",
 		Title:       toolutil.TitleFromName("my_pending_reviews"),
@@ -163,7 +163,7 @@ func handleMyPendingReviews(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerMyIssuesPrompt registers the my_issues prompt.
-func registerMyIssuesPrompt(server registrar, client *gitlabclient.Client) {
+func registerMyIssuesPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_issues",
 		Title:       toolutil.TitleFromName("my_issues"),
@@ -235,7 +235,7 @@ func handleMyIssues(ctx context.Context, client *gitlabclient.Client, req *mcp.G
 }
 
 // registerMyActivitySummaryPrompt registers the my_activity_summary prompt.
-func registerMyActivitySummaryPrompt(server registrar, client *gitlabclient.Client) {
+func registerMyActivitySummaryPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "my_activity_summary",
 		Title:       toolutil.TitleFromName("my_activity_summary"),
@@ -345,7 +345,7 @@ func writeDailyActivityChart(b *strings.Builder, dailyData []dayActivity) {
 }
 
 // registerCrossProjectPrompts registers all cross-project prompts.
-func registerCrossProjectPrompts(server registrar, client *gitlabclient.Client) {
+func registerCrossProjectPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerMyOpenMRsPrompt(server, client)
 	registerMyPendingReviewsPrompt(server, client)
 	registerMyIssuesPrompt(server, client)

--- a/internal/prompts/prompt_git_workflow.go
+++ b/internal/prompts/prompt_git_workflow.go
@@ -23,13 +23,13 @@ var (
 )
 
 // registerGitWorkflowPrompts registers prompts for Git history and MR authoring quality.
-func registerGitWorkflowPrompts(server registrar, client *gitlabclient.Client) {
+func registerGitWorkflowPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerAuditCommitHygienePrompt(server, client)
 	registerMRDescriptionQualityPrompt(server, client)
 }
 
 // registerAuditCommitHygienePrompt registers the audit_commit_hygiene prompt.
-func registerAuditCommitHygienePrompt(server registrar, client *gitlabclient.Client) {
+func registerAuditCommitHygienePrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "audit_commit_hygiene",
 		Title:       toolutil.TitleFromName("audit_commit_hygiene"),
@@ -94,7 +94,7 @@ func handleAuditCommitHygiene(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerMRDescriptionQualityPrompt registers the mr_description_quality prompt.
-func registerMRDescriptionQualityPrompt(server registrar, client *gitlabclient.Client) {
+func registerMRDescriptionQualityPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_description_quality",
 		Title:       toolutil.TitleFromName("mr_description_quality"),

--- a/internal/prompts/prompt_helpers.go
+++ b/internal/prompts/prompt_helpers.go
@@ -37,7 +37,7 @@ import (
 // later would have to remember. Registration is the one place every error
 // passes through, so the -32603 default lands here and the explicit
 // [errInvalidParams] calls in the handlers take precedence over it.
-func addPrompt(server registrar, prompt *mcp.Prompt, handler mcp.PromptHandler) {
+func addPrompt(server promptAdder, prompt *mcp.Prompt, handler mcp.PromptHandler) {
 	server.AddPrompt(prompt, func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		result, err := handler(ctx, req)
 		if err == nil {

--- a/internal/prompts/prompt_milestone_label.go
+++ b/internal/prompts/prompt_milestone_label.go
@@ -16,7 +16,7 @@ import (
 )
 
 // registerMilestoneLabelPrompts registers all milestone and label prompts.
-func registerMilestoneLabelPrompts(server registrar, client *gitlabclient.Client) {
+func registerMilestoneLabelPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerMilestoneProgressPrompt(server, client)
 	registerLabelDistributionPrompt(server, client)
 	registerGroupMilestoneProgressPrompt(server, client)
@@ -63,7 +63,7 @@ func writeDueDateSection(b *strings.Builder, dueDate *gl.ISOTime) {
 }
 
 // registerMilestoneProgressPrompt registers the milestone_progress prompt.
-func registerMilestoneProgressPrompt(server registrar, client *gitlabclient.Client) {
+func registerMilestoneProgressPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "milestone_progress",
 		Title:       toolutil.TitleFromName("milestone_progress"),
@@ -143,7 +143,7 @@ func handleMilestoneProgress(ctx context.Context, client *gitlabclient.Client, r
 }
 
 // registerLabelDistributionPrompt registers the label_distribution prompt.
-func registerLabelDistributionPrompt(server registrar, client *gitlabclient.Client) {
+func registerLabelDistributionPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "label_distribution",
 		Title:       toolutil.TitleFromName("label_distribution"),
@@ -223,7 +223,7 @@ func handleLabelDistribution(ctx context.Context, client *gitlabclient.Client, r
 }
 
 // registerGroupMilestoneProgressPrompt registers the group_milestone_progress prompt.
-func registerGroupMilestoneProgressPrompt(server registrar, client *gitlabclient.Client) {
+func registerGroupMilestoneProgressPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "group_milestone_progress",
 		Title:       toolutil.TitleFromName("group_milestone_progress"),
@@ -292,7 +292,7 @@ func handleGroupMilestoneProgress(ctx context.Context, client *gitlabclient.Clie
 }
 
 // registerProjectContributorsPrompt registers the project_contributors prompt.
-func registerProjectContributorsPrompt(server registrar, client *gitlabclient.Client) {
+func registerProjectContributorsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_contributors",
 		Title:       toolutil.TitleFromName("project_contributors"),

--- a/internal/prompts/prompt_project_reports.go
+++ b/internal/prompts/prompt_project_reports.go
@@ -23,7 +23,7 @@ const (
 )
 
 // registerProjectReportPrompts registers all project-level report prompts.
-func registerProjectReportPrompts(server registrar, client *gitlabclient.Client) {
+func registerProjectReportPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerBranchMRSummaryPrompt(server, client)
 	registerProjectActivityReportPrompt(server, client)
 	registerMRDiscussionHealthPrompt(server, client)
@@ -32,7 +32,7 @@ func registerProjectReportPrompts(server registrar, client *gitlabclient.Client)
 }
 
 // registerBranchMRSummaryPrompt registers the branch_mr_summary prompt.
-func registerBranchMRSummaryPrompt(server registrar, client *gitlabclient.Client) {
+func registerBranchMRSummaryPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "branch_mr_summary",
 		Title:       toolutil.TitleFromName("branch_mr_summary"),
@@ -102,7 +102,7 @@ func handleBranchMRSummary(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerProjectActivityReportPrompt registers the project_activity_report prompt.
-func registerProjectActivityReportPrompt(server registrar, client *gitlabclient.Client) {
+func registerProjectActivityReportPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_activity_report",
 		Title:       toolutil.TitleFromName("project_activity_report"),
@@ -193,7 +193,7 @@ func handleProjectActivityReport(ctx context.Context, client *gitlabclient.Clien
 }
 
 // registerMRDiscussionHealthPrompt registers the mr_discussion_health prompt.
-func registerMRDiscussionHealthPrompt(server registrar, client *gitlabclient.Client) {
+func registerMRDiscussionHealthPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_discussion_health",
 		Title:       toolutil.TitleFromName("mr_discussion_health"),
@@ -311,7 +311,7 @@ func countDiscussionThreads(info *mrDiscussionInfo, discussions []*gl.Discussion
 }
 
 // registerUnassignedItemsPrompt registers the unassigned_items prompt.
-func registerUnassignedItemsPrompt(server registrar, client *gitlabclient.Client) {
+func registerUnassignedItemsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "unassigned_items",
 		Title:       toolutil.TitleFromName("unassigned_items"),
@@ -377,7 +377,7 @@ func handleUnassignedItems(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerStaleItemsReportPrompt registers the stale_items_report prompt.
-func registerStaleItemsReportPrompt(server registrar, client *gitlabclient.Client) {
+func registerStaleItemsReportPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "stale_items_report",
 		Title:       toolutil.TitleFromName("stale_items_report"),

--- a/internal/prompts/prompt_team.go
+++ b/internal/prompts/prompt_team.go
@@ -35,7 +35,7 @@ type reviewerWorkloadStats struct {
 }
 
 // registerTeamPrompts registers all team management prompts.
-func registerTeamPrompts(server registrar, client *gitlabclient.Client) {
+func registerTeamPrompts(server promptAdder, client *gitlabclient.Client) {
 	registerUserActivityReportPrompt(server, client)
 	registerTeamOverviewPrompt(server, client)
 	registerGroupMRDashboardPrompt(server, client)
@@ -43,7 +43,7 @@ func registerTeamPrompts(server registrar, client *gitlabclient.Client) {
 }
 
 // registerUserActivityReportPrompt registers the user_activity_report prompt.
-func registerUserActivityReportPrompt(server registrar, client *gitlabclient.Client) {
+func registerUserActivityReportPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "user_activity_report",
 		Title:       toolutil.TitleFromName("user_activity_report"),
@@ -162,7 +162,7 @@ func handleUserActivityReport(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerTeamOverviewPrompt registers the team_overview prompt.
-func registerTeamOverviewPrompt(server registrar, client *gitlabclient.Client) {
+func registerTeamOverviewPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "team_overview",
 		Title:       toolutil.TitleFromName("team_overview"),
@@ -286,7 +286,7 @@ func writeTeamOverviewChart(b *strings.Builder, stats map[string]*teamOverviewMe
 }
 
 // registerGroupMRDashboardPrompt registers the group_mr_dashboard prompt.
-func registerGroupMRDashboardPrompt(server registrar, client *gitlabclient.Client) {
+func registerGroupMRDashboardPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "group_mr_dashboard",
 		Title:       toolutil.TitleFromName("group_mr_dashboard"),
@@ -367,7 +367,7 @@ func handleGroupMRDashboard(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerReviewerWorkloadPrompt registers the reviewer_workload prompt.
-func registerReviewerWorkloadPrompt(server registrar, client *gitlabclient.Client) {
+func registerReviewerWorkloadPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "reviewer_workload",
 		Title:       toolutil.TitleFromName("reviewer_workload"),

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -98,7 +98,7 @@ func Register(server *mcp.Server, client *gitlabclient.Client, opts ...RegisterO
 // build the shape. On stdio, and in every test that registers a real client,
 // nothing is ever bound and For returns the captured client unchanged, so the
 // call is invisible there.
-func registerAll(server registrar, client *gitlabclient.Client) {
+func registerAll(server promptAdder, client *gitlabclient.Client) {
 	registerSummarizeMRChangesPrompt(server, client)
 	registerReviewMRPrompt(server, client)
 	registerSummarizePipelineStatusPrompt(server, client)
@@ -135,7 +135,7 @@ func registerAll(server registrar, client *gitlabclient.Client) {
 }
 
 // registerSummarizeMRChangesPrompt registers the summarize_mr_changes prompt.
-func registerSummarizeMRChangesPrompt(server registrar, client *gitlabclient.Client) {
+func registerSummarizeMRChangesPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_mr_changes",
 		Title:       toolutil.TitleFromName("summarize_mr_changes"),
@@ -175,7 +175,7 @@ func handleSummarizeMRChanges(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerReviewMRPrompt registers the review_mr prompt.
-func registerReviewMRPrompt(server registrar, client *gitlabclient.Client) {
+func registerReviewMRPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "review_mr",
 		Title:       toolutil.TitleFromName("review_mr"),
@@ -298,7 +298,7 @@ func handleReviewMR(ctx context.Context, client *gitlabclient.Client, req *mcp.G
 }
 
 // registerSummarizePipelineStatusPrompt registers the summarize_pipeline_status prompt.
-func registerSummarizePipelineStatusPrompt(server registrar, client *gitlabclient.Client) {
+func registerSummarizePipelineStatusPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_pipeline_status",
 		Title:       toolutil.TitleFromName("summarize_pipeline_status"),
@@ -378,7 +378,7 @@ func handleSummarizePipelineStatus(ctx context.Context, client *gitlabclient.Cli
 }
 
 // registerSuggestMRReviewersPrompt registers the suggest_mr_reviewers prompt.
-func registerSuggestMRReviewersPrompt(server registrar, client *gitlabclient.Client) {
+func registerSuggestMRReviewersPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "suggest_mr_reviewers",
 		Title:       toolutil.TitleFromName("suggest_mr_reviewers"),
@@ -433,7 +433,7 @@ func handleSuggestMRReviewers(ctx context.Context, client *gitlabclient.Client, 
 }
 
 // registerGenerateReleaseNotesPrompt registers the generate_release_notes prompt.
-func registerGenerateReleaseNotesPrompt(server registrar, client *gitlabclient.Client) {
+func registerGenerateReleaseNotesPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "generate_release_notes",
 		Title:       toolutil.TitleFromName("generate_release_notes"),
@@ -593,7 +593,7 @@ func writeReleaseNotesStats(b *strings.Builder, comparison *gl.Compare) {
 }
 
 // registerSummarizeOpenMRsPrompt registers the summarize_open_mrs prompt.
-func registerSummarizeOpenMRsPrompt(server registrar, client *gitlabclient.Client) {
+func registerSummarizeOpenMRsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "summarize_open_mrs",
 		Title:       toolutil.TitleFromName("summarize_open_mrs"),
@@ -650,7 +650,7 @@ func handleSummarizeOpenMRs(ctx context.Context, client *gitlabclient.Client, re
 }
 
 // registerProjectHealthCheckPrompt registers the project_health_check prompt.
-func registerProjectHealthCheckPrompt(server registrar, client *gitlabclient.Client) {
+func registerProjectHealthCheckPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "project_health_check",
 		Title:       toolutil.TitleFromName("project_health_check"),
@@ -748,7 +748,7 @@ func countBranchStats(branches []*gl.Branch) (merged, stale int) {
 }
 
 // registerCompareBranchesPrompt registers the compare_branches prompt.
-func registerCompareBranchesPrompt(server registrar, client *gitlabclient.Client) {
+func registerCompareBranchesPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "compare_branches",
 		Title:       toolutil.TitleFromName("compare_branches"),
@@ -816,7 +816,7 @@ func handleCompareBranches(ctx context.Context, client *gitlabclient.Client, req
 }
 
 // registerDailyStandupPrompt registers the daily_standup prompt.
-func registerDailyStandupPrompt(server registrar, client *gitlabclient.Client) {
+func registerDailyStandupPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "daily_standup",
 		Title:       toolutil.TitleFromName("daily_standup"),
@@ -978,7 +978,7 @@ func writeIssueSection(b *strings.Builder, heading, username string, issues []*g
 }
 
 // registerTeamMemberWorkloadPrompt registers the team_member_workload prompt.
-func registerTeamMemberWorkloadPrompt(server registrar, client *gitlabclient.Client) {
+func registerTeamMemberWorkloadPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "team_member_workload",
 		Title:       toolutil.TitleFromName("team_member_workload"),
@@ -1124,7 +1124,7 @@ func writeCountRow(b *strings.Builder, label string, count int, fetchErr error) 
 }
 
 // registerUserStatsPrompt registers the user_stats prompt.
-func registerUserStatsPrompt(server registrar, client *gitlabclient.Client) {
+func registerUserStatsPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "user_stats",
 		Title:       toolutil.TitleFromName("user_stats"),
@@ -1348,7 +1348,7 @@ func safeLen(count int, err error) int {
 }
 
 // registerMRRiskAssessmentPrompt registers the mr_risk_assessment prompt.
-func registerMRRiskAssessmentPrompt(server registrar, client *gitlabclient.Client) {
+func registerMRRiskAssessmentPrompt(server promptAdder, client *gitlabclient.Client) {
 	addPrompt(server, &mcp.Prompt{
 		Name:        "mr_risk_assessment",
 		Title:       toolutil.TitleFromName("mr_risk_assessment"),

--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -1304,13 +1304,8 @@ func registerMergeRequestNotesResource(server registrar, base *gitlabclient.Clie
 		Icons:       toolutil.IconMR,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		uri := strings.TrimSuffix(req.Params.URI, "/notes")
-		projectID, mrIIDStr := extractTwoParts(uri, uriProjectPrefix, "/mr/")
-		if projectID == "" || mrIIDStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		mrIID, err := strconv.ParseInt(mrIIDStr, 10, 64)
-		if err != nil {
+		projectID, mrIID, ok := extractMRSubcollection(req.Params.URI, "/notes")
+		if !ok {
 			return nil, mcp.ResourceNotFoundError(req.Params.URI)
 		}
 		notes, resp, err := client.GL().Notes.ListMergeRequestNotes(projectID, mrIID, &gl.ListMergeRequestNotesOptions{PerPage: resourcePerPage}, gl.WithContext(ctx))
@@ -1356,13 +1351,8 @@ func registerMergeRequestDiscussionsResource(server registrar, base *gitlabclien
 		Icons:       toolutil.IconMR,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		uri := strings.TrimSuffix(req.Params.URI, "/discussions")
-		projectID, mrIIDStr := extractTwoParts(uri, uriProjectPrefix, "/mr/")
-		if projectID == "" || mrIIDStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		mrIID, err := strconv.ParseInt(mrIIDStr, 10, 64)
-		if err != nil {
+		projectID, mrIID, ok := extractMRSubcollection(req.Params.URI, "/discussions")
+		if !ok {
 			return nil, mcp.ResourceNotFoundError(req.Params.URI)
 		}
 		discussions, resp, err := client.GL().Discussions.ListMergeRequestDiscussions(projectID, mrIID, &gl.ListMergeRequestDiscussionsOptions{PerPage: resourcePerPage}, gl.WithContext(ctx))
@@ -1539,15 +1529,7 @@ func registerLabelResource(server registrar, base *gitlabclient.Client) {
 		if err != nil {
 			return nil, wrapErr("failed to get label", err)
 		}
-		out := LabelResourceOutput{
-			ID:                     l.ID,
-			Name:                   l.Name,
-			Color:                  l.Color,
-			Description:            l.Description,
-			OpenIssuesCount:        l.OpenIssuesCount,
-			OpenMergeRequestsCount: l.OpenMergeRequestsCount,
-		}
-		return marshalResourceJSON(out)
+		return marshalResourceJSON(labelToResourceOutput(l))
 	})
 }
 
@@ -1719,6 +1701,27 @@ func extractTwoParts(uri, prefix, separator string) (first, second string) {
 	return parts[0], parts[1]
 }
 
+// extractMRSubcollection splits a "gitlab://project/{id}/mr/{iid}/{listSuffix}"
+// URI into the project and the merge request IID it names, with ok false when
+// the URI does not carry both.
+//
+// The sub-collections of one merge request are read by separate handlers that
+// diverge only after this point, so the segment they agree on is parsed once:
+// the two of them disagreeing about which URI is a not-found is the failure
+// this shape is prone to, and there is nothing left here for them to disagree
+// about.
+func extractMRSubcollection(uri, listSuffix string) (projectID string, mrIID int64, ok bool) {
+	projectID, iidStr := extractTwoParts(strings.TrimSuffix(uri, listSuffix), uriProjectPrefix, "/mr/")
+	if projectID == "" || iidStr == "" {
+		return "", 0, false
+	}
+	iid, err := strconv.ParseInt(iidStr, 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return projectID, iid, true
+}
+
 // readProjectIntResource is the shared handler for resources that
 // extract a (projectID, int64) pair from the URI and dispatch to a
 // GitLab API call. The supplied separator and operation label are used
@@ -1834,6 +1837,38 @@ func marshalResourceList(v any, page listPage) (*mcp.ReadResourceResult, error) 
 	return result, nil
 }
 
+// snippetToResourceOutput converts a GitLab snippet to the resource output.
+//
+// One function for both scopes because the personal and the project snippet
+// endpoints answer with the same client-go type, so a field added to the
+// output has one place to be filled rather than two that must agree.
+func snippetToResourceOutput(s *gl.Snippet) SnippetResourceOutput {
+	return SnippetResourceOutput{
+		ID:          s.ID,
+		Title:       s.Title,
+		FileName:    s.FileName,
+		Description: s.Description,
+		Visibility:  s.Visibility,
+		WebURL:      s.WebURL,
+	}
+}
+
+// labelToResourceOutput converts a GitLab label to the resource output.
+//
+// Group labels reach it through a conversion rather than a second function:
+// client-go declares GroupLabel as a defined type over Label, so the two have
+// one field set by construction and cannot drift apart underneath this.
+func labelToResourceOutput(l *gl.Label) LabelResourceOutput {
+	return LabelResourceOutput{
+		ID:                     l.ID,
+		Name:                   l.Name,
+		Color:                  l.Color,
+		Description:            l.Description,
+		OpenIssuesCount:        l.OpenIssuesCount,
+		OpenMergeRequestsCount: l.OpenMergeRequestsCount,
+	}
+}
+
 // pipelineToResourceOutput converts a GitLab API [gl.Pipeline] to the
 // MCP resource output format, mapping the ID, IID, status, ref, SHA,
 // web URL, and source.
@@ -1872,29 +1907,24 @@ func registerDeploymentResource(server registrar, base *gitlabclient.Client) {
 		Icons:       toolutil.IconDeploy,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/deployment/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.ParseInt(idStr, 10, 64)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		d, _, err := client.GL().Deployments.GetProjectDeployment(projectID, id, gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get deployment", err)
-		}
-		out := DeploymentResourceOutput{
-			ID:     d.ID,
-			IID:    d.IID,
-			Ref:    d.Ref,
-			SHA:    d.SHA,
-			Status: d.Status,
-		}
-		if d.Environment != nil {
-			out.Environment = d.Environment.Name
-		}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/deployment/", "failed to get deployment",
+			func(projectID string, id int64) (DeploymentResourceOutput, error) {
+				d, _, err := client.GL().Deployments.GetProjectDeployment(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return DeploymentResourceOutput{}, err
+				}
+				out := DeploymentResourceOutput{
+					ID:     d.ID,
+					IID:    d.IID,
+					Ref:    d.Ref,
+					SHA:    d.SHA,
+					Status: d.Status,
+				}
+				if d.Environment != nil {
+					out.Environment = d.Environment.Name
+				}
+				return out, nil
+			})
 	})
 }
 
@@ -1913,26 +1943,20 @@ func registerEnvironmentResource(server registrar, base *gitlabclient.Client) {
 		Icons:       toolutil.IconEnvironment,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/environment/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		env, _, err := client.GL().Environments.GetEnvironment(projectID, int64(id), gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get environment", err)
-		}
-		out := EnvironmentResourceOutput{
-			ID:    env.ID,
-			Name:  env.Name,
-			Slug:  env.Slug,
-			State: env.State,
-			Tier:  env.Tier,
-		}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/environment/", "failed to get environment",
+			func(projectID string, id int64) (EnvironmentResourceOutput, error) {
+				env, _, err := client.GL().Environments.GetEnvironment(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return EnvironmentResourceOutput{}, err
+				}
+				return EnvironmentResourceOutput{
+					ID:    env.ID,
+					Name:  env.Name,
+					Slug:  env.Slug,
+					State: env.State,
+					Tier:  env.Tier,
+				}, nil
+			})
 	})
 }
 
@@ -1950,29 +1974,23 @@ func registerJobResource(server registrar, base *gitlabclient.Client) {
 		Icons:       toolutil.IconJob,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/job/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.ParseInt(idStr, 10, 64)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		j, _, err := client.GL().Jobs.GetJob(projectID, id, gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get job", err)
-		}
-		out := JobResourceOutput{
-			ID:            j.ID,
-			Name:          j.Name,
-			Stage:         j.Stage,
-			Status:        j.Status,
-			Ref:           j.Ref,
-			Duration:      j.Duration,
-			FailureReason: j.FailureReason,
-			WebURL:        j.WebURL,
-		}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/job/", "failed to get job",
+			func(projectID string, id int64) (JobResourceOutput, error) {
+				j, _, err := client.GL().Jobs.GetJob(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return JobResourceOutput{}, err
+				}
+				return JobResourceOutput{
+					ID:            j.ID,
+					Name:          j.Name,
+					Stage:         j.Stage,
+					Status:        j.Status,
+					Ref:           j.Ref,
+					Duration:      j.Duration,
+					FailureReason: j.FailureReason,
+					WebURL:        j.WebURL,
+				}, nil
+			})
 	})
 }
 
@@ -2002,15 +2020,7 @@ func registerSnippetResource(server registrar, base *gitlabclient.Client) {
 		if err != nil {
 			return nil, wrapErr("failed to get snippet", err)
 		}
-		out := SnippetResourceOutput{
-			ID:          s.ID,
-			Title:       s.Title,
-			FileName:    s.FileName,
-			Description: s.Description,
-			Visibility:  s.Visibility,
-			WebURL:      s.WebURL,
-		}
-		return marshalResourceJSON(out)
+		return marshalResourceJSON(snippetToResourceOutput(s))
 	})
 }
 
@@ -2029,27 +2039,14 @@ func registerProjectSnippetResource(server registrar, base *gitlabclient.Client)
 		Icons:       toolutil.IconSnippet,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/snippet/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		s, _, err := client.GL().ProjectSnippets.GetSnippet(projectID, int64(id), gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get project snippet", err)
-		}
-		out := SnippetResourceOutput{
-			ID:          s.ID,
-			Title:       s.Title,
-			FileName:    s.FileName,
-			Description: s.Description,
-			Visibility:  s.Visibility,
-			WebURL:      s.WebURL,
-		}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/snippet/", "failed to get project snippet",
+			func(projectID string, id int64) (SnippetResourceOutput, error) {
+				s, _, err := client.GL().ProjectSnippets.GetSnippet(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return SnippetResourceOutput{}, err
+				}
+				return snippetToResourceOutput(s), nil
+			})
 	})
 }
 
@@ -2091,25 +2088,19 @@ func registerDeployKeyResource(server registrar, base *gitlabclient.Client) {
 		Icons:       toolutil.IconKey,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/deploy_key/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.ParseInt(idStr, 10, 64)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		k, _, err := client.GL().DeployKeys.GetDeployKey(projectID, id, gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get deploy key", err)
-		}
-		out := DeployKeyResourceOutput{
-			ID:          k.ID,
-			Title:       k.Title,
-			Key:         k.Key,
-			Fingerprint: k.Fingerprint,
-		}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/deploy_key/", "failed to get deploy key",
+			func(projectID string, id int64) (DeployKeyResourceOutput, error) {
+				k, _, err := client.GL().DeployKeys.GetDeployKey(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return DeployKeyResourceOutput{}, err
+				}
+				return DeployKeyResourceOutput{
+					ID:          k.ID,
+					Title:       k.Title,
+					Key:         k.Key,
+					Fingerprint: k.Fingerprint,
+				}, nil
+			})
 	})
 }
 
@@ -2128,20 +2119,14 @@ func registerBoardResource(server registrar, base *gitlabclient.Client) {
 		Icons:       toolutil.IconBoard,
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		client := base.For(ctx)
-		projectID, idStr := extractTwoParts(req.Params.URI, uriProjectPrefix, "/board/")
-		if projectID == "" || idStr == "" {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			return nil, mcp.ResourceNotFoundError(req.Params.URI)
-		}
-		b, _, err := client.GL().Boards.GetIssueBoard(projectID, int64(id), gl.WithContext(ctx))
-		if err != nil {
-			return nil, wrapErr("failed to get board", err)
-		}
-		out := BoardResourceOutput{ID: b.ID, Name: b.Name}
-		return marshalResourceJSON(out)
+		return readProjectIntResource(ctx, req, "/board/", "failed to get board",
+			func(projectID string, id int64) (BoardResourceOutput, error) {
+				b, _, err := client.GL().Boards.GetIssueBoard(projectID, id, gl.WithContext(ctx))
+				if err != nil {
+					return BoardResourceOutput{}, err
+				}
+				return BoardResourceOutput{ID: b.ID, Name: b.Name}, nil
+			})
 	})
 }
 
@@ -2213,14 +2198,6 @@ func registerGroupLabelResource(server registrar, base *gitlabclient.Client) {
 		if err != nil {
 			return nil, wrapErr("failed to get group label", err)
 		}
-		out := LabelResourceOutput{
-			ID:                     l.ID,
-			Name:                   l.Name,
-			Color:                  l.Color,
-			Description:            l.Description,
-			OpenIssuesCount:        l.OpenIssuesCount,
-			OpenMergeRequestsCount: l.OpenMergeRequestsCount,
-		}
-		return marshalResourceJSON(out)
+		return marshalResourceJSON(labelToResourceOutput((*gl.Label)(l)))
 	})
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2846,3 +2846,60 @@ func TestRegister_ClientBoundToContext_ReadsFromTheBoundInstance(t *testing.T) {
 		})
 	}
 }
+
+// TestPageOf_ReadsCompletenessFromTheResponse covers the _meta a collection
+// resource carries, which is the only way a reader learns that it holds part
+// of a collection rather than all of it.
+//
+// The case that matters is the third: an endpoint GitLab paginates by keyset
+// sends no X-Total, so a total of zero is silence rather than a count, and
+// completeness has to be read from NextPage instead. Taking the total as the
+// answer there would report a truncated page as the whole collection.
+func TestPageOf_ReadsCompletenessFromTheResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *gl.Response
+		want listPage
+	}{
+		{
+			name: "no response to read",
+			resp: nil,
+			want: listPage{Returned: 3, Complete: true},
+		},
+		{
+			name: "a counted collection with nothing after it",
+			resp: &gl.Response{TotalItems: 3},
+			want: listPage{Returned: 3, Total: 3, Complete: true},
+		},
+		{
+			name: "an uncounted collection with a page after it",
+			resp: &gl.Response{NextPage: 2},
+			want: listPage{Returned: 3, Complete: false},
+		},
+		{
+			name: "a counted collection with a page after it",
+			resp: &gl.Response{TotalItems: 90, NextPage: 2},
+			want: listPage{Returned: 3, Total: 90, Complete: false},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pageOf(3, tc.resp); got != tc.want {
+				t.Errorf("pageOf(3, %+v) = %+v, want %+v", tc.resp, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMarshalResourceList_UnmarshalableValue_FailsRatherThanEmitsAnEmptyList
+// pins the error path, which no resource reaches with real GitLab data and
+// which would otherwise answer a read with an empty body and no error.
+func TestMarshalResourceList_UnmarshalableValue_FailsRatherThanEmitsAnEmptyList(t *testing.T) {
+	result, err := marshalResourceList(make(chan int), listPage{Returned: 1, Complete: true})
+	if err == nil {
+		t.Fatal("marshalResourceList accepted a value encoding/json cannot marshal")
+	}
+	if result != nil {
+		t.Errorf("marshalResourceList returned %+v alongside its error, want nil", result)
+	}
+}

--- a/internal/resources/tool_manifest_test.go
+++ b/internal/resources/tool_manifest_test.go
@@ -271,12 +271,59 @@ func TestToolManifestHelpers_DefensiveBranches(t *testing.T) {
 		t.Fatalf("rewriteSeeAlso(nil resolver) = %q, want description unchanged: %q", got, withSeeAlso)
 	}
 
+	// A resolver that recognizes none of the names must drop the clause
+	// whole. Keeping it would print "See also: ." to the model, and the
+	// names were dropped precisely because this surface cannot be told to
+	// call them, so a dangling clause would be an instruction to nowhere.
+	knowsNothing := func(string) (string, bool) { return "", false }
+	if got := rewriteSeeAlso(withSeeAlso, knowsNothing); got != "Get one project." {
+		t.Fatalf("rewriteSeeAlso(unknown names) = %q, want the clause removed entirely", got)
+	}
+
 	// newSeeAlsoIndex(nil) must not panic on a nil catalog and must report
 	// "no names known" via a nil map, which is what makes rewriteSeeAlso's
 	// resolvers built on top of it drop every "See also:" reference instead
 	// of indexing a non-existent catalog.
 	if index := newSeeAlsoIndex(nil); index != nil {
 		t.Fatalf("newSeeAlsoIndex(nil) = %v, want nil", index)
+	}
+}
+
+// TestNewToolSurfaceSnapshot_SubscriptionsSection_FollowsWhatIsOffered covers
+// the manifest's subscriptions block, which is how a client discovers that
+// resources/subscribe is answered here and for which URI templates.
+//
+// The section is absent rather than empty when nothing is subscribable, which
+// is the minimal capability surface. Both directions are asserted because the
+// failure that matters is the pair coming apart: a client reading
+// "supported" and subscribing would be refused, and one reading nothing would
+// poll instead of subscribing to a server that would have told it.
+func TestNewToolSurfaceSnapshot_SubscriptionsSection_FollowsWhatIsOffered(t *testing.T) {
+	templates := []string{
+		"gitlab://project/{project_id}/issue/{issue_iid}",
+		"gitlab://project/{project_id}/pipeline/{pipeline_id}",
+	}
+	offered := newToolSurfaceSnapshot(ToolSurfaceResourceOptions{
+		Surface:                  toolSurfaceIndividual,
+		SubscribableURITemplates: templates,
+	})
+	subscriptions := offered.manifest.Subscriptions
+	if subscriptions == nil {
+		t.Fatal("no subscriptions section on a server that lists subscribable templates")
+	}
+	if !subscriptions.Supported {
+		t.Error("the section reports subscriptions unsupported while listing subscribable templates")
+	}
+	if !reflect.DeepEqual(subscriptions.SubscribableURITemplates, templates) {
+		t.Errorf("SubscribableURITemplates = %v, want %v", subscriptions.SubscribableURITemplates, templates)
+	}
+	if !strings.Contains(subscriptions.Notification, "notifications/resources/updated") {
+		t.Errorf("Notification = %q, want the notification a subscriber waits for", subscriptions.Notification)
+	}
+
+	withheld := newToolSurfaceSnapshot(ToolSurfaceResourceOptions{Surface: toolSurfaceIndividual})
+	if withheld.manifest.Subscriptions != nil {
+		t.Errorf("subscriptions advertised (%+v) by a server that offers none", withheld.manifest.Subscriptions)
 	}
 }
 

--- a/internal/telemetry/pseudonym_test.go
+++ b/internal/telemetry/pseudonym_test.go
@@ -101,7 +101,7 @@ func TestResourcePseudonym_IsKeyedNotPlain(t *testing.T) {
 
 	sum := sha256.Sum256([]byte(uri))
 
-	if got := keys.ResourcePseudonym(uri); got == hex.EncodeToString(sum[:])[:16] {
+	if keys.ResourcePseudonym(uri) == hex.EncodeToString(sum[:])[:16] {
 		t.Error("the digest equals an unkeyed hash of the URI, so it is enumerable rather than pseudonymous")
 	}
 }

--- a/internal/tools/catalog_filter_test.go
+++ b/internal/tools/catalog_filter_test.go
@@ -199,7 +199,7 @@ func TestExcludeFromCatalog_NothingToExclude_ReturnsTheSameCatalog(t *testing.T)
 	t.Parallel()
 
 	catalog := actioncatalog.NewCatalog()
-	if got := ExcludeFromCatalog(catalog, nil); got != catalog {
+	if ExcludeFromCatalog(catalog, nil) != catalog {
 		t.Error("ExcludeFromCatalog with no patterns returned a different catalog")
 	}
 }

--- a/internal/tools/workitemsavedviews/markdown_test.go
+++ b/internal/tools/workitemsavedviews/markdown_test.go
@@ -117,7 +117,7 @@ func TestFormatMutateMarkdown(t *testing.T) {
 // TestPrettyJSON_Unmarshalable verifies that a value json cannot marshal falls
 // back to its Go rendering instead of producing an empty section.
 func TestPrettyJSON_Unmarshalable(t *testing.T) {
-	if got := prettyJSON(make(chan int)); got == "" {
+	if prettyJSON(make(chan int)) == "" {
 		t.Error("prettyJSON() = empty, want a fallback rendering")
 	}
 }
@@ -132,7 +132,7 @@ func TestMarkdownFormattersRegistered(t *testing.T) {
 	}
 	for name, out := range outputs {
 		t.Run(name, func(t *testing.T) {
-			if result := toolutil.MarkdownForResult(out); result == nil {
+			if toolutil.MarkdownForResult(out) == nil {
 				t.Errorf("MarkdownForResult(%T) = nil, want a registered formatter", out)
 			}
 		})


### PR DESCRIPTION
SonarCloud reported twenty-one code smells on `main`, no bugs and no vulnerabilities. Most were noise, but clearing the noise is what keeps the next real finding visible, and two of the twenty-one named something worth acting on. This clears all of them, and takes one duplication cluster that was genuinely a copy.

Eighteen were the same rule: an `if x := f(); x == nil` whose body never reads `x`. Each call is now inlined into its condition. I checked every one against the current code first: none of the bindings existed to satisfy `golangci-lint`, so nothing was traded for anything, and where a neighbouring assertion does print the value it binds, that binding stays exactly as it was.

The one critical finding was a documentation citation repeated verbatim three times in the enum exemption table, sitting beside neighbours that are already named constants. It is `memberRoleBaseLevels` now, spelled the way every other shared reason in that table is.

`walkSteps` in the benchmark took eight parameters. Rather than shuffle the list to get under the count, I grouped the five that are fixed for the length of a series into a `seriesInput`, one level above the `stepInput` that file already had. The result and the connection list stay as parameters because they are the only things that move, which is the distinction the flat eight-argument signature hid.

Two tests in `cmd/server` had byte-identical bodies and neither asserted anything at all, both ending in `_ = err`. They were not asking different questions. `TestRunStdio_PingSucceeds` claimed to cover the startup ping, but its context is cancelled before serving begins, so it never reaches the ping; the question its name asks is already answered deterministically by `TestPrepareStdioCatalog_ResolvesWhatStartupNeedsBeforeOpeningTheGate`, which asserts the connection is verified, the readiness gate opens, the tier is detected and the identity is published. I removed it and gave the survivor the assertion its name always promised: that stdio returns, and returns nil, when its context is already cancelled. That second half matters because a cancelled context is how a signal arrives, and `serveStdio` maps it to a clean return precisely so an operator's own shutdown does not exit nonzero.

I did not take the coverage question on trust. Comparing the two coverage profiles block by block, before and after the deletion, not one block that was covered stops being covered.

The remaining finding was the prompt registration interface. It has one method, so Go names it for that method, and it is `promptAdder` now. The concrete types satisfying it keep their names, because they are registrars and adding prompts is what they can do; the sibling interface in `internal/resources` keeps the plain name because it carries two methods and so has no single method to be named after.

On duplication, the resource layer was the one place worth changing, and the evidence there is not a resemblance. `internal/resources/resources.go` already has `readProjectIntResource`, already used by the pipeline and issue resources, and six further handlers reimplemented its body inline. That is one abstraction with six call sites that never adopted it, and the URI parsing and not-found semantics it owns were six copies waiting to disagree with each other. Job, deployment, deploy key, environment, board and project snippet now go through it.

Alongside them, snippets and labels get the field-mapping converters this file already uses for pipelines and issues. Both snippet endpoints answer with the same client-go type, and client-go declares `GroupLabel` as a defined type over `Label`, so in each case one converter is correct by construction rather than by two struct literals happening to agree. The merge request notes and discussions handlers now share the URI preamble, which was the only thing they ever agreed on.

Everything else SonarCloud counts stays, and I think the reasons are worth recording rather than just the decision. The benchmark figures at 24.3% are two translation bundles, English and Spanish, identical in shape because a label struct has one field set; the source already records that judgement in a `nolint:dupl` comment, and interleaving the two languages field by field would cost a proofreader the ability to read either one as continuous prose. The handler preambles in the epic packages look alike because 621 handlers across 109 files open exactly that way, so it is house style rather than copy-paste, and extracting it in two packages would make those two the odd ones out. The deploy key formatters mirror two distinct GitLab endpoints, with distinct Go types and genuinely divergent columns.

`internal/resources` is at 100% statement coverage, which meant covering four things I had not written: how a list resource decides whether it holds the whole collection, what happens when a value cannot be marshalled, the subscriptions section of the tool manifest, and the see-also clause whose names are all unknown to the surface. The subscriptions section had no test at all, and it is what tells a client whether to subscribe or to poll.

Two things I found while reading and deliberately did not fix here, because both change rendered output and this branch is meant to change none.

`internal/tools/runners/markdown.go` registers `FormatAuthTokenMarkdown` and `FormatRegTokenMarkdown` for the same Go type, `AuthTokenOutput`. `RegisterMarkdown` keys a `sync.Map` by `reflect.TypeOf`, and `Store` overwrites, so the second registration wins and the first is unreachable through the registry. The effect is that a runner authentication token is rendered under the heading "Runner Registration Token", naming the wrong kind of credential. I will open an issue.

`internal/tools/integrations/markdown.go` has already drifted in the way duplication drifts: `formatIntegrationItemString` gained a `fallback(i.Title, i.Slug)` for the heading and the inline copy in `formatGetMarkdownString` did not, so an integration with no title renders a heading with nothing after the colon. That one is a one-line fix, but it is a behaviour change, so it belongs in its own commit.

Gates run: `go build ./...`; `go test` on every touched package plus `internal/subscriptions` and the `audit_1to1` tree; `go test -race` on `internal/resources`, `internal/prompts` and the restructured `cmd/server` tests; `golangci-lint` on every touched package; `make check-test-subtests`, `make check-test-goroutines` and `make check-test-file-names`; `go run ./cmd/gen_stats/` and `go run ./cmd/gen_testing_docs/ --skip-coverage` with the regenerated files committed; `go run ./cmd/format_md_tables/ --check` and markdownlint on the two regenerated pages. `go run ./cmd/bench_resources/ -check` passes, which is the byte comparison of every committed SVG and generated table against a fresh render, so nothing the charts draw moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated repository and testing statistics to reflect current source, test, and coverage metrics.

- **Tests**
  - Expanded coverage for resource pagination, completeness metadata, and serialization error handling.
  - Added validation for subscription details in the tool manifest.
  - Improved coverage for handling unresolved “See also” references.
  - Strengthened server and resource test assertions without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->