### PR TITLE
test(e2e): assert what a mutation did, not only that it returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,181 |     243,591 |
 | Unit tests (`_test.go`)  |       683 |     401,315 |
-| End-to-end tests         |       243 |      64,335 |
-| **Total**                | **2,107** | **709,241** |
+| End-to-end tests         |       244 |      66,041 |
+| **Total**                | **2,108** | **710,947** |
 
 ### Functions
 
@@ -480,7 +480,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | . Exported (public)             |  2,905 |
 | . Unexported (private)          |  6,152 |
 | Unit test functions (`TestXxx`) | 13,883 |
-| Subtests (`t.Run(...)`)         |  5,442 |
+| Subtests (`t.Run(...)`)         |  5,445 |
 | End-to-end test functions       |    602 |
 
 ### Ratios worth noting
@@ -497,7 +497,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,550 |
+| `if err != nil` checks             | 7,551 |
 | `defer` statements                 | 1,316 |
 | `struct` types defined             | 3,008 |
 | `//nolint` suppressions            |   316 |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -24,7 +24,7 @@
 | cmd test functions                                    |  2,617 |
 | Test files (internal/)                                |    515 |
 | Test files (cmd/)                                     |    168 |
-| Test files (test/e2e/)                                |    237 |
+| Test files (test/e2e/)                                |    238 |
 | Tool sub-packages tested                              |    177 |
 | Core packages tested                                  |     22 |
 | Overall coverage (`go test ./internal/... ./cmd/...`) |  98.3% |
@@ -48,9 +48,9 @@
 | Core packages           |          2,376 |        141 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          8,558 |        359 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            602 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| E2E integration         |            602 |        238 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,617 |        168 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,485** |    **920** |                                                                                                 |
+| **Total**               |     **14,485** |    **921** |                                                                                                 |
 
 ### Core Packages
 
@@ -67,7 +67,7 @@
 | elicitation   |       129 |    98.3% | Package elicitation provides a Client for requesting structured user input via the MCP elicitation protocol.                                                                                                                                                       |
 | gatewaycompat |        19 |    99.4% | Package gatewaycompat rewrites the human-readable text this server lists — tool, prompt, resource and resource-template descriptions and titles, and the description and title annotations embedded in tool schemas — according to operator-defined substitutions. |
 | gitlab        |        86 |   100.0% | Package gitlab provides a wrapper around the GitLab REST API v4 client.                                                                                                                                                                                            |
-| graphqlschema |        20 |   100.0% | Package graphqlschema holds the pinned GitLab GraphQL schema and validates documents against it.                                                                                                                                                                   |
+| graphqlschema |        20 |      n/a | Package graphqlschema holds the pinned GitLab GraphQL schema and validates documents against it.                                                                                                                                                                   |
 | mcpotel       |        76 |    99.0% | Package mcpotel instruments MCP request handling with OpenTelemetry.                                                                                                                                                                                               |
 | oauth         |        78 |   100.0% | Package oauth provides GitLab-specific OAuth 2.0 support for HTTP mode.                                                                                                                                                                                            |
 | progress      |        17 |    83.8% | Package progress provides a Tracker for sending MCP progress notifications to the client during long-running tool operations.                                                                                                                                      |
@@ -76,7 +76,7 @@
 | serverpool    |       116 |   100.0% | Package serverpool manages a pool of credential entries keyed by GitLab token and URL.                                                                                                                                                                             |
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
-| testutil      |        49 |    91.7% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
+| testutil      |        49 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
 | toolutil      |       864 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
 | **Subtotal**  | **2,376** |          |                                                                                                                                                                                                                                                                    |
 
@@ -172,7 +172,7 @@
 | events                  |        52 |          2 |   100.0% |         2 |
 | externalstatuschecks    |        51 |          3 |   100.0% |         8 |
 | featureflags            |        44 |          2 |   100.0% |         5 |
-| features                |        23 |          2 |    98.0% |         4 |
+| features                |        23 |          2 |    97.8% |         4 |
 | ffuserlists             |        33 |          2 |   100.0% |         5 |
 | files                   |        83 |          2 |   100.0% |         8 |
 | freezeperiods           |        36 |          2 |   100.0% |         5 |
@@ -235,7 +235,7 @@
 | mrdiscussions           |        58 |          1 |   100.0% |         7 |
 | mrdraftnotes            |        71 |          2 |   100.0% |         7 |
 | mrnotes                 |        49 |          2 |   100.0% |         5 |
-| namespaces              |        37 |          1 |    99.3% |         4 |
+| namespaces              |        37 |          1 |    99.2% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
 | packages                |       131 |          6 |    99.0% |         9 |
@@ -246,7 +246,7 @@
 | planlimits              |        13 |          2 |   100.0% |         2 |
 | projectaliases          |        26 |          2 |   100.0% |         4 |
 | projectdiscovery        |        19 |          1 |   100.0% |         1 |
-| projectimportexport     |        40 |          1 |    99.6% |         5 |
+| projectimportexport     |        40 |          1 |    99.5% |         5 |
 | projectiterations       |        18 |          1 |   100.0% |         1 |
 | projectmirrors          |        63 |          2 |   100.0% |         7 |
 | projects                |       392 |          6 |   100.0% |        57 |
@@ -320,9 +320,9 @@
 | cmd/audit_e2e_gaps                             |    92.9% |
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    88.2% |
-| cmd/audit_graphql_documents                    |    94.7% |
+| cmd/audit_graphql_documents                    |      n/a |
 | cmd/audit_install_buttons                      |    84.2% |
-| cmd/audit_md_escaping                          |   100.0% |
+| cmd/audit_md_escaping                          |      n/a |
 | cmd/audit_metrics                              |    97.8% |
 | cmd/audit_readonly_graphql                     |    90.8% |
 | cmd/audit_string_dupes                         |    92.1% |
@@ -341,7 +341,7 @@
 | cmd/gen_action_catalog_manifest                |    66.7% |
 | cmd/gen_brand                                  |    87.1% |
 | cmd/gen_docker_tools                           |    95.9% |
-| cmd/gen_graphql_schema                         |    95.5% |
+| cmd/gen_graphql_schema                         |      n/a |
 | cmd/gen_icon_webp                              |    92.3% |
 | cmd/gen_lhm_manifest                           |    89.4% |
 | cmd/gen_llms                                   |    98.9% |
@@ -369,7 +369,7 @@
 | elicitation   |    98.3% |
 | gatewaycompat |    99.4% |
 | gitlab        |   100.0% |
-| graphqlschema |   100.0% |
+| graphqlschema |      n/a |
 | mcpotel       |    99.0% |
 | oauth         |   100.0% |
 | progress      |    83.8% |
@@ -378,7 +378,7 @@
 | serverpool    |   100.0% |
 | subscriptions |    98.5% |
 | telemetry     |    93.1% |
-| testutil      |    91.7% |
+| testutil      |    89.6% |
 | toolutil      |    98.6% |
 
 ### Tool Sub-Packages
@@ -441,7 +441,7 @@
 | events                  |   100.0% |
 | externalstatuschecks    |   100.0% |
 | featureflags            |   100.0% |
-| features                |    98.0% |
+| features                |    97.8% |
 | ffuserlists             |   100.0% |
 | files                   |   100.0% |
 | freezeperiods           |   100.0% |
@@ -504,7 +504,7 @@
 | mrdiscussions           |   100.0% |
 | mrdraftnotes            |   100.0% |
 | mrnotes                 |   100.0% |
-| namespaces              |    99.3% |
+| namespaces              |    99.2% |
 | notifications           |   100.0% |
 | orbit                   |   100.0% |
 | packages                |    99.0% |
@@ -515,7 +515,7 @@
 | planlimits              |   100.0% |
 | projectaliases          |   100.0% |
 | projectdiscovery        |   100.0% |
-| projectimportexport     |    99.6% |
+| projectimportexport     |    99.5% |
 | projectiterations       |   100.0% |
 | projectmirrors          |   100.0% |
 | projects                |   100.0% |
@@ -577,6 +577,7 @@ Coverage target: **>90%** per package. Packages below the target in the latest g
 - **cmd/eval_mcp_surfaces/internal/evalrun** (88.9%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/audit_test_names** (89.3%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
 - **cmd/gen_lhm_manifest** (89.4%) - developer command formatting and reporting branches are covered by focused unit tests plus manual/CI tooling runs.
+- **testutil** (89.6%) - some helpers are exercised by external packages or the build-tagged E2E suite rather than this package's own tests.
 
 <!-- END TESTING STATS -->
 

--- a/test/e2e/suite/access_extras2_ce_test.go
+++ b/test/e2e/suite/access_extras2_ce_test.go
@@ -172,6 +172,9 @@ func TestIndividual_AccessRequests(t *testing.T) {
 				UserID:    userDeny.ID,
 			})
 			requireNoError(t, err, "deny project access request")
+			requireNotListedOn(ctx, t, sess.individual, "project access requests after deny", "gitlab_access_request_list_project",
+				accessrequests.ListProjectInput{ProjectID: proj.pidOf()},
+				accessRequestUserIDs, userDeny.ID)
 			t.Logf("Denied project access for user %d", userDeny.ID)
 		})
 
@@ -192,6 +195,9 @@ func TestIndividual_AccessRequests(t *testing.T) {
 				UserID:  userDeny.ID,
 			})
 			requireNoError(t, err, "deny group access request")
+			requireNotListedOn(ctx, t, sess.individual, "group access requests after deny", "gitlab_access_request_list_group",
+				accessrequests.ListGroupInput{GroupID: groupID},
+				accessRequestUserIDs, userDeny.ID)
 			t.Logf("Denied group access for user %d", userDeny.ID)
 		})
 	})
@@ -248,6 +254,11 @@ func TestIndividual_PersonalAccessTokenAdminOps(t *testing.T) {
 				TokenID: latestTokenID,
 			})
 			requireNoError(t, err, "revoke personal access token")
+			// A revoked token stays listed under the default state filter, so the
+			// active listing is what observes the revocation.
+			requireNotListedOn(ctx, t, sess.individual, "active personal access tokens after revoke", "gitlab_personal_access_token_list",
+				accesstokens.PersonalListInput{UserID: user.ID, State: "active"},
+				personalAccessTokenIDs, latestTokenID)
 			t.Logf("Revoked PAT %d", latestTokenID)
 		})
 	})
@@ -280,7 +291,10 @@ func TestIndividual_PersonalAccessTokenSelfOps(t *testing.T) {
 		user := accessExtrasCreateUser(ctx, t, "pat-self")
 		pat := accessExtrasCreatePAT(ctx, t, user.ID, "pat-self")
 
-		var rotatedToken string
+		var (
+			rotatedToken   string
+			rotatedTokenID int64
+		)
 		t.Run("RotateSelf", func(t *testing.T) {
 			//nolint:contextcheck // The extra MCP session outlives this call context; its lifetime is bound to t.Cleanup.
 			selfSession := accessExtrasStartSession(t, "pat-self", pat.Token)
@@ -288,6 +302,7 @@ func TestIndividual_PersonalAccessTokenSelfOps(t *testing.T) {
 			requireNoError(t, err, "self-rotate personal access token")
 			requireTruef(t, out.Token != "", "expected self-rotated token value")
 			rotatedToken = out.Token
+			rotatedTokenID = out.ID
 			t.Logf("Self-rotated PAT %d → %d", pat.ID, out.ID)
 		})
 
@@ -297,6 +312,11 @@ func TestIndividual_PersonalAccessTokenSelfOps(t *testing.T) {
 			revokeSession := accessExtrasStartSession(t, "pat-self-revoke", rotatedToken)
 			err := callToolVoidOn(ctx, revokeSession, "gitlab_personal_access_token_revoke_self", accesstokens.PersonalRevokeSelfInput{})
 			requireNoError(t, err, "self-revoke personal access token")
+			// The revoked credential can no longer read anything, so the admin
+			// session is where the effect is observable.
+			requireNotListedOn(ctx, t, sess.individual, "active personal access tokens after self-revoke", "gitlab_personal_access_token_list",
+				accesstokens.PersonalListInput{UserID: user.ID, State: "active"},
+				personalAccessTokenIDs, rotatedTokenID)
 			t.Log("Self-revoked rotated PAT")
 		})
 	})

--- a/test/e2e/suite/access_extras_ce_test.go
+++ b/test/e2e/suite/access_extras_ce_test.go
@@ -134,6 +134,9 @@ func TestIndividual_GroupDeployTokens(t *testing.T) {
 			DeployTokenID: tokenID,
 		})
 		requireNoError(t, err, "delete group deploy token")
+		requireNotListedOn(ctx, t, sess.individual, "group deploy tokens after delete", "gitlab_deploy_token_list_group",
+			deploytokens.ListGroupInput{GroupID: groupID},
+			deployTokenIDs, tokenID)
 		t.Logf("Deleted group deploy token %d", tokenID)
 	})
 }

--- a/test/e2e/suite/access_meta_ce_test.go
+++ b/test/e2e/suite/access_meta_ce_test.go
@@ -11,6 +11,7 @@ package suite
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -305,6 +306,11 @@ func TestMeta_DeployKeysExtended(t *testing.T) {
 			"params": map[string]any{"user_id": sess.username},
 		})
 		requireNoError(t, err, "deploy_key_list_user_project")
+		// The key this test created is enabled on two projects the same account
+		// owns, which is exactly what this listing reports.
+		requireTruef(t, slices.ContainsFunc(out.DeployKeys, func(k deploykeys.Output) bool {
+			return k.ID == keyID
+		}), "deploy key %d is not among the account's project deploy keys: %+v", keyID, out.DeployKeys)
 		t.Logf("User project deploy keys: %d", len(out.DeployKeys))
 	})
 }
@@ -380,6 +386,17 @@ func TestMeta_Invitations(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "invite_project")
+		requireTruef(t, out.Status == "success", "invite status = %q (message %v), want %q", out.Status, out.Message, "success")
+		requireListedOn(ctx, t, sess.meta, "project invitations after invite", "gitlab_access", map[string]any{
+			"action": "invite_list_project",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(list invites.ListPendingInvitationsOutput) []string {
+			emails := make([]string, 0, len(list.Invitations))
+			for _, inv := range list.Invitations {
+				emails = append(emails, inv.InviteEmail)
+			}
+			return emails
+		}, email)
 		t.Logf("Invite result: status=%s", out.Status)
 	})
 }

--- a/test/e2e/suite/admin_meta_ce_test.go
+++ b/test/e2e/suite/admin_meta_ce_test.go
@@ -145,6 +145,7 @@ func TestMeta_AdminSettingsAppearance(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "appearance_update")
+			requireTruef(t, out.Appearance.Title == "E2E GitLab", "appearance title = %q, want %q", out.Appearance.Title, "E2E GitLab")
 			t.Logf("Updated appearance: title=%s", out.Appearance.Title)
 		})
 	})
@@ -261,6 +262,9 @@ func TestMeta_AdminFeatures(t *testing.T) {
 				"params": map[string]any{},
 			})
 			requireNoError(t, err, "feature_list_definitions")
+			// Feature flag definitions ship with GitLab, so an empty list means
+			// the read did not reach them rather than that there are none.
+			requireTruef(t, len(out.Definitions) > 0, "instance reports no feature flag definitions at all")
 			t.Logf("Feature definitions: %d", len(out.Definitions))
 		})
 
@@ -562,6 +566,8 @@ func TestMeta_AdminCustomAttributes(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "custom_attr_set")
+			requireTruef(t, out.Key == attrKey, "custom attribute key = %q, want %q", out.Key, attrKey)
+			requireTruef(t, out.Value == "test-value", "custom attribute value = %q, want %q", out.Value, "test-value")
 			t.Logf("Set custom attr: key=%s", out.Key)
 		})
 		defer func() {
@@ -585,6 +591,8 @@ func TestMeta_AdminCustomAttributes(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "custom_attr_get")
+			requireTruef(t, out.Key == attrKey, "custom attribute key = %q, want %q", out.Key, attrKey)
+			requireTruef(t, out.Value == "test-value", "read-back custom attribute value = %q, want the %q just set", out.Value, "test-value")
 			t.Logf("Got custom attr: key=%s value=%s", out.Key, out.Value)
 		})
 

--- a/test/e2e/suite/assert_helpers_test.go
+++ b/test/e2e/suite/assert_helpers_test.go
@@ -1,0 +1,354 @@
+//go:build e2e
+
+// assert_helpers_test.go holds the collection-membership assertions the domain
+// suites use to observe what a mutation actually did, rather than only that it
+// returned without an error.
+//
+// Build tag: e2e.
+package suite
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/accessrequests"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/accesstokens"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/awardemoji"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/badges"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/clusteragents"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/customemoji"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/deploytokens"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/groupboards"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/groupmarkdownuploads"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/groups"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/integrations"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/labels"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrdraftnotes"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/projects"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/resourceevents"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/usergpgkeys"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/users"
+)
+
+// membershipWait bounds how long a membership assertion re-reads a collection
+// before giving up. GitLab applies the mutations these assertions follow
+// synchronously, so the budget exists only to absorb the replication lag an
+// ephemeral instance under parallel load occasionally shows; a correct server
+// must not be failed over timing.
+const membershipWait = 20 * time.Second
+
+// membershipPollInterval is how often a membership assertion re-reads while it
+// waits for that lag to clear.
+const membershipPollInterval = 500 * time.Millisecond
+
+// The time-tracking suites send human durations ("2h", "30m") and GitLab
+// answers in seconds, so the assertions name both halves once here.
+const (
+	oneHourSeconds       = 60 * 60
+	twoHoursSeconds      = 2 * 60 * 60
+	threeHoursSeconds    = 3 * 60 * 60
+	thirtyMinutesSeconds = 30 * 60
+)
+
+// requireListedOn re-reads a collection through the named tool and fails unless
+// want is among the identifiers it reports.
+//
+// It exists because a mutation that answered without an error has not
+// necessarily had an effect: a handler that turns a request GitLab refused into
+// an empty result satisfies requireNoError and changes nothing, and only
+// reading the collection back tells the two apart.
+func requireListedOn[O any, K comparable](ctx context.Context, t *testing.T, session *mcp.ClientSession, label, tool string, input any, ids func(O) []K, want K) {
+	t.Helper()
+	requireMembership(ctx, t, session, label, tool, input, ids, want, true)
+}
+
+// requireNotListedOn is the counterpart of [requireListedOn] for a removal: it
+// fails while want is still among the identifiers the collection reports.
+func requireNotListedOn[O any, K comparable](ctx context.Context, t *testing.T, session *mcp.ClientSession, label, tool string, input any, ids func(O) []K, want K) {
+	t.Helper()
+	requireMembership(ctx, t, session, label, tool, input, ids, want, false)
+}
+
+// requireMembership polls the named list tool until want's presence among the
+// identifiers matches present, and fails the test with the last observed
+// collection when it never does.
+//
+// A failed re-read is retried rather than raised, because the budget exists to
+// absorb exactly this: a rate limit or a 5xx from an ephemeral instance under
+// parallel load says nothing about the mutation, and giving up on the first one
+// would fail the test for a reason that is not the code. The last error is kept
+// so a re-read that never recovers is still reported as itself.
+func requireMembership[O any, K comparable](ctx context.Context, t *testing.T, session *mcp.ClientSession, label, tool string, input any, ids func(O) []K, want K, present bool) {
+	t.Helper()
+	var (
+		last    []K
+		callErr error
+	)
+	pollErr := Poll(ctx, membershipPollInterval, membershipWait, func() (bool, string, error) {
+		out, err := callToolOn[O](ctx, session, tool, input)
+		if err != nil {
+			callErr = err
+			return false, fmt.Sprintf("re-read failed: %v", err), nil
+		}
+		callErr = nil
+		last = ids(out)
+		return slices.Contains(last, want) == present, fmt.Sprintf("%v", last), nil
+	})
+	switch {
+	case pollErr == nil:
+		return
+	case callErr != nil:
+		t.Fatalf("%s: re-reading the collection still failed after %s: %v", label, membershipWait, callErr)
+	case present:
+		t.Fatalf("%s: %v is not listed after the mutation; collection holds %v", label, want, last)
+	default:
+		t.Fatalf("%s: %v is still listed after the mutation; collection holds %v", label, want, last)
+	}
+}
+
+// requireGoneOn re-reads a single object through the named tool and fails while
+// that read still succeeds. It is the counterpart of [requireNotListedOn] for a
+// delete whose collection has no list action worth calling, and it insists the
+// read fail as a not-found: any other error means the re-read itself broke,
+// which proves nothing about the delete. Such an error is retried for the same
+// budget as a membership assertion, since a rate limit or a 5xx from a loaded
+// instance is not the answer being waited for either.
+func requireGoneOn(ctx context.Context, t *testing.T, session *mcp.ClientSession, label, tool string, input any) {
+	t.Helper()
+	var lastErr error
+	pollErr := Poll(ctx, membershipPollInterval, membershipWait, func() (bool, string, error) {
+		_, err := callToolWithRetry(ctx, session, tool, input)
+		lastErr = err
+		switch {
+		case err == nil:
+			return false, "the object is still readable", nil
+		case isNotFoundError(err):
+			return true, "not found", nil
+		default:
+			return false, fmt.Sprintf("re-read failed: %v", err), nil
+		}
+	})
+	switch {
+	case pollErr == nil:
+		return
+	case lastErr == nil:
+		t.Fatalf("%s: the object is still readable after the delete", label)
+	default:
+		t.Fatalf("%s: the re-read still failed with something other than a not-found after %s: %v", label, membershipWait, lastErr)
+	}
+}
+
+// isNotFoundError reports whether err is GitLab saying the object is not there,
+// either as an HTTP 404 or as one of the informational not-found results the
+// get handlers return in its place.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isHTTPStatus(err, http.StatusNotFound) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "doesn't exist") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "no longer exists")
+}
+
+// awardEmojiIDs maps an award emoji listing to the award IDs it holds. Every
+// award emoji surface answers with the same list shape, so the delete
+// assertions across the issue, note and merge request suites share it.
+func awardEmojiIDs(out awardemoji.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.AwardEmoji))
+	for _, e := range out.AwardEmoji {
+		ids = append(ids, e.ID)
+	}
+	return ids
+}
+
+// accessRequestUserIDs maps an access request listing to the user IDs that are
+// still waiting. An access request is keyed by its requester, so the user ID is
+// what an approval or a denial removes from the list.
+func accessRequestUserIDs(out accessrequests.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.AccessRequests))
+	for _, r := range out.AccessRequests {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// personalAccessTokenIDs maps a personal access token listing to the token IDs
+// it holds.
+func personalAccessTokenIDs(out accesstokens.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Tokens))
+	for _, tok := range out.Tokens {
+		ids = append(ids, tok.ID)
+	}
+	return ids
+}
+
+// projectBadgeIDs maps a project badge listing to the badge IDs it holds.
+func projectBadgeIDs(out badges.ListProjectOutput) []int64 {
+	ids := make([]int64, 0, len(out.Badges))
+	for _, b := range out.Badges {
+		ids = append(ids, b.ID)
+	}
+	return ids
+}
+
+// clusterAgentIDs maps a cluster agent listing to the agent IDs it holds.
+func clusterAgentIDs(out clusteragents.ListAgentsOutput) []int64 {
+	ids := make([]int64, 0, len(out.Agents))
+	for _, a := range out.Agents {
+		ids = append(ids, a.ID)
+	}
+	return ids
+}
+
+// customEmojiIDs maps a custom emoji listing to the emoji GIDs it holds.
+func customEmojiIDs(out customemoji.ListOutput) []string {
+	ids := make([]string, 0, len(out.Emoji))
+	for _, e := range out.Emoji {
+		ids = append(ids, e.ID)
+	}
+	return ids
+}
+
+// groupUploadIDs maps a group markdown upload listing to the upload IDs it
+// holds.
+func groupUploadIDs(out groupmarkdownuploads.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Uploads))
+	for _, u := range out.Uploads {
+		ids = append(ids, u.ID)
+	}
+	return ids
+}
+
+// labelEventNames maps a label event listing to the label names its events
+// carry, skipping any event GitLab returned without one.
+func labelEventNames(out resourceevents.ListLabelEventsOutput) []string {
+	names := make([]string, 0, len(out.Events))
+	for _, e := range out.Events {
+		if e.Label != nil {
+			names = append(names, e.Label.Name)
+		}
+	}
+	return names
+}
+
+// milestoneEventTitles maps a milestone event listing to the milestone titles
+// its events carry, skipping any event GitLab returned without one.
+func milestoneEventTitles(out resourceevents.ListMilestoneEventsOutput) []string {
+	titles := make([]string, 0, len(out.Events))
+	for _, e := range out.Events {
+		if e.Milestone != nil {
+			titles = append(titles, e.Milestone.Title)
+		}
+	}
+	return titles
+}
+
+// groupBoardIDs maps a group issue board listing to the board IDs it holds.
+func groupBoardIDs(out groupboards.ListGroupBoardsOutput) []int64 {
+	ids := make([]int64, 0, len(out.Boards))
+	for _, b := range out.Boards {
+		ids = append(ids, b.ID)
+	}
+	return ids
+}
+
+// groupMemberIDs maps a group member listing to the user IDs it holds.
+func groupMemberIDs(out groups.MemberListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Members))
+	for _, m := range out.Members {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
+// sharedWithGroupIDs maps a group to the IDs of the groups it is shared with.
+// A share and an unshare are both observable there.
+func sharedWithGroupIDs(out groups.Output) []int64 {
+	ids := make([]int64, 0, len(out.SharedWithGroups))
+	for _, s := range out.SharedWithGroups {
+		ids = append(ids, s.GroupID)
+	}
+	return ids
+}
+
+// projectLabelIDs maps a project label listing to the label IDs it holds.
+func projectLabelIDs(out labels.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Labels))
+	for _, l := range out.Labels {
+		ids = append(ids, l.ID)
+	}
+	return ids
+}
+
+// draftNoteIDs maps a merge request draft note listing to the note IDs it
+// holds.
+func draftNoteIDs(out mrdraftnotes.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.DraftNotes))
+	for _, n := range out.DraftNotes {
+		ids = append(ids, n.ID)
+	}
+	return ids
+}
+
+// integrationSlugs maps a project integration listing to the slugs it holds.
+// GitLab lists only active integrations, so a deleted one leaves the list.
+func integrationSlugs(out integrations.ListOutput) []string {
+	slugs := make([]string, 0, len(out.Integrations))
+	for _, i := range out.Integrations {
+		slugs = append(slugs, i.Slug)
+	}
+	return slugs
+}
+
+// deployTokenIDs maps a deploy token listing to the token IDs it holds. The
+// project-scoped and group-scoped listings share the shape.
+func deployTokenIDs(out deploytokens.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.DeployTokens))
+	for _, tok := range out.DeployTokens {
+		ids = append(ids, tok.ID)
+	}
+	return ids
+}
+
+// gpgKeyIDs maps a GPG key listing to the key IDs it holds. The account-scoped
+// and admin user-scoped listings share the shape.
+func gpgKeyIDs(out usergpgkeys.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Keys))
+	for _, k := range out.Keys {
+		ids = append(ids, k.ID)
+	}
+	return ids
+}
+
+// sshKeyIDs maps an SSH key listing to the key IDs it holds. The account-scoped
+// and admin user-scoped listings share the shape.
+func sshKeyIDs(out users.SSHKeyListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Keys))
+	for _, k := range out.Keys {
+		ids = append(ids, k.ID)
+	}
+	return ids
+}
+
+// hookCustomHeaderKeys maps a project webhook to the custom header keys it
+// carries. GitLab masks each header's value on read, so the key is the only
+// part of a header a read can observe.
+func hookCustomHeaderKeys(out projects.HookOutput) []string {
+	keys := make([]string, 0, len(out.CustomHeaders))
+	for _, h := range out.CustomHeaders {
+		keys = append(keys, h.Key)
+	}
+	return keys
+}

