### PR TITLE
test(gen_api_shapes): refuse the dial rather than close a server, so a loaded suite cannot answer on the freed port

### DIFF
--- a/cmd/gen_api_shapes/main_test.go
+++ b/cmd/gen_api_shapes/main_test.go
@@ -17,6 +17,15 @@ import (
 // fixedClock is the day a generated record is asserted against.
 func fixedClock() time.Time { return time.Date(2026, 9, 7, 11, 30, 0, 0, time.UTC) }
 
+// refusedDial is a transport nothing can answer through: every request fails
+// the way a connection refused fails, without a socket that another process
+// could answer on.
+type refusedDial struct{}
+
+func (refusedDial) RoundTrip(request *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("dial tcp %s: connect: connection refused", request.URL.Host)
+}
+
 // runCommand runs the command with both streams captured.
 func runCommand(t *testing.T, cfg genRun) (int, string, string) {
 	t.Helper()
@@ -122,9 +131,6 @@ func TestRun_GenerationFailures_ExitNonZeroAndSayWhy(t *testing.T) {
 	}))
 	t.Cleanup(refusing.Close)
 
-	unreachable := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	unreachable.Close()
-
 	cases := []struct {
 		name string
 		cfg  genRun
@@ -136,8 +142,12 @@ func TestRun_GenerationFailures_ExitNonZeroAndSayWhy(t *testing.T) {
 			want: "404",
 		},
 		{
+			// A refused dial rather than a closed httptest server: closing one
+			// frees its port, and under a parallel suite another test binary
+			// can bind that port between the close and the request, which is
+			// how this case answered once on a loaded box.
 			name: "nothing answered",
-			cfg:  genRun{dir: t.TempDir(), client: unreachable.Client(), url: unreachable.URL, now: fixedClock},
+			cfg:  genRun{dir: t.TempDir(), client: &http.Client{Transport: refusedDial{}}, url: "http://127.0.0.1:1", now: fixedClock},
 			want: "fetch ",
 		},
 		{


### PR DESCRIPTION
The "nothing answered" case of `TestRun_GenerationFailures_ExitNonZeroAndSayWhy` used to start an `httptest` server, close it, and point the generator at the address it had just freed, expecting a dial error. On a loaded host that port is handed to the next listener the suite opens, so the case was answered by a sibling test's server and failed on the body it read instead of the refusal it expected, which is how it flaked on the CI run of the layer below.

## What changes

The case injects a `refusedDial` round tripper that fails every request the way a connection refused fails, without a socket another process could answer on, so the generator's error path is reached by construction rather than by racing the kernel's port allocator. Nothing else in the generator changes.

## Where the freshness policy went

This branch used to carry the deferred freshness gates too. They now sit at the bottom of the stack, as their own pull request against `main`, so that every layer above them is built under the policy rather than only the ones above this one.
