### PR TITLE
feat(workitems): expose every filter and widget client-go carries, and the objects behind them

### DIFF
--- a/docs/reference/tools/issues.md
+++ b/docs/reference/tools/issues.md
@@ -393,21 +393,64 @@ List weight events for an issue (Premium) — every weight value set, with the w
 
 ### `gitlab_get_work_item`
 
-Get a single work item by IID. Returns hierarchy child work items (namespace path and IID) alongside linked items. Experimental: the Work Items API may introduce breaking changes between minor versions.
+Get a single work item by IID. Returns the hierarchy parent and child work items (namespace path and IID) alongside linked items, plus the widget values a work item type carries: `milestone_id`, `iteration_id`, `weight`, `health_status`, `color`, `start_date` and `due_date`. Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 | Annotation | **Read** |
 | ---------- | -------- |
 
 ### `gitlab_list_work_items`
 
-List work items for a project or group. Supports filtering by state, type, labels, author, search. Each item includes its assignees, labels, linked items and hierarchy child work items (namespace path and IID), with cursor pagination (`first`/`after` forward, `last`/`before` backward). The cursor picks the direction: `before` on its own pages backward at the default size, and naming both `first` and `last` is refused, because GitLab refuses it too. `sort` is a GraphQL `WorkItemSort` value such as `CREATED_DESC` (the default), `TITLE_ASC` or `PRIORITY_DESC`, not the `asc`/`desc` pair the REST endpoints take. Experimental: the Work Items API may introduce breaking changes between minor versions.
+List work items for a project or group. Each item includes its assignees, labels, linked items and hierarchy parent and child work items (namespace path and IID), with cursor pagination (`first`/`after` forward, `last`/`before` backward). The cursor picks the direction: `before` on its own pages backward at the default size, and naming both `first` and `last` is refused, because GitLab refuses it too. `sort` is a GraphQL `WorkItemSort` value such as `CREATED_DESC` (the default), `TITLE_ASC` or `PRIORITY_DESC`, not the `asc`/`desc` pair the REST endpoints take. On Premium and Ultimate instances each listed item also carries `status`, `weight`, `health_status`, `iteration_id` and `color`, which are asked for only there: a Community Edition schema does not define those widgets and one unknown field fails the whole query. Experimental: the Work Items API may introduce breaking changes between minor versions.
+
+The full filter set:
+
+| Parameter                                  | Type       | Description                                                                                                         |
+| ------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| `full_path`                                | string     | Project or group namespace. Required                                                                                |
+| `state`                                    | string     | `opened`, `closed` or `all`                                                                                         |
+| `search`                                   | string     | Free-text search over title and description                                                                         |
+| `in`                                       | array      | Fields `search` is matched against: `TITLE`, `DESCRIPTION`                                                          |
+| `types`                                    | array      | `IssueType` values such as `ISSUE`, `TASK`, `EPIC`                                                                  |
+| `author_username`                          | string     | Username of the author                                                                                              |
+| `assignee_usernames`                       | array      | Usernames of the assignees                                                                                          |
+| `assignee_wildcard_id`                     | string     | `ANY`, `ME` or `NONE`                                                                                               |
+| `my_reaction_emoji`                        | string     | Emoji the authenticated user reacted with                                                                           |
+| `subscribed`                               | string     | `EXPLICITLY_SUBSCRIBED` or `EXPLICITLY_UNSUBSCRIBED`                                                                |
+| `crm_contact_id`                           | string     | CRM contact numeric ID as a string, not a global ID                                                                 |
+| `crm_organization_id`                      | string     | CRM organization numeric ID as a string, not a global ID                                                            |
+| `ids`                                      | array      | Work item global IDs (`gid://gitlab/WorkItem/123`)                                                                  |
+| `iids`                                     | array      | Work item internal IDs, as strings                                                                                  |
+| `parent_ids`                               | array      | Parent work item global IDs. Pairs with `include_descendants`                                                       |
+| `label_name`                               | array      | Label names                                                                                                         |
+| `milestone_title`                          | array      | Milestone titles, not the `milestone_id` create and update take                                                     |
+| `milestone_wildcard_id`                    | string     | `ANY`, `NONE`, `STARTED` or `UPCOMING`                                                                              |
+| `release_tag`                              | array      | Release tags                                                                                                        |
+| `release_tag_wildcard_id`                  | string     | `ANY` or `NONE`                                                                                                     |
+| `iteration_id`                             | array      | Iteration global IDs. A list of global IDs, unlike the single numeric `iteration_id` of create and update (Premium) |
+| `iteration_cadence_id`                     | array      | Iteration cadence global IDs (Premium)                                                                              |
+| `iteration_wildcard_id`                    | string     | `ANY`, `CURRENT` or `NONE` (Premium)                                                                                |
+| `weight`                                   | string     | Weight to match. GitLab types this filter as a string (Premium)                                                     |
+| `weight_wildcard_id`                       | string     | `ANY` or `NONE` (Premium)                                                                                           |
+| `health_status_filter`                     | string     | `onTrack`, `needsAttention`, `atRisk`, `ANY` or `NONE`. Case sensitive (Ultimate)                                   |
+| `closed_after`, `closed_before`            | string     | ISO 8601 date-time. A bare date is read as midnight UTC                                                             |
+| `created_after`, `created_before`          | string     | ISO 8601 date-time. A bare date is read as midnight UTC                                                             |
+| `due_after`, `due_before`                  | string     | ISO 8601 date-time. A bare date is read as midnight UTC                                                             |
+| `updated_after`, `updated_before`          | string     | ISO 8601 date-time. A bare date is read as midnight UTC                                                             |
+| `confidential`                             | boolean    | Only confidential or only non-confidential work items                                                               |
+| `include_ancestors`, `include_descendants` | boolean    | Widen the search up or down the namespace hierarchy                                                                 |
+| `sort`                                     | string     | A `WorkItemSort` value                                                                                              |
+| `first`, `after`, `last`, `before`         | int/string | Cursor pagination                                                                                                   |
+
+A timestamp none of the three spellings can read stops the call and names the filter it came from, rather than being dropped: a list narrowed by a date the server ignored answers with more work items than were asked for, and nothing in the answer would say so.
 
 | Annotation | **Read** |
 | ---------- | -------- |
 
 ### `gitlab_create_work_item`
 
-Create a new work item. Requires full_path, work_item_type_id, and title. Supports status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE) and linked_items to link other work items on creation. Experimental: the Work Items API may introduce breaking changes between minor versions.
+Create a new work item. Requires full_path, work_item_type_id, and title. Supports status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE) and linked_items to link other work items on creation.
+
+Five further parameters: `parent_id` (numeric ID of the parent work item, which creates the item already under its parent instead of a create followed by an update), `iteration_id` (numeric ID of the iteration, Premium), `crm_contact_ids` (CRM contact IDs to attach), `created_at` (an ISO 8601 date-time recorded instead of now, which GitLab accepts from instance administrators and project owners only, and which is refused here by name when it cannot be read) and `create_source` (a free-text name of whatever triggered the creation, recorded for tracking and changing nothing about the work item). Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 | Annotation | **Create** |
 | ---------- | ---------- |

--- a/docs/reference/tools/issues.md
+++ b/docs/reference/tools/issues.md
@@ -393,14 +393,14 @@ List weight events for an issue (Premium) — every weight value set, with the w
 
 ### `gitlab_get_work_item`
 
-Get a single work item by IID. Returns the hierarchy parent and child work items (namespace path and IID) alongside linked items, plus the widget values a work item type carries: `milestone_id`, `iteration_id`, `weight`, `health_status`, `color`, `start_date` and `due_date`. Experimental: the Work Items API may introduce breaking changes between minor versions.
+Get a single work item by IID. Returns the hierarchy parent and child work items (namespace path and IID) alongside linked items, plus the widget values a work item type carries: `milestone_id`, `iteration_id`, `weight`, `health_status`, `color`, `start_date` and `due_date`. `author` and each entry of `assignees` are whole user objects (`id`, `username`, `name`, `state`, `avatar_url`, `web_url`, `created_at`) and each entry of `labels` is a whole label object (`id`, `name`, `color`, `description`, `description_html`, `text_color`), because the GraphQL fragment fetches all of those on every call. The Markdown rendering still prints names. Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 | Annotation | **Read** |
 | ---------- | -------- |
 
 ### `gitlab_list_work_items`
 
-List work items for a project or group. Each item includes its assignees, labels, linked items and hierarchy parent and child work items (namespace path and IID), with cursor pagination (`first`/`after` forward, `last`/`before` backward). The cursor picks the direction: `before` on its own pages backward at the default size, and naming both `first` and `last` is refused, because GitLab refuses it too. `sort` is a GraphQL `WorkItemSort` value such as `CREATED_DESC` (the default), `TITLE_ASC` or `PRIORITY_DESC`, not the `asc`/`desc` pair the REST endpoints take. On Premium and Ultimate instances each listed item also carries `status`, `weight`, `health_status`, `iteration_id` and `color`, which are asked for only there: a Community Edition schema does not define those widgets and one unknown field fails the whole query. Experimental: the Work Items API may introduce breaking changes between minor versions.
+List work items for a project or group. Each item includes its author, assignees and labels as whole objects, its linked items and its hierarchy parent and child work items (namespace path and IID), with cursor pagination (`first`/`after` forward, `last`/`before` backward). The cursor picks the direction: `before` on its own pages backward at the default size, and naming both `first` and `last` is refused, because GitLab refuses it too. `sort` is a GraphQL `WorkItemSort` value such as `CREATED_DESC` (the default), `TITLE_ASC` or `PRIORITY_DESC`, not the `asc`/`desc` pair the REST endpoints take. On Premium and Ultimate instances each listed item also carries `status`, `weight`, `health_status`, `iteration_id` and `color`, which are asked for only there: a Community Edition schema does not define those widgets and one unknown field fails the whole query. Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 The full filter set:
 
@@ -439,25 +439,28 @@ The full filter set:
 | `confidential`                             | boolean    | Only confidential or only non-confidential work items                                                               |
 | `include_ancestors`, `include_descendants` | boolean    | Widen the search up or down the namespace hierarchy                                                                 |
 | `sort`                                     | string     | A `WorkItemSort` value                                                                                              |
+| `returned_fields`                          | array      | Which fields of each item to ask for, not which items match. See below                                              |
 | `first`, `after`, `last`, `before`         | int/string | Cursor pagination                                                                                                   |
 
 A timestamp none of the three spellings can read stops the call and names the filter it came from, rather than being dropped: a list narrowed by a date the server ignored answers with more work items than were asked for, and nothing in the answer would say so.
+
+`returned_fields` selects the GraphQL fragment rather than the result set: it decides which fields of each matching work item come back, and no work item is included or excluded by it. Omitting it asks for the default set, which is every Community Edition field plus the five Enterprise ones on a Premium or Ultimate instance; naming a subset such as `["iid", "title"]` makes a large page much smaller. The accepted names are `assignees`, `author`, `closedAt`, `color`, `confidential`, `createdAt`, `description`, `healthStatus`, `hierarchy`, `id`, `iid`, `iteration`, `labels`, `linkedItems`, `milestone`, `startAndDueDate`, `state`, `status`, `title`, `type`, `updatedAt`, `webUrl` and `weight`. A name outside that set stops the call before anything is sent. The five Enterprise names (`color`, `healthStatus`, `iteration`, `status`, `weight`) fail the whole query against a Community Edition instance, whose schema does not define those widgets.
 
 | Annotation | **Read** |
 | ---------- | -------- |
 
 ### `gitlab_create_work_item`
 
-Create a new work item. Requires full_path, work_item_type_id, and title. Supports status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE) and linked_items to link other work items on creation.
+Create a new work item. Requires full_path, work_item_type_id, and title. Supports status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE, Premium) and linked_items to link other work items on creation. `status` and `color` are Premium: client-go groups both with weight, iteration and health status as fields the Community Edition schema does not define, and GitLab documents work item status and epics alike at Premium and Ultimate.
 
-Five further parameters: `parent_id` (numeric ID of the parent work item, which creates the item already under its parent instead of a create followed by an update), `iteration_id` (numeric ID of the iteration, Premium), `crm_contact_ids` (CRM contact IDs to attach), `created_at` (an ISO 8601 date-time recorded instead of now, which GitLab accepts from instance administrators and project owners only, and which is refused here by name when it cannot be read) and `create_source` (a free-text name of whatever triggered the creation, recorded for tracking and changing nothing about the work item). Experimental: the Work Items API may introduce breaking changes between minor versions.
+Five further parameters: `parent_id` (numeric ID of the parent work item, which creates the item already under its parent instead of a create followed by an update), `iteration_id` (numeric ID of the iteration, Premium), `crm_contact_ids` (CRM contact IDs to attach), `created_at` (an ISO 8601 date-time recorded instead of now, which GitLab accepts from instance administrators and project owners only, and which is refused here by name when it cannot be read) and `create_source` (a free-text name of whatever triggered the creation, recorded for tracking and changing nothing about the work item). `start_date` and `due_date` are calendar dates in `YYYY-MM-DD` form, and one that cannot be read stops the call and names the field rather than being dropped, so a work item is never created without a date that was asked for. Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 | Annotation | **Create** |
 | ---------- | ---------- |
 
 ### `gitlab_update_work_item`
 
-Update an existing work item by IID. Supports changing title, state (CLOSE/REOPEN), description, assignees, milestone, labels (add/remove), dates, weight, health status, iteration, color, and status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE). `assignee_ids` and `crm_contact_ids` replace the whole list: an empty array removes every entry, and omitting the field leaves it untouched; removing entries that exist requires `confirm=true` or an approved confirmation prompt. Experimental: the Work Items API may introduce breaking changes between minor versions.
+Update an existing work item by IID. Supports changing title, state (CLOSE/REOPEN), description, assignees, milestone, labels (add/remove), dates, weight, health status, iteration, color, and status (TODO/IN_PROGRESS/DONE/WONT_DO/DUPLICATE). `color` and `status` are Premium, as they are on create. `assignee_ids` and `crm_contact_ids` replace the whole list: an empty array removes every entry, and omitting the field leaves it untouched; removing entries that exist requires `confirm=true` or an approved confirmation prompt. `start_date` and `due_date` are calendar dates in `YYYY-MM-DD` form, and one that cannot be read stops the call by name before anything is sent. Experimental: the Work Items API may introduce breaking changes between minor versions.
 
 | Annotation | **Update** |
 | ---------- | ---------- |
@@ -487,6 +490,8 @@ A saved view stores a named, reusable work item filter under a group or project 
 `sort` is a `WorkItemSort` enum value (`CREATED_ASC`, `CREATED_DESC`, `TITLE_ASC`, `TITLE_DESC`, `UPDATED_ASC`, `UPDATED_DESC`, `PRIORITY_ASC`, `WEIGHT_DESC` and the rest of the enum). `display_settings` is an opaque JSON object GitLab validates against its own schema, so its keys are camelCase: `viewMode` (`list`, `board` or `table`), `hiddenMetadataKeys`, `collapsedGroups`, `visibleGroups`, `groupOrder`.
 
 `filters` mirrors GitLab's `WorkItemSavedViewFilterInput` one for one, including the nested `not`, `or`, `hierarchy_filters`, `status` and `custom_field` sub-objects. The eight time filters (`created_after`, `created_before`, `closed_after`, `closed_before`, `due_after`, `due_before`, `updated_after`, `updated_before`) take ISO 8601 timestamps.
+
+A saved view is available on every tier, but some of the conditions inside one are not, and each is advertised at the same tier `gitlab_list_work_items` advertises the filter of the same name: `iteration_id`, `iteration_cadence_id`, `iteration_wildcard_id`, `weight`, `weight_wildcard_id`, `status` and `custom_field` are Premium, and `health_status_filter` is Ultimate. The same applies to their counterparts inside `not` and `or`.
 
 ### `gitlab_work_item_saved_view_get`
 