--- a/test/e2e/suite/badges_ce_test.go
+++ b/test/e2e/suite/badges_ce_test.go
@@ -88,6 +88,9 @@ func TestIndividual_Badges(t *testing.T) {
 			BadgeID:   badgeID,
 		})
 		requireNoError(t, err, "delete badge")
+		requireNotListedOn(ctx, t, sess.individual, "project badges after delete", "gitlab_list_project_badges",
+			badges.ListProjectInput{ProjectID: proj.pidOf()},
+			projectBadgeIDs, badgeID)
 		t.Log("Deleted badge")
 	})
 }
@@ -162,6 +165,10 @@ func TestMeta_Badges(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "badge_id": badgeID},
 		})
 		requireNoError(t, err, "meta delete badge")
+		requireNotListedOn(ctx, t, sess.meta, "project badges after delete", "gitlab_project", map[string]any{
+			"action": "badge_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, projectBadgeIDs, badgeID)
 		t.Log("Deleted badge via meta-tool")
 	})
 }

--- a/test/e2e/suite/boards_ce_test.go
+++ b/test/e2e/suite/boards_ce_test.go
@@ -83,6 +83,16 @@ func TestMeta_Boards(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "board delete")
+		requireNotListedOn(ctx, t, sess.meta, "project boards after delete", "gitlab_project", map[string]any{
+			"action": "board_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out boards.ListBoardsOutput) []int64 {
+			ids := make([]int64, 0, len(out.Boards))
+			for _, b := range out.Boards {
+				ids = append(ids, b.ID)
+			}
+			return ids
+		}, boardID)
 		t.Logf("Deleted board %d", boardID)
 	})
 }

--- a/test/e2e/suite/branches_ce_test.go
+++ b/test/e2e/suite/branches_ce_test.go
@@ -154,6 +154,8 @@ func TestIndividual_Branches(t *testing.T) {
 			BranchName: featureBranch,
 		})
 		requireNoError(t, err, "delete branch")
+		requireGoneOn(ctx, t, sess.individual, "branch "+featureBranch+" after delete", "gitlab_branch_get",
+			branches.GetInput{ProjectID: proj.pidOf(), BranchName: featureBranch})
 		t.Logf("Deleted branch %s", featureBranch)
 	})
 }
@@ -361,6 +363,13 @@ func TestMeta_Branches(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta branch delete")
+		requireGoneOn(ctx, t, sess.meta, "branch "+featureBranch+" after delete", "gitlab_branch", map[string]any{
+			"action": "get",
+			"params": map[string]any{
+				"project_id":  proj.pidStr(),
+				"branch_name": featureBranch,
+			},
+		})
 		t.Logf("Deleted branch %s", featureBranch)
 	})
 }

--- a/test/e2e/suite/ci_runner_ce_test.go
+++ b/test/e2e/suite/ci_runner_ce_test.go
@@ -132,6 +132,9 @@ func TestIndividual_CIRunner(t *testing.T) {
 				PipelineID: pipelineID,
 			})
 			requireNoError(t, err, "pipeline retry")
+			// A retry re-runs the failed jobs of the same pipeline rather than
+			// creating a new one.
+			requireTruef(t, out.ID == pipelineID, "retry answered for pipeline %d, want %d", out.ID, pipelineID)
 			t.Logf("Retried pipeline: ID=%d status=%s", out.ID, out.Status)
 
 			waitForPipeline(ctx, t, sess.glClient, proj.ID, pipelineID, 900*time.Second)

--- a/test/e2e/suite/ci_variables_ce_test.go
+++ b/test/e2e/suite/ci_variables_ce_test.go
@@ -87,6 +87,8 @@ func TestIndividual_CIVariables(t *testing.T) {
 			Key:       varKey,
 		})
 		requireNoError(t, err, "delete CI variable")
+		requireGoneOn(ctx, t, sess.individual, "CI variable "+varKey+" after delete", "gitlab_ci_variable_get",
+			civariables.GetInput{ProjectID: proj.pidOf(), Key: varKey})
 		t.Log("Deleted CI variable")
 	})
 }
@@ -160,6 +162,10 @@ func TestMeta_CIVariables(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "key": varKey},
 		})
 		requireNoError(t, err, "meta delete CI variable")
+		requireGoneOn(ctx, t, sess.meta, "CI variable "+varKey+" after delete", "gitlab_ci_variable", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "key": varKey},
+		})
 		t.Log("Deleted CI variable via meta-tool")
 	})
 }

--- a/test/e2e/suite/cluster_agents_ce_test.go
+++ b/test/e2e/suite/cluster_agents_ce_test.go
@@ -115,6 +115,15 @@ func TestIndividual_ClusterAgents(t *testing.T) {
 			TokenID:   tokenID,
 		})
 		requireNoError(t, err, "revoke agent token")
+		// A revoked token is gone rather than readable with a revoked status:
+		// GitLab 19.3 answers the re-read with 404, which I checked against a
+		// live instance after this test asserted the status and failed.
+		requireGoneOn(ctx, t, sess.individual, "revoked agent token", "gitlab_get_cluster_agent_token",
+			clusteragents.GetAgentTokenInput{
+				ProjectID: proj.pidOf(),
+				AgentID:   agentID,
+				TokenID:   tokenID,
+			})
 		t.Logf("Revoked agent token %d", tokenID)
 	})
 
@@ -125,6 +134,9 @@ func TestIndividual_ClusterAgents(t *testing.T) {
 			AgentID:   agentID,
 		})
 		requireNoError(t, err, "delete cluster agent")
+		requireNotListedOn(ctx, t, sess.individual, "cluster agents after delete", "gitlab_list_cluster_agents",
+			clusteragents.ListAgentsInput{ProjectID: proj.pidOf()},
+			clusterAgentIDs, agentID)
 		t.Logf("Deleted cluster agent %d", agentID)
 	})
 }
@@ -250,6 +262,15 @@ func TestMeta_ClusterAgents(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "revoke agent token meta")
+		// Gone rather than revoked, the same as its individual twin above.
+		requireGoneOn(ctx, t, sess.meta, "revoked agent token (meta)", "gitlab_admin", map[string]any{
+			"action": "cluster_agent_token_get",
+			"params": map[string]any{
+				"project_id": proj.pidStr(),
+				"agent_id":   agentID,
+				"token_id":   tokenID,
+			},
+		})
 		t.Logf("Revoked agent token (meta) %d", tokenID)
 	})
 
@@ -263,6 +284,10 @@ func TestMeta_ClusterAgents(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "delete cluster agent meta")
+		requireNotListedOn(ctx, t, sess.meta, "cluster agents after delete", "gitlab_admin", map[string]any{
+			"action": "cluster_agent_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, clusterAgentIDs, agentID)
 		t.Logf("Deleted cluster agent (meta) %d", agentID)
 	})
 }

--- a/test/e2e/suite/custom_emoji_ce_test.go
+++ b/test/e2e/suite/custom_emoji_ce_test.go
@@ -74,6 +74,9 @@ func TestIndividual_CustomEmoji(t *testing.T) {
 			ID: emojiGID,
 		})
 		requireNoError(t, err, "delete custom emoji")
+		requireNotListedOn(ctx, t, sess.individual, "group custom emoji after delete", "gitlab_list_custom_emoji",
+			customemoji.ListInput{GroupPath: groupOut.Path},
+			customEmojiIDs, emojiGID)
 		t.Logf("Deleted custom emoji %s", emojiGID)
 	})
 }
@@ -146,6 +149,10 @@ func TestMeta_CustomEmoji(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta custom emoji delete")
+		requireNotListedOn(ctx, t, sess.meta, "group custom emoji after delete", "gitlab_custom_emoji", map[string]any{
+			"action": "list",
+			"params": map[string]any{"group_path": groupOut.Path},
+		}, customEmojiIDs, emojiGID)
 		t.Logf("Deleted custom emoji (meta) %s", emojiGID)
 	})
 }

--- a/test/e2e/suite/deploy_tokens_ce_test.go
+++ b/test/e2e/suite/deploy_tokens_ce_test.go
@@ -83,6 +83,10 @@ func TestMeta_DeployTokens(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "deploy token delete")
+		requireNotListedOn(ctx, t, sess.meta, "project deploy tokens after delete", "gitlab_access", map[string]any{
+			"action": "deploy_token_list_project",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, deployTokenIDs, tokenID)
 		t.Logf("Deleted deploy token %d", tokenID)
 	})
 }

--- a/test/e2e/suite/deployments_meta_ce_test.go
+++ b/test/e2e/suite/deployments_meta_ce_test.go
@@ -115,6 +115,8 @@ func TestMeta_DeploymentsGetUpdateDelete(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "deployment update")
+		requireTruef(t, out.ID == createOut.ID, "update answered for deployment %d, want %d", out.ID, createOut.ID)
+		requireTruef(t, out.Status == "success", "deployment status = %q, want %q", out.Status, "success")
 		t.Logf("Updated deployment %d: status=%s", out.ID, out.Status)
 	})
 

--- a/test/e2e/suite/dynamic_ce_test.go
+++ b/test/e2e/suite/dynamic_ce_test.go
@@ -16,8 +16,10 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/branches"
 	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/files"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/issues"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/projectdiscovery"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/projects"
 )
@@ -278,7 +280,7 @@ func TestDynamicToolSurface_WriteActionConfirmation(t *testing.T) {
 
 	// Execute branch.create with confirm=true — should succeed.
 	branchName := "e2e-dynamic-branch-" + sanitizeTestName(t.Name())
-	_, err := callToolOn[any](ctx, sess.dynamic, "gitlab_execute_action", dynamictools.ExecuteInput{
+	created, err := callToolOn[branches.Output](ctx, sess.dynamic, "gitlab_execute_action", dynamictools.ExecuteInput{
 		Action:  "branch.create",
 		Confirm: true,
 		Params: map[string]any{
@@ -288,6 +290,7 @@ func TestDynamicToolSurface_WriteActionConfirmation(t *testing.T) {
 		},
 	})
 	requireNoError(t, err, "branch.create with confirm=true")
+	requireTruef(t, created.Name == branchName, "dynamic branch.create answered with branch %q, want %q", created.Name, branchName)
 	t.Logf("Branch %q created successfully via dynamic surface", branchName)
 }
 
@@ -313,14 +316,17 @@ func TestDynamicToolSurface_DomainCoverage(t *testing.T) {
 	t.Run("Domain/Issue/Create", func(t *testing.T) {
 		// Find and execute issue creation.
 		_ = dynamicFindAction(ctx, t, "create issue in project", "issue.create")
-		out, err := callToolOn[any](ctx, sess.dynamic, "gitlab_execute_action", dynamictools.ExecuteInput{
+		const issueTitle = "Test issue from dynamic surface"
+		out, err := callToolOn[issues.Output](ctx, sess.dynamic, "gitlab_execute_action", dynamictools.ExecuteInput{
 			Action: "issue.create",
 			Params: map[string]any{
 				"project_id": proj.pidStr(),
-				"title":      "Test issue from dynamic surface",
+				"title":      issueTitle,
 			},
 		})
 		requireNoError(t, err, "issue.create via dynamic surface")
+		requireTruef(t, out.Title == issueTitle, "dynamic issue.create answered with title %q, want %q", out.Title, issueTitle)
+		requireTruef(t, out.IID > 0, "dynamic issue.create answered with IID %d, want a real issue", out.IID)
 		t.Logf("Issue created via dynamic surface: %+v", out)
 	})
 

--- a/test/e2e/suite/enterprise_ee_test.go
+++ b/test/e2e/suite/enterprise_ee_test.go
@@ -1383,6 +1383,14 @@ func TestMeta_StorageMoves(t *testing.T) {
 // TestMeta_SecurityFindings exercises security finding tools via the
 // gitlab_security_finding meta-tool.
 // Requires GitLab Premium/Ultimate (GITLAB_ENTERPRISE=true).
+//
+// Its fixture is a fresh project with no pipeline, so an empty listing is the
+// correct answer and these subtests can only show that the action routes and
+// that its filters are accepted. That is deliberately not enough to catch a
+// refused GraphQL document, which also answers empty and without an error: the
+// assertion that the findings really come back lives in
+// [TestMeta_VulnerabilityLifecycle], which owns a pipeline that publishes
+// three CRITICAL SAST findings.
 func TestMeta_SecurityFindings(t *testing.T) {
 	t.Parallel()
 	if !sess.enterprise {

--- a/test/e2e/suite/environments_ce_test.go
+++ b/test/e2e/suite/environments_ce_test.go
@@ -89,6 +89,10 @@ func TestIndividual_Environments(t *testing.T) {
 			EnvironmentID: envID,
 		})
 		requireNoError(t, err, "stop environment")
+		requireTruef(t, out.ID == envID, "stop answered for environment %d, want %d", out.ID, envID)
+		// The fixture environment has no stop action job, so GitLab completes the
+		// stop in the request rather than leaving it "stopping".
+		requireTruef(t, out.State == "stopped", "environment %d state = %q after stopping, want %q", envID, out.State, "stopped")
 		t.Logf("Stopped environment %s (state=%s)", out.Name, out.State)
 	})
 
@@ -99,6 +103,8 @@ func TestIndividual_Environments(t *testing.T) {
 			EnvironmentID: envID,
 		})
 		requireNoError(t, err, "delete environment")
+		requireGoneOn(ctx, t, sess.individual, "environment after delete", "gitlab_environment_get",
+			environments.GetInput{ProjectID: proj.pidOf(), EnvironmentID: envID})
 		t.Log("Deleted environment")
 	})
 }
@@ -164,6 +170,9 @@ func TestMeta_Environments(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "environment_id": envID, "external_url": "https://meta-staging.example.com"},
 		})
 		requireNoError(t, err, "meta update environment")
+		requireTruef(t, out.ID == envID, "update answered for environment %d, want %d", out.ID, envID)
+		requireTruef(t, out.ExternalURL == "https://meta-staging.example.com",
+			"environment external_url = %q, want the updated one", out.ExternalURL)
 		t.Logf("Updated environment %s via meta-tool", out.Name)
 	})
 
@@ -174,6 +183,7 @@ func TestMeta_Environments(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "environment_id": envID},
 		})
 		requireNoError(t, err, "meta stop environment")
+		requireTruef(t, out.State == "stopped", "environment %d state = %q after stopping, want %q", envID, out.State, "stopped")
 		t.Logf("Stopped environment %s via meta-tool", out.Name)
 	})
 
@@ -184,6 +194,10 @@ func TestMeta_Environments(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "environment_id": envID},
 		})
 		requireNoError(t, err, "meta delete environment")
+		requireGoneOn(ctx, t, sess.meta, "environment after delete", "gitlab_environment", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "environment_id": envID},
+		})
 		t.Log("Deleted environment via meta-tool")
 	})
 }

--- a/test/e2e/suite/epics_ee_test.go
+++ b/test/e2e/suite/epics_ee_test.go
@@ -9,6 +9,7 @@ package suite
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -173,6 +174,10 @@ func TestMeta_Epics(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "epic_delete")
+		requireGoneOn(ctx, t, sess.meta, "epic after delete", "gitlab_group", map[string]any{
+			"action": "epic_get",
+			"params": map[string]any{"full_path": groupPath, "epic_iid": epicIID},
+		})
 		t.Log("Deleted epic successfully")
 	})
 }
@@ -301,6 +306,16 @@ func TestMeta_EpicNotes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "epic_note_delete")
+		requireNotListedOn(ctx, t, sess.meta, "epic notes after delete", "gitlab_group", map[string]any{
+			"action": "epic_note_list",
+			"params": map[string]any{"full_path": groupPath, "epic_iid": epicIID},
+		}, func(out epicnotes.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.Notes))
+			for _, n := range out.Notes {
+				ids = append(ids, n.ID)
+			}
+			return ids
+		}, noteID)
 		t.Log("Deleted note successfully")
 	})
 }
@@ -451,6 +466,20 @@ func TestMeta_EpicDiscussions(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "epic_discussion_delete_note")
+		requireNotListedOn(ctx, t, sess.meta, "discussion notes after delete", "gitlab_group", map[string]any{
+			"action": "epic_discussion_get",
+			"params": map[string]any{
+				"full_path":     groupPath,
+				"epic_iid":      epicIID,
+				"discussion_id": discussionID,
+			},
+		}, func(out epicdiscussions.Output) []int64 {
+			ids := make([]int64, 0, len(out.Notes))
+			for _, n := range out.Notes {
+				ids = append(ids, n.ID)
+			}
+			return ids
+		}, replyNoteID)
 		t.Log("Deleted discussion note successfully")
 	})
 }
@@ -505,6 +534,9 @@ func TestMeta_EpicIssues(t *testing.T) {
 		},
 	})
 	requireNoError(t, setupErr, "create project in group")
+	requireTruef(t, projOut.ID > 0, "created project has no ID")
+	requireTruef(t, strings.HasPrefix(projOut.PathWithNamespace, grpOut.FullPath+"/"),
+		"project path %q is not under the group %q it was created in", projOut.PathWithNamespace, grpOut.FullPath)
 	t.Logf("Created project: %s (ID=%d)", projOut.PathWithNamespace, projOut.ID)
 
 	defer func() {
@@ -745,6 +777,9 @@ func TestMeta_EpicLinks(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "epic_get_links")
+		// The epic was created moments ago with no children, which is the case
+		// this subtest is named for.
+		requireTruef(t, len(out.ChildEpics) == 0, "fresh epic reports %d child epics, want none", len(out.ChildEpics))
 		t.Logf("Got %d linked epic(s) (expected 0)", len(out.ChildEpics))
 	})
 }

--- a/test/e2e/suite/files_ce_test.go
+++ b/test/e2e/suite/files_ce_test.go
@@ -228,6 +228,8 @@ func TestIndividual_Files(t *testing.T) {
 			CommitMessage: "delete crud test file",
 		})
 		requireNoError(t, err, "delete file")
+		requireGoneOn(ctx, t, sess.individual, "file "+crudPath+" after delete", "gitlab_file_get",
+			files.GetInput{ProjectID: proj.pidOf(), FilePath: crudPath, Ref: defaultBranch})
 		t.Logf("FileDelete: %s", crudPath)
 	})
 
@@ -410,6 +412,14 @@ func TestMeta_Files(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta file delete")
+		requireGoneOn(ctx, t, sess.meta, "file "+crudPath+" after delete", "gitlab_repository", map[string]any{
+			"action": "file_get",
+			"params": map[string]any{
+				"project_id": proj.pidStr(),
+				"file_path":  crudPath,
+				"ref":        defaultBranch,
+			},
+		})
 		t.Logf("Meta FileDelete: %s", crudPath)
 	})
 

--- a/test/e2e/suite/freeze_periods_ce_test.go
+++ b/test/e2e/suite/freeze_periods_ce_test.go
@@ -98,6 +98,16 @@ func TestMeta_FreezePeriods(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "freeze period delete")
+		requireNotListedOn(ctx, t, sess.meta, "freeze periods after delete", "gitlab_environment", map[string]any{
+			"action": "freeze_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out freezeperiods.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.FreezePeriods))
+			for _, f := range out.FreezePeriods {
+				ids = append(ids, f.ID)
+			}
+			return ids
+		}, freezePeriodID)
 		t.Logf("Deleted freeze period %d", freezePeriodID)
 	})
 }

--- a/test/e2e/suite/group_board_extras_ee_test.go
+++ b/test/e2e/suite/group_board_extras_ee_test.go
@@ -122,6 +122,16 @@ func TestMeta_GroupBoardListColumns(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group_board_delete_list")
+		requireNotListedOn(ctx, t, sess.meta, "group board lists after delete", "gitlab_group", map[string]any{
+			"action": "group_board_list_lists",
+			"params": map[string]any{"group_id": grp.gidStr(), "board_id": boardID},
+		}, func(out groupboards.ListBoardListsOutput) []int64 {
+			ids := make([]int64, 0, len(out.Lists))
+			for _, l := range out.Lists {
+				ids = append(ids, l.ID)
+			}
+			return ids
+		}, listID)
 		t.Logf("Deleted board list %d", listID)
 	})
 }

--- a/test/e2e/suite/group_extras2_ce_test.go
+++ b/test/e2e/suite/group_extras2_ce_test.go
@@ -87,6 +87,10 @@ func runGroupExtrasUploadHappyPath(t *testing.T, ctx context.Context, grp GroupF
 			},
 		})
 		requireNoError(t, err, "group_upload_delete_by_id")
