### PR TITLE
fix(audit): compare against an SDK struct that tags nothing, instead of reporting all of it as ours

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,208 |     250,803 |
-| Unit tests (`_test.go`)  |       704 |     410,985 |
+| Source (`.go`, non-test) |     1,208 |     250,888 |
+| Unit tests (`_test.go`)  |       704 |     411,021 |
 | End-to-end tests         |       244 |      66,211 |
-| **Total**                | **2,156** | **727,999** |
+| **Total**                | **2,156** | **728,120** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  9,282 |
-| . Exported (public)             |  2,929 |
-| . Unexported (private)          |  6,353 |
-| Unit test functions (`TestXxx`) | 14,111 |
-| Subtests (`t.Run(...)`)         |  5,592 |
+| Source functions                |  9,285 |
+| . Exported (public)             |  2,930 |
+| . Unexported (private)          |  6,355 |
+| Unit test functions (`TestXxx`) | 14,112 |
+| Subtests (`t.Run(...)`)         |  5,593 |
 | End-to-end test functions       |    603 |
 
 ### Ratios worth noting
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~208 lines |
 | Average test file length           |                 ~584 lines |
-| Comment lines in source            |  43,692 (~17.4% of source) |
+| Comment lines in source            |  43,723 (~17.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -522,7 +522,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,560 pages of A4                                                                                   |
+| Source code printed at 55 lines/page | ~4,561 pages of A4                                                                                   |
 | Source lines mentioning `"gitlab"`   | 14,554 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |

--- a/cmd/audit_1to1/internal/shared/tags.go
+++ b/cmd/audit_1to1/internal/shared/tags.go
@@ -38,6 +38,52 @@ func camelToSnake(s string) string {
 	return b.String()
 }
 
+// FieldNameTag is the name encoding/json gives an exported field that carries
+// no tag: its own, which this converts to the snake_case the MCP side writes.
+//
+// It is acronym-aware where [camelToSnake] is not, because it converts a Go
+// identifier rather than a tag somebody already wrote in one style: AvatarURL
+// is avatar_url and not avatar_u_r_l, NamespaceID is namespace_id.
+//
+// The plural of an acronym is the case the usual rule gets wrong. Breaking
+// before the last capital of a run that is followed by a lowercase letter is
+// right for CRMContact, and wrong for AssigneeIDs, which it renders
+// assignee_i_ds. A run whose whole lowercase remainder is a final "s" is
+// therefore kept together, which is the only shape Go spells that way.
+func FieldNameTag(name string) string {
+	runes := []rune(name)
+	upper := func(i int) bool { return i >= 0 && i < len(runes) && runes[i] >= 'A' && runes[i] <= 'Z' }
+	lower := func(i int) bool {
+		return i >= 0 && i < len(runes) && ((runes[i] >= 'a' && runes[i] <= 'z') || (runes[i] >= '0' && runes[i] <= '9'))
+	}
+
+	var b strings.Builder
+	for i, r := range runes {
+		if upper(i) && i > 0 {
+			switch {
+			case lower(i - 1):
+				// A capital after a lowercase letter always starts a word.
+				b.WriteByte('_')
+			case upper(i-1) && lower(i+1) && !pluralTail(runes, i+1):
+				// The last capital of an acronym run starts the next word,
+				// unless what follows is the acronym's own plural s.
+				b.WriteByte('_')
+			}
+			r += 'a' - 'A'
+		} else if upper(i) {
+			r += 'a' - 'A'
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// pluralTail reports whether the rest of the identifier from i is exactly "s",
+// which is how Go writes the plural of an acronym: IDs, URLs, IIDs.
+func pluralTail(runes []rune, i int) bool {
+	return i == len(runes)-1 && runes[i] == 's'
+}
+
 // TagName returns the name carried by the first of keys present in raw, with
 // any ",omitempty"-style options stripped. It is "" when none of the keys
 // names the field, and "-" when the field is explicitly excluded.

--- a/cmd/audit_1to1/internal/shared/tags_test.go
+++ b/cmd/audit_1to1/internal/shared/tags_test.go
@@ -32,6 +32,42 @@ func TestNormalizeSDKTag_Notations_MapToTheMCPSnakeCaseName(t *testing.T) {
 	}
 }
 
+// TestFieldNameTag_GoIdentifiers_BecomeTheNameEncodingJSONWouldUse verifies the
+// conversion the struct comparison falls back to when an SDK struct tags
+// nothing, which is every GraphQL-backed type client-go declares.
+//
+// The case that decides the algorithm is the plural acronym. The usual rule,
+// breaking before the last capital of a run followed by a lowercase letter, is
+// right for CRMContact and renders AssigneeIDs as assignee_i_ds, which matches
+// no tag anybody writes and would report a field we do have as one we lack.
+func TestFieldNameTag_GoIdentifiers_BecomeTheNameEncodingJSONWouldUse(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "plain_camel", field: "CreatedAt", want: "created_at"},
+		{name: "trailing_acronym", field: "NamespaceID", want: "namespace_id"},
+		{name: "trailing_acronym_three", field: "AvatarURL", want: "avatar_url"},
+		{name: "plural_acronym", field: "AssigneeIDs", want: "assignee_ids"},
+		{name: "acronym_then_word", field: "CRMContactIDs", want: "crm_contact_ids"},
+		{name: "acronym_alone", field: "ID", want: "id"},
+		{name: "plural_acronym_alone", field: "IDs", want: "ids"},
+		{name: "leading_acronym_word", field: "HTTPServer", want: "http_server"},
+		{name: "single_word", field: "Name", want: "name"},
+		{name: "digit_boundary", field: "Sha256Sum", want: "sha256_sum"},
+		{name: "already_lower", field: "name", want: "name"},
+		{name: "empty", field: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FieldNameTag(tc.field); got != tc.want {
+				t.Errorf("FieldNameTag(%q) = %q, want %q", tc.field, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestTagName_Keys_PrefersTheFirstKeyAndStripsOptions verifies tag selection
 // across the preferred key order, the stripping of ",omitempty"-style
 // suffixes, the "-" exclusion sentinel, and the empty result for a field

--- a/cmd/audit_1to1/internal/structs/analyze.go
+++ b/cmd/audit_1to1/internal/structs/analyze.go
@@ -1035,7 +1035,46 @@ func extraOutputFields(pkg, mcpType string, mcpFields, sdkFields map[string]stri
 func flattenFields(st *types.Struct, tagKeys []string) map[string]string {
 	out := map[string]string{}
 	flattenInto(st, tagKeys, out, 0)
+	if len(out) > 0 {
+		return out
+	}
+	// A struct that carries no tag of the kind we index by cannot be compared
+	// by tag at all: every field on our side is then reported as one the SDK
+	// does not have, which says nothing about either. client-go's Achievement
+	// and UserAchievement are exactly that, and they produced the only 18
+	// entries left in the backlog while our field names matched theirs one for
+	// one. encoding/json serializes such a field under its own name, so that is
+	// what the comparison uses.
+	//
+	// The fallback is per struct rather than per field on purpose. An untagged
+	// field in a struct that tags the rest is also serialized by its name, but
+	// changing that case would re-open every gap somebody has already
+	// adjudicated, for a shape nothing has yet been found in.
+	flattenNamesInto(st, out, 0)
 	return out
+}
+
+// flattenNamesInto is flattenInto keyed by the Go field name, for a struct that
+// tags nothing.
+func flattenNamesInto(st *types.Struct, out map[string]string, depth int) {
+	if st == nil || depth > 6 {
+		return
+	}
+	for field := range st.Fields() {
+		if !field.Exported() {
+			continue
+		}
+		if field.Embedded() {
+			if embedded, ok := structUnder(field.Type()); ok {
+				flattenNamesInto(embedded, out, depth+1)
+				continue
+			}
+		}
+		name := shared.FieldNameTag(field.Name())
+		if _, exists := out[name]; !exists {
+			out[name] = types.TypeString(field.Type(), shortQualifier)
+		}
+	}
 }
 
 func flattenInto(st *types.Struct, tagKeys []string, out map[string]string, depth int) {

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,714 |
-| Unit test functions                                   | 14,111 |
+| Total test functions                                  | 14,715 |
+| Unit test functions                                   | 14,112 |
 | E2E test functions                                    |    603 |
-| cmd test functions                                    |  2,792 |
+| cmd test functions                                    |  2,793 |
 | Test files (internal/)                                |    518 |
 | Test files (cmd/)                                     |    186 |
 | Test files (test/e2e/)                                |    238 |
@@ -37,7 +37,7 @@
 | -------------------------------------- | -----: | ----: |
 | `TestFunc_Scenario` (2-part)           | 11,837 | 80.4% |
 | `TestFunc` (no underscore)             |    981 |  6.7% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,896 | 12.9% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,897 | 12.9% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          8,561 |        359 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            603 |        238 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,792 |        186 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,714** |    **942** |                                                                                                 |
+| cmd packages            |          2,793 |        186 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,715** |    **942** |                                                                                                 |
 
 ### Core Packages
 


### PR DESCRIPTION
The struct dimension of the 1:1 audit indexes both sides by json tag. A client-go type that declares no tag therefore contributes no fields, so nothing of theirs can be missing from ours and everything of ours is reported as extra. That is not the comparison being lenient, it is the comparison not happening.

`v2.Achievement` and `v2.UserAchievement` are plain Go structs. Our field names match theirs one for one, and the audit called all 18 of them extra, which is why the backlog has never reached zero and why an entry in it had stopped meaning anything.

A struct that yields no tagged field is now read by field name, which is what `encoding/json` would call it. The fallback is per struct rather than per field on purpose: an untagged field in a struct that tags the rest is serialized by its name too, but changing that case would re-open every gap somebody has already adjudicated, for a shape nothing has been found in yet.

`FieldNameTag` is acronym-aware, and the case that decides its algorithm is the plural. The usual rule, breaking before the last capital of a run followed by a lowercase letter, is right for `CRMContact` and renders `AssigneeIDs` as `assignee_i_ds`, which matches no tag anybody writes and would report a field we do have as one we lack. A run whose whole lowercase remainder is a final `s` is kept together. Twelve cases pin it, including `IDs`, `AvatarURL`, `HTTPServer` and `Sha256Sum`.

What this uncovers is the point of the change rather than a side effect. The backlog went from one package with 18 imaginary extra fields to three packages missing 86 real ones: `epics` and `workitems` do not accept `iteration_id`, `milestone_id`, `parent_id`, `crm_contact_ids`, `assignee_usernames`, `closed_after`, `health_status_filter` or two dozen more filters client-go declares, and their outputs drop `parent`, `children`, `weight`, `health_status` and the dates. `achievements` does not accept the avatar upload. Every one is a GraphQL-backed domain, which is exactly where client-go writes a type as plain Go.

Those 86 are not fixed here. They are a work list, recorded as its own issue, because each needs the three questions the 1:1 norm always asks and none of the answers is automatic: whether the document the handler sends can carry the field, whether the pinned schema accepts it, and which tier it belongs to.

Coverage: `cmd/audit_1to1/internal/shared` at 100% statements, `internal/structs` at 99.8%.