--- a/internal/tools/workitems/action_specs.go
+++ b/internal/tools/workitems/action_specs.go
@@ -3,6 +3,9 @@ package workitems
 import (
 	"context"
 	"fmt"
+	"slices"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
@@ -53,10 +56,10 @@ func workItemReadSpec(name string, route toolutil.ActionRoute, individualTool st
 		opts.RelatedActions = []string{actionWorkItemList, "work_item.update", "work_item.delete"}
 		opts.IndividualTool.Description = "Get a single work item by namespace path and IID. Returns: id, iid, type, state, status, title, description, author, assignees, labels, linked items, parent and child work items, milestone, iteration, weight, health status, color, start and due dates, confidentiality, timestamps, and web URL. Experimental. See also: gitlab_list_work_items, gitlab_update_work_item, gitlab_delete_work_item."
 	case "gitlab_list_work_items":
-		opts.Usage = "List work items in one project or group namespace. Use filters such as state, search, types, author_username, assignee_usernames, label_name, milestone_title, iteration_id, weight, health_status_filter, the closed/created/due/updated date ranges, confidential, sort, include_ancestors/descendants, and cursor pagination when the prompt asks for matching work items in a known namespace. The ids, parent_ids, iteration_id and iteration_cadence_id filters take full global IDs (gid://gitlab/WorkItem/123), while iids takes the plain numbers shown in the UI and crm_contact_id and crm_organization_id take plain numeric ids as strings, never the gid:// form. Pages in both directions: first with after walks forward, last with before walks back from a start cursor."
+		opts.Usage = "List work items in one project or group namespace. Use filters such as state, search, types, author_username, assignee_usernames, label_name, milestone_title, iteration_id, weight, health_status_filter, the closed/created/due/updated date ranges, confidential, sort, include_ancestors/descendants, and cursor pagination when the prompt asks for matching work items in a known namespace. The ids, parent_ids, iteration_id and iteration_cadence_id filters take full global IDs (gid://gitlab/WorkItem/123), while iids takes the plain numbers shown in the UI and crm_contact_id and crm_organization_id take plain numeric ids as strings, never the gid:// form. returned_fields is not a filter: it names the fields of each matching work item the query asks for, so a listing that only needs iid and title can say so and pay for nothing else. Pages in both directions: first with after walks forward, last with before walks back from a start cursor."
 		opts.Aliases = []string{"list work items", "find work items in namespace", "show open work items", individualTool}
 		opts.RelatedActions = []string{actionWorkItemGet, "work_item.create", "work_item.type_list"}
-		opts.IndividualTool.Description = "List work items in a project or group namespace with filtering and cursor pagination. Returns: matching work items with type, state, title, author, assignees, labels, linked items, parent and child work items, milestone, start and due dates, timestamps, and the cursors for the next and previous pages. On Premium and Ultimate instances the status, weight, health status, iteration and color of each item come back too. Pages in both directions: first with after walks forward, last with before walks back. Experimental. See also: gitlab_get_work_item, gitlab_create_work_item, gitlab_list_work_item_types."
+		opts.IndividualTool.Description = "List work items in a project or group namespace with filtering and cursor pagination. Returns: matching work items with type, state, title, author, assignees, labels, linked items, parent and child work items, milestone, start and due dates, timestamps, and the cursors for the next and previous pages. On Premium and Ultimate instances the status, weight, health status, iteration and color of each item come back too. returned_fields narrows that set to the fields named, which shrinks a large page without changing which work items match. Pages in both directions: first with after walks forward, last with before walks back. Experimental. See also: gitlab_get_work_item, gitlab_create_work_item, gitlab_list_work_item_types."
 		opts.InputSchemaOverrides = workItemListEnumOverrides()
 	case "gitlab_list_work_item_types":
 		opts.Usage = "List available work item types (system-defined and custom) for a project or group namespace. Supports filtering by name and availability, with cursor-based pagination. Returns: type definitions with id, name, and enabled status. Experimental: the Work Items API may introduce breaking changes between minor versions."
@@ -154,8 +157,32 @@ func workItemListEnumOverrides() []toolutil.InputSchemaOverride {
 		toolutil.SchemaEnumOverride("release_tag_wildcard_id", "ANY", "NONE"),
 		toolutil.SchemaEnumOverride("subscribed", "EXPLICITLY_SUBSCRIBED", "EXPLICITLY_UNSUBSCRIBED"),
 		toolutil.SchemaEnumOverride("weight_wildcard_id", "ANY", "NONE"),
+		toolutil.SchemaPropertyOverride("returned_fields", map[string]any{
+			"items": map[string]any{"type": "string", "enum": workItemReturnedFieldValues()},
+		}),
 	}
 	return append(overrides, workItemTimeFilterFormatOverrides()...)
+}
+
+// workItemReturnedFieldValues is the closed set of field names
+// [gl.ListWorkItemsOptions.ReturnedFields] accepts.
+//
+// It is read out of client-go rather than written down here so the published
+// enum tracks the SDK: client-go refuses a name outside its own registry
+// before the request is built, and a hand-copied list would drift into
+// advertising a name that refusal rejects. The five Enterprise names are
+// published alongside the Community Edition ones because the tier this process
+// resolved is not the tier of every instance an HTTP deployment serves, and a
+// name a Community Edition schema cannot answer is refused by GitLab with its
+// own message rather than hidden here.
+func workItemReturnedFieldValues() []any {
+	names := append(gl.WorkItemDefaultListFields(), workItemEEListFields...)
+	slices.Sort(names)
+	values := make([]any, len(names))
+	for i, name := range names {
+		values[i] = name
+	}
+	return values
 }
 
 // workItemTimeFilterFormatOverrides publishes the date-time format on the four

--- a/internal/tools/workitems/action_specs.go
+++ b/internal/tools/workitems/action_specs.go
@@ -51,12 +51,12 @@ func workItemReadSpec(name string, route toolutil.ActionRoute, individualTool st
 		opts.Usage = "Get one exact work item by namespace full_path plus work_item_iid. Use this after list/search results or when the prompt already names a concrete work item number. Prefer work_item.get over work_item.list when the target is already known."
 		opts.Aliases = []string{"get work item", "show work item details", "fetch work item by iid", individualTool}
 		opts.RelatedActions = []string{actionWorkItemList, "work_item.update", "work_item.delete"}
-		opts.IndividualTool.Description = "Get a single work item by namespace path and IID. Returns: id, iid, type, state, status, title, description, author, assignees, labels, linked items, child work items, confidentiality, timestamps, and web URL. Experimental. See also: gitlab_list_work_items, gitlab_update_work_item, gitlab_delete_work_item."
+		opts.IndividualTool.Description = "Get a single work item by namespace path and IID. Returns: id, iid, type, state, status, title, description, author, assignees, labels, linked items, parent and child work items, milestone, iteration, weight, health status, color, start and due dates, confidentiality, timestamps, and web URL. Experimental. See also: gitlab_list_work_items, gitlab_update_work_item, gitlab_delete_work_item."
 	case "gitlab_list_work_items":
-		opts.Usage = "List work items in one project or group namespace. Use filters such as state, search, types, author_username, label_name, confidential, sort, include_ancestors/descendants, and cursor pagination when the prompt asks for matching work items in a known namespace. Pages in both directions: first with after walks forward, last with before walks back from a start cursor."
+		opts.Usage = "List work items in one project or group namespace. Use filters such as state, search, types, author_username, assignee_usernames, label_name, milestone_title, iteration_id, weight, health_status_filter, the closed/created/due/updated date ranges, confidential, sort, include_ancestors/descendants, and cursor pagination when the prompt asks for matching work items in a known namespace. The ids, parent_ids, iteration_id and iteration_cadence_id filters take full global IDs (gid://gitlab/WorkItem/123), while iids takes the plain numbers shown in the UI and crm_contact_id and crm_organization_id take plain numeric ids as strings, never the gid:// form. Pages in both directions: first with after walks forward, last with before walks back from a start cursor."
 		opts.Aliases = []string{"list work items", "find work items in namespace", "show open work items", individualTool}
 		opts.RelatedActions = []string{actionWorkItemGet, "work_item.create", "work_item.type_list"}
-		opts.IndividualTool.Description = "List work items in a project or group namespace with filtering and cursor pagination. Returns: matching work items with type, state, title, author, assignees, labels, linked items, child work items, timestamps, and the cursors for the next and previous pages. Pages in both directions: first with after walks forward, last with before walks back. Experimental. See also: gitlab_get_work_item, gitlab_create_work_item, gitlab_list_work_item_types."
+		opts.IndividualTool.Description = "List work items in a project or group namespace with filtering and cursor pagination. Returns: matching work items with type, state, title, author, assignees, labels, linked items, parent and child work items, milestone, start and due dates, timestamps, and the cursors for the next and previous pages. On Premium and Ultimate instances the status, weight, health status, iteration and color of each item come back too. Pages in both directions: first with after walks forward, last with before walks back. Experimental. See also: gitlab_get_work_item, gitlab_create_work_item, gitlab_list_work_item_types."
 		opts.InputSchemaOverrides = workItemListEnumOverrides()
 	case "gitlab_list_work_item_types":
 		opts.Usage = "List available work item types (system-defined and custom) for a project or group namespace. Supports filtering by name and availability, with cursor-based pagination. Returns: type definitions with id, name, and enabled status. Experimental: the Work Items API may introduce breaking changes between minor versions."
@@ -71,10 +71,10 @@ func workItemReadSpec(name string, route toolutil.ActionRoute, individualTool st
 // workItemCreateSpec builds the canonical create spec for a work item tool.
 func workItemCreateSpec(name string, route toolutil.ActionRoute, individualTool string) toolutil.ActionSpec {
 	opts := workItemOptions(individualTool)
-	opts.Usage = "Create a new work item under a project or group namespace. Provide full_path, a work_item_type_id (discover with work_item.type_list), and a title. Add description, confidential, assignee_ids, milestone_id, label_ids, weight, health_status, status, color, dates, or linked_items only when requested."
+	opts.Usage = "Create a new work item under a project or group namespace. Provide full_path, a work_item_type_id (discover with work_item.type_list), and a title. Add description, confidential, assignee_ids, milestone_id, label_ids, crm_contact_ids, parent_id, iteration_id, weight, health_status, status, color, dates, create_source, or linked_items only when requested. parent_id creates the item already under its parent, which otherwise takes a create followed by an update."
 	opts.Aliases = []string{"create work item", "open new work item", "add epic or task", individualTool}
 	opts.RelatedActions = []string{actionWorkItemGet, actionWorkItemList, "work_item.type_list"}
-	opts.IndividualTool.Description = "Create a new work item under a namespace. Returns: the created work item with id, iid, type, state, title, description, assignees, labels, linked items, child work items, and web URL. Experimental. See also: gitlab_get_work_item, gitlab_list_work_items, gitlab_list_work_item_types."
+	opts.IndividualTool.Description = "Create a new work item under a namespace. Returns: the created work item with id, iid, type, state, title, description, assignees, labels, linked items, parent and child work items, milestone, iteration, weight, health status, color, start and due dates, and web URL. Experimental. See also: gitlab_get_work_item, gitlab_list_work_items, gitlab_list_work_item_types."
 	opts.InputSchemaOverrides = workItemCreateEnumOverrides()
 	return toolutil.NewCreateActionSpec(name, route, opts)
 }
@@ -85,7 +85,7 @@ func workItemUpdateSpec(name string, route toolutil.ActionRoute, individualTool 
 	opts.Usage = "Update an existing work item's fields, status, labels, or hierarchy. Provide full_path plus work_item_iid. Set state_event to CLOSE or REOPEN to change state, and supply only the widget-supported fields you want to change. assignee_ids and crm_contact_ids replace the whole list: send an empty array to remove every entry, and omit the field to leave it untouched. Clearing entries that exist requires confirm=true (or an approved elicitation prompt)."
 	opts.Aliases = []string{"update work item", "edit work item fields", "close or reopen work item", individualTool}
 	opts.RelatedActions = []string{actionWorkItemGet, "work_item.delete", actionWorkItemList}
-	opts.IndividualTool.Description = "Update an existing work item by namespace path and IID. Returns: the updated work item with id, iid, type, state, status, title, description, assignees, labels, linked items, child work items, and web URL. Experimental. See also: gitlab_get_work_item, gitlab_delete_work_item, gitlab_list_work_items."
+	opts.IndividualTool.Description = "Update an existing work item by namespace path and IID. Returns: the updated work item with id, iid, type, state, status, title, description, assignees, labels, linked items, parent and child work items, milestone, iteration, weight, health status, color, start and due dates, and web URL. Experimental. See also: gitlab_get_work_item, gitlab_delete_work_item, gitlab_list_work_items."
 	opts.InputSchemaOverrides = workItemUpdateEnumOverrides()
 	return toolutil.NewUpdateActionSpec(name, route, opts)
 }
@@ -109,9 +109,10 @@ func workItemOptions(individualTool string) toolutil.ActionSpecOptions {
 	}
 }
 
-// workItemListEnumOverrides constrains the state and sort filters on the work
-// item list action. The state field maps to IssuableState in the GraphQL query;
-// the three values below are the safe, stable subset documented for work items.
+// workItemListEnumOverrides constrains the enum-valued and wildcard filters on
+// the work item list action. The state field maps to IssuableState in the
+// GraphQL query; the three values below are the safe, stable subset documented
+// for work items.
 //
 // The sort override is not decoration. Without it, toolutil.canonicalParamEnums
 // injects the REST-wide [asc, desc] pair, and this action's sort is a GraphQL
@@ -124,9 +125,18 @@ func workItemOptions(individualTool string) toolutil.ActionSpecOptions {
 // carried, and it survives here only because it is reached through client-go
 // rather than through one of this repository's own documents.
 //
+// That injection reaches the property literally named sort and no other, so the
+// seven wildcard and enum filters below are not exposed to it. They are
+// published for the plainer reason: each is a GraphQL enum GitLab matches case
+// sensitively, a model guessing "none" or "any" is refused before anything
+// executes, and the refusal names nothing the caller can act on. The health
+// status filter deliberately does not reuse the create and update
+// health_status list: HealthStatusFilter carries ANY and NONE on top of the
+// three HealthStatus values.
+//
 // GitLab API docs: https://docs.gitlab.com/api/graphql/reference/#workitemsort
 func workItemListEnumOverrides() []toolutil.InputSchemaOverride {
-	return []toolutil.InputSchemaOverride{
+	overrides := []toolutil.InputSchemaOverride{
 		toolutil.SchemaPropertyOverride("state", map[string]any{
 			"enum": []any{"opened", "closed", "all"},
 		}),
@@ -134,7 +144,35 @@ func workItemListEnumOverrides() []toolutil.InputSchemaOverride {
 		toolutil.SchemaPropertyOverride("types", map[string]any{
 			"items": map[string]any{"type": "string", "enum": issueTypeValues},
 		}),
+		toolutil.SchemaPropertyOverride("in", map[string]any{
+			"items": map[string]any{"type": "string", "enum": []any{"DESCRIPTION", "TITLE"}},
+		}),
+		toolutil.SchemaEnumOverride("assignee_wildcard_id", "ANY", "ME", "NONE"),
+		toolutil.SchemaEnumOverride("health_status_filter", "ANY", "NONE", "atRisk", "needsAttention", "onTrack"),
+		toolutil.SchemaEnumOverride("iteration_wildcard_id", "ANY", "CURRENT", "NONE"),
+		toolutil.SchemaEnumOverride("milestone_wildcard_id", "ANY", "NONE", "STARTED", "UPCOMING"),
+		toolutil.SchemaEnumOverride("release_tag_wildcard_id", "ANY", "NONE"),
+		toolutil.SchemaEnumOverride("subscribed", "EXPLICITLY_SUBSCRIBED", "EXPLICITLY_UNSUBSCRIBED"),
+		toolutil.SchemaEnumOverride("weight_wildcard_id", "ANY", "NONE"),
 	}
+	return append(overrides, workItemTimeFilterFormatOverrides()...)
+}
+
+// workItemTimeFilterFormatOverrides publishes the date-time format on the four
+// time filters toolutil.canonicalParamFormats does not know.
+//
+// It knows created_after, created_before, updated_after and updated_before by
+// name and injects the format into them centrally. Without these four the
+// other half of one filter set would publish no format at all, and one input
+// struct would advertise eight sibling filters as two different things while
+// the handler parses all eight the same way.
+func workItemTimeFilterFormatOverrides() []toolutil.InputSchemaOverride {
+	names := []string{"closed_after", "closed_before", "due_after", "due_before"}
+	overrides := make([]toolutil.InputSchemaOverride, 0, len(names))
+	for _, name := range names {
+		overrides = append(overrides, toolutil.SchemaFormatOverride(name, "date-time"))
+	}
+	return overrides
 }
 
 // issueTypeValues is the IssueType GraphQL enum, which the types filter and the
@@ -202,6 +240,9 @@ func workItemCreateEnumOverrides() []toolutil.InputSchemaOverride {
 		toolutil.SchemaPropertyOverride("status", map[string]any{
 			"enum": []any{"TODO", "IN_PROGRESS", "DONE", "WONT_DO", "DUPLICATE"},
 		}),
+		// created_at is a full timestamp, unlike the two date-only fields
+		// beside it, and is not one of the names toolutil knows centrally.
+		toolutil.SchemaFormatOverride("created_at", "date-time"),
 	}
 }
 

--- a/internal/tools/workitems/action_specs_test.go
+++ b/internal/tools/workitems/action_specs_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -209,6 +210,105 @@ func TestCatalogSurface_DeleteConfirmDeclined(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected non-nil result for declined confirmation")
 	}
+}
+
+// TestActionSpecs_ListFilters_PublishTheirEnums verifies the served schema
+// carries the closed value set of every enum and wildcard filter.
+//
+// Nothing injects these centrally: toolutil's canonical enums reach the
+// property literally named sort and no other. Without them a model guesses
+// "none" or "any", GitLab matches the enum case sensitively, and the document
+// is refused before anything executes with a message the caller cannot act on.
+func TestActionSpecs_ListFilters_PublishTheirEnums(t *testing.T) {
+	props := workItemToolProperties(t, "gitlab_list_work_items")
+
+	cases := []struct {
+		property string
+		want     []any
+	}{
+		{"assignee_wildcard_id", []any{"ANY", "ME", "NONE"}},
+		{"health_status_filter", []any{"ANY", "NONE", "atRisk", "needsAttention", "onTrack"}},
+		{"iteration_wildcard_id", []any{"ANY", "CURRENT", "NONE"}},
+		{"milestone_wildcard_id", []any{"ANY", "NONE", "STARTED", "UPCOMING"}},
+		{"release_tag_wildcard_id", []any{"ANY", "NONE"}},
+		{"subscribed", []any{"EXPLICITLY_SUBSCRIBED", "EXPLICITLY_UNSUBSCRIBED"}},
+		{"weight_wildcard_id", []any{"ANY", "NONE"}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.property, func(t *testing.T) {
+			property := schemaProperty(t, props, testCase.property)
+			if got := property["enum"]; !reflect.DeepEqual(got, testCase.want) {
+				t.Errorf("%s enum = %#v, want %#v", testCase.property, got, testCase.want)
+			}
+		})
+	}
+
+	t.Run("in publishes its enum on the array items", func(t *testing.T) {
+		items, ok := schemaProperty(t, props, "in")["items"].(map[string]any)
+		if !ok {
+			t.Fatal("in has no items schema")
+		}
+		want := []any{"DESCRIPTION", "TITLE"}
+		if got := items["enum"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("in items enum = %#v, want %#v", got, want)
+		}
+	})
+}
+
+// TestActionSpecs_TimeFilters_PublishOneFormat holds the eight date-range
+// filters to a single treatment. toolutil injects date-time into four of them
+// by name, and without the overrides beside them the other four would publish
+// no format at all, leaving one input struct advertising sibling filters as
+// two different things while the handler parses all eight the same way.
+func TestActionSpecs_TimeFilters_PublishOneFormat(t *testing.T) {
+	props := workItemToolProperties(t, "gitlab_list_work_items")
+
+	for _, name := range []string{
+		"closed_after", "closed_before", "created_after", "created_before",
+		"due_after", "due_before", "updated_after", "updated_before",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := schemaProperty(t, props, name)["format"]; got != "date-time" {
+				t.Errorf("%s format = %#v, want date-time", name, got)
+			}
+		})
+	}
+}
+
+// TestActionSpecs_CreateCreatedAt_PublishesDateTime covers the one create
+// field toolutil does not know by name, beside two date-only siblings.
+func TestActionSpecs_CreateCreatedAt_PublishesDateTime(t *testing.T) {
+	props := workItemToolProperties(t, "gitlab_create_work_item")
+	if got := schemaProperty(t, props, "created_at")["format"]; got != "date-time" {
+		t.Errorf("created_at format = %#v, want date-time", got)
+	}
+}
+
+// workItemToolProperties returns the served input-schema properties of one
+// work item tool, with every override and canonical injection applied.
+func workItemToolProperties(t *testing.T, tool string) map[string]any {
+	t.Helper()
+	byTool := workItemSpecsByTool(t, ActionSpecs(testutil.NewTestClient(t, testutil.ForbiddenHandler(t))))
+	spec, ok := byTool[tool]
+	if !ok {
+		t.Fatalf("no spec for %q", tool)
+	}
+	props, ok := spec.Route.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s input schema has no properties", tool)
+	}
+	return props
+}
+
+// schemaProperty returns one property schema, failing rather than returning a
+// nil map a later assertion would read as an absent enum.
+func schemaProperty(t *testing.T, props map[string]any, name string) map[string]any {
+	t.Helper()
+	property, ok := props[name].(map[string]any)
+	if !ok {
+		t.Fatalf("property %q = %#v, want an object", name, props[name])
+	}
+	return property
 }
 
 func workItemActionHandler() http.Handler {

--- a/internal/tools/workitems/action_specs_test.go
+++ b/internal/tools/workitems/action_specs_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/graphqlschema"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/testutil"
@@ -253,6 +254,50 @@ func TestActionSpecs_ListFilters_PublishTheirEnums(t *testing.T) {
 			t.Errorf("in items enum = %#v, want %#v", got, want)
 		}
 	})