+		requireNotListedOn(ctx, t, sess.meta, "group uploads after delete by ID", "gitlab_group", map[string]any{
+			"action": "group_upload_list",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		}, groupUploadIDs, first.ID)
 		t.Logf("Deleted upload %d by ID", first.ID)
 	})
 
@@ -105,6 +109,16 @@ func runGroupExtrasUploadHappyPath(t *testing.T, ctx context.Context, grp GroupF
 			},
 		})
 		requireNoError(t, err, "group_upload_delete_by_secret")
+		requireNotListedOn(ctx, t, sess.meta, "group uploads after delete by secret", "gitlab_group", map[string]any{
+			"action": "group_upload_list",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		}, func(out groupmarkdownuploads.ListOutput) []string {
+			names := make([]string, 0, len(out.Uploads))
+			for _, u := range out.Uploads {
+				names = append(names, u.Filename)
+			}
+			return names
+		}, second.Filename)
 		t.Logf("Deleted upload %q by secret", second.Filename)
 	})
 }

--- a/test/e2e/suite/group_extras_ce_test.go
+++ b/test/e2e/suite/group_extras_ce_test.go
@@ -96,6 +96,12 @@ func runGroupExtrasArchiveOps(t *testing.T, ctx context.Context, grp GroupFixtur
 			"params": map[string]any{"group_id": grp.gidStr()},
 		})
 		requireNoError(t, err, "group unarchive")
+		read, err := callToolOn[groups.Output](ctx, sess.meta, "gitlab_group", map[string]any{
+			"action": "get",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		})
+		requireNoError(t, err, "re-read group after unarchive")
+		requireTruef(t, !read.Archived, "group %d still reports archived after unarchiving", grp.ID)
 		t.Logf("Unarchived group %d", grp.ID)
 	})
 }
@@ -284,6 +290,10 @@ func TestMeta_GroupToGroupSharing(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group unshare_from_group")
+		requireNotListedOn(ctx, t, sess.meta, "host group shares after unshare", "gitlab_group", map[string]any{
+			"action": "get",
+			"params": map[string]any{"group_id": host.gidStr()},
+		}, sharedWithGroupIDs, guest.ID)
 		t.Logf("Unshared group %d from group %d", host.ID, guest.ID)
 	})
 
@@ -310,6 +320,10 @@ func TestMeta_GroupToGroupSharing(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group_member_unshare")
+		requireNotListedOn(ctx, t, sess.meta, "host group shares after member unshare", "gitlab_group", map[string]any{
+			"action": "get",
+			"params": map[string]any{"group_id": host.gidStr()},
+		}, sharedWithGroupIDs, guest.ID)
 		t.Logf("Unshared group %d from group %d via members surface", host.ID, guest.ID)
 	})
 }
@@ -380,6 +394,10 @@ func TestMeta_GroupMemberLifecycle(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group_member_remove")
+		requireNotListedOn(ctx, t, sess.meta, "group members after remove", "gitlab_group", map[string]any{
+			"action": "members",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		}, groupMemberIDs, userID)
 		t.Logf("Removed user %d from group %d", userID, grp.ID)
 	})
 }

--- a/test/e2e/suite/group_extras_ee_test.go
+++ b/test/e2e/suite/group_extras_ee_test.go
@@ -124,6 +124,10 @@ func TestMeta_GroupPushRules(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta group push rule delete")
+		requireGoneOn(ctx, t, sess.meta, "group push rules after delete", "gitlab_group", map[string]any{
+			"action": "push_rule_get",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		})
 		t.Log("Deleted group push rules")
 	})
 }
@@ -474,6 +478,26 @@ func groupExtrasAddHook(ctx context.Context, t *testing.T, grp GroupFixture) int
 	return out.ID
 }
 
+// groupHookCustomHeaderKeys maps a group webhook to the custom header keys it
+// carries. As with a project hook, GitLab masks the value and keeps the key.
+func groupHookCustomHeaderKeys(out groups.HookOutput) []string {
+	keys := make([]string, 0, len(out.CustomHeaders))
+	for _, h := range out.CustomHeaders {
+		keys = append(keys, h.Key)
+	}
+	return keys
+}
+
+// groupHookURLVariableKeys maps a group webhook to the URL variable keys it
+// carries; GitLab masks those values on read the same way.
+func groupHookURLVariableKeys(out groups.HookOutput) []string {
+	keys := make([]string, 0, len(out.URLVariables))
+	for _, v := range out.URLVariables {
+		keys = append(keys, v.Key)
+	}
+	return keys
+}
+
 // runGroupExtrasHookHeaderOps drives hook_set_custom_header and
 // hook_delete_custom_header; both are expected to succeed on a fresh hook.
 func runGroupExtrasHookHeaderOps(t *testing.T, ctx context.Context, grp GroupFixture, hookID int64) {
@@ -491,6 +515,11 @@ func runGroupExtrasHookHeaderOps(t *testing.T, ctx context.Context, grp GroupFix
 			},
 		})
 		requireNoError(t, err, "group hook_set_custom_header")
+		// GitLab masks a custom header's value on read but keeps its key.
+		requireListedOn(ctx, t, sess.meta, "group hook custom headers after set", "gitlab_group", map[string]any{
+			"action": "hook_get",
+			"params": map[string]any{"group_id": grp.gidStr(), "hook_id": hookID},
+		}, groupHookCustomHeaderKeys, "X-E2E-Group")
 		t.Log("Set custom header on group hook")
 	})
 
@@ -505,6 +534,10 @@ func runGroupExtrasHookHeaderOps(t *testing.T, ctx context.Context, grp GroupFix
 			},
 		})
 		requireNoError(t, err, "group hook_delete_custom_header")
+		requireNotListedOn(ctx, t, sess.meta, "group hook custom headers after delete", "gitlab_group", map[string]any{
+			"action": "hook_get",
+			"params": map[string]any{"group_id": grp.gidStr(), "hook_id": hookID},
+		}, groupHookCustomHeaderKeys, "X-E2E-Group")
 		t.Log("Deleted custom header from group hook")
 	})
 }
@@ -544,6 +577,10 @@ func runGroupExtrasHookURLVariableOps(t *testing.T, ctx context.Context, grp Gro
 		})
 		if variableSet {
 			requireNoError(t, err, "delete URL variable that was set")
+			requireNotListedOn(ctx, t, sess.meta, "group hook URL variables after delete", "gitlab_group", map[string]any{
+				"action": "hook_get",
+				"params": map[string]any{"group_id": grp.gidStr(), "hook_id": hookID},
+			}, groupHookURLVariableKeys, "e2e_var")
 			t.Log("Deleted URL variable from group hook")
 			return
 		}

--- a/test/e2e/suite/group_labels_ce_test.go
+++ b/test/e2e/suite/group_labels_ce_test.go
@@ -96,6 +96,16 @@ func TestMeta_GroupLabels(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group label delete")
+		requireNotListedOn(ctx, t, sess.meta, "group labels after delete", "gitlab_group", map[string]any{
+			"action": "group_label_list",
+			"params": map[string]any{"group_id": gid},
+		}, func(out grouplabels.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.Labels))
+			for _, l := range out.Labels {
+				ids = append(ids, l.ID)
+			}
+			return ids
+		}, labelID)
 		t.Logf("Deleted group label %d", labelID)
 	})
 }

--- a/test/e2e/suite/group_milestones_ce_test.go
+++ b/test/e2e/suite/group_milestones_ce_test.go
@@ -110,6 +110,16 @@ func TestMeta_GroupMilestones(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group milestone delete")
+		requireNotListedOn(ctx, t, sess.meta, "group milestones after delete", "gitlab_group", map[string]any{
+			"action": "group_milestone_list",
+			"params": map[string]any{"group_id": gid},
+		}, func(out groupmilestones.ListOutput) []int64 {
+			iids := make([]int64, 0, len(out.Milestones))
+			for _, m := range out.Milestones {
+				iids = append(iids, m.IID)
+			}
+			return iids
+		}, milestoneIID)
 		t.Logf("Deleted group milestone IID=%d", milestoneIID)
 	})
 }

--- a/test/e2e/suite/group_protected_branches_ee_test.go
+++ b/test/e2e/suite/group_protected_branches_ee_test.go
@@ -83,7 +83,7 @@ func TestMeta_GroupProtectedBranchesEE(t *testing.T) {
 	})
 
 	t.Run("Meta/GroupProtectedBranch/Update", func(t *testing.T) {
-		_, err := callToolOn[groupprotectedbranches.Output](ctx, sess.meta, "gitlab_group", map[string]any{
+		out, err := callToolOn[groupprotectedbranches.Output](ctx, sess.meta, "gitlab_group", map[string]any{
 			"action": "protected_branch_update",
 			"params": map[string]any{
 				"group_id":         grp.gidStr(),
@@ -92,6 +92,8 @@ func TestMeta_GroupProtectedBranchesEE(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "protected_branch_update")
+		requireTruef(t, out.Name == branchName, "update answered for branch %q, want %q", out.Name, branchName)
+		requireTruef(t, out.AllowForcePush, "allow_force_push = false after asking for true")
 		t.Logf("Updated group protected branch %s (allow_force_push=true)", branchName)
 	})
 
@@ -101,6 +103,10 @@ func TestMeta_GroupProtectedBranchesEE(t *testing.T) {
 			"params": map[string]any{"group_id": grp.gidStr(), "branch": branchName},
 		})
 		requireNoError(t, err, "protected_branch_unprotect")
+		requireGoneOn(ctx, t, sess.meta, "group protected branch after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_branch_get",
+			"params": map[string]any{"group_id": grp.gidStr(), "branch": branchName},
+		})
 		t.Logf("Unprotected group branch %s", branchName)
 	})
 }

--- a/test/e2e/suite/group_protected_envs_ee_test.go
+++ b/test/e2e/suite/group_protected_envs_ee_test.go
@@ -127,6 +127,16 @@ func TestMeta_GroupProtectedEnvironmentsEE(t *testing.T) {
 			"params": map[string]any{"group_id": grp.gidStr(), "environment": envName},
 		})
 		requireNoError(t, err, "protected_env_unprotect")
+		requireNotListedOn(ctx, t, sess.meta, "group protected environments after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_env_list",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		}, func(out groupprotectedenvs.ListOutput) []string {
+			names := make([]string, 0, len(out.Environments))
+			for _, e := range out.Environments {
+				names = append(names, e.Name)
+			}
+			return names
+		}, envName)
 		t.Logf("Unprotected group env %s", envName)
 	})
 }

--- a/test/e2e/suite/group_service_accounts_ee_test.go
+++ b/test/e2e/suite/group_service_accounts_ee_test.go
@@ -155,6 +155,21 @@ func TestMeta_GroupServiceAccounts(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "service_account_pat_revoke")
+			requireNotListedOn(ctx, t, sess.meta, "active service account PATs after revoke", "gitlab_group", map[string]any{
+				"action": "service_account_pat_list",
+				"params": map[string]any{
+					"group_id":           groupIDStr,
+					"service_account_id": saID,
+				},
+			}, func(out groupserviceaccounts.ListPATOutput) []int64 {
+				ids := make([]int64, 0, len(out.Tokens))
+				for _, tok := range out.Tokens {
+					if tok.Active && !tok.Revoked {
+						ids = append(ids, tok.ID)
+					}
+				}
+				return ids
+			}, patID)
 			t.Logf("Revoked PAT %d", patID)
 		})
 
@@ -170,6 +185,8 @@ func TestMeta_GroupServiceAccounts(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "service_account_delete")
+			// A hard delete schedules the user's removal rather than performing
+			// it, so the account can still be listed for a while afterwards.
 			t.Logf("Deleted service account %d", saID)
 		})
 	}

--- a/test/e2e/suite/group_variables_ce_test.go
+++ b/test/e2e/suite/group_variables_ce_test.go
@@ -123,6 +123,10 @@ func TestMeta_GroupVariables(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "group variable delete")
+		requireGoneOn(ctx, t, sess.meta, "group variable "+varKey+" after delete", "gitlab_ci_variable", map[string]any{
+			"action": "group_get",
+			"params": map[string]any{"group_id": gid, "key": varKey},
+		})
 		t.Logf("Deleted group variable: %s", varKey)
 	})
 }

--- a/test/e2e/suite/group_wikis_ee_test.go
+++ b/test/e2e/suite/group_wikis_ee_test.go
@@ -114,6 +114,16 @@ func TestMeta_GroupWikis(t *testing.T) {
 			"params": map[string]any{"group_id": grp.gidStr(), "slug": wikiSlug},
 		})
 		requireNoError(t, err, "wiki_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group wiki pages after delete", "gitlab_group", map[string]any{
+			"action": "wiki_list",
+			"params": map[string]any{"group_id": grp.gidStr()},
+		}, func(out groupwikis.ListOutput) []string {
+			slugs := make([]string, 0, len(out.WikiPages))
+			for _, p := range out.WikiPages {
+				slugs = append(slugs, p.Slug)
+			}
+			return slugs
+		}, wikiSlug)
 		t.Logf("Deleted group wiki page %s", wikiSlug)
 	})
 }

--- a/test/e2e/suite/groups_ce_test.go
+++ b/test/e2e/suite/groups_ce_test.go
@@ -9,6 +9,7 @@ package suite
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -88,6 +89,10 @@ func TestIndividual_Groups(t *testing.T) {
 			GroupID: toolutil.StringOrInt(gid),
 		})
 		requireNoError(t, err, "group members list")
+		// The account that created the group is its owner, so it is always a member.
+		requireTruef(t, slices.ContainsFunc(out.Members, func(m groups.MemberOutput) bool {
+			return m.Username == sess.username
+		}), "group %d members do not include its creator %q: %+v", groupID, sess.username, out.Members)
 		t.Logf("Group %d has %d members", groupID, len(out.Members))
 	})
 
@@ -291,6 +296,10 @@ func TestMeta_Groups(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta group members list")
+		// The account that created the group is its owner, so it is always a member.
+		requireTruef(t, slices.ContainsFunc(out.Members, func(m groups.MemberOutput) bool {
+			return m.Username == sess.username
+		}), "group %d members do not include its creator %q: %+v", groupID, sess.username, out.Members)
 		t.Logf("Group %d has %d members via meta-tool", groupID, len(out.Members))
 	})
 

--- a/test/e2e/suite/groups_meta_ee_test.go
+++ b/test/e2e/suite/groups_meta_ee_test.go
@@ -444,6 +444,8 @@ func runEnterpriseMetaGroupBoardOperations(t *testing.T, ctx context.Context, gr
 			},
 		})
 		requireNoError(t, err, "group_board_update")
+		requireTruef(t, out.ID == boardID, "update answered for board %d, want %d", out.ID, boardID)
+		requireTruef(t, out.Name == "Updated Board", "board name = %q, want %q", out.Name, "Updated Board")
 		t.Logf("Updated board %d: %s", out.ID, out.Name)
 	})
 
@@ -468,6 +470,10 @@ func runEnterpriseMetaGroupBoardOperations(t *testing.T, ctx context.Context, gr
 			"params": map[string]any{"group_id": groupIDStr, "board_id": boardID},
 		})
 		requireNoError(t, err, "group_board_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group boards after delete", "gitlab_group", map[string]any{
+			"action": "group_board_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, groupBoardIDs, boardID)
 		t.Logf("Deleted board %d", boardID)
 	})
 }
@@ -568,6 +574,9 @@ func runEnterpriseMetaGroupWikiOperations(t *testing.T, ctx context.Context, gro
 			},
 		})
 		requireNoError(t, err, "wiki_edit")
+		requireTruef(t, out.Slug == wikiSlug, "wiki_edit answered for slug %q, want %q", out.Slug, wikiSlug)
+		requireTruef(t, out.Content == "# E2E group wiki\n\nUpdated content.",
+			"wiki content = %q, want the text just written", out.Content)
 		t.Logf("Updated group wiki page %s", out.Slug)
 	})
 
@@ -578,6 +587,16 @@ func runEnterpriseMetaGroupWikiOperations(t *testing.T, ctx context.Context, gro
 			"params": map[string]any{"group_id": groupIDStr, "slug": wikiSlug},
 		})
 		requireNoError(t, err, "wiki_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group wiki pages after delete", "gitlab_group", map[string]any{
+			"action": "wiki_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupwikis.ListOutput) []string {
+			slugs := make([]string, 0, len(out.WikiPages))
+			for _, p := range out.WikiPages {
+				slugs = append(slugs, p.Slug)
+			}
+			return slugs
+		}, wikiSlug)
 		t.Logf("Deleted group wiki page %s", wikiSlug)
 	})
 }
@@ -645,6 +664,16 @@ func runEnterpriseMetaGroupProtectedBranchOperations(t *testing.T, ctx context.C
 			"params": map[string]any{"group_id": groupIDStr, "branch": branchName},
 		})
 		requireNoError(t, err, "protected_branch_unprotect")
+		requireNotListedOn(ctx, t, sess.meta, "group protected branches after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_branch_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupprotectedbranches.ListOutput) []string {
+			names := make([]string, 0, len(out.Branches))
+			for _, b := range out.Branches {
+				names = append(names, b.Name)
+			}
+			return names
+		}, branchName)
 		t.Logf("Unprotected group branch %s", branchName)
 	})
 }
@@ -747,6 +776,16 @@ func runEnterpriseMetaGroupProtectedEnvOperations(t *testing.T, ctx context.Cont
 			"params": map[string]any{"group_id": groupIDStr, "environment": envName},
 		})
 		requireNoError(t, err, "protected_env_unprotect")
+		requireNotListedOn(ctx, t, sess.meta, "group protected environments after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_env_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupprotectedenvs.ListOutput) []string {
+			names := make([]string, 0, len(out.Environments))
+			for _, e := range out.Environments {
+				names = append(names, e.Name)
+			}
+			return names
+		}, envName)
 		t.Logf("Unprotected group environment %s", envName)
 	})
 }
@@ -845,6 +884,9 @@ func metaGroupHookEdit(t *testing.T, ctx context.Context, groupID int64, groupID
 		},
 	})
 	requireNoError(t, err, "hook_edit")
+	requireTruef(t, out.ID == *hookID, "hook_edit answered for hook %d, want %d", out.ID, *hookID)
+	requireTruef(t, out.URL == "https://example.com/hook-updated", "hook url = %q, want the updated one", out.URL)
+	requireTruef(t, out.IssuesEvents, "hook issues_events = false after asking for true")
 	t.Logf("Edited hook %d", out.ID)
 }
 
@@ -860,6 +902,16 @@ func metaGroupHookDelete(t *testing.T, ctx context.Context, groupID int64, group
 		"params": map[string]any{"group_id": groupIDStr, "hook_id": *hookID},
 	})
 	requireNoError(t, err, "hook_delete")
+	requireNotListedOn(ctx, t, sess.meta, "group hooks after delete", "gitlab_group", map[string]any{
+		"action": "hook_list",
+		"params": map[string]any{"group_id": groupIDStr},
+	}, func(out groups.HookListOutput) []int64 {
+		ids := make([]int64, 0, len(out.Hooks))
+		for _, h := range out.Hooks {
+			ids = append(ids, h.ID)
+		}
+		return ids
+	}, *hookID)
 	t.Logf("Deleted hook %d", *hookID)
 }
 

--- a/test/e2e/suite/groups_meta_helpers_ce_test.go
+++ b/test/e2e/suite/groups_meta_helpers_ce_test.go
@@ -57,6 +57,8 @@ func runMetaGroupCoreOperations(t *testing.T, ctx context.Context, grpName strin
 			},
 		})
 		requireNoError(t, err, "group update")
+		requireTruef(t, out.ID == groupID, "update answered for group %d, want %d", out.ID, groupID)
+		requireTruef(t, out.Description == "Deep test group", "group description = %q, want %q", out.Description, "Deep test group")
 		t.Logf("Updated group %d", out.ID)
 	})
 
@@ -137,6 +139,9 @@ func runMetaGroupBadgeOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "badge_edit")
+		requireTruef(t, out.Badge.ID == badgeID, "badge_edit answered for badge %d, want %d", out.Badge.ID, badgeID)
+		requireTruef(t, out.Badge.LinkURL == "https://example.com/badge-updated",
+			"badge link_url = %q, want the updated one", out.Badge.LinkURL)
 		t.Logf("Edited badge %d", out.Badge.ID)
 	})
 
@@ -151,6 +156,9 @@ func runMetaGroupBadgeOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "badge_preview")
+		// The URL previewed carries no placeholders, so rendering leaves it alone.
+		requireTruef(t, out.Badge.RenderedLinkURL == "https://example.com/badge",
+			"rendered link_url = %q, want the URL previewed", out.Badge.RenderedLinkURL)
 		t.Logf("Preview rendered: %s", out.Badge.RenderedLinkURL)
 	})
 
@@ -161,6 +169,16 @@ func runMetaGroupBadgeOperations(t *testing.T, ctx context.Context, groupID int6
 			"params": map[string]any{"group_id": groupIDStr, "badge_id": badgeID},
 		})
 		requireNoError(t, err, "badge_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group badges after delete", "gitlab_group", map[string]any{
+			"action": "badge_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out badges.ListGroupOutput) []int64 {
+			ids := make([]int64, 0, len(out.Badges))
+			for _, b := range out.Badges {
+				ids = append(ids, b.ID)
+			}
+			return ids
+		}, badgeID)
 		t.Logf("Deleted badge %d", badgeID)
 	})
 }
@@ -219,6 +237,8 @@ func runMetaGroupLabelOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "label create")
+		requireTruef(t, out.Name == labelName, "label name = %q, want %q", out.Name, labelName)
+		requireTruef(t, strings.EqualFold(out.Color, "#FF0000"), "label color = %q, want %q", out.Color, "#FF0000")
 		t.Logf("Created label: %s (ID=%d)", out.Name, out.ID)
 	})
 
@@ -243,6 +263,7 @@ func runMetaGroupLabelOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "label get")
+		requireTruef(t, out.Name == labelName, "label get returned %q, want %q", out.Name, labelName)
 		t.Logf("Got label: %s", out.Name)
 	})
 
@@ -272,6 +293,8 @@ func runMetaGroupLabelOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "label subscribe")
+		requireTruef(t, out.Name == labelName, "subscribe answered for label %q, want %q", out.Name, labelName)
+		requireTruef(t, out.Subscribed, "label %q reports subscribed=false right after subscribing", labelName)
 		t.Logf("Subscribed to label: %s", out.Name)
 	})
 
@@ -285,6 +308,15 @@ func runMetaGroupLabelOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "label unsubscribe")
+		read, err := callToolOn[grouplabels.Output](ctx, sess.meta, "gitlab_group", map[string]any{
+			"action": "group_label_get",
+			"params": map[string]any{
+				"group_id": groupIDStr,
+				"label_id": labelName,
+			},
+		})
+		requireNoError(t, err, "re-read label after unsubscribe")
+		requireTruef(t, !read.Subscribed, "label %q still reports subscribed=true after unsubscribing", labelName)
 		t.Log("Unsubscribed from label")
 	})
 
@@ -298,6 +330,16 @@ func runMetaGroupLabelOperations(t *testing.T, ctx context.Context, groupID int6
 			},
 		})
 		requireNoError(t, err, "label delete")
+		requireNotListedOn(ctx, t, sess.meta, "group labels after delete", "gitlab_group", map[string]any{
+			"action": "group_label_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out grouplabels.ListOutput) []string {
+			names := make([]string, 0, len(out.Labels))
+			for _, l := range out.Labels {
+				names = append(names, l.Name)
+			}
+			return names
+		}, labelName)
 		t.Log("Deleted label")
 	})
 }
@@ -345,6 +387,10 @@ func runMetaGroupMilestoneOperations(t *testing.T, ctx context.Context, groupID 
 			},
 		})
 		requireNoError(t, err, "milestone update")
+		// milestoneID holds the IID the create answered with, which is what the
+		// update was addressed by.
+		requireTruef(t, out.IID == milestoneID, "update answered for milestone IID %d, want %d", out.IID, milestoneID)
+		requireTruef(t, out.Description == "Updated milestone", "milestone description = %q, want %q", out.Description, "Updated milestone")
 		t.Logf("Updated milestone %d", out.ID)
 	})
 
@@ -815,6 +861,8 @@ func runEnterpriseMetaGroupBoardOperations(t *testing.T, ctx context.Context, gr
 			},
 		})
 		requireNoError(t, err, "group_board_update")
+		requireTruef(t, out.ID == boardID, "update answered for board %d, want %d", out.ID, boardID)
+		requireTruef(t, out.Name == "Updated Board", "board name = %q, want %q", out.Name, "Updated Board")
 		t.Logf("Updated board %d: %s", out.ID, out.Name)
 	})
 
@@ -839,6 +887,10 @@ func runEnterpriseMetaGroupBoardOperations(t *testing.T, ctx context.Context, gr
 			"params": map[string]any{"group_id": groupIDStr, "board_id": boardID},
 		})
 		requireNoError(t, err, "group_board_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group boards after delete", "gitlab_group", map[string]any{
+			"action": "group_board_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, groupBoardIDs, boardID)
 		t.Logf("Deleted board %d", boardID)
 	})
 }
@@ -937,6 +989,9 @@ func runEnterpriseMetaGroupWikiOperations(t *testing.T, ctx context.Context, gro
 			},
 		})
 		requireNoError(t, err, "wiki_edit")
+		requireTruef(t, out.Slug == wikiSlug, "wiki_edit answered for slug %q, want %q", out.Slug, wikiSlug)
+		requireTruef(t, out.Content == "# E2E group wiki\n\nUpdated content.",
+			"wiki content = %q, want the text just written", out.Content)
 		t.Logf("Updated group wiki page %s", out.Slug)
 	})
 
@@ -947,6 +1002,16 @@ func runEnterpriseMetaGroupWikiOperations(t *testing.T, ctx context.Context, gro
 			"params": map[string]any{"group_id": groupIDStr, "slug": wikiSlug},
 		})
 		requireNoError(t, err, "wiki_delete")
+		requireNotListedOn(ctx, t, sess.meta, "group wiki pages after delete", "gitlab_group", map[string]any{
+			"action": "wiki_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupwikis.ListOutput) []string {
+			slugs := make([]string, 0, len(out.WikiPages))
+			for _, p := range out.WikiPages {
+				slugs = append(slugs, p.Slug)
+			}
+			return slugs
+		}, wikiSlug)
 		t.Logf("Deleted group wiki page %s", wikiSlug)
 	})
 }
@@ -1014,6 +1079,16 @@ func runEnterpriseMetaGroupProtectedBranchOperations(t *testing.T, ctx context.C
 			"params": map[string]any{"group_id": groupIDStr, "branch": branchName},
 		})
 		requireNoError(t, err, "protected_branch_unprotect")
+		requireNotListedOn(ctx, t, sess.meta, "group protected branches after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_branch_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupprotectedbranches.ListOutput) []string {
+			names := make([]string, 0, len(out.Branches))
+			for _, b := range out.Branches {
+				names = append(names, b.Name)
+			}
+			return names
+		}, branchName)
 		t.Logf("Unprotected group branch %s", branchName)
 	})
 }
@@ -1116,6 +1191,16 @@ func runEnterpriseMetaGroupProtectedEnvOperations(t *testing.T, ctx context.Cont
 			"params": map[string]any{"group_id": groupIDStr, "environment": envName},
 		})
 		requireNoError(t, err, "protected_env_unprotect")
+		requireNotListedOn(ctx, t, sess.meta, "group protected environments after unprotect", "gitlab_group", map[string]any{
+			"action": "protected_env_list",
+			"params": map[string]any{"group_id": groupIDStr},
+		}, func(out groupprotectedenvs.ListOutput) []string {
+			names := make([]string, 0, len(out.Environments))
+			for _, e := range out.Environments {
+				names = append(names, e.Name)
+			}
+			return names
+		}, envName)
 		t.Logf("Unprotected group environment %s", envName)
 	})
 }

--- a/test/e2e/suite/instance_variables_ce_test.go
+++ b/test/e2e/suite/instance_variables_ce_test.go
@@ -89,6 +89,10 @@ func TestMeta_CIVariablesInstance(t *testing.T) {
 			"params": map[string]any{"key": varKey},
 		})
 		requireNoError(t, err, "instance variable delete")
+		requireGoneOn(ctx, t, sess.meta, "instance variable "+varKey+" after delete", "gitlab_ci_variable", map[string]any{
+			"action": "instance_get",
+			"params": map[string]any{"key": varKey},
+		})
 		t.Logf("Deleted instance variable %s", varKey)
 	})
 }

--- a/test/e2e/suite/issues_ce_test.go
+++ b/test/e2e/suite/issues_ce_test.go
@@ -165,6 +165,8 @@ func TestIndividual_Issues(t *testing.T) {
 			IssueIID:  issueIID,
 		})
 		requireNoError(t, err, "delete issue")
+		requireGoneOn(ctx, t, sess.individual, "issue after delete", "gitlab_issue_get",
+			issues.GetInput{ProjectID: proj.pidOf(), IssueIID: issueIID})
 		t.Logf("Deleted issue #%d", issueIID)
 	})
 }
@@ -308,6 +310,10 @@ func TestMeta_Issues(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta issue delete")
+		requireGoneOn(ctx, t, sess.meta, "issue after delete", "gitlab_issue", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
+		})
 		t.Logf("Deleted issue #%d via meta-tool", issueIID)
 	})
 }

--- a/test/e2e/suite/issues_meta_ce_test.go
+++ b/test/e2e/suite/issues_meta_ce_test.go
@@ -10,7 +10,9 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +120,8 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "subscribe")
+		requireTruef(t, out.IID == issueIID, "subscribe answered for issue !%d, want !%d", out.IID, issueIID)
+		requireTruef(t, out.Subscribed, "issue !%d reports subscribed=false right after subscribing", issueIID)
 		t.Logf("Subscribed to issue !%d", out.IID)
 	})
 
@@ -128,6 +132,8 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "issue unsubscribe")
+		requireTruef(t, out.IID == issueIID, "unsubscribe answered for issue !%d, want !%d", out.IID, issueIID)
+		requireTruef(t, !out.Subscribed, "issue !%d still reports subscribed=true after unsubscribing", issueIID)
 		t.Logf("Unsubscribed from issue !%d", out.IID)
 	})
 
@@ -163,6 +169,11 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "issue participants")
+		// The fixture's own user opened the issue, and GitLab counts an author
+		// among the participants.
+		requireTruef(t, slices.ContainsFunc(out.Participants, func(p issues.ParticipantOutput) bool {
+			return p.Username == sess.username
+		}), "participants do not include the issue author %q: %+v", sess.username, out.Participants)
 		t.Logf("Issue has %d participants", len(out.Participants))
 	})
 
@@ -198,6 +209,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "time_estimate_set")
+		requireTruef(t, out.TimeEstimate == twoHoursSeconds, "time_estimate = %ds, want %ds", out.TimeEstimate, twoHoursSeconds)
 		t.Logf("Time estimate set: %ds", out.TimeEstimate)
 	})
 
@@ -208,6 +220,8 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "time_stats_get")
+		requireTruef(t, out.TimeEstimate == twoHoursSeconds, "time_estimate = %ds, want the %ds the previous subtest set", out.TimeEstimate, twoHoursSeconds)
+		requireTruef(t, out.TotalTimeSpent == 0, "total_time_spent = %ds, want 0 before any time is added", out.TotalTimeSpent)
 		t.Logf("Time stats: estimate=%ds, spent=%ds", out.TimeEstimate, out.TotalTimeSpent)
 	})
 
@@ -222,6 +236,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "spent_time_add")
+		requireTruef(t, out.TotalTimeSpent == thirtyMinutesSeconds, "total_time_spent = %ds, want %ds", out.TotalTimeSpent, thirtyMinutesSeconds)
 		t.Logf("Spent time added: %ds total", out.TotalTimeSpent)
 	})
 
@@ -232,6 +247,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "spent_time_reset")
+		requireTruef(t, out.TotalTimeSpent == 0, "total_time_spent = %ds after reset, want 0", out.TotalTimeSpent)
 		t.Logf("Spent time reset: %ds", out.TotalTimeSpent)
 	})
 
@@ -242,6 +258,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "time_estimate_reset")
+		requireTruef(t, out.TimeEstimate == 0, "time_estimate = %ds after reset, want 0", out.TimeEstimate)
 		t.Logf("Time estimate reset: %ds", out.TimeEstimate)
 	})
 
@@ -277,6 +294,10 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "link_get")
+		requireTruef(t, got.ID == link.ID, "link_get returned link %d, want %d", got.ID, link.ID)
+		requireTruef(t, got.TargetIssue != nil, "link %d carries no target issue", link.ID)
+		requireTruef(t, got.TargetIssue.IID == issue2.IID,
+			"link %d points at issue !%d, want !%d", link.ID, got.TargetIssue.IID, issue2.IID)
 		t.Logf("Got issue link %d", got.ID)
 	})
 
@@ -296,6 +317,8 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr()},
 		})
 		requireNoError(t, err, "statistics_get_project")
+		// This fixture's issues live in this project and none has been closed yet.
+		requireTruef(t, out.Statistics.Counts.Opened >= 1, "project reports %d open issues, want at least the fixture's own", out.Statistics.Counts.Opened)
 		t.Logf("Project issue statistics: open=%d", out.Statistics.Counts.Opened)
 	})
 
@@ -396,32 +419,49 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "emoji_issue_note_delete")
+		requireNotListedOn(ctx, t, sess.meta, "note award emoji after delete", "gitlab_issue", map[string]any{
+			"action": "emoji_issue_note_list",
+			"params": map[string]any{
+				"project_id": proj.pidStr(),
+				"issue_iid":  issueIID,
+				"note_id":    noteID,
+			},
+		}, awardEmojiIDs, noteEmojiID)
 		t.Logf("Deleted note emoji %d", noteEmojiID)
 	})
 
 	// ── Resource event setup: generate label, milestone, and state events ──
+	const (
+		eventLabelName      = "e2e-event-label"
+		eventLabelColor     = "#FF0000"
+		eventMilestoneTitle = "e2e-event-milestone"
+	)
 	t.Run("SetupLabelEvent", func(t *testing.T) {
 		requireTruef(t, issueIID > 0, "issueIID not set")
 		lbl, err := callToolOn[labels.Output](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "label_create",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
-				"name":       "e2e-event-label",
-				"color":      "#FF0000",
+				"name":       eventLabelName,
+				"color":      eventLabelColor,
 			},
 		})
 		requireNoError(t, err, "label_create for event setup")
+		requireTruef(t, lbl.Name == eventLabelName, "label name = %q, want %q", lbl.Name, eventLabelName)
+		requireTruef(t, strings.EqualFold(lbl.Color, eventLabelColor), "label color = %q, want %q", lbl.Color, eventLabelColor)
 		t.Logf("Created label %q (ID=%d)", lbl.Name, lbl.ID)
 
-		_, err = callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
+		updated, err := callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
 				"issue_iid":  issueIID,
-				"add_labels": "e2e-event-label",
+				"add_labels": eventLabelName,
 			},
 		})
 		requireNoError(t, err, "add label to issue")
+		requireTruef(t, slices.Contains(updated.Labels, eventLabelName),
+			"issue !%d labels = %v, want them to contain %q", issueIID, updated.Labels, eventLabelName)
 		t.Log("Added label to issue")
 	})
 
@@ -431,13 +471,14 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"action": "milestone_create",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
-				"title":      "e2e-event-milestone",
+				"title":      eventMilestoneTitle,
 			},
 		})
 		requireNoError(t, err, "milestone_create for event setup")
+		requireTruef(t, ms.Title == eventMilestoneTitle, "milestone title = %q, want %q", ms.Title, eventMilestoneTitle)
 		t.Logf("Created milestone %q (ID=%d)", ms.Title, ms.ID)
 
-		_, err = callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
+		updated, err := callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id":   proj.pidStr(),
@@ -446,6 +487,9 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "set milestone on issue")
+		requireTruef(t, updated.Milestone != nil, "issue !%d carries no milestone after the update", issueIID)
+		requireTruef(t, updated.Milestone.ID == ms.ID,
+			"issue !%d milestone = %d, want %d", issueIID, updated.Milestone.ID, ms.ID)
 		t.Log("Set milestone on issue")
 	})
 
@@ -461,7 +505,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "close issue for state event")
 
-		_, err = callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
+		reopened, err := callToolOn[issues.Output](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id":  proj.pidStr(),
@@ -470,6 +514,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "reopen issue for state event")
+		requireTruef(t, reopened.State == "opened", "issue !%d state = %q after reopen, want %q", issueIID, reopened.State, "opened")
 		t.Log("Closed and reopened issue to generate state events")
 	})
 
@@ -481,6 +526,9 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "event_issue_label_list")
+		// SetupLabelEvent added this exact label to this exact issue.
+		requireTruef(t, slices.Contains(labelEventNames(out), eventLabelName),
+			"no label event names %q among %d events", eventLabelName, len(out.Events))
 		t.Logf("Listed %d label events", len(out.Events))
 	})
 
@@ -491,6 +539,9 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
 		})
 		requireNoError(t, err, "event_issue_milestone_list")
+		// SetupMilestoneEvent put this exact milestone on this exact issue.
+		requireTruef(t, slices.Contains(milestoneEventTitles(out), eventMilestoneTitle),
+			"no milestone event names %q among %d events", eventMilestoneTitle, len(out.Events))
 		t.Logf("Listed %d milestone events", len(out.Events))
 	})
 
@@ -512,6 +563,9 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_issue_state_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "state event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
+		requireTruef(t, slices.Contains([]string{"closed", "reopened"}, out.State),
+			"state event %d has state %q, want closed or reopened", out.ID, out.State)
 		t.Logf("Got state event %d: %s", out.ID, out.State)
 	})
 
@@ -523,7 +577,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "list label events")
 		requireTruef(t, len(list.Events) > 0, "expected at least 1 label event after adding label")
-		_, err = callToolOn[resourceevents.LabelEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
+		out, err := callToolOn[resourceevents.LabelEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "event_issue_label_get",
 			"params": map[string]any{
 				"project_id":     proj.pidStr(),
@@ -532,6 +586,10 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_issue_label_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "label event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
+		requireTruef(t, out.Label != nil, "label event %d carries no label", out.ID)
+		requireTruef(t, out.Label.Name == eventLabelName,
+			"label event %d names %q, want %q", out.ID, out.Label.Name, eventLabelName)
 		t.Log("Got label event")
 	})
 
@@ -543,7 +601,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "list milestone events")
 		requireTruef(t, len(list.Events) > 0, "expected at least 1 milestone event after setting milestone")
-		_, err = callToolOn[resourceevents.MilestoneEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
+		out, err := callToolOn[resourceevents.MilestoneEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "event_issue_milestone_get",
 			"params": map[string]any{
 				"project_id":         proj.pidStr(),
@@ -552,6 +610,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_issue_milestone_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "milestone event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
 		t.Log("Got milestone event")
 	})
 
@@ -652,7 +711,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "list iteration events for get")
 		requireTruef(t, len(list.Events) > 0, "expected at least 1 iteration event for get")
-		_, err = callToolOn[resourceevents.IterationEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
+		out, err := callToolOn[resourceevents.IterationEventOutput](ctx, sess.meta, "gitlab_issue", map[string]any{
 			"action": "event_issue_iteration_get",
 			"params": map[string]any{
 				"project_id":         iterProj.pidStr(),
@@ -661,6 +720,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_issue_iteration_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "iteration event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
 		t.Log("Got iteration event")
 	})
 
@@ -678,6 +738,7 @@ func TestMeta_IssuesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "issue move")
+		requireTruef(t, out.ProjectID == proj2.ID, "moved issue reports project %d, want %d", out.ProjectID, proj2.ID)
 		t.Logf("Moved issue to project %s → IID %d", proj2.pidStr(), out.IID)
 	})
 }

--- a/test/e2e/suite/issues_meta_ee_test.go
+++ b/test/e2e/suite/issues_meta_ee_test.go
@@ -82,6 +82,8 @@ func TestMeta_IssueWorkItems(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "work_item_get")
+		requireTruef(t, out.WorkItem.IID == workItemIID, "work_item_get answered for IID %d, want %d", out.WorkItem.IID, workItemIID)
+		requireTruef(t, out.WorkItem.Title == workItemTitle, "work item title = %q, want %q", out.WorkItem.Title, workItemTitle)
 		t.Logf("Got work item: %s", out.WorkItem.Title)
 	})
 
@@ -98,6 +100,7 @@ func TestMeta_IssueWorkItems(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "work_item_update")
+		requireTruef(t, out.WorkItem.Title == "Updated Work Item", "work item title = %q, want %q", out.WorkItem.Title, "Updated Work Item")
 		t.Logf("Updated work item: %s", out.WorkItem.Title)
 	})
 
@@ -113,6 +116,10 @@ func TestMeta_IssueWorkItems(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "work_item_delete")
+		requireGoneOn(ctx, t, sess.meta, "work item after delete", "gitlab_issue", map[string]any{
+			"action": "work_item_get",
+			"params": map[string]any{"full_path": proj.Path, "work_item_iid": workItemIID},
+		})
 		t.Log("Deleted work item")
 	})
 }

--- a/test/e2e/suite/jobs_meta_ce_test.go
+++ b/test/e2e/suite/jobs_meta_ce_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/groups"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/jobs"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/jobtokenscope"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
 // TestMeta_JobTokenScope exercises job token scope actions via gitlab_job.
@@ -50,7 +51,9 @@ func TestMeta_JobTokenScope(t *testing.T) {
 	}()
 
 	t.Run("TokenScopePatch", func(t *testing.T) {
-		out, err := callToolOn[jobtokenscope.AccessSettingsOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+		// The action answers with a status rather than the settings it wrote,
+		// so the effect has to be read back rather than taken from the reply.
+		out, err := callToolOn[toolutil.DeleteOutput](ctx, sess.meta, "gitlab_job", map[string]any{
 			"action": "token_scope_patch",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
@@ -58,7 +61,15 @@ func TestMeta_JobTokenScope(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "token_scope_patch")
-		t.Logf("Token scope patched: inbound_enabled=%v", out.InboundEnabled)
+		requireTruef(t, out.Status == "updated", "token_scope_patch status = %q, want %q", out.Status, "updated")
+
+		settings, err := callToolOn[jobtokenscope.AccessSettingsOutput](ctx, sess.meta, "gitlab_job", map[string]any{
+			"action": "token_scope_get",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		})
+		requireNoError(t, err, "token_scope_get after patch")
+		requireTruef(t, settings.InboundEnabled, "inbound_enabled = false after asking for true")
+		t.Logf("Token scope patched and read back: inbound_enabled=%v", settings.InboundEnabled)
 	})
 
 	t.Run("TokenScopeListInbound", func(t *testing.T) {

--- a/test/e2e/suite/labels_ce_test.go
+++ b/test/e2e/suite/labels_ce_test.go
@@ -79,6 +79,9 @@ func TestIndividual_Labels(t *testing.T) {
 			LabelID:   toolutil.StringOrInt(strconv.FormatInt(labelID, 10)),
 		})
 		requireNoError(t, err, "label delete")
+		requireNotListedOn(ctx, t, sess.individual, "project labels after delete", "gitlab_label_list",
+			labels.ListInput{ProjectID: proj.pidOf()},
+			projectLabelIDs, labelID)
 		t.Log("Deleted label")
 	})
 }
@@ -156,6 +159,10 @@ func TestMeta_Labels(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta label delete")
+		requireNotListedOn(ctx, t, sess.meta, "project labels after delete", "gitlab_project", map[string]any{
+			"action": "label_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, projectLabelIDs, labelID)
 		t.Logf("Deleted label ID=%d", labelID)
 	})
 }

--- a/test/e2e/suite/merge_requests_meta_ce_test.go
+++ b/test/e2e/suite/merge_requests_meta_ce_test.go
@@ -10,6 +10,7 @@ package suite
 import (
 	"context"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -129,6 +130,8 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "subscribe")
+		requireTruef(t, out.IID == mrIID, "subscribe answered for MR !%d, want !%d", out.IID, mrIID)
+		requireTruef(t, out.Subscribed, "MR !%d reports subscribed=false right after subscribing", mrIID)
 		t.Logf("Subscribed to MR !%d", out.IID)
 	})
 
@@ -139,6 +142,8 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "unsubscribe")
+		requireTruef(t, out.IID == mrIID, "unsubscribe answered for MR !%d, want !%d", out.IID, mrIID)
+		requireTruef(t, !out.Subscribed, "MR !%d still reports subscribed=true after unsubscribing", mrIID)
 		t.Logf("Unsubscribed from MR !%d", out.IID)
 	})
 
@@ -154,6 +159,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "time_estimate_set")
+		requireTruef(t, out.TimeEstimate == threeHoursSeconds, "time_estimate = %ds, want %ds", out.TimeEstimate, threeHoursSeconds)
 		t.Logf("Time estimate set: %ds", out.TimeEstimate)
 	})
 
@@ -164,6 +170,8 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "time_stats")
+		requireTruef(t, out.TimeEstimate == threeHoursSeconds, "time_estimate = %ds, want the %ds the previous subtest set", out.TimeEstimate, threeHoursSeconds)
+		requireTruef(t, out.TotalTimeSpent == 0, "total_time_spent = %ds, want 0 before any time is added", out.TotalTimeSpent)
 		t.Logf("Time stats: estimate=%ds, spent=%ds", out.TimeEstimate, out.TotalTimeSpent)
 	})
 
@@ -178,6 +186,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "spent_time_add")
+		requireTruef(t, out.TotalTimeSpent == oneHourSeconds, "total_time_spent = %ds, want %ds", out.TotalTimeSpent, oneHourSeconds)
 		t.Logf("Spent time added: %ds total", out.TotalTimeSpent)
 	})
 
@@ -188,6 +197,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "spent_time_reset")
+		requireTruef(t, out.TotalTimeSpent == 0, "total_time_spent = %ds after reset, want 0", out.TotalTimeSpent)
 		t.Logf("Spent time reset: %ds", out.TotalTimeSpent)
 	})
 
@@ -198,6 +208,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "time_estimate_reset")
+		requireTruef(t, out.TimeEstimate == 0, "time_estimate = %ds after reset, want 0", out.TimeEstimate)
 		t.Logf("Time estimate reset: %ds", out.TimeEstimate)
 	})
 
@@ -235,7 +246,16 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "approval_config")
-		t.Logf("Approval config for MR %d (project_id=%d)", out.IID, out.ProjectID)
+		// The identity of the merge request is not assertable here. GitLab CE
+		// answers this endpoint with four fields, `approved`, `approved_by`,
+		// `user_can_approve` and `user_has_approved`, and none of the merge
+		// request's own fields the SDK type declares; I checked against a live
+		// 19.3 instance. What the fixture does guarantee is that nobody has
+		// approved the merge request it just created.
+		requireTruef(t, !out.Approved, "a freshly created MR reports approved = true")
+		requireTruef(t, len(out.ApprovedBy) == 0,
+			"a freshly created MR reports %d approvers, want none", len(out.ApprovedBy))
+		t.Logf("Approval config for MR !%d: approved=%v", mrIID, out.Approved)
 	})
 
 	var approvalRuleID int64
@@ -273,6 +293,9 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "approval_rule_update")
+		requireTruef(t, out.ID == approvalRuleID, "approval_rule_update answered for rule %d, want %d", out.ID, approvalRuleID)
+		requireTruef(t, out.Name == "updated-rule", "approval rule name = %q, want %q", out.Name, "updated-rule")
+		requireTruef(t, out.ApprovalsRequired == 2, "approvals_required = %d, want 2", out.ApprovalsRequired)
 		t.Logf("Updated approval rule %d: %s", out.ID, out.Name)
 	})
 
@@ -289,6 +312,16 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "approval_rule_delete")
+		requireNotListedOn(ctx, t, sess.meta, "MR approval rules after delete", "gitlab_merge_request", map[string]any{
+			"action": "approval_rules",
+			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
+		}, func(out mrapprovals.RulesOutput) []int64 {
+			ids := make([]int64, 0, len(out.Rules))
+			for _, r := range out.Rules {
+				ids = append(ids, r.ID)
+			}
+			return ids
+		}, approvalRuleID)
 		t.Logf("Deleted approval rule %d", approvalRuleID)
 	})
 