+}
+
+// TestActionSpecs_ReturnedFields_PublishTheSDKRegistry holds the served enum to
+// exactly the names client-go accepts, Enterprise ones included.
+//
+// The set is read out of the SDK rather than written down twice, so this test
+// asserts the two agree: client-go refuses an unknown name before the request
+// is built, and a hand-copied list would drift into advertising a name that
+// refusal rejects.
+func TestActionSpecs_ReturnedFields_PublishTheSDKRegistry(t *testing.T) {
+	props := workItemToolProperties(t, "gitlab_list_work_items")
+	items, ok := schemaProperty(t, props, "returned_fields")["items"].(map[string]any)
+	if !ok {
+		t.Fatal("returned_fields has no items schema")
+	}
+	got, ok := items["enum"].([]any)
+	if !ok {
+		t.Fatalf("returned_fields items enum = %#v, want a list", items["enum"])
+	}
+	want := make([]string, 0, len(got))
+	want = append(want, gl.WorkItemDefaultListFields()...)
+	want = append(want, workItemEEListFields...)
+	slices.Sort(want)
+	names := make([]string, 0, len(got))
+	for _, value := range got {
+		name, isString := value.(string)
+		if !isString {
+			t.Fatalf("returned_fields enum entry %#v is not a string", value)
+		}
+		names = append(names, name)
+	}
+	if !slices.Equal(names, want) {
+		t.Errorf("returned_fields enum = %v, want %v", names, want)
+	}
+	// The five Enterprise names must be offered even though the process may
+	// have resolved a Free tier: in HTTP mode one process serves instances of
+	// several tiers, and hiding them would refuse a valid call before it left.
+	for _, name := range workItemEEListFields {
+		t.Run("offers "+name, func(t *testing.T) {
+			if !slices.Contains(names, name) {
+				t.Errorf("returned_fields enum omits %q", name)
+			}
+		})
+	}
 }
 
 // TestActionSpecs_TimeFilters_PublishOneFormat holds the eight date-range

--- a/internal/tools/workitems/markdown.go
+++ b/internal/tools/workitems/markdown.go
@@ -35,6 +35,7 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 		// carries no comma.
 		fmt.Fprintf(&sb, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(wi.Labels, ", ")))
 	}
+	writeWidgetLines(&sb, wi)
 	if wi.WebURL != "" {
 		toolutil.WriteMdURL(&sb, wi.WebURL)
 	}
@@ -60,6 +61,44 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_update_work_item` to modify this work item")
 	return toolutil.ToolResultWithMarkdown(sb.String())
+}
+
+// writeWidgetLines renders the widget-backed values of a work item, each of
+// which is absent from a type that has no such widget and from a list answer
+// that did not ask for it.
+//
+// The parent goes here rather than beside the Children table because it is one
+// value, not a list, and a one-row table would read worse than a bullet.
+func writeWidgetLines(sb *strings.Builder, wi WorkItemItem) {
+	if wi.Parent != nil {
+		fmt.Fprintf(sb, "- **Parent**: #%d in %s\n", wi.Parent.IID, toolutil.EscapeMdTableCell(wi.Parent.Path))
+	}
+	if wi.MilestoneID != 0 {
+		fmt.Fprintf(sb, "- **Milestone ID**: %d\n", wi.MilestoneID)
+	}
+	if wi.IterationID != 0 {
+		fmt.Fprintf(sb, "- **Iteration ID**: %d\n", wi.IterationID)
+	}
+	if wi.Weight != nil {
+		fmt.Fprintf(sb, "- **Weight**: %d\n", *wi.Weight)
+	}
+	if wi.HealthStatus != "" {
+		//gitlab:allow-unescaped wi.HealthStatus: a value of the GraphQL HealthStatus enum (onTrack, needsAttention, atRisk), never text anybody types.
+		fmt.Fprintf(sb, "- **Health Status**: %s\n", wi.HealthStatus)
+	}
+	if wi.StartDate != "" {
+		//gitlab:allow-unescaped wi.StartDate: a date this package formatted itself from a gl.ISOTime, so it is YYYY-MM-DD or nothing.
+		fmt.Fprintf(sb, "- **Start Date**: %s\n", wi.StartDate)
+	}
+	if wi.DueDate != "" {
+		//gitlab:allow-unescaped wi.DueDate: a date this package formatted itself from a gl.ISOTime, so it is YYYY-MM-DD or nothing.
+		fmt.Fprintf(sb, "- **Due Date**: %s\n", wi.DueDate)
+	}
+	if wi.Color != "" {
+		// GitLab accepts a named CSS color as well as a hex code, so this is
+		// not the closed set the hex-only jsonschema example suggests.
+		fmt.Fprintf(sb, "- **Color**: %s\n", toolutil.EscapeMdTableCell(wi.Color))
+	}
 }
 
 // FormatListMarkdown formats a list of work items as markdown.

--- a/internal/tools/workitems/markdown.go
+++ b/internal/tools/workitems/markdown.go
@@ -24,16 +24,16 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 		// namespace's lifecycle, which an administrator can create and rename.
 		fmt.Fprintf(&sb, "- **Status**: %s\n", toolutil.EscapeMdTableCell(wi.Status))
 	}
-	if wi.Author != "" {
-		fmt.Fprintf(&sb, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(wi.Author))
+	if name := authorName(wi.Author); name != "" {
+		fmt.Fprintf(&sb, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(name))
 	}
 	if len(wi.Assignees) > 0 {
-		fmt.Fprintf(&sb, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(wi.Assignees, ", ")))
+		fmt.Fprintf(&sb, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(assigneeNames(wi.Assignees), ", ")))
 	}
 	if len(wi.Labels) > 0 {
 		// A label title is free text: GitLab's only rule on one is that it
 		// carries no comma.
-		fmt.Fprintf(&sb, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(wi.Labels, ", ")))
+		fmt.Fprintf(&sb, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(labelNames(wi.Labels), ", ")))
 	}
 	writeWidgetLines(&sb, wi)
 	if wi.WebURL != "" {
@@ -61,6 +61,39 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_update_work_item` to modify this work item")
 	return toolutil.ToolResultWithMarkdown(sb.String())
+}
+
+// authorName is the handle the rendered text names an author by, and the empty
+// string for a work item whose author the query did not ask for.
+func authorName(author *toolutil.BasicUserOutput) string {
+	if author == nil {
+		return ""
+	}
+	return author.Username
+}
+
+// assigneeNames flattens the assignee objects to the usernames the Markdown
+// prints.
+//
+// The JSON keeps the whole objects, which is what the 1:1 norm asks for; a
+// reader of the rendered text wants the handles, and seven fields per assignee
+// on one bullet line would bury the item they belong to.
+func assigneeNames(assignees []*toolutil.BasicUserOutput) []string {
+	names := make([]string, 0, len(assignees))
+	for _, assignee := range assignees {
+		names = append(names, assignee.Username)
+	}
+	return names
+}
+
+// labelNames flattens the label objects to the titles the Markdown prints, for
+// the same reason [assigneeNames] does.
+func labelNames(labels []*toolutil.LabelDetailsOutput) []string {
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		names = append(names, label.Name)
+	}
+	return names
 }
 
 // writeWidgetLines renders the widget-backed values of a work item, each of