@@ -361,6 +394,10 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "emoji_mr_delete")
+		requireNotListedOn(ctx, t, sess.meta, "MR award emoji after delete", "gitlab_merge_request", map[string]any{
+			"action": "emoji_mr_list",
+			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
+		}, awardEmojiIDs, mrEmojiID)
 		t.Logf("Deleted MR emoji %d", mrEmojiID)
 	})
 
@@ -441,32 +478,47 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "emoji_mr_note_delete")
+		requireNotListedOn(ctx, t, sess.meta, "MR note award emoji after delete", "gitlab_merge_request", map[string]any{
+			"action": "emoji_mr_note_list",
+			"params": map[string]any{
+				"project_id":        proj.pidStr(),
+				"merge_request_iid": mrIID,
+				"note_id":           mrNoteID,
+			},
+		}, awardEmojiIDs, mrNoteEmojiID)
 		t.Logf("Deleted MR note emoji %d", mrNoteEmojiID)
 	})
 
 	// ── Setup for resource event tests ───────────────────────────────────
+	const (
+		mrEventLabelName      = "e2e-mr-event-label"
+		mrEventMilestoneTitle = "e2e-mr-event-milestone"
+	)
 	t.Run("SetupLabelEvent", func(t *testing.T) {
 		requireTruef(t, mrIID > 0, "mrIID not set")
 		lbl, err := callToolOn[labels.Output](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "label_create",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
-				"name":       "e2e-mr-event-label",
+				"name":       mrEventLabelName,
 				"color":      "#0033cc",
 			},
 		})
 		requireNoError(t, err, "label_create for MR event setup")
+		requireTruef(t, lbl.Name == mrEventLabelName, "label name = %q, want %q", lbl.Name, mrEventLabelName)
 		t.Logf("Created label %q (ID=%d)", lbl.Name, lbl.ID)
 
-		_, err = callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+		updated, err := callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id":        proj.pidStr(),
 				"merge_request_iid": mrIID,
-				"add_labels":        []string{"e2e-mr-event-label"},
+				"add_labels":        []string{mrEventLabelName},
 			},
 		})
 		requireNoError(t, err, "add label to MR")
+		requireTruef(t, slices.Contains(updated.Labels, mrEventLabelName),
+			"MR !%d labels = %v, want them to contain %q", mrIID, updated.Labels, mrEventLabelName)
 		t.Log("Added label to MR")
 	})
 
@@ -476,13 +528,14 @@ func TestMeta_MRDeep(t *testing.T) {
 			"action": "milestone_create",
 			"params": map[string]any{
 				"project_id": proj.pidStr(),
-				"title":      "e2e-mr-event-milestone",
+				"title":      mrEventMilestoneTitle,
 			},
 		})
 		requireNoError(t, err, "milestone_create for MR event setup")
+		requireTruef(t, ms.Title == mrEventMilestoneTitle, "milestone title = %q, want %q", ms.Title, mrEventMilestoneTitle)
 		t.Logf("Created milestone %q (ID=%d)", ms.Title, ms.ID)
 
-		_, err = callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+		updated, err := callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id":        proj.pidStr(),
@@ -491,6 +544,8 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "set milestone on MR")
+		requireTruef(t, updated.Milestone != nil && updated.Milestone.ID == ms.ID,
+			"MR !%d milestone = %+v, want ID %d", mrIID, updated.Milestone, ms.ID)
 		t.Log("Set milestone on MR")
 	})
 
@@ -506,7 +561,7 @@ func TestMeta_MRDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "close MR for state event")
 
-		_, err = callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+		reopened, err := callToolOn[mergerequests.Output](ctx, sess.meta, "gitlab_merge_request", map[string]any{
 			"action": "update",
 			"params": map[string]any{
 				"project_id":        proj.pidStr(),
@@ -515,6 +570,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "reopen MR for state event")
+		requireTruef(t, reopened.State == "opened", "MR !%d state = %q after reopen, want %q", mrIID, reopened.State, "opened")
 		t.Log("Closed and reopened MR to generate state events")
 	})
 
@@ -526,6 +582,10 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "event_mr_label_list")
+		// SetupLabelEvent added this exact label to this exact merge request.
+		requireTruef(t, slices.ContainsFunc(out.Events, func(e resourceevents.LabelEventOutput) bool {
+			return e.Label != nil && e.Label.Name == mrEventLabelName
+		}), "no label event names %q among %d events", mrEventLabelName, len(out.Events))
 		t.Logf("Listed %d MR label events", len(out.Events))
 	})
 
@@ -537,7 +597,7 @@ func TestMeta_MRDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "list label events for get")
 		requireTruef(t, len(list.Events) > 0, "expected at least 1 MR label event after adding label")
-		_, err = callToolOn[resourceevents.LabelEventOutput](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+		out, err := callToolOn[resourceevents.LabelEventOutput](ctx, sess.meta, "gitlab_merge_request", map[string]any{
 			"action": "event_mr_label_get",
 			"params": map[string]any{
 				"project_id":        proj.pidStr(),
@@ -546,6 +606,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_mr_label_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "label event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
 		t.Log("Got MR label event")
 	})
 
@@ -556,6 +617,10 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "event_mr_milestone_list")
+		// SetupMilestoneEvent put this exact milestone on this exact merge request.
+		requireTruef(t, slices.ContainsFunc(out.Events, func(e resourceevents.MilestoneEventOutput) bool {
+			return e.Milestone != nil && e.Milestone.Title == mrEventMilestoneTitle
+		}), "no milestone event names %q among %d events", mrEventMilestoneTitle, len(out.Events))
 		t.Logf("Listed %d MR milestone events", len(out.Events))
 	})
 
@@ -567,7 +632,7 @@ func TestMeta_MRDeep(t *testing.T) {
 		})
 		requireNoError(t, err, "list milestone events for get")
 		requireTruef(t, len(list.Events) > 0, "expected at least 1 MR milestone event after setting milestone")
-		_, err = callToolOn[resourceevents.MilestoneEventOutput](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+		out, err := callToolOn[resourceevents.MilestoneEventOutput](ctx, sess.meta, "gitlab_merge_request", map[string]any{
 			"action": "event_mr_milestone_get",
 			"params": map[string]any{
 				"project_id":         proj.pidStr(),
@@ -576,6 +641,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_mr_milestone_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "milestone event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
 		t.Log("Got MR milestone event")
 	})
 
@@ -596,6 +662,7 @@ func TestMeta_MRDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "event_mr_state_get")
+		requireTruef(t, out.ID == list.Events[0].ID, "state event ID = %d, want the listed %d", out.ID, list.Events[0].ID)
 		t.Logf("Got MR state event %d: %s", out.ID, out.State)
 	})
 
@@ -607,7 +674,11 @@ func TestMeta_MRDeep(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "cancel_auto_merge")
-		t.Log("cancel_auto_merge completed")
+		// The response is not assertable: this fixture never enabled auto-merge,
+		// because doing so needs a pipeline, so the call is a no-op and GitLab
+		// answers it with a body it does not promise the shape of. A live 19.3
+		// instance returned one carrying no IID at all.
+		t.Logf("cancel_auto_merge completed for MR !%d (auto-merge was never enabled)", mrIID)
 	})
 }
 

--- a/test/e2e/suite/milestones_ce_test.go
+++ b/test/e2e/suite/milestones_ce_test.go
@@ -80,6 +80,8 @@ func TestIndividual_Milestones(t *testing.T) {
 			MilestoneIID: milestoneIID,
 		})
 		requireNoError(t, err, "milestone delete")
+		requireGoneOn(ctx, t, sess.individual, "milestone after delete", "gitlab_milestone_get",
+			milestones.GetInput{ProjectID: proj.pidOf(), MilestoneIID: milestoneIID})
 		t.Log("Deleted milestone")
 	})
 }
@@ -159,6 +161,10 @@ func TestMeta_Milestones(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta milestone delete")
+		requireGoneOn(ctx, t, sess.meta, "milestone after delete", "gitlab_project", map[string]any{
+			"action": "milestone_get",
+			"params": map[string]any{"project_id": proj.pidStr(), "milestone_iid": milestoneIID},
+		})
 		t.Logf("Deleted milestone IID=%d", milestoneIID)
 	})
 }

--- a/test/e2e/suite/misc_meta_ce_test.go
+++ b/test/e2e/suite/misc_meta_ce_test.go
@@ -9,8 +9,10 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"testing"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/branches"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/branchrules"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/cicatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/deployments"
@@ -59,6 +61,23 @@ func TestMeta_BranchRules(t *testing.T) {
 	ctx := context.Background()
 	proj := createProjectMeta(ctx, t, sess.meta)
 
+	// Protect a wildcard branch so the project owns a rule the list has to
+	// name. The list is served by a raw GraphQL document, and a document
+	// GitLab refuses comes back as an empty rule set rather than an error, so
+	// counting rules cannot tell the two apart and naming one can.
+	const ruleBranch = "e2e-rule-*"
+	protected, protectErr := callToolOn[branches.ProtectedOutput](ctx, sess.meta, "gitlab_branch", map[string]any{
+		"action": "protect",
+		"params": map[string]any{
+			"project_id":         proj.pidStr(),
+			"branch_name":        ruleBranch,
+			"push_access_level":  40,
+			"merge_access_level": 30,
+		},
+	})
+	requireNoError(t, protectErr, "protect branch for branch rule fixture")
+	requireTruef(t, protected.Name == ruleBranch, "protected branch = %q, want %q", protected.Name, ruleBranch)
+
 	t.Run("Meta/BranchRule/List", func(t *testing.T) {
 		out, err := callToolOn[branchrules.ListOutput](ctx, sess.meta, "gitlab_branch", map[string]any{
 			"action": "rule_list",
@@ -67,6 +86,9 @@ func TestMeta_BranchRules(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "branch rule list")
+		requireTruef(t, slices.ContainsFunc(out.Rules, func(r branchrules.BranchRuleItem) bool {
+			return r.Name == ruleBranch
+		}), "branch rules do not name the protected %q: %+v", ruleBranch, out.Rules)
 		t.Logf("Project %s has %d branch rule(s)", proj.Path, len(out.Rules))
 	})
 }
@@ -166,11 +188,26 @@ func TestIndividual_BranchRules(t *testing.T) {
 	ctx := context.Background()
 	proj := createProject(ctx, t, sess.individual)
 
+	// Same reasoning as TestMeta_BranchRules: give the project a rule of its
+	// own so an empty answer cannot pass for a correct one.
+	const ruleBranch = "e2e-rule-*"
+	protected, protectErr := callToolOn[branches.ProtectedOutput](ctx, sess.individual, "gitlab_branch_protect", branches.ProtectInput{
+		ProjectID:        proj.pidOf(),
+		BranchName:       ruleBranch,
+		PushAccessLevel:  40,
+		MergeAccessLevel: 30,
+	})
+	requireNoError(t, protectErr, "protect branch for branch rule fixture")
+	requireTruef(t, protected.Name == ruleBranch, "protected branch = %q, want %q", protected.Name, ruleBranch)
+
 	t.Run("ListBranchRules", func(t *testing.T) {
 		out, err := callToolOn[branchrules.ListOutput](ctx, sess.individual, "gitlab_list_branch_rules", branchrules.ListInput{
 			ProjectPath: proj.Path,
 		})
 		requireNoError(t, err, "list branch rules")
+		requireTruef(t, slices.ContainsFunc(out.Rules, func(r branchrules.BranchRuleItem) bool {
+			return r.Name == ruleBranch
+		}), "branch rules do not name the protected %q: %+v", ruleBranch, out.Rules)
 		t.Logf("Project %s has %d branch rule(s)", proj.Path, len(out.Rules))
 	})
 }
@@ -254,6 +291,8 @@ func TestMeta_FeatureFlagUserLists(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "ff_user_list_get")
+		requireTruef(t, out.IID == listIID, "ff_user_list_get answered for IID %d, want %d", out.IID, listIID)
+		requireTruef(t, out.Name == "e2e test user list", "user list name = %q, want the name the create sent", out.Name)
 		t.Logf("Got user list: IID=%d name=%q", out.IID, out.Name)
 	})
 

--- a/test/e2e/suite/mr_approval_ce_test.go
+++ b/test/e2e/suite/mr_approval_ce_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mergerequests"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrapprovals"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/projects"
 )
 
@@ -50,6 +51,8 @@ func TestIndividual_MRApproval(t *testing.T) {
 			SkipCI:    true,
 		})
 		requireNoError(t, err, "rebase MR")
+		// rebase_in_progress reports whether the queued job is still pending, so
+		// a rebase Sidekiq finishes first legitimately answers false.
 		t.Logf("Rebase MR !%d: in_progress=%v", mr.IID, out.RebaseInProgress)
 	})
 
@@ -59,6 +62,7 @@ func TestIndividual_MRApproval(t *testing.T) {
 			MRIID:     mr.IID,
 		})
 		requireNoError(t, err, "approve MR")
+		requireTruef(t, out.ApprovedBy > 0, "MR !%d reports %d approvers right after approving", mr.IID, out.ApprovedBy)
 		t.Logf("Approved MR !%d (approved=%v)", mr.IID, out.Approved)
 	})
 
@@ -68,6 +72,12 @@ func TestIndividual_MRApproval(t *testing.T) {
 			MRIID:     mr.IID,
 		})
 		requireNoError(t, err, "unapprove MR")
+		config, err := callToolOn[mrapprovals.ConfigOutput](ctx, sess.individual, "gitlab_mr_approval_config", mrapprovals.ConfigInput{
+			ProjectID: proj.pidOf(),
+			MRIID:     mr.IID,
+		})
+		requireNoError(t, err, "read approval config after unapprove")
+		requireTruef(t, len(config.ApprovedBy) == 0, "MR !%d still lists %d approvers after unapproving", mr.IID, len(config.ApprovedBy))
 		t.Logf("Unapproved MR !%d", mr.IID)
 	})
 
@@ -156,6 +166,7 @@ func TestMeta_MRApproval(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta approve MR")
+		requireTruef(t, out.ApprovedBy > 0, "MR !%d reports %d approvers right after approving", mr.IID, out.ApprovedBy)
 		t.Logf("Approved MR !%d (approved=%v)", mr.IID, out.Approved)
 	})
 
@@ -168,6 +179,15 @@ func TestMeta_MRApproval(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta unapprove MR")
+		config, err := callToolOn[mrapprovals.ConfigOutput](ctx, sess.meta, "gitlab_merge_request", map[string]any{
+			"action": "approval_config",
+			"params": map[string]any{
+				"project_id":        proj.pidStr(),
+				"merge_request_iid": mr.IID,
+			},
+		})
+		requireNoError(t, err, "read approval config after unapprove")
+		requireTruef(t, len(config.ApprovedBy) == 0, "MR !%d still lists %d approvers after unapproving", mr.IID, len(config.ApprovedBy))
 		t.Logf("Unapproved MR !%d via meta-tool", mr.IID)
 	})
 

--- a/test/e2e/suite/mr_draft_notes_ce_test.go
+++ b/test/e2e/suite/mr_draft_notes_ce_test.go
@@ -94,6 +94,9 @@ func TestIndividual_MRDraftNotes(t *testing.T) {
 			NoteID:    deleteNoteID,
 		})
 		requireNoError(t, err, "delete draft note")
+		requireNotListedOn(ctx, t, sess.individual, "MR draft notes after delete", "gitlab_mr_draft_note_list",
+			mrdraftnotes.ListInput{ProjectID: proj.pidOf(), MRIID: mr.IID},
+			draftNoteIDs, deleteNoteID)
 		t.Logf("Deleted draft note %d", deleteNoteID)
 	})
 
@@ -205,6 +208,13 @@ func TestMeta_MRDraftNotes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "delete draft note meta")
+		requireNotListedOn(ctx, t, sess.meta, "MR draft notes after delete", "gitlab_mr_review", map[string]any{
+			"action": "draft_note_list",
+			"params": map[string]any{
+				"project_id":        proj.pidStr(),
+				"merge_request_iid": mr.IID,
+			},
+		}, draftNoteIDs, deleteNoteID)
 		t.Logf("Deleted draft note (meta) %d", deleteNoteID)
 	})
 

--- a/test/e2e/suite/mr_review_meta_ce_test.go
+++ b/test/e2e/suite/mr_review_meta_ce_test.go
@@ -7,6 +7,7 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrchanges"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrdiscussions"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrdraftnotes"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/mrnotes"
 )
 
 // TestMeta_MRReviewChanges exercises changes_get, diff_versions_list, and
@@ -60,11 +62,19 @@ func TestMeta_MRReviewChanges(t *testing.T) {
 	mrIID := strconv.FormatInt(mrOut.IID, 10)
 
 	t.Run("ChangesGet", func(t *testing.T) {
+		// GitLab reports no changes while it is still preparing the diff, so the
+		// wait has to happen before the assertion rather than in the sibling
+		// subtest that already does it.
+		waitForMRReady(ctx, t, sess.glClient, proj.ID, mrOut.IID)
 		out, err := callToolOn[mrchanges.Output](ctx, sess.meta, "gitlab_mr_review", map[string]any{
 			"action": "changes_get",
 			"params": map[string]any{"project_id": proj.pidStr(), "merge_request_iid": mrIID},
 		})
 		requireNoError(t, err, "changes_get")
+		// The source branch adds exactly one file over the target.
+		requireTruef(t, slices.ContainsFunc(out.Changes, func(c mrchanges.FileDiffOutput) bool {
+			return c.NewPath == "new.txt"
+		}), "changes do not include the file the branch added: %+v", out.Changes)
 		t.Logf("Changes: %d files, truncated: %d", len(out.Changes), len(out.TruncatedFiles))
 	})
 
@@ -245,5 +255,27 @@ func TestMeta_DraftNotePublish(t *testing.T) {
 		},
 	})
 	requireNoError(t, err, "draft_note_publish")
+	// Publishing moves the draft out of the draft list and into the merge
+	// request's notes, so both halves are observable.
+	requireNotListedOn(ctx, t, sess.meta, "MR draft notes after publish", "gitlab_mr_review", map[string]any{
+		"action": "draft_note_list",
+		"params": map[string]any{
+			"project_id":        proj.pidStr(),
+			"merge_request_iid": mrIID,
+		},
+	}, draftNoteIDs, draftOut.ID)
+	requireListedOn(ctx, t, sess.meta, "MR notes after publish", "gitlab_mr_review", map[string]any{
+		"action": "note_list",
+		"params": map[string]any{
+			"project_id":        proj.pidStr(),
+			"merge_request_iid": mrIID,
+		},
+	}, func(list mrnotes.ListOutput) []string {
+		bodies := make([]string, 0, len(list.Notes))
+		for _, n := range list.Notes {
+			bodies = append(bodies, n.Body)
+		}
+		return bodies
+	}, "Draft to publish individually")
 	t.Logf("Published draft note %s", draftID)
 }

--- a/test/e2e/suite/notifications_ce_test.go
+++ b/test/e2e/suite/notifications_ce_test.go
@@ -41,6 +41,9 @@ func TestMeta_Notifications(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "project notification get")
+			// The project was created moments ago and carries no per-project
+			// override, so GitLab reports it as following the account default.
+			requireTruef(t, out.Level == "global", "fresh project notification level = %q, want %q", out.Level, "global")
 			t.Logf("Project notification level: %s", out.Level)
 		})
 	})

--- a/test/e2e/suite/package_extras_ce_test.go
+++ b/test/e2e/suite/package_extras_ce_test.go
@@ -341,6 +341,15 @@ func TestIndividual_PackageRegistryRules(t *testing.T) {
 			TagName:      "seed-b",
 		})
 		requireNoError(t, deleteErr, "delete registry tag seed-b")
+		requireNotListedOn(ctx, t, sess.individual, "registry tags after delete", "gitlab_registry_list_tags",
+			containerregistry.ListTagsInput{ProjectID: toolutil.StringOrInt(seedProject), RepositoryID: repo.ID},
+			func(out containerregistry.TagListOutput) []string {
+				names := make([]string, 0, len(out.Tags))
+				for _, tg := range out.Tags {
+					names = append(names, tg.Name)
+				}
+				return names
+			}, "seed-b")
 		t.Log("Deleted seeded registry tag seed-b")
 	})
 }

--- a/test/e2e/suite/pipeline_triggers_ce_test.go
+++ b/test/e2e/suite/pipeline_triggers_ce_test.go
@@ -87,6 +87,16 @@ func TestMeta_PipelineTriggers(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "pipeline trigger delete")
+		requireNotListedOn(ctx, t, sess.meta, "pipeline triggers after delete", "gitlab_pipeline", map[string]any{
+			"action": "trigger_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out pipelinetriggers.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.Triggers))
+			for _, tr := range out.Triggers {
+				ids = append(ids, tr.ID)
+			}
+			return ids
+		}, triggerID)
 		t.Logf("Deleted trigger %d", triggerID)
 	})
 }

--- a/test/e2e/suite/project_extras2_ce_test.go
+++ b/test/e2e/suite/project_extras2_ce_test.go
@@ -257,6 +257,11 @@ func TestMeta_ProjectIntegrationConfig(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "integration_delete (jira)")
+		// The listing reports only active integrations, so a deleted one leaves it.
+		requireNotListedOn(ctx, t, sess.meta, "project integrations after delete", "gitlab_project", map[string]any{
+			"action": "integration_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, integrationSlugs, "jira")
 		t.Log("Deleted Jira integration")
 	})
 
@@ -269,6 +274,10 @@ func TestMeta_ProjectIntegrationConfig(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "integration_delete")
+		requireNotListedOn(ctx, t, sess.meta, "project integrations after delete", "gitlab_project", map[string]any{
+			"action": "integration_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, integrationSlugs, projectExtrasIntegrationSlug)
 		t.Logf("Deleted integration %q", projectExtrasIntegrationSlug)
 	})
 }
@@ -346,6 +355,16 @@ func TestMeta_ProjectGroupIntegrations(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "integration_delete_group")
+		requireNotListedOn(ctx, t, sess.meta, "group integrations after delete", "gitlab_project", map[string]any{
+			"action": "integration_list_group",
+			"params": map[string]any{"group_id": groupID},
+		}, func(out integrations.ListGroupIntegrationsOutput) []string {
+			slugs := make([]string, 0, len(out.Integrations))
+			for _, i := range out.Integrations {
+				slugs = append(slugs, i.Slug)
+			}
+			return slugs
+		}, projectExtrasIntegrationSlug)
 		t.Logf("Deleted group integration %q", projectExtrasIntegrationSlug)
 	})
 
@@ -480,6 +499,10 @@ func TestMeta_ProjectPagesWrite(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "pages_domain_delete")
+		requireGoneOn(ctx, t, sess.meta, "Pages domain after delete", "gitlab_project", map[string]any{
+			"action": "pages_domain_get",
+			"params": map[string]any{"project_id": proj.pidStr(), "domain": domain},
+		})
 		t.Logf("Deleted Pages domain %q", domain)
 	})
 

--- a/test/e2e/suite/project_extras_ce_test.go
+++ b/test/e2e/suite/project_extras_ce_test.go
@@ -165,6 +165,16 @@ func TestMeta_ProjectMemberLifecycle(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "member_delete")
+		requireNotListedOn(ctx, t, sess.meta, "project members after delete", "gitlab_project", map[string]any{
+			"action": "members",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out members.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.Members))
+			for _, m := range out.Members {
+				ids = append(ids, m.ID)
+			}
+			return ids
+		}, userID)
 		t.Logf("Removed member %d", userID)
 	})
 }
@@ -232,6 +242,16 @@ func TestMeta_ProjectGroupSharing(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "delete_shared_group")
+		requireNotListedOn(ctx, t, sess.meta, "project invited groups after unshare", "gitlab_project", map[string]any{
+			"action": "list_invited_groups",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out projects.ListProjectGroupsOutput) []int64 {
+			ids := make([]int64, 0, len(out.Groups))
+			for _, g := range out.Groups {
+				ids = append(ids, g.ID)
+			}
+			return ids
+		}, group.ID)
 		t.Logf("Removed group share %d", group.ID)
 	})
 }
@@ -481,6 +501,12 @@ func TestMeta_ProjectForkRelations(t *testing.T) {
 			"params": map[string]any{"project_id": fork.pidStr()},
 		})
 		requireNoError(t, err, "delete_fork_relation")
+		// The tool answers with the project body rather than a relation object,
+		// so the relation is read back the way create_fork_relation verifies it.
+		unforked, _, getErr := sess.glClient.GL().Projects.GetProject(fork.ID, nil, gl.WithContext(ctx))
+		requireNoError(t, getErr, "read fork project after delete_fork_relation")
+		requireTruef(t, unforked.ForkedFromProject == nil,
+			"project %d still names a source project after the relation was deleted: %+v", fork.ID, unforked.ForkedFromProject)
 		t.Log("Deleted fork relation")
 	})
 }
@@ -535,6 +561,16 @@ func TestMeta_ProjectUploadDeletes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "upload_delete")
+		requireNotListedOn(ctx, t, sess.meta, "project uploads after delete by ID", "gitlab_project", map[string]any{
+			"action": "upload_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out uploads.ListOutput) []int64 {
+			ids := make([]int64, 0, len(out.Uploads))
+			for _, u := range out.Uploads {
+				ids = append(ids, u.ID)
+			}
+			return ids
+		}, up.ID)
 		t.Logf("Deleted upload %d by ID", up.ID)
 	})
 
@@ -550,6 +586,16 @@ func TestMeta_ProjectUploadDeletes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "upload_delete_by_secret")
+		requireNotListedOn(ctx, t, sess.meta, "project uploads after delete by secret", "gitlab_project", map[string]any{
+			"action": "upload_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out uploads.ListOutput) []string {
+			names := make([]string, 0, len(out.Uploads))
+			for _, u := range out.Uploads {
+				names = append(names, u.Filename)
+			}
+			return names
+		}, filename)
 		t.Logf("Deleted upload %s/%s by secret", secret, filename)
 	})
 }

--- a/test/e2e/suite/project_mirrors_ce_test.go
+++ b/test/e2e/suite/project_mirrors_ce_test.go
@@ -136,6 +136,7 @@ func TestMeta_ProjectRemoteMirrors(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "mirror_delete")
+		// MirrorList_AfterDelete is where this delete's effect is observed.
 		t.Logf("Deleted mirror %d", mirrorID)
 	})
 

--- a/test/e2e/suite/projects_meta_ce_test.go
+++ b/test/e2e/suite/projects_meta_ce_test.go
@@ -105,6 +105,9 @@ func TestMeta_ProjectCore(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr()},
 		})
 		requireNoError(t, err, "meta project unstar")
+		requireTruef(t, out.ID == proj.ID, "unstar answered for project %d, want %d", out.ID, proj.ID)
+		// The Star subtest is the only star this fixture project ever had.
+		requireTruef(t, out.StarCount == 0, "star_count = %d after unstarring, want 0", out.StarCount)
 		t.Logf("Unstarred project %d", out.ID)
 	})
 
@@ -182,6 +185,9 @@ func TestMeta_ProjectCore(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr()},
 		})
 		requireNoError(t, err, "meta project repository_storage_get")
+		// Every project lives on a named storage shard, "default" on a
+		// single-shard instance.
+		requireTruef(t, out.RepositoryStorage != "", "project %d reports no repository storage shard", proj.ID)
 		t.Logf("Got repository storage: %s", out.RepositoryStorage)
 	})
 
@@ -322,6 +328,12 @@ func TestMeta_ProjectHooks(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta project hook_set_custom_header")
+		// GitLab masks a custom header's value on read but keeps its key, so the
+		// key is what a read observes.
+		requireListedOn(ctx, t, sess.meta, "hook custom headers after set", "gitlab_project", map[string]any{
+			"action": "hook_get",
+			"params": map[string]any{"project_id": proj.pidStr(), "hook_id": hookID},
+		}, hookCustomHeaderKeys, "X-E2E-Test")
 		t.Log("Set custom header on hook")
 	})
 
@@ -336,6 +348,10 @@ func TestMeta_ProjectHooks(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta project hook_delete_custom_header")
+		requireNotListedOn(ctx, t, sess.meta, "hook custom headers after delete", "gitlab_project", map[string]any{
+			"action": "hook_get",
+			"params": map[string]any{"project_id": proj.pidStr(), "hook_id": hookID},
+		}, hookCustomHeaderKeys, "X-E2E-Test")
 		t.Log("Deleted custom header from hook")
 	})
 
@@ -394,6 +410,16 @@ func TestMeta_ProjectHooks(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta project hook_delete")
+		requireNotListedOn(ctx, t, sess.meta, "project hooks after delete", "gitlab_project", map[string]any{
+			"action": "hook_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out projects.ListHooksOutput) []int64 {
+			ids := make([]int64, 0, len(out.Hooks))
+			for _, h := range out.Hooks {
+				ids = append(ids, h.ID)
+			}
+			return ids
+		}, hookID)
 		t.Logf("Deleted hook %d", hookID)
 	})
 }
@@ -475,6 +501,19 @@ func TestMeta_ProjectLabelsDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "label unsubscribe")
+		// The action answers with no content, but the label a read returns
+		// carries the subscription, which is what the group twin asserts and
+		// what makes the difference between the call returning and the
+		// subscription actually ending.
+		read, err := callToolOn[labels.Output](ctx, sess.meta, "gitlab_project", map[string]any{
+			"action": "label_get",
+			"params": map[string]any{
+				"project_id": proj.pidStr(),
+				"label_id":   labelName,
+			},
+		})
+		requireNoError(t, err, "re-read label after unsubscribe")
+		requireTruef(t, !read.Subscribed, "label %q still reports subscribed=true after unsubscribing", labelName)
 		t.Logf("Unsubscribed from label %q", labelName)
 	})
 
@@ -666,6 +705,9 @@ func TestMeta_ProjectBadgesDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "badge_preview")
+		// The URL previewed carries no placeholders, so rendering leaves it alone.
+		requireTruef(t, out.Badge.RenderedLinkURL == "https://example.com/preview",
+			"rendered link_url = %q, want the URL previewed", out.Badge.RenderedLinkURL)
 		t.Logf("Badge preview rendered: link=%s", out.Badge.RenderedLinkURL)
 	})
 }
@@ -807,6 +849,19 @@ func TestMeta_ProjectBoardsDeep(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "board_list_delete")
+		requireNotListedOn(ctx, t, sess.meta, "board lists after delete", "gitlab_project", map[string]any{
+			"action": "board_list_list",
+			"params": map[string]any{
+				"project_id": proj.pidStr(),
+				"board_id":   boardID,
+			},
+		}, func(out boards.ListBoardListsOutput) []int64 {
+			ids := make([]int64, 0, len(out.Lists))
+			for _, l := range out.Lists {
+				ids = append(ids, l.ID)
+			}
+			return ids
+		}, listID)
 		t.Logf("Deleted board list %d", listID)
 	})
 }
@@ -852,7 +907,7 @@ func TestMeta_ProjectApprovals(t *testing.T) {
 		if !sess.enterprise {
 			return
 		}
-		_, err := callToolOn[projects.ApprovalConfigOutput](ctx, sess.meta, "gitlab_project", map[string]any{
+		out, err := callToolOn[projects.ApprovalConfigOutput](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "approval_config_change",
 			"params": map[string]any{
 				"project_id":              proj.pidStr(),
@@ -861,6 +916,9 @@ func TestMeta_ProjectApprovals(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "approval_config_change")
+		requireTruef(t, out.ResetApprovalsOnPush, "reset_approvals_on_push = false after asking for true")
+		requireTruef(t, !out.DisableOverridingApproversPerMergeRequest,
+			"disable_overriding_approvers_per_merge_request = true after asking for false")
 		t.Log("Changed approval config")
 	})
 
@@ -924,6 +982,9 @@ func TestMeta_ProjectApprovals(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "approval_rule_update")
+		requireTruef(t, out.ID == ruleID, "approval_rule_update answered for rule %d, want %d", out.ID, ruleID)
+		requireTruef(t, out.Name == "E2E Approval Rule Updated", "approval rule name = %q, want %q", out.Name, "E2E Approval Rule Updated")
+		requireTruef(t, out.ApprovalsRequired == 2, "approvals_required = %d, want 2", out.ApprovalsRequired)
 		t.Logf("Updated approval rule %d", out.ID)
 	})
 
@@ -939,6 +1000,16 @@ func TestMeta_ProjectApprovals(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "approval_rule_delete")
+		requireNotListedOn(ctx, t, sess.meta, "project approval rules after delete", "gitlab_project", map[string]any{
+			"action": "approval_rule_list",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		}, func(out projects.ListApprovalRulesOutput) []int64 {
+			ids := make([]int64, 0, len(out.Rules))
+			for _, r := range out.Rules {
+				ids = append(ids, r.ID)
+			}
+			return ids
+		}, ruleID)
 		t.Logf("Deleted approval rule %d", ruleID)
 	})
 }
@@ -974,11 +1045,15 @@ func TestMeta_ProjectExport(t *testing.T) {
 	})
 
 	t.Run("ExportStatus", func(t *testing.T) {
-		_, err := callToolOn[projectimportexport.ExportStatusOutput](ctx, sess.meta, "gitlab_project", map[string]any{
+		out, err := callToolOn[projectimportexport.ExportStatusOutput](ctx, sess.meta, "gitlab_project", map[string]any{
 			"action": "export_status",
 			"params": map[string]any{"project_id": proj.pidStr()},
 		})
 		requireNoError(t, err, "export_status")
+		requireTruef(t, out.ID == proj.ID, "export status is for project %d, want %d", out.ID, proj.ID)
+		// Which state the export has reached is Sidekiq's business, so only the
+		// presence of a state is assertable here.
+		requireTruef(t, out.ExportStatus != "", "project %d reports an empty export status", proj.ID)
 		t.Log("Got export status")
 	})
 
@@ -988,6 +1063,8 @@ func TestMeta_ProjectExport(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr()},
 		})
 		requireNoError(t, err, "import_status")
+		// The fixture created this project rather than importing it.
+		requireTruef(t, out.ImportStatus == "none", "import status = %q, want %q for a project that was never imported", out.ImportStatus, "none")
 		t.Logf("Import status: %s", out.ImportStatus)
 	})
 }

--- a/test/e2e/suite/protected_envs_ee_test.go
+++ b/test/e2e/suite/protected_envs_ee_test.go
@@ -82,6 +82,10 @@ func TestMeta_ProtectedEnvs(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta protected env unprotect")
+		requireGoneOn(ctx, t, sess.meta, "protected environment after unprotect", "gitlab_environment", map[string]any{
+			"action": "protected_get",
+			"params": map[string]any{"project_id": proj.pidStr(), "environment": envName},
+		})
 		t.Logf("Unprotected environment: %s", envName)
 	})
 }

--- a/test/e2e/suite/protected_tags_ce_test.go
+++ b/test/e2e/suite/protected_tags_ce_test.go
@@ -86,6 +86,10 @@ func TestMeta_ProtectedTags(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "unprotect tag")
+		requireGoneOn(ctx, t, sess.meta, "protected tag after unprotect", "gitlab_tag", map[string]any{
+			"action": "get_protected",
+			"params": map[string]any{"project_id": proj.pidStr(), "tag_name": tagName},
+		})
 		t.Logf("Unprotected tag %q", tagName)
 	})
 }

--- a/test/e2e/suite/push_rules_ee_test.go
+++ b/test/e2e/suite/push_rules_ee_test.go
@@ -67,6 +67,8 @@ func TestIndividual_PushRules(t *testing.T) {
 			ProjectID: proj.pidOf(),
 		})
 		requireNoError(t, err, "delete push rule")
+		requireGoneOn(ctx, t, sess.individual, "project push rule after delete", "gitlab_project_get_push_rules",
+			projects.GetPushRulesInput{ProjectID: proj.pidOf()})
 		t.Log("Deleted push rule")
 	})
 }
@@ -137,6 +139,10 @@ func TestMeta_PushRules(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta delete push rule")
+		requireGoneOn(ctx, t, sess.meta, "project push rule after delete", "gitlab_project", map[string]any{
+			"action": "push_rule_get",
+			"params": map[string]any{"project_id": proj.pidStr()},
+		})
 		t.Log("Deleted push rule via meta-tool")
 	})
 }

--- a/test/e2e/suite/releases_ce_test.go
+++ b/test/e2e/suite/releases_ce_test.go
@@ -47,6 +47,7 @@ func TestIndividual_Releases(t *testing.T) {
 		Message:   "Release E2E tag",
 	})
 	requireNoError(t, tagErr, "create tag for release")
+	requireTruef(t, tagOut.Name == tagName, "created tag = %q, want %q", tagOut.Name, tagName)
 	t.Logf("Created tag %s (target=%s)", tagOut.Name, tagOut.Target)
 
 	var releaseLinkID int64

--- a/test/e2e/suite/repository_meta_ce_test.go
+++ b/test/e2e/suite/repository_meta_ce_test.go
@@ -9,6 +9,7 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -212,6 +213,11 @@ func TestMeta_CommitExtended(t *testing.T) {
 			"params": map[string]any{"project_id": proj.pidStr(), "sha": sha},
 		})
 		requireNoError(t, err, "commit_refs")
+		// The SHA came from the tip of main, so main is one of the refs that
+		// reaches it.
+		requireTruef(t, slices.ContainsFunc(out.Refs, func(r commits.RefOutput) bool {
+			return r.Name == defaultBranch
+		}), "commit %s refs do not include %q: %+v", sha, defaultBranch, out.Refs)
 		t.Logf("Commit refs: %d", len(out.Refs))
 	})
 

--- a/test/e2e/suite/runner_controllers_ee_test.go
+++ b/test/e2e/suite/runner_controllers_ee_test.go
@@ -64,6 +64,37 @@ func runnerCtlScopeConflict(err error) bool {
 	return isHTTPStatus(err, 409) || strings.Contains(strings.ToLower(err.Error()), "already")
 }
 
+// runnerCtlTokenIDs maps a controller token listing to the token IDs it holds.
+func runnerCtlTokenIDs(out runnercontrollertokens.ListOutput) []int64 {
+	ids := make([]int64, 0, len(out.Tokens))
+	for _, tok := range out.Tokens {
+		ids = append(ids, tok.ID)
+	}
+	return ids
+}
+
+// runnerCtlScopedRunnerIDs maps a controller's scopings to the runners scoped
+// to it, which is what adding and removing a runner scope changes.
+func runnerCtlScopedRunnerIDs(out runnercontrollerscopes.ScopesOutput) []int64 {
+	ids := make([]int64, 0, len(out.RunnerLevelScopings))
+	for _, scoping := range out.RunnerLevelScopings {
+		ids = append(ids, scoping.RunnerID)
+	}
+	return ids
+}
+
+// runnerCtlScopes re-reads a controller's scopings, so the add and remove
+// subtests observe their effect instead of only their return.
+func runnerCtlScopes(ctx context.Context, t *testing.T, label string, controllerID int64) runnercontrollerscopes.ScopesOutput {
+	t.Helper()
+	out, err := callToolOn[runnercontrollerscopes.ScopesOutput](ctx, sess.meta, "gitlab_runner", map[string]any{
+		"action": "controller_scope_list",
+		"params": map[string]any{"controller_id": controllerID},
+	})
+	requireNoError(t, err, label)
+	return out
+}
+
 // TestMeta_RunnerControllerLifecycle exercises the runner controller CRUD,
 // token, and scope actions via the gitlab_runner meta-tool against a live
 // GitLab Ultimate instance.
@@ -197,6 +228,10 @@ func TestMeta_RunnerControllerLifecycle(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "controller_token_revoke")
+			requireNotListedOn(ctx, t, sess.meta, "controller tokens after revoke", "gitlab_runner", map[string]any{
+				"action": "controller_token_list",
+				"params": map[string]any{"controller_id": controllerID},
+			}, runnerCtlTokenIDs, tokenID)
 			t.Logf("Revoked controller token %d", tokenID)
 		})
 
@@ -220,6 +255,9 @@ func TestMeta_RunnerControllerLifecycle(t *testing.T) {
 				return
 			}
 			requireNoError(t, err, "controller_scope_add_instance")
+			scopes := runnerCtlScopes(ctx, t, "controller_scope_list after add instance", controllerID)
+			requireTruef(t, len(scopes.InstanceLevelScopings) > 0,
+				"controller %d reports no instance-level scoping right after adding one", controllerID)
 			t.Log("Added instance scope")
 		})
 
@@ -229,6 +267,9 @@ func TestMeta_RunnerControllerLifecycle(t *testing.T) {
 				"params": map[string]any{"controller_id": controllerID},
 			})
 			requireNoError(t, err, "controller_scope_remove_instance")
+			scopes := runnerCtlScopes(ctx, t, "controller_scope_list after remove instance", controllerID)
+			requireTruef(t, len(scopes.InstanceLevelScopings) == 0,
+				"controller %d still reports %d instance-level scopings after removing them", controllerID, len(scopes.InstanceLevelScopings))
 			t.Log("Removed instance scope")
 		})
 
@@ -266,6 +307,10 @@ func TestMeta_RunnerControllerLifecycle(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "controller_scope_remove_runner")
+			requireNotListedOn(ctx, t, sess.meta, "controller runner scopings after remove", "gitlab_runner", map[string]any{
+				"action": "controller_scope_list",
+				"params": map[string]any{"controller_id": controllerID},
+			}, runnerCtlScopedRunnerIDs, runnerID)
 			t.Logf("Removed runner %d from controller scope", runnerID)
 		})
 

--- a/test/e2e/suite/search_meta_ce_test.go
+++ b/test/e2e/suite/search_meta_ce_test.go
@@ -7,9 +7,12 @@ package suite
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/commits"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/search"
 )
 
@@ -71,6 +74,12 @@ func TestMeta_SearchExtended(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "search commits")
+		// The fixture's own commit message carries this word, and project commit
+		// search reads the repository through Gitaly rather than an index, so
+		// the match needs nothing beyond the commit existing.
+		requireTruef(t, slices.ContainsFunc(out.Commits, func(c commits.Output) bool {
+			return strings.Contains(c.Title, "searchable") || strings.Contains(c.Message, "searchable")
+		}), "commit search did not return the fixture's own commit: %+v", out.Commits)
 		t.Logf("Search commits: %d results", len(out.Commits))
 	})
 
@@ -110,13 +119,18 @@ func TestMeta_SearchExtended(t *testing.T) {
 	})
 
 	t.Run("SearchUsers", func(t *testing.T) {
+		// Search for the account this run authenticates as: it certainly exists,
+		// where the instance's other users are not this fixture's to assume.
 		out, err := callToolOn[search.UsersOutput](ctx, sess.meta, "gitlab_search", map[string]any{
 			"action": "users",
 			"params": map[string]any{
-				"query": "root",
+				"query": sess.username,
 			},
 		})
 		requireNoError(t, err, "search users")
+		requireTruef(t, slices.ContainsFunc(out.Users, func(u search.UserOutput) bool {
+			return u.Username == sess.username
+		}), "user search for %q did not return that account: %+v", sess.username, out.Users)
 		t.Logf("Search users: %d results", len(out.Users))
 	})
 

--- a/test/e2e/suite/security_attributes_ee_test.go
+++ b/test/e2e/suite/security_attributes_ee_test.go
@@ -115,6 +115,8 @@ func TestMeta_SecurityAttributes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "security_attribute_delete")
+		// The catalog exposes no read for security attributes, so the removal
+		// has nothing to be observed through.
 		t.Logf("Deleted security attribute %d", attributeID)
 	})
 
@@ -127,6 +129,8 @@ func TestMeta_SecurityAttributes(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "teardown category")
+		// Security categories have no read either, so this teardown is as
+		// unobservable as the attribute delete above.
 		t.Logf("Tore down category %d", categoryID)
 	})
 }

--- a/test/e2e/suite/security_categories_ee_test.go
+++ b/test/e2e/suite/security_categories_ee_test.go
@@ -92,6 +92,8 @@ func TestMeta_SecurityCategories(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "security_category_delete")
+		// The catalog exposes no read for security categories, so the removal
+		// has nothing to be observed through.
 		t.Logf("Deleted security category %d", categoryID)
 	})
 }

--- a/test/e2e/suite/security_scan_profiles_ee_test.go
+++ b/test/e2e/suite/security_scan_profiles_ee_test.go
@@ -67,6 +67,9 @@ func TestMeta_SecurityScanProfiles(t *testing.T) {
 		},
 	})
 	requireNoError(t, err, "create project in group for scan profile test")
+	requireTruef(t, proj.ID > 0, "created project has no ID")
+	requireTruef(t, strings.HasPrefix(proj.PathWithNamespace, grp.Path+"/"),
+		"project path %q is not under the group %q a scan profile needs", proj.PathWithNamespace, grp.Path)
 	t.Logf("Group %d, project %d (%s)", grp.ID, proj.ID, proj.PathWithNamespace)
 
 	t.Run("Meta/SecurityScanProfile/Attach", func(t *testing.T) {

--- a/test/e2e/suite/snippets_ce_test.go
+++ b/test/e2e/suite/snippets_ce_test.go
@@ -89,6 +89,8 @@ func TestIndividual_Snippets(t *testing.T) {
 			SnippetID: snippetID,
 		})
 		requireNoError(t, err, "delete snippet")
+		requireGoneOn(ctx, t, sess.individual, "snippet after delete", "gitlab_snippet_get",
+			snippets.GetInput{SnippetID: snippetID})
 		t.Log("Deleted snippet")
 	})
 }
@@ -177,6 +179,10 @@ func TestMeta_Snippets(t *testing.T) {
 			"params": map[string]any{"snippet_id": snippetID},
 		})
 		requireNoError(t, err, "meta delete snippet")
+		requireGoneOn(ctx, t, sess.meta, "snippet after delete", "gitlab_snippet", map[string]any{
+			"action": "get",
+			"params": map[string]any{"snippet_id": snippetID},
+		})
 		t.Log("Deleted snippet via meta-tool")
 	})
 }

--- a/test/e2e/suite/state_events_ce_test.go
+++ b/test/e2e/suite/state_events_ce_test.go
@@ -103,6 +103,10 @@ func TestMeta_StateEvents(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "delete issue for state events")
+		requireGoneOn(ctx, t, sess.meta, "issue after delete", "gitlab_issue", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "issue_iid": issueIID},
+		})
 		t.Logf("Deleted issue IID=%d", issueIID)
 	})
 }

--- a/test/e2e/suite/tags_ce_test.go
+++ b/test/e2e/suite/tags_ce_test.go
@@ -87,6 +87,8 @@ func TestIndividual_Tags(t *testing.T) {
 			TagName:   tagName,
 		})
 		requireNoError(t, err, "delete tag")
+		requireGoneOn(ctx, t, sess.individual, "tag "+tagName+" after delete", "gitlab_tag_get",
+			tags.GetInput{ProjectID: proj.pidOf(), TagName: tagName})
 		t.Logf("Deleted tag %s", tagName)
 	})
 }
@@ -177,6 +179,10 @@ func TestMeta_Tags(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta tag delete")
+		requireGoneOn(ctx, t, sess.meta, "tag "+tagName+" after delete", "gitlab_tag", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "tag_name": tagName},
+		})
 		t.Logf("Deleted tag %s", tagName)
 	})
 }

--- a/test/e2e/suite/templates_meta_ce_test.go
+++ b/test/e2e/suite/templates_meta_ce_test.go
@@ -7,6 +7,7 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -174,6 +175,12 @@ func TestMeta_TemplatesLicense(t *testing.T) {
 	})
 }
 
+// templatePageBudget bounds how many pages of a hundred a template listing is
+// walked for. GitLab's largest template family is well under a thousand
+// entries, so exhausting the budget means the pagination is not advancing
+// rather than that the family is long.
+const templatePageBudget = 10
+
 // TestMeta_TemplatesProject exercises project template list and get actions
 // through the gitlab_template meta-tool against a live GitLab instance.
 //