@@ -120,7 +153,7 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	for _, wi := range out.WorkItems {
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s | %s |\n",
 			wi.IID, toolutil.EscapeMdTableCell(wi.Type), wi.State, toolutil.EscapeMdTableCell(wi.Status),
-			toolutil.EscapeMdTableCell(wi.Title), toolutil.EscapeMdTableCell(wi.Author))
+			toolutil.EscapeMdTableCell(wi.Title), toolutil.EscapeMdTableCell(authorName(wi.Author)))
 	}
 	if out.Pagination.HasNextPage {
 		fmt.Fprintf(&sb, "\n> Next page cursor: `%s`\n", out.Pagination.EndCursor)

--- a/internal/tools/workitems/work_items.go
+++ b/internal/tools/workitems/work_items.go
@@ -30,36 +30,54 @@ type ChildItem struct {
 // WorkItemItem is a summary of a work item.
 //
 // The widget-backed fields below (color, dates, health status, iteration,
-// milestone, parent, weight) arrive on every get, create and update, because
-// the static fragment client-go uses for those three selects them
+// milestone, parent, status, weight) arrive on every get, create and update,
+// because the static fragment client-go uses for those three selects them
 // unconditionally. On the list path they arrive only when the query asked for
 // them: see [listReturnedFields].
+//
+// Author, assignees and labels carry the whole object client-go carries rather
+// than a name, because the fragment already pays for the whole object: the
+// UserCoreBasic fragment fetches id, username, name, state, avatarUrl, webUrl
+// and createdAt, and the labels fragment fetches id, title, color, description,
+// descriptionHtml and textColor. Publishing the name alone threw away every
+// other field the request had already spent. The Markdown formatter still
+// prints names, which is what a reader of the rendered text wants.
+//
+// Status and color are tagged Premium for the reason the list path already
+// gated them: client-go groups both with health status, iteration and weight as
+// fields that exist only in the Enterprise schema, and GitLab documents work
+// item status at "Tier: Premium, Ultimate"
+// (https://docs.gitlab.com/user/work_items/status/) and the epic the color
+// widget belongs to at the same pair
+// (https://docs.gitlab.com/user/group/epics/manage_epics/), both read on
+// 2026-09-07. Until now the two were advertised to every tier while being asked
+// for only on Enterprise instances.
 type WorkItemItem struct {
-	ID           int64        `json:"id"`
-	IID          int64        `json:"iid"`
-	Type         string       `json:"type"`
-	State        string       `json:"state"`
-	Status       string       `json:"status,omitempty"`
-	Title        string       `json:"title"`
-	Description  string       `json:"description,omitempty"`
-	WebURL       string       `json:"web_url,omitempty"`
-	Author       string       `json:"author,omitempty"`
-	Assignees    []string     `json:"assignees,omitempty"`
-	Labels       []string     `json:"labels,omitempty"`
-	LinkedItems  []LinkedItem `json:"linked_items,omitempty"`
-	Parent       *ChildItem   `json:"parent,omitempty" jsonschema:"Parent work item in the hierarchy (namespace path and IID)"`
-	Children     []ChildItem  `json:"children,omitempty" jsonschema:"Child work items in the hierarchy (each with namespace path and IID)"`
-	Color        string       `json:"color,omitempty" jsonschema:"Color of the work item as a hex code (e.g. #fefefe)"`
-	MilestoneID  int64        `json:"milestone_id,omitempty" jsonschema:"Numeric ID of the milestone the work item belongs to"`
-	IterationID  int64        `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Numeric ID of the iteration the work item belongs to"`
-	Weight       *int64       `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
-	HealthStatus string       `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
-	StartDate    string       `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD)"`
-	DueDate      string       `json:"due_date,omitempty" jsonschema:"Due date (YYYY-MM-DD)"`
-	Confidential bool         `json:"confidential,omitempty"`
-	CreatedAt    string       `json:"created_at,omitempty"`
-	UpdatedAt    string       `json:"updated_at,omitempty"`
-	ClosedAt     string       `json:"closed_at,omitempty"`
+	ID           int64                          `json:"id"`
+	IID          int64                          `json:"iid"`
+	Type         string                         `json:"type"`
+	State        string                         `json:"state"`
+	Status       string                         `json:"status,omitempty" tier:"premium" jsonschema:"Name of the work item status in the namespace's lifecycle"`
+	Title        string                         `json:"title"`
+	Description  string                         `json:"description,omitempty"`
+	WebURL       string                         `json:"web_url,omitempty"`
+	Author       *toolutil.BasicUserOutput      `json:"author,omitempty" jsonschema:"User who created the work item"`
+	Assignees    []*toolutil.BasicUserOutput    `json:"assignees,omitempty" jsonschema:"Users assigned to the work item"`
+	Labels       []*toolutil.LabelDetailsOutput `json:"labels,omitempty" jsonschema:"Labels applied to the work item, each with its id, name, color, description and text color"`
+	LinkedItems  []LinkedItem                   `json:"linked_items,omitempty"`
+	Parent       *ChildItem                     `json:"parent,omitempty" jsonschema:"Parent work item in the hierarchy (namespace path and IID)"`
+	Children     []ChildItem                    `json:"children,omitempty" jsonschema:"Child work items in the hierarchy (each with namespace path and IID)"`
+	Color        string                         `json:"color,omitempty" tier:"premium" jsonschema:"Color of the work item as a hex code (e.g. #fefefe)"`
+	MilestoneID  int64                          `json:"milestone_id,omitempty" jsonschema:"Numeric ID of the milestone the work item belongs to"`
+	IterationID  int64                          `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Numeric ID of the iteration the work item belongs to"`
+	Weight       *int64                         `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
+	HealthStatus string                         `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
+	StartDate    string                         `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD)"`
+	DueDate      string                         `json:"due_date,omitempty" jsonschema:"Due date (YYYY-MM-DD)"`
+	Confidential bool                           `json:"confidential,omitempty"`
+	CreatedAt    string                         `json:"created_at,omitempty"`
+	UpdatedAt    string                         `json:"updated_at,omitempty"`
+	ClosedAt     string                         `json:"closed_at,omitempty"`
 }
 
 // mapStatusToID maps a human-readable status string to the GitLab WorkItemStatusID GID.
@@ -95,15 +113,9 @@ func workItemToItem(wi *gl.WorkItem) WorkItemItem {
 	if wi.Status != nil {
 		item.Status = *wi.Status
 	}
-	if wi.Author != nil {
-		item.Author = wi.Author.Username
-	}
-	for _, a := range wi.Assignees {
-		item.Assignees = append(item.Assignees, a.Username)
-	}
-	for _, l := range wi.Labels {
-		item.Labels = append(item.Labels, l.Name)
-	}
+	item.Author = toolutil.NewBasicUserOutput(wi.Author)
+	item.Assignees = toolutil.NewBasicUserOutputs(wi.Assignees)
+	item.Labels = labelOutputs(wi.Labels)
 	for _, li := range wi.LinkedItems {
 		item.LinkedItems = append(item.LinkedItems, LinkedItem{
 			IID:      li.IID,
@@ -125,6 +137,29 @@ func workItemToItem(wi *gl.WorkItem) WorkItemItem {
 	item.UpdatedAt = toolutil.FormatTimePtr(wi.UpdatedAt)
 	item.ClosedAt = toolutil.FormatTimePtr(wi.ClosedAt)
 	return item
+}
+
+// labelOutputs converts the labels widget into the shared label object.
+//
+// toolutil.NewLabelDetailsOutputs cannot be used: client-go returns a value
+// slice here and a pointer slice on every REST domain, so the shared converter
+// takes the shape this one does not have.
+func labelOutputs(labels []gl.LabelDetails) []*toolutil.LabelDetailsOutput {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]*toolutil.LabelDetailsOutput, 0, len(labels))
+	for _, l := range labels {
+		out = append(out, &toolutil.LabelDetailsOutput{
+			ID:              l.ID,
+			Name:            l.Name,
+			Color:           l.Color,
+			Description:     l.Description,
+			DescriptionHTML: l.DescriptionHTML,
+			TextColor:       l.TextColor,
+		})
+	}
+	return out
 }
 
 // applyWidgetFields copies the widget-backed values of wi onto item.
@@ -240,6 +275,12 @@ type ListInput struct {
 	Sort               string `json:"sort,omitempty" jsonschema:"Sort order, a WorkItemSort enum value such as CREATED_DESC or TITLE_ASC"`
 	IncludeAncestors   *bool  `json:"include_ancestors,omitempty" jsonschema:"Include ancestor work items"`
 	IncludeDescendants *bool  `json:"include_descendants,omitempty" jsonschema:"Include descendant work items"`
+
+	// ReturnedFields selects the GraphQL fragment, not the result set: it
+	// decides which fields of each matching work item come back, and no work
+	// item is included or excluded by it. Naming a subset makes a listing
+	// smaller and cheaper; naming none asks for the per-tier default set.
+	ReturnedFields []string `json:"returned_fields,omitempty" jsonschema:"Fields of each work item the query asks for. Selects what comes back, not which work items match: an unselected field is absent from every item rather than empty. Omit for the default set, which is every Community Edition field plus the five Enterprise ones on a Premium or Ultimate instance. Naming color, healthStatus, iteration, status or weight against a Community Edition instance fails the whole query, since its schema does not define those widgets"`
 	toolutil.GraphQLCursorPaginationInput
 }
 
@@ -464,6 +505,12 @@ var workItemEEListFields = []string{"color", "healthStatus", "iteration", "statu
 // listReturnedFields picks the field set client-go renders into the WorkItem
 // fragment of a list query.
 //
+// An explicit returned_fields wins, because a caller who named a subset asked
+// for a smaller answer than the default and the default would undo that. The
+// names are passed through verbatim: client-go refuses one it does not know
+// before the request is built, and GitLab refuses an Enterprise one against a
+// Community Edition schema, so neither failure needs a second opinion here.
+//
 // Until this existed, list asked for the CE default alone, and the five names
 // above were requested by nothing: every listed work item came back with no
 // status, whatever the instance held, and the Markdown list printed a Status
@@ -474,7 +521,10 @@ var workItemEEListFields = []string{"color", "healthStatus", "iteration", "statu
 // The choice is made per call from the resolved tier rather than once, because
 // in HTTP mode one process serves many instances and the tier is a property of
 // the credential's pool entry, not of the build.
-func listReturnedFields(client *gitlabclient.Client) []string {
+func listReturnedFields(client *gitlabclient.Client, input ListInput) []string {
+	if len(input.ReturnedFields) > 0 {
+		return input.ReturnedFields
+	}
 	fields := gl.WorkItemDefaultListFields()
 	if client.IsEnterprise() {
 		fields = append(fields, workItemEEListFields...)
@@ -520,7 +570,7 @@ func List(ctx context.Context, client *gitlabclient.Client, input ListInput) (Li
 	if err != nil {
 		return ListOutput{}, fmt.Errorf("list_work_items: %w", err)
 	}
-	opts.ReturnedFields = listReturnedFields(client)
+	opts.ReturnedFields = listReturnedFields(client, input)
 
 	items, resp, err := client.GL().WorkItems.ListWorkItems(input.FullPath, opts, gl.WithContext(ctx))
 	if err != nil {
@@ -566,8 +616,8 @@ type CreateInput struct {
 	IterationID    *int64             `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Global ID of the iteration"`
 	Weight         *int64             `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
 	HealthStatus   string             `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
-	Color          string             `json:"color,omitempty" jsonschema:"Color hex code (e.g. #fefefe)"`
-	Status         string             `json:"status,omitempty" jsonschema:"Work item status: TODO, IN_PROGRESS, DONE, WONT_DO, or DUPLICATE"`
+	Color          string             `json:"color,omitempty" tier:"premium" jsonschema:"Color hex code (e.g. #fefefe)"`
+	Status         string             `json:"status,omitempty" tier:"premium" jsonschema:"Work item status: TODO, IN_PROGRESS, DONE, WONT_DO, or DUPLICATE"`
 	DueDate        string             `json:"due_date,omitempty" jsonschema:"Due date (YYYY-MM-DD)"`
 	StartDate      string             `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD)"`
 	CreatedAt      string             `json:"created_at,omitempty" jsonschema:"Creation timestamp to record instead of now. ISO 8601 date-time such as 2025-01-01T00:00:00Z. GitLab accepts it from instance administrators and project owners only"`
@@ -606,7 +656,9 @@ func buildCreateOptions(input CreateInput) (*gl.CreateWorkItemOptions, error) {
 		Title: input.Title,
 	}
 	applyCreateCore(opts, input)
-	applyCreateWidgets(opts, input)
+	if err := applyCreateWidgets(opts, input); err != nil {
+		return nil, err
+	}
 	if input.CreatedAt != "" {
 		createdAt, err := parseWorkItemTime("created_at", input.CreatedAt)
 		if err != nil {
@@ -651,7 +703,7 @@ func applyCreateCore(opts *gl.CreateWorkItemOptions, input CreateInput) {
 
 // applyCreateWidgets sets the fields that reach GitLab through a widget of
 // their own, each of which a work item type may or may not have.
-func applyCreateWidgets(opts *gl.CreateWorkItemOptions, input CreateInput) {
+func applyCreateWidgets(opts *gl.CreateWorkItemOptions, input CreateInput) error {
 	if input.MilestoneID != nil {
 		opts.MilestoneID = input.MilestoneID
 	}
@@ -670,20 +722,47 @@ func applyCreateWidgets(opts *gl.CreateWorkItemOptions, input CreateInput) {
 	if input.Color != "" {
 		opts.Color = new(input.Color)
 	}
-	if input.DueDate != "" {
-		d, err := time.Parse(toolutil.DateFormatISO, input.DueDate)
-		if err == nil {
-			isoDate := gl.ISOTime(d)
-			opts.DueDate = &isoDate
-		}
+	return applyWorkItemDates(input.StartDate, input.DueDate, &opts.StartDate, &opts.DueDate)
+}
+
+// applyWorkItemDates parses the start and due dates create and update share,
+// refusing the call on the first one it cannot read.
+//
+// Both used to drop a malformed date and report success, so a work item asked
+// for with a due date came back without one and nothing in the answer said the
+// date had been discarded. That is the same failure the eight list filters
+// refuse and the same one created_at refuses; these two now match.
+func applyWorkItemDates(startDate, dueDate string, start, due **gl.ISOTime) error {
+	dates := []struct {
+		name  string
+		value string
+		dest  **gl.ISOTime
+	}{
+		{"start_date", startDate, start},
+		{"due_date", dueDate, due},
 	}
-	if input.StartDate != "" {
-		d, err := time.Parse(toolutil.DateFormatISO, input.StartDate)
-		if err == nil {
-			isoDate := gl.ISOTime(d)
-			opts.StartDate = &isoDate
+	for _, date := range dates {
+		if date.value == "" {
+			continue
 		}
+		parsed, err := parseWorkItemDate(date.name, date.value)
+		if err != nil {
+			return err
+		}
+		*date.dest = parsed
 	}
+	return nil
+}
+
+// parseWorkItemDate reads one calendar date, naming the field it came from so
+// the caller learns which of the two was malformed.
+func parseWorkItemDate(field, value string) (*gl.ISOTime, error) {
+	parsed, err := time.Parse(toolutil.DateFormatISO, value)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be a date in YYYY-MM-DD form (e.g. 2025-01-31), got %q", field, value)
+	}
+	isoDate := gl.ISOTime(parsed)
+	return &isoDate, nil
 }
 
 // Update.
@@ -706,8 +785,8 @@ type UpdateInput struct {
 	Weight         *int64  `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
 	HealthStatus   string  `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
 	IterationID    *int64  `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Global ID of the iteration"`
-	Color          string  `json:"color,omitempty" jsonschema:"Color hex code (e.g. #fefefe)"`
-	Status         string  `json:"status,omitempty" jsonschema:"Work item status: TODO, IN_PROGRESS, DONE, WONT_DO, or DUPLICATE"`
+	Color          string  `json:"color,omitempty" tier:"premium" jsonschema:"Color hex code (e.g. #fefefe)"`
+	Status         string  `json:"status,omitempty" tier:"premium" jsonschema:"Work item status: TODO, IN_PROGRESS, DONE, WONT_DO, or DUPLICATE"`
 	// Confirm is declared so the input schema advertises the reserved confirm
 	// key and strict validation accepts it. Its value is never populated:
 	// toolutil strips reserved keys before unmarshalling, so the handler reads
@@ -720,10 +799,16 @@ func Update(ctx context.Context, client *gitlabclient.Client, input UpdateInput)
 	if input.IID <= 0 {
 		return GetOutput{}, toolutil.ErrRequiredInt64("update_work_item", "work_item_iid")
 	}
+	// The options are built before the clearing guard so a malformed date is
+	// refused without first spending a round trip to read the current
+	// assignees, which would have been read only to reject the call anyway.
+	opts, buildErr := buildUpdateOptions(input)
+	if buildErr != nil {
+		return GetOutput{}, fmt.Errorf("update_work_item: %w", buildErr)
+	}
 	if err := confirmListClearing(ctx, client, input); err != nil {
 		return GetOutput{}, err
 	}
-	opts := buildUpdateOptions(input)
 	wi, _, err := client.GL().WorkItems.UpdateWorkItem(input.FullPath, input.IID, opts, gl.WithContext(ctx))
 	if err != nil {
 		return GetOutput{}, toolutil.WrapErrWithStatusHint("update_work_item", err, http.StatusBadRequest,
@@ -732,7 +817,7 @@ func Update(ctx context.Context, client *gitlabclient.Client, input UpdateInput)
 	return GetOutput{WorkItem: workItemToItem(wi)}, nil
 }
 
-func buildUpdateOptions(input UpdateInput) *gl.UpdateWorkItemOptions {
+func buildUpdateOptions(input UpdateInput) (*gl.UpdateWorkItemOptions, error) {
 	opts := &gl.UpdateWorkItemOptions{}
 	if input.Title != "" {
 		opts.Title = &input.Title
@@ -762,19 +847,8 @@ func buildUpdateOptions(input UpdateInput) *gl.UpdateWorkItemOptions {
 	if len(input.RemoveLabelIDs) > 0 {
 		opts.RemoveLabelIDs = input.RemoveLabelIDs
 	}
-	if input.StartDate != "" {
-		d, err := time.Parse(toolutil.DateFormatISO, input.StartDate)
-		if err == nil {
-			isoDate := gl.ISOTime(d)
-			opts.StartDate = &isoDate
-		}
-	}
-	if input.DueDate != "" {
-		d, err := time.Parse(toolutil.DateFormatISO, input.DueDate)
-		if err == nil {
-			isoDate := gl.ISOTime(d)
-			opts.DueDate = &isoDate
-		}
+	if err := applyWorkItemDates(input.StartDate, input.DueDate, &opts.StartDate, &opts.DueDate); err != nil {
+		return nil, err
 	}
 	if input.Weight != nil {
 		opts.Weight = input.Weight
@@ -792,7 +866,7 @@ func buildUpdateOptions(input UpdateInput) *gl.UpdateWorkItemOptions {
 		status := mapStatusToID(input.Status)
 		opts.Status = &status
 	}
-	return opts
+	return opts, nil
 }
 
 // Delete.

--- a/internal/tools/workitems/work_items.go
+++ b/internal/tools/workitems/work_items.go
@@ -28,6 +28,12 @@ type ChildItem struct {
 }
 
 // WorkItemItem is a summary of a work item.
+//
+// The widget-backed fields below (color, dates, health status, iteration,
+// milestone, parent, weight) arrive on every get, create and update, because
+// the static fragment client-go uses for those three selects them
+// unconditionally. On the list path they arrive only when the query asked for
+// them: see [listReturnedFields].
 type WorkItemItem struct {
 	ID           int64        `json:"id"`
 	IID          int64        `json:"iid"`
@@ -41,7 +47,15 @@ type WorkItemItem struct {
 	Assignees    []string     `json:"assignees,omitempty"`
 	Labels       []string     `json:"labels,omitempty"`
 	LinkedItems  []LinkedItem `json:"linked_items,omitempty"`
+	Parent       *ChildItem   `json:"parent,omitempty" jsonschema:"Parent work item in the hierarchy (namespace path and IID)"`
 	Children     []ChildItem  `json:"children,omitempty" jsonschema:"Child work items in the hierarchy (each with namespace path and IID)"`
+	Color        string       `json:"color,omitempty" jsonschema:"Color of the work item as a hex code (e.g. #fefefe)"`
+	MilestoneID  int64        `json:"milestone_id,omitempty" jsonschema:"Numeric ID of the milestone the work item belongs to"`
+	IterationID  int64        `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Numeric ID of the iteration the work item belongs to"`
+	Weight       *int64       `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
+	HealthStatus string       `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
+	StartDate    string       `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD)"`
+	DueDate      string       `json:"due_date,omitempty" jsonschema:"Due date (YYYY-MM-DD)"`
 	Confidential bool         `json:"confidential,omitempty"`
 	CreatedAt    string       `json:"created_at,omitempty"`
 	UpdatedAt    string       `json:"updated_at,omitempty"`
@@ -103,6 +117,7 @@ func workItemToItem(wi *gl.WorkItem) WorkItemItem {
 			Path: c.NamespacePath,
 		})
 	}
+	applyWidgetFields(&item, wi)
 	// RFC 3339 rather than time.Time's own String(), which is what every other
 	// timestamp in this server emits (toolutil.FormatTimePtr) and what the raw
 	// GraphQL list handler passed through verbatim before it moved onto the SDK.
@@ -110,6 +125,32 @@ func workItemToItem(wi *gl.WorkItem) WorkItemItem {
 	item.UpdatedAt = toolutil.FormatTimePtr(wi.UpdatedAt)
 	item.ClosedAt = toolutil.FormatTimePtr(wi.ClosedAt)
 	return item
+}
+
+// applyWidgetFields copies the widget-backed values of wi onto item.
+//
+// Each is a pointer on the SDK type because the widget it comes from may be
+// absent from the answer: a work item type that carries no weight widget, or a
+// list query that did not ask for it, is not a work item of weight zero.
+func applyWidgetFields(item *WorkItemItem, wi *gl.WorkItem) {
+	if wi.Parent != nil {
+		item.Parent = &ChildItem{IID: wi.Parent.IID, Path: wi.Parent.NamespacePath}
+	}
+	if wi.Color != nil {
+		item.Color = *wi.Color
+	}
+	if wi.MilestoneID != nil {
+		item.MilestoneID = *wi.MilestoneID
+	}
+	if wi.IterationID != nil {
+		item.IterationID = *wi.IterationID
+	}
+	if wi.HealthStatus != nil {
+		item.HealthStatus = *wi.HealthStatus
+	}
+	item.Weight = wi.Weight
+	item.StartDate = toolutil.FormatISOTimePtr(wi.StartDate)
+	item.DueDate = toolutil.FormatISOTimePtr(wi.DueDate)
 }
 
 // Get.
@@ -149,16 +190,56 @@ func Get(ctx context.Context, client *gitlabclient.Client, input GetInput) (GetO
 // page and a start cursor. Publishing only the forward half named a cursor no
 // parameter here could spend.
 type ListInput struct {
-	FullPath           string   `json:"full_path" jsonschema:"Full path of the project or group,required"`
-	State              string   `json:"state,omitempty" jsonschema:"Filter by state (opened/closed/all)"`
-	Search             string   `json:"search,omitempty" jsonschema:"Search in title and description"`
-	Types              []string `json:"types,omitempty" jsonschema:"Filter by work item types, IssueType enum values such as ISSUE or TASK"`
-	AuthorUsername     string   `json:"author_username,omitempty" jsonschema:"Filter by author username"`
-	LabelName          []string `json:"label_name,omitempty" jsonschema:"Filter by label names"`
-	Confidential       *bool    `json:"confidential,omitempty" jsonschema:"Filter by confidentiality"`
-	Sort               string   `json:"sort,omitempty" jsonschema:"Sort order, a WorkItemSort enum value such as CREATED_DESC or TITLE_ASC"`
-	IncludeAncestors   *bool    `json:"include_ancestors,omitempty" jsonschema:"Include ancestor work items"`
-	IncludeDescendants *bool    `json:"include_descendants,omitempty" jsonschema:"Include descendant work items"`
+	FullPath       string   `json:"full_path" jsonschema:"Full path of the project or group,required"`
+	State          string   `json:"state,omitempty" jsonschema:"Filter by state (opened/closed/all)"`
+	Search         string   `json:"search,omitempty" jsonschema:"Search in title and description"`
+	In             []string `json:"in,omitempty" jsonschema:"Fields the search term is matched against: TITLE or DESCRIPTION. Only meaningful together with search"`
+	Types          []string `json:"types,omitempty" jsonschema:"Filter by work item types, IssueType enum values such as ISSUE or TASK"`
+	AuthorUsername string   `json:"author_username,omitempty" jsonschema:"Filter by author username"`
+
+	AssigneeUsernames  []string `json:"assignee_usernames,omitempty" jsonschema:"Filter by assignee usernames"`
+	AssigneeWildcardID string   `json:"assignee_wildcard_id,omitempty" jsonschema:"Assignee wildcard filter: ANY, ME or NONE"`
+	MyReactionEmoji    string   `json:"my_reaction_emoji,omitempty" jsonschema:"Filter by the emoji the authenticated user reacted with"`
+	Subscribed         string   `json:"subscribed,omitempty" jsonschema:"Filter by the authenticated user's subscription: EXPLICITLY_SUBSCRIBED or EXPLICITLY_UNSUBSCRIBED"`
+	// GitLab types both arguments String and compares the value against a
+	// numeric column without parsing it, so a gid:// form casts to 0 and
+	// silently matches nothing.
+	CRMContactID      string `json:"crm_contact_id,omitempty" jsonschema:"Filter by CRM contact numeric ID as a string, e.g. 1. Not a global ID"`
+	CRMOrganizationID string `json:"crm_organization_id,omitempty" jsonschema:"Filter by CRM organization numeric ID as a string, e.g. 1. Not a global ID"`
+
+	// The two identifier filters are deliberately different shapes because
+	// GitLab types them differently: ids takes full global IDs and iids takes
+	// the numbers shown in the UI, as strings.
+	IDs       []string `json:"ids,omitempty" jsonschema:"Filter by work item global IDs, each the full gid://gitlab/WorkItem/<id> form"`
+	IIDs      []string `json:"iids,omitempty" jsonschema:"Filter by work item internal IDs (IIDs) as strings, e.g. 12"`
+	ParentIDs []string `json:"parent_ids,omitempty" jsonschema:"Filter by parent work item global IDs, each the full gid://gitlab/WorkItem/<id> form. Pairs with include_descendants"`
+
+	LabelName            []string `json:"label_name,omitempty" jsonschema:"Filter by label names"`
+	MilestoneTitle       []string `json:"milestone_title,omitempty" jsonschema:"Filter by milestone titles. Titles, not the milestone_id that create and update take"`
+	MilestoneWildcardID  string   `json:"milestone_wildcard_id,omitempty" jsonschema:"Milestone wildcard filter: ANY, NONE, STARTED or UPCOMING"`
+	ReleaseTag           []string `json:"release_tag,omitempty" jsonschema:"Filter by release tags"`
+	ReleaseTagWildcardID string   `json:"release_tag_wildcard_id,omitempty" jsonschema:"Release tag wildcard filter: ANY or NONE"`
+
+	IterationID         []string `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Filter by iteration global IDs, each the full gid://gitlab/Iteration/<id> form. Unlike the iteration_id create and update take, this one is a list of global IDs rather than a single numeric ID"`
+	IterationCadenceID  []string `json:"iteration_cadence_id,omitempty" tier:"premium" jsonschema:"Filter by iteration cadence global IDs, each the full gid://gitlab/Iterations::Cadence/<id> form"`
+	IterationWildcardID string   `json:"iteration_wildcard_id,omitempty" tier:"premium" jsonschema:"Iteration wildcard filter: ANY, CURRENT or NONE"`
+	Weight              string   `json:"weight,omitempty" tier:"premium" jsonschema:"Filter by weight. GitLab types this filter as a string, so send 3 quoted rather than as a number"`
+	WeightWildcardID    string   `json:"weight_wildcard_id,omitempty" tier:"premium" jsonschema:"Weight wildcard filter: ANY or NONE"`
+	HealthStatusFilter  string   `json:"health_status_filter,omitempty" tier:"ultimate" jsonschema:"Filter by health status: onTrack, needsAttention, atRisk, ANY or NONE. Case sensitive"`
+
+	ClosedAfter   string `json:"closed_after,omitempty" jsonschema:"Match work items closed after this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	ClosedBefore  string `json:"closed_before,omitempty" jsonschema:"Match work items closed before this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	CreatedAfter  string `json:"created_after,omitempty" jsonschema:"Match work items created after this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	CreatedBefore string `json:"created_before,omitempty" jsonschema:"Match work items created before this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	DueAfter      string `json:"due_after,omitempty" jsonschema:"Match work items due after this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	DueBefore     string `json:"due_before,omitempty" jsonschema:"Match work items due before this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	UpdatedAfter  string `json:"updated_after,omitempty" jsonschema:"Match work items updated after this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+	UpdatedBefore string `json:"updated_before,omitempty" jsonschema:"Match work items updated before this timestamp. ISO 8601 date-time such as 2025-01-01T00:00:00Z. A bare date is read as midnight UTC"`
+
+	Confidential       *bool  `json:"confidential,omitempty" jsonschema:"Filter by confidentiality"`
+	Sort               string `json:"sort,omitempty" jsonschema:"Sort order, a WorkItemSort enum value such as CREATED_DESC or TITLE_ASC"`
+	IncludeAncestors   *bool  `json:"include_ancestors,omitempty" jsonschema:"Include ancestor work items"`
+	IncludeDescendants *bool  `json:"include_descendants,omitempty" jsonschema:"Include descendant work items"`
 	toolutil.GraphQLCursorPaginationInput
 }
 
@@ -173,16 +254,27 @@ const errHintWorkItemsFullPath = "verify full_path with gitlab_project_list or g
 
 // buildListOptions translates the tool input into SDK list options.
 //
-// Every filter the tool exposes has a direct counterpart on
-// [gl.ListWorkItemsOptions], which accepts a superset: assignee, milestone,
-// iteration, release, weight, CRM, reaction and date-range filters the tool
-// does not surface today.
+// Every filter [gl.ListWorkItemsOptions] accepts is exposed, and client-go
+// declares a GraphQL variable and passes an argument for each one it finds
+// set, so nothing here needs a document of its own.
 //
 // The cursor arrives already resolved, so exactly one of first and last
 // reaches GitLab: the cursor picks the direction and the count only sizes the
 // page.
-func buildListOptions(input ListInput, cursor toolutil.GraphQLCursor) *gl.ListWorkItemsOptions {
+func buildListOptions(input ListInput, cursor toolutil.GraphQLCursor) (*gl.ListWorkItemsOptions, error) {
 	opts := &gl.ListWorkItemsOptions{}
+	applyCursorOptions(opts, cursor)
+	applyScopeFilters(opts, input)
+	applyPeopleFilters(opts, input)
+	applyIdentifierFilters(opts, input)
+	applyPlanningFilters(opts, input)
+	if err := applyTimeFilters(opts, input); err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+func applyCursorOptions(opts *gl.ListWorkItemsOptions, cursor toolutil.GraphQLCursor) {
 	if cursor.First != nil {
 		opts.First = new(int64(*cursor.First))
 	}
@@ -195,20 +287,22 @@ func buildListOptions(input ListInput, cursor toolutil.GraphQLCursor) *gl.ListWo
 	if cursor.Before != "" {
 		opts.Before = new(cursor.Before)
 	}
+}
+
+// applyScopeFilters sets the filters that decide which work items of the
+// namespace are in scope at all: state, text search, type and hierarchy.
+func applyScopeFilters(opts *gl.ListWorkItemsOptions, input ListInput) {
 	if input.State != "" {
 		opts.State = &input.State
 	}
 	if input.Search != "" {
 		opts.Search = &input.Search
 	}
+	if len(input.In) > 0 {
+		opts.In = input.In
+	}
 	if len(input.Types) > 0 {
 		opts.Types = upperEach(input.Types)
-	}
-	if input.AuthorUsername != "" {
-		opts.AuthorUsername = &input.AuthorUsername
-	}
-	if len(input.LabelName) > 0 {
-		opts.LabelName = input.LabelName
 	}
 	if input.Confidential != nil {
 		opts.Confidential = input.Confidential
@@ -222,7 +316,170 @@ func buildListOptions(input ListInput, cursor toolutil.GraphQLCursor) *gl.ListWo
 	if input.IncludeDescendants != nil {
 		opts.IncludeDescendants = input.IncludeDescendants
 	}
-	return opts
+}
+
+// applyPeopleFilters sets the filters keyed on a person: the author, the
+// assignees, the caller's own reaction and subscription, and the CRM records a
+// work item is attached to.
+func applyPeopleFilters(opts *gl.ListWorkItemsOptions, input ListInput) {
+	if input.AuthorUsername != "" {
+		opts.AuthorUsername = &input.AuthorUsername
+	}
+	if len(input.AssigneeUsernames) > 0 {
+		opts.AssigneeUsernames = input.AssigneeUsernames
+	}
+	if input.AssigneeWildcardID != "" {
+		opts.AssigneeWildcardID = &input.AssigneeWildcardID
+	}
+	if input.MyReactionEmoji != "" {
+		opts.MyReactionEmoji = &input.MyReactionEmoji
+	}
+	if input.Subscribed != "" {
+		opts.Subscribed = &input.Subscribed
+	}
+	if input.CRMContactID != "" {
+		opts.CRMContactID = &input.CRMContactID
+	}
+	if input.CRMOrganizationID != "" {
+		opts.CRMOrganizationID = &input.CRMOrganizationID
+	}
+}
+
+// applyIdentifierFilters sets the filters that name work items outright.
+//
+// client-go passes all three through verbatim, without the newGIDStrings
+// wrapping it applies on create and update, so ids and parent_ids have to
+// arrive as full global IDs and iids as the plain numbers.
+func applyIdentifierFilters(opts *gl.ListWorkItemsOptions, input ListInput) {
+	if len(input.IDs) > 0 {
+		opts.IDs = input.IDs
+	}
+	if len(input.IIDs) > 0 {
+		opts.IIDs = input.IIDs
+	}
+	if len(input.ParentIDs) > 0 {
+		opts.ParentIDs = input.ParentIDs
+	}
+}
+
+// applyPlanningFilters sets the filters over the planning widgets: labels,
+// milestone, release, iteration, weight and health status.
+func applyPlanningFilters(opts *gl.ListWorkItemsOptions, input ListInput) {
+	if len(input.LabelName) > 0 {
+		opts.LabelName = input.LabelName
+	}
+	if len(input.MilestoneTitle) > 0 {
+		opts.MilestoneTitle = input.MilestoneTitle
+	}
+	if input.MilestoneWildcardID != "" {
+		opts.MilestoneWildcardID = &input.MilestoneWildcardID
+	}
+	if len(input.ReleaseTag) > 0 {
+		opts.ReleaseTag = input.ReleaseTag
+	}
+	if input.ReleaseTagWildcardID != "" {
+		opts.ReleaseTagWildcardID = &input.ReleaseTagWildcardID
+	}
+	if len(input.IterationID) > 0 {
+		opts.IterationID = input.IterationID
+	}
+	if len(input.IterationCadenceID) > 0 {
+		opts.IterationCadenceID = input.IterationCadenceID
+	}
+	if input.IterationWildcardID != "" {
+		opts.IterationWildcardID = &input.IterationWildcardID
+	}
+	if input.Weight != "" {
+		opts.Weight = &input.Weight
+	}
+	if input.WeightWildcardID != "" {
+		opts.WeightWildcardID = &input.WeightWildcardID
+	}
+	if input.HealthStatusFilter != "" {
+		opts.HealthStatusFilter = &input.HealthStatusFilter
+	}
+}
+
+// applyTimeFilters parses the eight date-range filters and refuses the whole
+// call on the first one it cannot read.
+//
+// Dropping an unparseable filter silently would be the dangerous half of the
+// choice: a list narrowed by a date the server ignored answers with more work
+// items than were asked for, and nothing in the answer says the range was not
+// applied.
+func applyTimeFilters(opts *gl.ListWorkItemsOptions, input ListInput) error {
+	filters := []struct {
+		name  string
+		value string
+		dest  **time.Time
+	}{
+		{"closed_after", input.ClosedAfter, &opts.ClosedAfter},
+		{"closed_before", input.ClosedBefore, &opts.ClosedBefore},
+		{"created_after", input.CreatedAfter, &opts.CreatedAfter},
+		{"created_before", input.CreatedBefore, &opts.CreatedBefore},
+		{"due_after", input.DueAfter, &opts.DueAfter},
+		{"due_before", input.DueBefore, &opts.DueBefore},
+		{"updated_after", input.UpdatedAfter, &opts.UpdatedAfter},
+		{"updated_before", input.UpdatedBefore, &opts.UpdatedBefore},
+	}
+	for _, filter := range filters {
+		if filter.value == "" {
+			continue
+		}
+		parsed, err := parseWorkItemTime(filter.name, filter.value)
+		if err != nil {
+			return err
+		}
+		*filter.dest = parsed
+	}
+	return nil
+}
+
+// workItemTimeLayouts are the timestamp spellings the time filters accept.
+//
+// RFC 3339 is what the published schema advertises through its date-time
+// format and what GitLab's Time scalar wants. The two shorter forms are here
+// because a model told a value is a date sends exactly "2025-01-01", and
+// refusing that would cost a round trip to learn nothing.
+// internal/tools/workitemsavedviews accepts the same three spellings for the
+// same eight filter names.
+var workItemTimeLayouts = []string{time.RFC3339, "2006-01-02T15:04:05", toolutil.DateFormatISO}
+
+// parseWorkItemTime reads one timestamp, naming the field it came from so the
+// caller learns which of eight filters was malformed.
+func parseWorkItemTime(field, value string) (*time.Time, error) {
+	for _, layout := range workItemTimeLayouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return &parsed, nil
+		}
+	}
+	return nil, fmt.Errorf("%s must be an ISO 8601 timestamp (e.g. 2025-01-01T00:00:00Z), got %q", field, value)
+}
+
+// workItemEEListFields are the five field names client-go keeps out of its
+// CE-safe default set, because a Community Edition schema does not define the
+// widgets behind them and asking for one fails the whole query.
+var workItemEEListFields = []string{"color", "healthStatus", "iteration", "status", "weight"}
+
+// listReturnedFields picks the field set client-go renders into the WorkItem
+// fragment of a list query.
+//
+// Until this existed, list asked for the CE default alone, and the five names
+// above were requested by nothing: every listed work item came back with no
+// status, whatever the instance held, and the Markdown list printed a Status
+// column that was permanently blank. get, create and update never had that
+// problem, because the static fragment client-go uses for those three selects
+// all five unconditionally.
+//
+// The choice is made per call from the resolved tier rather than once, because
+// in HTTP mode one process serves many instances and the tier is a property of
+// the credential's pool entry, not of the build.
+func listReturnedFields(client *gitlabclient.Client) []string {
+	fields := gl.WorkItemDefaultListFields()
+	if client.IsEnterprise() {
+		fields = append(fields, workItemEEListFields...)
+	}
+	return fields
 }
 
 // upperEach uppercases every entry of an enum-valued filter.
@@ -243,11 +500,11 @@ func upperEach(values []string) []string {
 
 // List retrieves work items for a project or group.
 //
-// The SDK requests its CE-safe default field set, which is a superset of the
-// query this handler used to send: assignees, labels and linked items now come
-// back on every listed item instead of only on [Get]. Enterprise-only widgets
-// (status, weight, health status, color, iteration) stay unrequested, because
-// asking for them errors against a Community Edition instance.
+// The SDK's CE-safe default field set is a superset of the query this handler
+// used to send: assignees, labels and linked items come back on every listed
+// item instead of only on [Get]. The five Enterprise-only widgets are asked
+// for on top of it when the instance can answer them: see
+// [listReturnedFields].
 func List(ctx context.Context, client *gitlabclient.Client, input ListInput) (ListOutput, error) {
 	if input.FullPath == "" {
 		return ListOutput{}, toolutil.ErrRequiredString("list_work_items", "full_path")
@@ -259,8 +516,13 @@ func List(ctx context.Context, client *gitlabclient.Client, input ListInput) (Li
 	if err != nil {
 		return ListOutput{}, fmt.Errorf("list_work_items: %w", err)
 	}
+	opts, err := buildListOptions(input, cursor)
+	if err != nil {
+		return ListOutput{}, fmt.Errorf("list_work_items: %w", err)
+	}
+	opts.ReturnedFields = listReturnedFields(client)
 
-	items, resp, err := client.GL().WorkItems.ListWorkItems(input.FullPath, buildListOptions(input, cursor), gl.WithContext(ctx))
+	items, resp, err := client.GL().WorkItems.ListWorkItems(input.FullPath, opts, gl.WithContext(ctx))
 	if err != nil {
 		// A query-level failure arrives as GraphQLResponseError with HTTP 200,
 		// so the status-keyed hint would never fire for it.
@@ -299,12 +561,17 @@ type CreateInput struct {
 	AssigneeIDs    []int64            `json:"assignee_ids,omitempty" jsonschema:"Global IDs of assignees"`
 	MilestoneID    *int64             `json:"milestone_id,omitempty" jsonschema:"Global ID of the milestone"`
 	LabelIDs       []int64            `json:"label_ids,omitempty" jsonschema:"Global IDs of labels"`
+	CRMContactIDs  []int64            `json:"crm_contact_ids,omitempty" jsonschema:"CRM contact IDs to attach to the new work item"`
+	ParentID       *int64             `json:"parent_id,omitempty" jsonschema:"Global ID of the parent work item. Creates the item already under its parent, which otherwise takes a create followed by an update"`
+	IterationID    *int64             `json:"iteration_id,omitempty" tier:"premium" jsonschema:"Global ID of the iteration"`
 	Weight         *int64             `json:"weight,omitempty" tier:"premium" jsonschema:"Weight of the work item"`
 	HealthStatus   string             `json:"health_status,omitempty" tier:"ultimate" jsonschema:"Health status (onTrack/needsAttention/atRisk)"`
 	Color          string             `json:"color,omitempty" jsonschema:"Color hex code (e.g. #fefefe)"`
 	Status         string             `json:"status,omitempty" jsonschema:"Work item status: TODO, IN_PROGRESS, DONE, WONT_DO, or DUPLICATE"`
 	DueDate        string             `json:"due_date,omitempty" jsonschema:"Due date (YYYY-MM-DD)"`
 	StartDate      string             `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD)"`
+	CreatedAt      string             `json:"created_at,omitempty" jsonschema:"Creation timestamp to record instead of now. ISO 8601 date-time such as 2025-01-01T00:00:00Z. GitLab accepts it from instance administrators and project owners only"`
+	CreateSource   string             `json:"create_source,omitempty" jsonschema:"Name of whatever triggered the creation. Recorded for tracking and changes nothing about the work item"`
 	LinkedItems    *CreateLinkedItems `json:"linked_items,omitempty" jsonschema:"Linked work items to add on creation"`
 }
 
@@ -316,9 +583,48 @@ type CreateLinkedItems struct {
 
 // Create creates a new work item.
 func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput) (GetOutput, error) {
+	opts, err := buildCreateOptions(input)
+	if err != nil {
+		return GetOutput{}, fmt.Errorf("create_work_item: %w", err)
+	}
+
+	wi, _, err := client.GL().WorkItems.CreateWorkItem(input.FullPath, gl.WorkItemTypeID(input.WorkItemTypeID), opts, gl.WithContext(ctx))
+	if err != nil {
+		return GetOutput{}, toolutil.WrapErrWithStatusHint("create_work_item", err, http.StatusBadRequest,
+			"work_item_type_id must be a valid type GID; verify type compatibility with full_path (e.g. Epic only at group level + Premium); title is required; Work Items API is experimental")
+	}
+	return GetOutput{WorkItem: workItemToItem(wi)}, nil
+}
+
+// buildCreateOptions translates the tool input into SDK create options.
+//
+// client-go folds each of these into the widget of the WorkItemCreateInput
+// that owns it, global ID wrapping included, so every field here is a plain
+// numeric ID or a plain string.
+func buildCreateOptions(input CreateInput) (*gl.CreateWorkItemOptions, error) {
 	opts := &gl.CreateWorkItemOptions{
 		Title: input.Title,
 	}
+	applyCreateCore(opts, input)
+	applyCreateWidgets(opts, input)
+	if input.CreatedAt != "" {
+		createdAt, err := parseWorkItemTime("created_at", input.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+		opts.CreatedAt = createdAt
+	}
+	if input.LinkedItems != nil && len(input.LinkedItems.WorkItemIDs) > 0 {
+		opts.LinkedItems = &gl.CreateWorkItemOptionsLinkedItems{
+			LinkType:    &input.LinkedItems.LinkType,
+			WorkItemIDs: input.LinkedItems.WorkItemIDs,
+		}
+	}
+	return opts, nil
+}
+
+// applyCreateCore sets the fields every work item type carries.
+func applyCreateCore(opts *gl.CreateWorkItemOptions, input CreateInput) {
 	if input.Description != "" {
 		opts.Description = new(input.Description)
 	}
@@ -332,11 +638,28 @@ func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput)
 	if len(input.AssigneeIDs) > 0 {
 		opts.AssigneeIDs = input.AssigneeIDs
 	}
+	if len(input.LabelIDs) > 0 {
+		opts.LabelIDs = input.LabelIDs
+	}
+	if len(input.CRMContactIDs) > 0 {
+		opts.CRMContactIDs = input.CRMContactIDs
+	}
+	if input.CreateSource != "" {
+		opts.CreateSource = new(input.CreateSource)
+	}
+}
+
+// applyCreateWidgets sets the fields that reach GitLab through a widget of
+// their own, each of which a work item type may or may not have.
+func applyCreateWidgets(opts *gl.CreateWorkItemOptions, input CreateInput) {
 	if input.MilestoneID != nil {
 		opts.MilestoneID = input.MilestoneID
 	}
-	if len(input.LabelIDs) > 0 {
-		opts.LabelIDs = input.LabelIDs
+	if input.ParentID != nil {
+		opts.ParentID = input.ParentID
+	}
+	if input.IterationID != nil {
+		opts.IterationID = input.IterationID
 	}
 	if input.Weight != nil {
 		opts.Weight = input.Weight
@@ -361,19 +684,6 @@ func Create(ctx context.Context, client *gitlabclient.Client, input CreateInput)
 			opts.StartDate = &isoDate
 		}
 	}
-	if input.LinkedItems != nil && len(input.LinkedItems.WorkItemIDs) > 0 {
-		opts.LinkedItems = &gl.CreateWorkItemOptionsLinkedItems{
-			LinkType:    &input.LinkedItems.LinkType,
-			WorkItemIDs: input.LinkedItems.WorkItemIDs,
-		}
-	}
-
-	wi, _, err := client.GL().WorkItems.CreateWorkItem(input.FullPath, gl.WorkItemTypeID(input.WorkItemTypeID), opts, gl.WithContext(ctx))
-	if err != nil {
-		return GetOutput{}, toolutil.WrapErrWithStatusHint("create_work_item", err, http.StatusBadRequest,
-			"work_item_type_id must be a valid type GID; verify type compatibility with full_path (e.g. Epic only at group level + Premium); title is required; Work Items API is experimental")
-	}
-	return GetOutput{WorkItem: workItemToItem(wi)}, nil
 }
 
 // Update.

--- a/internal/tools/workitems/work_items_test.go
+++ b/internal/tools/workitems/work_items_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -2498,6 +2499,367 @@ func TestGet_RichResponse(t *testing.T) {
 	}
 	if wi.WebURL != testWorkItemURL {
 		t.Errorf("WebURL = %q", wi.WebURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Filters, widgets and the field set a list asks for
+// ---------------------------------------------------------------------------.
+
+// graphQLRequest is what a test needs out of a recorded GraphQL POST: the
+// document, so it can assert which fields the query asked GitLab for, and the
+// variables, so it can assert what a filter turned into on the wire.
+type graphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+// recordGraphQL answers every POST with response and records the request into
+// got. The request is written before the answer and read after the call
+// returns, so the HTTP round trip orders the two.
+func recordGraphQL(t *testing.T, got *graphQLRequest, response string) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+			t.Errorf("decode GraphQL request: %v", err)
+			http.Error(w, "decode GraphQL request", http.StatusInternalServerError)
+			return
+		}
+		testutil.RespondJSON(w, http.StatusOK, response)
+	}
+}
+
+// emptyWorkItemsResponse is the shortest answer a list query accepts, for the
+// tests whose whole assertion is on the request.
+const emptyWorkItemsResponse = `{"data":{"namespace":{"workItems":{"nodes":[]}}}}`
+
+// TestList_Filters_ReachTheWire proves each filter this action exposes is
+// declared as a GraphQL variable carrying the value the caller sent.
+//
+// A filter that never reaches GitLab is worse than one that does not exist:
+// the answer comes back unnarrowed, and nothing in it says the condition was
+// dropped. The variable names are client-go's, and the pinned schema judges
+// both the document and these values on every request, so a case here also
+// proves GitLab would accept the pair.
+func TestList_Filters_ReachTheWire(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    ListInput
+		variable string
+		want     any
+	}{
+		{"assignee_usernames", ListInput{AssigneeUsernames: []string{testAuthorBob, testAuthorCarol}}, "assigneeUsernames", []any{testAuthorBob, testAuthorCarol}},
+		{"assignee_wildcard_id", ListInput{AssigneeWildcardID: "ANY"}, "assigneeWildcardId", "ANY"},
+		// GitLab compares both against a numeric column without parsing, so the
+		// value that reaches the wire has to be the bare id.
+		{"crm_contact_id", ListInput{CRMContactID: "1"}, "crmContactId", "1"},
+		{"crm_organization_id", ListInput{CRMOrganizationID: "2"}, "crmOrganizationId", "2"},
+		{"health_status_filter", ListInput{HealthStatusFilter: "onTrack"}, "healthStatusFilter", "onTrack"},
+		{"ids", ListInput{IDs: []string{"gid://gitlab/WorkItem/1"}}, "ids", []any{"gid://gitlab/WorkItem/1"}},
+		{"iids", ListInput{IIDs: []string{"12"}}, "iids", []any{"12"}},
+		{"in", ListInput{Search: "needle", In: []string{"TITLE"}}, "in", []any{"TITLE"}},
+		{"iteration_cadence_id", ListInput{IterationCadenceID: []string{"gid://gitlab/Iterations::Cadence/3"}}, "iterationCadenceId", []any{"gid://gitlab/Iterations::Cadence/3"}},
+		{"iteration_id", ListInput{IterationID: []string{"gid://gitlab/Iteration/4"}}, "iterationId", []any{"gid://gitlab/Iteration/4"}},
+		{"iteration_wildcard_id", ListInput{IterationWildcardID: "CURRENT"}, "iterationWildcardId", "CURRENT"},
+		{"milestone_title", ListInput{MilestoneTitle: []string{"v1.0"}}, "milestoneTitle", []any{"v1.0"}},
+		{"milestone_wildcard_id", ListInput{MilestoneWildcardID: "UPCOMING"}, "milestoneWildcardId", "UPCOMING"},
+		{"my_reaction_emoji", ListInput{MyReactionEmoji: "thumbsup"}, "myReactionEmoji", "thumbsup"},
+		{"parent_ids", ListInput{ParentIDs: []string{"gid://gitlab/WorkItem/9"}}, "parentIds", []any{"gid://gitlab/WorkItem/9"}},
+		{"release_tag", ListInput{ReleaseTag: []string{"v1.0.0"}}, "releaseTag", []any{"v1.0.0"}},
+		{"release_tag_wildcard_id", ListInput{ReleaseTagWildcardID: "ANY"}, "releaseTagWildcardId", "ANY"},
+		{"subscribed", ListInput{Subscribed: "EXPLICITLY_SUBSCRIBED"}, "subscribed", "EXPLICITLY_SUBSCRIBED"},
+		{"weight", ListInput{Weight: "3"}, "weight", "3"},
+		{"weight_wildcard_id", ListInput{WeightWildcardID: "NONE"}, "weightWildcardId", "NONE"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var got graphQLRequest
+			client := testutil.NewTestClient(t, recordGraphQL(t, &got, emptyWorkItemsResponse))
+			input := testCase.input
+			input.FullPath = testFullPath
+			if _, err := List(t.Context(), client, input); err != nil {
+				t.Fatalf(fmtUnexpErr, err)
+			}
+			if sent := got.Variables[testCase.variable]; !reflect.DeepEqual(sent, testCase.want) {
+				t.Errorf("variable %s = %#v, want %#v", testCase.variable, sent, testCase.want)
+			}
+		})
+	}
+}
+
+// TestList_TimeFilters_ReachTheWireAsRFC3339 covers the eight date-range
+// filters, which are the only ones this handler parses rather than forwards.
+func TestList_TimeFilters_ReachTheWireAsRFC3339(t *testing.T) {
+	const sent = "2025-03-04T05:06:07Z"
+	cases := []struct {
+		name     string
+		input    ListInput
+		variable string
+	}{
+		{"closed_after", ListInput{ClosedAfter: sent}, "closedAfter"},
+		{"closed_before", ListInput{ClosedBefore: sent}, "closedBefore"},
+		{"created_after", ListInput{CreatedAfter: sent}, "createdAfter"},
+		{"created_before", ListInput{CreatedBefore: sent}, "createdBefore"},
+		{"due_after", ListInput{DueAfter: sent}, "dueAfter"},
+		{"due_before", ListInput{DueBefore: sent}, "dueBefore"},
+		{"updated_after", ListInput{UpdatedAfter: sent}, "updatedAfter"},
+		{"updated_before", ListInput{UpdatedBefore: sent}, "updatedBefore"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var got graphQLRequest
+			client := testutil.NewTestClient(t, recordGraphQL(t, &got, emptyWorkItemsResponse))
+			input := testCase.input
+			input.FullPath = testFullPath
+			if _, err := List(t.Context(), client, input); err != nil {
+				t.Fatalf(fmtUnexpErr, err)
+			}
+			if value := got.Variables[testCase.variable]; value != sent {
+				t.Errorf("variable %s = %#v, want %q", testCase.variable, value, sent)
+			}
+		})
+	}
+}
+
+// TestList_TimeFilter_AcceptsTheThreeSpellings pins the leniency the schema
+// advertises in prose: the date-time format names the canonical spelling, and
+// a bare date is read as midnight UTC rather than refused, because a model
+// told a value is a date sends exactly that.
+func TestList_TimeFilter_AcceptsTheThreeSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		sent string
+		want string
+	}{
+		{"RFC 3339", "2025-03-04T05:06:07Z", "2025-03-04T05:06:07Z"},
+		{"bare datetime", "2025-03-04T05:06:07", "2025-03-04T05:06:07Z"},
+		{"bare date", "2025-03-04", "2025-03-04T00:00:00Z"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var got graphQLRequest
+			client := testutil.NewTestClient(t, recordGraphQL(t, &got, emptyWorkItemsResponse))
+			_, err := List(t.Context(), client, ListInput{FullPath: testFullPath, ClosedAfter: testCase.sent})
+			if err != nil {
+				t.Fatalf(fmtUnexpErr, err)
+			}
+			if value := got.Variables["closedAfter"]; value != testCase.want {
+				t.Errorf("closedAfter = %#v, want %q", value, testCase.want)
+			}
+		})
+	}
+}
+
+// TestList_MalformedTimeFilter_IsRefusedByName verifies the whole call fails
+// and names the offending filter, rather than dropping it and answering with
+// more work items than were asked for.
+func TestList_MalformedTimeFilter_IsRefusedByName(t *testing.T) {
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+	_, err := List(t.Context(), client, ListInput{FullPath: testFullPath, DueBefore: "next tuesday"})
+	if err == nil {
+		t.Fatal(errExpectedNil)
+	}
+	if !strings.Contains(err.Error(), "due_before") {
+		t.Errorf("error = %v, want it to name due_before", err)
+	}
+}
+
+// TestList_ReturnedFields_FollowTheResolvedTier covers the defect this change
+// closes: list asked for client-go's CE default alone, so status, weight,
+// health status, iteration and color were requested by nothing and every
+// listed work item came back without them whatever the instance held. They are
+// asked for only on Premium and Ultimate, because a Community Edition schema
+// does not define those widgets and one unknown field fails the whole query.
+func TestList_ReturnedFields_FollowTheResolvedTier(t *testing.T) {
+	eeFragments := []string{"color {", "healthStatus {", "iteration {", "status {", "weight {"}
+	cases := []struct {
+		name       string
+		enterprise bool
+	}{
+		{"community edition asks for the CE default only", false},
+		{"enterprise asks for the five EE widgets too", true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var got graphQLRequest
+			client := testutil.NewTestClient(t, recordGraphQL(t, &got, emptyWorkItemsResponse))
+			client.SetEnterprise(testCase.enterprise)
+			if _, err := List(t.Context(), client, ListInput{FullPath: testFullPath}); err != nil {
+				t.Fatalf(fmtUnexpErr, err)
+			}
+			for _, fragment := range eeFragments {
+				if strings.Contains(got.Query, fragment) != testCase.enterprise {
+					t.Errorf("query contains %q = %v, want %v\nquery: %s",
+						fragment, strings.Contains(got.Query, fragment), testCase.enterprise, got.Query)
+				}
+			}
+		})
+	}
+}
+
+// workItemWidgetsResponse is a get answer carrying every widget this package
+// reads, so one round trip covers the whole converter.
+const workItemWidgetsResponse = `{"data":{"namespace":{"workItem":{` +
+	`"id":"gid://gitlab/WorkItem/42","iid":"42","workItemType":{"name":"Epic"},"state":"OPEN","title":"Widgets",` +
+	`"author":{"username":"dev"},"features":{` +
+	`"color":{"color":"#ff0000","textColor":"#ffffff"},` +
+	`"healthStatus":{"healthStatus":"needsAttention"},` +
+	`"hierarchy":{"hasParent":true,"parent":{"iid":"3","namespace":{"fullPath":"my-group/parent"}},"hasChildren":false},` +
+	`"iteration":{"iteration":{"id":"gid://gitlab/Iteration/9"}},` +
+	`"milestone":{"milestone":{"id":"gid://gitlab/Milestone/4"}},` +
+	`"startAndDueDate":{"startDate":"2026-01-05","dueDate":"2026-02-10"},` +
+	`"status":{"status":{"name":"In progress"}},` +
+	`"weight":{"weight":5}}}}}}`
+
+// TestGet_WidgetFields_RoundTripFromTheFixture asserts every widget-backed
+// output field against one answer. The static fragment client-go uses for get,
+// create and update selects all of them unconditionally, so these arrive on
+// every one of the three whatever the tier.
+func TestGet_WidgetFields_RoundTripFromTheFixture(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		testutil.RespondJSON(w, http.StatusOK, workItemWidgetsResponse)
+	})
+	out, err := Get(t.Context(), testutil.NewTestClient(t, handler), GetInput{FullPath: testFullPath, IID: 42})
+	if err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	wi := out.WorkItem
+	if wi.Parent == nil {
+		t.Fatal("Parent = nil, want the hierarchy widget's parent")
+	}
+	if wi.Parent.IID != 3 || wi.Parent.Path != "my-group/parent" {
+		t.Errorf("Parent = %+v, want {3 my-group/parent}", *wi.Parent)
+	}
+	if wi.Weight == nil || *wi.Weight != 5 {
+		t.Errorf("Weight = %v, want 5", wi.Weight)
+	}
+	checks := []struct {
+		field string
+		got   any
+		want  any
+	}{
+		{"Color", wi.Color, "#ff0000"},
+		{"HealthStatus", wi.HealthStatus, "needsAttention"},
+		{"IterationID", wi.IterationID, int64(9)},
+		{"MilestoneID", wi.MilestoneID, int64(4)},
+		{"StartDate", wi.StartDate, "2026-01-05"},
+		{"DueDate", wi.DueDate, "2026-02-10"},
+		{"Status", wi.Status, "In progress"},
+	}
+	for _, check := range checks {
+		t.Run(check.field, func(t *testing.T) {
+			if check.got != check.want {
+				t.Errorf("%s = %#v, want %#v", check.field, check.got, check.want)
+			}
+		})
+	}
+}
+
+// TestFormatGetMarkdown_WidgetFields verifies the detail view renders the
+// widget values, since a field nothing prints is a field a reader never sees.
+func TestFormatGetMarkdown_WidgetFields(t *testing.T) {
+	weight := int64(5)
+	text := extractText(t, FormatGetMarkdown(GetOutput{WorkItem: WorkItemItem{
+		IID:          42,
+		Title:        "Widgets",
+		Parent:       &ChildItem{IID: 3, Path: "my-group/parent"},
+		MilestoneID:  4,
+		IterationID:  9,
+		Weight:       &weight,
+		HealthStatus: "needsAttention",
+		StartDate:    "2026-01-05",
+		DueDate:      "2026-02-10",
+		Color:        "#ff0000",
+	}}))
+	for _, want := range []string{
+		"- **Parent**: #3 in my-group/parent",
+		"- **Milestone ID**: 4",
+		"- **Iteration ID**: 9",
+		"- **Weight**: 5",
+		"- **Health Status**: needsAttention",
+		"- **Start Date**: 2026-01-05",
+		"- **Due Date**: 2026-02-10",
+		"- **Color**: #ff0000",
+	} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("markdown missing %q:\n%s", want, text)
+			}
+		})
+	}
+}
+
+// TestCreate_Fields_ReachTheWire proves the five create fields added for issue
+// 583 arrive inside the mutation input, each in the widget client-go folds it
+// into, with the global ID wrapping client-go applies.
+func TestCreate_Fields_ReachTheWire(t *testing.T) {
+	var got graphQLRequest
+	client := testutil.NewTestClient(t, recordGraphQL(t, &got,
+		`{"data":{"workItemCreate":{"workItem":{"id":"gid://gitlab/WorkItem/1","iid":"1","workItemType":{"name":"Task"},"state":"OPEN","title":"Fields","author":{"username":"dev"}}}}}`))
+
+	parent, iteration := int64(9), int64(7)
+	_, err := Create(t.Context(), client, CreateInput{
+		FullPath:       testFullPath,
+		WorkItemTypeID: testTypeGID,
+		Title:          "Fields",
+		CRMContactIDs:  []int64{4},
+		ParentID:       &parent,
+		IterationID:    &iteration,
+		CreatedAt:      "2025-03-04T05:06:07Z",
+		CreateSource:   "gitlab-mcp-server",
+	})
+	if err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	input, ok := got.Variables["input"].(map[string]any)
+	if !ok {
+		t.Fatalf("mutation input = %#v, want an object", got.Variables["input"])
+	}
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"createSource", input["createSource"], "gitlab-mcp-server"},
+		{"createdAt", input["createdAt"], "2025-03-04T05:06:07Z"},
+		{"crmContactsWidget.contactIds", widgetField(t, input, "crmContactsWidget", "contactIds"), []any{"gid://gitlab/CustomerRelations::Contact/4"}},
+		{"hierarchyWidget.parentId", widgetField(t, input, "hierarchyWidget", "parentId"), "gid://gitlab/WorkItem/9"},
+		{"iterationWidget.iterationId", widgetField(t, input, "iterationWidget", "iterationId"), "gid://gitlab/Iteration/7"},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if !reflect.DeepEqual(check.got, check.want) {
+				t.Errorf("%s = %#v, want %#v", check.name, check.got, check.want)
+			}
+		})
+	}
+}
+
+// widgetField reads one leaf out of a widget of the create mutation input.
+func widgetField(t *testing.T, input map[string]any, widget, field string) any {
+	t.Helper()
+	nested, ok := input[widget].(map[string]any)
+	if !ok {
+		t.Fatalf("input[%q] = %#v, want an object", widget, input[widget])
+	}
+	return nested[field]
+}
+
+// TestCreate_MalformedCreatedAt_IsRefusedByName verifies a created_at GitLab
+// could not read stops the call instead of creating a work item stamped now.
+func TestCreate_MalformedCreatedAt_IsRefusedByName(t *testing.T) {
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+	_, err := Create(t.Context(), client, CreateInput{
+		FullPath:       testFullPath,
+		WorkItemTypeID: testTypeGID,
+		Title:          "Bad timestamp",
+		CreatedAt:      "yesterday",
+	})
+	if err == nil {
+		t.Fatal(errExpectedNil)
+	}
+	if !strings.Contains(err.Error(), "created_at") {
+		t.Errorf("error = %v, want it to name created_at", err)
 	}
 }
 

--- a/internal/tools/workitems/work_items_test.go
+++ b/internal/tools/workitems/work_items_test.go
@@ -32,6 +32,31 @@ var invalidIIDCases = []struct {
 	{"large_negative", -100},
 }
 
+// namedUser builds the author or assignee object a test needs when only the
+// username matters to what it asserts.
+func namedUser(username string) *toolutil.BasicUserOutput {
+	return &toolutil.BasicUserOutput{Username: username}
+}
+
+// namedUsers builds an assignee list from usernames alone, for the same reason
+// [namedUser] exists.
+func namedUsers(usernames ...string) []*toolutil.BasicUserOutput {
+	users := make([]*toolutil.BasicUserOutput, 0, len(usernames))
+	for _, username := range usernames {
+		users = append(users, namedUser(username))
+	}
+	return users
+}
+
+// namedLabels builds a label list from titles alone.
+func namedLabels(names ...string) []*toolutil.LabelDetailsOutput {
+	labels := make([]*toolutil.LabelDetailsOutput, 0, len(names))
+	for _, name := range names {
+		labels = append(labels, &toolutil.LabelDetailsOutput{Name: name})
+	}
+	return labels
+}
+
 // TestGet_Success verifies Get when success.
 func TestGet_Success(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +120,7 @@ func TestList_Success(t *testing.T) {
 		t.Fatalf("expected 2 work items, got %d", len(out.WorkItems))
 	}
 	first := out.WorkItems[0]
-	if first.ID != 1 || first.IID != 10 || first.Type != testTypeIssue || first.Author != "dev1" {
+	if first.ID != 1 || first.IID != 10 || first.Type != testTypeIssue || authorName(first.Author) != "dev1" {
 		t.Fatalf("unexpected first work item: %+v", first)
 	}
 	if !first.Confidential || first.WebURL == "" || first.CreatedAt == "" || first.UpdatedAt == "" {
@@ -145,17 +170,66 @@ func TestList_WidgetFields_ArePopulatedFromTheDefaultFieldSet(t *testing.T) {
 		t.Fatalf("expected 1 work item, got %d", len(out.WorkItems))
 	}
 	item := out.WorkItems[0]
-	if len(item.Assignees) != 2 || item.Assignees[0] != testAuthorBob || item.Assignees[1] != testAuthorCarol {
-		t.Errorf("Assignees = %v, want [bob carol]", item.Assignees)
+	if got := assigneeNames(item.Assignees); len(got) != 2 || got[0] != testAuthorBob || got[1] != testAuthorCarol {
+		t.Errorf("Assignees = %v, want [bob carol]", got)
 	}
-	if len(item.Labels) != 1 || item.Labels[0] != testLabelBug {
-		t.Errorf("Labels = %v, want [bug]", item.Labels)
+	if got := labelNames(item.Labels); len(got) != 1 || got[0] != testLabelBug {
+		t.Errorf("Labels = %v, want [bug]", got)
 	}
 	if len(item.LinkedItems) != 1 {
 		t.Fatalf("LinkedItems = %d, want 1", len(item.LinkedItems))
 	}
 	if item.LinkedItems[0].IID != 7 || item.LinkedItems[0].LinkType != "blocks" || item.LinkedItems[0].Path != "my-group/other" {
 		t.Errorf("LinkedItems[0] = %+v, want {7 blocks my-group/other}", item.LinkedItems[0])
+	}
+}
+
+// TestList_AssigneesAndLabels_CarryTheWholeObject verifies that the fields the
+// UserCoreBasic and label fragments already fetch reach the output instead of
+// being reduced to a name.
+//
+// The fixture answers with every field of both fragments, because the fragment
+// pays for all of them on every list call: publishing only the username and
+// the title threw away six user fields and five label fields per entry.
+func TestList_AssigneesAndLabels_CarryTheWholeObject(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		testutil.RespondJSON(w, http.StatusOK, `{"data":{"namespace":{"workItems":{"nodes":[{"id":"gid://gitlab/WorkItem/1","iid":"10","workItemType":{"name":"Issue"},"state":"OPEN","title":"Item 1","author":{"id":"gid://gitlab/User/2","username":"alice","name":"Alice A","state":"active","avatarUrl":"https://gitlab.example.com/alice.png","webUrl":"https://gitlab.example.com/alice","createdAt":"2026-01-01T00:00:00Z"},"features":{"assignees":{"assignees":{"nodes":[{"id":"gid://gitlab/User/3","username":"bob","name":"Bob B","state":"active","avatarUrl":"https://gitlab.example.com/bob.png","webUrl":"https://gitlab.example.com/bob","createdAt":"2026-01-02T00:00:00Z"}]}},"labels":{"labels":{"nodes":[{"id":"gid://gitlab/ProjectLabel/7","title":"bug","color":"#d9534f","description":"Something is broken","descriptionHtml":"<p>Something is broken</p>","textColor":"#ffffff"}]}}}}]}}}}`)
+	})
+	client := testutil.NewTestClient(t, handler)
+	out, err := List(t.Context(), client, ListInput{FullPath: testFullPath})
+	if err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	if len(out.WorkItems) != 1 {
+		t.Fatalf("expected 1 work item, got %d", len(out.WorkItems))
+	}
+	item := out.WorkItems[0]
+	wantAuthor := &toolutil.BasicUserOutput{
+		ID: 2, Username: testAuthorAlice, Name: "Alice A", State: "active",
+		AvatarURL: "https://gitlab.example.com/alice.png",
+		WebURL:    "https://gitlab.example.com/alice",
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}
+	if !reflect.DeepEqual(item.Author, wantAuthor) {
+		t.Errorf("Author = %+v, want %+v", item.Author, wantAuthor)
+	}
+	wantAssignees := []*toolutil.BasicUserOutput{{
+		ID: 3, Username: testAuthorBob, Name: "Bob B", State: "active",
+		AvatarURL: "https://gitlab.example.com/bob.png",
+		WebURL:    "https://gitlab.example.com/bob",
+		CreatedAt: "2026-01-02T00:00:00Z",
+	}}
+	if !reflect.DeepEqual(item.Assignees, wantAssignees) {
+		t.Errorf("Assignees = %+v, want %+v", item.Assignees, wantAssignees)
+	}
+	wantLabels := []*toolutil.LabelDetailsOutput{{
+		ID: 7, Name: testLabelBug, Color: "#d9534f",
+		Description:     "Something is broken",
+		DescriptionHTML: "<p>Something is broken</p>",
+		TextColor:       "#ffffff",
+	}}
+	if !reflect.DeepEqual(item.Labels, wantLabels) {
+		t.Errorf("Labels = %+v, want %+v", item.Labels, wantLabels)
 	}
 }
 
@@ -589,7 +663,7 @@ func TestDelete_Error(t *testing.T) {
 // TestFormatGetMarkdown verifies FormatGetMarkdown.
 func TestFormatGetMarkdown(t *testing.T) {
 	result := FormatGetMarkdown(GetOutput{WorkItem: WorkItemItem{
-		IID: 42, Title: "Test", Type: "Issue", State: "OPEN", Author: "dev",
+		IID: 42, Title: "Test", Type: "Issue", State: "OPEN", Author: namedUser("dev"),
 	}})
 	if result == nil {
 		t.Fatal(errExpNonNilResult)
@@ -609,7 +683,7 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 // back through the after input.
 func TestFormatListMarkdown_WithNextPage_EmitsTheCursorLine(t *testing.T) {
 	out := ListOutput{
-		WorkItems: []WorkItemItem{{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "A", Author: testAuthorDev}},
+		WorkItems: []WorkItemItem{{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "A", Author: namedUser(testAuthorDev)}},
 		Pagination: toolutil.GraphQLPaginationOutput{
 			HasNextPage: true,
 			EndCursor:   "next-page-cursor",
@@ -624,7 +698,7 @@ func TestFormatListMarkdown_WithNextPage_EmitsTheCursorLine(t *testing.T) {
 // TestFormatListMarkdown_WithData verifies FormatListMarkdown when with data.
 func TestFormatListMarkdown_WithData(t *testing.T) {
 	out := ListOutput{WorkItems: []WorkItemItem{
-		{IID: 1, Type: "Issue", State: "OPEN", Title: "A", Author: "dev"},
+		{IID: 1, Type: "Issue", State: "OPEN", Title: "A", Author: namedUser("dev")},
 	}}
 	result := FormatListMarkdown(out)
 	if result == nil {
@@ -712,9 +786,12 @@ func TestWorkItemToItem_FullData(t *testing.T) {
 		Description:  "A detailed description",
 		WebURL:       testWorkItemURL,
 		Confidential: true,
-		Author:       &gl.BasicUser{Username: testAuthorAlice},
-		Assignees:    []*gl.BasicUser{{Username: testAuthorBob}, {Username: testAuthorCarol}},
-		Labels:       []gl.LabelDetails{{Name: testLabelBug}, {Name: testLabelUrgent}},
+		Author:       &gl.BasicUser{ID: 2, Username: testAuthorAlice, Name: "Alice A", State: "active"},
+		Assignees:    []*gl.BasicUser{{ID: 3, Username: testAuthorBob}, {ID: 4, Username: testAuthorCarol}},
+		Labels: []gl.LabelDetails{
+			{ID: 7, Name: testLabelBug, Color: "#d9534f", Description: "broken", DescriptionHTML: "<p>broken</p>", TextColor: "#ffffff"},
+			{ID: 8, Name: testLabelUrgent},
+		},
 		LinkedItems: []gl.LinkedWorkItem{
 			{NamespacePath: "my-group/other", IID: 7, LinkType: "blocks"},
 		},
@@ -787,16 +864,29 @@ func assertFullItemCore(t *testing.T, item WorkItemItem) {
 }
 
 // assertFullItemPeople checks full item people invariants for tests.
+//
+// Each of the three is checked whole rather than by name, because the whole
+// object is what the converter now carries and a name-only assertion is what
+// let the other fields go missing before.
 func assertFullItemPeople(t *testing.T, item WorkItemItem) {
 	t.Helper()
-	if item.Author != testAuthorAlice {
-		t.Errorf("Author = %q, want alice", item.Author)
+	wantAuthor := &toolutil.BasicUserOutput{ID: 2, Username: testAuthorAlice, Name: "Alice A", State: "active"}
+	if !reflect.DeepEqual(item.Author, wantAuthor) {
+		t.Errorf("Author = %+v, want %+v", item.Author, wantAuthor)
 	}
-	if len(item.Assignees) != 2 || item.Assignees[0] != testAuthorBob || item.Assignees[1] != testAuthorCarol {
-		t.Errorf("Assignees = %v, want [bob carol]", item.Assignees)
+	wantAssignees := []*toolutil.BasicUserOutput{
+		{ID: 3, Username: testAuthorBob},
+		{ID: 4, Username: testAuthorCarol},
 	}
-	if len(item.Labels) != 2 || item.Labels[0] != testLabelBug || item.Labels[1] != testLabelUrgent {
-		t.Errorf("Labels = %v, want [bug urgent]", item.Labels)
+	if !reflect.DeepEqual(item.Assignees, wantAssignees) {
+		t.Errorf("Assignees = %+v, want %+v", item.Assignees, wantAssignees)
+	}
+	wantLabels := []*toolutil.LabelDetailsOutput{
+		{ID: 7, Name: testLabelBug, Color: "#d9534f", Description: "broken", DescriptionHTML: "<p>broken</p>", TextColor: "#ffffff"},
+		{ID: 8, Name: testLabelUrgent},
+	}
+	if !reflect.DeepEqual(item.Labels, wantLabels) {
+		t.Errorf("Labels = %+v, want %+v", item.Labels, wantLabels)
 	}
 }
 
@@ -829,8 +919,8 @@ func TestWorkItemToItem_Minimal(t *testing.T) {
 	if item.Status != "" {
 		t.Errorf("Status should be empty, got %q", item.Status)
 	}
-	if item.Author != "" {
-		t.Errorf("Author should be empty, got %q", item.Author)
+	if item.Author != nil {
+		t.Errorf("Author should be absent, got %+v", item.Author)
 	}
 	if len(item.Assignees) != 0 {
 		t.Errorf("Assignees should be empty, got %v", item.Assignees)
@@ -863,8 +953,8 @@ func TestWorkItemToItemNilStatusNon_NilAuthor(t *testing.T) {
 	if item.Status != "" {
 		t.Errorf("Status = %q, want empty", item.Status)
 	}
-	if item.Author != testAuthorDev {
-		t.Errorf("Author = %q, want dev", item.Author)
+	if authorName(item.Author) != testAuthorDev {
+		t.Errorf("Author = %+v, want dev", item.Author)
 	}
 }
 
@@ -899,9 +989,9 @@ func TestFormatGetMarkdown_FullPopulated(t *testing.T) {
 		Title:       "Full WI",
 		Type:        testTypeTask,
 		State:       testStateOpen,
-		Author:      testAuthorAlice,
-		Assignees:   []string{testAuthorBob, testAuthorCarol},
-		Labels:      []string{testLabelBug, testLabelUrgent},
+		Author:      namedUser(testAuthorAlice),
+		Assignees:   namedUsers(testAuthorBob, testAuthorCarol),
+		Labels:      namedLabels(testLabelBug, testLabelUrgent),
 		WebURL:      "https://gitlab.example.com/work_items/42",
 		Description: "A very detailed description.",
 	}}
@@ -992,7 +1082,7 @@ func TestFormatGetMarkdown_OnlyAuthor(t *testing.T) {
 		Title:  "Simple",
 		Type:   testTypeIssue,
 		State:  testStateClosed,
-		Author: testAuthorDev,
+		Author: namedUser(testAuthorDev),
 	}}
 	result := FormatGetMarkdown(out)
 	text := extractText(t, result)
@@ -1011,7 +1101,7 @@ func TestFormatGetMarkdown_OnlyAssignees(t *testing.T) {
 		Title:     "Assigned",
 		Type:      testTypeTask,
 		State:     testStateOpen,
-		Assignees: []string{testAuthorAlice},
+		Assignees: namedUsers(testAuthorAlice),
 	}}
 	result := FormatGetMarkdown(out)
 	text := extractText(t, result)
@@ -1027,7 +1117,7 @@ func TestFormatGetMarkdown_OnlyLabels(t *testing.T) {
 		Title:  "Labeled",
 		Type:   testTypeIssue,
 		State:  testStateOpen,
-		Labels: []string{"feature"},
+		Labels: namedLabels("feature"),
 	}}
 	result := FormatGetMarkdown(out)
 	text := extractText(t, result)
@@ -1078,9 +1168,9 @@ func TestFormatGetMarkdown_OnlyDescription(t *testing.T) {
 // TestFormatListMarkdown_MultipleItems verifies FormatListMarkdown when multiple items.
 func TestFormatListMarkdown_MultipleItems(t *testing.T) {
 	out := ListOutput{WorkItems: []WorkItemItem{
-		{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "First", Author: "dev1"},
-		{IID: 2, Type: testTypeTask, State: testStateClosed, Title: "Second", Author: "dev2"},
-		{IID: 3, Type: "Epic", State: testStateOpen, Title: "Third", Author: "dev3"},
+		{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "First", Author: namedUser("dev1")},
+		{IID: 2, Type: testTypeTask, State: testStateClosed, Title: "Second", Author: namedUser("dev2")},
+		{IID: 3, Type: "Epic", State: testStateOpen, Title: "Third", Author: namedUser("dev3")},
 	}}
 	result := FormatListMarkdown(out)
 	if result == nil {
@@ -1110,7 +1200,7 @@ func TestFormatListMarkdown_EmptyReturnsMessage(t *testing.T) {
 // TestFormatListMarkdown_SpecialCharsInTitle verifies FormatListMarkdown when special chars in title.
 func TestFormatListMarkdown_SpecialCharsInTitle(t *testing.T) {
 	out := ListOutput{WorkItems: []WorkItemItem{
-		{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "Has | pipe", Author: testAuthorDev},
+		{IID: 1, Type: testTypeIssue, State: testStateOpen, Title: "Has | pipe", Author: namedUser(testAuthorDev)},
 	}}
 	result := FormatListMarkdown(out)
 	text := extractText(t, result)
@@ -1355,24 +1445,35 @@ func TestCreate_MinimalOptions(t *testing.T) {
 	}
 }
 
-// TestCreate_InvalidDueDate verifies Create when invalid due date.
-func TestCreate_InvalidDueDate(t *testing.T) {
-	// DueDate parsing uses time.Parse -- invalid format is silently ignored
-	// (err == nil check), so invalid dates just skip setting the field.
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		testutil.RespondJSON(w, http.StatusOK, `{"data":{"workItemCreate":{"workItem":{"id":"gid://gitlab/WorkItem/1","iid":"1","workItemType":{"name":"Issue"},"state":"OPEN","title":"Bad date","author":{"username":"dev"},"widgets":[]}}}}`)
-	})
-	client := testutil.NewTestClient(t, handler)
-
-	_, err := Create(t.Context(), client, CreateInput{
-		FullPath:       testProjectPath,
-		WorkItemTypeID: testTypeGID,
-		Title:          "Bad date",
-		DueDate:        "not-a-date",
-		StartDate:      "also-not-a-date",
-	})
-	if err != nil {
-		t.Fatalf(fmtUnexpErr, err)
+// TestCreate_MalformedDate_RefusesAndNamesTheField verifies that create stops
+// on a start_date or due_date it cannot read, naming the one at fault, instead
+// of dropping it and reporting a work item created without the date asked for.
+//
+// One case per field: a shared parser reached from two call sites is exactly
+// the shape where one of the two silently keeps the old behavior.
+func TestCreate_MalformedDate_RefusesAndNamesTheField(t *testing.T) {
+	cases := []struct {
+		name  string
+		input CreateInput
+	}{
+		{"start_date", CreateInput{StartDate: "not-a-date"}},
+		{"due_date", CreateInput{DueDate: "31/01/2025"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+			input := tc.input
+			input.FullPath = testProjectPath
+			input.WorkItemTypeID = testTypeGID
+			input.Title = "Bad date"
+			_, err := Create(t.Context(), client, input)
+			if err == nil {
+				t.Fatal(errExpectedNil)
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("error = %v, want it to name %s", err, tc.name)
+			}
+		})
 	}
 }
 
@@ -1649,32 +1750,32 @@ func TestUpdate_Error(t *testing.T) {
 	}
 }
 
-// TestUpdate_InvalidDates verifies that invalid date formats for StartDate
-// and DueDate are silently ignored (the field is not set) without causing errors.
-func TestUpdate_InvalidDates(t *testing.T) {
-	call := 0
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		call++
-		switch call {
-		case 1:
-			testutil.RespondJSON(w, http.StatusOK, `{"data":{"namespace":{"workItem":{"id":"gid://gitlab/WorkItem/1"}}}}`)
-		default:
-			testutil.RespondJSON(w, http.StatusOK, `{"data":{"workItemUpdate":{"workItem":{"id":"gid://gitlab/WorkItem/1","iid":"1","workItemType":{"name":"Issue"},"state":"OPEN","title":"Bad dates","author":{"username":"dev"},"widgets":[]}}}}`)
-		}
-	})
-	client := testutil.NewTestClient(t, handler)
-
-	out, err := Update(t.Context(), client, UpdateInput{
-		FullPath:  testFullPath,
-		IID:       1,
-		StartDate: "not-a-date",
-		DueDate:   "also-invalid",
-	})
-	if err != nil {
-		t.Fatalf(fmtUnexpErr, err)
+// TestUpdate_MalformedDate_RefusesBeforeAnyRequest verifies that update stops
+// on a start_date or due_date it cannot read, naming the one at fault, and
+// does so before issuing anything: the clearing guard's read would otherwise be
+// spent on a call already destined to be refused.
+func TestUpdate_MalformedDate_RefusesBeforeAnyRequest(t *testing.T) {
+	cases := []struct {
+		name  string
+		input UpdateInput
+	}{
+		{"start_date", UpdateInput{StartDate: "not-a-date"}},
+		{"due_date", UpdateInput{DueDate: "also-invalid"}},
 	}
-	if out.WorkItem.Title != "Bad dates" {
-		t.Errorf("Title = %q", out.WorkItem.Title)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+			input := tc.input
+			input.FullPath = testFullPath
+			input.IID = 1
+			_, err := Update(t.Context(), client, input)
+			if err == nil {
+				t.Fatal(errExpectedNil)
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("error = %v, want it to name %s", err, tc.name)
+			}
+		})
 	}
 }
 
@@ -2479,8 +2580,8 @@ func TestGet_RichResponse(t *testing.T) {
 	if wi.Title != "Rich item" {
 		t.Errorf("Title = %q", wi.Title)
 	}
-	if wi.Author != testAuthorAlice {
-		t.Errorf("Author = %q", wi.Author)
+	if authorName(wi.Author) != testAuthorAlice {
+		t.Errorf("Author = %+v", wi.Author)
 	}
 	if wi.Description != "Detailed desc" {
 		t.Errorf(fmtDescWant, wi.Description)
@@ -2694,6 +2795,107 @@ func TestList_ReturnedFields_FollowTheResolvedTier(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestWorkItems_TierTags_CoverEveryEnterpriseWidget pins the tier of every
+// gated field on the three shapes that carry one.
+//
+// It is the other half of the saved-views table: the two domains publish the
+// same conditions through different tools, and a tag dropped on either side is
+// a filter one tool offers a tier that cannot use it. The five widget fields
+// are the ones client-go keeps out of its Community Edition default set, so
+// this table and workItemEEListFields describe the same set from two angles.
+func TestWorkItems_TierTags_CoverEveryEnterpriseWidget(t *testing.T) {
+	cases := []struct {
+		object reflect.Type
+		field  string
+		want   string
+	}{
+		{reflect.TypeFor[WorkItemItem](), "Color", "premium"},
+		{reflect.TypeFor[WorkItemItem](), "HealthStatus", "ultimate"},
+		{reflect.TypeFor[WorkItemItem](), "IterationID", "premium"},
+		{reflect.TypeFor[WorkItemItem](), "Status", "premium"},
+		{reflect.TypeFor[WorkItemItem](), "Weight", "premium"},
+		{reflect.TypeFor[CreateInput](), "Color", "premium"},
+		{reflect.TypeFor[CreateInput](), "HealthStatus", "ultimate"},
+		{reflect.TypeFor[CreateInput](), "IterationID", "premium"},
+		{reflect.TypeFor[CreateInput](), "Status", "premium"},
+		{reflect.TypeFor[CreateInput](), "Weight", "premium"},
+		{reflect.TypeFor[UpdateInput](), "Color", "premium"},
+		{reflect.TypeFor[UpdateInput](), "HealthStatus", "ultimate"},
+		{reflect.TypeFor[UpdateInput](), "IterationID", "premium"},
+		{reflect.TypeFor[UpdateInput](), "Status", "premium"},
+		{reflect.TypeFor[UpdateInput](), "Weight", "premium"},
+		{reflect.TypeFor[ListInput](), "HealthStatusFilter", "ultimate"},
+		{reflect.TypeFor[ListInput](), "IterationCadenceID", "premium"},
+		{reflect.TypeFor[ListInput](), "IterationID", "premium"},
+		{reflect.TypeFor[ListInput](), "IterationWildcardID", "premium"},
+		{reflect.TypeFor[ListInput](), "Weight", "premium"},
+		{reflect.TypeFor[ListInput](), "WeightWildcardID", "premium"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.object.Name()+"."+testCase.field, func(t *testing.T) {
+			field, ok := testCase.object.FieldByName(testCase.field)
+			if !ok {
+				t.Fatalf("%s has no field %s", testCase.object.Name(), testCase.field)
+			}
+			if got := field.Tag.Get("tier"); got != testCase.want {
+				t.Errorf("tier tag = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestList_ReturnedFields_SelectTheFragment proves that returned_fields reaches
+// the rendered document: the fields named are the ones asked for, and the
+// per-tier default is not merged back in over the caller's narrower choice.
+//
+// The instance is Enterprise here on purpose, since that is the case where an
+// implementation that appended the default set instead of replacing it would
+// still look right on a Community Edition one.
+func TestList_ReturnedFields_SelectTheFragment(t *testing.T) {
+	var got graphQLRequest
+	client := testutil.NewTestClient(t, recordGraphQL(t, &got, emptyWorkItemsResponse))
+	client.SetEnterprise(true)
+	if _, err := List(t.Context(), client, ListInput{
+		FullPath:       testFullPath,
+		ReturnedFields: []string{"iid", "title", "weight"},
+	}); err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	for _, want := range []string{"iid", "title", "weight {"} {
+		t.Run("asks for "+want, func(t *testing.T) {
+			if !strings.Contains(got.Query, want) {
+				t.Errorf("query does not ask for %q:\n%s", want, got.Query)
+			}
+		})
+	}
+	// A default-set field the caller did not name: present without this
+	// input, and proof the selection replaces rather than extends.
+	for _, unwanted := range []string{"webUrl", "healthStatus {"} {
+		t.Run("omits "+unwanted, func(t *testing.T) {
+			if strings.Contains(got.Query, unwanted) {
+				t.Errorf("query still asks for %q:\n%s", unwanted, got.Query)
+			}
+		})
+	}
+}
+
+// TestList_ReturnedFields_UnknownName_IsRefusedBeforeTheRequest verifies that a
+// name outside client-go's registry stops the call rather than reaching GitLab,
+// which is what makes the published enum the whole story for a caller.
+func TestList_ReturnedFields_UnknownName_IsRefusedBeforeTheRequest(t *testing.T) {
+	client := testutil.NewTestClient(t, testutil.ForbiddenHandler(t))
+	_, err := List(t.Context(), client, ListInput{
+		FullPath:       testFullPath,
+		ReturnedFields: []string{"iid", "totallyMadeUp"},
+	})
+	if err == nil {
+		t.Fatal(errExpectedNil)
+	}
+	if !strings.Contains(err.Error(), "totallyMadeUp") {
+		t.Errorf("error = %v, want it to name the unknown field", err)
 	}
 }
 

--- a/internal/tools/workitemsavedviews/filters.go
+++ b/internal/tools/workitemsavedviews/filters.go
@@ -20,6 +20,16 @@ var timeLayouts = []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"}
 // omits empty values, so "" and "field absent" mean the same thing to the
 // server. Booleans stay pointers, because false and absent do not.
 //
+// The tier tags name the same tiers internal/tools/workitems puts on the
+// filters of the same name, so one filter is advertised at one tier whichever
+// domain a caller reaches it through: iterations, weight, custom fields and
+// status are Premium and health status is Ultimate. A saved view is itself
+// available on every tier; only these conditions inside one are gated. GitLab
+// documents work item status and custom fields at "Tier: Premium, Ultimate"
+// (https://docs.gitlab.com/user/work_items/status/ and
+// https://docs.gitlab.com/user/work_items/custom_fields/), both read on
+// 2026-09-07.
+//
 // GitLab API docs: https://docs.gitlab.com/api/graphql/reference/#workitemsavedviewfilterinput
 type Filters struct {
 	AssigneeUsernames          []string            `json:"assignee_usernames,omitempty"            jsonschema:"Usernames of the assignees to match"`
@@ -32,21 +42,21 @@ type Filters struct {
 	CreatedBefore              string              `json:"created_before,omitempty"                jsonschema:"Match work items created before this timestamp (ISO 8601)"`
 	CRMContactID               string              `json:"crm_contact_id,omitempty"                jsonschema:"CRM contact global ID whose work items to match"`
 	CRMOrganizationID          string              `json:"crm_organization_id,omitempty"           jsonschema:"CRM organization global ID whose work items to match"`
-	CustomField                []CustomFieldFilter `json:"custom_field,omitempty"                  jsonschema:"Custom field filters, each matching one custom field by ID or name"`
+	CustomField                []CustomFieldFilter `json:"custom_field,omitempty"                  tier:"premium" jsonschema:"Custom field filters, each matching one custom field by ID or name"`
 	DueAfter                   string              `json:"due_after,omitempty"                     jsonschema:"Match work items due after this timestamp (ISO 8601)"`
 	DueBefore                  string              `json:"due_before,omitempty"                    jsonschema:"Match work items due before this timestamp (ISO 8601)"`
 	ExcludeGroupWorkItems      *bool               `json:"exclude_group_work_items,omitempty"      jsonschema:"Exclude work items owned by the group itself"`
 	ExcludeProjects            *bool               `json:"exclude_projects,omitempty"              jsonschema:"Exclude work items owned by projects under the namespace"`
 	FullPath                   string              `json:"full_path,omitempty"                     jsonschema:"Full path of the project or group whose work items to match"`
-	HealthStatusFilter         string              `json:"health_status_filter,omitempty"          jsonschema:"Health status to match: onTrack, needsAttention, atRisk, ANY, or NONE"`
+	HealthStatusFilter         string              `json:"health_status_filter,omitempty"          tier:"ultimate" jsonschema:"Health status to match: onTrack, needsAttention, atRisk, ANY, or NONE"`
 	HierarchyFilters           *HierarchyFilter    `json:"hierarchy_filters,omitempty"             jsonschema:"Filter by position in the work item hierarchy"`
 	IID                        string              `json:"iid,omitempty"                           jsonschema:"Internal ID (IID) of a single work item to match"`
 	In                         []string            `json:"in,omitempty"                            jsonschema:"Fields the search term is matched against, e.g. TITLE or DESCRIPTION"`
 	IncludeDescendantWorkItems *bool               `json:"include_descendant_work_items,omitempty" jsonschema:"Include work items below the matched ones in the hierarchy"`
 	IncludeDescendants         *bool               `json:"include_descendants,omitempty"           jsonschema:"Include work items from descendant namespaces"`
-	IterationCadenceID         []string            `json:"iteration_cadence_id,omitempty"          jsonschema:"Iteration cadence global IDs to match"`
-	IterationID                []string            `json:"iteration_id,omitempty"                  jsonschema:"Iteration global IDs to match"`
-	IterationWildcardID        string              `json:"iteration_wildcard_id,omitempty"         jsonschema:"Iteration wildcard filter: NONE, ANY, CURRENT"`
+	IterationCadenceID         []string            `json:"iteration_cadence_id,omitempty"          tier:"premium" jsonschema:"Iteration cadence global IDs to match"`
+	IterationID                []string            `json:"iteration_id,omitempty"                  tier:"premium" jsonschema:"Iteration global IDs to match"`
+	IterationWildcardID        string              `json:"iteration_wildcard_id,omitempty"         tier:"premium" jsonschema:"Iteration wildcard filter: NONE, ANY, CURRENT"`
 	LabelName                  []string            `json:"label_name,omitempty"                    jsonschema:"Label names to match"`
 	MilestoneTitle             []string            `json:"milestone_title,omitempty"               jsonschema:"Milestone titles to match"`
 	MilestoneWildcardID        string              `json:"milestone_wildcard_id,omitempty"         jsonschema:"Milestone wildcard filter: NONE, ANY, STARTED, UPCOMING"`
@@ -57,13 +67,13 @@ type Filters struct {
 	ReleaseTagWildcardID       string              `json:"release_tag_wildcard_id,omitempty"       jsonschema:"Release tag wildcard filter: NONE or ANY"`
 	Search                     string              `json:"search,omitempty"                        jsonschema:"Free-text search term"`
 	State                      string              `json:"state,omitempty"                         jsonschema:"Work item state: opened, closed, locked, or all"`
-	Status                     *StatusFilter       `json:"status,omitempty"                        jsonschema:"Filter by the work item status widget value"`
+	Status                     *StatusFilter       `json:"status,omitempty"                        tier:"premium" jsonschema:"Filter by the work item status widget value"`
 	Subscribed                 string              `json:"subscribed,omitempty"                    jsonschema:"Subscription state of the authenticated user: EXPLICITLY_SUBSCRIBED, EXPLICITLY_UNSUBSCRIBED"`
 	Types                      []string            `json:"types,omitempty"                         jsonschema:"Work item type names to match, e.g. ISSUE, TASK, EPIC"`
 	UpdatedAfter               string              `json:"updated_after,omitempty"                 jsonschema:"Match work items updated after this timestamp (ISO 8601)"`
 	UpdatedBefore              string              `json:"updated_before,omitempty"                jsonschema:"Match work items updated before this timestamp (ISO 8601)"`
-	Weight                     string              `json:"weight,omitempty"                        jsonschema:"Weight to match"`
-	WeightWildcardID           string              `json:"weight_wildcard_id,omitempty"            jsonschema:"Weight wildcard filter: NONE or ANY"`
+	Weight                     string              `json:"weight,omitempty"                        tier:"premium" jsonschema:"Weight to match"`
+	WeightWildcardID           string              `json:"weight_wildcard_id,omitempty"            tier:"premium" jsonschema:"Weight wildcard filter: NONE or ANY"`
 	WorkItemTypeIDs            []string            `json:"work_item_type_ids,omitempty"            jsonschema:"Work item type global IDs to match"`
 }
 
@@ -74,10 +84,10 @@ type Filters struct {
 type NegatedFilters struct {
 	AssigneeUsernames   []string            `json:"assignee_usernames,omitempty"    jsonschema:"Assignee usernames to exclude"`
 	AuthorUsername      []string            `json:"author_username,omitempty"       jsonschema:"Author usernames to exclude"`
-	CustomField         []CustomFieldFilter `json:"custom_field,omitempty"          jsonschema:"Custom field values to exclude"`
-	HealthStatusFilter  []string            `json:"health_status_filter,omitempty"  jsonschema:"Health statuses to exclude"`
-	IterationID         []string            `json:"iteration_id,omitempty"          jsonschema:"Iteration global IDs to exclude"`
-	IterationWildcardID string              `json:"iteration_wildcard_id,omitempty" jsonschema:"Iteration wildcard filter to exclude"`
+	CustomField         []CustomFieldFilter `json:"custom_field,omitempty"          tier:"premium" jsonschema:"Custom field values to exclude"`
+	HealthStatusFilter  []string            `json:"health_status_filter,omitempty"  tier:"ultimate" jsonschema:"Health statuses to exclude"`
+	IterationID         []string            `json:"iteration_id,omitempty"          tier:"premium" jsonschema:"Iteration global IDs to exclude"`
+	IterationWildcardID string              `json:"iteration_wildcard_id,omitempty" tier:"premium" jsonschema:"Iteration wildcard filter to exclude"`
 	LabelName           []string            `json:"label_name,omitempty"            jsonschema:"Label names to exclude"`
 	MilestoneTitle      []string            `json:"milestone_title,omitempty"       jsonschema:"Milestone titles to exclude"`
 	MilestoneWildcardID string              `json:"milestone_wildcard_id,omitempty" jsonschema:"Milestone wildcard filter to exclude"`
@@ -85,7 +95,7 @@ type NegatedFilters struct {
 	ParentIDs           []string            `json:"parent_ids,omitempty"            jsonschema:"Parent work item global IDs to exclude"`
 	ReleaseTag          []string            `json:"release_tag,omitempty"           jsonschema:"Release tags to exclude"`
 	Types               []string            `json:"types,omitempty"                 jsonschema:"Work item type names to exclude"`
-	Weight              string              `json:"weight,omitempty"                jsonschema:"Weight to exclude"`
+	Weight              string              `json:"weight,omitempty"                tier:"premium" jsonschema:"Weight to exclude"`
 	WorkItemTypeIDs     []string            `json:"work_item_type_ids,omitempty"    jsonschema:"Work item type global IDs to exclude"`
 }
 
@@ -96,7 +106,7 @@ type NegatedFilters struct {
 type UnionedFilters struct {
 	AssigneeUsernames []string            `json:"assignee_usernames,omitempty" jsonschema:"Assignee usernames where matching any one includes the work item"`
 	AuthorUsernames   []string            `json:"author_usernames,omitempty"   jsonschema:"Author usernames where matching any one includes the work item"`
-	CustomField       []CustomFieldFilter `json:"custom_field,omitempty"       jsonschema:"Custom field values where matching any one includes the work item"`
+	CustomField       []CustomFieldFilter `json:"custom_field,omitempty"       tier:"premium" jsonschema:"Custom field values where matching any one includes the work item"`
 	LabelNames        []string            `json:"label_names,omitempty"        jsonschema:"Label names where matching any one includes the work item"`
 }
 

--- a/internal/tools/workitemsavedviews/filters_test.go
+++ b/internal/tools/workitemsavedviews/filters_test.go
@@ -4,6 +4,7 @@
 package workitemsavedviews
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -427,6 +428,50 @@ func TestSubFilters_NilReceivers(t *testing.T) {
 			t.Errorf("customFieldsToSDK(nil) = %+v, want nil", got)
 		}
 	})
+}
+
+// TestFilters_TierTags_MatchTheWorkItemListFilters pins the tier of every
+// gated filter, in all three filter objects, to the tier
+// internal/tools/workitems publishes for the filter of the same name.
+//
+// The two domains publish the same condition names through different tools,
+// and until this change one of them advertised every one of them as Free. The
+// table is written down rather than read from the sibling package because
+// ADR-0004 forbids a domain sub-package from importing another; the names are
+// the join, so a tag dropped or downgraded on either side shows up as a
+// mismatch here or in that package's own tier assertions.
+func TestFilters_TierTags_MatchTheWorkItemListFilters(t *testing.T) {
+	cases := []struct {
+		object reflect.Type
+		field  string
+		want   string
+	}{
+		{reflect.TypeFor[Filters](), "CustomField", "premium"},
+		{reflect.TypeFor[Filters](), "HealthStatusFilter", "ultimate"},
+		{reflect.TypeFor[Filters](), "IterationCadenceID", "premium"},
+		{reflect.TypeFor[Filters](), "IterationID", "premium"},
+		{reflect.TypeFor[Filters](), "IterationWildcardID", "premium"},
+		{reflect.TypeFor[Filters](), "Status", "premium"},
+		{reflect.TypeFor[Filters](), "Weight", "premium"},
+		{reflect.TypeFor[Filters](), "WeightWildcardID", "premium"},
+		{reflect.TypeFor[NegatedFilters](), "CustomField", "premium"},
+		{reflect.TypeFor[NegatedFilters](), "HealthStatusFilter", "ultimate"},
+		{reflect.TypeFor[NegatedFilters](), "IterationID", "premium"},
+		{reflect.TypeFor[NegatedFilters](), "IterationWildcardID", "premium"},
+		{reflect.TypeFor[NegatedFilters](), "Weight", "premium"},
+		{reflect.TypeFor[UnionedFilters](), "CustomField", "premium"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.object.Name()+"."+testCase.field, func(t *testing.T) {
+			field, ok := testCase.object.FieldByName(testCase.field)
+			if !ok {
+				t.Fatalf("%s has no field %s", testCase.object.Name(), testCase.field)
+			}
+			if got := field.Tag.Get("tier"); got != testCase.want {
+				t.Errorf("tier tag = %q, want %q", got, testCase.want)
+			}
+		})
+	}
 }
 
 // TestOptionalString verifies that only a non-empty string produces a pointer.


### PR DESCRIPTION
`internal/tools/workitems` now exposes every filter `gl.ListWorkItemsOptions` accepts (28 were missing on `list`), the five create fields the update action already had and create did not (`parent_id`, `iteration_id`, `crm_contact_ids`, `created_at`, `create_source`), and the eight widget-backed output fields the SDK carried and the output dropped (`parent`, `color`, `milestone_id`, `iteration_id`, `weight`, `health_status`, `start_date`, `due_date`). No GraphQL document changed: client-go declares a variable and passes an argument for each option it finds set, and the pinned-schema test transport confirms every new variable on every request the new tests drive.

This is the workitems half of #583, and the part of it that was invisible until #582 taught the struct audit to read a type that tags nothing.

## A live defect found on the way

`work_item.list` never set `ReturnedFields`, so client-go asked for its CE default alone and the five Enterprise names, `status` among them, were requested by nothing, which is why `FormatListMarkdown` printed a permanently blank Status column. The field set is now chosen per call from the client's tier, and `returned_fields` is exposed as an input with an enum read out of client-go's own field registry, since the 1:1 norm covers it: it selects the fragment rather than filtering.

## Nothing left out

The output publishes the objects client-go fetches rather than names: `author`, `assignees` and `labels` carry the whole `BasicUser` and `LabelDetails` the fragments already paid for, and the Markdown keeps the handles and titles. `start_date` and `due_date` refuse a malformed value on create and update instead of silently dropping it, the way `created_at` and the eight time filters do. The tier tags are reconciled with `internal/tools/workitemsavedviews`, which published the same filter names untagged: `weight`, the iteration filters, `status`, `custom_field` are Premium and `health_status_filter` Ultimate in both packages, in the direct, negated and unioned filter shapes, pinned by a reflect table in each. The eight time filters publish `format: date-time` uniformly, since `toolutil` injects it for four of the eight by name and an override can add a format but not remove one; a bare date is read as midnight UTC and the description says so.

The plan's verifier corrected one thing worth recording: `crm_contact_id` and `crm_organization_id` take numeric ids as strings, not global ids; the descriptions and docs say so now.

## Verification

`internal/tools/workitems` and `internal/tools/workitemsavedviews` at 100% statement coverage, every new input field with a wire assertion on the GraphQL variable, every output field with a fixture round trip. Both lint passes clean; the full unit suite green; the e2e suite compiles under both tag sets. Snapshots, `llms*.txt`, the token footprint and the stats are regenerated.

Part of #583.