@@ -194,15 +201,34 @@ func TestMeta_TemplatesProject(t *testing.T) {
 	proj := createProjectMeta(ctx, t, sess.meta)
 
 	t.Run("ProjectTemplateList", func(t *testing.T) {
-		out, err := callToolOn[projecttemplates.ListOutput](ctx, sess.meta, "gitlab_template", map[string]any{
-			"action": "project_template_list",
-			"params": map[string]any{
-				"project_id":    proj.pidStr(),
-				"template_type": "gitignores",
-			},
-		})
-		requireNoError(t, err, "project_template_list")
-		t.Logf("Project templates (gitignores): %d", len(out.Templates))
+		// GitLab ships around two hundred gitignore templates and serves them
+		// in alphabetical order, so Go is nowhere near the first default page
+		// of twenty: the listing has to be walked for the assertion below to be
+		// an assertion rather than a coin toss. The walk is bounded so a
+		// pagination defect ends the subtest instead of spinning it.
+		var keys []string
+		for page := 1; page <= templatePageBudget; page++ {
+			out, err := callToolOn[projecttemplates.ListOutput](ctx, sess.meta, "gitlab_template", map[string]any{
+				"action": "project_template_list",
+				"params": map[string]any{
+					"project_id":    proj.pidStr(),
+					"template_type": "gitignores",
+					"per_page":      100,
+					"page":          page,
+				},
+			})
+			requireNoError(t, err, "project_template_list")
+			for _, tpl := range out.Templates {
+				keys = append(keys, tpl.Key)
+			}
+			if !out.Pagination.HasMore {
+				break
+			}
+		}
+		// The gitignore templates ship with GitLab, so the sibling subtest can
+		// ask for Go by key only because this listing really carries it.
+		requireTruef(t, slices.Contains(keys, "Go"), "gitignore templates do not include Go: %v", keys)
+		t.Logf("Project templates (gitignores): %d", len(keys))
 	})
 
 	t.Run("ProjectTemplateGet", func(t *testing.T) {
@@ -215,6 +241,8 @@ func TestMeta_TemplatesProject(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "project_template_get")
+		requireTruef(t, out.Name == "Go", "template name = %q, want %q", out.Name, "Go")
+		requireTruef(t, out.Content != "", "template %q came back with no content", out.Name)
 		t.Logf("Got project template: %s", out.Name)
 	})
 }

--- a/test/e2e/suite/user_extras2_ce_test.go
+++ b/test/e2e/suite/user_extras2_ce_test.go
@@ -141,6 +141,8 @@ func TestIndividual_UserGPGKeysForUser(t *testing.T) {
 				KeyID:  keyID,
 			})
 			requireNoError(t, err, "delete gpg key for user")
+			requireNotListedOn(ctx, t, sess.individual, "user GPG keys after delete", "gitlab_list_gpg_keys_for_user",
+				usergpgkeys.ListForUserInput{UserID: user.ID}, gpgKeyIDs, keyID)
 			t.Logf("Deleted GPG key %d for user %d", keyID, user.ID)
 		})
 	})

--- a/test/e2e/suite/user_extras_ce_test.go
+++ b/test/e2e/suite/user_extras_ce_test.go
@@ -120,6 +120,15 @@ func TestIndividual_UserEmails(t *testing.T) {
 			requireTruef(t, emailID > 0, "emailID not set")
 			err := callToolVoidOn(ctx, sess.individual, "gitlab_delete_email", useremails.DeleteInput{EmailID: emailID})
 			requireNoError(t, err, "delete email")
+			requireNotListedOn(ctx, t, sess.individual, "account emails after delete", "gitlab_list_emails",
+				users.ListEmailsInput{},
+				func(out users.EmailListOutput) []int64 {
+					ids := make([]int64, 0, len(out.Emails))
+					for _, e := range out.Emails {
+						ids = append(ids, e.ID)
+					}
+					return ids
+				}, emailID)
 			t.Logf("Deleted secondary email %d", emailID)
 			emailID = 0
 		})
@@ -178,6 +187,8 @@ func TestIndividual_UserGPGKeys(t *testing.T) {
 			requireTruef(t, keyID > 0, "keyID not set")
 			err := callToolVoidOn(ctx, sess.individual, "gitlab_delete_gpg_key", usergpgkeys.DeleteInput{KeyID: keyID})
 			requireNoError(t, err, "delete gpg key")
+			requireNotListedOn(ctx, t, sess.individual, "account GPG keys after delete", "gitlab_list_gpg_keys",
+				usergpgkeys.ListInput{}, gpgKeyIDs, keyID)
 			t.Logf("Deleted GPG key %d", keyID)
 			keyID = 0
 		})

--- a/test/e2e/suite/users_meta_ce_test.go
+++ b/test/e2e/suite/users_meta_ce_test.go
@@ -8,6 +8,7 @@ package suite
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -75,6 +76,8 @@ func TestMeta_UserSelf(t *testing.T) {
 				},
 			})
 			requireNoError(t, err, "set_status")
+			requireTruef(t, out.Emoji == "coffee", "status emoji = %q, want %q", out.Emoji, "coffee")
+			requireTruef(t, out.Message == "e2e-testing", "status message = %q, want %q", out.Message, "e2e-testing")
 			t.Logf("Set status: emoji=%s message=%s", out.Emoji, out.Message)
 
 			// Get status back
@@ -84,6 +87,10 @@ func TestMeta_UserSelf(t *testing.T) {
 				"params": map[string]any{"user_id": currentUserID},
 			})
 			requireNoError(t, err, "get_status")
+			// The status was set on this same account a moment ago, and the test
+			// holds CapabilityCurrentUserState so nothing else writes it.
+			requireTruef(t, got.Emoji == "coffee", "read-back status emoji = %q, want %q", got.Emoji, "coffee")
+			requireTruef(t, got.Message == "e2e-testing", "read-back status message = %q, want %q", got.Message, "e2e-testing")
 			t.Logf("Got status: emoji=%s message=%s", got.Emoji, got.Message)
 
 			// Clear status
@@ -246,6 +253,10 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"query": username},
 			})
 			requireNoError(t, err, "namespace_search")
+			// Every account owns a personal namespace whose path is its username.
+			requireTruef(t, slices.ContainsFunc(out.Namespaces, func(n namespaces.Output) bool {
+				return n.Path == username
+			}), "namespace search for %q did not return the account's own namespace: %+v", username, out.Namespaces)
 			t.Logf("Namespace search '%s': %d results", username, len(out.Namespaces))
 		})
 
@@ -256,6 +267,9 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"id": username},
 			})
 			requireNoError(t, err, "namespace_exists")
+			// The account's own namespace path is taken, which is what this
+			// endpoint reports.
+			requireTruef(t, out.Exists, "namespace %q reported as free, but it is the account's own", username)
 			t.Logf("Namespace exists: %v", out.Exists)
 		})
 
@@ -292,6 +306,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				})
 			})
 			requireNoError(t, err, "notification_global_update")
+			requireTruef(t, out.Level == "participating", "global notification level = %q, want %q", out.Level, "participating")
 			t.Logf("Updated global notification level: %s", out.Level)
 		})
 
@@ -302,6 +317,9 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"project_id": proj.pidStr()},
 			})
 			requireNoError(t, err, "notification_project_get")
+			// A project created moments ago carries no per-project override, so
+			// GitLab reports it as following the account default.
+			requireTruef(t, out.Level == "global", "fresh project notification level = %q, want %q", out.Level, "global")
 			t.Logf("Project notification level: %s", out.Level)
 
 			upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
@@ -309,6 +327,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"project_id": proj.pidStr(), "level": "watch"},
 			})
 			requireNoError(t, err, "notification_project_update")
+			requireTruef(t, upd.Level == "watch", "project notification level = %q, want %q", upd.Level, "watch")
 			t.Logf("Updated project notification level: %s", upd.Level)
 		})
 
@@ -320,6 +339,8 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"group_id": grp.gidStr()},
 			})
 			requireNoError(t, err, "notification_group_get")
+			// The group was created moments ago and carries no override either.
+			requireTruef(t, out.Level == "global", "fresh group notification level = %q, want %q", out.Level, "global")
 			t.Logf("Group notification level: %s", out.Level)
 
 			upd, err := callToolOn[notifications.Output](ctx, sess.meta, "gitlab_user", map[string]any{
@@ -327,6 +348,7 @@ func TestMeta_UserNamespacesNotifications(t *testing.T) {
 				"params": map[string]any{"group_id": grp.gidStr(), "level": "watch"},
 			})
 			requireNoError(t, err, "notification_group_update")
+			requireTruef(t, upd.Level == "watch", "group notification level = %q, want %q", upd.Level, "watch")
 			t.Logf("Updated group notification level: %s", upd.Level)
 		})
 
@@ -412,6 +434,10 @@ func TestMeta_UserSSHKeyLifecycle(t *testing.T) {
 				"params": map[string]any{"key_id": keyID},
 			})
 			requireNoError(t, err, "delete_ssh_key")
+			requireNotListedOn(ctx, t, sess.meta, "account SSH keys after delete", "gitlab_user", map[string]any{
+				"action": "ssh_keys",
+				"params": map[string]any{},
+			}, sshKeyIDs, keyID)
 			t.Logf("Deleted SSH key %d", keyID)
 		})
 	})
@@ -596,6 +622,10 @@ func TestMeta_UserAdmin(t *testing.T) {
 				"params": map[string]any{"user_id": testUserID, "key_id": userKeyID},
 			})
 			requireNoError(t, err, "delete_ssh_key_for_user")
+			requireNotListedOn(ctx, t, sess.meta, "user SSH keys after delete", "gitlab_user", map[string]any{
+				"action": "ssh_keys_for_user",
+				"params": map[string]any{"user_id": testUserID},
+			}, sshKeyIDs, userKeyID)
 			t.Logf("Deleted SSH key %d for user %d", userKeyID, testUserID)
 		})
 
@@ -645,6 +675,16 @@ func TestMeta_UserAdmin(t *testing.T) {
 				"params": map[string]any{"user_id": testUserID, "email_id": emailID},
 			})
 			requireNoError(t, err, "delete_email_for_user")
+			requireNotListedOn(ctx, t, sess.meta, "user emails after delete", "gitlab_user", map[string]any{
+				"action": "emails_for_user",
+				"params": map[string]any{"user_id": testUserID},
+			}, func(out useremails.ListOutput) []int64 {
+				ids := make([]int64, 0, len(out.Emails))
+				for _, e := range out.Emails {
+					ids = append(ids, e.ID)
+				}
+				return ids
+			}, emailID)
 			t.Logf("Deleted email %d for user %d", emailID, testUserID)
 		})
 
@@ -705,6 +745,18 @@ func TestMeta_UserAdmin(t *testing.T) {
 				"params": map[string]any{"user_id": testUserID, "token_id": impTokenID},
 			})
 			requireNoError(t, err, "revoke_impersonation_token")
+			// A revoked token stays listed under state=all, so the active
+			// listing is what observes the revocation.
+			requireNotListedOn(ctx, t, sess.meta, "active impersonation tokens after revoke", "gitlab_user", map[string]any{
+				"action": "list_impersonation_tokens",
+				"params": map[string]any{"user_id": testUserID, "state": "active"},
+			}, func(out impersonationtokens.ListOutput) []int64 {
+				ids := make([]int64, 0, len(out.Tokens))
+				for _, tok := range out.Tokens {
+					ids = append(ids, tok.ID)
+				}
+				return ids
+			}, impTokenID)
 			t.Logf("Revoked impersonation token %d", impTokenID)
 		})
 

--- a/test/e2e/suite/vulnerabilities_ee_test.go
+++ b/test/e2e/suite/vulnerabilities_ee_test.go
@@ -7,8 +7,8 @@ package suite
 
 import (
 	"context"
-	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -16,6 +16,7 @@ import (
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/pipelines"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/securityfindings"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/vulnerabilities"
 )
 
@@ -98,10 +99,12 @@ func TestMeta_Vulnerabilities(t *testing.T) {
 	})
 }
 
-// TestMeta_VulnerabilityLifecycle exercises the full vulnerability mutation
-// lifecycle via gitlab_vulnerability: get, dismiss, confirm, resolve,
-// revert, and pipeline_security_summary. The fixture is a project whose
-// pipeline publishes a deterministic gl-sast-report.json as an
+// TestMeta_VulnerabilityLifecycle exercises the full vulnerability lifecycle
+// via gitlab_vulnerability and gitlab_security_finding: the report is read back
+// through list, pipeline_security_summary and the pipeline's security findings
+// before anything is mutated, then get, confirm, resolve, revert and dismiss
+// walk the states. The fixture is a project whose pipeline
+// publishes a deterministic gl-sast-report.json as an
 // artifacts:reports:sast report (three CRITICAL findings: SQL injection,
 // command injection, eval). GitLab ingests it into the project Vulnerability
 // Report exactly as a real scan would, so the test validates our vulnerability
@@ -139,28 +142,244 @@ func TestMeta_VulnerabilityLifecycle(t *testing.T) {
 		})
 	})
 
-	// This fixture verifies the GitLab vulnerability *reporting* path and our
-	// vulnerability MCP tools end-to-end — NOT GitLab's Semgrep analyzer itself.
-	// Earlier revisions ran the real `Security/SAST.gitlab-ci.yml` template, but
-	// that job pulls a heavy, version-pinned analyzer image
-	// (registry.gitlab.com/security-products/semgrep:<major>) which is unreliable
-	// on the ephemeral Docker runner: when the pull fails the job's default
-	// `allow_failure: true` left the pipeline "success" with no security report,
-	// so the lifecycle silently found zero vulnerabilities.
-	//
-	// Instead the pipeline *generates* a deterministic, schema-valid
-	// gl-sast-report.json in-job and publishes it as an artifacts:reports:sast
-	// report. The job runs on the pre-pulled alpine image with GIT_STRATEGY:none
-	// (no repo clone — the report is self-contained), so it depends on nothing
-	// the ephemeral runner might fail to pull or fetch. GitLab ingests the report
-	// into the project Vulnerability Report exactly as a real scan would
-	// (Ultimate, default-branch pipeline), which is what exercises
-	// gitlab_vulnerability list/get/resolve/etc.
+	// 1. Commit the intentionally vulnerable source the report points at.
+	commitFileMeta(ctx, t, sess.meta, proj, defaultBranch,
+		"app.py",
+		vulnerabilityFixtureSource,
+		"add intentionally vulnerable code for E2E SAST fixture")
 
-	// 1. Commit the intentionally vulnerable source the report points at. It is
-	// not scanned (GIT_STRATEGY:none), but keeps the fixture self-documenting and
-	// gives the report's `location.file` a real target in the repo.
-	const vulnerablePy = `# E2E fixture: intentionally vulnerable code referenced by the SAST report.
+	// 2. Commit the pipeline that publishes the SAST report.
+	commitFileMeta(ctx, t, sess.meta, proj, defaultBranch,
+		".gitlab-ci.yml",
+		vulnerabilityFixturePipeline,
+		"add SAST report-publishing pipeline")
+
+	// 3. Manually trigger a pipeline so the runner processes the
+	// SAST job.
+	created, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
+		"action": "create",
+		"params": map[string]any{
+			"project_id": proj.pidStr(),
+			"ref":        defaultBranch,
+		},
+	})
+	if err != nil {
+		t.Skipf("could not trigger vulnerability pipeline (fixture not available): %v", err)
+	}
+	pipelineID := created.ID
+	pipelineIID := strconv.FormatInt(created.IID, 10)
+	t.Logf("Triggered pipeline ID=%d IID=%s", pipelineID, pipelineIID)
+
+	// 4. Wait for the pipeline to reach a terminal state. The runner
+	// is shared with the rest of the suite, so this can take a few
+	// minutes. We tolerate transient connection failures and skip the
+	// lifecycle if GitLab appears unhealthy.
+	pipelineStatus := waitForPipelineStatusEE(ctx, t, sess.glClient, proj.ID, pipelineID, 300*time.Second)
+	if pipelineStatus != "success" && pipelineStatus != "failed" && pipelineStatus != "canceled" && pipelineStatus != "skipped" {
+		t.Skipf("pipeline %d did not reach a terminal status (last status: %s); skipping lifecycle to avoid fixture flakiness", pipelineID, pipelineStatus)
+	}
+	t.Logf("Pipeline %d status: %s", pipelineID, pipelineStatus)
+
+	// 5. Wait for GitLab to promote the published SAST findings into the project
+	// Vulnerability Report. This ingestion is asynchronous (Sidekiq) and only
+	// runs for the default-branch pipeline; on a heavily loaded ephemeral
+	// instance it can lag or, occasionally, not complete within the test budget.
+	//
+	// The wait asks GitLab directly rather than through gitlab_vulnerability,
+	// because the tool is what this lifecycle exists to test: a handler whose
+	// GraphQL document GitLab refuses gets no data back, asks REST whether the
+	// project exists, and answers an empty list with no error. Deriving the
+	// fixture from it would therefore skip every assertion below in precisely
+	// the state they were written to catch, which is what a licensed Ultimate
+	// run did while three of these tools could not work at all.
+	fixtureVulns := waitForProjectVulnerabilities(ctx, t, proj.Path, vulnerabilityReportWait)
+	if len(fixtureVulns) == 0 {
+		// GitLab's own vulnerability report is empty, so there is nothing here
+		// for a tool to have hidden and nothing for the lifecycle to act on.
+		// Distinguish a broken fixture from an environment that simply cannot
+		// perform the async promotion: the pipeline-level security report
+		// summary is derived directly from the uploaded artifact, so findings
+		// there mean the report WAS published and parsed and only the
+		// project-level ingestion is missing, which is outside our control on
+		// the ephemeral runner.
+		sastParsed := pipelineSASTFindingCount(ctx, t, proj.Path, pipelineIID)
+		logPipelineJobDiagnostics(ctx, t, proj.ID, pipelineID)
+		if sastParsed > 0 {
+			t.Skipf("SAST report published and parsed (%d findings in pipeline %d's security summary) but GitLab did not promote them into the project Vulnerability Report within %s on this ephemeral instance; skipping the mutation lifecycle (async default-branch ingestion unavailable here). project=%s",
+				sastParsed, pipelineID, vulnerabilityReportWait, proj.Path)
+		}
+		// Neither the project Vulnerability Report nor the pipeline security
+		// summary reported findings. The 'sast' job succeeded and uploaded the
+		// artifact (see diagnostics above) and the fixture report is validated in
+		// CI, so this indicates the ephemeral instance is not performing security
+		// report ingestion at all (Sidekiq pressure / disabled processing) rather
+		// than a broken fixture. Skip rather than fail the whole EE suite over an
+		// environment limitation.
+		t.Skipf("pipeline %d (status: %s) uploaded a SAST report but this instance ingested no findings into either the pipeline security summary or the project Vulnerability Report within %s; skipping the mutation lifecycle (security report ingestion appears unavailable on this ephemeral instance). project=%s",
+			pipelineID, pipelineStatus, vulnerabilityReportWait, proj.Path)
+	}
+	var vulnGID string
+	for _, v := range fixtureVulns {
+		if v.Severity == "CRITICAL" || v.Severity == "HIGH" {
+			vulnGID = v.ID
+			t.Logf("Using vulnerability %q (severity=%s, state=%s)", v.ID, v.Severity, v.State)
+			break
+		}
+	}
+	if vulnGID == "" {
+		vulnGID = fixtureVulns[0].ID
+		t.Logf("Falling back to first vulnerability %q", vulnGID)
+	}
+
+	// 6. Read the report back through the tools, while GitLab's own answer is
+	// known and nothing has been mutated yet.
+	assertVulnerabilityReadBacks(ctx, t, proj, pipelineIID, vulnGID, len(fixtureVulns))
+
+	// 7. Exercise the vulnerability mutation actions.
+
+	t.Run("Meta/Vulnerability/Get", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.GetOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "get",
+			"params": map[string]any{"id": vulnGID},
+		})
+		requireNoError(t, err, "vulnerability get")
+		requireTruef(t, out.Vulnerability.ID == vulnGID, "vulnerability ID = %q, want %q", out.Vulnerability.ID, vulnGID)
+		t.Logf("Got vulnerability %q state=%s", out.Vulnerability.ID, out.Vulnerability.State)
+	})
+
+	t.Run("Meta/Vulnerability/Confirm", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "confirm",
+			"params": map[string]any{"id": vulnGID},
+		})
+		requireNoError(t, err, "vulnerability confirm")
+		assertVulnerabilityState(t, out, vulnGID, "CONFIRMED")
+		t.Logf("Confirmed vulnerability %q", vulnGID)
+	})
+
+	t.Run("Meta/Vulnerability/Resolve", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "resolve",
+			"params": map[string]any{"id": vulnGID},
+		})
+		requireNoError(t, err, "vulnerability resolve")
+		assertVulnerabilityState(t, out, vulnGID, "RESOLVED")
+		t.Logf("Resolved vulnerability %q", vulnGID)
+	})
+
+	t.Run("Meta/Vulnerability/Revert", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "revert",
+			"params": map[string]any{"id": vulnGID},
+		})
+		requireNoError(t, err, "vulnerability revert")
+		assertVulnerabilityState(t, out, vulnGID, "DETECTED")
+		t.Logf("Reverted vulnerability %q to detected state", vulnGID)
+	})
+
+	t.Run("Meta/Vulnerability/Dismiss", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "dismiss",
+			"params": map[string]any{
+				"id":               vulnGID,
+				"comment":          "E2E dismiss test",
+				"dismissal_reason": "USED_IN_TESTS",
+			},
+		})
+		requireNoError(t, err, "vulnerability dismiss")
+		assertVulnerabilityState(t, out, vulnGID, "DISMISSED")
+		t.Logf("Dismissed vulnerability %q", vulnGID)
+	})
+}
+
+// assertVulnerabilityReadBacks reads the fixture's own SAST report back through
+// every read tool the lifecycle covers, while GitLab's answer to the same
+// question is known and no state mutation has run yet. reported is how many
+// vulnerabilities GitLab itself listed, which the failure message names so a
+// disagreement between the two is legible.
+func assertVulnerabilityReadBacks(ctx context.Context, t *testing.T, proj ProjectFixture, pipelineIID, vulnGID string, reported int) {
+	t.Helper()
+
+	t.Run("Meta/Vulnerability/List", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.ListOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "list",
+			"params": map[string]any{
+				"project_path": proj.Path,
+			},
+		})
+		requireNoError(t, err, "vulnerability list for lifecycle")
+		listed := make([]string, 0, len(out.Vulnerabilities))
+		for _, v := range out.Vulnerabilities {
+			listed = append(listed, v.ID)
+		}
+		// GitLab answered this same question a moment ago and named this
+		// vulnerability, so a list that does not hold it is the tool rather
+		// than the instance. This is the assertion a refused list document
+		// fails: the handler turns the data GitLab never sent into an empty
+		// list and no error, which is why a licensed Ultimate run passed
+		// while the tool could not work at all.
+		requireTruef(t, slices.Contains(listed, vulnGID),
+			"gitlab_vulnerability list does not report %q, which GitLab's own vulnerability report holds among %d findings; the tool answered %v",
+			vulnGID, reported, listed)
+	})
+
+	t.Run("Meta/Vulnerability/PipelineSecuritySummary", func(t *testing.T) {
+		out, err := callToolOn[vulnerabilities.PipelineSecuritySummaryOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
+			"action": "pipeline_security_summary",
+			"params": map[string]any{
+				"project_path": proj.Path,
+				"pipeline_iid": pipelineIID,
+			},
+		})
+		requireNoError(t, err, "vulnerability pipeline_security_summary")
+		// The count is derived from the pipeline's own report artifact, which
+		// publishes exactly three CRITICAL findings, and this subtest runs
+		// before the state mutations so nothing has had a chance to move it.
+		// It is evidence that the report was ingested rather than evidence
+		// about the refused list document: the summary is served by a separate
+		// document that GitLab validates cleanly.
+		requireTruef(t, out.Sast != nil, "pipeline %s security summary has no SAST section; the fixture published a SAST report", pipelineIID)
+		requireTruef(t, out.Sast.VulnerabilitiesCount == fixtureSASTFindingCount,
+			"SAST vulnerabilities_count = %d, want %d (the fixture report's findings)", out.Sast.VulnerabilitiesCount, fixtureSASTFindingCount)
+		t.Logf("Pipeline security summary: SAST=%v DAST=%v DepScanning=%v ContainerScanning=%v",
+			out.Sast != nil, out.Dast != nil, out.DependencyScanning != nil, out.ContainerScanning != nil)
+	})
+
+	t.Run("Meta/SecurityFinding/List", func(t *testing.T) {
+		out, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
+			"action": "list",
+			"params": map[string]any{
+				"project_path": proj.Path,
+				"pipeline_iid": pipelineIID,
+			},
+		})
+		requireNoError(t, err, "security finding list for lifecycle")
+		assertFixtureSASTFindings(t, out, "unfiltered")
+	})
+
+	t.Run("Meta/SecurityFinding/ListFiltered", func(t *testing.T) {
+		out, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
+			"action": "list",
+			"params": map[string]any{
+				"project_path": proj.Path,
+				"pipeline_iid": pipelineIID,
+				"severity":     []string{"HIGH", "CRITICAL"},
+				"report_type":  []string{"SAST"},
+				"first":        10,
+			},
+		})
+		requireNoError(t, err, "security finding list with filters")
+		// Every fixture finding is a CRITICAL SAST one, so the filters are
+		// asked for exactly what the pipeline holds and must not narrow it.
+		assertFixtureSASTFindings(t, out, "filtered to CRITICAL/HIGH SAST")
+	})
+}
+
+// vulnerabilityFixtureSource is the intentionally vulnerable file
+// [TestMeta_VulnerabilityLifecycle] commits. It is never scanned, since the
+// pipeline job clones nothing, but it keeps the fixture self-documenting and
+// gives the report's location.file a real target in the repository.
+const vulnerabilityFixtureSource = `# E2E fixture: intentionally vulnerable code referenced by the SAST report.
 import os
 import sqlite3
 db = sqlite3.connect(":memory:")
@@ -178,21 +397,26 @@ os.system("ls " + cmd)
 expr = input("expr: ")
 result = eval(expr)
 `
-	commitFileMeta(ctx, t, sess.meta, proj, defaultBranch,
-		"app.py",
-		vulnerablePy,
-		"add intentionally vulnerable code for E2E SAST fixture")
 
-	// 2. Commit a .gitlab-ci.yml whose single job writes a deterministic SAST
-	// report (GitLab secure-report schema 15.x, three CRITICAL findings:
-	// SQLi/command-injection/eval) and publishes it as the pipeline's SAST
-	// security report. printf with a single-quoted minified JSON payload avoids
-	// heredoc/indentation pitfalls; the JSON contains only double quotes so the
-	// single-quote wrapping is safe. `when: always` uploads the report even if a
-	// later step were to fail.
-	commitFileMeta(ctx, t, sess.meta, proj, defaultBranch,
-		".gitlab-ci.yml",
-		`stages:
+// vulnerabilityFixturePipeline is the pipeline [TestMeta_VulnerabilityLifecycle]
+// commits: one job that writes a deterministic, schema-valid gl-sast-report.json
+// (GitLab secure-report schema 15.x, the three CRITICAL findings named by
+// [fixtureSASTIdentifiers]) and publishes it as an artifacts:reports:sast report.
+//
+// The fixture verifies the GitLab vulnerability reporting path and our own
+// tools, not GitLab's Semgrep analyzer. Earlier revisions ran the real
+// Security/SAST.gitlab-ci.yml template, whose job pulls a heavy version-pinned
+// analyzer image that the ephemeral Docker runner cannot be relied on to fetch;
+// when the pull failed, the job's default allow_failure left the pipeline
+// successful with no security report and the lifecycle silently found nothing.
+// Generating the report in-job on the pre-pulled alpine image with
+// GIT_STRATEGY:none depends on nothing the runner might fail to fetch, and
+// GitLab ingests it exactly as it would a real scan.
+//
+// printf with a single-quoted minified payload avoids heredoc and indentation
+// pitfalls, and the JSON contains only double quotes so the wrapping is safe;
+// when: always uploads the report even if a later step were to fail.
+const vulnerabilityFixturePipeline = `stages:
   - test
 
 sast:
@@ -208,174 +432,146 @@ sast:
     when: always
     reports:
       sast: gl-sast-report.json
-`,
-		"add SAST report-publishing pipeline")
+`
 
-	// 4. Manually trigger a pipeline so the runner processes the
-	// SAST job.
-	created, err := callToolOn[pipelines.DetailOutput](ctx, sess.meta, "gitlab_pipeline", map[string]any{
-		"action": "create",
-		"params": map[string]any{
-			"project_id": proj.pidStr(),
-			"ref":        defaultBranch,
-		},
-	})
-	if err != nil {
-		t.Skipf("could not trigger vulnerability pipeline (fixture not available): %v", err)
+// fixtureSASTFindingCount is how many findings the SAST report committed by
+// [TestMeta_VulnerabilityLifecycle] publishes: SQL injection, OS command
+// injection and code injection, all CRITICAL.
+const fixtureSASTFindingCount = 3
+
+// fixtureSASTIdentifiers are the CWE identifiers those three findings carry.
+// They are what the fixture owns: a finding's title and name are what the
+// report says they are, while the identifier is the thing a scanner and a
+// consumer agree on, so an assertion written against them survives a repair of
+// the fields the query selects.
+var fixtureSASTIdentifiers = []string{"CWE-78", "CWE-89", "CWE-95"}
+
+// vulnerabilityReportWait bounds how long the lifecycle waits for GitLab to
+// promote the pipeline's published SAST findings into the project Vulnerability
+// Report, which is asynchronous and runs behind whatever else Sidekiq is doing
+// on the ephemeral instance.
+const vulnerabilityReportWait = 240 * time.Second
+
+// assertVulnerabilityState fails the test unless a vulnerability state mutation
+// answered with the vulnerability it was asked about, moved to the state the
+// action names. A mutation whose GraphQL document GitLab refuses answers with an
+// empty payload rather than an error, so checking the returned state is what
+// tells a working mutation from a silently rejected one.
+func assertVulnerabilityState(t *testing.T, out vulnerabilities.MutationOutput, wantID, wantState string) {
+	t.Helper()
+	requireTruef(t, out.Vulnerability.ID == wantID,
+		"mutation answered for vulnerability %q, want %q", out.Vulnerability.ID, wantID)
+	requireTruef(t, out.Vulnerability.State == wantState,
+		"vulnerability %q state = %q, want %q", wantID, out.Vulnerability.State, wantState)
+}
+
+// assertFixtureSASTFindings fails unless a security finding listing holds
+// exactly the three CRITICAL findings the lifecycle's own SAST report
+// publishes, identified by the CWE identifiers the report carries.
+//
+// It is the assertion a refused findings document fails: the handler answers a
+// document GitLab rejected with an empty list and no error, which a length log
+// cannot tell from a pipeline that really found nothing. The scope names which
+// listing failed, since the filtered and unfiltered calls share this check.
+func assertFixtureSASTFindings(t *testing.T, out securityfindings.ListOutput, scope string) {
+	t.Helper()
+	requireTruef(t, len(out.Findings) == fixtureSASTFindingCount,
+		"%s security findings = %d, want %d (the fixture report's findings): %+v",
+		scope, len(out.Findings), fixtureSASTFindingCount, out.Findings)
+	identifiers := make([]string, 0, len(out.Findings))
+	for _, f := range out.Findings {
+		requireTruef(t, f.Severity == "CRITICAL",
+			"%s security finding %q severity = %q, want CRITICAL", scope, f.UUID, f.Severity)
+		for _, id := range f.Identifiers {
+			identifiers = append(identifiers, id.Name)
+		}
 	}
-	pipelineID := created.ID
-	pipelineIID := strconv.FormatInt(created.IID, 10)
-	t.Logf("Triggered pipeline ID=%d IID=%s", pipelineID, pipelineIID)
-
-	// 5. Wait for the pipeline to reach a terminal state. The runner
-	// is shared with the rest of the suite, so this can take a few
-	// minutes. We tolerate transient connection failures and skip the
-	// lifecycle if GitLab appears unhealthy.
-	pipelineStatus := waitForPipelineStatusEE(ctx, t, sess.glClient, proj.ID, pipelineID, 300*time.Second)
-	if pipelineStatus != "success" && pipelineStatus != "failed" && pipelineStatus != "canceled" && pipelineStatus != "skipped" {
-		t.Skipf("pipeline %d did not reach a terminal status (last status: %s); skipping lifecycle to avoid fixture flakiness", pipelineID, pipelineStatus)
+	slices.Sort(identifiers)
+	for _, want := range fixtureSASTIdentifiers {
+		requireTruef(t, slices.Contains(identifiers, want),
+			"%s security findings do not carry identifier %s; they carry %v", scope, want, identifiers)
 	}
-	t.Logf("Pipeline %d status: %s", pipelineID, pipelineStatus)
+	t.Logf("%s security findings: %d carrying %v", scope, len(out.Findings), identifiers)
+}
 
-	// 5. Wait for GitLab to promote the published SAST findings into the project
-	// Vulnerability Report, then list them. This ingestion is asynchronous
-	// (Sidekiq) and only runs for the default-branch pipeline; on a heavily
-	// loaded ephemeral instance it can lag or, occasionally, not complete within
-	// the test budget. Poll generously with backoff.
-	var (
-		listed       vulnerabilities.ListOutput
-		listErr      error
-		listDeadline = time.Now().Add(240 * time.Second)
-		listDelay    = 2 * time.Second
-	)
+// projectVulnerability is the part of a vulnerability report entry the
+// lifecycle needs from GitLab itself: which vulnerability to act on, and what
+// it looked like before anything acted on it.
+type projectVulnerability struct {
+	ID       string `json:"id"`
+	Severity string `json:"severity"`
+	State    string `json:"state"`
+}
+
+// waitForProjectVulnerabilities polls GitLab's project vulnerability report
+// until it holds something or the budget runs out, and returns what it found.
+//
+// It sends a document written here rather than calling gitlab_vulnerability,
+// because the lifecycle's assertions are about that tool. A handler whose
+// document GitLab refuses receives no data, falls back to asking REST whether
+// the project exists, and returns an empty list with no error; a fixture taken
+// from it would skip the lifecycle exactly when the tool is broken. Asking
+// GitLab directly makes the tool's own answer something to assert against
+// rather than something to depend on.
+//
+// A query error is logged and retried rather than raised: the caller
+// distinguishes an empty report from a broken fixture with the pipeline's own
+// security summary, and reports both as a skip.
+func waitForProjectVulnerabilities(ctx context.Context, t *testing.T, projectPath string, budget time.Duration) []projectVulnerability {
+	t.Helper()
+	const query = `query($projectPath: ID!, $first: Int!) {
+  project(fullPath: $projectPath) {
+    vulnerabilities(first: $first) {
+      nodes {
+        id
+        severity
+        state
+      }
+    }
+  }
+}`
+	deadline := time.Now().Add(budget)
+	delay := 2 * time.Second
 	for {
-		listed, listErr = callToolOn[vulnerabilities.ListOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "list",
-			"params": map[string]any{
-				"project_path": proj.Path,
-			},
-		})
-		if listErr == nil && len(listed.Vulnerabilities) > 0 {
-			break
+		var resp struct {
+			Data struct {
+				Project *struct {
+					Vulnerabilities struct {
+						Nodes []projectVulnerability `json:"nodes"`
+					} `json:"vulnerabilities"`
+				} `json:"project"`
+			} `json:"data"`
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
 		}
-		if listErr != nil {
-			break
+		_, err := sess.glClient.GL().GraphQL.Do(gl.GraphQLQuery{
+			Query:     query,
+			Variables: map[string]any{"projectPath": projectPath, "first": 20},
+		}, &resp, gl.WithContext(ctx))
+		switch {
+		case err != nil:
+			t.Logf("fixture: vulnerability report query failed: %v", err)
+		case len(resp.Errors) > 0:
+			// GitLab refusing the fixture's own document would make every
+			// assertion below meaningless, so it is said out loud.
+			t.Logf("fixture: vulnerability report query reported GraphQL errors: %+v", resp.Errors)
+		case resp.Data.Project != nil && len(resp.Data.Project.Vulnerabilities.Nodes) > 0:
+			return resp.Data.Project.Vulnerabilities.Nodes
 		}
-		if time.Now().After(listDeadline) {
-			break
+		if time.Now().After(deadline) {
+			return nil
 		}
 		select {
 		case <-ctx.Done():
-			listErr = fmt.Errorf("context canceled while waiting for vulnerability report: %w", ctx.Err())
-		case <-time.After(listDelay):
+			t.Logf("fixture: context ended while waiting for the vulnerability report: %v", ctx.Err())
+			return nil
+		case <-time.After(delay):
 		}
-		if listDelay < 8*time.Second {
-			listDelay *= 2
-		}
-	}
-	requireNoError(t, listErr, "vulnerability list for lifecycle")
-	if len(listed.Vulnerabilities) == 0 {
-		// The project Vulnerability Report never populated. Distinguish a broken
-		// fixture from an environment that simply cannot perform the async
-		// promotion: query the pipeline-level security report summary, which is
-		// derived directly from the uploaded artifact. If it shows the SAST
-		// findings, the report WAS published and parsed correctly — the gap is
-		// the project-level ingestion, which is outside our control on the
-		// ephemeral runner, so skip the mutation lifecycle rather than fail.
-		sastParsed := pipelineSASTFindingCount(ctx, t, proj.Path, pipelineIID)
-		logPipelineJobDiagnostics(ctx, t, proj.ID, pipelineID)
-		if sastParsed > 0 {
-			t.Skipf("SAST report published and parsed (%d findings in pipeline %d's security summary) but GitLab did not promote them into the project Vulnerability Report within %s on this ephemeral instance; skipping the mutation lifecycle (async default-branch ingestion unavailable here). project=%s",
-				sastParsed, pipelineID, 240*time.Second, proj.Path)
-		}
-		// Neither the project Vulnerability Report nor the pipeline security
-		// summary reported findings. The 'sast' job succeeded and uploaded the
-		// artifact (see diagnostics above) and the fixture report is validated in
-		// CI, so this indicates the ephemeral instance is not performing security
-		// report ingestion at all (Sidekiq pressure / disabled processing) rather
-		// than a broken fixture. Skip rather than fail the whole EE suite over an
-		// environment limitation — the list/get/severity tools are still covered
-		// by TestMeta_Vulnerabilities and TestIndividual_Vulnerabilities.
-		t.Skipf("pipeline %d (status: %s) uploaded a SAST report but this instance ingested no findings into either the pipeline security summary or the project Vulnerability Report within %s; skipping the mutation lifecycle (security report ingestion appears unavailable on this ephemeral instance). project=%s",
-			pipelineID, pipelineStatus, 240*time.Second, proj.Path)
-	}
-	var vulnGID string
-	for _, v := range listed.Vulnerabilities {
-		if v.Severity == "CRITICAL" || v.Severity == "HIGH" {
-			vulnGID = v.ID
-			t.Logf("Using vulnerability %q (severity=%s, state=%s)", v.ID, v.Severity, v.State)
-			break
+		if delay < 8*time.Second {
+			delay *= 2
 		}
 	}
-	if vulnGID == "" {
-		vulnGID = listed.Vulnerabilities[0].ID
-		t.Logf("Falling back to first vulnerability %q", vulnGID)
-	}
-
-	// 6. Exercise the vulnerability mutation actions.
-
-	t.Run("Meta/Vulnerability/Get", func(t *testing.T) {
-		out, err := callToolOn[vulnerabilities.GetOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "get",
-			"params": map[string]any{"id": vulnGID},
-		})
-		requireNoError(t, err, "vulnerability get")
-		requireTruef(t, out.Vulnerability.ID == vulnGID, "vulnerability ID = %q, want %q", out.Vulnerability.ID, vulnGID)
-		t.Logf("Got vulnerability %q state=%s", out.Vulnerability.ID, out.Vulnerability.State)
-	})
-
-	t.Run("Meta/Vulnerability/Confirm", func(t *testing.T) {
-		_, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "confirm",
-			"params": map[string]any{"id": vulnGID},
-		})
-		requireNoError(t, err, "vulnerability confirm")
-		t.Logf("Confirmed vulnerability %q", vulnGID)
-	})
-
-	t.Run("Meta/Vulnerability/Resolve", func(t *testing.T) {
-		_, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "resolve",
-			"params": map[string]any{"id": vulnGID},
-		})
-		requireNoError(t, err, "vulnerability resolve")
-		t.Logf("Resolved vulnerability %q", vulnGID)
-	})
-
-	t.Run("Meta/Vulnerability/Revert", func(t *testing.T) {
-		_, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "revert",
-			"params": map[string]any{"id": vulnGID},
-		})
-		requireNoError(t, err, "vulnerability revert")
-		t.Logf("Reverted vulnerability %q to detected state", vulnGID)
-	})
-
-	t.Run("Meta/Vulnerability/Dismiss", func(t *testing.T) {
-		_, err := callToolOn[vulnerabilities.MutationOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "dismiss",
-			"params": map[string]any{
-				"id":               vulnGID,
-				"comment":          "E2E dismiss test",
-				"dismissal_reason": "USED_IN_TESTS",
-			},
-		})
-		requireNoError(t, err, "vulnerability dismiss")
-		t.Logf("Dismissed vulnerability %q", vulnGID)
-	})
-
-	t.Run("Meta/Vulnerability/PipelineSecuritySummary", func(t *testing.T) {
-		out, err := callToolOn[vulnerabilities.PipelineSecuritySummaryOutput](ctx, sess.meta, "gitlab_vulnerability", map[string]any{
-			"action": "pipeline_security_summary",
-			"params": map[string]any{
-				"project_path": proj.Path,
-				"pipeline_iid": pipelineIID,
-			},
-		})
-		requireNoError(t, err, "vulnerability pipeline_security_summary")
-		t.Logf("Pipeline security summary: SAST=%v DAST=%v DepScanning=%v ContainerScanning=%v",
-			out.Sast != nil, out.Dast != nil, out.DependencyScanning != nil, out.ContainerScanning != nil)
-	})
 }
 
 // logPipelineJobDiagnostics logs every job of a pipeline (name, stage, status,

--- a/test/e2e/suite/wikis_ce_test.go
+++ b/test/e2e/suite/wikis_ce_test.go
@@ -75,6 +75,8 @@ func TestIndividual_Wikis(t *testing.T) {
 			Content:   "Updated E2E wiki content.",
 		})
 		requireNoError(t, err, "wiki update")
+		requireTruef(t, out.Slug == wikiSlug, "wiki update answered for slug %q, want %q", out.Slug, wikiSlug)
+		requireTruef(t, out.Content == "Updated E2E wiki content.", "wiki content = %q, want the text just written", out.Content)
 		t.Logf("Updated wiki page: %s", out.Title)
 	})
 
@@ -85,6 +87,8 @@ func TestIndividual_Wikis(t *testing.T) {
 			Slug:      wikiSlug,
 		})
 		requireNoError(t, err, "wiki delete")
+		requireGoneOn(ctx, t, sess.individual, "wiki page after delete", "gitlab_wiki_get",
+			wikis.GetInput{ProjectID: proj.pidOf(), Slug: wikiSlug})
 		t.Log("Deleted wiki page")
 	})
 }
@@ -178,6 +182,10 @@ func TestMeta_Wikis(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "meta wiki delete")
+		requireGoneOn(ctx, t, sess.meta, "wiki page after delete", "gitlab_wiki", map[string]any{
+			"action": "get",
+			"params": map[string]any{"project_id": proj.pidStr(), "slug": wikiSlug},
+		})
 		t.Logf("Deleted wiki page: %s", wikiSlug)
 	})
 }

--- a/test/e2e/suite/work_item_saved_views_ce_test.go
+++ b/test/e2e/suite/work_item_saved_views_ce_test.go
@@ -15,6 +15,7 @@ package suite
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +100,9 @@ func TestMeta_WorkItemSavedViews(t *testing.T) {
 			},
 		})
 		requireNoError(t, err, "work_item_saved_view_update")
+		requireTruef(t, out.SavedView.Sort == "UPDATED_DESC", "saved view sort = %q, want %q", out.SavedView.Sort, "UPDATED_DESC")
+		requireTruef(t, out.SavedView.Description == "updated by the e2e suite",
+			"saved view description = %q, want the text sent", out.SavedView.Description)
 		t.Logf("Updated saved view: sort=%q description=%q", out.SavedView.Sort, out.SavedView.Description)
 	})
 
@@ -111,6 +115,7 @@ func TestMeta_WorkItemSavedViews(t *testing.T) {
 			"params": map[string]any{"saved_view_id": savedViewID},
 		})
 		requireNoError(t, err, "work_item_saved_view_subscribe")
+		requireTruef(t, out.SavedView.Subscribed, "saved view %d reports subscribed=false right after subscribing", savedViewID)
 		t.Logf("Subscribed to saved view: subscribed=%v", out.SavedView.Subscribed)
 	})
 
@@ -123,6 +128,7 @@ func TestMeta_WorkItemSavedViews(t *testing.T) {
 			"params": map[string]any{"saved_view_id": savedViewID},
 		})
 		requireNoError(t, err, "work_item_saved_view_unsubscribe")
+		requireTruef(t, !out.SavedView.Subscribed, "saved view %d still reports subscribed=true after unsubscribing", savedViewID)
 		t.Logf("Unsubscribed from saved view: subscribed=%v", out.SavedView.Subscribed)
 	})
 
@@ -152,6 +158,11 @@ func TestMeta_WorkItemSavedViews(t *testing.T) {
 			"params": map[string]any{"saved_view_id": savedViewID, "confirm": true},
 		})
 		requireNoError(t, err, "work_item_saved_view_delete")
+		remaining, listErr := listSavedViews(ctx, t, grp.Path)
+		requireNoError(t, listErr, "work_item_saved_view_list after delete")
+		requireTruef(t, !slices.ContainsFunc(remaining.SavedViews, func(v workitemsavedviews.Item) bool {
+			return v.ID == savedViewID
+		}), "saved view %d is still listed after the delete: %+v", savedViewID, remaining.SavedViews)
 		t.Log("Deleted saved view")
 	})
 }


### PR DESCRIPTION
389 assertions in `test/e2e/suite` were a `requireNoError` followed by nothing but a log. They proved the call did not error, which is the one thing a broken tool also achieves.

I ran the Enterprise suite against a licensed GitLab EE Ultimate to find out whether that mattered. 398 tests, one skipped, two failures, and neither failure was a security tool, while three security tools could not work at all: their documents are refused by that very instance, and `vulnerabilities.List` answers a refusal by asking REST whether the project exists and returning an empty list with no error. There is no error to require, and the count is real. It is zero, and zero is what the code decided.

## The triage

Every site was classified before anything was written, against what the fixture in front of it actually guarantees. 226 now carry an assertion and 163 are left alone with a recorded reason, the largest categories being a fixture that creates nothing to find (62), instance state the fixture does not own (28), and a read that runs before the mutation that would populate it (23). Leaving those alone is the point rather than a shortfall: an assertion that fails when the instance is busy or a sibling fixture ran in parallel costs more than the assertion is worth, because a job that is red for a boring reason gets ignored, which is how this class of defect survived in the first place.

Where a fixture creates an identity, the assertion names that identity rather than a count, since a count is fragile against a parallel fixture and an identity is not. Where a mutation has an observable effect, the effect is now observed: `subscribe` used to log the returned IID and never check that the caller ended up subscribed.

## The assertions this exists for

The vulnerability lifecycle no longer derives its fixture from the tool under test. It waits on a document the test sends itself, so a refused list query now fails four subtests where it used to skip all of them, and the skip survives only for an instance whose own report is genuinely empty, discriminated by the pipeline security summary. The four state mutations assert that the vulnerability came back in the state the action names, rather than discarding the payload with `_, err :=`. And the two security-finding subtests now run against the pipeline that publishes three CRITICAL SAST findings and assert exactly those three, keyed on their CWE identifiers.

Those last ones fail on a tree where the documents of https://github.com/jmrplens/gitlab-mcp-server/issues/568 are still refused, which is what they are for, and is why this sits above the branch that repairs them.

## What these assertions do not prove

101 of the added statements are removals: `requireNotListedOn` and `requireGoneOn` prove a writer worked and cannot prove a reader does, because a reader that always answers empty satisfies them. That is inherent to asserting a removal, it is not coverage of the read path, and it is written here so nobody later reads the count as if it were.

The suite was not run for this branch. Both tag combinations vet and compile, every static gate passes, and the semantic bets are named in the commit message.

Refs https://github.com/jmrplens/gitlab-mcp-server/issues/570
