### PR TITLE
feat(tooling): gate the Markdown escaping rule, and fix everything it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
         run: make check-test-goroutines
       - name: Check case loops run as subtests
         run: make check-test-subtests
+      - name: Check Markdown formatters escape what they interpolate
+        run: make check-md-escaping
       - name: Check gateway-safe served characters
         run: make check-gateway-chars
       - name: Check test-file naming convention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ gitlab-mcp-server/
 │   ├── audit_gateway_chars/     # Audits served descriptions/titles for characters MCP gateway validators reject (make check-gateway-chars)
 │   ├── audit_install_buttons/  # Decodes every one-click install payload (base64 or percent-encoded JSON) and holds the buttons to one configuration per command (make check-install-buttons)
 │   ├── godoc_tool/              # Consolidated Go doc auditor + fixer (was audit_godocs + add_docs)
+│   ├── audit_md_escaping/       # Fails when a Markdown formatter interpolates a GitLab-authored value into a table cell, heading, list item or link without EscapeMdTableCell/EscapeMdHeading/MdTitleLink; `//gitlab:allow-unescaped <expr>: <reason>` declares a value that needs none (make check-md-escaping)
 │   ├── audit_metrics/           # Audits MCP tool/resource/prompt metrics
 │   ├── audit_readonly_graphql/  # Fails when an action classified ReadOnly can reach a GraphQL mutation, which `--read-only` and a read_api token's narrowed surface would both keep (make check-readonly-graphql)
 │   ├── audit_supply_chain/      # Audits five release-configuration invariants: SHA-pinned uses:, credentialed jobs that run no run-time-resolved code, stated Dependabot cooldowns, a current SECURITY.md, signature-verifying installers (make check-supply-chain)
@@ -723,6 +724,8 @@ Markdown formatters use a type-based registry in `internal/toolutil/md_registry.
 - `toolutil.MarkdownForResult(result any)` — looks up and invokes the registered formatter by `reflect.Type`
 - `internal/tools/markdown.go` is a thin delegator (~16 lines) that calls `toolutil.MarkdownForResult`
 - ~578 registrations across 166 sub-packages, validated by `TestAllMarkdownFormattersRegistered`
+
+A formatter escapes what it interpolates: `toolutil.EscapeMdTableCell` on every GitLab-authored string between two pipes of a table row and on every single-line list value, `toolutil.EscapeMdHeading` on the one value that lands in a heading, and `toolutil.MdTitleLink` on both halves of a link rather than hand-writing `[%s](%s)`. `make check-md-escaping` (`cmd/audit_md_escaping`) is the gate; a value that needs none is declared in its own package with `//gitlab:allow-unescaped <expression>: <reason>`, and a declaration that excuses nothing fails too.
 
 ### Dynamic toolset mode
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 	audit-output audit-tokens audit-tools audit-surface-quality audit-metrics audit-dynamic-aliases audit-test-names audit-godocs audit-godocs-check fix-godocs \
 	audit-struct-completeness audit-action-coverage audit-metadata-completeness audit-1to1 audit-1to1-sdk audit-1to1-enums audit-1to1-validate-docs audit-edition-tier \
 	audit-discovery audit-discovery-check audit-e2e-gaps audit-gateway-chars check-gateway-chars check-test-file-names audit-test-subtests check-test-subtests check-supply-chain \
+	audit-md-escaping check-md-escaping \
 	check-readonly-graphql audit-readonly-graphql \
 	audit-doc-coverage audit-doc-coverage-check \
 	gen-action-catalog-manifest check-action-catalog-manifest gen-llms check-llms gen-lhm-manifest check-lhm-manifest gen-icon-webp check-icon-webp check-server-json check-server-json-packages check-openplugin audit-doc-tool-names check-doc-tool-names check-install-buttons check-mcpb mcpb gen-npm sync-npm-version validate-npm validate-npm-local publish-npm-dry publish-npm gen-pypi validate-pypi validate-pypi-local publish-pypi-dry publish-pypi gen-nuget validate-nuget validate-nuget-local publish-nuget-dry publish-nuget publish-lobehub gen-readme gen-footprint check-footprint gen-stats check-stats gen-site-stats check-site-stats gen-testing-docs check-testing-docs update-all \
@@ -589,14 +590,15 @@ analyze:
 	echo "Go analysis packages: $(GO_ANALYSIS_PKGS)"; \
 	echo "Go analysis build tags: $(GO_ANALYSIS_TAGS)"; \
 	echo ""; \
-	run_check "[1/8] golangci-lint config verify" golangci-lint config verify; \
-	run_check "[2/8] golangci-lint fmt" golangci-lint fmt --diff; \
-	run_check "[3/8] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[4/8] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
-	run_check "[5/8] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
-	run_check "[6/8] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
-	run_check "[7/8] case loops without subtests" go run ./cmd/audit_test_subtests --check; \
-	run_check "[8/8] supply-chain policy" go run ./cmd/audit_supply_chain; \
+	run_check "[1/9] golangci-lint config verify" golangci-lint config verify; \
+	run_check "[2/9] golangci-lint fmt" golangci-lint fmt --diff; \
+	run_check "[3/9] golangci-lint run" golangci-lint run --build-tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[4/9] govulncheck" ./scripts/govulncheck.sh -tags $(GO_ANALYSIS_TAGS) $(GO_ANALYSIS_PKGS); \
+	run_check "[5/9] markdownlint" npx markdownlint-cli2 "**/*.md" "#plan"; \
+	run_check "[6/9] test-goroutine aborts" go run ./cmd/audit_test_goroutines --check; \
+	run_check "[7/9] case loops without subtests" go run ./cmd/audit_test_subtests --check; \
+	run_check "[8/9] supply-chain policy" go run ./cmd/audit_supply_chain; \
+	run_check "[9/9] Markdown escaping" go run ./cmd/audit_md_escaping --check; \
 	echo "============================================================"; \
 	if [ "$$analysis_status" -ne 0 ]; then \
 		echo "Analysis failed. Review findings above."; \
@@ -1219,6 +1221,20 @@ audit-test-subtests:
 ## subtest. CI gate.
 check-test-subtests:
 	go run ./cmd/audit_test_subtests/ -check
+
+## audit-md-escaping: report every value a Markdown formatter interpolates into
+## a table cell, a heading, a list item or a link without routing it through
+## toolutil.EscapeMdTableCell, EscapeMdHeading or MdTitleLink, with the JSON
+## work list. `-contexts` narrows the sweep to some of the five constructs;
+## `//gitlab:allow-unescaped <expression>: <reason>` in the owning package
+## declares a value that needs none.
+audit-md-escaping:
+	go run ./cmd/audit_md_escaping/ -v -json plan/md-escaping-backlog.json
+
+## check-md-escaping: fail when a value still reaches a Markdown construct
+## unescaped, or when a directive excuses nothing. CI gate.
+check-md-escaping:
+	go run ./cmd/audit_md_escaping/ -check
 
 ## audit-gateway-chars: report served descriptions and titles violating the
 ## gateway-safe text policy (pure ASCII prose, no semicolons), across every

--- a/README.md
+++ b/README.md
@@ -467,39 +467,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,168 |     239,762 |
-| Unit tests (`_test.go`)  |       672 |     396,266 |
-| End-to-end tests         |       243 |      64,277 |
-| **Total**                | **2,083** | **700,305** |
+| Source (`.go`, non-test) |     1,168 |     240,735 |
+| Unit tests (`_test.go`)  |       673 |     396,895 |
+| End-to-end tests         |       243 |      64,335 |
+| **Total**                | **2,084** | **701,965** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,962 |
-| . Exported (public)             |  2,886 |
-| . Unexported (private)          |  6,076 |
-| Unit test functions (`TestXxx`) | 13,761 |
-| Subtests (`t.Run(...)`)         |  5,383 |
-| End-to-end test functions       |    601 |
+| Source functions                |  8,968 |
+| . Exported (public)             |  2,890 |
+| . Unexported (private)          |  6,078 |
+| Unit test functions (`TestXxx`) | 13,771 |
+| Subtests (`t.Run(...)`)         |  5,394 |
+| End-to-end test functions       |    602 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
 | Test lines vs source lines         | 1.65× more tests than code |
-| Average source file length         |                 ~205 lines |
+| Average source file length         |                 ~206 lines |
 | Average test file length           |                 ~590 lines |
-| Comment lines in source            |  39,205 (~16.4% of source) |
+| Comment lines in source            |  40,092 (~16.7% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,464 |
+| `if err != nil` checks             | 7,468 |
 | `defer` statements                 | 1,313 |
-| `struct` types defined             | 2,984 |
+| `struct` types defined             | 2,987 |
 | `//nolint` suppressions            |   316 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -515,15 +515,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,625 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,400 lines |
+| Longest source file | `cmd/server/main.go`. 4,643 lines       |
+| Longest test file   | `cmd/server/main_test.go`. 10,455 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,359 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,802 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,377 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 14,269 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -467,39 +467,39 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,157 |     237,725 |
-| Unit tests (`_test.go`)  |       662 |     394,103 |
-| End-to-end tests         |       243 |      64,335 |
-| **Total**                | **2,062** | **696,163** |
+| Source (`.go`, non-test) |     1,168 |     239,762 |
+| Unit tests (`_test.go`)  |       672 |     396,266 |
+| End-to-end tests         |       243 |      64,277 |
+| **Total**                | **2,083** | **700,305** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  8,882 |
-| . Exported (public)             |  2,887 |
-| . Unexported (private)          |  5,995 |
-| Unit test functions (`TestXxx`) | 13,696 |
-| Subtests (`t.Run(...)`)         |  5,361 |
-| End-to-end test functions       |    602 |
+| Source functions                |  8,962 |
+| . Exported (public)             |  2,886 |
+| . Unexported (private)          |  6,076 |
+| Unit test functions (`TestXxx`) | 13,761 |
+| Subtests (`t.Run(...)`)         |  5,383 |
+| End-to-end test functions       |    601 |
 
 ### Ratios worth noting
 
 | Observation                        |                      Value |
 | ---------------------------------- | -------------------------: |
-| Test lines vs source lines         | 1.66× more tests than code |
+| Test lines vs source lines         | 1.65× more tests than code |
 | Average source file length         |                 ~205 lines |
-| Average test file length           |                 ~595 lines |
-| Comment lines in source            |  38,737 (~16.3% of source) |
+| Average test file length           |                 ~590 lines |
+| Comment lines in source            |  39,205 (~16.4% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,456 |
-| `defer` statements                 | 1,310 |
-| `struct` types defined             | 2,967 |
+| `if err != nil` checks             | 7,464 |
+| `defer` statements                 | 1,313 |
+| `struct` types defined             | 2,984 |
 | `//nolint` suppressions            |   316 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
@@ -507,7 +507,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Metric                         | Value |
 | ------------------------------ | ----: |
-| Go packages                    |   254 |
+| Go packages                    |   255 |
 | Direct dependencies (`go.mod`) |    31 |
 | Indirect dependencies          |    38 |
 
@@ -515,15 +515,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
-| Longest source file | `cmd/server/main.go`. 4,643 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,455 lines |
+| Longest source file | `cmd/server/main.go`. 4,625 lines       |
+| Longest test file   | `cmd/server/main_test.go`. 10,400 lines |
 
 ### Because why not
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,322 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 13,783 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,359 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 13,802 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,157 |     237,725 |
-| Unit tests (`_test.go`)  |       662 |     394,179 |
+| Unit tests (`_test.go`)  |       662 |     394,103 |
 | End-to-end tests         |       243 |      64,335 |
-| **Total**                | **2,062** | **696,239** |
+| **Total**                | **2,062** | **696,163** |
 
 ### Functions
 
@@ -479,8 +479,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  8,882 |
 | . Exported (public)             |  2,887 |
 | . Unexported (private)          |  5,995 |
-| Unit test functions (`TestXxx`) | 13,697 |
-| Subtests (`t.Run(...)`)         |  5,364 |
+| Unit test functions (`TestXxx`) | 13,696 |
+| Subtests (`t.Run(...)`)         |  5,361 |
 | End-to-end test functions       |    602 |
 
 ### Ratios worth noting
@@ -498,7 +498,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
 | `if err != nil` checks             | 7,456 |
-| `defer` statements                 | 1,312 |
+| `defer` statements                 | 1,310 |
 | `struct` types defined             | 2,967 |
 | `//nolint` suppressions            |   316 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |

--- a/cmd/audit_md_escaping/audit.go
+++ b/cmd/audit_md_escaping/audit.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"go/types"
+	"sort"
+)
+
+// Finding is one value reaching a Markdown construct with nothing between it
+// and the page.
+type Finding struct {
+	Package    string `json:"package"`
+	File       string `json:"file"`
+	Line       int    `json:"line"`
+	Func       string `json:"func"`
+	Context    string `json:"context"`
+	Verb       string `json:"verb"`
+	Expression string `json:"expression"`
+	Wants      string `json:"wants"`
+	Reason     string `json:"reason"`
+}
+
+// Report is the work list one run produces.
+type Report struct {
+	Findings []Finding `json:"findings"`
+	// Unresolved holds the values the audit could not follow to either
+	// answer. They are not failures by default and are not safe either: they
+	// are the audit's own blind spots, listed so they can be looked at.
+	Unresolved []Finding `json:"unresolved"`
+	// Excused holds the findings a source directive declared safe, so an
+	// exemption is reviewable rather than invisible.
+	Excused         []Finding   `json:"excused"`
+	StaleDirectives []Directive `json:"stale_directives"`
+	Summary         Summary     `json:"summary"`
+}
+
+// Summary aggregates what the sweep saw, including the two breakdowns the walk
+// through the findings is organized by.
+type Summary struct {
+	Contexts   string         `json:"contexts"`
+	Sinks      int            `json:"sinks"`
+	Holes      int            `json:"holes"`
+	Safe       int            `json:"safe"`
+	Findings   int            `json:"findings"`
+	Unresolved int            `json:"unresolved"`
+	Excused    int            `json:"excused"`
+	Stale      int            `json:"stale_directives"`
+	Packages   int            `json:"packages"`
+	ByContext  map[string]int `json:"findings_by_context"`
+	ByPackage  map[string]int `json:"findings_by_package"`
+}
+
+// audit classifies every value that lands in one of the selected Markdown
+// constructs and returns the work list.
+func audit(prog *program, sel selection, root string) Report {
+	c := newClassifier(prog)
+	directives := collectDirectives(prog, root)
+	used := make(map[directiveKey]bool, len(directives))
+	report := Report{Summary: Summary{Contexts: sel.label}}
+	for _, s := range collectSinks(prog) {
+		report.Summary.Sinks++
+		auditSink(prog, c, s, sel, root, directives, used, &report)
+	}
+	report.StaleDirectives = staleDirectives(directives, used)
+	finish(&report)
+	return report
+}
+
+// auditSink classifies every hole of one sink.
+func auditSink(prog *program, c *classifier, s sink, sel selection, root string,
+	directives map[directiveKey]Directive, used map[directiveKey]bool, report *Report,
+) {
+	for _, h := range s.holes {
+		if !sel.judges(h.ctx) {
+			continue
+		}
+		report.Summary.Holes++
+		got, why := c.classifyExpr(s.pkg, h.expr, nil, 0)
+		if got == safe {
+			report.Summary.Safe++
+			continue
+		}
+		finding := newFinding(prog, s, h, why, root)
+		key := directiveKey{pkg: finding.Package, expression: finding.Expression}
+		if _, excused := directives[key]; excused {
+			used[key] = true
+			report.Excused = append(report.Excused, finding)
+			continue
+		}
+		if got == unescaped {
+			report.Findings = append(report.Findings, finding)
+			continue
+		}
+		report.Unresolved = append(report.Unresolved, finding)
+	}
+}
+
+// finish counts and orders what the sweep collected, so two runs over one tree
+// produce the same work list.
+func finish(report *Report) {
+	sortFindings(report.Findings)
+	sortFindings(report.Unresolved)
+	sortFindings(report.Excused)
+	report.Summary.ByContext = map[string]int{}
+	report.Summary.ByPackage = map[string]int{}
+	packages := map[string]bool{}
+	for _, finding := range report.Findings {
+		report.Summary.ByContext[finding.Context]++
+		report.Summary.ByPackage[finding.Package]++
+		packages[finding.Package] = true
+	}
+	report.Summary.Findings = len(report.Findings)
+	report.Summary.Unresolved = len(report.Unresolved)
+	report.Summary.Excused = len(report.Excused)
+	report.Summary.Stale = len(report.StaleDirectives)
+	report.Summary.Packages = len(packages)
+}
+
+// newFinding renders one classified hole as a reportable finding.
+//
+// The expression is printed as go/types renders it, on one line, because a
+// finding has to name the value rather than a position: it is what the report
+// groups by, and what an exemption directive is written by copying.
+func newFinding(prog *program, s sink, h sinkHole, why, root string) Finding {
+	pos := prog.position(h.expr.Pos())
+	return Finding{
+		Package:    shortPackage(s.pkg.PkgPath),
+		File:       relativePath(pos.Filename, root),
+		Line:       pos.Line,
+		Func:       enclosingFunc(s.pkg, s.call.Pos()),
+		Context:    h.ctx.String(),
+		Verb:       h.verb,
+		Expression: types.ExprString(h.expr),
+		Wants:      h.ctx.wants(),
+		Reason:     why,
+	}
+}
+
+// sortFindings orders findings by package, file, line and expression.
+func sortFindings(findings []Finding) {
+	sort.Slice(findings, func(i, j int) bool {
+		return findingLess(findings[i], findings[j])
+	})
+}
+
+// findingLess is the order two runs of the audit have to agree on.
+func findingLess(a, b Finding) bool {
+	switch {
+	case a.Package != b.Package:
+		return a.Package < b.Package
+	case a.File != b.File:
+		return a.File < b.File
+	case a.Line != b.Line:
+		return a.Line < b.Line
+	default:
+		return a.Expression < b.Expression
+	}
+}
+
+// sortDirectives orders declared exemptions the way findings are ordered.
+func sortDirectives(directives []Directive) {
+	sort.Slice(directives, func(i, j int) bool {
+		if directives[i].File != directives[j].File {
+			return directives[i].File < directives[j].File
+		}
+		return directives[i].Line < directives[j].Line
+	})
+}

--- a/cmd/audit_md_escaping/audit.go
+++ b/cmd/audit_md_escaping/audit.go
@@ -52,45 +52,61 @@ type Summary struct {
 // audit classifies every value that lands in one of the selected Markdown
 // constructs and returns the work list.
 func audit(prog *program, sel selection, root string) Report {
-	c := newClassifier(prog)
-	directives := collectDirectives(prog, root)
-	used := make(map[directiveKey]bool, len(directives))
-	report := Report{Summary: Summary{Contexts: sel.label}}
-	for _, s := range collectSinks(prog) {
-		report.Summary.Sinks++
-		auditSink(prog, c, s, sel, root, directives, used, &report)
+	run := auditPass{
+		prog:       prog,
+		classifier: newClassifier(prog),
+		sel:        sel,
+		root:       root,
+		directives: collectDirectives(prog, root),
+		report:     Report{Summary: Summary{Contexts: sel.label}},
 	}
-	report.StaleDirectives = staleDirectives(directives, used)
-	finish(&report)
-	return report
+	run.used = make(map[directiveKey]bool, len(run.directives))
+	for _, s := range collectSinks(prog) {
+		run.report.Summary.Sinks++
+		run.auditSink(s)
+	}
+	run.report.StaleDirectives = staleDirectives(run.directives, run.used)
+	finish(&run.report)
+	return run.report
+}
+
+// auditPass is one pass over the program: everything the classification of a
+// hole consults, and the report it accumulates into. It exists so the per-sink
+// step reads as one step rather than as a signature.
+type auditPass struct {
+	prog       *program
+	classifier *classifier
+	sel        selection
+	root       string
+	directives map[directiveKey]Directive
+	used       map[directiveKey]bool
+	report     Report
 }
 
 // auditSink classifies every hole of one sink.
-func auditSink(prog *program, c *classifier, s sink, sel selection, root string,
-	directives map[directiveKey]Directive, used map[directiveKey]bool, report *Report,
-) {
+func (r *auditPass) auditSink(s sink) {
 	for _, h := range s.holes {
-		if !sel.judges(h.ctx) {
+		if !r.sel.judges(h.ctx) {
 			continue
 		}
-		report.Summary.Holes++
-		got, why := c.classifyExpr(s.pkg, h.expr, nil, 0)
+		r.report.Summary.Holes++
+		got, why := r.classifier.classifyExpr(s.pkg, h.expr, nil, 0)
 		if got == safe {
-			report.Summary.Safe++
+			r.report.Summary.Safe++
 			continue
 		}
-		finding := newFinding(prog, s, h, why, root)
+		finding := newFinding(r.prog, s, h, why, r.root)
 		key := directiveKey{pkg: finding.Package, expression: finding.Expression}
-		if _, excused := directives[key]; excused {
-			used[key] = true
-			report.Excused = append(report.Excused, finding)
+		if _, excused := r.directives[key]; excused {
+			r.used[key] = true
+			r.report.Excused = append(r.report.Excused, finding)
 			continue
 		}
 		if got == unescaped {
-			report.Findings = append(report.Findings, finding)
+			r.report.Findings = append(r.report.Findings, finding)
 			continue
 		}
-		report.Unresolved = append(report.Unresolved, finding)
+		r.report.Unresolved = append(r.report.Unresolved, finding)
 	}
 }
 

--- a/cmd/audit_md_escaping/audit_test.go
+++ b/cmd/audit_md_escaping/audit_test.go
@@ -83,6 +83,7 @@ var wantFindings = []string{
 	"mdcase table-cell *item.Author",
 	"mdcase table-cell []string{…}",
 	"mdcase table-cell cells",
+	"mdcase table-cell delegated(item)",
 	"mdcase table-cell item.Extra.(string)",
 	"mdcase table-cell item.State",
 	"mdcase table-cell item.Title",

--- a/cmd/audit_md_escaping/audit_test.go
+++ b/cmd/audit_md_escaping/audit_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// auditFixture runs the audit over the shared fixture with every context
+// judged.
+func auditFixture(t *testing.T) Report {
+	t.Helper()
+	prog := loadFixture(t, caseFixture)
+	sel, err := parseContexts(allContexts)
+	if err != nil {
+		t.Fatalf("parseContexts: %v", err)
+	}
+	return audit(prog, sel, repoRoot(t))
+}
+
+// entries renders the fixture's findings as "package context expression"
+// lines, which is what the tests below compare: a line is stable across edits
+// to the fixture in a way a file position is not.
+//
+// toolutil is loaded beside the fixture and has findings of its own, which
+// belong to the sweep rather than to this test, so they are filtered out here.
+func entries(findings []Finding) []string {
+	rendered := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		if !strings.HasPrefix(finding.Package, fixtureDir) {
+			continue
+		}
+		rendered = append(rendered, fmt.Sprintf("%s %s %s", shortName(finding.Package), finding.Context, finding.Expression))
+	}
+	sort.Strings(rendered)
+	return rendered
+}
+
+// shortName drops the fixture directory from a package path so a want list
+// reads as the package name alone.
+func shortName(pkg string) string {
+	if idx := strings.LastIndex(pkg, "/"); idx >= 0 {
+		return pkg[idx+1:]
+	}
+	return pkg
+}
+
+// diff reports what one list has that the other does not, in both directions.
+func diff(got, want []string) (missing, extra []string) {
+	inWant := map[string]int{}
+	for _, line := range want {
+		inWant[line]++
+	}
+	for _, line := range got {
+		if inWant[line] > 0 {
+			inWant[line]--
+			continue
+		}
+		extra = append(extra, line)
+	}
+	for line, count := range inWant {
+		for range count {
+			missing = append(missing, line)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
+}
+
+// wantFindings is every value the fixture leaves unescaped in a construct that
+// value can change the shape of.
+var wantFindings = []string{
+	"mdcase heading item.Title",
+	"mdcase link-destination item.URL",
+	"mdcase link-destination item.URL",
+	"mdcase link-label item.Title",
+	"mdcase link-label name",
+	"mdcase list-item item.Labels[0]",
+	"mdcase table-cell \"opened by \" + item.Title",
+	"mdcase table-cell (*(&item)).Title",
+	"mdcase table-cell *item.Author",
+	"mdcase table-cell []string{…}",
+	"mdcase table-cell cells",
+	"mdcase table-cell item.Extra.(string)",
+	"mdcase table-cell item.State",
+	"mdcase table-cell item.Title",
+	"mdcase table-cell item.Title + \" (open)\"",
+	"mdcase table-cell item.Title",
+	"mdcase table-cell item.Title[:8]",
+	"mdcase table-cell map[string]string{…}",
+	"mdcase table-cell name",
+	"mdcase table-cell pair.Right",
+	"mdcase table-cell repeat(item.Title, depth)",
+	"mdcase table-cell strings.Join([]string{…}, \", \")",
+	"mdcase table-cell title",
+	"mdexempt table-cell result.Title",
+}
+
+// wantUnresolved is every value the fixture writes in a shape the audit
+// answers with neither verdict.
+var wantUnresolved = []string{
+	"mdcase table-cell fmt.Sprintf(dynamicTemplate(), item.Title)",
+	"mdcase table-cell left",
+	"mdcase table-cell mutableTitle",
+	"mdcase table-cell namedResult(item)",
+	"mdcase table-cell pair.Left",
+	"mdcase table-cell render(item)",
+	"mdcase table-cell rest[0]",
+	"mdcase table-cell right",
+	"mdcase table-cell title",
+	"mdcase table-cell value",
+}
+
+// TestAudit_Fixture_ReportsEveryUnescapedValue is the audit's own regression
+// test: the fixture holds one of each shape the classifier has to answer for,
+// and this pins what it answered.
+func TestAudit_Fixture_ReportsEveryUnescapedValue(t *testing.T) {
+	report := auditFixture(t)
+
+	missing, extra := diff(entries(report.Findings), wantFindings)
+	for _, line := range missing {
+		t.Errorf("finding not reported: %s", line)
+	}
+	for _, line := range extra {
+		t.Errorf("unexpected finding: %s", line)
+	}
+}
+
+// TestAudit_Fixture_SeparatesTheValuesItCannotFollow checks that a value the
+// audit cannot follow lands in its own bucket rather than among the failures
+// or among the values it called safe.
+func TestAudit_Fixture_SeparatesTheValuesItCannotFollow(t *testing.T) {
+	report := auditFixture(t)
+
+	missing, extra := diff(entries(report.Unresolved), wantUnresolved)
+	for _, line := range missing {
+		t.Errorf("unresolved value not reported: %s", line)
+	}
+	for _, line := range extra {
+		t.Errorf("unexpected unresolved value: %s", line)
+	}
+}
+
+// TestAudit_Fixture_LeavesSafeValuesAlone checks that the package written the
+// way the rule asks produces no finding at all, which is what makes the gate
+// worth keeping.
+func TestAudit_Fixture_LeavesSafeValuesAlone(t *testing.T) {
+	report := auditFixture(t)
+
+	for _, finding := range append(append([]Finding{}, report.Findings...), report.Unresolved...) {
+		if strings.HasSuffix(finding.Package, "/mdsafe") {
+			t.Errorf("reported a safe value: %s %s (%s)", finding.Context, finding.Expression, finding.Reason)
+		}
+	}
+	if report.Summary.Safe == 0 {
+		t.Error("the sweep counted no safe value at all")
+	}
+}
+
+// TestAudit_Fixture_ExcusesDeclaredValuesAndReportsStaleDirectives checks both
+// halves of the exemption mechanism: a declared value leaves the failures, and
+// a directive that excuses nothing is itself reported.
+func TestAudit_Fixture_ExcusesDeclaredValuesAndReportsStaleDirectives(t *testing.T) {
+	report := auditFixture(t)
+
+	if got := entries(report.Excused); len(got) != 1 || got[0] != "mdexempt table-cell result.ID" {
+		t.Errorf("excused = %v, want the declared catalog ID alone", got)
+	}
+	if len(report.StaleDirectives) != 1 {
+		t.Fatalf("stale directives = %d, want the one that excuses nothing", len(report.StaleDirectives))
+	}
+	if report.StaleDirectives[0].Expression != "result.Retired" {
+		t.Errorf("stale directive names %q, want result.Retired", report.StaleDirectives[0].Expression)
+	}
+	if report.StaleDirectives[0].Line == 0 || !strings.HasSuffix(report.StaleDirectives[0].File, "mdexempt.go") {
+		t.Errorf("stale directive at %s:%d does not point at the source that declared it",
+			report.StaleDirectives[0].File, report.StaleDirectives[0].Line)
+	}
+}
+
+// TestAudit_Fixture_NamesTheCallSiteThatPassesARawValue checks the rule that
+// keeps a shared row helper quiet: the helper is judged by what its callers
+// pass, and the reason says which call site made it fail.
+func TestAudit_Fixture_NamesTheCallSiteThatPassesARawValue(t *testing.T) {
+	report := auditFixture(t)
+
+	for _, finding := range report.Findings {
+		if finding.Expression != "title" {
+			continue
+		}
+		if !strings.Contains(finding.Reason, "call site of FormatRow") {
+			t.Errorf("reason %q does not name the call site the raw value came from", finding.Reason)
+		}
+		if finding.Func != "FormatRow" {
+			t.Errorf("finding names %q, want the formatter holding the hole", finding.Func)
+		}
+		return
+	}
+	t.Error("the shared row helper was not reported at all")
+}
+
+// TestAudit_Fixture_SummarisesWhatItSaw checks the counts a report ends with,
+// which are what the walk through the findings is planned from.
+func TestAudit_Fixture_SummarisesWhatItSaw(t *testing.T) {
+	report := auditFixture(t)
+	summary := report.Summary
+
+	if summary.Findings != len(report.Findings) || summary.Unresolved != len(report.Unresolved) ||
+		summary.Excused != len(report.Excused) || summary.Stale != len(report.StaleDirectives) {
+		t.Errorf("summary counts %+v disagree with the lists they count", summary)
+	}
+	if summary.Packages < 2 {
+		t.Errorf("summary counts %d packages with findings, want at least mdcase and mdexempt", summary.Packages)
+	}
+	if summary.Holes <= summary.Findings || summary.Sinks == 0 {
+		t.Errorf("summary judged %d value(s) in %d sink(s), which cannot hold %d findings",
+			summary.Holes, summary.Sinks, summary.Findings)
+	}
+	if summary.ByContext["table-cell"] == 0 || summary.ByPackage[fixtureDir+"/mdcase"] == 0 {
+		t.Errorf("summary breakdowns %v / %v are missing the packages that failed", summary.ByContext, summary.ByPackage)
+	}
+	if summary.Contexts != "table-cell, heading, list-item, link-label, link-destination" {
+		t.Errorf("summary names contexts %q, want every structural one", summary.Contexts)
+	}
+}
+
+// TestAudit_Fixture_NarrowedToOneContext_JudgesOnlyThat checks that staging the
+// sweep by context leaves the other contexts unjudged rather than passed.
+func TestAudit_Fixture_NarrowedToOneContext_JudgesOnlyThat(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	sel, err := parseContexts("heading")
+	if err != nil {
+		t.Fatalf("parseContexts: %v", err)
+	}
+
+	report := audit(prog, sel, repoRoot(t))
+
+	for _, finding := range report.Findings {
+		if finding.Context != "heading" {
+			t.Errorf("a narrowed run reported a %s finding: %s", finding.Context, finding.Expression)
+		}
+	}
+	if len(report.Findings) == 0 {
+		t.Error("a narrowed run reported nothing at all")
+	}
+}
+
+// TestAudit_Fixture_IsDeterministic checks that two runs produce the same work
+// list, since a gate whose output moves cannot be reviewed in a diff.
+func TestAudit_Fixture_IsDeterministic(t *testing.T) {
+	first := auditFixture(t)
+	second := auditFixture(t)
+
+	if got, want := strings.Join(entries(first.Findings), "\n"), strings.Join(entries(second.Findings), "\n"); got != want {
+		t.Errorf("two runs disagree:\n%s\n---\n%s", got, want)
+	}
+}
+
+// TestFindingLess_Cases_OrdersByPackageFileLineExpression checks the order two
+// runs have to agree on, field by field.
+func TestFindingLess_Cases_OrdersByPackageFileLineExpression(t *testing.T) {
+	base := Finding{Package: "b", File: "b.go", Line: 2, Expression: "b"}
+	cases := []struct {
+		name  string
+		other Finding
+		want  bool
+	}{
+		{name: "earlier package", other: Finding{Package: "a", File: "z.go", Line: 9, Expression: "z"}, want: true},
+		{name: "later package", other: Finding{Package: "c"}, want: false},
+		{name: "earlier file", other: Finding{Package: "b", File: "a.go", Line: 9, Expression: "z"}, want: true},
+		{name: "later file", other: Finding{Package: "b", File: "c.go"}, want: false},
+		{name: "earlier line", other: Finding{Package: "b", File: "b.go", Line: 1, Expression: "z"}, want: true},
+		{name: "later line", other: Finding{Package: "b", File: "b.go", Line: 3}, want: false},
+		{name: "earlier expression", other: Finding{Package: "b", File: "b.go", Line: 2, Expression: "a"}, want: true},
+		{name: "later expression", other: Finding{Package: "b", File: "b.go", Line: 2, Expression: "c"}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := findingLess(tc.other, base); got != tc.want {
+				t.Errorf("findingLess(%+v, %+v) = %v, want %v", tc.other, base, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSortDirectives_TwoDirectives_OrdersByFileThenLine checks that stale
+// exemptions are listed in source order.
+func TestSortDirectives_TwoDirectives_OrdersByFileThenLine(t *testing.T) {
+	directives := []Directive{
+		{File: "b.go", Line: 1},
+		{File: "a.go", Line: 9},
+		{File: "a.go", Line: 2},
+	}
+
+	sortDirectives(directives)
+
+	var order []string
+	for _, directive := range directives {
+		order = append(order, fmt.Sprintf("%s:%d", directive.File, directive.Line))
+	}
+	if got, want := strings.Join(order, " "), "a.go:2 a.go:9 b.go:1"; got != want {
+		t.Errorf("directives ordered %s, want %s", got, want)
+	}
+}

--- a/cmd/audit_md_escaping/classify.go
+++ b/cmd/audit_md_escaping/classify.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// verdict is what the classifier concluded about one value reaching a Markdown
+// construct.
+type verdict int
+
+const (
+	// safe means the value cannot carry a character that changes the
+	// document's shape, either because of what it is or because it has already
+	// been through an escaper.
+	safe verdict = iota
+	// unescaped means the value is text this server did not write and no
+	// escaper stands between it and the page.
+	unescaped
+	// unresolved means the classifier could not follow the value to either
+	// answer. It is reported separately: a gate that silently counted these as
+	// safe would be a gate with a hole in it.
+	unresolved
+)
+
+// escapers are the toolutil functions whose result is safe to interpolate.
+// Each neutralizes a superset of what the weakest construct needs, so a value
+// that has been through any of them is safe in any context.
+//
+// StripControlBytes is deliberately absent. It drops the C0 and C1 bytes and
+// leaves both the pipe and the angle bracket, so accepting it as an answer
+// would pass exactly the values this audit exists to find.
+var escapers = map[string]bool{
+	"EscapeMdTableCell":       true,
+	"EscapeMdHeading":         true,
+	"EscapeMdLinkLabel":       true,
+	"EscapeMdLinkDestination": true,
+	"MdTitleLink":             true,
+	"FormatTarget":            true,
+	"WrapGFMBody":             true,
+}
+
+// externalSafe names functions outside the audited packages whose result
+// cannot carry GitLab-authored text. Their bodies are not loaded, so they are
+// judged by what they are documented to return: a number's decimal form, a
+// duration, a formatted instant.
+var externalSafe = map[string]bool{
+	"strconv.Itoa":         true,
+	"strconv.FormatInt":    true,
+	"strconv.FormatUint":   true,
+	"strconv.FormatFloat":  true,
+	"strconv.FormatBool":   true,
+	"time.Time.Format":     true,
+	"time.Time.String":     true,
+	"time.Duration.String": true,
+}
+
+// passThroughArgs names functions outside the audited packages whose result is
+// made of the arguments listed, so the question passes to those arguments
+// instead of stopping at a body the audit never loaded.
+//
+// It is what lets the escaping helpers be recognized through the transforms
+// wrapped around them: the prompts package renders a value as
+// DefuseHintsHeading(EscapeMdTableCell(s)), and DefuseHintsHeading is a
+// strings.ReplaceAll of its argument.
+var passThroughArgs = map[string][]int{
+	"strings.Join":       {0},
+	"strings.Map":        {1},
+	"strings.Repeat":     {0},
+	"strings.Replace":    {0, 2},
+	"strings.ReplaceAll": {0, 2},
+	"strings.ToLower":    {0},
+	"strings.ToTitle":    {0},
+	"strings.ToUpper":    {0},
+	"strings.Trim":       {0},
+	"strings.TrimLeft":   {0},
+	"strings.TrimPrefix": {0},
+	"strings.TrimRight":  {0},
+	"strings.TrimSpace":  {0},
+	"strings.TrimSuffix": {0},
+}
+
+// classifier answers whether one expression can carry text that changes the
+// shape of the Markdown around it.
+type classifier struct {
+	prog *program
+	// assigns maps a local variable to every expression assigned to it, so a
+	// value escaped into a variable and then written is recognized.
+	assigns map[*types.Var][]ast.Expr
+	// pkgOf maps an assigned expression to the package it was written in, so
+	// it is resolved against its own type information.
+	pkgOf map[ast.Expr]*packages.Package
+	// params maps a parameter to the function that declares it and its
+	// position in the signature, which is how a parameter with no binding is
+	// resolved to what every caller passes.
+	params map[*types.Var]paramRef
+	// fieldWritten records the variables a field was assigned on. Such a
+	// variable no longer answers for its fields through the literal that
+	// built it: a struct built empty and filled afterwards would otherwise
+	// read as one that left every field at its zero value, which is the one
+	// way this audit could call a raw value safe.
+	fieldWritten map[*types.Var]bool
+	// returnMemo caches a declared function's verdict, for the calls whose
+	// answer does not depend on what the caller passed.
+	returnMemo map[resultKey]verdict
+	// inProgress guards the recursion against a function that reaches itself.
+	inProgress map[resultKey]bool
+	// inVar guards it against a variable assigned from itself.
+	inVar map[*types.Var]bool
+	// bindHits counts how often a parameter was answered from a caller's
+	// argument. A result reached through one is not cached, because it holds
+	// for that call site rather than for the function.
+	bindHits int
+}
+
+// paramRef is one parameter: the function that declares it and its index in
+// the flattened parameter list.
+type paramRef struct {
+	fn    *types.Func
+	index int
+}
+
+// resultKey names one result of one declared function.
+type resultKey struct {
+	fn    *types.Func
+	index int
+}
+
+// env binds a called function's parameters to the expressions its caller
+// passed, together with the environment those expressions are meaningful in.
+//
+// It is what makes a finding belong to a call site. toolutil.FormatTime
+// returns its argument verbatim when neither layout parses, and it is called
+// from about a hundred and fifty places: without a binding, the one caller
+// that passes an unescaped field would condemn every other caller too, and the
+// report would name the wrong lines.
+type env struct {
+	binds map[*types.Var]bound
+}
+
+// bound is one argument a caller passed, kept with everything needed to judge
+// it where it was written.
+type bound struct {
+	expr ast.Expr
+	pkg  *packages.Package
+	env  *env
+}
+
+// lookup returns the argument bound to v, if this environment binds it.
+func (e *env) lookup(v *types.Var) (bound, bool) {
+	if e == nil || e.binds == nil {
+		return bound{}, false
+	}
+	b, ok := e.binds[v]
+	return b, ok
+}
+
+// newClassifier indexes every local assignment and parameter in the loaded
+// packages.
+func newClassifier(prog *program) *classifier {
+	c := &classifier{
+		prog:         prog,
+		assigns:      make(map[*types.Var][]ast.Expr),
+		pkgOf:        make(map[ast.Expr]*packages.Package),
+		params:       make(map[*types.Var]paramRef),
+		fieldWritten: make(map[*types.Var]bool),
+		returnMemo:   make(map[resultKey]verdict),
+		inProgress:   make(map[resultKey]bool),
+		inVar:        make(map[*types.Var]bool),
+	}
+	for _, pkg := range prog.order {
+		c.indexPackage(pkg)
+	}
+	return c
+}
+
+// indexPackage records the assignments and parameters of one package.
+func (c *classifier) indexPackage(pkg *packages.Package) {
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.AssignStmt:
+				c.indexAssign(pkg, typed)
+			case *ast.ValueSpec:
+				c.indexValueSpec(pkg, typed)
+			case *ast.RangeStmt:
+				c.indexRange(pkg, typed)
+			}
+			return true
+		})
+	}
+	for obj, decl := range c.prog.decls {
+		if decl.pkg != pkg {
+			continue
+		}
+		c.indexParams(pkg, obj, decl.decl)
+	}
+}
+
+// indexAssign records the right-hand sides of an assignment against the
+// variables they land in.
+//
+// A multi-value call assigned to several names is recorded as an unfollowable
+// assignment rather than skipped, so a variable that receives one is reported
+// unresolved instead of being judged on its other assignments alone.
+func (c *classifier) indexAssign(pkg *packages.Package, stmt *ast.AssignStmt) {
+	if len(stmt.Lhs) != len(stmt.Rhs) {
+		c.indexUnbalancedAssign(pkg, stmt)
+		return
+	}
+	for i, lhs := range stmt.Lhs {
+		c.noteFieldWrite(pkg, lhs)
+		if v := c.localVar(pkg, lhs); v != nil {
+			c.assigns[v] = append(c.assigns[v], stmt.Rhs[i])
+			c.pkgOf[stmt.Rhs[i]] = pkg
+		}
+	}
+}
+
+// noteFieldWrite records that a field was assigned on a variable, when the
+// assignment target is a field of one.
+func (c *classifier) noteFieldWrite(pkg *packages.Package, lhs ast.Expr) {
+	sel, ok := ast.Unparen(lhs).(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	base, ok := ast.Unparen(sel.X).(*ast.Ident)
+	if !ok {
+		return
+	}
+	if v, isVar := pkg.TypesInfo.Uses[base].(*types.Var); isVar {
+		c.fieldWritten[v] = true
+	}
+}
+
+// indexRange records a loop's key and value variables against the collection
+// they come from, so a value interpolated straight out of a range is judged by
+// what it was ranged over.
+func (c *classifier) indexRange(pkg *packages.Package, stmt *ast.RangeStmt) {
+	for _, target := range []ast.Expr{stmt.Key, stmt.Value} {
+		if target == nil {
+			continue
+		}
+		if v := c.localVar(pkg, target); v != nil {
+			c.assigns[v] = append(c.assigns[v], stmt.X)
+			c.pkgOf[stmt.X] = pkg
+		}
+	}
+}
+
+// indexUnbalancedAssign records an assignment whose right-hand side does not
+// line up with its left.
+//
+// The comma-ok forms are followed, because the value they produce is the
+// element the operand holds: a lookup in a table of status emoji answers for
+// the string it yields. Everything else is recorded as an assignment the audit
+// cannot follow, so a variable that receives one is reported unresolved rather
+// than judged on its other assignments alone.
+func (c *classifier) indexUnbalancedAssign(pkg *packages.Package, stmt *ast.AssignStmt) {
+	value := ast.Expr(nil)
+	if len(stmt.Lhs) == 2 && len(stmt.Rhs) == 1 && commaOK(stmt.Rhs[0]) {
+		value = stmt.Rhs[0]
+		c.pkgOf[value] = pkg
+	}
+	for i, lhs := range stmt.Lhs {
+		v := c.localVar(pkg, lhs)
+		if v == nil {
+			continue
+		}
+		if i == 0 {
+			c.assigns[v] = append(c.assigns[v], value)
+			continue
+		}
+		c.assigns[v] = append(c.assigns[v], nil)
+	}
+}
+
+// commaOK reports whether an operand is one of the forms that yield a value
+// and a boolean: a map index, a type assertion or a channel receive.
+func commaOK(expr ast.Expr) bool {
+	switch typed := ast.Unparen(expr).(type) {
+	case *ast.IndexExpr, *ast.TypeAssertExpr:
+		return true
+	case *ast.UnaryExpr:
+		return typed.Op == token.ARROW
+	default:
+		return false
+	}
+}
+
+// indexValueSpec records the initialisers of a var declaration. A declaration
+// with no initialiser leaves the variable holding whatever a later assignment
+// put there, which the assignments above cover, so the zero value is recorded
+// as unfollowable rather than as safe.
+func (c *classifier) indexValueSpec(pkg *packages.Package, spec *ast.ValueSpec) {
+	if len(spec.Values) == 0 {
+		for _, name := range spec.Names {
+			if v := c.localVar(pkg, name); v != nil {
+				c.assigns[v] = append(c.assigns[v], nil)
+			}
+		}
+		return
+	}
+	if len(spec.Names) != len(spec.Values) {
+		return
+	}
+	for i, name := range spec.Names {
+		if v := c.localVar(pkg, name); v != nil {
+			c.assigns[v] = append(c.assigns[v], spec.Values[i])
+			c.pkgOf[spec.Values[i]] = pkg
+		}
+	}
+}
+
+// indexParams records each parameter of a declared function against its
+// position, so a parameter no caller bound can still be resolved to the
+// arguments every caller passes.
+func (c *classifier) indexParams(pkg *packages.Package, obj *types.Func, decl *ast.FuncDecl) {
+	index := 0
+	for _, field := range decl.Type.Params.List {
+		if len(field.Names) == 0 {
+			index++
+			continue
+		}
+		for _, name := range field.Names {
+			if v, ok := pkg.TypesInfo.Defs[name].(*types.Var); ok {
+				c.params[v] = paramRef{fn: obj, index: index}
+			}
+			index++
+		}
+	}
+}
+
+// localVar returns the variable an assignment target names, when that target is
+// a plain identifier bound to a variable the classifier can follow. A field, an
+// index and the blank identifier are all skipped: none of them is a value the
+// classifier can follow backwards, and a struct field is where it stops
+// looking by design.
+//
+// A package-level variable is followed like a local one, so a formatter
+// interpolating a package's own default label is answered by the literal that
+// declared it rather than reported as a value nobody assigns.
+func (c *classifier) localVar(pkg *packages.Package, expr ast.Expr) *types.Var {
+	ident, ok := expr.(*ast.Ident)
+	if !ok || ident.Name == "_" {
+		return nil
+	}
+	obj := pkg.TypesInfo.Defs[ident]
+	if obj == nil {
+		obj = pkg.TypesInfo.Uses[ident]
+	}
+	v, ok := obj.(*types.Var)
+	if !ok || v.Parent() == nil {
+		return nil
+	}
+	return v
+}

--- a/cmd/audit_md_escaping/classify_test.go
+++ b/cmd/audit_md_escaping/classify_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+)
+
+// fixtureClassifier builds the classifier over the shared fixture.
+func fixtureClassifier(t *testing.T) *classifier {
+	t.Helper()
+	return newClassifier(loadFixture(t, caseFixture))
+}
+
+// assignedNames renders what the classifier recorded for the fixture's
+// variables: the variable's name against the expressions it holds, with an
+// assignment the audit cannot follow written as a dash.
+func assignedNames(t *testing.T, c *classifier) map[string][]string {
+	t.Helper()
+	recorded := map[string][]string{}
+	for v, exprs := range c.assigns {
+		if !strings.Contains(v.Pkg().Path(), fixtureDir) {
+			continue
+		}
+		for _, expr := range exprs {
+			if expr == nil {
+				recorded[v.Name()] = append(recorded[v.Name()], "-")
+				continue
+			}
+			recorded[v.Name()] = append(recorded[v.Name()], types.ExprString(expr))
+		}
+	}
+	return recorded
+}
+
+// TestNewClassifier_Fixture_RecordsWhereAValueCanComeFrom checks each way the
+// classifier learns what a variable holds, since a shape it does not index is
+// a value it cannot follow.
+func TestNewClassifier_Fixture_RecordsWhereAValueCanComeFrom(t *testing.T) {
+	recorded := assignedNames(t, fixtureClassifier(t))
+
+	cases := []struct {
+		name     string
+		variable string
+		want     []string
+	}{
+		// go/types abbreviates a composite literal, which is what a finding
+		// prints too: the value is named by the variable holding it.
+		{name: "a short variable declaration", variable: "cells", want: []string{"[]string{…}"}},
+		{name: "an escaped local reassigned from itself", variable: "name", want: []string{
+			"toolutil.EscapeMdTableCell(item.Title)", "fmt.Sprintf(\"[%s](%s)\", name, item.URL)",
+		}},
+		{name: "a declaration with no value", variable: "mutableTitle", want: []string{"-"}},
+		{name: "the value half of a comma-ok lookup", variable: "icon", want: []string{"icons[item.Title]"}},
+		{name: "a result the audit cannot follow", variable: "value", want: []string{"-"}},
+		{name: "a package-level table", variable: "icons", want: []string{"map[string]string{…}"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := recorded[tc.variable]
+			if len(got) != len(tc.want) {
+				t.Fatalf("%s holds %v, want %v", tc.variable, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("%s holds %q at %d, want %q", tc.variable, got[i], i, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNewClassifier_Fixture_RecordsFieldWrites checks the guard that keeps a
+// struct filled after it was built from answering through the empty literal
+// that built it.
+func TestNewClassifier_Fixture_RecordsFieldWrites(t *testing.T) {
+	c := fixtureClassifier(t)
+
+	var found bool
+	for v := range c.fieldWritten {
+		if v.Name() == "pair" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no field write was recorded for the struct the fixture fills after building it")
+	}
+}
+
+// TestNewClassifier_Fixture_RecordsParameters checks that a parameter is
+// indexed against its position, which is what lets it be resolved to the
+// arguments callers pass.
+func TestNewClassifier_Fixture_RecordsParameters(t *testing.T) {
+	c := fixtureClassifier(t)
+
+	positions := map[string]int{}
+	for v, ref := range c.params {
+		if ref.fn.Name() == "FormatVariadic" {
+			positions[v.Name()] = ref.index
+		}
+	}
+	if positions["prefix"] != 0 || positions["rest"] != 1 {
+		t.Errorf("FormatVariadic parameters indexed as %v, want prefix at 0 and rest at 1", positions)
+	}
+}
+
+// TestCommaOK_Operands_RecognisesTheTwoValueForms checks which right-hand
+// sides yield a value the audit can follow and which do not.
+func TestCommaOK_Operands_RecognisesTheTwoValueForms(t *testing.T) {
+	cases := []struct {
+		name string
+		expr ast.Expr
+		want bool
+	}{
+		{name: "a map or slice index", expr: &ast.IndexExpr{X: ast.NewIdent("m"), Index: ast.NewIdent("k")}, want: true},
+		{name: "a type assertion", expr: &ast.TypeAssertExpr{X: ast.NewIdent("v")}, want: true},
+		{name: "a channel receive", expr: &ast.UnaryExpr{Op: token.ARROW, X: ast.NewIdent("ch")}, want: true},
+		{name: "an address-of is not one", expr: &ast.UnaryExpr{Op: token.AND, X: ast.NewIdent("v")}, want: false},
+		{name: "a call is not one", expr: &ast.CallExpr{Fun: ast.NewIdent("f")}, want: false},
+		{name: "a parenthesised index still is", expr: &ast.ParenExpr{X: &ast.IndexExpr{X: ast.NewIdent("m")}}, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commaOK(tc.expr); got != tc.want {
+				t.Errorf("commaOK(%T) = %v, want %v", tc.expr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLocalVar_Fixture_SkipsWhatCannotBeFollowed checks the targets the
+// classifier refuses to record: the blank identifier, a field, and an index.
+func TestLocalVar_Fixture_SkipsWhatCannotBeFollowed(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg := fixturePackage(t, prog, "mdcase")
+
+	cases := []struct {
+		name string
+		expr ast.Expr
+	}{
+		{name: "the blank identifier", expr: ast.NewIdent("_")},
+		{name: "a field", expr: &ast.SelectorExpr{X: ast.NewIdent("pair"), Sel: ast.NewIdent("Left")}},
+		{name: "an index", expr: &ast.IndexExpr{X: ast.NewIdent("cells")}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.localVar(pkg, tc.expr); got != nil {
+				t.Errorf("localVar recorded %s as %v", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestEscapers_Set_RefusesStripControlBytes checks the one helper that must
+// not be read as an answer: it drops the control bytes and leaves both the
+// pipe and the angle bracket, so accepting it would pass exactly the values
+// this audit exists to find.
+func TestEscapers_Set_RefusesStripControlBytes(t *testing.T) {
+	if escapers["StripControlBytes"] {
+		t.Error("StripControlBytes is accepted as an escaper")
+	}
+	for _, name := range []string{"EscapeMdTableCell", "EscapeMdHeading", "MdTitleLink"} {
+		t.Run(name, func(t *testing.T) {
+			if !escapers[name] {
+				t.Errorf("%s is not accepted as an escaper", name)
+			}
+		})
+	}
+}

--- a/cmd/audit_md_escaping/context.go
+++ b/cmd/audit_md_escaping/context.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// mdContext is where in a Markdown document a value lands, which decides both
+// whether it needs escaping and which helper is the right one.
+type mdContext int
+
+const (
+	// ctxProse is a paragraph. A pipe means nothing there and a newline is
+	// legal, so only a heading or a list marker at the start of a line would
+	// change the document's structure, and neither can be typed mid-line.
+	ctxProse mdContext = iota
+	// ctxCell is between two pipes of a table row.
+	ctxCell
+	// ctxHeading is on a line that opens with one to six '#'.
+	ctxHeading
+	// ctxListItem is on a line that opens with a bullet or an ordered marker.
+	ctxListItem
+	// ctxLinkLabel is between '[' and the '](' that closes the label.
+	ctxLinkLabel
+	// ctxLinkDest is between '](' and the ')' that closes the destination.
+	ctxLinkDest
+)
+
+// structuralContexts are the contexts a value can change the shape of, in the
+// order a report lists them. Prose is absent because a paragraph holds a pipe,
+// an angle bracket and a newline without the document changing shape, and the
+// formatters that render GitLab-authored prose route it through WrapGFMBody.
+var structuralContexts = []mdContext{ctxCell, ctxHeading, ctxListItem, ctxLinkLabel, ctxLinkDest}
+
+// contextLabels name each context for the command line and for a report.
+var contextLabels = map[mdContext]string{
+	ctxProse:     "prose",
+	ctxCell:      "table-cell",
+	ctxHeading:   "heading",
+	ctxListItem:  "list-item",
+	ctxLinkLabel: "link-label",
+	ctxLinkDest:  "link-destination",
+}
+
+// String names the context for a report.
+func (c mdContext) String() string {
+	if label, ok := contextLabels[c]; ok {
+		return label
+	}
+	return "prose"
+}
+
+// wants names the helper that belongs in this context, which is what a finding
+// tells its reader to reach for.
+func (c mdContext) wants() string {
+	switch c {
+	case ctxCell, ctxListItem:
+		return "toolutil.EscapeMdTableCell"
+	case ctxHeading:
+		return "toolutil.EscapeMdHeading"
+	case ctxLinkLabel, ctxLinkDest:
+		return "toolutil.MdTitleLink"
+	default:
+		return ""
+	}
+}
+
+// structural reports whether a value landing in this context can change the
+// shape of the document around it rather than only its own text.
+func (c mdContext) structural() bool {
+	return c != ctxProse
+}
+
+// allContexts is the value of -contexts that judges every structural context.
+const allContexts = "all"
+
+// selection is the set of contexts one run judges. Staging the sweep by
+// context is a flag rather than a branch because the four contexts carry
+// genuinely different strengths of claim: a raw value ends a table cell
+// outright, while in a list item it costs the containment and a line break.
+type selection struct {
+	chosen map[mdContext]bool
+	label  string
+}
+
+// judges reports whether this run judges values landing in c.
+func (s selection) judges(c mdContext) bool {
+	return c.structural() && s.chosen[c]
+}
+
+// contextNames lists the accepted -contexts values, for the flag's own help
+// and for the error a wrong one produces.
+func contextNames() string {
+	names := make([]string, 0, len(structuralContexts))
+	for _, c := range structuralContexts {
+		names = append(names, c.String())
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// parseContexts turns the -contexts value into the set of contexts to judge.
+//
+// An unknown name is an error rather than an empty selection, because a
+// misspelled context would otherwise read as a gate that passed.
+func parseContexts(value string) (selection, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == allContexts {
+		chosen := make(map[mdContext]bool, len(structuralContexts))
+		labels := make([]string, 0, len(structuralContexts))
+		for _, c := range structuralContexts {
+			chosen[c] = true
+			labels = append(labels, c.String())
+		}
+		return selection{chosen: chosen, label: strings.Join(labels, ", ")}, nil
+	}
+	chosen := map[mdContext]bool{}
+	var labels []string
+	for name := range strings.SplitSeq(value, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		ctx, ok := contextNamed(name)
+		if !ok {
+			return selection{}, fmt.Errorf("unknown Markdown context %q: expected %s, or %s", name, allContexts, contextNames())
+		}
+		if !chosen[ctx] {
+			labels = append(labels, ctx.String())
+		}
+		chosen[ctx] = true
+	}
+	if len(chosen) == 0 {
+		return selection{}, fmt.Errorf("no Markdown context selected: expected %s, or %s", allContexts, contextNames())
+	}
+	return selection{chosen: chosen, label: strings.Join(labels, ", ")}, nil
+}
+
+// contextNamed resolves a context by the name a report prints for it.
+func contextNamed(name string) (mdContext, bool) {
+	for _, c := range structuralContexts {
+		if c.String() == name {
+			return c, true
+		}
+	}
+	return ctxProse, false
+}
+
+// contextAt classifies the Markdown context of the hole at offset within
+// template.
+//
+// The line the hole sits on is what decides it, because every Markdown
+// construct this audit cares about is a line-level one: a table row, a heading
+// and a list item are each recognized by how their line opens. A link is
+// looked for on the line as well, since a link written across two lines is not
+// a link.
+func contextAt(template string, offset int) mdContext {
+	lineStart := strings.LastIndexByte(template[:offset], '\n') + 1
+	before := template[lineStart:offset]
+	if ctx, ok := linkContext(before); ok {
+		return ctx
+	}
+	opening := strings.TrimLeft(before, " \t")
+	switch {
+	case strings.HasPrefix(opening, "|"):
+		return ctxCell
+	case headingPrefix(opening):
+		return ctxHeading
+	case listPrefix(opening):
+		return ctxListItem
+	default:
+		return ctxProse
+	}
+}
+
+// linkContext reports whether the text before the hole leaves it inside a
+// Markdown link, and in which half.
+//
+// The scan is over the unclosed brackets on the line: a hole after a '[' that
+// nothing has closed is in a label, and a hole after the '](' that closed one
+// is in a destination until the ')' arrives.
+func linkContext(before string) (mdContext, bool) {
+	label := strings.LastIndex(before, "[")
+	if label < 0 {
+		return ctxProse, false
+	}
+	rest := before[label:]
+	_, destination, closed := strings.Cut(rest, "](")
+	if !closed {
+		// The label is still open, unless a lone ']' already ended it without
+		// opening a destination, which is not a link at all.
+		if strings.Contains(rest, "]") {
+			return ctxProse, false
+		}
+		return ctxLinkLabel, true
+	}
+	if strings.Contains(destination, ")") {
+		return ctxProse, false
+	}
+	return ctxLinkDest, true
+}
+
+// headingPrefix reports whether a line opens an ATX heading: one to six '#'
+// followed by a space, which is what CommonMark requires.
+func headingPrefix(opening string) bool {
+	hashes := 0
+	for hashes < len(opening) && opening[hashes] == '#' {
+		hashes++
+	}
+	if hashes == 0 || hashes > 6 {
+		return false
+	}
+	return hashes < len(opening) && (opening[hashes] == ' ' || opening[hashes] == '\t')
+}
+
+// listPrefix reports whether a line opens a list item, bulleted or ordered.
+func listPrefix(opening string) bool {
+	if len(opening) >= 2 && strings.IndexByte("-*+", opening[0]) >= 0 && opening[1] == ' ' {
+		return true
+	}
+	digits := 0
+	for digits < len(opening) && opening[digits] >= '0' && opening[digits] <= '9' {
+		digits++
+	}
+	if digits == 0 || digits+1 >= len(opening) {
+		return false
+	}
+	return (opening[digits] == '.' || opening[digits] == ')') && opening[digits+1] == ' '
+}

--- a/cmd/audit_md_escaping/context_test.go
+++ b/cmd/audit_md_escaping/context_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestContextAt_Templates_ClassifiesTheConstructTheHoleSitsIn covers each
+// construct the audit judges and the prose it skips, including the shapes that
+// look like a construct and are not.
+func TestContextAt_Templates_ClassifiesTheConstructTheHoleSitsIn(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		want     mdContext
+	}{
+		{name: "table cell", template: "| %s |", want: ctxCell},
+		{name: "indented table cell", template: "  | %s |", want: ctxCell},
+		{name: "cell on the second line", template: "## Title\n| %s |", want: ctxCell},
+		{name: "heading", template: "## %s", want: ctxHeading},
+		{name: "deepest heading", template: "###### %s", want: ctxHeading},
+		{name: "seven hashes is not a heading", template: "####### %s", want: ctxProse},
+		{name: "hash without a space is not a heading", template: "##%s", want: ctxProse},
+		{name: "hash alone is not a heading", template: "%s", want: ctxProse},
+		{name: "bullet list item", template: "- %s", want: ctxListItem},
+		{name: "star list item", template: "* %s", want: ctxListItem},
+		{name: "ordered list item", template: "1. %s", want: ctxListItem},
+		{name: "parenthesised ordered item", template: "12) %s", want: ctxListItem},
+		{name: "a number alone is not a list", template: "12%s", want: ctxProse},
+		{name: "a number and a dot at the end is not a list", template: "12.%s", want: ctxProse},
+		{name: "a dash without a space is not a list", template: "-%s", want: ctxProse},
+		{name: "link label", template: "[%s](https://example.invalid)", want: ctxLinkLabel},
+		{name: "link destination", template: "[title](%s)", want: ctxLinkDest},
+		{name: "link label inside a cell", template: "| [%s](x) |", want: ctxLinkLabel},
+		{name: "a closed link is prose again", template: "[a](b) %s", want: ctxProse},
+		{name: "a closed bracket is not a label", template: "[a] %s", want: ctxProse},
+		{name: "prose", template: "%s wrote it", want: ctxProse},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			offset := strings.Index(tc.template, "%s")
+			if got := contextAt(tc.template, offset); got != tc.want {
+				t.Errorf("contextAt(%q) = %s, want %s", tc.template, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMdContext_Values_NameTheHelperTheyNeed checks that every context reports
+// the helper a finding tells its reader to reach for, and that prose is the
+// one that needs none.
+func TestMdContext_Values_NameTheHelperTheyNeed(t *testing.T) {
+	cases := []struct {
+		name       string
+		ctx        mdContext
+		label      string
+		wants      string
+		structural bool
+	}{
+		{name: "cell", ctx: ctxCell, label: "table-cell", wants: "toolutil.EscapeMdTableCell", structural: true},
+		{name: "list item", ctx: ctxListItem, label: "list-item", wants: "toolutil.EscapeMdTableCell", structural: true},
+		{name: "heading", ctx: ctxHeading, label: "heading", wants: "toolutil.EscapeMdHeading", structural: true},
+		{name: "link label", ctx: ctxLinkLabel, label: "link-label", wants: "toolutil.MdTitleLink", structural: true},
+		{name: "link destination", ctx: ctxLinkDest, label: "link-destination", wants: "toolutil.MdTitleLink", structural: true},
+		{name: "prose", ctx: ctxProse, label: "prose", wants: "", structural: false},
+		{name: "a value that names nothing", ctx: mdContext(99), label: "prose", wants: "", structural: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ctx.String(); got != tc.label {
+				t.Errorf("String() = %q, want %q", got, tc.label)
+			}
+			if got := tc.ctx.wants(); got != tc.wants {
+				t.Errorf("wants() = %q, want %q", got, tc.wants)
+			}
+			if got := tc.ctx.structural(); got != tc.structural {
+				t.Errorf("structural() = %v, want %v", got, tc.structural)
+			}
+		})
+	}
+}
+
+// TestParseContexts_Values_SelectsWhatToJudge covers the flag's accepted
+// spellings: the default, the empty value that means the same, and a list with
+// the spacing and repetition a command line really carries.
+func TestParseContexts_Values_SelectsWhatToJudge(t *testing.T) {
+	everything := "table-cell, heading, list-item, link-label, link-destination"
+	cases := []struct {
+		name      string
+		value     string
+		wantLabel string
+		judges    []mdContext
+		refuses   []mdContext
+	}{
+		{
+			name:      "all",
+			value:     allContexts,
+			wantLabel: everything,
+			judges:    []mdContext{ctxCell, ctxHeading, ctxListItem, ctxLinkLabel, ctxLinkDest},
+			refuses:   []mdContext{ctxProse},
+		},
+		{name: "empty means all", value: "   ", wantLabel: everything, judges: []mdContext{ctxCell}},
+		{
+			name:      "a list",
+			value:     " table-cell , heading ,, table-cell ",
+			wantLabel: "table-cell, heading",
+			judges:    []mdContext{ctxCell, ctxHeading},
+			refuses:   []mdContext{ctxListItem, ctxLinkLabel},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel, err := parseContexts(tc.value)
+			if err != nil {
+				t.Fatalf("parseContexts(%q): %v", tc.value, err)
+			}
+			if sel.label != tc.wantLabel {
+				t.Errorf("label = %q, want %q", sel.label, tc.wantLabel)
+			}
+			assertJudges(t, sel, tc.judges, tc.refuses)
+		})
+	}
+}
+
+// assertJudges checks what a selection judges and what it leaves alone.
+func assertJudges(t *testing.T, sel selection, judges, refuses []mdContext) {
+	t.Helper()
+	for _, ctx := range judges {
+		if !sel.judges(ctx) {
+			t.Errorf("selection does not judge %s", ctx)
+		}
+	}
+	for _, ctx := range refuses {
+		if sel.judges(ctx) {
+			t.Errorf("selection judges %s, which it was not asked to", ctx)
+		}
+	}
+}
+
+// TestParseContexts_WrongValues_AreRefused checks that a value naming no
+// context is an error rather than a run with nothing to judge, which would
+// read as a gate that passed.
+func TestParseContexts_WrongValues_AreRefused(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "an unknown name", value: "cells", want: "unknown Markdown context"},
+		{name: "nothing but separators", value: ",,", want: "no Markdown context selected"},
+		{name: "prose is not selectable", value: "prose", want: "unknown Markdown context"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseContexts(tc.value)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("parseContexts(%q) error = %v, want one saying %q", tc.value, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestContextNames_Default_ListsEverySelectableContext checks the help text
+// the flag prints, since a wrong value is answered with it.
+func TestContextNames_Default_ListsEverySelectableContext(t *testing.T) {
+	names := contextNames()
+
+	for _, ctx := range structuralContexts {
+		if !strings.Contains(names, ctx.String()) {
+			t.Errorf("contextNames() = %q, missing %s", names, ctx)
+		}
+	}
+	if strings.Contains(names, "prose") {
+		t.Errorf("contextNames() = %q, which offers a context the audit never judges", names)
+	}
+}

--- a/cmd/audit_md_escaping/directive.go
+++ b/cmd/audit_md_escaping/directive.go
@@ -1,0 +1,105 @@
+package main
+
+import "strings"
+
+// exemptionDirective is how a value that needs no escaping is declared: in the
+// source, in the package that owns the formatter, never in a list this audit
+// carries.
+//
+//	//gitlab:allow-unescaped <expression>: <reason>
+//
+// The expression is the one a finding prints, so an exemption is written by
+// copying the value the report named. It excuses that expression wherever the
+// package interpolates it, which is what a value repeated across a domain's
+// eight formatters needs, and a directive that excuses nothing is itself
+// reported, so one left behind by a later change cannot quietly widen the
+// gate.
+//
+// Escaping a value that needs no escaping is not free, which is why this
+// exists at all rather than a blanket instruction to wrap everything: a
+// canonical catalog ID compiled in from an ActionSpec is not GitLab-authored
+// text, and wrapping it teaches the next reader a rule that is not the rule.
+const exemptionDirective = "//gitlab:allow-unescaped"
+
+// Directive is one declared exemption, kept with where it was declared so a
+// stale one can be pointed at.
+type Directive struct {
+	Package    string `json:"package"`
+	File       string `json:"file"`
+	Line       int    `json:"line"`
+	Expression string `json:"expression"`
+	Reason     string `json:"reason"`
+}
+
+// directiveKey identifies the findings one directive excuses: an expression,
+// in the package that writes it.
+type directiveKey struct {
+	pkg        string
+	expression string
+}
+
+// collectDirectives reads every exemption declared in the loaded packages.
+func collectDirectives(prog *program, root string) map[directiveKey]Directive {
+	found := map[directiveKey]Directive{}
+	for _, pkg := range prog.order {
+		for _, file := range pkg.Syntax {
+			for _, group := range file.Comments {
+				for _, comment := range group.List {
+					expression, reason, ok := parseDirective(comment.Text)
+					if !ok {
+						continue
+					}
+					pos := prog.position(comment.Pos())
+					key := directiveKey{pkg: shortPackage(pkg.PkgPath), expression: expression}
+					found[key] = Directive{
+						Package:    key.pkg,
+						File:       relativePath(pos.Filename, root),
+						Line:       pos.Line,
+						Expression: expression,
+						Reason:     reason,
+					}
+				}
+			}
+		}
+	}
+	return found
+}
+
+// parseDirective splits one comment into the expression it excuses and the
+// reason given for it.
+//
+// Both halves are required. A directive with no reason is not read as an
+// exemption at all, because the reason is the whole value of the mechanism:
+// the next reader has to be able to tell a value that needs no escaping from
+// one somebody decided not to escape.
+func parseDirective(text string) (expression, reason string, ok bool) {
+	rest, isDirective := strings.CutPrefix(strings.TrimSpace(text), exemptionDirective)
+	if !isDirective {
+		return "", "", false
+	}
+	expression, reason, hasReason := strings.Cut(strings.TrimSpace(rest), ":")
+	expression = strings.TrimSpace(expression)
+	reason = strings.TrimSpace(reason)
+	if expression == "" || !hasReason || reason == "" {
+		return "", "", false
+	}
+	return expression, reason, true
+}
+
+// staleDirectives lists the exemptions that excused nothing this run.
+func staleDirectives(declared map[directiveKey]Directive, used map[directiveKey]bool) []Directive {
+	var stale []Directive
+	for key, directive := range declared {
+		if !used[key] {
+			stale = append(stale, directive)
+		}
+	}
+	sortDirectives(stale)
+	return stale
+}
+
+// shortPackage renders an import path as the repository-relative path a report
+// prints.
+func shortPackage(path string) string {
+	return strings.TrimPrefix(path, modulePath+"/")
+}

--- a/cmd/audit_md_escaping/directive_test.go
+++ b/cmd/audit_md_escaping/directive_test.go
@@ -77,8 +77,18 @@ func TestCollectDirectives_Fixture_KeysOnPackageAndExpression(t *testing.T) {
 	if _, wrongPackage := directives[directiveKey{pkg: fixtureDir + "/mdcase", expression: "result.ID"}]; wrongPackage {
 		t.Error("an exemption was read as belonging to a package that did not declare it")
 	}
-	if len(directives) != 2 {
-		t.Errorf("read %d exemptions, want the two well-formed ones", len(directives))
+	// Counted over the fixture alone. collectDirectives reads every package
+	// the load pulled in, and the fixture type-checks against the real
+	// toolutil, which declares exemptions of its own; counting those here
+	// would make this assertion fail whenever a real package gains one.
+	var inFixture int
+	for key := range directives {
+		if strings.HasPrefix(key.pkg, fixtureDir) {
+			inFixture++
+		}
+	}
+	if inFixture != 2 {
+		t.Errorf("read %d exemptions in the fixture, want the two well-formed ones", inFixture)
 	}
 }
 

--- a/cmd/audit_md_escaping/directive_test.go
+++ b/cmd/audit_md_escaping/directive_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseDirective_Comments_ReadsOnlyAWellFormedExemption covers what counts
+// as an exemption and what does not. Both halves are required: without the
+// reason, the next reader cannot tell a value that needs no escaping from one
+// somebody decided not to escape.
+func TestParseDirective_Comments_ReadsOnlyAWellFormedExemption(t *testing.T) {
+	cases := []struct {
+		name           string
+		comment        string
+		wantExpression string
+		wantReason     string
+	}{
+		{
+			name:           "an expression and a reason",
+			comment:        "//gitlab:allow-unescaped result.ID: a canonical catalog ID, compiled in.",
+			wantExpression: "result.ID",
+			wantReason:     "a canonical catalog ID, compiled in.",
+		},
+		{
+			name:           "indented in a doc comment",
+			comment:        "   //gitlab:allow-unescaped  result.ID :  a reason  ",
+			wantExpression: "result.ID",
+			wantReason:     "a reason",
+		},
+		{name: "another comment", comment: "// result.ID is fine"},
+		{name: "another directive", comment: "//gitlab:allow-readonly-graphql-mutation x: y"},
+		{name: "no reason", comment: "//gitlab:allow-unescaped result.ID"},
+		{name: "an empty reason", comment: "//gitlab:allow-unescaped result.ID:   "},
+		{name: "no expression", comment: "//gitlab:allow-unescaped : a reason"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expression, reason, ok := parseDirective(tc.comment)
+			if tc.wantExpression == "" {
+				if ok {
+					t.Errorf("parseDirective(%q) read an exemption: %q / %q", tc.comment, expression, reason)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("parseDirective(%q) read no exemption", tc.comment)
+			}
+			if expression != tc.wantExpression || reason != tc.wantReason {
+				t.Errorf("parseDirective(%q) = %q / %q, want %q / %q",
+					tc.comment, expression, reason, tc.wantExpression, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestCollectDirectives_Fixture_KeysOnPackageAndExpression checks that an
+// exemption is read where it was declared and belongs to the package that
+// declared it, so one package cannot excuse another's value.
+func TestCollectDirectives_Fixture_KeysOnPackageAndExpression(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+
+	directives := collectDirectives(prog, repoRoot(t))
+
+	key := directiveKey{pkg: fixtureDir + "/mdexempt", expression: "result.ID"}
+	declared, ok := directives[key]
+	if !ok {
+		t.Fatalf("the declared exemption was not read; got %v", directives)
+	}
+	if !strings.Contains(declared.Reason, "canonical catalog ID") {
+		t.Errorf("reason %q is not the one the source gives", declared.Reason)
+	}
+	if !strings.HasSuffix(declared.File, "mdexempt.go") || declared.Line == 0 {
+		t.Errorf("exemption at %s:%d does not point at the source that declared it", declared.File, declared.Line)
+	}
+	if _, wrongPackage := directives[directiveKey{pkg: fixtureDir + "/mdcase", expression: "result.ID"}]; wrongPackage {
+		t.Error("an exemption was read as belonging to a package that did not declare it")
+	}
+	if len(directives) != 2 {
+		t.Errorf("read %d exemptions, want the two well-formed ones", len(directives))
+	}
+}
+
+// TestStaleDirectives_Cases_ReportWhatExcusedNothing checks the half of the
+// mechanism that keeps it honest: an exemption nothing used has outlived the
+// reason it was written for.
+func TestStaleDirectives_Cases_ReportWhatExcusedNothing(t *testing.T) {
+	declared := map[directiveKey]Directive{
+		{pkg: "a", expression: "used"}:   {Package: "a", Expression: "used", File: "a.go", Line: 1},
+		{pkg: "a", expression: "unused"}: {Package: "a", Expression: "unused", File: "a.go", Line: 2},
+	}
+	used := map[directiveKey]bool{{pkg: "a", expression: "used"}: true}
+
+	stale := staleDirectives(declared, used)
+
+	if len(stale) != 1 || stale[0].Expression != "unused" {
+		t.Errorf("stale = %v, want the one exemption nothing used", stale)
+	}
+	if len(staleDirectives(declared, map[directiveKey]bool{
+		{pkg: "a", expression: "used"}:   true,
+		{pkg: "a", expression: "unused"}: true,
+	})) != 0 {
+		t.Error("an exemption that excused something was reported stale")
+	}
+}
+
+// TestShortPackage_Paths_TrimsTheModule checks that a report names a package
+// the way the repository does.
+func TestShortPackage_Paths_TrimsTheModule(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "a package of this module", path: modulePath + "/internal/tools/issues", want: "internal/tools/issues"},
+		{name: "the module itself", path: modulePath, want: modulePath},
+		{name: "another module", path: "example.invalid/other", want: "example.invalid/other"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shortPackage(tc.path); got != tc.want {
+				t.Errorf("shortPackage(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/audit_md_escaping/doc.go
+++ b/cmd/audit_md_escaping/doc.go
@@ -1,0 +1,110 @@
+// Command audit_md_escaping fails when a Markdown formatter interpolates a
+// value this server did not write into a construct that value can change the
+// shape of.
+//
+// The rule it enforces is already the house rule. toolutil.EscapeMdTableCell
+// belongs on every GitLab-authored string that lands between two pipes of a
+// table row and on every single-line list value, toolutil.EscapeMdHeading on
+// the one value a formatter puts in a heading, and toolutil.MdTitleLink on
+// both halves of a link. docs/concepts/security.md names all three, and most
+// of the packages that register a formatter call them. Until this audit
+// existed the rule was enforced by habit and by review, which is the kind of
+// rule that survives until someone writes a domain in one sitting: a whole
+// tool domain shipped with eight formatters and no escaping at all, and every
+// gate passed.
+//
+// What the omission costs is not only table geometry. EscapeMdTableCell
+// entity-encodes '<' on purpose, so GitLab-authored text cannot open raw HTML
+// in a client that renders Markdown, and it strips control bytes. A title of
+//
+//	<a href="http://attacker.invalid/x">Fix login</a>
+//
+// reaches such a client as a working link to a host that is not GitLab, and a
+// title of
+//
+//	Fix login](http://attacker.invalid/x)
+//
+// does the same by closing the label of a link the server wrote around it, on
+// this server's own instruction, since HintPreserveLinks tells the model to
+// keep those links clickable.
+//
+// # How it decides
+//
+// The audit type-checks the packages under internal/, finds every call that
+// writes Markdown with a runtime value in it, and asks of each value whether
+// it can carry a character that changes the document around it.
+//
+// A sink is an fmt formatting call whose format argument is a constant (a
+// literal or a named constant, both resolved by the type checker), or a call
+// of toolutil.MarkdownTableRow or MarkdownTableHeader, which have no template
+// at all because every argument they take is a cell by construction. The
+// template is parsed with fmt's own grammar, flags, explicit argument indices,
+// '*' widths and '%%' included, so a verb is never paired with the wrong
+// expression: one formatter in this repository writes "[%[1]s](%[1]s)", which
+// a regular expression mispairs. Only %s, %v and %q are judged. %q is judged
+// despite quoting because Go's quoting escapes a quote and a backslash and
+// neither a pipe nor an angle bracket, and the numeric verbs are skipped
+// because none of them can emit any of the three whatever they are handed.
+//
+// Where a hole sits decides whether it matters, and the line it sits on
+// decides where it sits: a pipe first means a table cell, one to six '#' and a
+// space means a heading, a bullet or an ordered marker means a list item, an
+// unclosed '[' means a link label, and the text after a '](' means a link
+// destination. Everything else is prose and is skipped, because a paragraph
+// holds a pipe, an angle bracket and a newline without changing shape, and the
+// formatters that render GitLab-authored prose route it through WrapGFMBody.
+// The -contexts flag narrows the run to some of the five, since the claim a
+// table cell makes is stronger than the one a list item makes and the sweep
+// can be staged by it.
+//
+// The value is then followed backwards to where it came from. It is safe when
+// it is a compile-time constant, when its static type cannot render as text
+// this server did not write (a number, a boolean, a time.Time or a Duration),
+// when it has been through one of the toolutil escapers, when it is a nested
+// Sprintf whose own holes are all safe, when it is a standard-library
+// formatter of a non-textual value or a strings transform of values that are
+// themselves safe, when every return of the declared function producing it is
+// safe, when every assignment to the local holding it is safe, or when every
+// caller passes a safe value to the parameter carrying it. A call binds its
+// arguments to the callee's parameters, so a helper is judged at the call site
+// that reaches it: toolutil.FormatTime returns its argument verbatim when
+// neither layout parses, and without that binding the one caller passing a raw
+// field would condemn the other hundred and fifty. It is unsafe when it
+// bottoms out at a field of a struct filled from a GitLab response. Anything
+// else is unresolved, which is reported in a bucket of its own and never
+// counted as safe, because a gate that quietly called what it could not follow
+// safe would be a gate with a hole in it.
+//
+// # Declaring that a value is already safe
+//
+// Some values that bottom out at a struct field need no escaping, and wrapping
+// them would be noise that teaches the next reader the wrong rule: a canonical
+// catalog ID compiled in from an ActionSpec is not GitLab-authored text at
+// all. Those are declared in the source, in the package that owns the
+// formatter, so the exemption is read beside the code it excuses:
+//
+//	//gitlab:allow-unescaped result.ID: a canonical catalog ID, compiled in from an ActionSpec rather than read from GitLab.
+//
+// The expression is the one the report prints, and the directive excuses every
+// finding in its own package for that expression. A directive that excuses
+// nothing is itself a finding, so an exemption cannot outlive the reason it
+// was written for and cannot quietly widen the gate.
+//
+// # What it cannot see
+//
+// A format string assembled at runtime carries no template to parse, so a
+// formatter that builds one is invisible. A value reaching a cell through a
+// function value, through a call with several results, or out of a struct
+// built positionally is reported unresolved rather than judged. Whether a
+// struct is GitLab-derived at all is assumed rather than proven, which is what
+// the directive is for. And a value breaking out of a fenced code block is out
+// of scope entirely: those holes classify as prose, so a value carrying a
+// fence of its own is a defect class this audit does not cover.
+//
+// Usage:
+//
+//	go run ./cmd/audit_md_escaping/
+//	go run ./cmd/audit_md_escaping/ -json plan/md-escaping-backlog.json
+//	go run ./cmd/audit_md_escaping/ -check
+//	go run ./cmd/audit_md_escaping/ -contexts table-cell,heading -check
+package main

--- a/cmd/audit_md_escaping/expr.go
+++ b/cmd/audit_md_escaping/expr.go
@@ -1,0 +1,545 @@
+package main
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// maxDepth bounds the walk backwards from a value to where it came from. The
+// real chains are three or four steps (a field, a helper's return, a local), so
+// this is slack rather than a limit anyone reaches; it exists so a mutually
+// recursive pair of helpers cannot hang the audit.
+const maxDepth = 24
+
+// classifyExpr answers whether the value expr produces can carry a character
+// that changes the shape of the Markdown it lands in.
+func (c *classifier) classifyExpr(pkg *packages.Package, expr ast.Expr, e *env, depth int) (outcome verdict, explanation string) {
+	if depth > maxDepth {
+		return unresolved, "the chain back to a source is deeper than the audit follows"
+	}
+	if expr == nil {
+		return unresolved, "the value arrives through an assignment the audit does not follow"
+	}
+	expr = ast.Unparen(expr)
+	tv, known := pkg.TypesInfo.Types[expr]
+	if known && tv.Value != nil {
+		return safe, "a compile-time constant"
+	}
+	if known && tv.Type != nil && !textual(tv.Type) {
+		return safe, "a value of a type that renders as a number, a boolean or a timestamp"
+	}
+	switch typed := expr.(type) {
+	case *ast.CallExpr:
+		return c.classifyCall(pkg, typed, e, depth)
+	case *ast.Ident:
+		return c.classifyIdent(pkg, typed, e, depth)
+	case *ast.BinaryExpr:
+		return c.classifyBinary(pkg, typed, e, depth)
+	case *ast.SelectorExpr:
+		return c.classifySelector(pkg, typed, e, depth)
+	case *ast.CompositeLit:
+		return c.classifyComposite(pkg, typed, e, depth)
+	case *ast.StarExpr:
+		return c.classifyExpr(pkg, typed.X, e, depth+1)
+	case *ast.TypeAssertExpr:
+		return c.classifyExpr(pkg, typed.X, e, depth+1)
+	case *ast.IndexExpr:
+		// An element is judged by the collection it came from, which answers
+		// for a lookup in a table of emoji the server wrote as readily as for
+		// one in a slice filled from a GitLab response.
+		return c.classifyExpr(pkg, typed.X, e, depth+1)
+	case *ast.SliceExpr:
+		return c.classifyExpr(pkg, typed.X, e, depth+1)
+	default:
+		return unresolved, "the value is written in a shape the audit does not follow"
+	}
+}
+
+// classifyCall answers for a call: an escaper makes its result safe, a
+// conversion passes the question to its operand, and a declared function is
+// answered by what its returns are, with its parameters bound to what this call
+// site passed.
+func (c *classifier) classifyCall(pkg *packages.Package, call *ast.CallExpr, e *env, depth int) (outcome verdict, explanation string) {
+	// A conversion is a call of a type, and takes exactly one operand, so the
+	// question simply passes to it.
+	if tv, ok := pkg.TypesInfo.Types[call.Fun]; ok && tv.IsType() {
+		return c.classifyExpr(pkg, call.Args[0], e, depth+1)
+	}
+	callee := calleeOf(pkg, call)
+	if callee == nil {
+		return unresolved, "the call is of a function value rather than of a named function"
+	}
+	if isEscaper(callee) {
+		return safe, "already through toolutil." + callee.Name()
+	}
+	if isSprintf(callee) {
+		return c.classifySprintf(pkg, call, e, depth)
+	}
+	name := qualifiedName(callee)
+	if externalSafe[name] {
+		return safe, "a standard-library formatter of a non-textual value"
+	}
+	if carried, ok := passThroughArgs[name]; ok {
+		return c.classifyPassThrough(pkg, call, carried, e, depth)
+	}
+	decl, ok := c.prog.decls[callee]
+	if !ok {
+		return unresolved, "the body of " + name + " is outside the audited packages"
+	}
+	return c.classifyReturns(decl, 0, bindParams(pkg, call, callee, e), depth)
+}
+
+// classifyPassThrough answers for a call whose result is made of the arguments
+// it was given, by asking the same question of each of them.
+func (c *classifier) classifyPassThrough(pkg *packages.Package, call *ast.CallExpr, carried []int, e *env, depth int) (outcome verdict, explanation string) {
+	worst, reason := safe, "made only of values that are already safe"
+	for _, index := range carried {
+		if index >= len(call.Args) {
+			return unresolved, "the call passes its arguments in a shape the audit does not follow"
+		}
+		got, why := c.classifyExpr(pkg, call.Args[index], e, depth+1)
+		if got > worst {
+			worst, reason = got, why
+		}
+	}
+	return worst, reason
+}
+
+// bindParams binds a called function's parameters to the arguments this call
+// passes. A variadic call and a call whose arguments do not line up with the
+// signature (one spreading several results of another call, say) bind nothing,
+// which leaves the callee's parameters to be resolved from every caller
+// instead.
+func bindParams(pkg *packages.Package, call *ast.CallExpr, callee *types.Func, caller *env) *env {
+	sig := callee.Signature()
+	if sig.Variadic() || sig.Params().Len() != len(call.Args) {
+		return nil
+	}
+	binds := make(map[*types.Var]bound, len(call.Args))
+	for i := range sig.Params().Len() {
+		binds[sig.Params().At(i)] = bound{expr: call.Args[i], pkg: pkg, env: caller}
+	}
+	return &env{binds: binds}
+}
+
+// classifySprintf answers for a nested Sprintf by asking the same question of
+// every value it interpolates. A Sprintf that composes a cell out of escaped
+// halves is safe; one that composes it out of raw ones is not, and the reason
+// names the raw half.
+func (c *classifier) classifySprintf(pkg *packages.Package, call *ast.CallExpr, e *env, depth int) (outcome verdict, explanation string) {
+	tv, ok := pkg.TypesInfo.Types[call.Args[0]]
+	if !ok || tv.Value == nil {
+		return unresolved, "the nested format string is not a constant"
+	}
+	args := call.Args[1:]
+	worst, reason := safe, "every value the nested Sprintf interpolates is safe"
+	for _, h := range parseVerbs(constantText(tv)) {
+		if !stringishVerbs[h.verb] || h.arg >= len(args) {
+			continue
+		}
+		got, why := c.classifyExpr(pkg, args[h.arg], e, depth+1)
+		if got > worst {
+			worst, reason = got, why
+		}
+	}
+	return worst, reason
+}
+
+// classifyIdent answers for an identifier by following it to the values it
+// holds: the argument its caller passed for a bound parameter, every argument
+// any caller passes for an unbound one, and every assignment for a local.
+func (c *classifier) classifyIdent(pkg *packages.Package, ident *ast.Ident, e *env, depth int) (outcome verdict, explanation string) {
+	obj := pkg.TypesInfo.Uses[ident]
+	if obj == nil {
+		obj = pkg.TypesInfo.Defs[ident]
+	}
+	v, ok := obj.(*types.Var)
+	if !ok {
+		return unresolved, "the identifier names something other than a variable"
+	}
+	if b, bound := e.lookup(v); bound {
+		c.bindHits++
+		return c.classifyExpr(b.pkg, b.expr, b.env, depth+1)
+	}
+	if ref, isParam := c.params[v]; isParam {
+		return c.classifyParam(ref, depth)
+	}
+	assigned, found := c.assigns[v]
+	if !found || len(assigned) == 0 {
+		return unresolved, "nothing the audit can see assigns " + ident.Name
+	}
+	// A variable built from itself is the common shape in these formatters:
+	// a cell is escaped into a local and then wrapped in a link that
+	// interpolates the local again. Meeting it a second time contributes
+	// nothing, so the walk skips it and judges the rest of the assignment,
+	// which is where the raw value would be.
+	if c.inVar[v] {
+		return safe, "a value already being resolved"
+	}
+	c.inVar[v] = true
+	defer delete(c.inVar, v)
+
+	worst, reason := safe, "every value assigned to "+ident.Name+" is safe"
+	for _, rhs := range assigned {
+		got, why := c.classifyExpr(c.packageOf(rhs, pkg), rhs, e, depth+1)
+		if got > worst {
+			worst, reason = got, why
+		}
+	}
+	return worst, reason
+}
+
+// packageOf returns the package an indexed expression was written in, falling
+// back to the package asking about it.
+func (c *classifier) packageOf(expr ast.Expr, fallback *packages.Package) *packages.Package {
+	if pkg, ok := c.pkgOf[expr]; ok {
+		return pkg
+	}
+	return fallback
+}
+
+// classifyParam answers for a parameter no call site bound, by asking what
+// every caller passes.
+//
+// This is the rule that keeps a shared row helper from being reported once per
+// caller: a helper whose callers all pass escaped strings is safe, and a
+// finding belongs at whichever call site passes a raw value.
+func (c *classifier) classifyParam(ref paramRef, depth int) (outcome verdict, explanation string) {
+	sites := c.prog.callers[ref.fn]
+	if len(sites) == 0 {
+		return unresolved, "nothing in the audited packages calls " + ref.fn.Name()
+	}
+	worst, reason := safe, "every caller of "+ref.fn.Name()+" passes a safe value"
+	for _, site := range sites {
+		if ref.index >= len(site.call.Args) {
+			return unresolved, "a call of " + ref.fn.Name() + " passes its arguments in a shape the audit does not follow"
+		}
+		got, why := c.classifyExpr(site.pkg, site.call.Args[ref.index], nil, depth+1)
+		if got > worst {
+			worst, reason = got, "from a call site of "+ref.fn.Name()+": "+why
+		}
+	}
+	return worst, reason
+}
+
+// classifyBinary answers for a concatenation by asking the same question of
+// both halves.
+func (c *classifier) classifyBinary(pkg *packages.Package, expr *ast.BinaryExpr, e *env, depth int) (outcome verdict, explanation string) {
+	left, leftWhy := c.classifyExpr(pkg, expr.X, e, depth+1)
+	right, rightWhy := c.classifyExpr(pkg, expr.Y, e, depth+1)
+	if left >= right {
+		return left, leftWhy
+	}
+	return right, rightWhy
+}
+
+// classifyComposite answers for a literal by taking the worst of the values it
+// is built from. It is how a slice of cells spread into a row builder is
+// judged, and how a struct built at a call site answers for its own fields.
+func (c *classifier) classifyComposite(pkg *packages.Package, lit *ast.CompositeLit, e *env, depth int) (outcome verdict, explanation string) {
+	worst, reason := safe, "every value in the literal is safe"
+	for _, elt := range lit.Elts {
+		value := elt
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			value = kv.Value
+		}
+		got, why := c.classifyExpr(pkg, value, e, depth+1)
+		if got > worst {
+			worst, reason = got, why
+		}
+	}
+	return worst, reason
+}
+
+// classifySelector answers for a field access.
+//
+// A string field is where the audit stops looking and starts reporting, unless
+// the struct holding it was built where the audit can see it. Every struct
+// these formatters render is filled from a GitLab response, so a string field
+// on one holds whatever the person who opened the issue, pushed the branch or
+// named the label typed. A struct built at the call site is different: an
+// options struct carrying a title the server itself wrote answers for that
+// title, which is why the literal is looked for first.
+func (c *classifier) classifySelector(pkg *packages.Package, sel *ast.SelectorExpr, e *env, depth int) (outcome verdict, explanation string) {
+	obj := pkg.TypesInfo.Uses[sel.Sel]
+	if v, ok := obj.(*types.Var); ok && packageLevel(v) {
+		return c.classifyIdent(pkg, sel.Sel, e, depth+1)
+	}
+	if _, ok := obj.(*types.Func); ok {
+		return unresolved, "the value is a method value the audit does not follow"
+	}
+	base := c.resolveBase(pkg, sel.X, e, depth)
+	if lit, ok := ast.Unparen(base.expr).(*ast.CompositeLit); ok {
+		return c.classifyField(base.pkg, lit, base.env, sel.Sel.Name, depth)
+	}
+	if ref, isParam := c.paramOf(base); isParam {
+		return c.classifyParamField(ref, sel.Sel.Name, depth)
+	}
+	return unescaped, "a field of a value filled from a GitLab response"
+}
+
+// resolveBase follows the value a field is read from back to where it was
+// built, through the parameter bindings and the single-assignment locals the
+// audit records. A variable with more than one assignment answers for none of
+// them, because a field read from it could have come from either.
+func (c *classifier) resolveBase(pkg *packages.Package, expr ast.Expr, e *env, depth int) bound {
+	here := bound{expr: expr, pkg: pkg, env: e}
+	if depth > maxDepth || expr == nil {
+		return here
+	}
+	switch typed := ast.Unparen(expr).(type) {
+	case *ast.UnaryExpr:
+		return c.resolveBase(pkg, typed.X, e, depth+1)
+	case *ast.StarExpr:
+		return c.resolveBase(pkg, typed.X, e, depth+1)
+	case *ast.Ident:
+		v, ok := pkg.TypesInfo.Uses[typed].(*types.Var)
+		if !ok {
+			return here
+		}
+		if b, isBound := e.lookup(v); isBound {
+			c.bindHits++
+			return c.resolveBase(b.pkg, b.expr, b.env, depth+1)
+		}
+		if assigned := c.assigns[v]; len(assigned) == 1 && assigned[0] != nil && !c.fieldWritten[v] {
+			return c.resolveBase(c.packageOf(assigned[0], pkg), assigned[0], e, depth+1)
+		}
+		return bound{expr: typed, pkg: pkg, env: e}
+	default:
+		return here
+	}
+}
+
+// paramOf reports whether a resolved base is a parameter no call site bound,
+// which is what lets a field of an options struct be answered by the literals
+// callers build rather than assumed to be GitLab-authored.
+func (c *classifier) paramOf(base bound) (paramRef, bool) {
+	ident, ok := ast.Unparen(base.expr).(*ast.Ident)
+	if !ok {
+		return paramRef{}, false
+	}
+	v, ok := base.pkg.TypesInfo.Uses[ident].(*types.Var)
+	if !ok {
+		return paramRef{}, false
+	}
+	ref, isParam := c.params[v]
+	return ref, isParam
+}
+
+// classifyParamField answers for a field of a struct a caller passed, by
+// asking what every caller put in that field.
+//
+// The shared formatters in toolutil take their titles and column names this
+// way, and the callers write them as literals, so without this rule a title
+// the server itself wrote would be reported as GitLab-authored text.
+func (c *classifier) classifyParamField(ref paramRef, field string, depth int) (outcome verdict, explanation string) {
+	sites := c.prog.callers[ref.fn]
+	if len(sites) == 0 {
+		// A Markdown formatter is registered by value rather than called, so
+		// the audit sees no call site for the one function whose parameter is
+		// always the output struct filled from a GitLab response. Reading
+		// that as a value the audit cannot follow would excuse the whole
+		// registered surface, which is most of it.
+		return unescaped, "a field of the value handed to " + ref.fn.Name() + ", which nothing in the audited packages calls"
+	}
+	worst, reason := safe, "every caller of "+ref.fn.Name()+" passes a safe "+field
+	for _, site := range sites {
+		if ref.index >= len(site.call.Args) {
+			return unresolved, "a call of " + ref.fn.Name() + " passes its arguments in a shape the audit does not follow"
+		}
+		base := c.resolveBase(site.pkg, site.call.Args[ref.index], nil, depth+1)
+		lit, ok := ast.Unparen(base.expr).(*ast.CompositeLit)
+		if !ok {
+			return unescaped, "a field of a value a caller of " + ref.fn.Name() + " filled from a GitLab response"
+		}
+		got, why := c.classifyField(base.pkg, lit, base.env, field, depth+1)
+		if got > worst {
+			worst, reason = got, "from a call site of "+ref.fn.Name()+": "+why
+		}
+	}
+	return worst, reason
+}
+
+// classifyField answers for one field of a literal the audit resolved.
+//
+// A keyed literal that names no such field left it at its zero value, which is
+// the empty string and carries nothing. A literal written positionally is not
+// followed: matching an element to a field would need the struct's declared
+// order, and no formatter in this repository builds its options that way.
+func (c *classifier) classifyField(pkg *packages.Package, lit *ast.CompositeLit, e *env, field string, depth int) (outcome verdict, explanation string) {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			return unresolved, "the struct is built positionally, so the audit cannot tell which element is " + field
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != field {
+			continue
+		}
+		return c.classifyExpr(pkg, kv.Value, e, depth+1)
+	}
+	return safe, "a field the literal that built the struct leaves at its zero value"
+}
+
+// classifyReturns answers for a declared function by taking the worst of its
+// return expressions at the given result index, judged with its parameters
+// bound to what the call site passed.
+func (c *classifier) classifyReturns(decl *funcDecl, index int, e *env, depth int) (outcome verdict, explanation string) {
+	key := resultKey{fn: decl.obj, index: index}
+	if cached, ok := c.returnMemo[key]; ok {
+		return cached, "what " + decl.obj.Name() + " returns"
+	}
+	if c.inProgress[key] {
+		return safe, "a recursive call already being resolved"
+	}
+	c.inProgress[key] = true
+	defer delete(c.inProgress, key)
+
+	before := c.bindHits
+	worst, reason := safe, "everything "+decl.obj.Name()+" returns is safe"
+	found := false
+	ast.Inspect(decl.decl.Body, func(node ast.Node) bool {
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok || index >= len(ret.Results) {
+			return true
+		}
+		found = true
+		got, why := c.classifyExpr(decl.pkg, ret.Results[index], e, depth+1)
+		if got > worst {
+			worst, reason = got, why
+		}
+		return true
+	})
+	if !found {
+		return unresolved, decl.obj.Name() + " returns through a named result the audit does not follow"
+	}
+	// A verdict reached through a caller's argument holds for that call site
+	// and not for the function, so only a verdict the body settled on its own
+	// is worth remembering.
+	if c.bindHits == before {
+		c.returnMemo[key] = worst
+	}
+	return worst, reason
+}
+
+// packageLevel reports whether v is declared at a package's top level, which
+// is what tells a qualified variable of another package apart from a field of
+// a struct: a package scope is the one whose parent is the universe.
+func packageLevel(v *types.Var) bool {
+	scope := v.Parent()
+	return scope != nil && scope.Parent() == types.Universe
+}
+
+// isEscaper reports whether callee is one of the toolutil helpers that makes a
+// value safe to interpolate.
+func isEscaper(callee *types.Func) bool {
+	if callee.Pkg() == nil || callee.Pkg().Path() != toolutilPath {
+		return false
+	}
+	return escapers[callee.Name()]
+}
+
+// isSprintf reports whether callee is fmt.Sprintf.
+func isSprintf(callee *types.Func) bool {
+	return callee.Pkg() != nil && callee.Pkg().Path() == "fmt" && callee.Name() == "Sprintf"
+}
+
+// qualifiedName renders a function as package.Name, with the receiver type
+// included for a method so a whitelist entry cannot match the wrong one.
+func qualifiedName(callee *types.Func) string {
+	pkgName := ""
+	if callee.Pkg() != nil {
+		pkgName = callee.Pkg().Name()
+	}
+	recv := callee.Signature().Recv()
+	if recv == nil {
+		return pkgName + "." + callee.Name()
+	}
+	recvName := recv.Type().String()
+	if idx := strings.LastIndex(recvName, "."); idx >= 0 {
+		recvName = recvName[idx+1:]
+	}
+	return pkgName + "." + strings.TrimPrefix(recvName, "*") + "." + callee.Name()
+}
+
+// textual reports whether a value of type t can render as text this server did
+// not write.
+//
+// A number, a boolean and a timestamp cannot: whatever GitLab put in them, the
+// rendering is digits, "true" or a formatted instant. Everything else is
+// treated as able to carry a string, an interface included, since its dynamic
+// type is not knowable here.
+func textual(t types.Type) bool {
+	return textualDepth(t, 0, map[types.Type]bool{})
+}
+
+// textualDepth is textual with a guard against a type that contains itself.
+//
+// The alias is unwrapped first, and that is load-bearing: since Go 1.23 the
+// type checker reports `any` as an alias rather than as the interface it
+// names, so a field declared `any` would fall past every case below and be
+// read as a value that cannot carry text.
+func textualDepth(t types.Type, depth int, seen map[types.Type]bool) bool {
+	if t == nil || depth > 8 || seen[t] {
+		return false
+	}
+	seen[t] = true
+	t = types.Unalias(t)
+	if named, ok := t.(*types.Named); ok {
+		if rendersAsInstant(named) {
+			return false
+		}
+		return textualDepth(named.Underlying(), depth+1, seen)
+	}
+	switch typed := t.(type) {
+	case *types.Basic:
+		return typed.Info()&types.IsString != 0
+	case *types.Interface:
+		return true
+	case *types.Pointer:
+		return textualDepth(typed.Elem(), depth+1, seen)
+	case *types.Slice:
+		return textualDepth(typed.Elem(), depth+1, seen)
+	case *types.Array:
+		return textualDepth(typed.Elem(), depth+1, seen)
+	case *types.Map:
+		return textualDepth(typed.Key(), depth+1, seen) || textualDepth(typed.Elem(), depth+1, seen)
+	case *types.Struct:
+		for field := range typed.Fields() {
+			if textualDepth(field.Type(), depth+1, seen) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// rendersAsInstant names the standard-library types whose own String method
+// renders them as a timestamp or a duration, so their fields never reach the
+// page even under %v.
+func rendersAsInstant(named *types.Named) bool {
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != "time" {
+		return false
+	}
+	switch obj.Name() {
+	case "Time", "Duration", "Month", "Weekday":
+		return true
+	default:
+		return false
+	}
+}
+
+// constantText unwraps a constant string value.
+func constantText(tv types.TypeAndValue) string {
+	if tv.Value == nil || tv.Value.Kind() != constant.String {
+		return ""
+	}
+	return constant.StringVal(tv.Value)
+}

--- a/cmd/audit_md_escaping/expr_test.go
+++ b/cmd/audit_md_escaping/expr_test.go
@@ -1,0 +1,487 @@
+package main
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// holeByExpression finds one hole of the fixture by the expression a finding
+// would print for it, so a case names a value rather than a position.
+func holeByExpression(t *testing.T, prog *program, pkgName, expression string) (*packages.Package, ast.Expr) {
+	t.Helper()
+	for _, s := range collectSinks(prog) {
+		if !strings.HasSuffix(s.pkg.PkgPath, "/"+pkgName) {
+			continue
+		}
+		for _, h := range s.holes {
+			if types.ExprString(h.expr) == expression {
+				return s.pkg, h.expr
+			}
+		}
+	}
+	t.Fatalf("no hole in %s interpolates %s", pkgName, expression)
+	return nil, nil
+}
+
+// TestClassifyExpr_Fixture_AnswersEachShape walks one value of every shape the
+// classifier has a rule for, and pins both the verdict and the reason it gives,
+// since the reason is what the walk through the findings acts on.
+func TestClassifyExpr_Fixture_AnswersEachShape(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+
+	cases := []struct {
+		name       string
+		pkg        string
+		expression string
+		want       verdict
+		reason     string
+	}{
+		{
+			name: "a value already through an escaper", pkg: "mdsafe",
+			expression: "toolutil.EscapeMdHeading(item.Title)", want: safe, reason: "already through toolutil.EscapeMdHeading",
+		},
+		{
+			name: "a number", pkg: "mdsafe",
+			expression: "item.Count", want: safe, reason: "renders as a number",
+		},
+		{
+			name: "a timestamp", pkg: "mdsafe",
+			expression: "item.When", want: safe, reason: "renders as a number",
+		},
+		{
+			name: "a standard-library formatter", pkg: "mdsafe",
+			expression: "strconv.Itoa(item.Count)", want: safe, reason: "standard-library formatter",
+		},
+		{
+			name: "a strings transform of a safe value", pkg: "mdsafe",
+			expression: "strings.TrimSpace(toolutil.EscapeMdTableCell(item.Title))", want: safe, reason: "already safe",
+		},
+		{
+			name: "a helper whose every return is safe", pkg: "mdsafe",
+			expression: "label(item)", want: safe, reason: "everything label returns is safe",
+		},
+		{
+			name: "a lookup in a table the server wrote", pkg: "mdsafe",
+			expression: "statusIcon(item)", want: safe, reason: "everything statusIcon returns is safe",
+		},
+		{
+			name: "a nested Sprintf of safe halves", pkg: "mdsafe",
+			expression: `fmt.Sprintf("%s (%s)", toolutil.EscapeMdTableCell(item.Title), "server text")`,
+			want:       safe, reason: "every value the nested Sprintf interpolates is safe",
+		},
+		{
+			name: "a field of an options struct the caller built", pkg: "mdsafe",
+			expression: "opts.Title", want: safe, reason: "every caller of FormatItem passes a safe Title",
+		},
+		{
+			name: "a field the caller's literal leaves empty", pkg: "mdsafe",
+			expression: "opts.Column", want: safe, reason: "every caller of FormatItem passes a safe Column",
+		},
+		{
+			name: "a conversion of a number", pkg: "mdsafe",
+			expression: "string(rune(item.Count))", want: safe, reason: "renders as a number",
+		},
+		{
+			name: "a value bound to a constant through a helper", pkg: "mdsafe",
+			expression: `toolutil.FormatTime("2024-01-01")`, want: safe, reason: "everything FormatTime returns is safe",
+		},
+		{
+			name: "a field of a GitLab response", pkg: "mdcase",
+			expression: "item.State", want: unescaped, reason: "handed to FormatOutputMarkdown",
+		},
+		{
+			name: "an element of a field", pkg: "mdcase",
+			expression: "item.Labels[0]", want: unescaped, reason: "handed to FormatOutputMarkdown",
+		},
+		{
+			name: "a shared helper one caller passes a raw value to", pkg: "mdcase",
+			expression: "title", want: unescaped, reason: "from a call site of FormatRow",
+		},
+		{
+			name: "a recursive helper carrying a raw value", pkg: "mdcase",
+			expression: "repeat(item.Title, depth)", want: unescaped, reason: "handed to FormatRecursive",
+		},
+		{
+			name: "a field filled after the struct was built", pkg: "mdcase",
+			expression: "pair.Right", want: unescaped, reason: "a field of a value filled from a GitLab response",
+		},
+		{
+			name: "a call of a function value", pkg: "mdcase",
+			expression: "render(item)", want: unresolved, reason: "function value",
+		},
+		{
+			name: "a field of a struct built positionally", pkg: "mdcase",
+			expression: "pair.Left", want: unresolved, reason: "built positionally",
+		},
+		{
+			name: "one of several results", pkg: "mdcase",
+			expression: "value", want: unresolved, reason: "an assignment the audit does not follow",
+		},
+		{
+			name: "a named result", pkg: "mdcase",
+			expression: "namedResult(item)", want: unresolved, reason: "named result",
+		},
+		{
+			name: "a variadic parameter no caller fills", pkg: "mdcase",
+			expression: "rest[0]", want: unresolved, reason: "shape the audit does not follow",
+		},
+		{
+			name: "a package-level variable nothing assigns", pkg: "mdcase",
+			expression: "mutableTitle", want: unresolved, reason: "an assignment the audit does not follow",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg, expr := holeByExpression(t, prog, tc.pkg, tc.expression)
+			got, why := c.classifyExpr(pkg, expr, nil, 0)
+			if got != tc.want {
+				t.Errorf("classifyExpr(%s) = %v (%s), want %v", tc.expression, got, why, tc.want)
+			}
+			if !strings.Contains(why, tc.reason) {
+				t.Errorf("reason for %s is %q, want one saying %q", tc.expression, why, tc.reason)
+			}
+		})
+	}
+}
+
+// TestClassifyExpr_Guards_StopWithoutCallingAValueSafe checks the two ends of
+// the walk that are not shapes at all: a chain deeper than it follows, and an
+// assignment it was handed nothing for.
+func TestClassifyExpr_Guards_StopWithoutCallingAValueSafe(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg, expr := holeByExpression(t, prog, "mdcase", "item.State")
+
+	cases := []struct {
+		name   string
+		expr   ast.Expr
+		depth  int
+		reason string
+	}{
+		{name: "deeper than the walk follows", expr: expr, depth: maxDepth + 1, reason: "deeper than the audit follows"},
+		{name: "nothing to judge", expr: nil, reason: "an assignment the audit does not follow"},
+		{name: "a shape with no rule", expr: &ast.FuncLit{Type: &ast.FuncType{}, Body: &ast.BlockStmt{}}, reason: "a shape the audit does not follow"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, why := c.classifyExpr(pkg, tc.expr, nil, tc.depth)
+			if got != unresolved {
+				t.Errorf("classifyExpr = %v, want unresolved", got)
+			}
+			if !strings.Contains(why, tc.reason) {
+				t.Errorf("reason %q does not say %q", why, tc.reason)
+			}
+		})
+	}
+}
+
+// TestResolveBase_Depth_StopsAtTheExpressionItHas checks that the guard on the
+// walk back to a literal returns the expression it was looking at rather than
+// nothing, so the caller still has something to judge.
+func TestResolveBase_Depth_StopsAtTheExpressionItHas(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg, expr := holeByExpression(t, prog, "mdcase", "item.State")
+
+	base := c.resolveBase(pkg, expr, nil, maxDepth+1)
+
+	if base.expr != expr {
+		t.Errorf("resolveBase past the depth guard returned %v, want the expression it was given", base.expr)
+	}
+	if got := c.resolveBase(pkg, nil, nil, 0); got.expr != nil {
+		t.Errorf("resolveBase(nil) returned %v, want nothing", got.expr)
+	}
+	unknown := ast.NewIdent("nothingNamesThis")
+	if got := c.resolveBase(pkg, unknown, nil, 0); got.expr != unknown {
+		t.Errorf("resolveBase of an identifier that names nothing returned %v, want the identifier", got.expr)
+	}
+	if _, isParam := c.paramOf(bound{expr: unknown, pkg: pkg}); isParam {
+		t.Error("an identifier that names nothing was read as a parameter")
+	}
+	if _, isParam := c.paramOf(bound{expr: &ast.CompositeLit{}, pkg: pkg}); isParam {
+		t.Error("a literal was read as a parameter")
+	}
+}
+
+// TestClassifyParamField_ShortCall_IsUnresolved checks the guard on a call
+// that passes fewer arguments than the parameter being asked about, which a
+// variadic signature makes possible.
+func TestClassifyParamField_ShortCall_IsUnresolved(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	ref, ok := paramNamed(c, "FormatVariadic", "rest")
+	if !ok {
+		t.Fatal("the fixture's variadic parameter was not indexed")
+	}
+
+	got, why := c.classifyParamField(ref, "Title", 0)
+
+	if got != unresolved || !strings.Contains(why, "shape the audit does not follow") {
+		t.Errorf("classifyParamField = %v (%s), want unresolved", got, why)
+	}
+}
+
+// paramNamed finds one indexed parameter by the function and name declaring it.
+func paramNamed(c *classifier, fn, name string) (paramRef, bool) {
+	for v, ref := range c.params {
+		if ref.fn.Name() == fn && v.Name() == name {
+			return ref, true
+		}
+	}
+	return paramRef{}, false
+}
+
+// TestConstantText_Values_ReadsOnlyAString checks that a constant of another
+// kind yields no template, since a numeric constant in the format position is
+// not something to parse holes out of.
+func TestConstantText_Values_ReadsOnlyAString(t *testing.T) {
+	cases := []struct {
+		name string
+		tv   types.TypeAndValue
+		want string
+	}{
+		{name: "a string", tv: types.TypeAndValue{Value: constant.MakeString("| %s |")}, want: "| %s |"},
+		{name: "a number", tv: types.TypeAndValue{Value: constant.MakeInt64(7)}},
+		{name: "no constant at all", tv: types.TypeAndValue{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := constantText(tc.tv); got != tc.want {
+				t.Errorf("constantText = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyPassThrough_ShortCall_IsUnresolved checks the guard on a
+// transform called with fewer arguments than the audit expects, which is a
+// shape it must not read as safe.
+func TestClassifyPassThrough_ShortCall_IsUnresolved(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg, expr := holeByExpression(t, prog, "mdcase", "item.State")
+
+	got, why := c.classifyPassThrough(pkg, &ast.CallExpr{Fun: ast.NewIdent("f"), Args: []ast.Expr{expr}}, []int{0, 2}, nil, 0)
+
+	if got != unresolved || !strings.Contains(why, "shape the audit does not follow") {
+		t.Errorf("classifyPassThrough = %v (%s), want unresolved", got, why)
+	}
+}
+
+// TestClassifyIdent_NotAVariable_IsUnresolved checks the answer for an
+// identifier that names something other than a value.
+func TestClassifyIdent_NotAVariable_IsUnresolved(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg := fixturePackage(t, prog, "mdcase")
+
+	got, why := c.classifyIdent(pkg, ast.NewIdent("nothingNamesThis"), nil, 0)
+
+	if got != unresolved || !strings.Contains(why, "other than a variable") {
+		t.Errorf("classifyIdent = %v (%s), want unresolved", got, why)
+	}
+}
+
+// TestClassifySelector_MethodValue_IsUnresolved checks that a method used as a
+// value is answered by the bucket for what the audit cannot follow.
+func TestClassifySelector_MethodValue_IsUnresolved(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	c := newClassifier(prog)
+	pkg, expr := holeByExpression(t, prog, "mdsafe", "statusIcon(item)")
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("expected a call, got %T", expr)
+	}
+
+	got, why := c.classifyExpr(pkg, &ast.SelectorExpr{X: call.Args[0], Sel: call.Fun.(*ast.Ident)}, nil, 0)
+
+	if got != unresolved || !strings.Contains(why, "method value") {
+		t.Errorf("classifyExpr on a method value = %v (%s), want unresolved", got, why)
+	}
+}
+
+// TestTextual_Types_TellsTextFromEverythingElse checks the rule that makes the
+// numeric verbs free without a whitelist, over the type shapes a formatter's
+// output structs are built from.
+func TestTextual_Types_TellsTextFromEverythingElse(t *testing.T) {
+	str := types.Typ[types.String]
+	num := types.Typ[types.Int]
+	textStruct := types.NewStruct([]*types.Var{types.NewField(token.NoPos, nil, "Title", str, false)}, nil)
+	numStruct := types.NewStruct([]*types.Var{types.NewField(token.NoPos, nil, "Count", num, false)}, nil)
+
+	cases := []struct {
+		name string
+		typ  types.Type
+		want bool
+	}{
+		{name: "a string", typ: str, want: true},
+		{name: "a number", typ: num, want: false},
+		{name: "a boolean", typ: types.Typ[types.Bool], want: false},
+		{name: "a pointer to a string", typ: types.NewPointer(str), want: true},
+		{name: "a slice of strings", typ: types.NewSlice(str), want: true},
+		{name: "a slice of numbers", typ: types.NewSlice(num), want: false},
+		{name: "an array of strings", typ: types.NewArray(str, 2), want: true},
+		{name: "a map keyed by a string", typ: types.NewMap(str, num), want: true},
+		{name: "a map of numbers", typ: types.NewMap(num, num), want: false},
+		{name: "a struct holding a string", typ: textStruct, want: true},
+		{name: "a struct holding only numbers", typ: numStruct, want: false},
+		{name: "an interface, whose contents are not knowable", typ: types.NewInterfaceType(nil, nil), want: true},
+		{name: "a signature is not text", typ: types.NewSignatureType(nil, nil, nil, nil, nil, false), want: false},
+		{name: "nothing at all", typ: nil, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := textual(tc.typ); got != tc.want {
+				t.Errorf("textual(%v) = %v, want %v", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTextual_SelfContainingType_Terminates checks the guard against a type
+// that holds itself, which a formatter's tree-shaped output can be.
+func TestTextual_SelfContainingType_Terminates(t *testing.T) {
+	pkg := types.NewPackage("example.invalid/node", "node")
+	named := types.NewNamed(types.NewTypeName(token.NoPos, pkg, "Node", nil), nil, nil)
+	named.SetUnderlying(types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg, "Next", types.NewPointer(named), false),
+		types.NewField(token.NoPos, pkg, "Count", types.Typ[types.Int], false),
+	}, nil))
+
+	if textual(named) {
+		t.Error("a struct of numbers pointing at itself was read as text")
+	}
+}
+
+// TestRendersAsInstant_Types_CoversTheTimePackageOnly checks which named types
+// answer for themselves as a timestamp, since their fields never reach the page.
+func TestRendersAsInstant_Types_CoversTheTimePackageOnly(t *testing.T) {
+	timePkg := types.NewPackage("time", "time")
+	other := types.NewPackage("example.invalid/other", "other")
+
+	cases := []struct {
+		name string
+		typ  *types.Named
+		want bool
+	}{
+		{name: "time.Time", typ: namedType(timePkg, "Time"), want: true},
+		{name: "time.Duration", typ: namedType(timePkg, "Duration"), want: true},
+		{name: "time.Month", typ: namedType(timePkg, "Month"), want: true},
+		{name: "time.Weekday", typ: namedType(timePkg, "Weekday"), want: true},
+		{name: "time.Timer, which is not one", typ: namedType(timePkg, "Timer"), want: false},
+		{name: "another package's Time", typ: namedType(other, "Time"), want: false},
+		{name: "a type belonging to no package", typ: namedType(nil, "Time"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rendersAsInstant(tc.typ); got != tc.want {
+				t.Errorf("rendersAsInstant(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// namedType builds a named type over an empty struct, for the cases above.
+func namedType(pkg *types.Package, name string) *types.Named {
+	named := types.NewNamed(types.NewTypeName(token.NoPos, pkg, name, nil), nil, nil)
+	named.SetUnderlying(types.NewStruct(nil, nil))
+	return named
+}
+
+// TestQualifiedName_Functions_NamesTheReceiverToo checks the name a whitelist
+// entry is matched against, so an entry cannot match the wrong method.
+func TestQualifiedName_Functions_NamesTheReceiverToo(t *testing.T) {
+	pkg := types.NewPackage("time", "time")
+	instant := namedType(pkg, "Time")
+	recv := types.NewVar(token.NoPos, pkg, "t", instant)
+	pointerRecv := types.NewVar(token.NoPos, pkg, "t", types.NewPointer(instant))
+
+	cases := []struct {
+		name string
+		fn   *types.Func
+		want string
+	}{
+		{
+			name: "a function",
+			fn:   types.NewFunc(token.NoPos, pkg, "Now", types.NewSignatureType(nil, nil, nil, nil, nil, false)),
+			want: "time.Now",
+		},
+		{
+			name: "a method",
+			fn:   types.NewFunc(token.NoPos, pkg, "Format", types.NewSignatureType(recv, nil, nil, nil, nil, false)),
+			want: "time.Time.Format",
+		},
+		{
+			name: "a method on a pointer",
+			fn:   types.NewFunc(token.NoPos, pkg, "String", types.NewSignatureType(pointerRecv, nil, nil, nil, nil, false)),
+			want: "time.Time.String",
+		},
+		{
+			name: "a function belonging to no package",
+			fn:   types.NewFunc(token.NoPos, nil, "Anonymous", types.NewSignatureType(nil, nil, nil, nil, nil, false)),
+			want: ".Anonymous",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := qualifiedName(tc.fn); got != tc.want {
+				t.Errorf("qualifiedName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsEscaperAndIsSprintf_Functions_KeyOnTheImportPath checks that a helper
+// with the right name in the wrong package is not read as an escaper, which is
+// what keys the resolution on the path rather than on the package name.
+func TestIsEscaperAndIsSprintf_Functions_KeyOnTheImportPath(t *testing.T) {
+	impostor := types.NewPackage("example.invalid/toolutil", "toolutil")
+	genuine := types.NewPackage(toolutilPath, "toolutil")
+	signature := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+	if isEscaper(types.NewFunc(token.NoPos, impostor, "EscapeMdTableCell", signature)) {
+		t.Error("a helper from another package was accepted as an escaper")
+	}
+	if !isEscaper(types.NewFunc(token.NoPos, genuine, "EscapeMdTableCell", signature)) {
+		t.Error("the real escaper was not recognized")
+	}
+	if isEscaper(types.NewFunc(token.NoPos, nil, "EscapeMdTableCell", signature)) {
+		t.Error("a function belonging to no package was accepted as an escaper")
+	}
+	if isSprintf(types.NewFunc(token.NoPos, impostor, "Sprintf", signature)) {
+		t.Error("another package's Sprintf was accepted")
+	}
+	if !isSprintf(types.NewFunc(token.NoPos, types.NewPackage("fmt", "fmt"), "Sprintf", signature)) {
+		t.Error("fmt.Sprintf was not recognized")
+	}
+}
+
+// TestPackageLevel_Variables_TellsAGlobalFromAField checks the rule that
+// separates another package's variable from a field of a struct, which decides
+// whether the audit keeps looking or starts reporting.
+func TestPackageLevel_Variables_TellsAGlobalFromAField(t *testing.T) {
+	pkg := types.NewPackage("example.invalid/x", "x")
+	scope := types.NewScope(types.Universe, token.NoPos, token.NoPos, "package")
+	global := types.NewVar(token.NoPos, pkg, "Global", types.Typ[types.String])
+	scope.Insert(global)
+
+	if !packageLevel(global) {
+		t.Error("a package-level variable was not recognized as one")
+	}
+	if packageLevel(types.NewField(token.NoPos, pkg, "Title", types.Typ[types.String], false)) {
+		t.Error("a struct field was read as a package-level variable")
+	}
+}

--- a/cmd/audit_md_escaping/expr_test.go
+++ b/cmd/audit_md_escaping/expr_test.go
@@ -113,6 +113,15 @@ func TestClassifyExpr_Fixture_AnswersEachShape(t *testing.T) {
 			expression: "pair.Right", want: unescaped, reason: "a field of a value filled from a GitLab response",
 		},
 		{
+			// The helper reads it.Title, and it is bound to the argument
+			// FormatDelegated passed, so the answer names FormatDelegated
+			// rather than every caller of the helper. Following the binding is
+			// what keeps a helper called once from reading as a value the
+			// audit cannot resolve.
+			name: "a field of a value the caller bound to the helper", pkg: "mdcase",
+			expression: "delegated(item)", want: unescaped, reason: "handed to FormatDelegated",
+		},
+		{
 			name: "a call of a function value", pkg: "mdcase",
 			expression: "render(item)", want: unresolved, reason: "function value",
 		},

--- a/cmd/audit_md_escaping/format.go
+++ b/cmd/audit_md_escaping/format.go
@@ -1,0 +1,116 @@
+package main
+
+import "strings"
+
+// hole is one place a runtime value lands inside a Markdown template: the verb
+// that renders it, the argument index it consumes, and where in the template
+// text it sits, which is what decides the Markdown context around it.
+type hole struct {
+	verb byte
+	// arg is the index into the call's argument list, after the format
+	// string. It is -1 when the verb consumes no argument.
+	arg int
+	// offset is the byte offset of the verb's '%' within the template.
+	offset int
+}
+
+// parseVerbs splits a printf template into the holes it declares.
+//
+// Argument consumption follows the fmt package: flags, an explicit argument
+// index, a width and a precision may precede the verb, and a '*' for either
+// consumes an argument of its own. Getting this wrong would pair a verb with
+// the wrong expression, which is worse than not looking at all, so the walk
+// mirrors fmt's own grammar rather than matching a regular expression.
+func parseVerbs(template string) []hole {
+	var holes []hole
+	next := 0
+	for i := 0; i < len(template); i++ {
+		if template[i] != '%' {
+			continue
+		}
+		start := i
+		i++
+		if i >= len(template) {
+			break
+		}
+		if template[i] == '%' {
+			continue
+		}
+		i = skipFlags(template, i)
+		if idx, after, ok := explicitArgIndex(template, i); ok {
+			next = idx
+			i = after
+		}
+		i, next = consumeStar(template, i, next, &holes, start)
+		i = skipDigits(template, i)
+		if i < len(template) && template[i] == '.' {
+			i++
+			i, next = consumeStar(template, i, next, &holes, start)
+			i = skipDigits(template, i)
+		}
+		if i >= len(template) {
+			break
+		}
+		holes = append(holes, hole{verb: template[i], arg: next, offset: start})
+		next++
+	}
+	return holes
+}
+
+// skipFlags advances past the printf flag characters.
+func skipFlags(template string, i int) int {
+	for i < len(template) && strings.IndexByte("+-# 0", template[i]) >= 0 {
+		i++
+	}
+	return i
+}
+
+// skipDigits advances past a run of decimal digits.
+func skipDigits(template string, i int) int {
+	for i < len(template) && template[i] >= '0' && template[i] <= '9' {
+		i++
+	}
+	return i
+}
+
+// explicitArgIndex reads a "[n]" argument selector, returning the zero-based
+// index it names and the offset just past it.
+func explicitArgIndex(template string, i int) (index, after int, ok bool) {
+	if i >= len(template) || template[i] != '[' {
+		return 0, i, false
+	}
+	j := i + 1
+	value := 0
+	digits := 0
+	for j < len(template) && template[j] >= '0' && template[j] <= '9' {
+		value = value*10 + int(template[j]-'0')
+		digits++
+		j++
+	}
+	if digits == 0 || j >= len(template) || template[j] != ']' || value < 1 {
+		return 0, i, false
+	}
+	return value - 1, j + 1, true
+}
+
+// consumeStar accounts for a '*' width or precision, which takes an argument
+// of its own. The consumed argument is recorded as a hole so a caller counting
+// arguments stays in step, with a verb of '*' that no context ever judges.
+func consumeStar(template string, i, next int, holes *[]hole, start int) (offset, nextArg int) {
+	if i >= len(template) || template[i] != '*' {
+		return i, next
+	}
+	*holes = append(*holes, hole{verb: '*', arg: next, offset: start})
+	return i + 1, next + 1
+}
+
+// stringishVerbs are the verbs that render a value as text a Markdown reader
+// sees as text. They are the only ones through which a pipe, a newline or an
+// opening angle bracket can reach the page: %d and its numeric siblings can
+// emit none of the three whatever they are handed.
+//
+// %q is here despite quoting its argument. Go's quoting escapes a quote and a
+// backslash and nothing else that matters here, so a title holding a pipe
+// still ends the cell, and one holding an opening angle bracket still opens a
+// tag.
+var stringishVerbs = map[byte]bool{'s': true, 'v': true, 'q': true}

--- a/cmd/audit_md_escaping/format_test.go
+++ b/cmd/audit_md_escaping/format_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestParseVerbs_Templates_PairsEachVerbWithItsArgument covers fmt's grammar
+// as far as the audit reads it. Getting this wrong would pair a verb with the
+// wrong expression, which is worse than not looking at all.
+func TestParseVerbs_Templates_PairsEachVerbWithItsArgument(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		want     []string
+	}{
+		{name: "one verb", template: "| %s |", want: []string{"s@0"}},
+		{name: "two verbs", template: "| %s | %d |", want: []string{"s@0", "d@1"}},
+		{name: "a literal percent consumes nothing", template: "100%% of %s", want: []string{"s@0"}},
+		{name: "flags and width", template: "|%-10.3s|", want: []string{"s@0"}},
+		{name: "a star width takes an argument", template: "%*s", want: []string{"*@0", "s@1"}},
+		{name: "a star precision takes one too", template: "%.*f", want: []string{"*@0", "f@1"}},
+		{name: "explicit indices", template: "[%[1]s](%[1]s)", want: []string{"s@0", "s@0"}},
+		{name: "an index resets the run", template: "%[2]s %s", want: []string{"s@1", "s@2"}},
+		// fmt itself answers a malformed index with %!s(BADINDEX), so a
+		// template carrying one is already broken. The walk stops at the
+		// bracket rather than guessing, which leaves a verb no context judges.
+		{name: "a malformed index stops at the bracket", template: "%[x]s", want: []string{"[@0"}},
+		{name: "a zero index stops there too", template: "%[0]s", want: []string{"[@0"}},
+		{name: "a trailing percent declares nothing", template: "value: %", want: nil},
+		{name: "a truncated verb declares nothing", template: "value: %-", want: nil},
+		{name: "a truncated precision declares nothing", template: "%.", want: nil},
+		{name: "no verbs at all", template: "| name |", want: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			for _, h := range parseVerbs(tc.template) {
+				got = append(got, fmt.Sprintf("%c@%d", h.verb, h.arg))
+			}
+			if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+				t.Errorf("parseVerbs(%q) = %v, want %v", tc.template, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseVerbs_Offsets_PointAtThePercentSign checks that a hole is located
+// where its verb begins, which is what decides the construct around it.
+func TestParseVerbs_Offsets_PointAtThePercentSign(t *testing.T) {
+	template := "## %s\n| %s |"
+
+	holes := parseVerbs(template)
+
+	if len(holes) != 2 {
+		t.Fatalf("parseVerbs found %d holes, want 2", len(holes))
+	}
+	if contextAt(template, holes[0].offset) != ctxHeading {
+		t.Errorf("the first hole is not in the heading")
+	}
+	if contextAt(template, holes[1].offset) != ctxCell {
+		t.Errorf("the second hole is not in the cell")
+	}
+}
+
+// TestStringishVerbs_Set_JudgesOnlyWhatCanCarryText checks that the numeric
+// verbs are skipped and %q is not, since Go's quoting escapes neither a pipe
+// nor an angle bracket.
+func TestStringishVerbs_Set_JudgesOnlyWhatCanCarryText(t *testing.T) {
+	for _, verb := range []string{"s", "v", "q"} {
+		t.Run(verb, func(t *testing.T) {
+			if !stringishVerbs[verb[0]] {
+				t.Errorf("%%%s is not judged, though it renders text", verb)
+			}
+		})
+	}
+	for _, verb := range []string{"d", "f", "t", "x", "*"} {
+		t.Run(verb, func(t *testing.T) {
+			if stringishVerbs[verb[0]] {
+				t.Errorf("%%%s is judged, though it cannot emit a pipe, a newline or an angle bracket", verb)
+			}
+		})
+	}
+}

--- a/cmd/audit_md_escaping/main.go
+++ b/cmd/audit_md_escaping/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// toolName prefixes every line this command writes about itself, so a failure
+// in a suite of gates names the gate that failed.
+const toolName = "audit_md_escaping"
+
+// auditPatterns are the packages the audit loads. Every Markdown formatter in
+// this project lives under them, as do the escaping helpers themselves.
+var auditPatterns = []string{"./internal/..."}
+
+// exit is os.Exit behind a variable, so the one line main carries is reachable
+// from a test rather than only from a process.
+var exit = os.Exit
+
+// absRoot resolves the repository root, behind a variable for the same reason:
+// filepath.Abs fails only when the working directory has been removed under
+// the process, and a gate's error path is worth a test even when reaching it
+// for real takes a deleted directory.
+var absRoot = filepath.Abs
+
+// auditRun is one configured run: where to look, what to judge, and what to
+// write.
+type auditRun struct {
+	dir            string
+	jsonPath       string
+	contexts       string
+	check          bool
+	verbose        bool
+	failUnresolved bool
+	patterns       []string
+	// overlay supplies source that is not on disk, which is how a test hands
+	// the audit a fixture package instead of the repository.
+	overlay map[string][]byte
+}
+
+func main() {
+	exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run parses the command line and performs the sweep.
+//
+// It returns 0 when the run is clean, 1 when -check found something, and 2 when
+// the audit itself could not do its job, which is the split its sibling audits
+// use: a gate that cannot run must not read as a gate that passed.
+func run(args []string, out, errOut io.Writer) int {
+	flags := flag.NewFlagSet(toolName, flag.ContinueOnError)
+	flags.SetOutput(errOut)
+	cfg := auditRun{patterns: auditPatterns}
+	flags.StringVar(&cfg.dir, "dir", ".", "repository root to audit")
+	flags.StringVar(&cfg.jsonPath, "json", "", "write the JSON work list to this path")
+	flags.StringVar(&cfg.contexts, "contexts", allContexts,
+		"Markdown contexts to judge: "+allContexts+", or a comma-separated list of "+contextNames())
+	flags.BoolVar(&cfg.check, "check", false, "exit non-zero when a value still reaches a Markdown construct unescaped")
+	flags.BoolVar(&cfg.verbose, "v", false, "list the excused and unresolved values as well as the failing ones")
+	flags.BoolVar(&cfg.failUnresolved, "fail-unresolved", false, "count a value the audit cannot follow as a failure")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	// Package patterns after the flags narrow the sweep to part of the tree,
+	// which is what makes checking one domain while working on it cheap.
+	if patterns := flags.Args(); len(patterns) > 0 {
+		cfg.patterns = patterns
+	}
+	return execute(cfg, out, errOut)
+}
+
+// execute performs one configured run, so a test can drive the whole audit
+// over a fixture without going through a command line.
+func execute(cfg auditRun, out, errOut io.Writer) int {
+	sel, err := parseContexts(cfg.contexts)
+	if err != nil {
+		fmt.Fprintf(errOut, "%s: %v\n", toolName, err)
+		return 2
+	}
+	root, err := absRoot(cfg.dir)
+	if err != nil {
+		fmt.Fprintf(errOut, "%s: %v\n", toolName, err)
+		return 2
+	}
+	prog, err := loadProgram(root, cfg.patterns, cfg.overlay)
+	if err != nil {
+		fmt.Fprintf(errOut, "%s: %v\n", toolName, err)
+		return 2
+	}
+
+	report := audit(prog, sel, root)
+	writeReport(out, report, cfg.verbose)
+
+	if cfg.jsonPath != "" {
+		if writeErr := writeJSON(cfg.jsonPath, report); writeErr != nil {
+			fmt.Fprintf(errOut, "%s: %v\n", toolName, writeErr)
+			return 2
+		}
+		fmt.Fprintf(out, "work list written to %s\n", cfg.jsonPath)
+	}
+	if !cfg.check {
+		return 0
+	}
+	return gate(out, report, cfg.failUnresolved)
+}
+
+// gate turns the report into the check-mode verdict.
+//
+// A stale directive fails alongside a finding on purpose. An exemption that
+// excuses nothing has outlived whatever made its value safe, and leaving it in
+// place is how a gate widens without anyone deciding to widen it.
+func gate(out io.Writer, report Report, failUnresolved bool) int {
+	failures := report.Summary.Findings + report.Summary.Stale
+	if failUnresolved {
+		failures += report.Summary.Unresolved
+	}
+	if failures > 0 {
+		fmt.Fprintf(out, "check: FAIL. %d value(s) reach a Markdown construct unescaped, %d directive(s) excuse nothing, %d unresolved\n",
+			report.Summary.Findings, report.Summary.Stale, report.Summary.Unresolved)
+		return 1
+	}
+	fmt.Fprintf(out, "check: PASS. Every value reaching %s is escaped or declared safe (%d excused by directive, %d unresolved)\n",
+		report.Summary.Contexts, report.Summary.Excused, report.Summary.Unresolved)
+	return 0
+}

--- a/cmd/audit_md_escaping/main_test.go
+++ b/cmd/audit_md_escaping/main_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runFixture runs the audit over the named fixture packages, with the
+// repository as the root and the streams captured.
+func runFixture(t *testing.T, cfg auditRun, sources map[string]string) (code int, out, errOut string) {
+	t.Helper()
+	cfg.dir = repoRoot(t)
+	cfg.patterns = []string{fixturePattern}
+	cfg.overlay = fixtureOverlay(t, sources)
+	var stdout, stderr strings.Builder
+	code = execute(cfg, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+// cleanFixture is a fixture with nothing to report, so the passing side of the
+// gate is exercised on real source rather than on an empty report.
+var cleanFixture = map[string]string{"mdsafe/mdsafe.go": mdsafeSource}
+
+// TestExecute_CleanTree_PassesTheGate checks the answer a green run gives,
+// which has to name what it judged rather than only say nothing was wrong.
+func TestExecute_CleanTree_PassesTheGate(t *testing.T) {
+	code, out, errOut := runFixture(t, auditRun{contexts: allContexts, check: true}, cleanFixture)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0\n%s%s", code, out, errOut)
+	}
+	if !strings.Contains(out, "check: PASS") {
+		t.Errorf("a clean run does not say it passed:\n%s", out)
+	}
+	if !strings.Contains(out, "table-cell, heading, list-item, link-label, link-destination") {
+		t.Errorf("the passing line does not name what was judged:\n%s", out)
+	}
+}
+
+// TestExecute_CleanTree_FailUnresolved_Fails checks the stricter gate: a value
+// the audit could not follow is a documented hole, and an operator who wants
+// none can say so.
+func TestExecute_CleanTree_FailUnresolved_Fails(t *testing.T) {
+	code, out, _ := runFixture(t, auditRun{contexts: allContexts, check: true, failUnresolved: true}, cleanFixture)
+
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 with -fail-unresolved\n%s", code, out)
+	}
+	if !strings.Contains(out, "check: FAIL") {
+		t.Errorf("the run does not say it failed:\n%s", out)
+	}
+}
+
+// TestExecute_UnescapedValue_FailsTheGate checks the failing side, including
+// that the failure names the counts a reader needs.
+func TestExecute_UnescapedValue_FailsTheGate(t *testing.T) {
+	code, out, _ := runFixture(t, auditRun{contexts: allContexts, check: true}, caseFixture)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", code, out)
+	}
+	if !strings.Contains(out, "check: FAIL") || !strings.Contains(out, "reach a Markdown construct unescaped") {
+		t.Errorf("the failure does not say what failed:\n%s", out)
+	}
+}
+
+// TestExecute_WithoutCheck_ReportsWithoutFailing checks that the report mode
+// is a report: it lists the same findings and exits 0, which is what makes it
+// usable while the sweep is under way.
+func TestExecute_WithoutCheck_ReportsWithoutFailing(t *testing.T) {
+	code, out, _ := runFixture(t, auditRun{contexts: allContexts, verbose: true}, caseFixture)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0 without -check\n%s", code, out)
+	}
+	if !strings.Contains(out, "=== "+fixtureDir+"/mdcase ===") {
+		t.Errorf("the report does not group the fixture's findings:\n%s", out)
+	}
+	if strings.Contains(out, "check:") {
+		t.Errorf("the report mode printed a gate verdict:\n%s", out)
+	}
+}
+
+// TestExecute_JSONPath_WritesTheWorkListOrSaysWhyNot covers both ends of the
+// work list: the file the walk reads, and the failure that must not read as a
+// clean run.
+func TestExecute_JSONPath_WritesTheWorkListOrSaysWhyNot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backlog.json")
+
+	code, out, _ := runFixture(t, auditRun{contexts: allContexts, jsonPath: path}, caseFixture)
+
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "work list written to "+path) {
+		t.Errorf("the run does not say where it wrote the work list:\n%s", out)
+	}
+	if info, err := os.Stat(path); err != nil || info.Size() == 0 {
+		t.Errorf("work list at %s: %v", path, err)
+	}
+
+	failing, _, errOut := runFixture(t,
+		auditRun{contexts: allContexts, jsonPath: filepath.Join(path, "nested.json")}, caseFixture)
+	if failing != 2 {
+		t.Errorf("exit code = %d, want 2 when the work list cannot be written", failing)
+	}
+	if !strings.Contains(errOut, toolName+":") {
+		t.Errorf("the failure does not name the gate that failed: %q", errOut)
+	}
+}
+
+// TestExecute_Failures_ExitTwo checks that a gate which could not do its job
+// says so with the exit code its siblings use, rather than reading as a gate
+// that passed.
+func TestExecute_Failures_ExitTwo(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  auditRun
+		want string
+	}{
+		{name: "an unknown context", cfg: auditRun{contexts: "cells"}, want: "unknown Markdown context"},
+		{name: "a tree that cannot be loaded", cfg: auditRun{contexts: allContexts, dir: filepath.Join(t.TempDir(), "absent")}, want: "load"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			if cfg.dir == "" {
+				cfg.dir = repoRoot(t)
+			}
+			cfg.patterns = []string{fixturePattern}
+			var out, errOut strings.Builder
+
+			if got := execute(cfg, &out, &errOut); got != 2 {
+				t.Errorf("exit code = %d, want 2", got)
+			}
+			if !strings.Contains(errOut.String(), tc.want) {
+				t.Errorf("error %q does not say %q", errOut.String(), tc.want)
+			}
+		})
+	}
+}
+
+// TestExecute_UnresolvableRoot_ExitsTwo checks the one failure that needs the
+// working directory to have been removed under the process, through the seam
+// that stands in for it.
+func TestExecute_UnresolvableRoot_ExitsTwo(t *testing.T) {
+	original := absRoot
+	t.Cleanup(func() { absRoot = original })
+	absRoot = func(string) (string, error) { return "", errors.New("no working directory") }
+	var out, errOut strings.Builder
+
+	code := execute(auditRun{contexts: allContexts, dir: "."}, &out, &errOut)
+
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errOut.String(), "no working directory") {
+		t.Errorf("error %q does not name the failure", errOut.String())
+	}
+}
+
+// TestRun_CommandLine_ParsesItsFlags covers the command line itself: the help
+// that is not a failure, the flag that is, and a real run driven the way the
+// Makefile drives it.
+func TestRun_CommandLine_ParsesItsFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "help", args: []string{"-h"}, want: 0},
+		{name: "a flag that does not exist", args: []string{"-no-such-flag"}, want: 2},
+		{name: "an unknown context", args: []string{"-contexts", "cells"}, want: 2},
+		{name: "a report over the packages named after the flags", args: []string{"-dir", repoRoot(t), "-contexts", "heading", "./internal/toolutil"}, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errOut strings.Builder
+
+			if got := run(tc.args, &out, &errOut); got != tc.want {
+				t.Errorf("run(%v) = %d, want %d\n%s%s", tc.args, got, tc.want, out.String(), errOut.String())
+			}
+		})
+	}
+}
+
+// TestGate_Report_DecidesWhatFails checks the verdict itself, since what the
+// gate counts as a failure is the whole of its behavior in CI.
+func TestGate_Report_DecidesWhatFails(t *testing.T) {
+	cases := []struct {
+		name           string
+		summary        Summary
+		failUnresolved bool
+		want           int
+		says           string
+	}{
+		{name: "nothing at all", summary: Summary{Contexts: "table-cell"}, want: 0, says: "check: PASS"},
+		{name: "an unescaped value", summary: Summary{Findings: 1}, want: 1, says: "check: FAIL"},
+		{name: "a directive that excuses nothing", summary: Summary{Stale: 1}, want: 1, says: "check: FAIL"},
+		{name: "an unresolved value is not a failure", summary: Summary{Unresolved: 3, Contexts: "table-cell"}, want: 0, says: "3 unresolved"},
+		{name: "unless the operator asks", summary: Summary{Unresolved: 3}, failUnresolved: true, want: 1, says: "check: FAIL"},
+		{name: "an excused value is not one either", summary: Summary{Excused: 2, Contexts: "table-cell"}, want: 0, says: "2 excused"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out strings.Builder
+
+			got := gate(&out, Report{Summary: tc.summary}, tc.failUnresolved)
+
+			if got != tc.want {
+				t.Errorf("gate = %d, want %d", got, tc.want)
+			}
+			if !strings.Contains(out.String(), tc.says) {
+				t.Errorf("gate said %q, want it to say %q", out.String(), tc.says)
+			}
+		})
+	}
+}
+
+// TestMain_HelpFlag_ExitsThroughTheSeam checks the one line main carries, so
+// the command's entry point is exercised rather than assumed.
+func TestMain_HelpFlag_ExitsThroughTheSeam(t *testing.T) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+	originalArgs, originalExit, originalOut, originalErr := os.Args, exit, os.Stdout, os.Stderr
+	t.Cleanup(func() { os.Args, exit, os.Stdout, os.Stderr = originalArgs, originalExit, originalOut, originalErr })
+	code := -1
+	exit = func(got int) { code = got }
+	os.Args = []string{toolName, "-h"}
+	os.Stdout, os.Stderr = devNull, devNull
+
+	main()
+
+	if code != 0 {
+		t.Errorf("main exited %d, want 0", code)
+	}
+}

--- a/cmd/audit_md_escaping/program.go
+++ b/cmd/audit_md_escaping/program.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// loadMode is everything the audit needs: syntax to walk, types to tell a
+// number from a string, and imports so an object has one identity across the
+// packages that share it.
+//
+// NeedDeps is absent for the reason its sibling audits give. Every function
+// whose body this audit reads lives under internal/, and type-checking the
+// dependency tree from source would cost minutes to learn nothing: what a
+// dependency's function returns is judged by name, not by body.
+const loadMode = packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+	packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports
+
+// modulePath is this repository's module path, trimmed off an import path so a
+// report names a package the way the repository does.
+const modulePath = "github.com/jmrplens/gitlab-mcp-server/v2"
+
+// toolutilPath is the import path of the package that owns the escaping
+// helpers. Resolution keys on the path rather than on the package name so an
+// import alias cannot fool it.
+const toolutilPath = modulePath + "/internal/toolutil"
+
+// program is the loaded, indexed source the audit reasons over.
+type program struct {
+	fset  *token.FileSet
+	order []*packages.Package
+	// decls maps a declared function to its body and the package it was
+	// written in, so a return expression can be resolved in its own scope.
+	decls map[*types.Func]*funcDecl
+	// callers maps a declared function to every argument list it is called
+	// with, which is how a parameter is resolved to the values that reach it.
+	callers map[*types.Func][]callSite
+}
+
+// funcDecl is one declared function the audit may need to look inside.
+type funcDecl struct {
+	obj  *types.Func
+	pkg  *packages.Package
+	decl *ast.FuncDecl
+}
+
+// callSite is one call of a declared function, kept with the package it was
+// written in so its arguments resolve in their own scope.
+type callSite struct {
+	call *ast.CallExpr
+	pkg  *packages.Package
+}
+
+// loadProgram loads and indexes the packages named by patterns, rooted at dir.
+//
+// The overlay is how a test supplies source that is not on disk: a fixture
+// package written in the test file itself type-checks against the real
+// toolutil, so the classifier is exercised on the shapes it has to handle
+// rather than on a mock of them. Production passes nil.
+func loadProgram(dir string, patterns []string, overlay map[string][]byte) (*program, error) {
+	cfg := &packages.Config{Mode: loadMode, Dir: dir, Tests: false, Overlay: overlay}
+	loaded, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("load packages: %w", err)
+	}
+	if len(loaded) == 0 {
+		return nil, fmt.Errorf("no packages matched %s in %s", strings.Join(patterns, " "), dir)
+	}
+	prog := &program{
+		fset:    loaded[0].Fset,
+		decls:   make(map[*types.Func]*funcDecl),
+		callers: make(map[*types.Func][]callSite),
+	}
+	for _, pkg := range loaded {
+		if loadErr := packageLoadError(pkg); loadErr != nil {
+			return nil, loadErr
+		}
+		prog.order = append(prog.order, pkg)
+	}
+	for _, pkg := range prog.order {
+		prog.indexDecls(pkg)
+	}
+	for _, pkg := range prog.order {
+		prog.indexCalls(pkg)
+	}
+	return prog, nil
+}
+
+// packageLoadError turns a package's load errors into one reportable error. A
+// partially typed package would make every classification below fall back to
+// "cannot tell", which is exactly the failure mode a gate must not have.
+//
+// It is also what lets everything downstream read TypesInfo without checking
+// it: the loader fills it for every package it type-checked without error, and
+// a package it could not is refused here.
+func packageLoadError(pkg *packages.Package) error {
+	if len(pkg.Errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("load %s: %w", pkg.PkgPath, pkg.Errors[0])
+}
+
+// indexDecls records every declared function's body.
+func (p *program) indexDecls(pkg *packages.Package) {
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if obj, isFunc := pkg.TypesInfo.Defs[fn.Name].(*types.Func); isFunc {
+				p.decls[obj] = &funcDecl{obj: obj, pkg: pkg, decl: fn}
+			}
+		}
+	}
+}
+
+// indexCalls records where each declared function is called, so a parameter
+// can be resolved to every value that reaches it.
+func (p *program) indexCalls(pkg *packages.Package) {
+	for _, file := range pkg.Syntax {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if callee := calleeOf(pkg, call); callee != nil {
+				p.callers[callee] = append(p.callers[callee], callSite{call: call, pkg: pkg})
+			}
+			return true
+		})
+	}
+}
+
+// calleeOf returns the function a call names, or nil when the call is of a
+// value rather than of a declared function.
+func calleeOf(pkg *packages.Package, call *ast.CallExpr) *types.Func {
+	var ident *ast.Ident
+	switch fun := ast.Unparen(call.Fun).(type) {
+	case *ast.Ident:
+		ident = fun
+	case *ast.SelectorExpr:
+		ident = fun.Sel
+	default:
+		return nil
+	}
+	fn, _ := pkg.TypesInfo.Uses[ident].(*types.Func)
+	return fn
+}
+
+// position renders a source position.
+func (p *program) position(pos token.Pos) token.Position {
+	return p.fset.Position(pos)
+}

--- a/cmd/audit_md_escaping/program_test.go
+++ b/cmd/audit_md_escaping/program_test.go
@@ -283,6 +283,18 @@ func FormatThroughValue(render func(Item) string, item Item) string {
 	return fmt.Sprintf("| %s |\n", render(item))
 }
 
+// FormatDelegated hands its whole value to a helper that reads a field of it.
+// The helper's parameter is bound to this call's argument, so the field is
+// answered by where that argument came from rather than by every caller of the
+// helper.
+func FormatDelegated(item Item) string {
+	return fmt.Sprintf("| %s |\n", delegated(item))
+}
+
+func delegated(it Item) string {
+	return it.Title
+}
+
 // FormatPositional reads a field of a struct built positionally.
 func FormatPositional() string {
 	pair := Pair{"a|b", "c"}

--- a/cmd/audit_md_escaping/program_test.go
+++ b/cmd/audit_md_escaping/program_test.go
@@ -1,0 +1,523 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// fixtureDir is the directory the in-memory fixture packages pretend to live
+// in. Nothing is written there: the packages exist only in the loader overlay,
+// which keeps generated Go source out of the repository while still
+// type-checking it against the real toolutil.
+const fixtureDir = "cmd/audit_md_escaping/fixture"
+
+// fixturePattern matches every fixture package at once.
+const fixturePattern = "./" + fixtureDir + "/..."
+
+// fixturePatterns load the fixture together with the package that owns the
+// escaping helpers.
+//
+// toolutil is loaded from source rather than left to export data because the
+// audit's answers depend on its bodies: FormatTime returns its argument
+// verbatim when neither layout parses, and that one fallback is what a
+// hundred and fifty call sites in this repository hang on. A fixture that
+// mocked it would test the mock.
+var fixturePatterns = []string{fixturePattern, "./internal/toolutil"}
+
+// repoRoot walks up from the test's working directory to the module root, so
+// the overlay can name absolute paths inside the module and the loader
+// resolves the module's own import paths.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// fixtureOverlay turns a map of repository-relative fixture path to source
+// into a loader overlay rooted at the module.
+func fixtureOverlay(t *testing.T, sources map[string]string) map[string][]byte {
+	t.Helper()
+	root := repoRoot(t)
+	overlay := make(map[string][]byte, len(sources))
+	for name, source := range sources {
+		overlay[filepath.Join(root, filepath.FromSlash(fixtureDir), filepath.FromSlash(name))] = []byte(source)
+	}
+	return overlay
+}
+
+// fixtureCache memoizes one loaded program per fixture source set. Loading is
+// a full type-check of the fixture against toolutil, the result is read-only
+// for everything the tests ask of it, and the tests run in one goroutine, so
+// paying for it once keeps the package's tests from re-parsing the same few
+// packages for every case.
+var fixtureCache = map[string]*program{}
+
+// loadFixture loads the fixture packages described by sources.
+func loadFixture(t *testing.T, sources map[string]string) *program {
+	t.Helper()
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	key := strings.Join(names, "|")
+	if cached, ok := fixtureCache[key]; ok {
+		return cached
+	}
+	prog, err := loadProgram(repoRoot(t), fixturePatterns, fixtureOverlay(t, sources))
+	if err != nil {
+		t.Fatalf("loadProgram: %v", err)
+	}
+	fixtureCache[key] = prog
+	return prog
+}
+
+// fixturePackage returns one loaded fixture package by name.
+func fixturePackage(t *testing.T, prog *program, name string) *packages.Package {
+	t.Helper()
+	for _, pkg := range prog.order {
+		if strings.HasSuffix(pkg.PkgPath, "/"+name) {
+			return pkg
+		}
+	}
+	t.Fatalf("fixture package %s was not loaded", name)
+	return nil
+}
+
+// caseFixture is the fixture the audit tests share. Every package in it is
+// written the way a real domain is written, so the classifier is exercised on
+// the shapes it has to handle rather than on a mock of them.
+var caseFixture = map[string]string{
+	"mdcase/mdcase.go":     mdcaseSource,
+	"mdcase/extra.go":      mdcaseExtraSource,
+	"mdsafe/mdsafe.go":     mdsafeSource,
+	"mdexempt/mdexempt.go": mdexemptSource,
+}
+
+// mdcaseSource holds the shapes a formatter gets wrong, one of each: a value
+// in a heading, in a cell, in a list item, in both halves of a hand-built
+// link, in a cell builder with no template, and the shapes the audit answers
+// with something other than a verdict.
+const mdcaseSource = `package mdcase
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/audit_md_escaping/fixture/mdsafe"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// Item is the shape a GitLab response fills.
+type Item struct {
+	Title  string
+	URL    string
+	State  string
+	Count  int
+	Labels []string
+	Author *string
+	Extra  any
+}
+
+// Pair is a struct callers build positionally.
+type Pair struct {
+	Left  string
+	Right string
+}
+
+const headingTemplate = "## %s\n"
+
+// packageRow is written outside any function, so a finding about it names no
+// enclosing formatter.
+var packageRow = fmt.Sprintf("| %s |\n", mutableTitle)
+
+var mutableTitle string
+
+// FormatOutputMarkdown is registered by value, the way every Markdown
+// formatter in this repository is, so nothing calls it.
+func FormatOutputMarkdown(item Item) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, headingTemplate, item.Title)
+	fmt.Fprintf(&b, "| %s | %d |\n", item.State, item.Count)
+	fmt.Fprintf(&b, "- %s\n", item.Labels[0])
+	fmt.Fprintf(&b, "| [%[1]s](%[2]s) |\n", item.Title, item.URL)
+	fmt.Fprintf(&b, "| %q |\n", item.Title)
+	b.WriteString(toolutil.MarkdownTableRow(item.Title, toolutil.EscapeMdTableCell(item.State)))
+	b.WriteString(prose(item))
+	b.WriteString(packageRow)
+	return b.String()
+}
+
+// prose renders a paragraph, where a pipe and an angle bracket change nothing.
+func prose(item Item) string {
+	return fmt.Sprintf("%s wrote %s\n", item.Title, item.State)
+}
+
+// FormatLinked escapes a title into a local and then builds a link out of the
+// local and a raw URL, which is how a cell ends up holding an unescaped
+// destination.
+func FormatLinked(item Item) string {
+	name := toolutil.EscapeMdTableCell(item.Title)
+	if item.URL != "" {
+		name = fmt.Sprintf("[%s](%s)", name, item.URL)
+	}
+	return fmt.Sprintf("| %s |\n", name)
+}
+
+// FormatRow is the shared row helper: one caller passes an escaped title and
+// another passes a raw one, so the reason names the call site.
+func FormatRow(title string) string {
+	return fmt.Sprintf("| %s |\n", title)
+}
+
+// RenderRows calls it both ways.
+func RenderRows(item Item) string {
+	return FormatRow(toolutil.EscapeMdTableCell(item.Title)) + FormatRow(item.State)
+}
+
+// FormatRecursive reaches itself, which the walk has to cut without calling
+// the value safe.
+func FormatRecursive(item Item, depth int) string {
+	return fmt.Sprintf("| %s |\n", repeat(item.Title, depth))
+}
+
+func repeat(s string, n int) string {
+	if n <= 0 {
+		return s
+	}
+	return repeat(s, n-1)
+}
+
+// FormatSpread spreads a slice of cells into the row builder.
+func FormatSpread(item Item) string {
+	cells := []string{toolutil.EscapeMdTableCell(item.Title), item.State}
+	return toolutil.MarkdownTableRow(cells...)
+}
+
+// FormatDynamic builds its template at run time, so it is not a sink at all.
+func FormatDynamic(item Item, width int) string {
+	template := "| %-" + strconv.Itoa(width) + "s |\n"
+	return fmt.Sprintf(template, item.Title)
+}
+
+// FormatShapes writes the value shapes the walk has a rule for, one each.
+func FormatShapes(item Item) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "| %s |\n", "opened by "+item.Title)
+	fmt.Fprintf(&b, "| %s |\n", item.Title+" (open)")
+	fmt.Fprintf(&b, "| %s |\n", *item.Author)
+	fmt.Fprintf(&b, "| %s |\n", item.Extra.(string))
+	fmt.Fprintf(&b, "| %s |\n", item.Title[:8])
+	fmt.Fprintf(&b, "| %v |\n", []string{item.Title})
+	fmt.Fprintf(&b, "| %v |\n", map[string]string{"title": item.Title})
+	fmt.Fprintf(&b, "| %s |\n", strings.Join([]string{item.State, "open"}, ", "))
+	fmt.Fprintf(&b, "| %s |\n", fmt.Sprintf(dynamicTemplate(), item.Title))
+	fmt.Fprintf(&b, "| %s |\n", (*(&item)).Title)
+	fmt.Fprintf(&b, "| %s |\n", mdsafe.DefaultLabel)
+	fmt.Fprintf(&b, "| %s |\n", emptyTemplate)
+	return b.String()
+}
+
+// dynamicTemplate is a template the audit cannot read, even inside a call it
+// otherwise follows.
+func dynamicTemplate() string {
+	return "| %s |"
+}
+
+// FormatThroughClosure formats inside a function literal, whose parameters no
+// call site of a declared function binds.
+func FormatThroughClosure() func(string) string {
+	return func(title string) string {
+		return fmt.Sprintf("| %s |\n", title)
+	}
+}
+
+const emptyTemplate = ""
+
+// FormatEmptyTemplate writes a constant template with nothing in it.
+func FormatEmptyTemplate(b *strings.Builder) {
+	fmt.Fprintf(b, emptyTemplate)
+}
+
+// FormatUnnamed takes a value it does not name, which the index of parameters
+// has to step over.
+func FormatUnnamed(Item) string {
+	return "| unnamed |\n"
+}
+
+// FormatPair reads two results into two names, which the audit follows to
+// neither.
+func FormatPair() string {
+	var left, right = split("a|b")
+	return fmt.Sprintf("| %s | %s |\n", left, right)
+}
+`
+
+// mdcaseExtraSource is a second file of the same package, so the walk that
+// names the enclosing formatter has more than one file to choose from.
+const mdcaseExtraSource = `package mdcase
+
+import "fmt"
+
+// FormatThroughValue renders through a function it was handed, which the audit
+// cannot name.
+func FormatThroughValue(render func(Item) string, item Item) string {
+	return fmt.Sprintf("| %s |\n", render(item))
+}
+
+// FormatPositional reads a field of a struct built positionally.
+func FormatPositional() string {
+	pair := Pair{"a|b", "c"}
+	return fmt.Sprintf("| %s |\n", pair.Left)
+}
+
+// FormatFieldAssign fills a field after building the struct, which must not
+// read as a literal that left every field empty.
+func FormatFieldAssign(item Item) string {
+	pair := Pair{}
+	pair.Right = item.Title
+	return fmt.Sprintf("| %s |\n", pair.Right)
+}
+
+// FormatMulti takes one of two results, which the audit does not follow.
+func FormatMulti(item Item) string {
+	value, _ := split(item.Title)
+	return fmt.Sprintf("| %s |\n", value)
+}
+
+func split(s string) (string, string) {
+	return s, s
+}
+
+// FormatNamedResult returns through a named result.
+func FormatNamedResult(item Item) string {
+	return fmt.Sprintf("| %s |\n", namedResult(item))
+}
+
+func namedResult(item Item) (out string) {
+	out = item.Title
+	return
+}
+
+// FormatVariadic interpolates a variadic parameter its caller never fills.
+func FormatVariadic(prefix string, rest ...string) string {
+	return fmt.Sprintf("| %s |\n", rest[0])
+}
+
+// CallVariadic is that caller.
+func CallVariadic() string {
+	return FormatVariadic("x")
+}
+`
+
+// mdsafeSource holds the shapes that must not be reported: every escaper, the
+// non-textual types, a helper whose returns are all safe, a nested Sprintf, a
+// standard-library transform, an options struct built at the call site, and a
+// lookup in a table the server wrote.
+const mdsafeSource = `package mdsafe
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// Item is the shape a GitLab response fills.
+type Item struct {
+	Title string
+	URL   string
+	Count int
+	When  time.Time
+}
+
+// Options is the shape a caller builds at the call site.
+type Options struct {
+	Title  string
+	Column string
+}
+
+const rowTemplate = "| %s | %s |\n"
+
+var icons = map[string]string{"open": "ok"}
+
+// DefaultLabel is a value this package wrote, which another package reads
+// through its name rather than out of a struct.
+var DefaultLabel = "none"
+
+// FormatItem renders an item with every value already made safe.
+func FormatItem(item Item, opts Options) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s\n", toolutil.EscapeMdHeading(item.Title))
+	fmt.Fprintf(&b, rowTemplate, toolutil.EscapeMdTableCell(item.Title), toolutil.MdTitleLink(item.Title, item.URL))
+	fmt.Fprintf(&b, "| %v | %v |\n", item.Count, item.When)
+	fmt.Fprintf(&b, "| %s |\n", strconv.Itoa(item.Count))
+	fmt.Fprintf(&b, "- %s\n", strings.TrimSpace(toolutil.EscapeMdTableCell(item.Title)))
+	fmt.Fprintf(&b, "| %s | %s |\n", opts.Title, opts.Column)
+	fmt.Fprintf(&b, "| %s |\n", DefaultLabel)
+	fmt.Fprintf(&b, "| %s |\n", label(item))
+	fmt.Fprintf(&b, "| %s |\n", fmt.Sprintf("%s (%s)", toolutil.EscapeMdTableCell(item.Title), "server text"))
+	fmt.Fprintf(&b, "| %s |\n", toolutil.FormatTime("2024-01-01"))
+	fmt.Fprintf(&b, "| %s |\n", string(rune(item.Count)))
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "State"))
+	b.WriteString(toolutil.MarkdownTableRow(toolutil.EscapeMdTableCell(item.Title), statusIcon(item)))
+	return b.String()
+}
+
+// label returns an escaped cell whichever branch it takes.
+func label(item Item) string {
+	if item.Title == "" {
+		return "-"
+	}
+	return toolutil.EscapeMdTableCell(item.Title)
+}
+
+// statusIcon looks the icon up in a table the server wrote.
+func statusIcon(item Item) string {
+	if icon, ok := icons[item.Title]; ok {
+		return icon
+	}
+	return "-"
+}
+
+// Render builds the options at the call site, which is what answers for their
+// fields.
+func Render(item Item) string {
+	return FormatItem(item, Options{Title: "Items"})
+}
+`
+
+// mdexemptSource holds a value declared safe in the source, one declared safe
+// that no longer reaches a Markdown construct, and two malformed directives
+// that are not read as exemptions at all.
+const mdexemptSource = `package mdexempt
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Result is the shape the action catalog fills, which is not GitLab-authored
+// text at all.
+type Result struct {
+	ID    string
+	Title string
+}
+
+//gitlab:allow-unescaped result.ID: a canonical catalog ID, compiled in from an ActionSpec rather than read from GitLab.
+//gitlab:allow-unescaped result.Retired: nothing interpolates this any more.
+//gitlab:allow-unescaped result.Title
+//gitlab:allow-unescaped : a reason with nothing to excuse
+func FormatResult(result Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "| %s | %s |\n", result.ID, result.Title)
+	return b.String()
+}
+`
+
+// brokenFixture is a package that does not type-check, which the loader has to
+// refuse rather than audit half of.
+var brokenFixture = map[string]string{
+	"mdbroken/mdbroken.go": `package mdbroken
+
+func Broken() string {
+	return undefinedHelper()
+}
+`,
+}
+
+// TestLoadProgram_Fixture_IndexesDeclarationsAndCalls checks that a loaded
+// program can answer both questions the classifier asks of it: what a declared
+// function's body is, and where that function is called.
+func TestLoadProgram_Fixture_IndexesDeclarationsAndCalls(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+
+	if len(prog.order) != 4 {
+		t.Fatalf("loaded %d packages, want the 3 fixture packages and toolutil", len(prog.order))
+	}
+	var found, called bool
+	for fn, decl := range prog.decls {
+		if fn.Name() != "FormatRow" {
+			continue
+		}
+		found = true
+		if decl.decl.Body == nil {
+			t.Errorf("FormatRow indexed without a body")
+		}
+		if len(prog.callers[fn]) != 2 {
+			t.Errorf("FormatRow has %d recorded call sites, want 2", len(prog.callers[fn]))
+		}
+		called = true
+	}
+	if !found || !called {
+		t.Errorf("FormatRow not indexed: found=%v called=%v", found, called)
+	}
+}
+
+// TestLoadProgram_MissingDirectory_Fails checks that a root the loader cannot
+// enter is reported rather than read as an empty tree.
+func TestLoadProgram_MissingDirectory_Fails(t *testing.T) {
+	_, err := loadProgram(filepath.Join(t.TempDir(), "absent"), []string{"./..."}, nil)
+	if err == nil {
+		t.Fatal("loadProgram accepted a directory that does not exist")
+	}
+}
+
+// TestLoadProgram_NoMatch_Fails checks that a pattern matching nothing fails,
+// since a gate that audited no package would otherwise pass.
+func TestLoadProgram_NoMatch_Fails(t *testing.T) {
+	_, err := loadProgram(repoRoot(t), []string{modulePath + "/internal/nothing-here/..."}, nil)
+	if err == nil {
+		t.Fatal("loadProgram accepted a pattern that matched nothing")
+	}
+	if !strings.Contains(err.Error(), "no packages matched") {
+		t.Errorf("error %q does not say the pattern matched nothing", err)
+	}
+}
+
+// TestLoadProgram_BrokenPackage_Fails checks that a package that does not
+// type-check stops the run. Auditing it would classify every value as one the
+// audit cannot follow, which is the one failure mode a gate must not have.
+func TestLoadProgram_BrokenPackage_Fails(t *testing.T) {
+	_, err := loadProgram(repoRoot(t), fixturePatterns, fixtureOverlay(t, brokenFixture))
+	if err == nil {
+		t.Fatal("loadProgram accepted a package that does not type-check")
+	}
+	if !strings.Contains(err.Error(), "mdbroken") {
+		t.Errorf("error %q does not name the package that failed to load", err)
+	}
+}
+
+// TestProgramPosition_Fixture_ResolvesAFile checks that a position renders
+// with the file the expression was written in.
+func TestProgramPosition_Fixture_ResolvesAFile(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	sinks := collectSinks(prog)
+	if len(sinks) == 0 {
+		t.Fatal("no sinks collected from the fixture")
+	}
+	pos := prog.position(sinks[0].call.Pos())
+	if !strings.HasSuffix(filepath.ToSlash(pos.Filename), ".go") || pos.Line == 0 {
+		t.Errorf("position %s is not a source line", pos)
+	}
+}

--- a/cmd/audit_md_escaping/report.go
+++ b/cmd/audit_md_escaping/report.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// writeReport prints the human report: the findings grouped by the package
+// that has to act on them, then what the sweep saw.
+//
+// Verbose adds the two buckets that are not failures. The excused one is
+// printed so an exemption stays reviewable, and the unresolved one because a
+// value the audit could not follow is the audit's own blind spot rather than a
+// clean answer.
+func writeReport(out io.Writer, report Report, verbose bool) {
+	writeGroups(out, "", report.Findings)
+	if verbose {
+		writeGroups(out, "excused by directive: ", report.Excused)
+		writeGroups(out, "unresolved: ", report.Unresolved)
+	}
+	writeStale(out, report.StaleDirectives)
+	writeSummary(out, report.Summary)
+}
+
+// writeGroups prints findings under one `=== package ===` heading each.
+func writeGroups(out io.Writer, prefix string, findings []Finding) {
+	current := ""
+	for _, finding := range findings {
+		if finding.Package != current {
+			current = finding.Package
+			fmt.Fprintf(out, "=== %s%s ===\n", prefix, current)
+		}
+		fmt.Fprintf(out, "  %s:%d %s %s %s %s\n", finding.File, finding.Line, orDash(finding.Func),
+			finding.Context, finding.Verb, finding.Expression)
+		fmt.Fprintf(out, "      wants %s: %s\n", finding.Wants, finding.Reason)
+	}
+}
+
+// writeStale prints the exemptions that excused nothing.
+func writeStale(out io.Writer, stale []Directive) {
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "=== directives that excuse nothing ===\n")
+	for _, directive := range stale {
+		fmt.Fprintf(out, "  %s:%d %s %s\n", directive.File, directive.Line, directive.Package, directive.Expression)
+		fmt.Fprintf(out, "      %s no longer reaches a Markdown construct unescaped. Remove the directive.\n", directive.Expression)
+	}
+}
+
+// writeSummary prints what the sweep saw, with the two breakdowns the walk
+// through the findings is organized by.
+func writeSummary(out io.Writer, summary Summary) {
+	fmt.Fprintf(out, "%s: %d value(s) unescaped in %d package(s); %d excused; %d unresolved; %d stale directive(s)\n",
+		toolName, summary.Findings, summary.Packages, summary.Excused, summary.Unresolved, summary.Stale)
+	fmt.Fprintf(out, "  judged %d value(s) in %d Markdown sink(s), %d already safe; contexts: %s\n",
+		summary.Holes, summary.Sinks, summary.Safe, summary.Contexts)
+	if len(summary.ByContext) > 0 {
+		fmt.Fprintf(out, "  by context: %s\n", byCount(summary.ByContext))
+	}
+}
+
+// byCount renders a breakdown, biggest first, so the report opens with where
+// the work is.
+func byCount(counts map[string]int) string {
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if counts[keys[i]] != counts[keys[j]] {
+			return counts[keys[i]] > counts[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s %d", key, counts[key]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// orDash renders an empty field as a dash, so a column never disappears.
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+// writeJSON writes the machine-readable work list.
+//
+// It takes the report as any so that the encoding failure is a path a test can
+// reach: a gate that cannot write its work list has to say so rather than
+// report a clean run.
+func writeJSON(path string, report any) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if writeErr := os.WriteFile(path, append(data, '\n'), 0o600); writeErr != nil {
+		return fmt.Errorf("write %s: %w", path, writeErr)
+	}
+	return nil
+}
+
+// relativePath renders a file below the repository root, so a finding reads
+// the same wherever the audit was run from.
+func relativePath(path, root string) string {
+	if rel, err := filepath.Rel(root, path); err == nil && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(path)
+}

--- a/cmd/audit_md_escaping/report_test.go
+++ b/cmd/audit_md_escaping/report_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleReport is a report with one of everything a run can produce, so the
+// writers are exercised on every section they know how to print.
+func sampleReport() Report {
+	report := Report{
+		Findings: []Finding{
+			{
+				Package: "internal/tools/issues", File: "internal/tools/issues/markdown.go", Line: 42,
+				Func: "formatIssue", Context: "table-cell", Verb: "%s", Expression: "issue.Title",
+				Wants: "toolutil.EscapeMdTableCell", Reason: "a field of a value filled from a GitLab response",
+			},
+			{
+				Package: "internal/tools/issues", File: "internal/tools/issues/markdown.go", Line: 43,
+				Context: "heading", Verb: "%s", Expression: "issue.Title",
+				Wants: "toolutil.EscapeMdHeading", Reason: "a field of a value filled from a GitLab response",
+			},
+			{
+				Package: "internal/tools/users", File: "internal/tools/users/markdown.go", Line: 7,
+				Func: "formatUser", Context: "list-item", Verb: "%s", Expression: "user.Name",
+				Wants: "toolutil.EscapeMdTableCell", Reason: "a field of a value filled from a GitLab response",
+			},
+		},
+		Unresolved: []Finding{{
+			Package: "internal/tools/dynamic", File: "internal/tools/dynamic/register.go", Line: 9,
+			Func: "formatFind", Context: "table-cell", Verb: "%s", Expression: "render(result)",
+			Wants: "toolutil.EscapeMdTableCell", Reason: "the call is of a function value rather than of a named function",
+		}},
+		Excused: []Finding{{
+			Package: "internal/tools/dynamic", File: "internal/tools/dynamic/register.go", Line: 11,
+			Func: "formatFind", Context: "table-cell", Verb: "%s", Expression: "result.ID",
+			Wants: "toolutil.EscapeMdTableCell", Reason: "a field of a value filled from a GitLab response",
+		}},
+		StaleDirectives: []Directive{{
+			Package: "internal/tools/dynamic", File: "internal/tools/dynamic/register.go", Line: 3,
+			Expression: "result.Retired", Reason: "nothing interpolates this any more",
+		}},
+	}
+	report.Summary.Contexts = "table-cell, heading"
+	finish(&report)
+	return report
+}
+
+// TestWriteReport_Sample_GroupsFindingsByPackage checks the report a person
+// reads: one section per package, the helper each finding wants, and the
+// counts the walk is planned from.
+func TestWriteReport_Sample_GroupsFindingsByPackage(t *testing.T) {
+	var out strings.Builder
+
+	writeReport(&out, sampleReport(), false)
+
+	text := out.String()
+	for _, want := range []string{
+		"=== internal/tools/issues ===",
+		"=== internal/tools/users ===",
+		"internal/tools/issues/markdown.go:42 formatIssue table-cell %s issue.Title",
+		"wants toolutil.EscapeMdTableCell: a field of a value filled from a GitLab response",
+		"internal/tools/issues/markdown.go:43 - heading %s issue.Title",
+		"=== directives that excuse nothing ===",
+		"result.Retired no longer reaches a Markdown construct unescaped",
+		"audit_md_escaping: 3 value(s) unescaped in 2 package(s); 1 excused; 1 unresolved; 1 stale directive(s)",
+		"by context: heading 1, list-item 1, table-cell 1",
+	} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("report does not contain %q:\n%s", want, text)
+			}
+		})
+	}
+	for _, unwanted := range []string{"excused by directive:", "unresolved:"} {
+		t.Run(unwanted, func(t *testing.T) {
+			if strings.Contains(text, unwanted) {
+				t.Errorf("the quiet report printed the %q section:\n%s", unwanted, text)
+			}
+		})
+	}
+}
+
+// TestWriteReport_Verbose_AddsTheBucketsThatAreNotFailures checks that the two
+// lists a gate does not fail on are printed when asked for, since a value the
+// audit could not follow is its own blind spot rather than a clean answer.
+func TestWriteReport_Verbose_AddsTheBucketsThatAreNotFailures(t *testing.T) {
+	var out strings.Builder
+
+	writeReport(&out, sampleReport(), true)
+
+	text := out.String()
+	for _, want := range []string{
+		"=== excused by directive: internal/tools/dynamic ===",
+		"=== unresolved: internal/tools/dynamic ===",
+		"render(result)",
+	} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(text, want) {
+				t.Errorf("verbose report does not contain %q:\n%s", want, text)
+			}
+		})
+	}
+}
+
+// TestWriteReport_Clean_SaysSoWithoutASection checks the shape of a run with
+// nothing to report.
+func TestWriteReport_Clean_SaysSoWithoutASection(t *testing.T) {
+	var out strings.Builder
+	report := Report{Summary: Summary{Contexts: "table-cell"}}
+	finish(&report)
+
+	writeReport(&out, report, true)
+
+	text := out.String()
+	if strings.Contains(text, "===") {
+		t.Errorf("a clean run printed a section:\n%s", text)
+	}
+	if !strings.Contains(text, "0 value(s) unescaped in 0 package(s)") {
+		t.Errorf("a clean run does not say so:\n%s", text)
+	}
+	if strings.Contains(text, "by context:") {
+		t.Errorf("a clean run printed an empty breakdown:\n%s", text)
+	}
+}
+
+// TestByCount_Breakdown_OrdersByCountThenName checks that a breakdown opens
+// with where the work is, and is stable when two counts tie.
+func TestByCount_Breakdown_OrdersByCountThenName(t *testing.T) {
+	got := byCount(map[string]int{"heading": 2, "table-cell": 9, "list-item": 2, "link-label": 1})
+
+	if want := "table-cell 9, heading 2, list-item 2, link-label 1"; got != want {
+		t.Errorf("byCount = %q, want %q", got, want)
+	}
+}
+
+// TestWriteJSON_Report_RoundTrips checks that the work list on disk is the
+// report, since the walk through the findings reads that file rather than the
+// terminal.
+func TestWriteJSON_Report_RoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backlog.json")
+	report := sampleReport()
+
+	if err := writeJSON(path, report); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var decoded Report
+	if decodeErr := json.Unmarshal(data, &decoded); decodeErr != nil {
+		t.Fatalf("decode: %v", decodeErr)
+	}
+	if len(decoded.Findings) != len(report.Findings) || decoded.Summary.Findings != report.Summary.Findings {
+		t.Errorf("the work list read back as %+v, want the report that was written", decoded.Summary)
+	}
+	if decoded.StaleDirectives[0].Expression != "result.Retired" {
+		t.Errorf("the stale directive did not survive the round trip: %+v", decoded.StaleDirectives)
+	}
+}
+
+// TestWriteJSON_Failures_AreReported checks both ways writing the work list can
+// fail, because a gate that could not write one must say so rather than report
+// a clean run.
+func TestWriteJSON_Failures_AreReported(t *testing.T) {
+	dir := t.TempDir()
+	notADirectory := filepath.Join(dir, "file")
+	if err := os.WriteFile(notADirectory, []byte("x"), 0o600); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		path   string
+		report any
+		want   string
+	}{
+		{name: "a path that cannot be written", path: filepath.Join(notADirectory, "backlog.json"), report: Report{}, want: "write"},
+		{name: "a report that cannot be encoded", path: filepath.Join(dir, "backlog.json"), report: make(chan int), want: "marshal"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := writeJSON(tc.path, tc.report)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("writeJSON error = %v, want one saying %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestRelativePath_Paths_RenderBelowTheRoot checks that a finding reads the
+// same wherever the audit was run from, and that a file outside the tree keeps
+// the only name it has.
+func TestRelativePath_Paths_RenderBelowTheRoot(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		root string
+		want string
+	}{
+		{name: "inside the tree", path: "/repo/internal/tools/x.go", root: "/repo", want: "internal/tools/x.go"},
+		{name: "the root itself", path: "/repo", root: "/repo", want: "."},
+		{name: "outside the tree", path: "/elsewhere/x.go", root: "/repo", want: "/elsewhere/x.go"},
+		{name: "no root at all", path: "/repo/x.go", root: "", want: "/repo/x.go"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relativePath(tc.path, tc.root); got != tc.want {
+				t.Errorf("relativePath(%q, %q) = %q, want %q", tc.path, tc.root, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOrDash_Values_KeepsTheColumn checks that a finding with no enclosing
+// formatter still prints a column where one is expected.
+func TestOrDash_Values_KeepsTheColumn(t *testing.T) {
+	if got := orDash(""); got != "-" {
+		t.Errorf("orDash(\"\") = %q, want a dash", got)
+	}
+	if got := orDash("formatIssue"); got != "formatIssue" {
+		t.Errorf("orDash = %q, want the name it was given", got)
+	}
+}

--- a/cmd/audit_md_escaping/sink.go
+++ b/cmd/audit_md_escaping/sink.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// sink is one call that writes Markdown with runtime values in it, already
+// split into the places those values land.
+type sink struct {
+	pkg    *packages.Package
+	call   *ast.CallExpr
+	callee string
+	holes  []sinkHole
+}
+
+// sinkHole is one place a runtime value lands: the expression that produces
+// it, the Markdown construct it lands in, and how the call names it, which a
+// report prints so a reader can find the hole in the template.
+type sinkHole struct {
+	expr ast.Expr
+	ctx  mdContext
+	verb string
+}
+
+// formatArgIndex names, per fmt function, which argument is the template.
+// Errorf is absent on purpose: its result is an error message, which the error
+// path renders with containment of its own.
+var formatArgIndex = map[string]int{
+	"Sprintf": 0,
+	"Fprintf": 1,
+	"Printf":  0,
+	"Appendf": 1,
+}
+
+// cellArgFuncs are the toolutil builders with no template at all, because
+// every argument they take is a table cell by construction. A gate that only
+// parsed printf templates would not see them.
+var cellArgFuncs = map[string]bool{
+	"MarkdownTableRow":    true,
+	"MarkdownTableHeader": true,
+}
+
+// collectSinks finds every call in the loaded packages that writes Markdown
+// with a runtime value in it.
+//
+// A WriteString of a constant carries no runtime value, and one of a
+// concatenation builds its pieces with Sprintf in this codebase, which is
+// itself a sink.
+func collectSinks(prog *program) []sink {
+	var sinks []sink
+	for _, pkg := range prog.order {
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if s, isSink := sinkOf(pkg, call); isSink {
+					sinks = append(sinks, s)
+				}
+				return true
+			})
+		}
+	}
+	return sinks
+}
+
+// sinkOf recognizes a Markdown-writing call and splits it into its holes.
+func sinkOf(pkg *packages.Package, call *ast.CallExpr) (sink, bool) {
+	callee := calleeOf(pkg, call)
+	if callee == nil || callee.Pkg() == nil {
+		return sink{}, false
+	}
+	switch callee.Pkg().Path() {
+	case "fmt":
+		return formatSink(pkg, call, callee.Name())
+	case toolutilPath:
+		return cellSink(pkg, call, callee.Name())
+	default:
+		return sink{}, false
+	}
+}
+
+// formatSink splits an fmt formatting call whose template is a constant.
+//
+// The template must be constant for the audit to know where a value lands, and
+// the type checker resolves a named constant as readily as a literal, which
+// matters because several formatters pass a shared template constant rather
+// than writing the string at the call.
+func formatSink(pkg *packages.Package, call *ast.CallExpr, name string) (sink, bool) {
+	index, known := formatArgIndex[name]
+	if !known || index >= len(call.Args) {
+		return sink{}, false
+	}
+	tv, ok := pkg.TypesInfo.Types[call.Args[index]]
+	if !ok || tv.Value == nil {
+		return sink{}, false
+	}
+	template := constantText(tv)
+	if template == "" {
+		return sink{}, false
+	}
+	args := call.Args[index+1:]
+	s := sink{pkg: pkg, call: call, callee: name}
+	for _, h := range parseVerbs(template) {
+		if !stringishVerbs[h.verb] || h.arg >= len(args) {
+			continue
+		}
+		s.holes = append(s.holes, sinkHole{
+			expr: args[h.arg],
+			ctx:  contextAt(template, h.offset),
+			verb: "%" + string(h.verb),
+		})
+	}
+	return s, len(s.holes) > 0
+}
+
+// cellSink splits a call whose every argument is a table cell.
+//
+// A slice spread with '...' is one hole holding the whole slice, since which
+// element carries what is not knowable from the call. Classifying the slice
+// answers the same question for every cell at once when the slice is built
+// where the audit can see it, and is reported unresolved when it is not.
+func cellSink(pkg *packages.Package, call *ast.CallExpr, name string) (sink, bool) {
+	if !cellArgFuncs[name] || len(call.Args) == 0 {
+		return sink{}, false
+	}
+	s := sink{pkg: pkg, call: call, callee: name}
+	verb := "cell"
+	if call.Ellipsis.IsValid() {
+		verb = "cells..."
+	}
+	for _, arg := range call.Args {
+		s.holes = append(s.holes, sinkHole{expr: arg, ctx: ctxCell, verb: verb})
+	}
+	return s, true
+}
+
+// enclosingFunc names the function a position sits in, so a finding points at
+// the formatter rather than only at a line.
+func enclosingFunc(pkg *packages.Package, pos token.Pos) string {
+	for _, file := range pkg.Syntax {
+		if pos < file.Pos() || pos > file.End() {
+			continue
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && pos >= fn.Pos() && pos <= fn.End() {
+				return fn.Name.Name
+			}
+		}
+	}
+	return ""
+}

--- a/cmd/audit_md_escaping/sink_test.go
+++ b/cmd/audit_md_escaping/sink_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// fixtureSinks indexes the fixture's sinks by the formatter they were written
+// in, so a case can name a shape rather than a line.
+func fixtureSinks(t *testing.T) map[string][]sink {
+	t.Helper()
+	prog := loadFixture(t, caseFixture)
+	byFunc := map[string][]sink{}
+	for _, s := range collectSinks(prog) {
+		if !strings.HasPrefix(s.pkg.PkgPath, modulePath+"/"+fixtureDir) {
+			continue
+		}
+		byFunc[enclosingFunc(s.pkg, s.call.Pos())] = append(byFunc[enclosingFunc(s.pkg, s.call.Pos())], s)
+	}
+	return byFunc
+}
+
+// TestCollectSinks_Fixture_FindsTheCallsThatWriteMarkdown checks which calls
+// are sinks and which are not, which is the first thing a wrong answer here
+// would silently change.
+func TestCollectSinks_Fixture_FindsTheCallsThatWriteMarkdown(t *testing.T) {
+	byFunc := fixtureSinks(t)
+
+	cases := []struct {
+		name  string
+		fn    string
+		holes int
+	}{
+		{name: "every formatting call in the formatter", fn: "FormatOutputMarkdown", holes: 8},
+		{name: "the cell builder has one hole per argument", fn: "FormatSpread", holes: 1},
+		{name: "a runtime template is not a sink", fn: "FormatDynamic", holes: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			holes := 0
+			for _, s := range byFunc[tc.fn] {
+				holes += len(s.holes)
+			}
+			if holes != tc.holes {
+				t.Errorf("%s has %d hole(s), want %d", tc.fn, holes, tc.holes)
+			}
+		})
+	}
+}
+
+// TestCollectSinks_Fixture_ReadsANamedConstantTemplate checks the case a
+// regular expression over the source would miss: a formatter that passes a
+// shared template constant instead of writing the string at the call.
+func TestCollectSinks_Fixture_ReadsANamedConstantTemplate(t *testing.T) {
+	byFunc := fixtureSinks(t)
+
+	for _, s := range byFunc["FormatOutputMarkdown"] {
+		for _, h := range s.holes {
+			if h.ctx == ctxHeading {
+				return
+			}
+		}
+	}
+	t.Error("the heading written through a named template constant was not found")
+}
+
+// TestSinkOf_Fixture_RefusesWhatCarriesNoTemplate checks the calls sinkOf has
+// to decline: everything that is not fmt or a cell builder, an fmt function
+// with no template, and a template that is not a constant.
+func TestSinkOf_Fixture_RefusesWhatCarriesNoTemplate(t *testing.T) {
+	prog := loadFixture(t, caseFixture)
+	refused := map[string]bool{}
+	for _, pkg := range prog.order {
+		if !strings.HasPrefix(pkg.PkgPath, modulePath+"/"+fixtureDir) {
+			continue
+		}
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if _, isSink := sinkOf(pkg, call); !isSink {
+					refused[calleeName(pkg, call)] = true
+				}
+				return true
+			})
+		}
+	}
+
+	for _, name := range []string{"Sprintf", "Itoa", "WriteString", "String", "repeat"} {
+		t.Run(name, func(t *testing.T) {
+			if !refused[name] {
+				t.Errorf("no call of %s was refused, so the refusal path is untested", name)
+			}
+		})
+	}
+}
+
+// calleeName renders the function a call names, for the test above to group by.
+func calleeName(pkg *packages.Package, call *ast.CallExpr) string {
+	callee := calleeOf(pkg, call)
+	if callee == nil {
+		return "(a function value)"
+	}
+	return callee.Name()
+}
+
+// TestSinkOf_CellBuilders_TreatEveryArgumentAsACell checks that a call with no
+// template at all is still split into cells, spread included.
+func TestSinkOf_CellBuilders_TreatEveryArgumentAsACell(t *testing.T) {
+	byFunc := fixtureSinks(t)
+
+	cases := []struct {
+		name string
+		fn   string
+		verb string
+	}{
+		{name: "one argument per cell", fn: "FormatOutputMarkdown", verb: "cell"},
+		{name: "a slice spread into the builder", fn: "FormatSpread", verb: "cells..."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, s := range byFunc[tc.fn] {
+				if !cellArgFuncs[s.callee] {
+					continue
+				}
+				for _, h := range s.holes {
+					if h.ctx != ctxCell {
+						t.Errorf("%s writes a %s, want a table cell", s.callee, h.ctx)
+					}
+					if h.verb != tc.verb {
+						t.Errorf("%s names its hole %q, want %q", s.callee, h.verb, tc.verb)
+					}
+				}
+				return
+			}
+			t.Errorf("%s calls no cell builder", tc.fn)
+		})
+	}
+}
+
+// TestEnclosingFunc_Fixture_NamesTheFormatterOrNothing checks both answers: a
+// sink inside a function is named by it, and one written at package level is
+// named by nothing rather than by whichever function happens to be first.
+func TestEnclosingFunc_Fixture_NamesTheFormatterOrNothing(t *testing.T) {
+	byFunc := fixtureSinks(t)
+
+	if len(byFunc["FormatLinked"]) == 0 {
+		t.Error("a sink inside FormatLinked was not attributed to it")
+	}
+	if len(byFunc[""]) == 0 {
+		t.Error("the package-level sink was attributed to some function")
+	}
+}

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -369,14 +369,23 @@ MCP tool output contains user-generated content (UGC) from GitLab — issue desc
 
 ### Escaping Strategy
 
-All Markdown formatters apply context-appropriate escaping to UGC fields:
+Markdown formatters apply context-appropriate escaping to UGC fields:
 
-| Context                  | Escape Function       | Purpose                                                   |
-| ------------------------ | --------------------- | --------------------------------------------------------- |
-| Table cells              | `EscapeMdTableCell()` | Prevents pipe characters from breaking table structure    |
-| Headings                 | `EscapeMdHeading()`   | Prevents `#` injection that would break heading hierarchy |
-| Multi-line body content  | `WrapGFMBody()`       | Wraps in blockquote (`>`) to contain structural Markdown  |
-| List items (single-line) | `EscapeMdTableCell()` | Strips newlines and pipes from inline values              |
+| Context                  | Escape Function       | Purpose                                                     |
+| ------------------------ | --------------------- | ----------------------------------------------------------- |
+| Table cells              | `EscapeMdTableCell()` | Prevents pipe characters from breaking table structure      |
+| Headings                 | `EscapeMdHeading()`   | Prevents `#` injection that would break heading hierarchy   |
+| Multi-line body content  | `WrapGFMBody()`       | Wraps in blockquote (`>`) to contain structural Markdown    |
+| List items (single-line) | `EscapeMdTableCell()` | Strips newlines and pipes from inline values                |
+| Links                    | `MdTitleLink()`       | Escapes both halves, so neither can end the link it sits in |
+
+Habit and review are not what holds this: `make check-md-escaping` type-checks
+every formatter under `internal/` and fails when a value that came from GitLab
+reaches one of those constructs with no helper between it and the page. A value
+that needs no escaping is declared where it is written, with
+`//gitlab:allow-unescaped <expression>: <reason>`, and a declaration that
+excuses nothing fails the gate too. See
+[cmd utilities](../development/cmd-utilities.md#audit_md_escaping).
 
 ### UGC Boundary Markers
 
@@ -388,7 +397,7 @@ Explicit boundary markers (e.g., `<user_content>...</user_content>`) were evalua
 
 ### Coverage
 
-Escaping is applied to UGC fields across the 177 packages under `internal/tools`. Key field types:
+Escaping is applied to UGC fields across the packages under `internal/tools`, and what is not yet routed through a helper is what `make audit-md-escaping` lists. Key field types:
 
 - **Titles/names**: `EscapeMdTableCell()` in table contexts, `EscapeMdHeading()` in heading contexts
 - **Descriptions/bodies**: `WrapGFMBody()` for multi-line GFM content

--- a/docs/development/cmd-utilities.md
+++ b/docs/development/cmd-utilities.md
@@ -27,6 +27,7 @@ Every utility can be run directly with `go run ./cmd/<name>/ [flags]`, or throug
 | `audit_test_names`             | Source quality audits         | Classifies `Test*` functions by naming pattern; emits rename hints; `-check-files` gates test-file naming                                                                                           | `make audit-test-names`, `make check-test-file-names` |
 | `audit_test_goroutines`        | Source quality audits         | `testing.T` aborts made off the test goroutine                                                                                                                                                      | `make check-test-goroutines`                          |
 | `audit_test_subtests`          | Source quality audits         | Case loops that assert without a `t.Run` subtest; `-fix` rewrites the unambiguous ones                                                                                                              | `make check-test-subtests`                            |
+| `audit_md_escaping`            | Source quality audits         | Values a Markdown formatter interpolates into a table cell, heading, list item or link without an escaping helper                                                                                   | `make check-md-escaping`                              |
 | `audit_string_dupes`           | Source quality audits         | Finds duplicated string literals missing `const`/`var` declarations                                                                                                                                 | —                                                     |
 | `audit_supply_chain`           | Release & supply-chain audits | Five release-configuration invariants: pinned actions, credentialed jobs that run no run-time-resolved code, stated Dependabot cooldowns, a current security policy, signature-verifying installers | `make check-supply-chain`                             |
 | `audit_install_buttons`        | Release & supply-chain audits | Decodes every one-click install button and holds the buttons to one configuration per command                                                                                                       | `make check-install-buttons`                          |
@@ -720,7 +721,55 @@ Per-file tallies (`sites`, `fixable`), a summary line, and optionally the JSON w
 #### Make targets
 
 - `make audit-test-subtests` — writes `plan/test-subtests-backlog.json`.
-- `make check-test-subtests` — CI gate; also step [7/8] of `make analyze`.
+- `make check-test-subtests` — CI gate; also step [7/9] of `make analyze`.
+
+### audit_md_escaping
+
+Type-checks the packages under `internal/`, finds every call that writes Markdown with a runtime value in it, and fails when a value this server did not write can reach a construct it can change the shape of. `toolutil.EscapeMdTableCell` belongs on every GitLab-authored string between two pipes of a table row and on every single-line list value, `toolutil.EscapeMdHeading` on the one value a formatter puts in a heading, and `toolutil.MdTitleLink` on both halves of a link. The containment is not only table geometry: `EscapeMdTableCell` entity-encodes `<` so GitLab-authored text cannot open raw HTML in a client that renders Markdown, and a title of `` Fix login](http://attacker.invalid/x) `` closes the label of a hand-built link and opens a destination of its own.
+
+A sink is an `fmt` formatting call whose format argument is a constant (a literal or a named constant, both resolved by the type checker) or a call of `toolutil.MarkdownTableRow` or `MarkdownTableHeader`, which have no template because every argument they take is a cell. The template is parsed with `fmt`'s own grammar, explicit argument indices included, so `[%[1]s](%[1]s)` pairs correctly; only `%s`, `%v` and `%q` are judged. The construct comes from the line the hole sits on: a leading pipe is a table cell, one to six `#` and a space a heading, a bullet or ordered marker a list item, an unclosed `[` a link label, and the text after `](` a link destination. Prose is skipped.
+
+Each value is then followed back to where it came from: a constant, a non-textual type, an escaper, a nested `Sprintf` of safe halves, a `strings` transform of safe values, a helper whose every return is safe, a local whose every assignment is safe, or a parameter every caller passes a safe value to. A call binds its arguments to the callee's parameters, so a helper is judged at the call site that reaches it, which matters for `toolutil.FormatTime`: it returns its argument verbatim when neither layout parses, and it is called from about a hundred and fifty places. A value that bottoms out at a field of a struct filled from a GitLab response is a finding; anything the walk cannot follow is reported in an unresolved bucket of its own and never counted as safe.
+
+```bash
+go run ./cmd/audit_md_escaping/
+go run ./cmd/audit_md_escaping/ -v -json plan/md-escaping-backlog.json
+go run ./cmd/audit_md_escaping/ -check
+go run ./cmd/audit_md_escaping/ -contexts table-cell,heading -check
+go run ./cmd/audit_md_escaping/ -check ./internal/tools/issues
+```
+
+#### Flags
+
+| Flag               | Type   | Default | Description                                                                                                                     |
+| ------------------ | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `-dir`             | string | `.`     | Repository root to audit                                                                                                        |
+| `-json`            | string | _(off)_ | Write the JSON work list to this path                                                                                           |
+| `-contexts`        | string | `all`   | Constructs to judge: `all`, or a comma-separated list of `heading`, `link-destination`, `link-label`, `list-item`, `table-cell` |
+| `-check`           | bool   | `false` | Exit non-zero when a value still reaches a Markdown construct unescaped                                                         |
+| `-v`               | bool   | `false` | List the excused and unresolved values as well as the failing ones                                                              |
+| `-fail-unresolved` | bool   | `false` | Count a value the audit cannot follow as a failure                                                                              |
+
+Package patterns after the flags narrow the sweep, which makes checking one domain while working on it cheap. The default is `./internal/...`.
+
+#### Declaring that a value is already safe
+
+Escaping a value that needs none is noise that teaches the next reader the wrong rule, so an exemption is declared in the source, in the package that owns the formatter:
+
+```go
+//gitlab:allow-unescaped result.ID: a canonical catalog ID, compiled in from an ActionSpec rather than read from GitLab.
+```
+
+The expression is the one the report prints, and the directive excuses that expression wherever the package interpolates it. A directive that excuses nothing fails the gate, so an exemption cannot outlive the reason it was written for.
+
+#### Output
+
+Findings grouped by package, each naming the file, line, formatter, construct, verb, expression, the helper it wants and how the walk got there; then a summary with the counts and a breakdown by construct. `-v` adds the excused and unresolved buckets. The JSON work list carries `findings`, `unresolved`, `excused`, `stale_directives` and a `summary` with per-construct and per-package counts.
+
+#### Make targets
+
+- `make audit-md-escaping` — report plus `plan/md-escaping-backlog.json`.
+- `make check-md-escaping` — CI gate; also step [9/9] of `make analyze`.
 
 ### audit_string_dupes
 
@@ -1250,6 +1299,7 @@ The following utilities expose a verification mode (`--check` or `-check`, or an
 | `check-test-goroutines`                  | `audit_test_goroutines`            | No `testing.T` abort is made off the test goroutine                                                                        | Non-zero if any abort site exists                         |
 | `check-test-subtests`                    | `audit_test_subtests`              | No case loop asserts without a `t.Run` subtest                                                                             | Non-zero if any site remains                              |
 | `check-test-file-names`                  | `audit_test_names -check-files`    | Every `_test.go` is named after a module it tests                                                                          | Non-zero on a violation                                   |
+| `check-md-escaping`                      | `audit_md_escaping -check`         | No value reaches a Markdown table cell, heading, list item or link unescaped                                               | Non-zero on a finding or a directive that excuses nothing |
 | `check-site-stats`                       | `audit_metrics -site-stats -check` | `site/src/data/stats.json` is current                                                                                      | Non-zero if the file is stale                             |
 | `check-bench-resources`                  | `bench_resources -check`           | The committed benchmark charts and tables match the committed record                                                       | Non-zero if they are stale                                |
 | `brand-check`                            | `gen_brand --check`                | The committed brand assets match the geometry                                                                              | Non-zero on drift                                         |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,12 +18,12 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,298 |
-| Unit test functions                                   | 13,696 |
-| E2E test functions                                    |    602 |
-| cmd test functions                                    |  2,507 |
+| Total test functions                                  | 14,362 |
+| Unit test functions                                   | 13,761 |
+| E2E test functions                                    |    601 |
+| cmd test functions                                    |  2,576 |
 | Test files (internal/)                                |    511 |
-| Test files (cmd/)                                     |    151 |
+| Test files (cmd/)                                     |    161 |
 | Test files (test/e2e/)                                |    237 |
 | Tool sub-packages tested                              |    177 |
 | Core packages tested                                  |     21 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,721 | 82.0% |
+| `TestFunc_Scenario` (2-part)           | 11,715 | 81.6% |
 | `TestFunc` (no underscore)             |    976 |  6.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,601 | 11.2% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,671 | 11.6% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,334 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,330 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          8,523 |        358 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            602 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,507 |        151 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,298** |    **899** |                                                                                                 |
+| E2E integration         |            601 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          2,576 |        161 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,362** |    **909** |                                                                                                 |
 
 ### Core Packages
 
@@ -76,8 +76,8 @@
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
-| toolutil      |       854 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,334** |          |                                                                                                                                                                                                                                                                    |
+| toolutil      |       850 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
+| **Subtotal**  | **2,330** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -320,6 +320,7 @@
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    88.2% |
 | cmd/audit_install_buttons                      |    84.2% |
+| cmd/audit_md_escaping                          |      n/a |
 | cmd/audit_metrics                              |    97.8% |
 | cmd/audit_readonly_graphql                     |    90.8% |
 | cmd/audit_string_dupes                         |    92.1% |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,11 +18,11 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,362 |
-| Unit test functions                                   | 13,761 |
-| E2E test functions                                    |    601 |
-| cmd test functions                                    |  2,576 |
-| Test files (internal/)                                |    511 |
+| Total test functions                                  | 14,373 |
+| Unit test functions                                   | 13,771 |
+| E2E test functions                                    |    602 |
+| cmd test functions                                    |  2,577 |
+| Test files (internal/)                                |    512 |
 | Test files (cmd/)                                     |    161 |
 | Test files (test/e2e/)                                |    237 |
 | Tool sub-packages tested                              |    177 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,715 | 81.6% |
+| `TestFunc_Scenario` (2-part)           | 11,721 | 81.5% |
 | `TestFunc` (no underscore)             |    976 |  6.8% |
-| `TestFunc_Scenario_Expected` (3+ part) |  1,671 | 11.6% |
+| `TestFunc_Scenario_Expected` (3+ part) |  1,676 | 11.7% |
 
 ## Test Distribution
 
@@ -45,12 +45,12 @@
 
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
-| Core packages           |          2,330 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
+| Core packages           |          2,336 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (177) |          8,523 |        358 | domain-specific GitLab tool handlers                                                            |
-| E2E integration         |            601 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,576 |        161 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,362** |    **909** |                                                                                                 |
+| Tool sub-packages (177) |          8,526 |        359 | domain-specific GitLab tool handlers                                                            |
+| E2E integration         |            602 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
+| cmd packages            |          2,577 |        161 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,373** |    **910** |                                                                                                 |
 
 ### Core Packages
 
@@ -76,8 +76,8 @@
 | subscriptions |        90 |    98.5% | Package subscriptions implements MCP resource subscriptions (resources/subscribe) over GitLab resources.                                                                                                                                                           |
 | telemetry     |       102 |    93.1% | Package telemetry is the only place in this server that knows about OpenTelemetry.                                                                                                                                                                                 |
 | testutil      |        37 |    89.6% | Package testutil provides test helpers for gitlab-mcp-server.                                                                                                                                                                                                      |
-| toolutil      |       850 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
-| **Subtotal**  | **2,330** |          |                                                                                                                                                                                                                                                                    |
+| toolutil      |       856 |    98.6% | Package toolutil provides shared utilities for MCP tool handler sub-packages.                                                                                                                                                                                      |
+| **Subtotal**  | **2,336** |          |                                                                                                                                                                                                                                                                    |
 
 ### Tool Sub-Packages (Top Domains by Test Count)
 
@@ -85,7 +85,7 @@
 | ----------------- | ----: | -------: | ----: |
 | projects          |   392 |   100.0% |    57 |
 | groups            |   249 |   100.0% |    37 |
-| mergerequests     |   242 |   100.0% |    30 |
+| mergerequests     |   245 |   100.0% |    30 |
 | issues            |   223 |   100.0% |    21 |
 | users             |   210 |   100.0% |    38 |
 | dynamic           |   176 |    99.9% |     2 |
@@ -171,7 +171,7 @@
 | events                  |        52 |          2 |   100.0% |         2 |
 | externalstatuschecks    |        51 |          3 |   100.0% |         8 |
 | featureflags            |        44 |          2 |   100.0% |         5 |
-| features                |        23 |          2 |    97.8% |         4 |
+| features                |        23 |          2 |    98.0% |         4 |
 | ffuserlists             |        33 |          2 |   100.0% |         5 |
 | files                   |        83 |          2 |   100.0% |         8 |
 | freezeperiods           |        36 |          2 |   100.0% |         5 |
@@ -222,7 +222,7 @@
 | markdown                |         8 |          1 |   100.0% |         1 |
 | memberroles             |        47 |          3 |   100.0% |         6 |
 | members                 |        60 |          2 |   100.0% |         6 |
-| mergerequests           |       242 |          2 |   100.0% |        30 |
+| mergerequests           |       245 |          3 |   100.0% |        30 |
 | mergetrains             |        16 |          2 |   100.0% |         4 |
 | metadata                |         8 |          1 |   100.0% |         1 |
 | milestones              |        73 |          1 |   100.0% |         7 |
@@ -234,7 +234,7 @@
 | mrdiscussions           |        58 |          1 |   100.0% |         7 |
 | mrdraftnotes            |        71 |          2 |   100.0% |         7 |
 | mrnotes                 |        49 |          2 |   100.0% |         5 |
-| namespaces              |        37 |          1 |    99.2% |         4 |
+| namespaces              |        37 |          1 |    99.3% |         4 |
 | notifications           |        29 |          1 |   100.0% |         6 |
 | orbit                   |        57 |          4 |   100.0% |         6 |
 | packages                |       131 |          6 |    99.0% |         9 |
@@ -245,7 +245,7 @@
 | planlimits              |        13 |          2 |   100.0% |         2 |
 | projectaliases          |        26 |          2 |   100.0% |         4 |
 | projectdiscovery        |        19 |          1 |   100.0% |         1 |
-| projectimportexport     |        40 |          1 |    99.5% |         5 |
+| projectimportexport     |        40 |          1 |    99.6% |         5 |
 | projectiterations       |        18 |          1 |   100.0% |         1 |
 | projectmirrors          |        63 |          2 |   100.0% |         7 |
 | projects                |       392 |          6 |   100.0% |        57 |
@@ -293,7 +293,7 @@
 | wikis                   |        61 |          2 |   100.0% |         6 |
 | workitems               |        95 |          3 |   100.0% |         6 |
 | workitemsavedviews      |        50 |          4 |   100.0% |         7 |
-| **Total**               | **8,523** |    **358** |          | **1,187** |
+| **Total**               | **8,526** |    **359** |          | **1,187** |
 
 </details>
 
@@ -320,7 +320,7 @@
 | cmd/audit_edition_tier                         |    86.9% |
 | cmd/audit_gateway_chars                        |    88.2% |
 | cmd/audit_install_buttons                      |    84.2% |
-| cmd/audit_md_escaping                          |      n/a |
+| cmd/audit_md_escaping                          |   100.0% |
 | cmd/audit_metrics                              |    97.8% |
 | cmd/audit_readonly_graphql                     |    90.8% |
 | cmd/audit_string_dupes                         |    92.1% |
@@ -437,7 +437,7 @@
 | events                  |   100.0% |
 | externalstatuschecks    |   100.0% |
 | featureflags            |   100.0% |
-| features                |    97.8% |
+| features                |    98.0% |
 | ffuserlists             |   100.0% |
 | files                   |   100.0% |
 | freezeperiods           |   100.0% |
@@ -500,7 +500,7 @@
 | mrdiscussions           |   100.0% |
 | mrdraftnotes            |   100.0% |
 | mrnotes                 |   100.0% |
-| namespaces              |    99.2% |
+| namespaces              |    99.3% |
 | notifications           |   100.0% |
 | orbit                   |   100.0% |
 | packages                |    99.0% |
@@ -511,7 +511,7 @@
 | planlimits              |   100.0% |
 | projectaliases          |   100.0% |
 | projectdiscovery        |   100.0% |
-| projectimportexport     |    99.5% |
+| projectimportexport     |    99.6% |
 | projectiterations       |   100.0% |
 | projectmirrors          |   100.0% |
 | projects                |   100.0% |

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,299 |
-| Unit test functions                                   | 13,697 |
+| Total test functions                                  | 14,298 |
+| Unit test functions                                   | 13,696 |
 | E2E test functions                                    |    602 |
 | cmd test functions                                    |  2,507 |
 | Test files (internal/)                                |    511 |
@@ -35,7 +35,7 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,722 | 82.0% |
+| `TestFunc_Scenario` (2-part)           | 11,721 | 82.0% |
 | `TestFunc` (no underscore)             |    976 |  6.8% |
 | `TestFunc_Scenario_Expected` (3+ part) |  1,601 | 11.2% |
 
@@ -46,11 +46,11 @@
 | Layer                   | Test Functions | Test Files | Description                                                                                     |
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,334 |        138 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
-| Tools orchestration     |            333 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
+| Tools orchestration     |            332 |         15 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          8,523 |        358 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            602 |        237 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,507 |        151 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,299** |    **899** |                                                                                                 |
+| **Total**               |     **14,298** |    **899** |                                                                                                 |
 
 ### Core Packages
 

--- a/internal/prompts/prompt_audit.go
+++ b/internal/prompts/prompt_audit.go
@@ -86,8 +86,9 @@ func handleAuditProjectSettings(ctx context.Context, client *gitlabclient.Client
 	fmt.Fprintf(&b, "| Name | %s |\n", mdInline(project.Name))
 	fmt.Fprintf(&b, "| Path | %s |\n", mdInline(project.PathWithNamespace))
 	fmt.Fprintf(&b, "| Description | %s |\n", mdInline(emptyDash(project.Description)))
+	//gitlab:allow-unescaped string(project.Visibility): a gl.VisibilityValue, which GitLab fills with private, internal or public.
 	fmt.Fprintf(&b, "| Visibility | %s |\n", string(project.Visibility))
-	fmt.Fprintf(&b, "| Default branch | %s |\n", emptyDash(project.DefaultBranch))
+	fmt.Fprintf(&b, "| Default branch | %s |\n", mdInline(emptyDash(project.DefaultBranch)))
 	fmt.Fprintf(&b, "| Created | %s |\n", formatAuditDate(project.CreatedAt))
 	fmt.Fprintf(&b, "| Last activity | %s |\n", formatAuditDate(project.LastActivityAt))
 	b.WriteString("\n")
@@ -106,7 +107,9 @@ func handleAuditProjectSettings(ctx context.Context, client *gitlabclient.Client
 	// Merge settings
 	b.WriteString("## Merge Settings\n\n")
 	b.WriteString(settingValueTableHeader)
+	//gitlab:allow-unescaped emptyDash(string(project.MergeMethod)): a gl.MergeMethodValue, which GitLab fills with merge, ff or rebase_merge.
 	fmt.Fprintf(&b, "| Merge method | %s |\n", emptyDash(string(project.MergeMethod)))
+	//gitlab:allow-unescaped emptyDash(string(project.SquashOption)): a gl.SquashOptionValue, which GitLab fills with never, always, default_on or default_off.
 	fmt.Fprintf(&b, "| Squash option | %s |\n", emptyDash(string(project.SquashOption)))
 	fmt.Fprintf(&b, "| Only merge if pipeline succeeds | %s |\n", toolutil.BoolEmoji(project.OnlyAllowMergeIfPipelineSucceeds))
 	fmt.Fprintf(&b, "| Only merge if all discussions resolved | %s |\n", toolutil.BoolEmoji(project.OnlyAllowMergeIfAllDiscussionsAreResolved))
@@ -117,7 +120,7 @@ func handleAuditProjectSettings(ctx context.Context, client *gitlabclient.Client
 	// CI/CD settings
 	b.WriteString("## CI/CD Settings\n\n")
 	b.WriteString(settingValueTableHeader)
-	fmt.Fprintf(&b, "| CI config path | %s |\n", emptyDash(project.CIConfigPath))
+	fmt.Fprintf(&b, "| CI config path | %s |\n", mdInline(emptyDash(project.CIConfigPath)))
 	fmt.Fprintf(&b, "| Auto DevOps enabled | %s |\n", toolutil.BoolEmoji(project.AutoDevopsEnabled))
 	fmt.Fprintf(&b, "| Public pipelines | %s |\n", toolutil.BoolEmoji(project.PublicJobs))
 	fmt.Fprintf(&b, "| Shared runners | %s |\n", toolutil.BoolEmoji(project.SharedRunnersEnabled))
@@ -134,10 +137,13 @@ func handleAuditProjectSettings(ctx context.Context, client *gitlabclient.Client
 		fmt.Fprintf(&b, "| Deny delete tag | %s |\n", toolutil.BoolEmoji(pushRule.DenyDeleteTag))
 		fmt.Fprintf(&b, "| Member check | %s |\n", toolutil.BoolEmoji(pushRule.MemberCheck))
 		fmt.Fprintf(&b, "| Prevent secrets | %s |\n", toolutil.BoolEmoji(pushRule.PreventSecrets))
-		fmt.Fprintf(&b, "| Commit message regex | %s |\n", emptyDash(pushRule.CommitMessageRegex))
-		fmt.Fprintf(&b, "| Branch name regex | %s |\n", emptyDash(pushRule.BranchNameRegex))
-		fmt.Fprintf(&b, "| Author email regex | %s |\n", emptyDash(pushRule.AuthorEmailRegex))
-		fmt.Fprintf(&b, "| File name regex | %s |\n", emptyDash(pushRule.FileNameRegex))
+		// A push rule is a regular expression a maintainer types, where '|' is
+		// the alternation operator, so an ordinary rule breaks the row on its
+		// own with nobody attacking anything.
+		fmt.Fprintf(&b, "| Commit message regex | %s |\n", mdInline(emptyDash(pushRule.CommitMessageRegex)))
+		fmt.Fprintf(&b, "| Branch name regex | %s |\n", mdInline(emptyDash(pushRule.BranchNameRegex)))
+		fmt.Fprintf(&b, "| Author email regex | %s |\n", mdInline(emptyDash(pushRule.AuthorEmailRegex)))
+		fmt.Fprintf(&b, "| File name regex | %s |\n", mdInline(emptyDash(pushRule.FileNameRegex)))
 		fmt.Fprintf(&b, "| Max file size (MB) | %d |\n", pushRule.MaxFileSize)
 		b.WriteString("\n")
 	}
@@ -296,7 +302,7 @@ func writeSharedGroups(b *strings.Builder, groups []gl.ProjectSharedWithGroup) {
 			expires = sg.ExpiresAt.String()
 		}
 		fmt.Fprintf(b, "| %s (#%d) | %s | %s |\n",
-			sg.GroupName, sg.GroupID,
+			mdInline(sg.GroupName), sg.GroupID,
 			accessLevelName(gl.AccessLevelValue(sg.GroupAccessLevel)),
 			expires)
 	}
@@ -378,8 +384,10 @@ func writeMemberTable(b *strings.Builder, members []*gl.ProjectMember) {
 	b.WriteString("| User | Name | Access | State |\n")
 	b.WriteString("|------|------|--------|-------|\n")
 	for _, m := range members {
+		//gitlab:allow-unescaped m.Username: a GitLab namespace path, which the instance holds to letters, digits, underscore, dash and dot.
+		//gitlab:allow-unescaped m.State: a membership state GitLab picks from a fixed set (active, blocked, awaiting and the rest).
 		fmt.Fprintf(b, "| @%s | %s | %s | %s |\n",
-			m.Username, m.Name, accessLevelName(m.AccessLevel), m.State)
+			m.Username, mdInline(m.Name), accessLevelName(m.AccessLevel), m.State)
 	}
 	b.WriteString("\n")
 }
@@ -478,8 +486,9 @@ func writeLabelsAudit(b *strings.Builder, labels []*gl.Label) {
 		if desc == "" {
 			desc = toolutil.EmojiWarning + " _missing_"
 		}
+		//gitlab:allow-unescaped l.Color: a label color, which GitLab validates as a #RGB or #RRGGBB literal.
 		fmt.Fprintf(b, "| %s | %s | %s | %d | %d |\n",
-			l.Name, l.Color, desc, l.OpenIssuesCount, l.OpenMergeRequestsCount)
+			mdInline(l.Name), l.Color, mdInline(desc), l.OpenIssuesCount, l.OpenMergeRequestsCount)
 	}
 	b.WriteString("\n")
 }
@@ -669,13 +678,13 @@ func writeFullSettingsSection(b *strings.Builder, project *gl.Project) {
 	b.WriteString("## 1. Project Settings\n\n")
 	b.WriteString(settingValueTableHeader)
 	fmt.Fprintf(b, "| Visibility | %s |\n", string(project.Visibility))
-	fmt.Fprintf(b, "| Default branch | %s |\n", emptyDash(project.DefaultBranch))
+	fmt.Fprintf(b, "| Default branch | %s |\n", mdInline(emptyDash(project.DefaultBranch)))
 	fmt.Fprintf(b, "| Merge method | %s |\n", emptyDash(string(project.MergeMethod)))
 	fmt.Fprintf(b, "| Squash option | %s |\n", emptyDash(string(project.SquashOption)))
 	fmt.Fprintf(b, "| Pipeline required | %s |\n", toolutil.BoolEmoji(project.OnlyAllowMergeIfPipelineSucceeds))
 	fmt.Fprintf(b, "| All discussions resolved | %s |\n", toolutil.BoolEmoji(project.OnlyAllowMergeIfAllDiscussionsAreResolved))
 	fmt.Fprintf(b, "| Remove source branch | %s |\n", toolutil.BoolEmoji(project.RemoveSourceBranchAfterMerge))
-	fmt.Fprintf(b, "| CI config path | %s |\n", emptyDash(project.CIConfigPath))
+	fmt.Fprintf(b, "| CI config path | %s |\n", mdInline(emptyDash(project.CIConfigPath)))
 	b.WriteString("\n")
 }
 
@@ -692,7 +701,7 @@ func writeFullBranchSection(b *strings.Builder, branches []*gl.ProtectedBranch) 
 		push := formatAccessLevels(pb.PushAccessLevels)
 		merge := formatAccessLevels(pb.MergeAccessLevels)
 		fmt.Fprintf(b, "| %s | %s | %s | %s | %s |\n",
-			pb.Name, push, merge, toolutil.BoolEmoji(pb.AllowForcePush), toolutil.BoolEmoji(pb.CodeOwnerApprovalRequired))
+			mdInline(pb.Name), push, merge, toolutil.BoolEmoji(pb.AllowForcePush), toolutil.BoolEmoji(pb.CodeOwnerApprovalRequired))
 	}
 	b.WriteString("\n")
 }
@@ -769,8 +778,9 @@ func writeFullWebhooksSection(b *strings.Builder, webhooks []*gl.ProjectHook) {
 	if len(webhooks) > 0 {
 		b.WriteString("\n| URL | Push | MR | Issues | SSL |\n|-----|------|-----|--------|-----|\n")
 		for _, h := range webhooks {
+			// Escaped outside the truncation, so no entity is cut in half.
 			fmt.Fprintf(b, "| %s | %s | %s | %s | %s |\n",
-				maskURL(h.URL), toolutil.BoolEmoji(h.PushEvents), toolutil.BoolEmoji(h.MergeRequestsEvents),
+				mdInline(maskURL(h.URL)), toolutil.BoolEmoji(h.PushEvents), toolutil.BoolEmoji(h.MergeRequestsEvents),
 				toolutil.BoolEmoji(h.IssuesEvents), toolutil.BoolEmoji(h.EnableSSLVerification))
 		}
 	}
@@ -787,9 +797,9 @@ func writeFullPushRulesSection(b *strings.Builder, pushRule *gl.ProjectPushRules
 	b.WriteString("| Rule | Value |\n|------|-------|\n")
 	fmt.Fprintf(b, "| Prevent secrets | %s |\n", toolutil.BoolEmoji(pushRule.PreventSecrets))
 	fmt.Fprintf(b, "| Member check | %s |\n", toolutil.BoolEmoji(pushRule.MemberCheck))
-	fmt.Fprintf(b, "| Commit message regex | %s |\n", emptyDash(pushRule.CommitMessageRegex))
-	fmt.Fprintf(b, "| Branch name regex | %s |\n", emptyDash(pushRule.BranchNameRegex))
-	fmt.Fprintf(b, "| Author email regex | %s |\n", emptyDash(pushRule.AuthorEmailRegex))
+	fmt.Fprintf(b, "| Commit message regex | %s |\n", mdInline(emptyDash(pushRule.CommitMessageRegex)))
+	fmt.Fprintf(b, "| Branch name regex | %s |\n", mdInline(emptyDash(pushRule.BranchNameRegex)))
+	fmt.Fprintf(b, "| Author email regex | %s |\n", mdInline(emptyDash(pushRule.AuthorEmailRegex)))
 	b.WriteString("\n")
 }
 

--- a/internal/prompts/prompt_audit_test.go
+++ b/internal/prompts/prompt_audit_test.go
@@ -110,7 +110,9 @@ func TestAuditProject_Settings(t *testing.T) {
 			"Merge Settings",
 			"Push Rules",
 			"Commit message regex",
-			"^(feat|fix|docs):.*",
+			// The pipe of the alternation is entity-encoded, because it would
+			// otherwise be read as the end of the cell holding the rule.
+			"^(feat&#124;fix&#124;docs):.*",
 			"Storage Statistics",
 		}
 		for _, want := range checks {

--- a/internal/prompts/prompt_git_workflow.go
+++ b/internal/prompts/prompt_git_workflow.go
@@ -85,6 +85,7 @@ func handleAuditCommitHygiene(ctx context.Context, client *gitlabclient.Client, 
 	b.WriteString("| Commit | Title | Author | Hygiene |\n")
 	b.WriteString("|--------|-------|--------|---------|\n")
 	for _, commit := range comparison.Commits {
+		//gitlab:allow-unescaped shortSHA(commit.ID): the first characters of a commit SHA, which is hexadecimal.
 		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", shortSHA(commit.ID), mdInline(firstLine(commit.Title)), mdInline(commit.AuthorName), commitHygieneLabel(commit))
 	}
 

--- a/internal/prompts/prompt_helpers_test.go
+++ b/internal/prompts/prompt_helpers_test.go
@@ -1046,8 +1046,13 @@ func TestWriteFullPushRulesSection(t *testing.T) {
 		if !strings.Contains(out, "Prevent secrets") {
 			t.Errorf("expected push rule rows, got: %s", out)
 		}
-		if !strings.Contains(out, "^(feat|fix):") {
+		// The rule reaches the reader with its alternation pipe encoded, since
+		// a raw one would end the cell it is written into.
+		if !strings.Contains(out, "^(feat&#124;fix):") {
 			t.Errorf("expected commit regex, got: %s", out)
+		}
+		if strings.Contains(out, "^(feat|fix):") {
+			t.Errorf("commit regex reached the row with a raw pipe, got: %s", out)
 		}
 	})
 }

--- a/internal/prompts/prompt_team.go
+++ b/internal/prompts/prompt_team.go
@@ -267,7 +267,7 @@ func writeTeamOverviewWorkload(b *strings.Builder, stats map[string]*teamOvervie
 	b.WriteString("|--------|------|----------|--------|-----------|\n")
 	for _, username := range sortedKeys(stats) {
 		stat := stats[username]
-		fmt.Fprintf(b, "| @%s | %s | %d | %d | %d |\n", username, stat.name, stat.openMRs, stat.mergedMRs, stat.reviewMRs)
+		fmt.Fprintf(b, "| @%s | %s | %d | %d | %d |\n", username, mdInline(stat.name), stat.openMRs, stat.mergedMRs, stat.reviewMRs)
 	}
 	b.WriteString("\n")
 }
@@ -326,7 +326,9 @@ func handleGroupMRDashboard(ctx context.Context, client *gitlabclient.Client, re
 	var b strings.Builder
 	branchInfo := ""
 	if opts.TargetBranch != nil {
-		branchInfo = " targeting " + *opts.TargetBranch
+		// The branch is escaped rather than branchInfo, because EscapeMdHeading
+		// trims the leading space this string starts with.
+		branchInfo = " targeting " + mdHeading(*opts.TargetBranch)
 	}
 	fmt.Fprintf(&b, "# Group MR Dashboard: %s (%d %s MRs%s)\n\n", mdHeading(groupID), len(mrs), state, branchInfo)
 
@@ -475,7 +477,7 @@ func writeReviewerWorkloadTable(b *strings.Builder, stats map[string]*reviewerWo
 		if stat.oldestMR != nil {
 			oldest = formatAge(time.Since(*stat.oldestMR))
 		}
-		fmt.Fprintf(b, "| @%s | %s | %d | %s |\n", username, stat.name, stat.count, oldest)
+		fmt.Fprintf(b, "| @%s | %s | %d | %s |\n", username, mdInline(stat.name), stat.count, oldest)
 	}
 	b.WriteString("\n")
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -166,7 +166,7 @@ func handleSummarizeMRChanges(ctx context.Context, client *gitlabclient.Client, 
 
 	var summary []string
 	for _, c := range changes {
-		line := fmt.Sprintf("- %s -> %s (%s)", c.OldPath, c.NewPath, changeType(c))
+		line := fmt.Sprintf("- %s -> %s (%s)", mdInline(c.OldPath), mdInline(c.NewPath), changeType(c))
 		summary = append(summary, line)
 	}
 	msg := "Changed files:\n" + strings.Join(summary, "\n")
@@ -337,7 +337,8 @@ func handleSummarizePipelineStatus(ctx context.Context, client *gitlabclient.Cli
 
 	var failed, passed, other []string
 	for _, j := range jobs {
-		line := fmt.Sprintf("- **%s** (%s): %s", j.Name, j.Stage, j.Status)
+		//gitlab:allow-unescaped j.Status: a job status GitLab picks from a fixed set (created, running, success, failed and the rest).
+		line := fmt.Sprintf("- **%s** (%s): %s", mdInline(j.Name), mdInline(j.Stage), j.Status)
 		if j.FailureReason != "" {
 			line += ", reason: " + j.FailureReason
 		}
@@ -411,7 +412,7 @@ func handleSuggestMRReviewers(ctx context.Context, client *gitlabclient.Client, 
 
 	fmt.Fprintf(&b, "## Changed Files (%d)\n", len(diffs))
 	for _, d := range diffs {
-		fmt.Fprintf(&b, fmtListItem, d.NewPath, changeType(d))
+		fmt.Fprintf(&b, fmtListItem, mdInline(d.NewPath), changeType(d))
 	}
 
 	authorName := ""
@@ -419,6 +420,7 @@ func handleSuggestMRReviewers(ctx context.Context, client *gitlabclient.Client, 
 		authorName = mr.Author.Username
 	}
 
+	//gitlab:allow-unescaped authorName: mr.Author.Username, a GitLab namespace path, which the instance holds to letters, digits, underscore, dash and dot.
 	fmt.Fprintf(&b, "\n## Project Members (excluding author: %s)\n", authorName)
 	for _, m := range members {
 		if m.Username == authorName || m.State != "active" {
@@ -480,6 +482,7 @@ func handleGenerateReleaseNotes(ctx context.Context, client *gitlabclient.Client
 	fmt.Fprintf(&b, "## Commits (%d)\n\n", len(comparison.Commits))
 	for _, c := range comparison.Commits {
 		title, _, _ := strings.Cut(c.Title, "\n")
+		//gitlab:allow-unescaped shortSHA(c.ID): the first characters of a commit SHA, which is hexadecimal.
 		fmt.Fprintf(&b, "- %s: %s (%s)\n", shortSHA(c.ID), mdInline(title), mdInline(c.AuthorName))
 	}
 
@@ -633,6 +636,7 @@ func handleSummarizeOpenMRs(ctx context.Context, client *gitlabclient.Client, re
 		age := time.Since(*mr.CreatedAt).Hours() / 24
 		fmt.Fprintf(&b, "## !%d: %s\n", mr.IID, mdHeading(mr.Title))
 		fmt.Fprintf(&b, "- **Author**: %s | **Branch**: %s -> %s\n", mdInline(author), mdInline(mr.SourceBranch), mdInline(mr.TargetBranch))
+		//gitlab:allow-unescaped mr.DetailedMergeStatus: a merge status GitLab computes from a fixed set (mergeable, ci_must_pass, conflict and the rest).
 		fmt.Fprintf(&b, "- **Age**: %.0f days | **Status**: %s\n", age, mr.DetailedMergeStatus)
 		if mr.Description != "" {
 			desc := mr.Description
@@ -697,8 +701,9 @@ func writePipelineSection(ctx context.Context, b *strings.Builder, client *gitla
 		return
 	}
 	fmt.Fprintf(b, "## Latest Pipeline: %s\n", mdHeading(strings.ToUpper(pipeline.Status)))
-	fmt.Fprintf(b, "- **Ref**: %s | **SHA**: %s\n", pipeline.Ref, shortSHA(pipeline.SHA))
-	fmt.Fprintf(b, "- **URL**: %s\n\n", pipeline.WebURL)
+	//gitlab:allow-unescaped shortSHA(pipeline.SHA): the first characters of a commit SHA, which is hexadecimal.
+	fmt.Fprintf(b, "- **Ref**: %s | **SHA**: %s\n", mdInline(pipeline.Ref), shortSHA(pipeline.SHA))
+	fmt.Fprintf(b, "- **URL**: %s\n\n", mdInline(pipeline.WebURL))
 }
 
 // writeOpenMRsSection appends a list of open merge requests to the builder.
@@ -793,6 +798,7 @@ func handleCompareBranches(ctx context.Context, client *gitlabclient.Client, req
 	fmt.Fprintf(&b, "## Commits (%d)\n\n", len(comparison.Commits))
 	for _, c := range comparison.Commits {
 		title, _, _ := strings.Cut(c.Title, "\n")
+		//gitlab:allow-unescaped shortSHA(c.ID): the first characters of a commit SHA, which is hexadecimal.
 		fmt.Fprintf(&b, "- %s: %s (%s)\n", shortSHA(c.ID), mdInline(title), mdInline(c.AuthorName))
 	}
 
@@ -807,7 +813,7 @@ func handleCompareBranches(ctx context.Context, client *gitlabclient.Client, req
 		case d.RenamedFile:
 			ct = "renamed"
 		}
-		fmt.Fprintf(&b, fmtListItem, d.NewPath, ct)
+		fmt.Fprintf(&b, fmtListItem, mdInline(d.NewPath), ct)
 	}
 
 	b.WriteString("\nPlease summarize the key differences between these branches.")
@@ -897,7 +903,9 @@ func handleDailyStandup(ctx context.Context, client *gitlabclient.Client, req *m
 		b.WriteString("No events found in the last 24 hours.\n")
 	}
 	for _, e := range events {
-		fmt.Fprintf(&b, "- %s %s: %s\n", e.ActionName, e.TargetType, e.TargetTitle)
+		//gitlab:allow-unescaped e.ActionName: a contribution-event action GitLab writes from its own vocabulary (opened, closed, pushed to and the rest).
+		//gitlab:allow-unescaped e.TargetType: the Rails class name of the event's target, which GitLab fills with Issue, MergeRequest, Note and the rest.
+		fmt.Fprintf(&b, "- %s %s: %s\n", e.ActionName, e.TargetType, mdInline(e.TargetTitle))
 	}
 
 	// Authored MRs section
@@ -1282,6 +1290,7 @@ func writeDailyActivity(b *strings.Builder, username string, dailyActivity []day
 	b.WriteString("| Date | Events |\n")
 	b.WriteString("|------|--------|\n")
 	for _, da := range dailyActivity {
+		//gitlab:allow-unescaped da.date: a day this package formats itself, as CreatedAt.Format("2006-01-02") in groupEventsByDay.
 		fmt.Fprintf(b, fmtTableCountRow, da.date, da.count)
 	}
 
@@ -1386,7 +1395,7 @@ func handleMRRiskAssessment(ctx context.Context, client *gitlabclient.Client, re
 
 	fmt.Fprintf(&b, "\n## Changed Files\n")
 	for _, d := range diffs {
-		fmt.Fprintf(&b, fmtListItem, d.NewPath, changeType(d))
+		fmt.Fprintf(&b, fmtListItem, mdInline(d.NewPath), changeType(d))
 	}
 
 	b.WriteString("\nBased on the above metrics, provide a risk assessment (LOW / MEDIUM / HIGH / CRITICAL) with justification and recommendations.")

--- a/internal/tools/accessrequests/markdown.go
+++ b/internal/tools/accessrequests/markdown.go
@@ -13,8 +13,9 @@ func FormatOutputMarkdown(out Output) string {
 	fmt.Fprintf(&b, "## Access Request #%d\n\n", out.ID)
 	b.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&b, "| ID | %d |\n", out.ID)
-	fmt.Fprintf(&b, "| Username | %s |\n", out.Username)
-	fmt.Fprintf(&b, "| Name | %s |\n", out.Name)
+	fmt.Fprintf(&b, "| Username | %s |\n", toolutil.EscapeMdTableCell(out.Username))
+	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
+	//gitlab:allow-unescaped out.State: a membership state GitLab picks from a fixed set (active, awaiting, blocked and the rest).
 	fmt.Fprintf(&b, "| State | %s |\n", out.State)
 	fmt.Fprintf(&b, "| Access Level | %d |\n", out.AccessLevel)
 	if out.CreatedAt != "" {
@@ -45,7 +46,8 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString(toolutil.MarkdownTableHeader("ID", "Username", "Name", "State", "Access Level"))
 	for _, ar := range out.AccessRequests {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %d |\n",
-			ar.ID, ar.Username, ar.Name, ar.State, ar.AccessLevel)
+			//gitlab:allow-unescaped ar.State: a membership state GitLab picks from a fixed set (active, awaiting, blocked and the rest).
+			ar.ID, toolutil.EscapeMdTableCell(ar.Username), toolutil.EscapeMdTableCell(ar.Name), ar.State, ar.AccessLevel)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/accesstokens/markdown.go
+++ b/internal/tools/accesstokens/markdown.go
@@ -11,13 +11,14 @@ import (
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Access Token #%d\n\n", out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
 	if out.Description != "" {
 		toolutil.WriteDescription(&b, out.Description)
 	}
 	fmt.Fprintf(&b, "- **Active**: %t\n", out.Active)
 	fmt.Fprintf(&b, "- **Revoked**: %t\n", out.Revoked)
 	if len(out.Scopes) > 0 {
+		//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 		fmt.Fprintf(&b, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	}
 	if out.AccessLevel > 0 {
@@ -30,6 +31,7 @@ func FormatOutputMarkdown(out Output) string {
 		fmt.Fprintf(&b, "- **Expires**: %s\n", toolutil.FormatTime(out.ExpiresAt))
 	}
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/alertmanagement/markdown.go
+++ b/internal/tools/alertmanagement/markdown.go
@@ -32,9 +32,10 @@ func FormatListMarkdown(out ListMetricImagesOutput) string {
 // FormatImageMarkdown formats a single metric image as markdown.
 func FormatImageMarkdown(img MetricImageItem) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Metric Image\n\n- **ID**: %d\n- **Filename**: %s\n", img.ID, img.Filename)
-	fmt.Fprintf(&b, toolutil.FmtMdURL, img.URL)
-	fmt.Fprintf(&b, "- **URL Text**: %s\n", img.URLText)
+	// Both are chosen by whoever uploaded the image.
+	fmt.Fprintf(&b, "## Metric Image\n\n- **ID**: %d\n- **Filename**: %s\n", img.ID, toolutil.EscapeMdTableCell(img.Filename))
+	toolutil.WriteMdURL(&b, img.URL)
+	fmt.Fprintf(&b, "- **URL Text**: %s\n", toolutil.EscapeMdTableCell(img.URLText))
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/tools/appearance/markdown.go
+++ b/internal/tools/appearance/markdown.go
@@ -15,19 +15,21 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 	var sb strings.Builder
 	sb.WriteString("# Application Appearance\n\n")
 	sb.WriteString(toolutil.MarkdownTableHeader("Property", "Value"))
-	fmt.Fprintf(&sb, "| Title | %s |\n", a.Title)
-	fmt.Fprintf(&sb, "| Description | %s |\n", a.Description)
+	// Every field here is free text an administrator typed into the appearance
+	// settings, and the two messages are rendered as Markdown by GitLab itself.
+	fmt.Fprintf(&sb, "| Title | %s |\n", toolutil.EscapeMdTableCell(a.Title))
+	fmt.Fprintf(&sb, "| Description | %s |\n", toolutil.EscapeMdTableCell(a.Description))
 	if a.PWAName != "" {
-		fmt.Fprintf(&sb, "| PWA Name | %s |\n", a.PWAName)
+		fmt.Fprintf(&sb, "| PWA Name | %s |\n", toolutil.EscapeMdTableCell(a.PWAName))
 	}
 	if a.PWAShortName != "" {
-		fmt.Fprintf(&sb, "| PWA Short Name | %s |\n", a.PWAShortName)
+		fmt.Fprintf(&sb, "| PWA Short Name | %s |\n", toolutil.EscapeMdTableCell(a.PWAShortName))
 	}
 	if a.HeaderMessage != "" {
-		fmt.Fprintf(&sb, "| Header Message | %s |\n", a.HeaderMessage)
+		fmt.Fprintf(&sb, "| Header Message | %s |\n", toolutil.EscapeMdTableCell(a.HeaderMessage))
 	}
 	if a.FooterMessage != "" {
-		fmt.Fprintf(&sb, "| Footer Message | %s |\n", a.FooterMessage)
+		fmt.Fprintf(&sb, "| Footer Message | %s |\n", toolutil.EscapeMdTableCell(a.FooterMessage))
 	}
 	fmt.Fprintf(&sb, "| Email Header/Footer | %v |\n", a.EmailHeaderAndFooterEnabled)
 	toolutil.WriteHints(&sb, "Use `gitlab_update_appearance` to modify appearance settings")

--- a/internal/tools/attestations/markdown.go
+++ b/internal/tools/attestations/markdown.go
@@ -16,23 +16,29 @@ func FormatOutputMarkdown(o Output) string {
 	fmt.Fprintf(&b, "## Attestation #%d (IID %d)\n\n", o.ID, o.IID)
 	fmt.Fprintf(&b, "- **Project ID**: %d\n", o.ProjectID)
 	fmt.Fprintf(&b, "- **Build ID**: %d\n", o.BuildID)
+	//gitlab:allow-unescaped o.Status: an attestation status GitLab picks from a fixed set (pending, success, failed).
 	fmt.Fprintf(&b, "- **Status**: %s\n", o.Status)
 	if o.PredicateKind != "" {
-		fmt.Fprintf(&b, "- **Predicate Kind**: %s\n", o.PredicateKind)
+		fmt.Fprintf(&b, "- **Predicate Kind**: %s\n", toolutil.EscapeMdTableCell(o.PredicateKind))
 	}
 	if o.PredicateType != "" {
-		fmt.Fprintf(&b, "- **Predicate Type**: %s\n", o.PredicateType)
+		// The predicate type is a URI the attestation's producer chose, such as
+		// https://slsa.dev/provenance/v1, not a set GitLab constrains.
+		fmt.Fprintf(&b, "- **Predicate Type**: %s\n", toolutil.EscapeMdTableCell(o.PredicateType))
 	}
 	if o.SubjectDigest != "" {
+		//gitlab:allow-unescaped o.SubjectDigest: a subject digest, hexadecimal digits after an algorithm name.
 		fmt.Fprintf(&b, "- **Subject Digest**: `%s`\n", o.SubjectDigest)
 	}
 	if o.DownloadURL != "" {
-		fmt.Fprintf(&b, "- **Download URL**: %s\n", o.DownloadURL)
+		fmt.Fprintf(&b, "- **Download URL**: %s\n", toolutil.EscapeMdTableCell(o.DownloadURL))
 	}
 	if o.CreatedAt != "" {
+		//gitlab:allow-unescaped o.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, o.CreatedAt)
 	}
 	if o.ExpireAt != "" {
+		//gitlab:allow-unescaped o.ExpireAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 		fmt.Fprintf(&b, "- **Expires**: %s\n", o.ExpireAt)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/auditevents/markdown.go
+++ b/internal/tools/auditevents/markdown.go
@@ -19,6 +19,7 @@ func FormatMarkdown(e Output) string {
 	fmt.Fprintf(&sb, "| Entity Type | %s |\n", toolutil.EscapeMdTableCell(e.EntityType))
 	fmt.Fprintf(&sb, "| Event Name | %s |\n", toolutil.EscapeMdTableCell(e.EventName))
 	fmt.Fprintf(&sb, "| Event Type | %s |\n", toolutil.EscapeMdTableCell(e.EventType))
+	//gitlab:allow-unescaped e.CreatedAt: a timestamp this package formatted itself from the time client-go parsed.
 	fmt.Fprintf(&sb, "| Created At | %s |\n", e.CreatedAt)
 	if e.Details.AuthorName != "" {
 		fmt.Fprintf(&sb, "| Author Name | %s |\n", toolutil.EscapeMdTableCell(e.Details.AuthorName))
@@ -30,6 +31,7 @@ func FormatMarkdown(e Output) string {
 		fmt.Fprintf(&sb, "| Target Details | %s |\n", toolutil.EscapeMdTableCell(e.Details.TargetDetails))
 	}
 	if e.Details.IPAddress != "" {
+		//gitlab:allow-unescaped e.Details.IPAddress: GitLab records the address the request arrived from, so it is an IP literal.
 		fmt.Fprintf(&sb, "| IP Address | %s |\n", e.Details.IPAddress)
 	}
 	if e.Details.EntityPath != "" {

--- a/internal/tools/avatar/markdown.go
+++ b/internal/tools/avatar/markdown.go
@@ -10,7 +10,7 @@ import (
 // FormatMarkdown formats the avatar output as markdown.
 func FormatMarkdown(out GetOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Avatar\n\n- **URL**: %s\n", out.AvatarURL)
+	fmt.Fprintf(&b, "## Avatar\n\n- **URL**: %s\n", toolutil.EscapeMdTableCell(out.AvatarURL))
 	toolutil.WriteHints(&b, "Use the avatar URL directly in your application")
 	return b.String()
 }

--- a/internal/tools/awardemoji/markdown.go
+++ b/internal/tools/awardemoji/markdown.go
@@ -33,7 +33,10 @@ func FormatListMarkdownString(out ListOutput) string {
 	fmt.Fprintf(&b, "## Award Emoji (%d)\n\n", len(out.AwardEmoji))
 	toolutil.WriteListSummary(&b, len(out.AwardEmoji), out.Pagination)
 	for _, e := range out.AwardEmoji {
-		fmt.Fprintf(&b, "- :%s: by %s (ID: %d) - %s\n", e.Name, awardEmojiUserMarkdown(e), e.ID, toolutil.FormatTime(e.CreatedAt))
+		// An emoji name is not held to GitLab's own list: an instance may carry
+		// custom emoji whose name a person chose.
+		fmt.Fprintf(&b, "- :%s: by %s (ID: %d) - %s\n", toolutil.EscapeMdTableCell(e.Name),
+			toolutil.EscapeMdTableCell(awardEmojiUserMarkdown(e)), e.ID, toolutil.FormatTime(e.CreatedAt))
 	}
 	b.WriteString(toolutil.FormatPagination(out.Pagination))
 	toolutil.WriteHints(&b, toolutil.HintPreserveLinks, "Use the selected tool surface's matching award emoji actions for this resource; delete actions require explicit confirm=true plus the same resource identifiers and award_id")
@@ -59,10 +62,10 @@ func FormatMarkdown(out Output) *mcp.CallToolResult {
 func FormatMarkdownString(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Award Emoji\n\n")
-	fmt.Fprintf(&b, "- **Name**: :%s:\n", out.Name)
+	fmt.Fprintf(&b, "- **Name**: :%s:\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
 	if out.User != nil {
-		fmt.Fprintf(&b, "- **User**: %s (ID: %d)\n", out.User.Username, out.User.ID)
+		fmt.Fprintf(&b, "- **User**: %s (ID: %d)\n", toolutil.EscapeMdTableCell(out.User.Username), out.User.ID)
 	}
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))

--- a/internal/tools/badges/markdown.go
+++ b/internal/tools/badges/markdown.go
@@ -34,6 +34,7 @@ func FormatBadgeListMarkdown(badges []BadgeItem, title string, pagination toolut
 			toolutil.EscapeMdTableCell(b.Name),
 			toolutil.EscapeMdTableCell(b.LinkURL),
 			toolutil.EscapeMdTableCell(b.ImageURL),
+			//gitlab:allow-unescaped b.Kind: a badge kind GitLab picks from a fixed set (project, group).
 			b.Kind)
 	}
 	toolutil.WritePagination(&sb, pagination)
@@ -44,16 +45,19 @@ func FormatBadgeListMarkdown(badges []BadgeItem, title string, pagination toolut
 // FormatBadgeMarkdown formats a single badge.
 func FormatBadgeMarkdown(b BadgeItem) *mcp.CallToolResult {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Badge: %s (ID: %d)\n\n", b.Name, b.ID)
-	fmt.Fprintf(&sb, "- **Link URL**: %s\n", b.LinkURL)
-	fmt.Fprintf(&sb, "- **Image URL**: %s\n", b.ImageURL)
+	fmt.Fprintf(&sb, "## Badge: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(b.Name), b.ID)
+	// Every URL here is one a maintainer typed into the badge, placeholders
+	// included, and GitLab renders the last two by substituting into it.
+	fmt.Fprintf(&sb, "- **Link URL**: %s\n", toolutil.EscapeMdTableCell(b.LinkURL))
+	fmt.Fprintf(&sb, "- **Image URL**: %s\n", toolutil.EscapeMdTableCell(b.ImageURL))
 	if b.RenderedLinkURL != "" {
-		fmt.Fprintf(&sb, "- **Rendered Link**: %s\n", b.RenderedLinkURL)
+		fmt.Fprintf(&sb, "- **Rendered Link**: %s\n", toolutil.EscapeMdTableCell(b.RenderedLinkURL))
 	}
 	if b.RenderedImageURL != "" {
-		fmt.Fprintf(&sb, "- **Rendered Image**: %s\n", b.RenderedImageURL)
+		fmt.Fprintf(&sb, "- **Rendered Image**: %s\n", toolutil.EscapeMdTableCell(b.RenderedImageURL))
 	}
 	if b.Kind != "" {
+		//gitlab:allow-unescaped b.Kind: a badge kind GitLab picks from a fixed set (project, group).
 		fmt.Fprintf(&sb, "- **Kind**: %s\n", b.Kind)
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_edit_project_badge` (or `gitlab_edit_group_badge`) to modify this badge")

--- a/internal/tools/branches/markdown.go
+++ b/internal/tools/branches/markdown.go
@@ -30,10 +30,11 @@ func FormatOutputMarkdown(br Output) string {
 	fmt.Fprintf(&b, "- **Default**: %v\n", br.Default)
 	fmt.Fprintf(&b, "- **Merged**: %v\n", br.Merged)
 	if br.Commit != nil {
+		//gitlab:allow-unescaped br.Commit.ID: a commit SHA, hexadecimal by construction.
 		fmt.Fprintf(&b, "- **Commit**: %s\n", br.Commit.ID)
 	}
 	if br.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, br.WebURL)
+		toolutil.WriteMdURL(&b, br.WebURL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -56,10 +57,7 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| Name | Protected | Default | Merged |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, br := range out.Branches {
-		name := toolutil.EscapeMdTableCell(br.Name)
-		if br.WebURL != "" {
-			name = fmt.Sprintf("[%s](%s)", name, br.WebURL)
-		}
+		name := toolutil.MdTitleLink(br.Name, br.WebURL)
 		fmt.Fprintf(&b, "| %s | %v | %v | %v |\n", name, br.Protected, br.Default, br.Merged)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/branchrules/markdown.go
+++ b/internal/tools/branchrules/markdown.go
@@ -50,7 +50,8 @@ func FormatListMarkdown(out ListOutput) string {
 	// Render detailed sections for rules with approval rules or external status checks.
 	for _, r := range out.Rules {
 		if len(r.ApprovalRules) > 0 {
-			fmt.Fprintf(&sb, "### Approval Rules for `%s`\n\n", r.Name)
+			// A branch rule's name is the branch pattern a maintainer typed.
+			fmt.Fprintf(&sb, "### Approval Rules for `%s`\n\n", toolutil.EscapeMdHeading(r.Name))
 			sb.WriteString("| Name | Approvals Required | Type |\n")
 			sb.WriteString("|------|--------------------|------|\n")
 			for _, ar := range r.ApprovalRules {
@@ -64,7 +65,7 @@ func FormatListMarkdown(out ListOutput) string {
 			sb.WriteString("\n")
 		}
 		if len(r.ExternalStatusChecks) > 0 {
-			fmt.Fprintf(&sb, "### External Status Checks for `%s`\n\n", r.Name)
+			fmt.Fprintf(&sb, "### External Status Checks for `%s`\n\n", toolutil.EscapeMdHeading(r.Name))
 			sb.WriteString("| Name | URL |\n")
 			sb.WriteString("|------|-----|\n")
 			for _, esc := range r.ExternalStatusChecks {

--- a/internal/tools/broadcastmessages/markdown.go
+++ b/internal/tools/broadcastmessages/markdown.go
@@ -20,6 +20,9 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	}
 	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Message", "Type", "Active", "Starts", "Ends"))
 	for _, m := range out.Messages {
+		//gitlab:allow-unescaped m.BroadcastType: a broadcast type GitLab picks from a fixed set (banner, notification).
+		//gitlab:allow-unescaped m.StartsAt: a timestamp toMessageItem formatted itself, with time.Time.Format as RFC 3339.
+		//gitlab:allow-unescaped m.EndsAt: a timestamp toMessageItem formatted itself, with time.Time.Format as RFC 3339.
 		fmt.Fprintf(&sb, "| %d | %s | %s | %v | %s | %s |\n",
 			m.ID, toolutil.EscapeMdTableCell(m.Message), m.BroadcastType, m.Active, m.StartsAt, m.EndsAt)
 	}
@@ -33,7 +36,8 @@ func FormatMessageMarkdown(item MessageItem) *mcp.CallToolResult {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# Broadcast Message #%d\n\n", item.ID)
 	sb.WriteString(toolutil.MarkdownTableHeader("Property", "Value"))
-	fmt.Fprintf(&sb, "| Message | %s |\n", item.Message)
+	fmt.Fprintf(&sb, "| Message | %s |\n", toolutil.EscapeMdTableCell(item.Message))
+	//gitlab:allow-unescaped item.BroadcastType: a broadcast type GitLab picks from a fixed set (banner, notification).
 	fmt.Fprintf(&sb, "| Type | %s |\n", item.BroadcastType)
 	fmt.Fprintf(&sb, "| Active | %v |\n", item.Active)
 	fmt.Fprintf(&sb, "| Dismissable | %v |\n", item.Dismissable)
@@ -44,10 +48,12 @@ func FormatMessageMarkdown(item MessageItem) *mcp.CallToolResult {
 		fmt.Fprintf(&sb, "| Ends At | %s |\n", toolutil.FormatTime(item.EndsAt))
 	}
 	if item.Theme != "" {
+		//gitlab:allow-unescaped item.Theme: a broadcast theme GitLab picks from a fixed set of color names (indigo, light-indigo, blue and the rest).
 		fmt.Fprintf(&sb, "| Theme | %s |\n", item.Theme)
 	}
 	if item.TargetPath != "" {
-		fmt.Fprintf(&sb, "| Target Path | %s |\n", item.TargetPath)
+		// A target path is a path glob an administrator types into the message.
+		fmt.Fprintf(&sb, "| Target Path | %s |\n", toolutil.EscapeMdTableCell(item.TargetPath))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_update_broadcast_message` to modify this message")
 	return toolutil.ToolResultWithMarkdown(sb.String())

--- a/internal/tools/bulkimports/markdown.go
+++ b/internal/tools/bulkimports/markdown.go
@@ -7,6 +7,29 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// The cells that hold text somebody typed are escaped where they are written:
+// a migration's source URL, an entity's source and destination paths, and a
+// failure's exception message. The values below are declared instead, because
+// none of them can carry a pipe, a newline or a '<'.
+//
+// Two kinds are represented. The statuses and the two type fields are enums the
+// destination instance writes. The four failure fields are derived from the
+// importer's own Ruby code rather than from anything the source instance sent:
+// the pipeline and exception class names are constant paths, the step is the
+// pipeline stage that raised, and the relation is the pipeline class name with
+// its namespace and suffix removed.
+//
+//gitlab:allow-unescaped out.Status: a migration status GitLab writes, one of created, started, finished, timeout, failed or canceled.
+//gitlab:allow-unescaped out.SourceType: a migration source type GitLab writes, which is "gitlab".
+//gitlab:allow-unescaped m.Status: a migration status GitLab writes, one of created, started, finished, timeout, failed or canceled.
+//gitlab:allow-unescaped m.SourceType: a migration source type GitLab writes, which is "gitlab".
+//gitlab:allow-unescaped e.Status: an entity status GitLab writes, the same set a migration's status comes from.
+//gitlab:allow-unescaped e.EntityType: an entity type GitLab writes, either "group" or "project".
+//gitlab:allow-unescaped f.Relation: the importer relation the failure belongs to, derived from the pipeline class name.
+//gitlab:allow-unescaped f.Step: the importer step that raised, one of extractor, transformer or loader.
+//gitlab:allow-unescaped f.PipelineClass: the importer pipeline's Ruby class name, a constant path.
+//gitlab:allow-unescaped f.ExceptionClass: the raised exception's Ruby class name, a constant path.
+
 // FormatStartMigrationMarkdown formats a start migration result as markdown.
 func FormatStartMigrationMarkdown(out MigrationOutput) string {
 	var sb strings.Builder

--- a/internal/tools/cicatalog/markdown.go
+++ b/internal/tools/cicatalog/markdown.go
@@ -23,7 +23,7 @@ func FormatListMarkdown(out ListOutput) string {
 
 	for _, r := range out.Resources {
 		desc := toolutil.EscapeMdTableCell(truncate(r.Description, 60))
-		name := fmt.Sprintf("[%s](%s)", toolutil.EscapeMdTableCell(r.Name), r.WebPath)
+		name := toolutil.MdTitleLink(r.Name, r.WebPath)
 		fmt.Fprintf(
 			&sb, "| %s | %s | %d | %d | %s | %s | %s |\n",
 			name,
@@ -47,7 +47,7 @@ func FormatGetMarkdown(out GetOutput) string {
 	r := out.Resource
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "## Catalog Resource: %s\n\n", r.Name)
+	fmt.Fprintf(&sb, "## Catalog Resource: %s\n\n", toolutil.EscapeMdHeading(r.Name))
 	writeCatalogResourceSummary(&sb, r)
 	writeCatalogResourceComponents(&sb, r.Components)
 	writeCatalogResourceVersions(&sb, r.Versions)
@@ -58,7 +58,7 @@ func writeCatalogResourceSummary(sb *strings.Builder, r ResourceDetail) {
 	sb.WriteString("| Field | Value |\n|-------|-------|\n")
 	fmt.Fprintf(sb, "| ID | %s |\n", toolutil.EscapeMdTableCell(r.ID))
 	fmt.Fprintf(sb, "| Full Path | %s |\n", toolutil.EscapeMdTableCell(r.FullPath))
-	fmt.Fprintf(sb, "| Web Path | [%s](%s) |\n", toolutil.EscapeMdTableCell(r.WebPath), r.WebPath)
+	fmt.Fprintf(sb, "| Web Path | %s |\n", toolutil.MdTitleLink(r.WebPath, r.WebPath))
 	fmt.Fprintf(sb, "| Stars | %d |\n", r.StarCount)
 	fmt.Fprintf(sb, "| Usage (30d) | %d |\n", r.Last30DayUsageCount)
 	if r.VerificationLevel != "" {
@@ -92,7 +92,7 @@ func writeCatalogResourceComponents(sb *strings.Builder, components []ComponentI
 }
 
 func writeCatalogResourceComponent(sb *strings.Builder, component ComponentItem) {
-	fmt.Fprintf(sb, "#### `%s`\n\n", component.Name)
+	fmt.Fprintf(sb, "#### `%s`\n\n", toolutil.EscapeMdHeading(component.Name))
 	if component.Description != "" {
 		fmt.Fprintf(sb, "%s\n\n", component.Description)
 	}
@@ -115,7 +115,7 @@ func writeCatalogComponentInput(sb *strings.Builder, input InputItem) {
 	}
 	fmt.Fprintf(
 		sb, "| `%s` | %s | %s | %s | %s |\n",
-		input.Name,
+		toolutil.EscapeMdTableCell(input.Name),
 		toolutil.EscapeMdTableCell(input.Type),
 		required,
 		toolutil.EscapeMdTableCell(input.Default),
@@ -159,14 +159,18 @@ func truncate(s string, maxLen int) string {
 
 // formatDate extracts the YYYY-MM-DD date portion from an ISO 8601 timestamp.
 // Returns an empty string if iso is empty.
+//
+// Slicing the first ten bytes shortens the value without saying anything about
+// what is in them, so the result is escaped: what arrives here is a GraphQL
+// field this package copies verbatim, and a cell is where it lands.
 func formatDate(iso string) string {
 	if iso == "" {
 		return ""
 	}
 	if len(iso) >= 10 {
-		return iso[:10]
+		return toolutil.EscapeMdTableCell(iso[:10])
 	}
-	return iso
+	return toolutil.EscapeMdTableCell(iso)
 }
 
 func init() {

--- a/internal/tools/cilint/markdown.go
+++ b/internal/tools/cilint/markdown.go
@@ -21,14 +21,16 @@ func FormatOutputMarkdown(v Output) string {
 	if len(v.Errors) > 0 {
 		b.WriteString("### Errors\n\n")
 		for _, e := range v.Errors {
-			fmt.Fprintf(&b, "- %s\n", e)
+			// A lint message quotes the user's own CI file back, job and stage
+			// names included.
+			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(e))
 		}
 		b.WriteString("\n")
 	}
 	if len(v.Warnings) > 0 {
 		b.WriteString("### Warnings\n\n")
 		for _, w := range v.Warnings {
-			fmt.Fprintf(&b, "- %s\n", w)
+			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(w))
 		}
 		b.WriteString("\n")
 	}
@@ -38,6 +40,7 @@ func FormatOutputMarkdown(v Output) string {
 		b.WriteString("| --- | --- | --- |\n")
 		for _, inc := range v.Includes {
 			fmt.Fprintf(&b, "| %s | %s | %s |\n",
+				//gitlab:allow-unescaped inc.Type: an include kind GitLab names, one of local, file, remote, template or component.
 				inc.Type, toolutil.EscapeMdTableCell(inc.Location), toolutil.EscapeMdTableCell(inc.ContextProject))
 		}
 		b.WriteString("\n")

--- a/internal/tools/clusteragents/markdown.go
+++ b/internal/tools/clusteragents/markdown.go
@@ -28,8 +28,9 @@ func FormatAgentsListMarkdown(out ListAgentsOutput) string {
 // FormatAgentMarkdown renders a single cluster agent summary.
 func FormatAgentMarkdown(a AgentItem) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Cluster Agent\n\n- **ID**: %d\n- **Name**: %s\n", a.ID, a.Name)
+	fmt.Fprintf(&b, "## Cluster Agent\n\n- **ID**: %d\n- **Name**: %s\n", a.ID, toolutil.EscapeMdTableCell(a.Name))
 	if a.CreatedAt != "" {
+		//gitlab:allow-unescaped a.CreatedAt: a timestamp this package formatted itself, through toolutil.FormatTimePtr.
 		fmt.Fprintf(&b, "- **Created At**: %s\n", a.CreatedAt)
 	}
 	if a.CreatedByUserID != 0 {
@@ -58,6 +59,7 @@ func FormatTokensListMarkdown(out ListAgentTokensOutput) string {
 	}
 	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Status"))
 	for _, t := range out.Tokens {
+		//gitlab:allow-unescaped t.Status: an agent token status GitLab picks from a fixed set (active, revoked).
 		fmt.Fprintf(&sb, "| %d | %s | %s |\n", t.ID, toolutil.EscapeMdTableCell(t.Name), t.Status)
 	}
 	toolutil.WritePagination(&sb, out.Pagination)
@@ -68,17 +70,21 @@ func FormatTokensListMarkdown(out ListAgentTokensOutput) string {
 // FormatTokenMarkdown renders a single cluster agent token summary.
 func FormatTokenMarkdown(t AgentTokenItem) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Agent Token\n\n- **ID**: %d\n- **Name**: %s\n- **Status**: %s\n", t.ID, t.Name, t.Status)
+	//gitlab:allow-unescaped t.Status: an agent token status GitLab picks from a fixed set (active, revoked).
+	fmt.Fprintf(&sb, "## Agent Token\n\n- **ID**: %d\n- **Name**: %s\n- **Status**: %s\n", t.ID, toolutil.EscapeMdTableCell(t.Name), t.Status)
 	if t.Description != "" {
 		fmt.Fprintf(&sb, "- **Description**: %s\n", toolutil.EscapeMdTableCell(t.Description))
 	}
 	if t.CreatedAt != "" {
+		//gitlab:allow-unescaped t.CreatedAt: a timestamp this package formatted itself, through toolutil.FormatTimePtr.
 		fmt.Fprintf(&sb, "- **Created At**: %s\n", t.CreatedAt)
 	}
 	if t.LastUsedAt != "" {
+		//gitlab:allow-unescaped t.LastUsedAt: a timestamp this package formatted itself, through toolutil.FormatTimePtr.
 		fmt.Fprintf(&sb, "- **Last Used At**: %s\n", t.LastUsedAt)
 	}
 	if t.Token != "" {
+		//gitlab:allow-unescaped t.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&sb, "- **Token**: %s\n", t.Token)
 	}
 	toolutil.WriteHints(&sb, "Store the token value securely. It cannot be retrieved later")

--- a/internal/tools/commitdiscussions/markdown.go
+++ b/internal/tools/commitdiscussions/markdown.go
@@ -30,7 +30,7 @@ func noteAuthorUsername(n NoteOutput) string {
 func FormatNoteMarkdownString(n NoteOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Discussion Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, noteAuthorUsername(n))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(noteAuthorUsername(n)))
 	if n.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
 	}

--- a/internal/tools/commits/markdown.go
+++ b/internal/tools/commits/markdown.go
@@ -27,11 +27,15 @@ func userDisplay(u *BasicUserOutput) string {
 // FormatOutputMarkdown renders a single commit as a Markdown summary.
 func FormatOutputMarkdown(c Output) string {
 	var b strings.Builder
+	//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which is hexadecimal.
 	fmt.Fprintf(&b, "## Commit %s\n\n", c.ShortID)
-	fmt.Fprintf(&b, toolutil.FmtMdTitle, c.Title)
-	fmt.Fprintf(&b, "- **Author**: %s <%s>\n", c.AuthorName, c.AuthorEmail)
+	// A commit's title and ident are what whoever made the commit typed, and
+	// this server's own commit.create passes an author name and email through.
+	fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(c.Title))
+	fmt.Fprintf(&b, "- **Author**: %s <%s>\n",
+		toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.AuthorEmail))
 	fmt.Fprintf(&b, "- **Date**: %s\n", toolutil.FormatTime(c.CommittedDate))
-	fmt.Fprintf(&b, toolutil.FmtMdURL, c.WebURL)
+	toolutil.WriteMdURL(&b, c.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use action 'commit_get' with this SHA to see full commit details and stats",
@@ -53,7 +57,7 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| Short ID | Title | Author | Date |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, c := range out.Commits {
-		fmt.Fprintf(&b, "| [%s](%s) | %s | %s | %s |\n", c.ShortID, c.WebURL, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(c.ShortID, c.WebURL), toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -68,11 +72,16 @@ func FormatListMarkdown(out ListOutput) string {
 // FormatDetailMarkdown renders a single commit detail as a Markdown summary.
 func FormatDetailMarkdown(c DetailOutput) string {
 	var b strings.Builder
+	//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which is hexadecimal.
 	fmt.Fprintf(&b, "## Commit %s\n\n", c.ShortID)
-	fmt.Fprintf(&b, toolutil.FmtMdTitle, c.Title)
-	fmt.Fprintf(&b, "- **Author**: %s <%s>\n", c.AuthorName, c.AuthorEmail)
+	// A commit's title and ident are what whoever made the commit typed, and
+	// this server's own commit.create passes an author name and email through.
+	fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(c.Title))
+	fmt.Fprintf(&b, "- **Author**: %s <%s>\n",
+		toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.AuthorEmail))
 	fmt.Fprintf(&b, "- **Date**: %s\n", toolutil.FormatTime(c.CommittedDate))
 	if len(c.ParentIDs) > 0 {
+		//gitlab:allow-unescaped strings.Join(c.ParentIDs, ", "): full git object ids, which are hexadecimal.
 		fmt.Fprintf(&b, "- **Parents**: %s\n", strings.Join(c.ParentIDs, ", "))
 	}
 	if c.Stats != nil {
@@ -81,7 +90,7 @@ func FormatDetailMarkdown(c DetailOutput) string {
 	if c.Message != "" && c.Message != c.Title {
 		fmt.Fprintf(&b, "\n### Message\n\n%s\n", toolutil.WrapGFMBody(c.Message))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURLNewline, c.WebURL)
+	toolutil.WriteMdURLNewline(&b, c.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use `gitlab_commit_diff` to view file changes",
@@ -132,6 +141,7 @@ func FormatRefsMarkdown(out RefsOutput) string {
 	b.WriteString("| Type | Name |\n")
 	b.WriteString(toolutil.TblSep2Col)
 	for _, r := range out.Refs {
+		//gitlab:allow-unescaped r.Type: the ref kind GitLab answers with, either branch or tag.
 		fmt.Fprintf(&b, "| %s | %s |\n", r.Type, toolutil.EscapeMdTableCell(r.Name))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -177,10 +187,10 @@ func FormatCommentsMarkdown(out CommentsOutput) string {
 func FormatCommentMarkdown(c CommentOutput) string {
 	var b strings.Builder
 	b.WriteString("## Commit Comment\n\n")
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, userDisplay(c.Author))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(userDisplay(c.Author)))
 	fmt.Fprintf(&b, "- **Note**: %s\n", toolutil.EscapeMdTableCell(c.Note))
 	if c.Path != "" {
-		fmt.Fprintf(&b, "- **Path**: %s (line %d)\n", c.Path, c.Line)
+		fmt.Fprintf(&b, "- **Path**: %s (line %d)\n", toolutil.EscapeMdTableCell(c.Path), c.Line)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -201,6 +211,7 @@ func FormatStatusesMarkdown(out StatusesOutput) string {
 	b.WriteString("| ID | Status | Name | Ref | Description |\n")
 	b.WriteString(toolutil.TblSep5Col)
 	for _, s := range out.Statuses {
+		//gitlab:allow-unescaped s.Status: a build state GitLab rejects with a 400 unless it is one of the six its own schema enumerates.
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n", s.ID, s.Status, toolutil.EscapeMdTableCell(s.Name), toolutil.EscapeMdTableCell(s.Ref), toolutil.EscapeMdTableCell(s.Description))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -217,13 +228,15 @@ func FormatStatusMarkdown(s StatusOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Commit Status #%d\n\n", s.ID)
 	fmt.Fprintf(&b, toolutil.FmtMdStatus, s.Status)
-	fmt.Fprintf(&b, toolutil.FmtMdName, s.Name)
-	fmt.Fprintf(&b, "- **Ref**: %s\n", s.Ref)
+	// The name and the ref of a commit status are both supplied by whatever CI
+	// system posted it, and this server's own commit_status_set writes them.
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(s.Name))
+	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(s.Ref))
 	if s.Description != "" {
 		toolutil.WriteDescription(&b, s.Description)
 	}
 	if s.TargetURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, s.TargetURL)
+		toolutil.WriteMdURL(&b, s.TargetURL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -245,6 +258,7 @@ func FormatMRsByCommitMarkdown(out MRsByCommitOutput) string {
 	b.WriteString(toolutil.TblSep5Col)
 	for _, mr := range out.MergeRequests {
 		fmt.Fprintf(&b, "| !%d | %s | %s | %s -> %s | %s |\n",
+			//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
 			mr.IID, toolutil.EscapeMdTableCell(mr.Title), mr.State,
 			toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch),
 			toolutil.EscapeMdTableCell(mr.Author))
@@ -262,28 +276,37 @@ func FormatGPGSignatureMarkdown(sig GPGSignatureOutput) string {
 	var b strings.Builder
 	b.WriteString("## Commit Signature\n\n")
 	if sig.SignatureType != "" {
+		//gitlab:allow-unescaped sig.SignatureType: the signing scheme GitLab names, one of PGP, SSH or X509.
 		fmt.Fprintf(&b, "- **Type**: %s\n", sig.SignatureType)
 	}
+	//gitlab:allow-unescaped sig.VerificationStatus: a verification verdict GitLab computes, not text it stored.
 	fmt.Fprintf(&b, "- **Verification**: %s\n", sig.VerificationStatus)
 	switch {
 	case sig.X509Certificate != nil:
 		fmt.Fprintf(&b, "- **X.509 Subject**: %s\n", toolutil.EscapeMdTableCell(sig.X509Certificate.Subject))
 		if sig.X509Certificate.Email != "" {
-			fmt.Fprintf(&b, "- **X.509 Email**: %s\n", sig.X509Certificate.Email)
+			// Read out of the signer's own certificate, like the subject above.
+			fmt.Fprintf(&b, "- **X.509 Email**: %s\n", toolutil.EscapeMdTableCell(sig.X509Certificate.Email))
 		}
 	case sig.Key != nil:
 		if sig.Key.Title != "" {
 			fmt.Fprintf(&b, "- **SSH Key**: %s\n", toolutil.EscapeMdTableCell(sig.Key.Title))
 		}
 		if sig.Key.UsageType != "" {
+			//gitlab:allow-unescaped sig.Key.UsageType: the key usage GitLab records, one of auth, signing or auth_and_signing.
 			fmt.Fprintf(&b, "- **Usage**: %s\n", sig.Key.UsageType)
 		}
 	default:
-		fmt.Fprintf(&b, "- **Key User**: %s <%s>\n", sig.KeyUserName, sig.KeyUserEmail)
+		// Both come out of the GPG key's user ID packet, which is whatever the
+		// key's owner typed when they generated it.
+		fmt.Fprintf(&b, "- **Key User**: %s <%s>\n",
+			toolutil.EscapeMdTableCell(sig.KeyUserName), toolutil.EscapeMdTableCell(sig.KeyUserEmail))
 		fmt.Fprintf(&b, "- **Key ID**: %d\n", sig.KeyID)
+		//gitlab:allow-unescaped sig.KeyPrimaryKeyID: a GPG key id, which is hexadecimal.
 		fmt.Fprintf(&b, "- **Primary Key ID**: %s\n", sig.KeyPrimaryKeyID)
 	}
 	if sig.CommitSource != "" {
+		//gitlab:allow-unescaped sig.CommitSource: where GitLab read the commit from, either gitaly or rugged.
 		fmt.Fprintf(&b, "- **Commit Source**: %s\n", sig.CommitSource)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/containerregistry/markdown.go
+++ b/internal/tools/containerregistry/markdown.go
@@ -16,13 +16,18 @@ func FormatRepositoryMarkdown(out RepositoryOutput) string {
 		heading = out.Name
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Registry Repository: %s\n\n", heading)
+	// The name, the path and the location a path is built into are the image
+	// name whoever pushed it chose. What holds them to a safe character set is
+	// the OCI reference grammar, which a separate service enforces and this one
+	// neither sees nor models.
+	fmt.Fprintf(&b, "## Registry Repository: %s\n\n", toolutil.EscapeMdHeading(heading))
 	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Name | %s |\n", out.Name)
-	fmt.Fprintf(&b, "| Path | %s |\n", out.Path)
-	fmt.Fprintf(&b, "| Location | %s |\n", out.Location)
+	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, "| Path | %s |\n", toolutil.EscapeMdTableCell(out.Path))
+	fmt.Fprintf(&b, "| Location | %s |\n", toolutil.EscapeMdTableCell(out.Location))
 	fmt.Fprintf(&b, "| Tags Count | %d |\n", out.TagsCount)
 	if out.Status != "" {
+		//gitlab:allow-unescaped out.Status: a container repository status, a gl.ContainerRegistryStatus GitLab picks from a fixed set (delete_scheduled, delete_failed, delete_ongoing).
 		fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
 	}
 	if out.CreatedAt != "" {
@@ -48,7 +53,8 @@ func FormatRepositoryListMarkdown(out RepositoryListOutput) string {
 	}
 	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Tags Count"))
 	for _, r := range out.Repositories {
-		fmt.Fprintf(&b, "| %s | %s | %d |\n", r.Name, r.Path, r.TagsCount)
+		fmt.Fprintf(&b, "| %s | %s | %d |\n",
+			toolutil.EscapeMdTableCell(r.Name), toolutil.EscapeMdTableCell(r.Path), r.TagsCount)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -61,15 +67,17 @@ func FormatRepositoryListMarkdown(out RepositoryListOutput) string {
 // FormatTagMarkdown formats a single registry tag as markdown.
 func FormatTagMarkdown(out TagOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Registry Tag: %s\n\n", out.Name)
+	fmt.Fprintf(&b, "## Registry Tag: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Name | %s |\n", out.Name)
-	fmt.Fprintf(&b, "| Path | %s |\n", out.Path)
-	fmt.Fprintf(&b, "| Location | %s |\n", out.Location)
+	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, "| Path | %s |\n", toolutil.EscapeMdTableCell(out.Path))
+	fmt.Fprintf(&b, "| Location | %s |\n", toolutil.EscapeMdTableCell(out.Location))
 	if out.Digest != "" {
+		//gitlab:allow-unescaped out.Digest: an image manifest digest, an algorithm name and hexadecimal digits.
 		fmt.Fprintf(&b, "| Digest | %s |\n", out.Digest)
 	}
 	if out.Revision != "" {
+		//gitlab:allow-unescaped out.Revision: an image revision, hexadecimal digits only.
 		fmt.Fprintf(&b, "| Revision | %s |\n", out.Revision)
 	}
 	fmt.Fprintf(&b, "| Total Size | %d |\n", out.TotalSize)
@@ -95,7 +103,8 @@ func FormatTagListMarkdown(out TagListOutput) string {
 	}
 	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Total Size"))
 	for _, t := range out.Tags {
-		fmt.Fprintf(&b, "| %s | %s | %d |\n", t.Name, t.Path, t.TotalSize)
+		fmt.Fprintf(&b, "| %s | %s | %d |\n",
+			toolutil.EscapeMdTableCell(t.Name), toolutil.EscapeMdTableCell(t.Path), t.TotalSize)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -109,10 +118,14 @@ func FormatTagListMarkdown(out TagListOutput) string {
 // FormatProtectionRuleMarkdown formats a single protection rule as markdown.
 func FormatProtectionRuleMarkdown(out ProtectionRuleOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protection Rule: %s\n\n", out.RepositoryPathPattern)
+	// The pattern is free text this server's own registry_rule_create and
+	// registry_rule_update pass through with no validation of their own.
+	fmt.Fprintf(&b, "## Protection Rule: %s\n\n", toolutil.EscapeMdHeading(out.RepositoryPathPattern))
 	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Repository Path Pattern | %s |\n", out.RepositoryPathPattern)
+	fmt.Fprintf(&b, "| Repository Path Pattern | %s |\n", toolutil.EscapeMdTableCell(out.RepositoryPathPattern))
+	//gitlab:allow-unescaped out.MinimumAccessLevelForPush: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
 	fmt.Fprintf(&b, "| Min Access Level (Push) | %s |\n", out.MinimumAccessLevelForPush)
+	//gitlab:allow-unescaped out.MinimumAccessLevelForDelete: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
 	fmt.Fprintf(&b, "| Min Access Level (Delete) | %s |\n", out.MinimumAccessLevelForDelete)
 	toolutil.WriteHints(
 		&b,
@@ -135,7 +148,9 @@ func FormatProtectionRuleListMarkdown(out ProtectionRuleListOutput) string {
 	b.WriteString(toolutil.MarkdownTableHeader("Pattern", "Min Push", "Min Delete"))
 	for _, r := range out.Rules {
 		fmt.Fprintf(&b, "| %s | %s | %s |\n",
-			r.RepositoryPathPattern, r.MinimumAccessLevelForPush, r.MinimumAccessLevelForDelete)
+			//gitlab:allow-unescaped r.MinimumAccessLevelForPush: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
+			//gitlab:allow-unescaped r.MinimumAccessLevelForDelete: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
+			toolutil.EscapeMdTableCell(r.RepositoryPathPattern), r.MinimumAccessLevelForPush, r.MinimumAccessLevelForDelete)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -148,10 +163,14 @@ func FormatProtectionRuleListMarkdown(out ProtectionRuleListOutput) string {
 // FormatTagProtectionRuleMarkdown formats a single tag protection rule as markdown.
 func FormatTagProtectionRuleMarkdown(out TagProtectionRuleOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Tag Protection Rule: %s\n\n", out.TagNamePattern)
+	// An RE2 pattern a person types, where '|' is ordinary alternation, so
+	// "v.+|latest" would end the heading's own line without it.
+	fmt.Fprintf(&b, "## Tag Protection Rule: %s\n\n", toolutil.EscapeMdHeading(out.TagNamePattern))
 	fmt.Fprint(&b, toolutil.TblFieldValue)
 	fmt.Fprintf(&b, "| Tag Name Pattern | %s |\n", toolutil.EscapeMdTableCell(out.TagNamePattern))
+	//gitlab:allow-unescaped protectionAccessLabel(out.MinimumAccessLevelForPush): the same access level through a helper whose only other result is the constant "immutable".
 	fmt.Fprintf(&b, "| Min Access Level (Push) | %s |\n", protectionAccessLabel(out.MinimumAccessLevelForPush))
+	//gitlab:allow-unescaped protectionAccessLabel(out.MinimumAccessLevelForDelete): the same access level through a helper whose only other result is the constant "immutable".
 	fmt.Fprintf(&b, "| Min Access Level (Delete) | %s |\n", protectionAccessLabel(out.MinimumAccessLevelForDelete))
 	toolutil.WriteHints(
 		&b,
@@ -174,6 +193,8 @@ func FormatTagProtectionRuleListMarkdown(out TagProtectionRuleListOutput) string
 	b.WriteString(toolutil.MarkdownTableHeader("Tag Pattern", "Min Push", "Min Delete"))
 	for _, r := range out.Rules {
 		fmt.Fprintf(&b, "| %s | %s | %s |\n",
+			//gitlab:allow-unescaped protectionAccessLabel(r.MinimumAccessLevelForPush): the same access level through a helper whose only other result is the constant "immutable".
+			//gitlab:allow-unescaped protectionAccessLabel(r.MinimumAccessLevelForDelete): the same access level through a helper whose only other result is the constant "immutable".
 			toolutil.EscapeMdTableCell(r.TagNamePattern), protectionAccessLabel(r.MinimumAccessLevelForPush), protectionAccessLabel(r.MinimumAccessLevelForDelete))
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/customemoji/markdown.go
+++ b/internal/tools/customemoji/markdown.go
@@ -51,6 +51,7 @@ func FormatCreateMarkdown(out CreateOutput) string {
 	sb.WriteString(toolutil.EmojiSuccess + " Custom emoji created.\n\n")
 	sb.WriteString("| Field | Value |\n")
 	sb.WriteString("|-------|-------|\n")
+	//gitlab:allow-unescaped out.Emoji.ID: a GraphQL global id GitLab mints, gid://gitlab/CustomEmoji/ and a number.
 	fmt.Fprintf(&sb, "| ID | `%s` |\n", out.Emoji.ID)
 	fmt.Fprintf(&sb, "| Name | :%s: |\n", toolutil.EscapeMdTableCell(out.Emoji.Name))
 	fmt.Fprintf(&sb, "| URL | %s |\n", toolutil.MdTitleLink(out.Emoji.Name, out.Emoji.URL))

--- a/internal/tools/dependencies/markdown.go
+++ b/internal/tools/dependencies/markdown.go
@@ -23,6 +23,7 @@ func FormatListMarkdown(out ListOutput) string {
 			&sb, "| %s | %s | %s | %d | %d |\n",
 			toolutil.EscapeMdTableCell(d.Name),
 			toolutil.EscapeMdTableCell(d.Version),
+			//gitlab:allow-unescaped d.PackageManager: a package manager GitLab names from the scanner it ran (bundler, npm, maven and the rest).
 			d.PackageManager,
 			len(d.Vulnerabilities),
 			len(d.Licenses),
@@ -40,10 +41,10 @@ func FormatExportMarkdown(e ExportOutput) string {
 	fmt.Fprintf(&sb, "| ID | %d |\n", e.ID)
 	fmt.Fprintf(&sb, "| Finished | %s |\n", toolutil.BoolEmoji(e.HasFinished))
 	if e.Self != "" {
-		fmt.Fprintf(&sb, "| Self | %s |\n", e.Self)
+		fmt.Fprintf(&sb, "| Self | %s |\n", toolutil.EscapeMdTableCell(e.Self))
 	}
 	if e.Download != "" {
-		fmt.Fprintf(&sb, "| Download | %s |\n", e.Download)
+		fmt.Fprintf(&sb, "| Download | %s |\n", toolutil.EscapeMdTableCell(e.Download))
 	}
 	return sb.String()
 }

--- a/internal/tools/deploykeys/markdown.go
+++ b/internal/tools/deploykeys/markdown.go
@@ -10,14 +10,18 @@ import (
 // FormatOutputMarkdown formats a single deploy key.
 func FormatOutputMarkdown(o Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Deploy Key: %s (ID: %d)\n\n", o.Title, o.ID)
+	// A deploy key title is free text, and this server's own deploy_key.add and
+	// deploy_key.update send it.
+	fmt.Fprintf(&b, "## Deploy Key: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(o.Title), o.ID)
 	fmt.Fprintf(&b, "| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", o.ID)
-	fmt.Fprintf(&b, "| Title | %s |\n", o.Title)
+	fmt.Fprintf(&b, "| Title | %s |\n", toolutil.EscapeMdTableCell(o.Title))
 	if o.Fingerprint != "" {
+		//gitlab:allow-unescaped o.Fingerprint: an MD5 fingerprint GitLab derives from the key, colon-separated hexadecimal digits.
 		fmt.Fprintf(&b, "| Fingerprint | %s |\n", o.Fingerprint)
 	}
 	if o.FingerprintSHA256 != "" {
+		//gitlab:allow-unescaped o.FingerprintSHA256: a SHA256 fingerprint GitLab derives from the key, base64 digits after a "SHA256:" prefix.
 		fmt.Fprintf(&b, "| SHA256 | %s |\n", o.FingerprintSHA256)
 	}
 	fmt.Fprintf(&b, "| Can Push | %t |\n", o.CanPush)
@@ -50,7 +54,9 @@ func FormatListMarkdown(o ListOutput) string {
 	b.WriteString("|---|---|---|---|---|\n")
 	for _, k := range o.DeployKeys {
 		fmt.Fprintf(&b, "| %d | %s | %t | %s | %s |\n",
-			k.ID, k.Title, k.CanPush, k.Fingerprint, k.CreatedAt)
+			//gitlab:allow-unescaped k.Fingerprint: an MD5 fingerprint GitLab derives from the key, colon-separated hexadecimal digits.
+			//gitlab:allow-unescaped k.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
+			k.ID, toolutil.EscapeMdTableCell(k.Title), k.CanPush, k.Fingerprint, k.CreatedAt)
 	}
 	toolutil.WritePagination(&b, o.Pagination)
 	toolutil.WriteHints(
@@ -65,14 +71,16 @@ func FormatListMarkdown(o ListOutput) string {
 // FormatInstanceOutputMarkdown formats a single instance deploy key.
 func FormatInstanceOutputMarkdown(o InstanceOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Instance Deploy Key: %s (ID: %d)\n\n", o.Title, o.ID)
+	fmt.Fprintf(&b, "## Instance Deploy Key: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(o.Title), o.ID)
 	fmt.Fprintf(&b, "| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", o.ID)
-	fmt.Fprintf(&b, "| Title | %s |\n", o.Title)
+	fmt.Fprintf(&b, "| Title | %s |\n", toolutil.EscapeMdTableCell(o.Title))
 	if o.Fingerprint != "" {
+		//gitlab:allow-unescaped o.Fingerprint: an MD5 fingerprint GitLab derives from the key, colon-separated hexadecimal digits.
 		fmt.Fprintf(&b, "| Fingerprint | %s |\n", o.Fingerprint)
 	}
 	if o.FingerprintSHA256 != "" {
+		//gitlab:allow-unescaped o.FingerprintSHA256: a SHA256 fingerprint GitLab derives from the key, base64 digits after a "SHA256:" prefix.
 		fmt.Fprintf(&b, "| SHA256 | %s |\n", o.FingerprintSHA256)
 	}
 	if o.CreatedAt != "" {
@@ -85,14 +93,16 @@ func FormatInstanceOutputMarkdown(o InstanceOutput) string {
 		b.WriteString("\n### Projects with Write Access\n\n")
 		b.WriteString("| ID | Name | Path |\n|---|---|---|\n")
 		for _, p := range o.ProjectsWithWriteAccess {
-			fmt.Fprintf(&b, "| %d | %s | %s |\n", p.ID, p.Name, p.PathWithNamespace)
+			fmt.Fprintf(&b, "| %d | %s | %s |\n", p.ID,
+				toolutil.EscapeMdTableCell(p.Name), toolutil.EscapeMdTableCell(p.PathWithNamespace))
 		}
 	}
 	if len(o.ProjectsWithReadonlyAccess) > 0 {
 		b.WriteString("\n### Projects with Readonly Access\n\n")
 		b.WriteString("| ID | Name | Path |\n|---|---|---|\n")
 		for _, p := range o.ProjectsWithReadonlyAccess {
-			fmt.Fprintf(&b, "| %d | %s | %s |\n", p.ID, p.Name, p.PathWithNamespace)
+			fmt.Fprintf(&b, "| %d | %s | %s |\n", p.ID,
+				toolutil.EscapeMdTableCell(p.Name), toolutil.EscapeMdTableCell(p.PathWithNamespace))
 		}
 	}
 	toolutil.WriteHints(
@@ -117,7 +127,8 @@ func FormatInstanceListMarkdown(o InstanceListOutput) string {
 	b.WriteString("|---|---|---|---|---|\n")
 	for _, k := range o.DeployKeys {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
-			k.ID, k.Title, k.Fingerprint, k.CreatedAt, k.ExpiresAt)
+			//gitlab:allow-unescaped k.ExpiresAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
+			k.ID, toolutil.EscapeMdTableCell(k.Title), k.Fingerprint, k.CreatedAt, k.ExpiresAt)
 	}
 	toolutil.WritePagination(&b, o.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/deploymentmergerequests/markdown.go
+++ b/internal/tools/deploymentmergerequests/markdown.go
@@ -27,10 +27,11 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 		fmt.Fprintf(&sb, "| !%d | %s | %s | %s | %s -> %s |\n",
 			mr.IID,
 			toolutil.MdTitleLink(mr.Title, mr.WebURL),
+			//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
 			mr.State,
-			author,
-			mr.SourceBranch,
-			mr.TargetBranch)
+			toolutil.EscapeMdTableCell(author),
+			toolutil.EscapeMdTableCell(mr.SourceBranch),
+			toolutil.EscapeMdTableCell(mr.TargetBranch))
 	}
 	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_mr_get` to view full MR details")
 	return toolutil.ToolResultWithMarkdown(sb.String())

--- a/internal/tools/deployments/markdown.go
+++ b/internal/tools/deployments/markdown.go
@@ -32,7 +32,9 @@ func FormatOutputMarkdown(d Output) string {
 	b.WriteString(toolutil.TblSep2Col)
 	fmt.Fprintf(&b, "| IID | %d |\n", d.IID)
 	fmt.Fprintf(&b, "| Ref | %s |\n", toolutil.EscapeMdTableCell(d.Ref))
+	//gitlab:allow-unescaped d.SHA: a commit SHA, hexadecimal by construction.
 	fmt.Fprintf(&b, "| SHA | %s |\n", d.SHA)
+	//gitlab:allow-unescaped d.Status: a deployment status GitLab picks from a fixed set (created, running, success, failed, canceled, blocked).
 	fmt.Fprintf(&b, "| Status | %s |\n", d.Status)
 	if d.User != nil && d.User.Username != "" {
 		fmt.Fprintf(&b, "| User | %s |\n", toolutil.EscapeMdTableCell(d.User.Username))
@@ -47,7 +49,8 @@ func FormatOutputMarkdown(d Output) string {
 		fmt.Fprintf(&b, "| Updated | %s |\n", toolutil.FormatTime(d.UpdatedAt))
 	}
 	if d.Deployable != nil && d.Deployable.Pipeline != nil && d.Deployable.Pipeline.WebURL != "" {
-		fmt.Fprintf(&b, "| Pipeline | [#%d](%s) |\n", d.Deployable.Pipeline.ID, d.Deployable.Pipeline.WebURL)
+		fmt.Fprintf(&b, "| Pipeline | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", d.Deployable.Pipeline.ID), d.Deployable.Pipeline.WebURL))
 	}
 	toolutil.WriteHints(
 		&b,

--- a/internal/tools/deploytokens/markdown.go
+++ b/internal/tools/deploytokens/markdown.go
@@ -10,14 +10,16 @@ import (
 // FormatOutputMarkdown formats a single deploy token.
 func FormatOutputMarkdown(o Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Deploy Token: %s (ID: %d)\n\n", o.Name, o.ID)
+	fmt.Fprintf(&b, "## Deploy Token: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(o.Name), o.ID)
 	b.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&b, "| ID | %d |\n", o.ID)
-	fmt.Fprintf(&b, "| Name | %s |\n", o.Name)
-	fmt.Fprintf(&b, "| Username | %s |\n", o.Username)
+	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(o.Name))
+	fmt.Fprintf(&b, "| Username | %s |\n", toolutil.EscapeMdTableCell(o.Username))
 	if o.Token != "" {
+		//gitlab:allow-unescaped o.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&b, "| Token | %s |\n", o.Token)
 	}
+	//gitlab:allow-unescaped strings.Join(o.Scopes, ", "): deploy token scopes, which GitLab accepts only from its own fixed set.
 	fmt.Fprintf(&b, "| Scopes | %s |\n", strings.Join(o.Scopes, ", "))
 	fmt.Fprintf(&b, "| Revoked | %t |\n", o.Revoked)
 	fmt.Fprintf(&b, "| Expired | %t |\n", o.Expired)
@@ -44,8 +46,9 @@ func FormatListMarkdown(o ListOutput) string {
 	}
 	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Username", "Scopes", "Revoked", "Expired"))
 	for _, t := range o.DeployTokens {
+		//gitlab:allow-unescaped strings.Join(t.Scopes, ", "): deploy token scopes, which GitLab accepts only from its own fixed set.
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %t | %t |\n",
-			t.ID, t.Name, t.Username, strings.Join(t.Scopes, ", "), t.Revoked, t.Expired)
+			t.ID, toolutil.EscapeMdTableCell(t.Name), toolutil.EscapeMdTableCell(t.Username), strings.Join(t.Scopes, ", "), t.Revoked, t.Expired)
 	}
 	toolutil.WritePagination(&b, o.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/dorametrics/markdown.go
+++ b/internal/tools/dorametrics/markdown.go
@@ -21,6 +21,7 @@ func FormatMarkdown(out Output, metric string) string {
 	}
 	sb.WriteString("| Date | Value |\n|------|-------|\n")
 	for _, m := range out.Metrics {
+		//gitlab:allow-unescaped m.Date: the day GitLab reports the metric for, a YYYY-MM-DD date.
 		fmt.Fprintf(&sb, "| %s | %.4f |\n", m.Date, m.Value)
 	}
 	fmt.Fprintf(&sb, "\n**Total data points:** %d\n", len(out.Metrics))

--- a/internal/tools/dynamic/ranking.go
+++ b/internal/tools/dynamic/ranking.go
@@ -2,7 +2,8 @@ package dynamic
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
 const (
@@ -147,6 +148,16 @@ type ScoringExplanation struct {
 	Reasons       []MatchReason `json:"reasons,omitempty" jsonschema:"Deterministic match reasons that contributed to the score."`
 }
 
+// explanationSummary renders one scoring explanation as a table cell.
+//
+// The matched value it quotes is catalog text, but not always an identifier:
+// on the schema-description branch it is a whole property description reduced
+// to its words, and those are ordinary English. Two in the served catalog
+// carry the characters at issue today, "Order by: id | name | username" and
+// "(GitLab < 14 only)". This used to fold the pipe and the newline through a
+// local helper and leave the angle bracket alone, which is half of the rule
+// the shared escaper is, and a package-local half of a rule is how the next
+// reader learns the wrong one.
 func explanationSummary(explanation *ScoringExplanation) string {
 	if explanation == nil || len(explanation.Reasons) == 0 {
 		return "-"
@@ -163,7 +174,7 @@ func explanationSummary(explanation *ScoringExplanation) string {
 	if reason.Fuzzy {
 		text = fmt.Sprintf("%s fuzzy-matched %q", reason.Field, matched)
 	}
-	return markdownTableText(text)
+	return toolutil.EscapeMdTableCell(text)
 }
 
 func hasSearchExplanations(results []SearchResult) bool {
@@ -194,10 +205,4 @@ func ambiguousTargetsFromSearchResults(results []SearchResult) []string {
 		}
 	}
 	return nil
-}
-
-func markdownTableText(text string) string {
-	text = strings.ReplaceAll(text, "|", "\\|")
-	text = strings.ReplaceAll(text, "\n", " ")
-	return text
 }

--- a/internal/tools/dynamic/register.go
+++ b/internal/tools/dynamic/register.go
@@ -3917,6 +3917,16 @@ func hasExplicitConfirm(params map[string]any) bool {
 	return false
 }
 
+// formatSearchOutput renders a catalog search as a Markdown table.
+//
+// Every cell but the Why column holds catalog metadata compiled into the
+// binary from an ActionSpec rather than text read from a GitLab response, so
+// escaping it would teach the next reader a rule that is not the rule.
+// formatFindOutput builds the same two values under the same names, and one
+// declaration covers a package.
+//
+//gitlab:allow-unescaped result.ID: a canonical catalog ID such as project.create, compiled in from an ActionSpec rather than read from a GitLab response.
+//gitlab:allow-unescaped required: the action's required parameter names, joined from its compiled-in input schema, so each one is a JSON property identifier.
 func formatSearchOutput(output SearchOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## GitLab Action Search\n\n")
@@ -3961,6 +3971,19 @@ func formatSearchOutput(output SearchOutput) string {
 	return b.String()
 }
 
+// formatDescribeOutput renders one or more catalog actions as a heading and a
+// list of their metadata.
+//
+// Everything it interpolates is compiled into the binary from an ActionSpec or
+// derived from the action's own input schema, so none of it is GitLab-authored
+// text and none of it wants an escaper.
+//
+//gitlab:allow-unescaped action.ID: a canonical catalog ID such as project.create, compiled in from an ActionSpec rather than read from a GitLab response.
+//gitlab:allow-unescaped action.Tool: the backing meta-tool name of the catalog group, such as gitlab_issue, compiled in from an ActionSpec.
+//gitlab:allow-unescaped action.Action: the action name inside the catalog group, compiled in from an ActionSpec.
+//gitlab:allow-unescaped strings.Join(action.RequiredParams, "`, `"): the action's required parameter names, read from its compiled-in input schema, so each one is a JSON property identifier.
+//gitlab:allow-unescaped strings.Join(action.RelatedActions, "`, `"): curated canonical catalog IDs, compiled in from an ActionSpec or from actionUXMetadataByID.
+//gitlab:allow-unescaped action.SchemaURI: the constant gitlab://tools/ prefix concatenated with a canonical catalog ID by toolDetailURIForID.
 func formatDescribeOutput(output DescribeOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## GitLab Action Description\n\n")

--- a/internal/tools/enterpriseusers/markdown.go
+++ b/internal/tools/enterpriseusers/markdown.go
@@ -15,8 +15,9 @@ func FormatOutputMarkdown(o Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Enterprise User: %s\n\n", toolutil.EscapeMdHeading(o.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdUsername, o.Username)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, o.Email)
+	fmt.Fprintf(&b, toolutil.FmtMdUsername, toolutil.EscapeMdTableCell(o.Username))
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(o.Email))
+	//gitlab:allow-unescaped o.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
 	fmt.Fprintf(&b, toolutil.FmtMdState, o.State)
 	fmt.Fprintf(&b, "- **Admin**: %v\n", o.IsAdmin)
 	fmt.Fprintf(&b, "- **2FA Enabled**: %v\n", o.TwoFactorEnabled)
@@ -24,9 +25,10 @@ func FormatOutputMarkdown(o Output) string {
 	fmt.Fprintf(&b, "- **Locked**: %v\n", o.Locked)
 	fmt.Fprintf(&b, "- **Bot**: %v\n", o.Bot)
 	if o.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, o.WebURL)
+		toolutil.WriteMdURL(&b, o.WebURL)
 	}
 	if o.CreatedAt != "" {
+		//gitlab:allow-unescaped o.CreatedAt: a timestamp this package formatted itself from the time client-go parsed.
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, o.CreatedAt)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/environments/markdown.go
+++ b/internal/tools/environments/markdown.go
@@ -32,6 +32,7 @@ func FormatOutputMarkdown(e Output) string {
 	b.WriteString(toolutil.TblSep2Col)
 	fmt.Fprintf(&b, "| ID | %d |\n", e.ID)
 	fmt.Fprintf(&b, "| Slug | %s |\n", toolutil.EscapeMdTableCell(e.Slug))
+	//gitlab:allow-unescaped e.State: an environment state GitLab picks from a fixed set (available, stopping, stopped).
 	fmt.Fprintf(&b, "| State | %s |\n", e.State)
 	if e.Tier != "" {
 		fmt.Fprintf(&b, "| Tier | %s |\n", toolutil.EscapeMdTableCell(e.Tier))
@@ -71,7 +72,7 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, e := range out.Environments {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
-			e.ID, toolutil.EscapeMdTableCell(e.Name), e.State, e.Tier, toolutil.EscapeMdTableCell(e.ExternalURL))
+			e.ID, toolutil.EscapeMdTableCell(e.Name), e.State, toolutil.EscapeMdTableCell(e.Tier), toolutil.EscapeMdTableCell(e.ExternalURL))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/epicissues/markdown.go
+++ b/internal/tools/epicissues/markdown.go
@@ -26,6 +26,7 @@ func FormatListMarkdown(out ListOutput) string {
 			&b, "| #%d | %s | %s | %s | %s | %s |\n",
 			issue.IID,
 			toolutil.EscapeMdTableCell(issue.Title),
+			//gitlab:allow-unescaped issue.State: an issue state, one of GitLab's fixed set (opened, closed).
 			issue.State,
 			toolutil.EscapeMdTableCell(issue.Author),
 			toolutil.EscapeMdTableCell(labels),
@@ -51,9 +52,11 @@ func FormatAssignMarkdown(out AssignOutput, action string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Epic Issue %s\n\n", action)
 	if out.EpicGID != "" {
+		//gitlab:allow-unescaped out.EpicGID: a GraphQL global id GitLab mints, gid://gitlab/Epic/ and a number.
 		fmt.Fprintf(&b, "- **Epic**: %s\n", out.EpicGID)
 	}
 	if out.ChildGID != "" {
+		//gitlab:allow-unescaped out.ChildGID: a GraphQL global id GitLab mints, gid://gitlab/Issue/ and a number.
 		fmt.Fprintf(&b, "- **Issue**: %s\n", out.ChildGID)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/epicnotes/markdown.go
+++ b/internal/tools/epicnotes/markdown.go
@@ -20,7 +20,7 @@ func noteAuthorUsername(n Output) string {
 func FormatOutputMarkdown(n Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Epic Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, noteAuthorUsername(n))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(noteAuthorUsername(n)))
 	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
 	if n.System {
 		b.WriteString("- **System note**\n")

--- a/internal/tools/epics/markdown.go
+++ b/internal/tools/epics/markdown.go
@@ -34,51 +34,61 @@ func userNames(users []*BasicUserOutput) []string {
 func FormatOutputMarkdown(e Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Epic &%d: %s\n\n", e.IID, toolutil.EscapeMdTableCell(e.Title))
+	//gitlab:allow-unescaped e.State: an epic state GitLab writes, opened or closed on the REST epic and OPEN or CLOSED on the work item.
 	fmt.Fprintf(&b, toolutil.FmtMdState, e.State)
 	if e.Status != "" {
-		fmt.Fprintf(&b, "- **Status**: %s\n", e.Status)
+		// The status widget carries the display name of a status in the
+		// namespace's lifecycle, which a group owner can create and rename.
+		fmt.Fprintf(&b, "- **Status**: %s\n", toolutil.EscapeMdTableCell(e.Status))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, userName(e.Author))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(userName(e.Author)))
 	if len(e.Assignees) > 0 {
-		fmt.Fprintf(&b, "- **Assignees**: %s\n", strings.Join(userNames(e.Assignees), ", "))
+		fmt.Fprintf(&b, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(userNames(e.Assignees), ", ")))
 	}
 	if e.Confidential {
 		b.WriteString("- **Confidential**: yes\n")
 	}
 	if len(e.Labels) > 0 {
-		fmt.Fprintf(&b, "- **Labels**: %s\n", strings.Join(e.Labels, ", "))
+		// A label title is free text: GitLab's only rule on one is that it
+		// carries no comma.
+		fmt.Fprintf(&b, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(e.Labels, ", ")))
 	}
 	if e.HealthStatus != "" {
+		//gitlab:allow-unescaped e.HealthStatus: the GraphQL HealthStatus enum, one of onTrack, needsAttention and atRisk.
 		fmt.Fprintf(&b, "- **Health**: %s\n", e.HealthStatus)
 	}
 	if e.Weight != nil {
 		fmt.Fprintf(&b, "- **Weight**: %d\n", *e.Weight)
 	}
 	if e.StartDate != "" {
+		//gitlab:allow-unescaped e.StartDate: a date this package wrote itself, with time.Format on the DateOnly layout.
 		fmt.Fprintf(&b, "- **Start date**: %s\n", e.StartDate)
 	}
 	if e.DueDate != "" {
+		//gitlab:allow-unescaped e.DueDate: a date this package wrote itself, with time.Format on the DateOnly layout.
 		fmt.Fprintf(&b, "- **Due date**: %s\n", e.DueDate)
 	}
 	if e.Color != "" {
+		//gitlab:allow-unescaped e.Color: a hex code or a CSS color name, which GitLab validates before it stores it.
 		fmt.Fprintf(&b, "- **Color**: %s\n", e.Color)
 	}
 	if e.ParentIID > 0 {
-		fmt.Fprintf(&b, "- **Parent**: &%d (%s)\n", e.ParentIID, e.ParentPath)
+		fmt.Fprintf(&b, "- **Parent**: &%d (%s)\n", e.ParentIID, toolutil.EscapeMdTableCell(e.ParentPath))
 	}
 	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(e.CreatedAt))
 	if e.ClosedAt != "" {
 		fmt.Fprintf(&b, "- **Closed**: %s\n", toolutil.FormatTime(e.ClosedAt))
 	}
 	if e.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, e.WebURL)
+		toolutil.WriteMdURL(&b, e.WebURL)
 	}
 	if len(e.LinkedItems) > 0 {
 		b.WriteString("\n### Linked Items\n\n")
 		b.WriteString("| IID | Link Type | Path |\n")
 		b.WriteString("| --- | --- | --- |\n")
 		for _, li := range e.LinkedItems {
-			fmt.Fprintf(&b, "| %d | %s | %s |\n", li.IID, li.LinkType, li.Path)
+			//gitlab:allow-unescaped li.LinkType: a link type the Work Items API documents, one of blocks, is_blocked_by and relates_to.
+			fmt.Fprintf(&b, "| %d | %s | %s |\n", li.IID, li.LinkType, toolutil.EscapeMdTableCell(li.Path))
 		}
 	}
 	if e.Description != "" {

--- a/internal/tools/errortracking/markdown.go
+++ b/internal/tools/errortracking/markdown.go
@@ -14,10 +14,11 @@ func FormatSettingsMarkdown(out SettingsOutput) string {
 	fmt.Fprintf(&sb, "- **Active**: %v\n", out.Active)
 	fmt.Fprintf(&sb, "- **Integrated**: %v\n", out.Integrated)
 	if out.ProjectName != "" {
-		fmt.Fprintf(&sb, "- **Project Name**: %s\n", out.ProjectName)
+		fmt.Fprintf(&sb, "- **Project Name**: %s\n", toolutil.EscapeMdTableCell(out.ProjectName))
 	}
 	if out.SentryExternalURL != "" {
-		fmt.Fprintf(&sb, "- **Sentry URL**: %s\n", out.SentryExternalURL)
+		// Both come from the Sentry integration a maintainer configured.
+		fmt.Fprintf(&sb, "- **Sentry URL**: %s\n", toolutil.EscapeMdTableCell(out.SentryExternalURL))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_list_error_tracking_client_keys` to view client keys")
 	return sb.String()
@@ -44,6 +45,8 @@ func FormatListKeysMarkdown(out ListClientKeysOutput) string {
 func FormatKeyMarkdown(k ClientKeyItem) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Error Tracking Client Key\n\n- **ID**: %d\n- **Active**: %v\n- **Public Key**: %s\n- **Sentry DSN**: %s\n",
+		//gitlab:allow-unescaped k.PublicKey: the client key GitLab generated, hexadecimal digits.
+		//gitlab:allow-unescaped k.SentryDsn: the DSN GitLab composed from the instance URL, that generated key and a numeric project id.
 		k.ID, k.Active, k.PublicKey, k.SentryDsn)
 	toolutil.WriteHints(&b, "Use `gitlab_delete_error_tracking_client_key` to revoke this key")
 	return b.String()

--- a/internal/tools/events/markdown.go
+++ b/internal/tools/events/markdown.go
@@ -19,12 +19,12 @@ func formatTarget(targetType string, targetIID int64, targetTitle, targetURL str
 	if targetType == "" {
 		return ""
 	}
-	label := fmt.Sprintf("%s #%d", targetType, targetIID)
-	if targetURL != "" {
-		label = fmt.Sprintf("[%s](%s)", label, targetURL)
-	}
+	// The target type is a class name GitLab writes and the IID an integer, so
+	// the label is safe; the URL and the title are not, and MdTitleLink is what
+	// escapes both halves of the link they end up in.
+	label := toolutil.MdTitleLink(fmt.Sprintf("%s #%d", targetType, targetIID), targetURL)
 	if targetTitle != "" {
-		label += fmt.Sprintf(" %q", targetTitle)
+		label += fmt.Sprintf(" %q", toolutil.EscapeMdTableCell(targetTitle))
 	}
 	return " " + label
 }
@@ -69,7 +69,8 @@ func formatEventListMarkdown(title, emptyText string, events []markdownEvent, pa
 	for _, e := range events {
 		target := formatTarget(e.TargetType, e.TargetIID, e.TargetTitle, e.TargetURL)
 		author := formatAuthor(e.AuthorUsername)
-		fmt.Fprintf(&b, "- **%s**%s by %s, %s\n", e.ActionName, target, author, toolutil.FormatTime(e.CreatedAt))
+		//gitlab:allow-unescaped e.ActionName: a contribution-event action GitLab writes from its own vocabulary (opened, closed, pushed to and the rest).
+		fmt.Fprintf(&b, "- **%s**%s by %s, %s\n", e.ActionName, target, toolutil.EscapeMdTableCell(author), toolutil.FormatTime(e.CreatedAt))
 	}
 	b.WriteString(toolutil.FormatPagination(pagination))
 	toolutil.WriteHints(

--- a/internal/tools/externalstatuschecks/markdown.go
+++ b/internal/tools/externalstatuschecks/markdown.go
@@ -12,7 +12,9 @@ func FormatMergeCheckMarkdown(out MergeStatusCheckOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## External Status Check: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, "- **External URL**: %s\n", out.ExternalURL)
+	// The external URL is whatever the maintainer who added the check typed.
+	fmt.Fprintf(&b, "- **External URL**: %s\n", toolutil.EscapeMdTableCell(out.ExternalURL))
+	//gitlab:allow-unescaped out.Status: an external status check state GitLab picks from a fixed set (passed, failed, pending).
 	fmt.Fprintf(&b, toolutil.FmtMdStatus, out.Status)
 	toolutil.WriteHints(
 		&b,
@@ -28,12 +30,13 @@ func FormatProjectCheckMarkdown(out ProjectStatusCheckOutput) string {
 	fmt.Fprintf(&b, "## External Status Check: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
 	fmt.Fprintf(&b, "- **Project ID**: %d\n", out.ProjectID)
-	fmt.Fprintf(&b, "- **External URL**: %s\n", out.ExternalURL)
+	// The external URL is whatever the maintainer who added the check typed.
+	fmt.Fprintf(&b, "- **External URL**: %s\n", toolutil.EscapeMdTableCell(out.ExternalURL))
 	fmt.Fprintf(&b, "- **HMAC**: %s\n", toolutil.BoolEmoji(out.HMAC))
 	if len(out.ProtectedBranches) > 0 {
 		fmt.Fprintf(&b, "- **Protected Branches**: %d\n", len(out.ProtectedBranches))
 		for _, pb := range out.ProtectedBranches {
-			fmt.Fprintf(&b, "  - %s (ID: %d)\n", pb.Name, pb.ID)
+			fmt.Fprintf(&b, "  - %s (ID: %d)\n", toolutil.EscapeMdTableCell(pb.Name), pb.ID)
 		}
 	}
 	toolutil.WriteHints(

--- a/internal/tools/features/markdown.go
+++ b/internal/tools/features/markdown.go
@@ -56,14 +56,19 @@ func FormatListDefinitionsMarkdown(output ListDefinitionsOutput) *mcp.CallToolRe
 func FormatFeatureMarkdown(output SetOutput) *mcp.CallToolResult {
 	f := output.Feature
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Feature Flag: %s\n\n", f.Name)
+	// A feature flag name is the string the caller of feature.set supplied,
+	// which GitLab creates on demand rather than validating against a list.
+	fmt.Fprintf(&sb, "## Feature Flag: %s\n\n", toolutil.EscapeMdHeading(f.Name))
 	sb.WriteString("| Property | Value |\n")
 	sb.WriteString("|----------|-------|\n")
+	//gitlab:allow-unescaped f.State: a feature flag state GitLab picks from a fixed set (on, off, conditional).
 	fmt.Fprintf(&sb, "| State | %s |\n", f.State)
 	fmt.Fprintf(&sb, "| Gates | %s |\n", toolutil.EscapeMdTableCell(formatGates(f.Gates)))
 	if f.Definition != nil {
-		fmt.Fprintf(&sb, "| Type | %s |\n", f.Definition.Type)
-		fmt.Fprintf(&sb, "| Group | %s |\n", f.Definition.Group)
+		// Both are read out of the flag's definition file in GitLab's own
+		// source tree, so neither is a set this server can know.
+		fmt.Fprintf(&sb, "| Type | %s |\n", toolutil.EscapeMdTableCell(f.Definition.Type))
+		fmt.Fprintf(&sb, "| Group | %s |\n", toolutil.EscapeMdTableCell(f.Definition.Group))
 		fmt.Fprintf(&sb, "| Default Enabled | %v |\n", f.Definition.DefaultEnabled)
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_set_feature_flag` to toggle this feature")

--- a/internal/tools/ffuserlists/markdown.go
+++ b/internal/tools/ffuserlists/markdown.go
@@ -13,7 +13,8 @@ func FormatUserListMarkdown(out Output) string {
 	fmt.Fprintf(&b, "## Feature Flag User List: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, "- **ID**: %d (IID: %d)\n", out.ID, out.IID)
 	if out.UserXIDs != "" {
-		fmt.Fprintf(&b, "- **User XIDs**: %s\n", out.UserXIDs)
+		// The external user ids are a comma-separated list a person supplies.
+		fmt.Fprintf(&b, "- **User XIDs**: %s\n", toolutil.EscapeMdTableCell(out.UserXIDs))
 	}
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))

--- a/internal/tools/files/markdown.go
+++ b/internal/tools/files/markdown.go
@@ -28,13 +28,18 @@ func FormatOutputMarkdown(f Output) string {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File: %s\n\n", f.FilePath)
+	// A repository path is whatever whoever added the file named it, and git
+	// forbids only NUL and the separator inside a path component.
+	fmt.Fprintf(&b, "## File: %s\n\n", toolutil.EscapeMdHeading(f.FilePath))
 	fmt.Fprintf(&b, fmtSizeBytes, f.Size)
-	fmt.Fprintf(&b, "- **Ref**: %s\n", f.Ref)
+	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(f.Ref))
+	//gitlab:allow-unescaped f.Encoding: a content encoding GitLab emits as the literal "base64", never text anybody typed.
 	fmt.Fprintf(&b, "- **Encoding**: %s\n", f.Encoding)
+	//gitlab:allow-unescaped f.BlobID: a git blob object id, hexadecimal digits only.
 	fmt.Fprintf(&b, "- **Blob ID**: %s\n", f.BlobID)
 	switch f.ContentCategory {
 	case "image":
+		//gitlab:allow-unescaped f.ImageMIMEType: a MIME type this package derived from the file extension through toolutil.ImageMIMEType, which returns a compiled-in constant.
 		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", f.ImageMIMEType)
 		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
 	case "binary":
@@ -65,12 +70,14 @@ func fileGetResult(out Output) *mcp.CallToolResult {
 func FormatFileInfoMarkdown(out FileInfoOutput) string {
 	var b strings.Builder
 	b.WriteString("## File Operation Result\n\n")
-	fmt.Fprintf(&b, "- **File**: %s\n", out.FilePath)
-	fmt.Fprintf(&b, "- **Branch**: %s\n", out.Branch)
+	fmt.Fprintf(&b, "- **File**: %s\n", toolutil.EscapeMdTableCell(out.FilePath))
+	fmt.Fprintf(&b, "- **Branch**: %s\n", toolutil.EscapeMdTableCell(out.Branch))
 	if out.CommitID != "" {
+		//gitlab:allow-unescaped out.CommitID: a git commit SHA, hexadecimal digits only.
 		fmt.Fprintf(&b, "- **Commit ID**: %s\n", out.CommitID)
 	}
 	if out.LastCommitID != "" {
+		//gitlab:allow-unescaped out.LastCommitID: a git commit SHA, hexadecimal digits only.
 		fmt.Fprintf(&b, "- **Last commit ID**: %s\n", out.LastCommitID)
 	}
 	toolutil.WriteHints(
@@ -84,14 +91,18 @@ func FormatFileInfoMarkdown(out FileInfoOutput) string {
 // FormatBlameMarkdown renders blame information as Markdown.
 func FormatBlameMarkdown(out BlameOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File Blame: %s\n\n", out.FilePath)
+	fmt.Fprintf(&b, "## File Blame: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
 	if len(out.Ranges) == 0 {
 		b.WriteString("No blame data found.\n")
 		return b.String()
 	}
 	for i, r := range out.Ranges {
+		// Named rather than sliced inline so the exemption below can refer to
+		// it: a directive's expression is cut at its first colon.
+		shortID := r.Commit.ID[:minLen(len(r.Commit.ID), 8)]
+		//gitlab:allow-unescaped shortID: the first eight characters of a git commit SHA, hexadecimal digits only.
 		fmt.Fprintf(&b, "### Range %d: %s (%s)\n\n", i+1,
-			toolutil.EscapeMdTableCell(r.Commit.AuthorName), r.Commit.ID[:minLen(len(r.Commit.ID), 8)])
+			toolutil.EscapeMdTableCell(r.Commit.AuthorName), shortID)
 		fmt.Fprintf(&b, "**%s**\n\n", toolutil.EscapeMdTableCell(r.Commit.Message))
 		b.WriteString(toolutil.MarkdownFencedBlock(langFromPath(out.FilePath), strings.Join(r.Lines, "\n")))
 		b.WriteString("\n")
@@ -107,14 +118,17 @@ func FormatBlameMarkdown(out BlameOutput) string {
 // FormatMetaDataMarkdown renders file metadata as Markdown.
 func FormatMetaDataMarkdown(out MetaDataOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File Metadata: %s\n\n", out.FilePath)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.FileName)
+	fmt.Fprintf(&b, "## File Metadata: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.FileName))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	fmt.Fprintf(&b, "- **Ref**: %s\n", out.Ref)
+	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(out.Ref))
+	//gitlab:allow-unescaped out.Encoding: a content encoding GitLab emits as the literal "base64", never text anybody typed.
 	fmt.Fprintf(&b, "- **Encoding**: %s\n", out.Encoding)
+	//gitlab:allow-unescaped out.BlobID: a git blob object id, hexadecimal digits only.
 	fmt.Fprintf(&b, "- **Blob ID**: %s\n", out.BlobID)
 	fmt.Fprintf(&b, "- **Commit ID**: %s\n", out.CommitID)
 	fmt.Fprintf(&b, "- **Last Commit ID**: %s\n", out.LastCommitID)
+	//gitlab:allow-unescaped out.SHA256: a SHA-256 digest of the file content, hexadecimal digits only.
 	fmt.Fprintf(&b, "- **SHA-256**: %s\n", out.SHA256)
 	if out.ExecuteFilemode {
 		b.WriteString("- **Executable**: yes\n")
@@ -130,7 +144,7 @@ func FormatMetaDataMarkdown(out MetaDataOutput) string {
 // FormatRawMarkdown renders raw file content as Markdown.
 func FormatRawMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Raw File: %s\n\n", out.FilePath)
+	fmt.Fprintf(&b, "## Raw File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
 	fmt.Fprintf(&b, fmtSizeBytes+"\n", out.Size)
 	b.WriteString(toolutil.MarkdownFencedBlock(langFromPath(out.FilePath), out.Content))
 	toolutil.WriteHints(
@@ -144,8 +158,9 @@ func FormatRawMarkdown(out RawOutput) string {
 // FormatRawImageMarkdown renders metadata for a raw image file.
 func FormatRawImageMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Image File: %s\n\n", out.FilePath)
+	fmt.Fprintf(&b, "## Image File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
+	//gitlab:allow-unescaped out.ImageMIMEType: a MIME type this package derived from the file extension through toolutil.ImageMIMEType, which returns a compiled-in constant.
 	fmt.Fprintf(&b, "- **Content type**: %s\n", out.ImageMIMEType)
 	b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
 	return b.String()
@@ -154,7 +169,7 @@ func FormatRawImageMarkdown(out RawOutput) string {
 // FormatRawBinaryMarkdown renders metadata for a raw binary file.
 func FormatRawBinaryMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Binary File: %s\n\n", out.FilePath)
+	fmt.Fprintf(&b, "## Binary File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
 	b.WriteString("- **Content type**: binary (content omitted, not viewable as text)\n")
 	toolutil.WriteHints(

--- a/internal/tools/freezeperiods/markdown.go
+++ b/internal/tools/freezeperiods/markdown.go
@@ -23,7 +23,9 @@ func FormatListMarkdownString(out ListOutput) string {
 	fmt.Fprintf(&b, "## Freeze Periods (%d)\n\n", len(out.FreezePeriods))
 	toolutil.WriteListSummary(&b, len(out.FreezePeriods), out.Pagination)
 	for _, fp := range out.FreezePeriods {
-		fmt.Fprintf(&b, "- **ID %d**: start=`%s` end=`%s` tz=%s\n", fp.ID, fp.FreezeStart, fp.FreezeEnd, fp.CronTimezone)
+		fmt.Fprintf(&b, "- **ID %d**: start=`%s` end=`%s` tz=%s\n", fp.ID,
+			toolutil.EscapeMdTableCell(fp.FreezeStart), toolutil.EscapeMdTableCell(fp.FreezeEnd),
+			toolutil.EscapeMdTableCell(fp.CronTimezone))
 	}
 	b.WriteString(toolutil.FormatPagination(out.Pagination))
 	toolutil.WriteHints(&b, "Use `gitlab_get_freeze_period` to view details of a specific freeze period")
@@ -40,10 +42,12 @@ func FormatMarkdownString(out Output) string {
 	var b strings.Builder
 	b.WriteString("## Freeze Period\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, "- **Start**: `%s`\n", out.FreezeStart)
-	fmt.Fprintf(&b, "- **End**: `%s`\n", out.FreezeEnd)
+	// A freeze window is two cron expressions and a timezone a maintainer
+	// types, and GitLab validates only that the cron parses.
+	fmt.Fprintf(&b, "- **Start**: `%s`\n", toolutil.EscapeMdTableCell(out.FreezeStart))
+	fmt.Fprintf(&b, "- **End**: `%s`\n", toolutil.EscapeMdTableCell(out.FreezeEnd))
 	if out.CronTimezone != "" {
-		fmt.Fprintf(&b, "- **Timezone**: %s\n", out.CronTimezone)
+		fmt.Fprintf(&b, "- **Timezone**: %s\n", toolutil.EscapeMdTableCell(out.CronTimezone))
 	}
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))

--- a/internal/tools/geo/markdown.go
+++ b/internal/tools/geo/markdown.go
@@ -10,13 +10,16 @@ import (
 // FormatOutputMarkdown formats a single Geo site as a Markdown table.
 func FormatOutputMarkdown(o Output) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Geo Site: %s\n\n", o.Name)
+	// A Geo site's name and both URLs are typed by an administrator, and this
+	// server's own geo.create and geo.edit set them; GitLab validates that a
+	// URL parses, not which characters its path holds.
+	fmt.Fprintf(&sb, "## Geo Site: %s\n\n", toolutil.EscapeMdHeading(o.Name))
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, "| ID | %d |\n", o.ID)
-	fmt.Fprintf(&sb, "| Name | %s |\n", o.Name)
-	fmt.Fprintf(&sb, "| URL | %s |\n", o.URL)
+	fmt.Fprintf(&sb, "| Name | %s |\n", toolutil.EscapeMdTableCell(o.Name))
+	fmt.Fprintf(&sb, "| URL | %s |\n", toolutil.EscapeMdTableCell(o.URL))
 	if o.InternalURL != "" {
-		fmt.Fprintf(&sb, "| Internal URL | %s |\n", o.InternalURL)
+		fmt.Fprintf(&sb, "| Internal URL | %s |\n", toolutil.EscapeMdTableCell(o.InternalURL))
 	}
 	fmt.Fprintf(&sb, "| Primary | %t |\n", o.Primary)
 	fmt.Fprintf(&sb, "| Enabled | %t |\n", o.Enabled)
@@ -26,10 +29,11 @@ func FormatOutputMarkdown(o Output) string {
 	fmt.Fprintf(&sb, "| Verification Max Capacity | %d |\n", o.VerificationMaxCapacity)
 	fmt.Fprintf(&sb, "| Sync Object Storage | %t |\n", o.SyncObjectStorage)
 	if o.SelectiveSyncType != "" {
+		//gitlab:allow-unescaped o.SelectiveSyncType: one of the two values GitLab validates this field against, namespaces or shards.
 		fmt.Fprintf(&sb, "| Selective Sync Type | %s |\n", o.SelectiveSyncType)
 	}
 	if o.WebEditURL != "" {
-		fmt.Fprintf(&sb, "| Web Edit URL | [Edit](%s) |\n", o.WebEditURL)
+		fmt.Fprintf(&sb, "| Web Edit URL | %s |\n", toolutil.MdTitleLink("Edit", o.WebEditURL))
 	}
 	return sb.String()
 }
@@ -42,7 +46,7 @@ func FormatListMarkdown(o ListOutput) string {
 	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "URL", "Primary", "Enabled"))
 	for _, s := range o.Sites {
 		fmt.Fprintf(&sb, "| %d | %s | %s | %t | %t |\n",
-			s.ID, s.Name, s.URL, s.Primary, s.Enabled)
+			s.ID, toolutil.EscapeMdTableCell(s.Name), toolutil.EscapeMdTableCell(s.URL), s.Primary, s.Enabled)
 	}
 	if o.Pagination.Page != 0 {
 		fmt.Fprintf(&sb, "\n_Page %d, %d sites shown._\n", o.Pagination.Page, len(o.Sites))
@@ -56,17 +60,26 @@ func FormatStatusMarkdown(o StatusOutput) string {
 	fmt.Fprintf(&sb, "## Geo Site Status (Node ID: %d)\n\n", o.GeoNodeID)
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, "| Healthy | %t |\n", o.Healthy)
+	//gitlab:allow-unescaped o.HealthStatus: the state GitLab derives from the health check, Healthy or Unhealthy, never the message itself.
 	fmt.Fprintf(&sb, "| Health Status | %s |\n", o.HealthStatus)
 	if o.Health != "" {
-		fmt.Fprintf(&sb, "| Health | %s |\n", o.Health)
+		// This is the health check's own output, which GitLab's troubleshooting
+		// docs say carries the exception message, so an unhealthy secondary
+		// alone puts a newline in this cell.
+		fmt.Fprintf(&sb, "| Health | %s |\n", toolutil.EscapeMdTableCell(o.Health))
 	}
 	fmt.Fprintf(&sb, "| DB Replication Lag | %ds |\n", o.DBReplicationLagSeconds)
 	fmt.Fprintf(&sb, "| Missing OAuth App | %t |\n", o.MissingOAuthApplication)
 	fmt.Fprintf(&sb, "| Projects Count | %d |\n", o.ProjectsCount)
+	//gitlab:allow-unescaped o.LFSObjectsSyncedInPercentage: a percentage GitLab formatted for display, of the shape "100.00%".
 	fmt.Fprintf(&sb, "| LFS Synced | %s |\n", o.LFSObjectsSyncedInPercentage)
+	//gitlab:allow-unescaped o.JobArtifactsSyncedInPercentage: a percentage GitLab formatted for display, of the shape "100.00%".
 	fmt.Fprintf(&sb, "| Job Artifacts Synced | %s |\n", o.JobArtifactsSyncedInPercentage)
+	//gitlab:allow-unescaped o.UploadsSyncedInPercentage: a percentage GitLab formatted for display, of the shape "100.00%".
 	fmt.Fprintf(&sb, "| Uploads Synced | %s |\n", o.UploadsSyncedInPercentage)
+	//gitlab:allow-unescaped o.Version: the GitLab version the site runs, compiled into that instance rather than typed by anyone.
 	fmt.Fprintf(&sb, "| Version | %s |\n", o.Version)
+	//gitlab:allow-unescaped o.Revision: the short Git revision of the site's build, hexadecimal digits.
 	fmt.Fprintf(&sb, "| Revision | %s |\n", o.Revision)
 	fmt.Fprintf(&sb, "| Storage Shards Match | %t |\n", o.StorageShardsMatch)
 	if !o.UpdatedAt.IsZero() {
@@ -83,6 +96,8 @@ func FormatListStatusMarkdown(o ListStatusOutput) string {
 	sb.WriteString(toolutil.MarkdownTableHeader("Node ID", "Healthy", "Health Status", "DB Lag (s)", "Projects", "Version"))
 	for _, s := range o.Statuses {
 		fmt.Fprintf(&sb, "| %d | %t | %s | %d | %d | %s |\n",
+			//gitlab:allow-unescaped s.HealthStatus: the state GitLab derives from the health check, Healthy or Unhealthy, never the message itself.
+			//gitlab:allow-unescaped s.Version: the GitLab version the site runs, compiled into that instance rather than typed by anyone.
 			s.GeoNodeID, s.Healthy, s.HealthStatus, s.DBReplicationLagSeconds, s.ProjectsCount, s.Version)
 	}
 	if o.Pagination.Page != 0 {

--- a/internal/tools/groupanalytics/markdown.go
+++ b/internal/tools/groupanalytics/markdown.go
@@ -14,7 +14,7 @@ func FormatIssuesCountMarkdown(out IssuesCountOutput) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "## Recently Created Issues Count\n\n")
 	fmt.Fprint(&sb, toolutil.TblFieldValue)
-	fmt.Fprintf(&sb, fmtGroupRow, out.GroupPath)
+	fmt.Fprintf(&sb, fmtGroupRow, toolutil.EscapeMdTableCell(out.GroupPath))
 	fmt.Fprintf(&sb, "| Issues Count (last 90 days) | **%d** |\n", out.IssuesCount)
 	toolutil.WriteHints(
 		&sb,
@@ -29,7 +29,7 @@ func FormatMRCountMarkdown(out MRCountOutput) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "## Recently Created Merge Requests Count\n\n")
 	fmt.Fprint(&sb, toolutil.TblFieldValue)
-	fmt.Fprintf(&sb, fmtGroupRow, out.GroupPath)
+	fmt.Fprintf(&sb, fmtGroupRow, toolutil.EscapeMdTableCell(out.GroupPath))
 	fmt.Fprintf(&sb, "| Merge Requests Count (last 90 days) | **%d** |\n", out.MergeRequestsCount)
 	toolutil.WriteHints(
 		&sb,
@@ -44,7 +44,7 @@ func FormatMembersCountMarkdown(out MembersCountOutput) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "## Recently Added Members Count\n\n")
 	fmt.Fprint(&sb, toolutil.TblFieldValue)
-	fmt.Fprintf(&sb, fmtGroupRow, out.GroupPath)
+	fmt.Fprintf(&sb, fmtGroupRow, toolutil.EscapeMdTableCell(out.GroupPath))
 	fmt.Fprintf(&sb, "| New Members Count (last 90 days) | **%d** |\n", out.NewMembersCount)
 	toolutil.WriteHints(
 		&sb,

--- a/internal/tools/groupcredentials/markdown.go
+++ b/internal/tools/groupcredentials/markdown.go
@@ -7,15 +7,27 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// The three timestamps below are written by this package's own converters with
+// a constant layout, so nothing a person typed survives into them. Both the
+// token and the SSH key formatter name their parameter out, and one
+// declaration covers a package, so each is declared once here rather than six
+// times below.
+//
+//gitlab:allow-unescaped out.CreatedAt: a timestamp toPATOutput or toSSHKeyOutput rendered with the constant toolutil.DateTimeFormat layout.
+//gitlab:allow-unescaped out.LastUsedAt: a timestamp toPATOutput or toSSHKeyOutput rendered with the constant toolutil.DateTimeFormat layout.
+//gitlab:allow-unescaped out.ExpiresAt: a date rendered with a constant layout, gl.ISOTime.String for a token and toolutil.DateTimeFormat for an SSH key.
+
 // FormatPATMarkdown formats a single personal access token as Markdown.
 func FormatPATMarkdown(out PATOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Personal Access Token: %s (ID: %d)\n\n", out.Name, out.ID)
+	// A token name is free text whoever created the token typed.
+	fmt.Fprintf(&sb, "## Personal Access Token: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(out.Name), out.ID)
 	sb.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, "| **User ID** | %d |\n", out.UserID)
 	fmt.Fprintf(&sb, "| **Active** | %t |\n", out.Active)
 	fmt.Fprintf(&sb, "| **Revoked** | %t |\n", out.Revoked)
 	if len(out.Scopes) > 0 {
+		//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 		fmt.Fprintf(&sb, "| **Scopes** | %s |\n", strings.Join(out.Scopes, ", "))
 	}
 	if out.ExpiresAt != "" {
@@ -41,7 +53,9 @@ func FormatPATListMarkdown(out PATListOutput) string {
 	for _, t := range out.Tokens {
 		scopes := strings.Join(t.Scopes, ", ")
 		fmt.Fprintf(&sb, "| %d | %s | %d | %t | %t | %s | %s |\n",
-			t.ID, t.Name, t.UserID, t.Active, t.Revoked, scopes, t.ExpiresAt)
+			//gitlab:allow-unescaped scopes: the same token scopes, joined for one row of the list.
+			//gitlab:allow-unescaped t.ExpiresAt: a date gl.ISOTime rendered as YYYY-MM-DD.
+			t.ID, toolutil.EscapeMdTableCell(t.Name), t.UserID, t.Active, t.Revoked, scopes, t.ExpiresAt)
 	}
 	sb.WriteString(toolutil.FormatPagination(out.Pagination))
 	return sb.String()
@@ -50,10 +64,13 @@ func FormatPATListMarkdown(out PATListOutput) string {
 // FormatSSHKeyMarkdown formats a single SSH key as Markdown.
 func FormatSSHKeyMarkdown(out SSHKeyOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## SSH Key: %s (ID: %d)\n\n", out.Title, out.ID)
+	// An SSH key title is the name its owner gave it, with GitLab falling back
+	// to the key's own comment field, which the owner also wrote.
+	fmt.Fprintf(&sb, "## SSH Key: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(out.Title), out.ID)
 	sb.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, "| **User ID** | %d |\n", out.UserID)
 	if out.UsageType != "" {
+		//gitlab:allow-unescaped out.UsageType: an SSH key usage GitLab picks from a fixed set (auth, signing, auth_and_signing).
 		fmt.Fprintf(&sb, "| **Usage Type** | %s |\n", out.UsageType)
 	}
 	fmt.Fprintf(&sb, "| **Created At** | %s |\n", out.CreatedAt)
@@ -78,7 +95,9 @@ func FormatSSHKeyListMarkdown(out SSHKeyListOutput) string {
 	sb.WriteString("|---|---|---|---|---|\n")
 	for _, k := range out.Keys {
 		fmt.Fprintf(&sb, "| %d | %s | %d | %s | %s |\n",
-			k.ID, k.Title, k.UserID, k.CreatedAt, k.ExpiresAt)
+			//gitlab:allow-unescaped k.CreatedAt: a timestamp toSSHKeyOutput rendered with the constant toolutil.DateTimeFormat layout.
+			//gitlab:allow-unescaped k.ExpiresAt: a timestamp toSSHKeyOutput rendered with the constant toolutil.DateTimeFormat layout.
+			k.ID, toolutil.EscapeMdTableCell(k.Title), k.UserID, k.CreatedAt, k.ExpiresAt)
 	}
 	sb.WriteString(toolutil.FormatPagination(out.Pagination))
 	return sb.String()

--- a/internal/tools/groupldap/markdown.go
+++ b/internal/tools/groupldap/markdown.go
@@ -11,12 +11,15 @@ import (
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## LDAP Link: %s\n\n", toolutil.EscapeMdHeading(out.CN))
-	fmt.Fprintf(&b, "- **CN**: %s\n", out.CN)
+	// The common name, the LDAP filter and the provider label are all typed by
+	// the administrator who configured the link, and a filter is an expression
+	// whose own syntax uses parentheses and vertical bars.
+	fmt.Fprintf(&b, "- **CN**: %s\n", toolutil.EscapeMdTableCell(out.CN))
 	if out.Filter != "" {
-		fmt.Fprintf(&b, "- **Filter**: %s\n", out.Filter)
+		fmt.Fprintf(&b, "- **Filter**: %s\n", toolutil.EscapeMdTableCell(out.Filter))
 	}
 	fmt.Fprintf(&b, "- **Access Level**: %d\n", out.GroupAccess)
-	fmt.Fprintf(&b, "- **Provider**: %s\n", out.Provider)
+	fmt.Fprintf(&b, "- **Provider**: %s\n", toolutil.EscapeMdTableCell(out.Provider))
 	if out.MemberRoleID != 0 {
 		fmt.Fprintf(&b, "- **Member Role ID**: %d\n", out.MemberRoleID)
 	}

--- a/internal/tools/groupmembers/markdown.go
+++ b/internal/tools/groupmembers/markdown.go
@@ -17,6 +17,7 @@ func FormatMemberMarkdown(out Output) string {
 	fmt.Fprintf(&b, "| ID | %d |\n", out.ID)
 	fmt.Fprintf(&b, "| Username | %s |\n", toolutil.EscapeMdTableCell(out.Username))
 	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
+	//gitlab:allow-unescaped out.State: a membership state GitLab picks from a fixed set (active, awaiting and the rest).
 	fmt.Fprintf(&b, "| State | %s |\n", out.State)
 	fmt.Fprintf(&b, "| Access Level | %s (%d) |\n", toolutil.AccessLevelDescription(gl.AccessLevelValue(out.AccessLevel)), out.AccessLevel)
 	if out.MemberRole != nil {
@@ -77,6 +78,7 @@ func FormatBillableMembersMarkdown(out BillableMembersOutput) string {
 			&b, "| %s | %s | %s | %s | %t | %s |\n",
 			username,
 			toolutil.EscapeMdTableCell(m.Name),
+			//gitlab:allow-unescaped m.State: a membership state GitLab picks from a fixed set (active, awaiting and the rest).
 			m.State,
 			toolutil.EscapeMdTableCell(m.MembershipType),
 			m.Removable,

--- a/internal/tools/groupmilestones/markdown.go
+++ b/internal/tools/groupmilestones/markdown.go
@@ -15,6 +15,7 @@ func FormatMarkdown(v Output) string {
 	fmt.Fprintf(&b, "## Group Milestone: %s\n\n", toolutil.EscapeMdHeading(v.Title))
 	fmt.Fprintf(&b, "- **ID**: %d (IID: %d)\n", v.ID, v.IID)
 	fmt.Fprintf(&b, "- **Group**: %d\n", v.GroupID)
+	//gitlab:allow-unescaped v.State: GitLab computes a milestone's state, which is active or closed and never text a person typed.
 	fmt.Fprintf(&b, toolutil.FmtMdState, v.State)
 	if v.Description != "" {
 		toolutil.WriteDescription(&b, v.Description)
@@ -55,6 +56,9 @@ func FormatListMarkdownString(out ListOutput) string {
 	b.WriteString("|----|-----|-------|-------|------------|----------|\n")
 	for _, m := range out.Milestones {
 		fmt.Fprintf(&b, "| %d | %d | %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped m.State: GitLab computes a milestone's state, which is active or closed and never text a person typed.
+			//gitlab:allow-unescaped m.StartDate: toOutput renders this from the ISO date the client library decoded, so it holds digits and hyphens.
+			//gitlab:allow-unescaped m.DueDate: toOutput renders this from the ISO date the client library decoded, so it holds digits and hyphens.
 			m.ID, m.IID, toolutil.EscapeMdTableCell(m.Title), m.State, m.StartDate, m.DueDate)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -85,6 +89,7 @@ func FormatIssuesMarkdownString(out IssuesOutput) string {
 	b.WriteString("|----|-----|-------|-------|\n")
 	for _, issue := range out.Issues {
 		fmt.Fprintf(&b, "| %d | %d | %s | %s |\n",
+			//gitlab:allow-unescaped issue.State: GitLab computes an issue's state, which is opened or closed and never text a person typed.
 			issue.ID, issue.IID, toolutil.MdTitleLink(issue.Title, issue.WebURL), issue.State)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -110,6 +115,7 @@ func FormatMergeRequestsMarkdownString(out MergeRequestsOutput) string {
 	b.WriteString("|----|-----|-------|-------|--------|--------|\n")
 	for _, mr := range out.MergeRequests {
 		fmt.Fprintf(&b, "| %d | %d | %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped mr.State: GitLab computes a merge request's state, one of opened, closed, locked or merged.
 			mr.ID, mr.IID, toolutil.MdTitleLink(mr.Title, mr.WebURL), mr.State,
 			toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
 	}
@@ -135,6 +141,7 @@ func FormatBurndownChartEventsMarkdownString(out BurndownChartEventsOutput) stri
 	b.WriteString("| Created At | Weight | Action |\n")
 	b.WriteString("|------------|--------|--------|\n")
 	for _, e := range out.Events {
+		//gitlab:allow-unescaped e.Action: GitLab names the resource event that moved the burndown line, which is an enum of its own.
 		fmt.Fprintf(&b, "| %s | %d | %s |\n", toolutil.FormatTime(e.CreatedAt), e.Weight, e.Action)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/groupprotectedbranches/markdown.go
+++ b/internal/tools/groupprotectedbranches/markdown.go
@@ -32,7 +32,9 @@ func writeAccessLevels(b *strings.Builder, heading string, levels []AccessLevelO
 	fmt.Fprintf(b, "\n### %s\n\n", heading)
 	b.WriteString("| ID | Level | Description |\n| --- | --- | --- |\n")
 	for _, l := range levels {
-		fmt.Fprintf(b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, l.AccessLevelDescription)
+		// GitLab's access-level description is a role name for a plain rule but
+		// a user's display name or a group's name for a granular one.
+		fmt.Fprintf(b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, toolutil.EscapeMdTableCell(l.AccessLevelDescription))
 	}
 }
 

--- a/internal/tools/groupprotectedenvs/markdown.go
+++ b/internal/tools/groupprotectedenvs/markdown.go
@@ -16,14 +16,16 @@ func FormatOutputMarkdown(out Output) string {
 		b.WriteString("\n### Deploy Access Levels\n\n")
 		b.WriteString("| ID | Level | Description |\n| --- | --- | --- |\n")
 		for _, l := range out.DeployAccessLevels {
-			fmt.Fprintf(&b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, l.AccessLevelDescription)
+			// GitLab's access-level description is a role name for a plain rule
+			// but a user's display name or a group's name for a granular one.
+			fmt.Fprintf(&b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, toolutil.EscapeMdTableCell(l.AccessLevelDescription))
 		}
 	}
 	if len(out.ApprovalRules) > 0 {
 		b.WriteString("\n### Approval Rules\n\n")
 		b.WriteString("| ID | Level | Description | Required |\n| --- | --- | --- | --- |\n")
 		for _, r := range out.ApprovalRules {
-			fmt.Fprintf(&b, "| %d | %d | %s | %d |\n", r.ID, r.AccessLevel, r.AccessLevelDescription, r.RequiredApprovalCount)
+			fmt.Fprintf(&b, "| %d | %d | %s | %d |\n", r.ID, r.AccessLevel, toolutil.EscapeMdTableCell(r.AccessLevelDescription), r.RequiredApprovalCount)
 		}
 	}
 	toolutil.WriteHints(

--- a/internal/tools/groupreleases/markdown.go
+++ b/internal/tools/groupreleases/markdown.go
@@ -42,16 +42,17 @@ func FormatListMarkdown(out ListOutput) string {
 	toolutil.WriteListSummary(&b, len(out.Releases), out.Pagination)
 	b.WriteString("| Tag | Name | Released | Author |\n| --- | --- | --- | --- |\n")
 	for _, r := range out.Releases {
-		tag := toolutil.EscapeMdTableCell(r.TagName)
-		if webURL := releaseWebURL(r); webURL != "" {
-			tag = fmt.Sprintf("[%s](%s)", tag, webURL)
-		}
+		// A tag name may hold ']' and both angle brackets, which the cell
+		// escaper leaves alone, so the label of a hand-built link could be
+		// closed from inside it.
+		tag := toolutil.MdTitleLink(r.TagName, releaseWebURL(r))
 		fmt.Fprintf(
 			&b, "| %s | %s | %s | %s |\n",
 			tag,
 			toolutil.EscapeMdTableCell(r.Name),
+			//gitlab:allow-unescaped r.ReleasedAt: a timestamp this package formatted itself from the time client-go parsed.
 			r.ReleasedAt,
-			releaseAuthor(r),
+			toolutil.EscapeMdTableCell(releaseAuthor(r)),
 		)
 	}
 	return b.String()

--- a/internal/tools/groups/markdown.go
+++ b/internal/tools/groups/markdown.go
@@ -28,15 +28,18 @@ func FormatOutputMarkdown(g Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Group: %s\n\n", toolutil.EscapeMdHeading(g.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, g.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdPath, g.FullPath)
+	fmt.Fprintf(&b, toolutil.FmtMdPath, toolutil.EscapeMdTableCell(g.FullPath))
 	if g.FullName != "" {
-		fmt.Fprintf(&b, "- **Full Name**: %s\n", g.FullName)
+		// A full name is the group names of the ancestry joined, and a group
+		// name is free text a person types.
+		fmt.Fprintf(&b, "- **Full Name**: %s\n", toolutil.EscapeMdTableCell(g.FullName))
 	}
+	//gitlab:allow-unescaped g.Visibility: a gl.VisibilityValue, which GitLab fills with private, internal or public.
 	fmt.Fprintf(&b, toolutil.FmtMdVisibility, g.Visibility)
 	if g.Description != "" {
 		toolutil.WriteDescription(&b, g.Description)
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, g.WebURL)
+	toolutil.WriteMdURL(&b, g.WebURL)
 	if g.ParentID != 0 {
 		fmt.Fprintf(&b, "- **Parent ID**: %d\n", g.ParentID)
 	}
@@ -44,6 +47,7 @@ func FormatOutputMarkdown(g Output) string {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(g.CreatedAt))
 	}
 	if g.MarkedForDeletion != "" {
+		//gitlab:allow-unescaped g.MarkedForDeletion: a date ToOutput rendered from a gl.ISOTime as YYYY-MM-DD.
 		fmt.Fprintf(&b, "- %s **Marked for deletion**: %s\n", toolutil.EmojiWarning, g.MarkedForDeletion)
 	}
 	toolutil.WriteHints(
@@ -90,6 +94,7 @@ func FormatMemberListMarkdown(out MemberListOutput) string {
 	b.WriteString("| Username | Name | Access Level | State |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, m := range out.Members {
+		//gitlab:allow-unescaped m.State: a membership state GitLab picks from a fixed set (active, awaiting and the rest).
 		fmt.Fprintf(&b, toolutil.FmtRow4Str, toolutil.EscapeMdTableCell(m.Username), toolutil.EscapeMdTableCell(m.Name), toolutil.EscapeMdTableCell(toolutil.AccessLevelDescription(gl.AccessLevelValue(m.AccessLevel))), m.State)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -120,6 +125,7 @@ func FormatListProjectsMarkdown(out ListProjectsOutput) string {
 			p.ID,
 			toolutil.EscapeMdTableCell(p.Name),
 			toolutil.EscapeMdTableCell(p.PathWithNamespace),
+			//gitlab:allow-unescaped p.Visibility: a gl.VisibilityValue, which GitLab fills with private, internal or public.
 			p.Visibility,
 			archived,
 		)
@@ -142,9 +148,9 @@ func FormatHookMarkdown(h HookOutput) string {
 	}
 	fmt.Fprintf(&b, "## Group Hook: %s\n\n", toolutil.EscapeMdHeading(title))
 	fmt.Fprintf(&b, toolutil.FmtMdID, h.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdURL, h.URL)
+	toolutil.WriteMdURL(&b, h.URL)
 	if h.Name != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdName, h.Name)
+		fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(h.Name))
 	}
 	if h.Description != "" {
 		toolutil.WriteDescription(&b, h.Description)
@@ -155,6 +161,7 @@ func FormatHookMarkdown(h HookOutput) string {
 	fmt.Fprintf(&b, "- **Signing Token Present**: %v\n", h.SigningTokenPresent)
 	fmt.Fprintf(&b, "- **Events**: %s\n", enabledEvents(h))
 	if h.AlertStatus != "" {
+		//gitlab:allow-unescaped h.AlertStatus: a hook alert status GitLab picks from a fixed set (executable, disabled, temporarily_disabled).
 		fmt.Fprintf(&b, "- **Alert Status**: %s\n", h.AlertStatus)
 	}
 	if h.DisabledUntil != "" {
@@ -222,7 +229,7 @@ func FormatTransferLocationsListMarkdown(out TransferLocationsListOutput) string
 	for _, l := range out.Locations {
 		name := toolutil.EscapeMdTableCell(l.Name)
 		if l.WebURL != "" {
-			name = fmt.Sprintf("[%s](%s)", name, l.WebURL)
+			name = toolutil.MdTitleLink(l.Name, l.WebURL)
 		}
 		fmt.Fprintf(&b, "| %d | %s | %s |\n", l.ID, name, toolutil.EscapeMdTableCell(l.FullPath))
 	}
@@ -258,6 +265,7 @@ func FormatProvisionedUsersListMarkdown(out ProvisionedUsersListOutput) string {
 			u.ID,
 			username,
 			toolutil.EscapeMdTableCell(u.Name),
+			//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
 			u.State,
 			toolutil.EscapeMdTableCell(u.Email),
 		)

--- a/internal/tools/groups/push_rules.go
+++ b/internal/tools/groups/push_rules.go
@@ -326,9 +326,13 @@ func writePushRuleRegex(b *strings.Builder, r PushRuleOutput) {
 		{"Author Email Regex", r.AuthorEmailRegex},
 		{"File Name Regex", r.FileNameRegex},
 	}
+	//gitlab:allow-unescaped re.label: the labels are the compiled-in strings of the literal above.
 	for _, re := range regexes {
 		if re.value != "" {
-			fmt.Fprintf(b, "- **%s**: `%s`\n", re.label, re.value)
+			// A push rule is a regular expression a maintainer types, where
+			// '|' is the alternation operator, so an ordinary rule ends the
+			// list item on its own.
+			fmt.Fprintf(b, "- **%s**: `%s`\n", re.label, toolutil.EscapeMdTableCell(re.value))
 		}
 	}
 }
@@ -346,6 +350,7 @@ func writePushRuleFlags(b *strings.Builder, r PushRuleOutput) {
 		{"Reject Unsigned Commits", r.RejectUnsignedCommits},
 		{"Reject Non-DCO Commits", r.RejectNonDCOCommits},
 	}
+	//gitlab:allow-unescaped f.label: the labels are the compiled-in strings of the literal above.
 	for _, f := range flags {
 		fmt.Fprintf(b, "- **%s**: %v\n", f.label, f.value)
 	}

--- a/internal/tools/groups/sharing.go
+++ b/internal/tools/groups/sharing.go
@@ -261,6 +261,7 @@ func FormatShareGroupMarkdown(out ShareGroupOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s %s\n", toolutil.EmojiSuccess, out.Message)
 	if out.AccessRole != "" {
+		//gitlab:allow-unescaped out.AccessRole: accessLevelName returns one of this package's own role names, or "Level" and the requested number.
 		fmt.Fprintf(&b, "- **Access**: %s (%d)\n", out.AccessRole, out.GroupAccess)
 	}
 	toolutil.WriteHints(
@@ -293,6 +294,7 @@ func FormatSharedProjectsListMarkdown(out SharedProjectsListOutput) string {
 		}
 		fmt.Fprintf(
 			&b, "| %d | %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped p.Visibility: a gl.VisibilityValue, which GitLab fills with private, internal or public.
 			p.ID, name, toolutil.EscapeMdTableCell(p.PathWithNamespace), p.Visibility, archived,
 		)
 	}

--- a/internal/tools/groupsaml/markdown.go
+++ b/internal/tools/groupsaml/markdown.go
@@ -11,13 +11,15 @@ import (
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## SAML Link: %s\n\n", toolutil.EscapeMdHeading(out.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
+	// The SAML group name and the provider label are typed by the
+	// administrator who configured the link.
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, "- **Access Level**: %d\n", out.AccessLevel)
 	if out.MemberRoleID != 0 {
 		fmt.Fprintf(&b, "- **Member Role ID**: %d\n", out.MemberRoleID)
 	}
 	if out.Provider != "" {
-		fmt.Fprintf(&b, "- **Provider**: %s\n", out.Provider)
+		fmt.Fprintf(&b, "- **Provider**: %s\n", toolutil.EscapeMdTableCell(out.Provider))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -61,10 +63,8 @@ func FormatSAMLUsersListMarkdown(out SAMLUsersListOutput) string {
 	}
 	b.WriteString("| ID | Username | Name | State |\n| --- | --- | --- | --- |\n")
 	for _, u := range out.Users {
-		username := toolutil.EscapeMdTableCell(u.Username)
-		if u.WebURL != "" {
-			username = fmt.Sprintf("[%s](%s)", username, u.WebURL)
-		}
+		username := toolutil.MdTitleLink(u.Username, u.WebURL)
+		//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
 		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n",
 			u.ID, username, toolutil.EscapeMdTableCell(u.Name), u.State)
 	}

--- a/internal/tools/groupscim/markdown.go
+++ b/internal/tools/groupscim/markdown.go
@@ -14,7 +14,8 @@ func FormatOutputMarkdown(o Output) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## SCIM Identity\n\n")
-	fmt.Fprintf(&b, "- **External UID**: `%s`\n", o.ExternalUID)
+	// The external UID is whatever the identity provider sent for the user.
+	fmt.Fprintf(&b, "- **External UID**: `%s`\n", toolutil.EscapeMdTableCell(o.ExternalUID))
 	fmt.Fprintf(&b, "- **User ID**: %d\n", o.UserID)
 	fmt.Fprintf(&b, "- **Active**: %t\n", o.Active)
 	toolutil.WriteHints(
@@ -35,7 +36,7 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| External UID | User ID | Active |\n")
 	b.WriteString("| ------------ | ------: | ------ |\n")
 	for _, id := range out.Identities {
-		fmt.Fprintf(&b, "| `%s` | %d | %t |\n", id.ExternalUID, id.UserID, id.Active)
+		fmt.Fprintf(&b, "| `%s` | %d | %t |\n", toolutil.EscapeMdTableCell(id.ExternalUID), id.UserID, id.Active)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -49,7 +50,7 @@ func FormatUpdateMarkdown(out UpdateOutput) string {
 	var b strings.Builder
 	b.WriteString("## SCIM Identity Updated\n\n")
 	fmt.Fprintf(&b, "- **Updated**: %t\n", out.Updated)
-	fmt.Fprintf(&b, "- **Message**: %s\n", out.Message)
+	fmt.Fprintf(&b, "- **Message**: %s\n", toolutil.EscapeMdTableCell(out.Message))
 	toolutil.WriteHints(
 		&b,
 		"Use `gitlab_get_group_scim_identity` to verify the new external UID",

--- a/internal/tools/groupserviceaccounts/group_service_accounts.go
+++ b/internal/tools/groupserviceaccounts/group_service_accounts.go
@@ -406,9 +406,9 @@ func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Service Account: %s\n\n", toolutil.EscapeMdHeading(out.Username))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
-	fmt.Fprintf(&b, toolutil.FmtMdUsername, out.Username)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, out.Email)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, toolutil.FmtMdUsername, toolutil.EscapeMdTableCell(out.Username))
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(out.Email))
 	toolutil.WriteHints(
 		&b,
 		"Use gitlab_group_service_account_update to modify this account",
@@ -443,17 +443,21 @@ func FormatPATOutputMarkdown(out PATOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## PAT: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, "- **Active**: %t\n", out.Active)
 	fmt.Fprintf(&b, "- **Revoked**: %t\n", out.Revoked)
+	//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 	fmt.Fprintf(&b, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	if out.CreatedAt != "" {
+		//gitlab:allow-unescaped out.CreatedAt: a timestamp toPATOutput formatted itself, with time.Time.Format.
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, out.CreatedAt)
 	}
 	if out.ExpiresAt != "" {
+		//gitlab:allow-unescaped out.ExpiresAt: a date toPATOutput formatted itself, on the ISO date layout.
 		fmt.Fprintf(&b, "- **Expires**: %s\n", out.ExpiresAt)
 	}
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
 	}
 	toolutil.WriteHints(
@@ -479,6 +483,7 @@ func FormatListPATMarkdown(out ListPATOutput) string {
 			toolutil.EscapeMdTableCell(t.Name),
 			t.Active,
 			t.Revoked,
+			//gitlab:allow-unescaped strings.Join(t.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 			strings.Join(t.Scopes, ", "),
 		)
 	}

--- a/internal/tools/groupserviceaccounts/markdown.go
+++ b/internal/tools/groupserviceaccounts/markdown.go
@@ -19,9 +19,9 @@ func FormatMarkdownString(o Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Service Account: %s\n\n", toolutil.EscapeMdHeading(o.Username))
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
-	fmt.Fprintf(&b, "- **Name**: %s\n", o.Name)
-	fmt.Fprintf(&b, "- **Username**: %s\n", o.Username)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, o.Email)
+	fmt.Fprintf(&b, "- **Name**: %s\n", toolutil.EscapeMdTableCell(o.Name))
+	fmt.Fprintf(&b, "- **Username**: %s\n", toolutil.EscapeMdTableCell(o.Username))
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(o.Email))
 	return b.String()
 }
 
@@ -53,18 +53,23 @@ func FormatPATMarkdownString(o PATOutput) string {
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
 	fmt.Fprintf(&b, "- **Active**: %s\n", toolutil.BoolEmoji(o.Active))
 	fmt.Fprintf(&b, "- **Revoked**: %s\n", toolutil.BoolEmoji(o.Revoked))
+	//gitlab:allow-unescaped strings.Join(o.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 	fmt.Fprintf(&b, "- **Scopes**: %s\n", strings.Join(o.Scopes, ", "))
 	fmt.Fprintf(&b, "- **User ID**: %d\n", o.UserID)
 	if o.CreatedAt != "" {
+		//gitlab:allow-unescaped o.CreatedAt: a timestamp toPATOutput formatted itself, with time.Time.Format.
 		fmt.Fprintf(&b, "- **Created**: %s\n", o.CreatedAt)
 	}
 	if o.LastUsedAt != "" {
+		//gitlab:allow-unescaped o.LastUsedAt: a timestamp toPATOutput formatted itself, with time.Time.Format.
 		fmt.Fprintf(&b, "- **Last Used**: %s\n", o.LastUsedAt)
 	}
 	if o.ExpiresAt != "" {
+		//gitlab:allow-unescaped o.ExpiresAt: a date toPATOutput formatted itself, on the ISO date layout.
 		fmt.Fprintf(&b, "- **Expires**: %s\n", o.ExpiresAt)
 	}
 	if o.Token != "" {
+		//gitlab:allow-unescaped o.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&b, "- **Token**: `%s`\n", o.Token)
 	}
 	return b.String()
@@ -87,6 +92,7 @@ func FormatListPATMarkdownString(o ListPATOutput) string {
 				toolutil.BoolEmoji(t.Active),
 				toolutil.BoolEmoji(t.Revoked),
 				strings.Join(t.Scopes, ", "),
+				//gitlab:allow-unescaped t.ExpiresAt: a date toPATOutput formatted itself, on the ISO date layout.
 				t.ExpiresAt)
 		}
 	}

--- a/internal/tools/groupsshcerts/markdown.go
+++ b/internal/tools/groupsshcerts/markdown.go
@@ -18,9 +18,12 @@ func FormatOutputMarkdown(o Output) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## SSH Certificate #%d\n\n", o.ID)
-	fmt.Fprintf(&b, "- **Title**: %s\n", o.Title)
-	fmt.Fprintf(&b, "- **Key**: `%s`\n", key)
+	// The title is the name whoever added the certificate gave it, and the key
+	// is truncated here rather than constrained.
+	fmt.Fprintf(&b, "- **Title**: %s\n", toolutil.EscapeMdTableCell(o.Title))
+	fmt.Fprintf(&b, "- **Key**: `%s`\n", toolutil.EscapeMdTableCell(key))
 	if o.CreatedAt != "" {
+		//gitlab:allow-unescaped o.CreatedAt: a timestamp this package formatted itself from the time client-go parsed.
 		fmt.Fprintf(&b, "- **Created**: %s\n", o.CreatedAt)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/groupwikis/markdown.go
+++ b/internal/tools/groupwikis/markdown.go
@@ -11,10 +11,11 @@ import (
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Wiki: %s\n\n", toolutil.EscapeMdHeading(out.Title))
-	fmt.Fprintf(&b, "- **Slug**: %s\n", out.Slug)
+	fmt.Fprintf(&b, "- **Slug**: %s\n", toolutil.EscapeMdTableCell(out.Slug))
+	//gitlab:allow-unescaped out.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
 	fmt.Fprintf(&b, "- **Format**: %s\n", out.Format)
 	if out.Encoding != "" {
-		fmt.Fprintf(&b, "- **Encoding**: %s\n", out.Encoding)
+		fmt.Fprintf(&b, "- **Encoding**: %s\n", toolutil.EscapeMdTableCell(out.Encoding))
 	}
 	if out.Content != "" {
 		fmt.Fprintf(&b, "\n### Content\n\n%s\n", out.Content)
@@ -41,6 +42,7 @@ func FormatListMarkdown(out ListOutput) string {
 			&b, "| %s | %s | %s |\n",
 			toolutil.EscapeMdTableCell(w.Title),
 			toolutil.EscapeMdTableCell(w.Slug),
+			//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
 			w.Format,
 		)
 	}

--- a/internal/tools/health/markdown.go
+++ b/internal/tools/health/markdown.go
@@ -21,6 +21,19 @@ func FormatMarkdownString(s Output) string {
 	default:
 		statusEmoji = toolutil.EmojiSuccess
 	}
+	// Half of this report is the server describing itself rather than GitLab
+	// describing anything, and those values are declared below instead of
+	// escaped, because wrapping a compiled-in constant teaches the next reader
+	// a rule that is not the rule. Everything read out of a GitLab response is
+	// escaped, the error string first of all: client-go puts the whole response
+	// body in its message when the body is not the JSON it expected, so a
+	// proxy's HTML error page arrives here with its tags and line breaks intact.
+	//
+	//gitlab:allow-unescaped s.Status: one of the three literals Check assigns, "healthy", "degraded" or "unhealthy".
+	//gitlab:allow-unescaped s.MCPServerVersion: this binary's own version, stamped by ldflags at build time or read from debug.BuildInfo.
+	//gitlab:allow-unescaped s.Author: a constant of cmd/server, handed over once at startup through SetServerInfo.
+	//gitlab:allow-unescaped s.Department: a constant of cmd/server, handed over once at startup through SetServerInfo.
+	//gitlab:allow-unescaped s.Repository: a constant of cmd/server, handed over once at startup through SetServerInfo.
 	fmt.Fprintf(&b, "## %s GitLab Server Status: %s\n\n", statusEmoji, s.Status)
 	if s.MCPServerVersion != "" {
 		fmt.Fprintf(&b, "- **MCP Server Version**: %s\n", s.MCPServerVersion)
@@ -34,17 +47,20 @@ func FormatMarkdownString(s Output) string {
 	if s.Repository != "" {
 		fmt.Fprintf(&b, "- **Repository**: %s\n", s.Repository)
 	}
-	fmt.Fprintf(&b, "- **GitLab URL**: %s\n", s.GitLabURL)
+	// net/url permits '<' in a host and leaves it there, and under
+	// --allow-any-gitlab-url the host is a value the caller supplied.
+	fmt.Fprintf(&b, "- **GitLab URL**: %s\n", toolutil.EscapeMdTableCell(s.GitLabURL))
 	if s.GitLabVersion != "" {
-		fmt.Fprintf(&b, "- **Version**: %s (revision: %s)\n", s.GitLabVersion, s.GitLabRevision)
+		fmt.Fprintf(&b, "- **Version**: %s (revision: %s)\n",
+			toolutil.EscapeMdTableCell(s.GitLabVersion), toolutil.EscapeMdTableCell(s.GitLabRevision))
 	}
 	fmt.Fprintf(&b, "- **Authenticated**: %v\n", s.Authenticated)
 	if s.Username != "" {
-		fmt.Fprintf(&b, "- **User**: %s (ID: %d)\n", s.Username, s.UserID)
+		fmt.Fprintf(&b, "- **User**: %s (ID: %d)\n", toolutil.EscapeMdTableCell(s.Username), s.UserID)
 	}
 	fmt.Fprintf(&b, "- **Response Time**: %d ms\n", s.ResponseTimeMS)
 	if s.Error != "" {
-		fmt.Fprintf(&b, "- **Error**: %s\n", s.Error)
+		fmt.Fprintf(&b, "- **Error**: %s\n", toolutil.EscapeMdTableCell(s.Error))
 	}
 	toolutil.WriteHints(
 		&b,

--- a/internal/tools/impersonationtokens/impersonation_tokens.go
+++ b/internal/tools/impersonationtokens/impersonation_tokens.go
@@ -262,7 +262,9 @@ func FormatListMarkdownString(out ListOutput) string {
 			expires = t.ExpiresAt
 		}
 		fmt.Fprintf(&sb, "| %d | %s | %v | %s | %s |\n",
-			t.ID, t.Name, t.Active, strings.Join(t.Scopes, ", "), expires)
+			//gitlab:allow-unescaped strings.Join(t.Scopes, ", "): a scope is one of the fixed identifiers GitLab accepts on creation and refuses anything outside.
+			//gitlab:allow-unescaped expires: toOutput renders the expiry with time.Time.Format, so the cell is digits and dashes, or the literal dash.
+			t.ID, toolutil.EscapeMdTableCell(t.Name), t.Active, strings.Join(t.Scopes, ", "), expires)
 	}
 	return sb.String()
 }
@@ -272,13 +274,16 @@ func FormatMarkdownString(out Output) string {
 	var sb strings.Builder
 	sb.WriteString("## Impersonation Token\n\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&sb, "- **Name**: %s\n", out.Name)
+	fmt.Fprintf(&sb, "- **Name**: %s\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&sb, "- **Active**: %v\n", out.Active)
+	//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): a scope is one of the fixed identifiers GitLab accepts on creation and refuses anything outside.
 	fmt.Fprintf(&sb, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	if out.ExpiresAt != "" {
+		//gitlab:allow-unescaped out.ExpiresAt: both token shapes render the expiry with time.Time.Format, so it is digits and dashes.
 		fmt.Fprintf(&sb, "- **Expires At**: %s\n", out.ExpiresAt)
 	}
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the secret GitLab generated, which the reader has to copy back verbatim.
 		fmt.Fprintf(&sb, "- **Token**: `%s`\n", out.Token)
 	}
 	return sb.String()
@@ -289,11 +294,11 @@ func FormatPATMarkdownString(out PATOutput) string {
 	var sb strings.Builder
 	sb.WriteString("## Personal Access Token\n\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&sb, "- **Name**: %s\n", out.Name)
+	fmt.Fprintf(&sb, "- **Name**: %s\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&sb, "- **Active**: %v\n", out.Active)
 	fmt.Fprintf(&sb, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	if out.Description != "" {
-		fmt.Fprintf(&sb, "- **Description**: %s\n", out.Description)
+		fmt.Fprintf(&sb, "- **Description**: %s\n", toolutil.EscapeMdTableCell(out.Description))
 	}
 	fmt.Fprintf(&sb, "- **User ID**: %d\n", out.UserID)
 	if out.ExpiresAt != "" {

--- a/internal/tools/importservice/import_service.go
+++ b/internal/tools/importservice/import_service.go
@@ -301,7 +301,9 @@ func ImportFromBitbucketServer(ctx context.Context, client *gitlabclient.Client,
 // FormatGitHubImport formats a GitHub import result as markdown.
 func FormatGitHubImport(out *GitHubImportOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## GitHub Import: %s\n\n", out.Name)
+	// The imported project's name is whatever the source repository was called,
+	// which is why the row below escapes the same value.
+	fmt.Fprintf(&sb, "## GitHub Import: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, fmtIDRow, out.ID)
 	fmt.Fprintf(&sb, fmtNameRow, toolutil.EscapeMdTableCell(out.Name))
@@ -321,7 +323,7 @@ func FormatGitHubImport(out *GitHubImportOutput) string {
 // FormatCancelledImport formats a canceled import result as markdown.
 func FormatCancelledImport(out *CancelledImportOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Canceled Import: %s\n\n", out.Name)
+	fmt.Fprintf(&sb, "## Canceled Import: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, fmtIDRow, out.ID)
 	fmt.Fprintf(&sb, fmtNameRow, toolutil.EscapeMdTableCell(out.Name))
@@ -333,7 +335,7 @@ func FormatCancelledImport(out *CancelledImportOutput) string {
 // FormatBitbucketCloudImport formats a Bitbucket Cloud import result as markdown.
 func FormatBitbucketCloudImport(out *BitbucketCloudImportOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Bitbucket Cloud Import: %s\n\n", out.Name)
+	fmt.Fprintf(&sb, "## Bitbucket Cloud Import: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, fmtIDRow, out.ID)
 	fmt.Fprintf(&sb, fmtNameRow, toolutil.EscapeMdTableCell(out.Name))
@@ -347,7 +349,7 @@ func FormatBitbucketCloudImport(out *BitbucketCloudImportOutput) string {
 // FormatBitbucketServerImport formats a Bitbucket Server import result as markdown.
 func FormatBitbucketServerImport(out *BitbucketServerImportOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Bitbucket Server Import: %s\n\n", out.Name)
+	fmt.Fprintf(&sb, "## Bitbucket Server Import: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	sb.WriteString(toolutil.TblFieldValue)
 	fmt.Fprintf(&sb, fmtIDRow, out.ID)
 	fmt.Fprintf(&sb, fmtNameRow, toolutil.EscapeMdTableCell(out.Name))

--- a/internal/tools/instancevariables/markdown.go
+++ b/internal/tools/instancevariables/markdown.go
@@ -13,7 +13,8 @@ func FormatOutputMarkdown(v Output) string {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Instance Variable: %s\n\n", v.Key)
+	fmt.Fprintf(&b, "## Instance Variable: %s\n\n", toolutil.EscapeMdHeading(v.Key))
+	//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
 	fmt.Fprintf(&b, "- **Type**: %s\n", v.VariableType)
 	fmt.Fprintf(&b, "- **Protected**: %t\n", v.Protected)
 	fmt.Fprintf(&b, "- **Masked**: %t\n", v.Masked)
@@ -22,7 +23,7 @@ func FormatOutputMarkdown(v Output) string {
 		toolutil.WriteDescription(&b, v.Description)
 	}
 	if !v.Masked {
-		fmt.Fprintf(&b, "- **Value**: %s\n", v.Value)
+		fmt.Fprintf(&b, "- **Value**: %s\n", toolutil.EscapeMdTableCell(v.Value))
 	} else {
 		b.WriteString("- **Value**: [masked]\n")
 	}

--- a/internal/tools/integrations/markdown.go
+++ b/internal/tools/integrations/markdown.go
@@ -29,6 +29,8 @@ func writeGroupDatadogActiveLine(sb *strings.Builder, active bool) {
 
 // writeGroupDatadogSlugLine emits the Slug line for a Datadog integration,
 // using the supplied default when the Slug is empty.
+//
+//gitlab:allow-unescaped fallback(slug, groupDatadogDefaultTitle): the same type-derived slug as i.Slug, here always the literal datadog, with a compiled-in default when the response omits it.
 func writeGroupDatadogSlugLine(sb *strings.Builder, slug string) {
 	fmt.Fprintf(sb, groupDatadogSlugLineFmt, fallback(slug, groupDatadogDefaultTitle))
 }
@@ -39,7 +41,9 @@ func writeGroupDatadogStringField(sb *strings.Builder, label, value string) {
 	if value == "" {
 		return
 	}
-	fmt.Fprintf(sb, groupDatadogLabelValueFmt, label, value)
+	// Every caller passes a Datadog configuration string, which this server's
+	// own set action sends and GitLab stores verbatim.
+	fmt.Fprintf(sb, groupDatadogLabelValueFmt, label, toolutil.EscapeMdTableCell(value))
 }
 
 // writeGroupDatadogBoolField emits a single label-bool line when the
@@ -63,7 +67,7 @@ func writeGroupDatadogTimestamp(sb *strings.Builder, label, value string) {
 // writeGroupDatadogHeader emits the top-level "## Group Datadog Integration"
 // heading. headingSuffix lets the mutate formatter reuse the same body.
 func writeGroupDatadogHeader(sb *strings.Builder, i GroupDatadogItem, headingSuffix string) {
-	fmt.Fprintf(sb, groupDatadogHeaderFmt, headingSuffix, fallback(i.Title, groupDatadogDefaultTitle))
+	fmt.Fprintf(sb, groupDatadogHeaderFmt, headingSuffix, toolutil.EscapeMdHeading(fallback(i.Title, groupDatadogDefaultTitle)))
 }
 
 // formatGroupDatadogItem renders the common body of a group-level Datadog
@@ -118,6 +122,7 @@ func formatListMarkdownString(out ListOutput) string {
 	sb.WriteString("| ID | Title | Slug | Active |\n")
 	sb.WriteString("|----|-------|------|--------|\n")
 	for _, i := range out.Integrations {
+		//gitlab:allow-unescaped i.Slug: GitLab derives an integration's slug from the integration type rather than from anything a person writes, and every value it takes is a URL path segment such as jira.
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", i.ID, toolutil.EscapeMdTableCell(i.Title), i.Slug, yesNo(i.Active))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_get_integration` to view details of a specific integration")
@@ -128,7 +133,10 @@ func formatListMarkdownString(out ListOutput) string {
 func formatGetMarkdownString(out GetOutput) string {
 	i := out.Integration
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Integration: %s\n\n", i.Title)
+	// The title is a locale-dependent display name GitLab returns, and older
+	// self-managed instances let a person fill it in for some integrations;
+	// this file's own tables escape the same field.
+	fmt.Fprintf(&sb, "## Integration: %s\n\n", toolutil.EscapeMdHeading(i.Title))
 	fmt.Fprintf(&sb, toolutil.FmtMdID, i.ID)
 	fmt.Fprintf(&sb, "- **Slug**: %s\n", i.Slug)
 	writeGroupDatadogActiveLine(&sb, i.Active)
@@ -165,7 +173,7 @@ func formatSetGroupDatadogMarkdownString(out SetGroupDatadogOutput) string {
 // integration set/get formatters.
 func formatIntegrationItemString(heading string, i IntegrationItem) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## %s: %s\n\n", heading, fallback(i.Title, i.Slug))
+	fmt.Fprintf(&sb, "## %s: %s\n\n", heading, toolutil.EscapeMdHeading(fallback(i.Title, i.Slug)))
 	fmt.Fprintf(&sb, toolutil.FmtMdID, i.ID)
 	fmt.Fprintf(&sb, "- **Slug**: %s\n", i.Slug)
 	writeGroupDatadogActiveLine(&sb, i.Active)
@@ -202,6 +210,7 @@ func formatGroupIntegrationListString(out ListGroupIntegrationsOutput) string {
 	sb.WriteString("| ID | Title | Slug | Active |\n")
 	sb.WriteString("|----|-------|------|--------|\n")
 	for _, i := range out.Integrations {
+		//gitlab:allow-unescaped i.Slug: GitLab derives an integration's slug from the integration type rather than from anything a person writes, and every value it takes is a URL path segment such as jira.
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", i.ID, toolutil.EscapeMdTableCell(i.Title), i.Slug, yesNo(i.Active))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_get_group_integration` to view details of a specific group integration")

--- a/internal/tools/invites/markdown.go
+++ b/internal/tools/invites/markdown.go
@@ -23,7 +23,7 @@ func FormatListPendingMarkdownString(out ListPendingInvitationsOutput) string {
 	fmt.Fprintf(&b, "## Pending Invitations (%d)\n\n", len(out.Invitations))
 	toolutil.WriteListSummary(&b, len(out.Invitations), out.Pagination)
 	for _, inv := range out.Invitations {
-		fmt.Fprintf(&b, "- **%s** (ID: %d), Access Level: %d", inv.InviteEmail, inv.ID, inv.AccessLevel)
+		fmt.Fprintf(&b, "- **%s** (ID: %d), Access Level: %d", toolutil.EscapeMdTableCell(inv.InviteEmail), inv.ID, inv.AccessLevel)
 		if inv.UserName != "" {
 			fmt.Fprintf(&b, ", User: %s", inv.UserName)
 		}
@@ -48,8 +48,10 @@ func FormatInviteResultMarkdownString(out InviteResultOutput) string {
 	fmt.Fprintf(&b, "## Invitation Result\n\n**Status**: %s\n", out.Status)
 	if len(out.Message) > 0 {
 		b.WriteString("\n**Messages**:\n")
+		// GitLab keys these messages by the address that was invited and
+		// answers with its own text about it.
 		for k, v := range out.Message {
-			fmt.Fprintf(&b, "- %s: %s\n", k, v)
+			fmt.Fprintf(&b, "- %s: %s\n", toolutil.EscapeMdTableCell(k), toolutil.EscapeMdTableCell(v))
 		}
 	}
 	toolutil.WriteHints(&b, "Check invitation status or resend if the invite was not received")

--- a/internal/tools/issuelinks/markdown.go
+++ b/internal/tools/issuelinks/markdown.go
@@ -15,9 +15,11 @@ func FormatOutputMarkdown(v Output) string {
 	var b strings.Builder
 	b.WriteString("## Issue Link\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, v.ID)
+	//gitlab:allow-unescaped v.LinkType: an issue link type GitLab picks from a fixed set (relates_to, blocks, is_blocked_by).
 	fmt.Fprintf(&b, "- **Link Type**: %s\n", v.LinkType)
-	fmt.Fprintf(&b, "- **Source Issue**: %s\n", issueRefLine(v.SourceIssue))
-	fmt.Fprintf(&b, "- **Target Issue**: %s\n", issueRefLine(v.TargetIssue))
+	// The reference line carries the issue's title, which a person types.
+	fmt.Fprintf(&b, "- **Source Issue**: %s\n", toolutil.EscapeMdTableCell(issueRefLine(v.SourceIssue)))
+	fmt.Fprintf(&b, "- **Target Issue**: %s\n", toolutil.EscapeMdTableCell(issueRefLine(v.TargetIssue)))
 	toolutil.WriteHints(&b, "Use `gitlab_issue_link_list` to see all links for this issue")
 	return b.String()
 }
@@ -46,7 +48,10 @@ func FormatListMarkdown(out ListOutput) string {
 			author = r.Author.Username
 		}
 		fmt.Fprintf(&b, "| %d | %d | %s | %s | %s | %d | %s |\n",
-			r.ID, r.IID, toolutil.MdTitleLink(r.Title, r.WebURL), r.State, r.LinkType, r.IssueLinkID, author)
+			//gitlab:allow-unescaped r.State: an issue state, one of GitLab's fixed set (opened, closed).
+			//gitlab:allow-unescaped r.LinkType: an issue link type GitLab picks from a fixed set (relates_to, blocks, is_blocked_by).
+			r.ID, r.IID, toolutil.MdTitleLink(r.Title, r.WebURL), r.State, r.LinkType, r.IssueLinkID,
+			toolutil.EscapeMdTableCell(author))
 	}
 	toolutil.WriteHints(&b, toolutil.HintPreserveLinks, "Use `gitlab_issue_link_create` to add a new link between issues")
 	return b.String()

--- a/internal/tools/issues/markdown.go
+++ b/internal/tools/issues/markdown.go
@@ -13,17 +13,20 @@ import (
 func FormatTodoMarkdown(t TodoOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Todo #%d\n\n", t.ID)
+	//gitlab:allow-unescaped t.ActionName: a to-do action, a gl.TodoAction GitLab picks from a fixed set.
 	fmt.Fprintf(&b, "- **Action**: %s\n", t.ActionName)
+	//gitlab:allow-unescaped t.TargetType: a to-do target type, a gl.TodoTargetType GitLab picks from a fixed set.
 	fmt.Fprintf(&b, "- **Target Type**: %s\n", t.TargetType)
 	if t.TargetTitle != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdTarget, t.TargetTitle)
+		fmt.Fprintf(&b, toolutil.FmtMdTarget, toolutil.EscapeMdTableCell(t.TargetTitle))
 	}
+	//gitlab:allow-unescaped t.State: a to-do state GitLab picks from a fixed set (pending, done).
 	fmt.Fprintf(&b, toolutil.FmtMdState, t.State)
 	if t.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(t.CreatedAt))
 	}
 	if t.TargetURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURLNewline, t.TargetURL)
+		toolutil.WriteMdURLNewline(&b, t.TargetURL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -53,7 +56,8 @@ func formatIssueList(out ListOutput, heading string, hints ...string) string {
 	b.WriteString(toolutil.TblSep5Col)
 	for _, i := range out.Issues {
 		labels := strings.Join(i.Labels, ", ")
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s %s | %s | %s |\n", i.IID, i.WebURL, toolutil.EscapeMdTableCell(i.Title), toolutil.IssueStateEmoji(i.State), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
+		//gitlab:allow-unescaped i.State: an issue state, one of GitLab's fixed set (opened, closed).
+		fmt.Fprintf(&b, "| %s | %s | %s %s | %s | %s |\n", toolutil.MdTitleLink(fmt.Sprintf("#%d", i.IID), i.WebURL), toolutil.EscapeMdTableCell(i.Title), toolutil.IssueStateEmoji(i.State), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, append([]string{toolutil.HintPreserveLinks}, hints...)...)
@@ -105,9 +109,11 @@ func FormatTimeStatsMarkdown(ts TimeStatsOutput) string {
 	var b strings.Builder
 	b.WriteString("## Time Tracking\n\n")
 	if ts.HumanTimeEstimate != "" {
+		//gitlab:allow-unescaped ts.HumanTimeEstimate: a duration GitLab renders from a count of seconds, "3d 4h 30m".
 		fmt.Fprintf(&b, "- **Estimate**: %s\n", ts.HumanTimeEstimate)
 	}
 	if ts.HumanTotalTimeSpent != "" {
+		//gitlab:allow-unescaped ts.HumanTotalTimeSpent: a duration GitLab renders from a count of seconds, "3d 4h 30m".
 		fmt.Fprintf(&b, "- **Spent**: %s\n", ts.HumanTotalTimeSpent)
 	}
 	fmt.Fprintf(&b, "- **Estimate (seconds)**: %d\n", ts.TimeEstimate)
@@ -155,7 +161,8 @@ func FormatRelatedMRsMarkdown(out RelatedMRsOutput, heading string) string {
 		if mr.Author != nil {
 			author = mr.Author.Username
 		}
-		fmt.Fprintf(&b, "| !%d | %s | %s | @%s | %s -> %s |\n", mr.IID, toolutil.EscapeMdTableCell(mr.Title), mr.State, toolutil.EscapeMdTableCell(author), mr.SourceBranch, mr.TargetBranch)
+		//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
+		fmt.Fprintf(&b, "| !%d | %s | %s | @%s | %s -> %s |\n", mr.IID, toolutil.EscapeMdTableCell(mr.Title), mr.State, toolutil.EscapeMdTableCell(author), toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -175,31 +182,34 @@ func FormatMarkdown(i Output) string {
 	}
 	fmt.Fprintf(&b, "## %s Issue #%d: %s%s\n\n", toolutil.IssueStateEmoji(i.State), i.IID, toolutil.EscapeMdHeading(i.Title), confidentialTag)
 	if i.References != nil && i.References.Full != "" {
-		fmt.Fprintf(&b, "- **Reference**: %s\n", i.References.Full)
+		fmt.Fprintf(&b, "- **Reference**: %s\n", toolutil.EscapeMdTableCell(i.References.Full))
 	}
 	fmt.Fprintf(&b, "- **State**: %s %s\n", toolutil.IssueStateEmoji(i.State), i.State)
+	//gitlab:allow-unescaped i.IssueType: an issue type GitLab picks from a fixed set (issue, incident, test_case, task).
 	if i.IssueType != "" && i.IssueType != "issue" {
 		fmt.Fprintf(&b, "- **Type**: %s\n", i.IssueType)
 	}
 	if i.Confidential {
 		fmt.Fprintf(&b, "- %s **Confidential**\n", toolutil.EmojiConfidential)
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdAuthorAt, AuthorName(i))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthorAt, toolutil.EscapeMdTableCell(AuthorName(i)))
 	if len(i.Labels) > 0 {
-		fmt.Fprintf(&b, "- **Labels**: %s\n", strings.Join(i.Labels, ", "))
+		// A label title is free text: GitLab's only rule on one is that it
+		// carries no comma.
+		fmt.Fprintf(&b, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(i.Labels, ", ")))
 	}
 	if names := assigneeUsernames(i); len(names) > 0 {
-		fmt.Fprintf(&b, "- **Assignees**: %s\n", strings.Join(prefixAt(names), ", "))
+		fmt.Fprintf(&b, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(prefixAt(names), ", ")))
 	}
 	if i.Milestone != nil && i.Milestone.Title != "" {
-		fmt.Fprintf(&b, "- **Milestone**: %s\n", i.Milestone.Title)
+		fmt.Fprintf(&b, "- **Milestone**: %s\n", toolutil.EscapeMdTableCell(i.Milestone.Title))
 	}
 	if i.DueDate != "" {
 		fmt.Fprintf(&b, "- **Due Date**: %s\n", toolutil.FormatTime(i.DueDate))
 	}
 	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(i.CreatedAt))
 	if i.State == "closed" && closerName(i) != "" {
-		fmt.Fprintf(&b, "- **Closed By**: @%s", closerName(i))
+		fmt.Fprintf(&b, "- **Closed By**: @%s", toolutil.EscapeMdTableCell(closerName(i)))
 		if i.ClosedAt != "" {
 			fmt.Fprintf(&b, " on %s", toolutil.FormatTime(i.ClosedAt))
 		}
@@ -217,7 +227,7 @@ func FormatMarkdown(i Output) string {
 	if i.Description != "" {
 		fmt.Fprintf(&b, "\n### Description\n\n%s%s\n", toolutil.WrapGFMBody(i.Description), toolutil.RichContentHint(toolutil.DetectRichContent(i.Description), i.WebURL))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURLNewline, i.WebURL)
+	toolutil.WriteMdURLNewline(&b, i.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use gitlab_issue action 'note_list' to see comments on this issue",
@@ -256,7 +266,7 @@ func FormatListGroupMarkdown(out ListGroupOutput) string {
 	b.WriteString(toolutil.TblSep5Col)
 	for _, i := range out.Issues {
 		labels := strings.Join(i.Labels, ", ")
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s | %s | %s |\n", i.IID, i.WebURL, toolutil.EscapeMdTableCell(i.Title), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n", toolutil.MdTitleLink(fmt.Sprintf("#%d", i.IID), i.WebURL), toolutil.EscapeMdTableCell(i.Title), i.State, toolutil.EscapeMdTableCell(AuthorName(i)), toolutil.EscapeMdTableCell(labels))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/iterationdata/markdown.go
+++ b/internal/tools/iterationdata/markdown.go
@@ -18,10 +18,7 @@ func FormatListMarkdown(title, emptyText string, iterations []Output, pagination
 	builder.WriteString(toolutil.MarkdownTableHeader("ID", "IID", "Title", "State", "Start", "Due", "URL"))
 	for _, iteration := range iterations {
 		state := StateName(iteration.State)
-		url := toolutil.EscapeMdTableCell(iteration.WebURL)
-		if iteration.WebURL != "" {
-			url = fmt.Sprintf("[%s](%s)", state, iteration.WebURL)
-		}
+		url := toolutil.MdTitleLink(state, iteration.WebURL)
 		fmt.Fprintf(&builder, "| %d | %d | %s | %s | %s | %s | %s |\n",
 			iteration.ID, iteration.IID, toolutil.EscapeMdTableCell(iteration.Title),
 			state, toolutil.FormatTime(iteration.StartDate), toolutil.FormatTime(iteration.DueDate), url)
@@ -44,7 +41,7 @@ func FormatOutputMarkdown(output Output, hints ...string) string {
 	fmt.Fprintf(&builder, "| Start | %s |\n", toolutil.FormatTime(output.StartDate))
 	fmt.Fprintf(&builder, "| Due | %s |\n", toolutil.FormatTime(output.DueDate))
 	if output.WebURL != "" {
-		fmt.Fprintf(&builder, toolutil.FmtMdURL, output.WebURL)
+		toolutil.WriteMdURL(&builder, output.WebURL)
 	}
 	fmt.Fprintf(&builder, toolutil.FmtMdCreated, toolutil.FormatTime(output.CreatedAt))
 	if output.Description != "" {

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -1972,8 +1972,10 @@ func TestFormatListMarkdown_WithJobs(t *testing.T) {
 		"## Jobs (2)",
 		"| ID |",
 		"| --- |",
-		"[#100]",
-		"[#101]",
+		// These jobs carry no web URL, and MdTitleLink renders a bare label
+		// rather than the empty link the hand-written "[%d](%s)" produced.
+		"#100",
+		"#101",
 		"build",
 		"test",
 		"success",

--- a/internal/tools/jobs/markdown.go
+++ b/internal/tools/jobs/markdown.go
@@ -16,14 +16,21 @@ func FormatOutputMarkdown(j Output) string {
 	if j.Pipeline != nil && j.Pipeline.ID > 0 {
 		fmt.Fprintf(&b, "- **Pipeline**: #%d\n", j.Pipeline.ID)
 	}
-	fmt.Fprintf(&b, "- **Stage**: %s\n", j.Stage)
+	// A stage name is written in .gitlab-ci.yml, and GitLab constrains its
+	// length rather than its characters; the jobs tables already escape it.
+	fmt.Fprintf(&b, "- **Stage**: %s\n", toolutil.EscapeMdTableCell(j.Stage))
+	//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
 	fmt.Fprintf(&b, toolutil.FmtMdStatus, j.Status)
 	if j.AllowFailure {
 		b.WriteString("- **Allow Failure**: yes\n")
 	}
-	fmt.Fprintf(&b, "- **Ref**: %s\n", j.Ref)
+	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(j.Ref))
 	if j.Commit != nil && j.Commit.ID != "" {
-		fmt.Fprintf(&b, "- **Commit**: `%s`\n", j.Commit.ID[:min(len(j.Commit.ID), 12)])
+		// Named rather than sliced inline so the exemption can refer to it: a
+		// directive's expression is cut at its first colon.
+		shortID := j.Commit.ID[:min(len(j.Commit.ID), 12)]
+		//gitlab:allow-unescaped shortID: the first twelve characters of a git object id, which is hexadecimal.
+		fmt.Fprintf(&b, "- **Commit**: `%s`\n", shortID)
 	}
 	if j.Duration > 0 {
 		fmt.Fprintf(&b, "- **Duration**: %.1fs\n", j.Duration)
@@ -32,18 +39,19 @@ func FormatOutputMarkdown(j Output) string {
 		fmt.Fprintf(&b, "- **Queued**: %.1fs\n", j.QueuedDuration)
 	}
 	if j.FailureReason != "" {
+		//gitlab:allow-unescaped j.FailureReason: GitLab stores the failure reason as an integer column behind a fixed enum map and serializes the key, such as script_failure.
 		fmt.Fprintf(&b, "- **Failure Reason**: %s\n", j.FailureReason)
 	}
 	if j.Coverage > 0 {
 		fmt.Fprintf(&b, "- **Coverage**: %.1f%%\n", j.Coverage)
 	}
 	if j.User != nil && j.User.Username != "" {
-		fmt.Fprintf(&b, "- **User**: %s\n", j.User.Username)
+		fmt.Fprintf(&b, "- **User**: %s\n", toolutil.EscapeMdTableCell(j.User.Username))
 	}
 	if j.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(j.CreatedAt))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, j.WebURL)
+	toolutil.WriteMdURL(&b, j.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use action 'trace' to view the full job log output",
@@ -65,8 +73,8 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| ID | Name | Stage | Status | Duration |\n")
 	b.WriteString(toolutil.TblSep5Col)
 	for _, j := range out.Jobs {
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s | %s %s | %.1fs |\n",
-			j.ID, j.WebURL, toolutil.EscapeMdTableCell(j.Name), toolutil.EscapeMdTableCell(j.Stage), toolutil.PipelineStatusEmoji(j.Status), j.Status, j.Duration)
+		fmt.Fprintf(&b, "| %s | %s | %s | %s %s | %.1fs |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", j.ID), j.WebURL), toolutil.EscapeMdTableCell(j.Name), toolutil.EscapeMdTableCell(j.Stage), toolutil.PipelineStatusEmoji(j.Status), j.Status, j.Duration)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -112,6 +120,7 @@ func FormatBridgeListMarkdown(out BridgeListOutput) string {
 		}
 		fmt.Fprintf(&b, "| %d | %s | %s | %s %s | %.1fs | %s |\n",
 			br.ID, toolutil.EscapeMdTableCell(br.Name), toolutil.EscapeMdTableCell(br.Stage),
+			//gitlab:allow-unescaped br.Status: a bridge carries the same job status enum a job does.
 			toolutil.PipelineStatusEmoji(br.Status), br.Status, br.Duration, ds)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -146,9 +155,11 @@ func FormatArtifactsMarkdown(out ArtifactsOutput) string {
 func FormatSingleArtifactMarkdown(out SingleArtifactOutput) string {
 	var b strings.Builder
 	if out.JobID > 0 {
-		fmt.Fprintf(&b, "## Job #%d: %s\n\n", out.JobID, out.ArtifactPath)
+		// The artifact path is echoed from the caller's own argument: an entry
+		// name in a zip, authored by whoever wrote the CI job.
+		fmt.Fprintf(&b, "## Job #%d: %s\n\n", out.JobID, toolutil.EscapeMdHeading(out.ArtifactPath))
 	} else {
-		fmt.Fprintf(&b, "## %s\n\n", out.ArtifactPath)
+		fmt.Fprintf(&b, "## %s\n\n", toolutil.EscapeMdHeading(out.ArtifactPath))
 	}
 	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
 	if out.Truncated {
@@ -168,6 +179,9 @@ func FormatSingleArtifactMarkdown(out SingleArtifactOutput) string {
 func FormatWaitMarkdown(out WaitOutput) string {
 	var b strings.Builder
 	if out.TimedOut {
+		//gitlab:allow-unescaped out.Job.Status: the polled job's status is the same GitLab enum a job's own status is.
+		//gitlab:allow-unescaped out.FinalStatus: the status the poller last read off the job, so the same GitLab enum.
+		//gitlab:allow-unescaped out.WaitedFor: the poller writes this duration itself, with time.Duration.String over time.Since.
 		fmt.Fprintf(&b, "## \u23F0 Job #%d: Timed Out (current: %s)\n\n", out.Job.ID, out.Job.Status)
 	} else {
 		var emoji string

--- a/internal/tools/jobtokenscope/markdown.go
+++ b/internal/tools/jobtokenscope/markdown.go
@@ -33,7 +33,8 @@ func FormatListInboundAllowlistMarkdown(out ListInboundAllowlistOutput) *mcp.Cal
 	sb.WriteString("| ID | Name | Path | URL |\n")
 	sb.WriteString("|----|------|------|-----|\n")
 	for _, p := range out.Projects {
-		fmt.Fprintf(&sb, "| %d | %s | %s | [View](%s) |\n", p.ID, toolutil.EscapeMdTableCell(p.Name), p.PathWithNamespace, p.WebURL)
+		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", p.ID, toolutil.EscapeMdTableCell(p.Name),
+			toolutil.EscapeMdTableCell(p.PathWithNamespace), toolutil.MdTitleLink("View", p.WebURL))
 	}
 	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_add_project_job_token_allowlist` to add a project")
 	return toolutil.ToolResultWithMarkdown(sb.String())
@@ -54,7 +55,8 @@ func FormatListGroupAllowlistMarkdown(out ListGroupAllowlistOutput) *mcp.CallToo
 	sb.WriteString("| ID | Name | Path | URL |\n")
 	sb.WriteString("|----|------|------|-----|\n")
 	for _, g := range out.Groups {
-		fmt.Fprintf(&sb, "| %d | %s | %s | [View](%s) |\n", g.ID, toolutil.EscapeMdTableCell(g.Name), g.FullPath, g.WebURL)
+		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", g.ID, toolutil.EscapeMdTableCell(g.Name),
+			toolutil.EscapeMdTableCell(g.FullPath), toolutil.MdTitleLink("View", g.WebURL))
 	}
 	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_add_group_job_token_allowlist` to add a group")
 	return toolutil.ToolResultWithMarkdown(sb.String())

--- a/internal/tools/keys/markdown.go
+++ b/internal/tools/keys/markdown.go
@@ -23,13 +23,16 @@ func FormatMarkdownString(out Output) string {
 	b.WriteString("## SSH Key\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
 	if out.Title != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdTitle, out.Title)
+		fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(out.Title))
 	}
-	fmt.Fprintf(&b, "- **Key**: `%s`\n", truncateKey(out.Key))
+	// The key is truncated here rather than constrained, and its trailing
+	// comment is whatever the key's owner typed.
+	fmt.Fprintf(&b, "- **Key**: `%s`\n", toolutil.EscapeMdTableCell(truncateKey(out.Key)))
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
 	}
-	fmt.Fprintf(&b, "- **User**: %s (ID: %d, @%s)\n", out.User.Name, out.User.ID, out.User.Username)
+	fmt.Fprintf(&b, "- **User**: %s (ID: %d, @%s)\n",
+		toolutil.EscapeMdTableCell(out.User.Name), out.User.ID, toolutil.EscapeMdTableCell(out.User.Username))
 	toolutil.WriteHints(&b, "Use `gitlab_get_key_by_fingerprint` to look up a key by its fingerprint")
 	return b.String()
 }

--- a/internal/tools/license/markdown.go
+++ b/internal/tools/license/markdown.go
@@ -15,6 +15,7 @@ func FormatLicenseMarkdown(item Item) *mcp.CallToolResult {
 	fmt.Fprintf(&sb, "## License #%d\n\n", item.ID)
 	sb.WriteString("| Property | Value |\n")
 	sb.WriteString("|----------|-------|\n")
+	//gitlab:allow-unescaped item.Plan: a license plan GitLab picks from a fixed set (free, premium, ultimate and the trial variants).
 	fmt.Fprintf(&sb, "| Plan | %s |\n", item.Plan)
 	fmt.Fprintf(&sb, "| Expired | %v |\n", item.Expired)
 	fmt.Fprintf(&sb, "| Active Users | %d |\n", item.ActiveUsers)
@@ -32,7 +33,8 @@ func FormatLicenseMarkdown(item Item) *mcp.CallToolResult {
 		fmt.Fprintf(&sb, "| Created At | %s |\n", toolutil.FormatTime(item.CreatedAt))
 	}
 	fmt.Fprintf(&sb, "| Licensee | %s (%s) - %s |\n",
-		item.Licensee.Name, item.Licensee.Company, item.Licensee.Email)
+		toolutil.EscapeMdTableCell(item.Licensee.Name), toolutil.EscapeMdTableCell(item.Licensee.Company),
+		toolutil.EscapeMdTableCell(item.Licensee.Email))
 	toolutil.WriteHints(&sb, "Check license expiry date and plan for renewal if needed")
 	return toolutil.ToolResultWithMarkdown(sb.String())
 }

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -115,10 +115,14 @@ func TestFormatProject_Markdown(t *testing.T) {
 // and the empty-state message.
 func TestFormatProject_ListMarkdown(t *testing.T) {
 	t.Run("with projects", func(t *testing.T) {
+		// Each fixture carries a web_url because the row is asserted to be a
+		// link: toolutil.MdTitleLink renders a bare label when it has no
+		// address to point at, rather than the empty link "[alpha]()" this
+		// formatter used to write from the same fixture.
 		out := projects.ListOutput{
 			Projects: []projects.Output{
-				{ID: 1, Name: "alpha", PathWithNamespace: "g/alpha", Visibility: "public"},
-				{ID: 2, Name: "beta", PathWithNamespace: "g/beta", Visibility: "private"},
+				{ID: 1, Name: "alpha", PathWithNamespace: "g/alpha", Visibility: "public", WebURL: "https://gl.example.com/g/alpha"},
+				{ID: 2, Name: "beta", PathWithNamespace: "g/beta", Visibility: "private", WebURL: "https://gl.example.com/g/beta"},
 			},
 			Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 2, PerPage: 20},
 		}
@@ -126,7 +130,7 @@ func TestFormatProject_ListMarkdown(t *testing.T) {
 		if !strings.Contains(md, "## Projects (2)") {
 			t.Error(errMissingHeader)
 		}
-		if !strings.Contains(md, "[alpha]") {
+		if !strings.Contains(md, "[alpha](https://gl.example.com/g/alpha)") {
 			t.Error("missing project row")
 		}
 		if !strings.Contains(md, "Page 1 of 1") {
@@ -841,14 +845,17 @@ func TestIssueState_Emoji(t *testing.T) {
 func TestFormatCommit_ListMarkdown(t *testing.T) {
 	t.Run("with commits", func(t *testing.T) {
 		out := commits.ListOutput{
-			Commits:    []commits.Output{{ShortID: "abc1234", Title: "fix bug", AuthorName: "dev", CommittedDate: testDate20260101}},
+			Commits: []commits.Output{{
+				ShortID: "abc1234", Title: "fix bug", AuthorName: "dev",
+				CommittedDate: testDate20260101, WebURL: "https://gl.example.com/c/abc1234",
+			}},
 			Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
 		}
 		md := commits.FormatListMarkdown(out)
 		if !strings.Contains(md, "## Commits (1)") {
 			t.Error(errMissingHeader)
 		}
-		if !strings.Contains(md, "[abc1234]") {
+		if !strings.Contains(md, "[abc1234](https://gl.example.com/c/abc1234)") {
 			t.Error("missing commit row")
 		}
 	})
@@ -907,14 +914,17 @@ func TestFormatCommit_DiffMarkdown(t *testing.T) {
 // TestFormatMR_CommitsMarkdown verifies MR commits table rendering.
 func TestFormatMR_CommitsMarkdown(t *testing.T) {
 	out := mergerequests.CommitsOutput{
-		Commits:    []commits.Output{{ShortID: "abc", Title: "fix", AuthorName: "dev", CommittedDate: testDate20260101}},
+		Commits: []commits.Output{{
+			ShortID: "abc", Title: "fix", AuthorName: "dev",
+			CommittedDate: testDate20260101, WebURL: "https://gl.example.com/c/abc",
+		}},
 		Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
 	}
 	md := mergerequests.FormatCommitsMarkdown(out)
 	if !strings.Contains(md, "## MR Commits (1)") {
 		t.Error(errMissingHeader)
 	}
-	if !strings.Contains(md, "[abc]") {
+	if !strings.Contains(md, "[abc](https://gl.example.com/c/abc)") {
 		t.Error("missing commit row")
 	}
 }
@@ -923,13 +933,16 @@ func TestFormatMR_CommitsMarkdown(t *testing.T) {
 func TestFormatMR_PipelinesMarkdown(t *testing.T) {
 	t.Run("with pipelines", func(t *testing.T) {
 		out := mergerequests.PipelinesOutput{
-			Pipelines: []pipelines.Output{{ID: 50, Status: "success", Source: "push", Ref: "main"}},
+			Pipelines: []pipelines.Output{{
+				ID: 50, Status: "success", Source: "push", Ref: "main",
+				WebURL: "https://gl.example.com/p/50",
+			}},
 		}
 		md := mergerequests.FormatPipelinesMarkdown(out)
 		if !strings.Contains(md, "## MR Pipelines (1)") {
 			t.Error(errMissingHeader)
 		}
-		if !strings.Contains(md, "[#50]") {
+		if !strings.Contains(md, "[#50](https://gl.example.com/p/50)") {
 			t.Error("missing pipeline row")
 		}
 	})
@@ -1017,7 +1030,10 @@ func TestFormatLabel_ListMarkdown(t *testing.T) {
 func TestFormatMilestone_ListMarkdown(t *testing.T) {
 	t.Run("with milestones", func(t *testing.T) {
 		out := milestones.ListOutput{
-			Milestones: []milestones.Output{{IID: 1, Title: "v1.0", State: "active", DueDate: "2026-06-01", Expired: false}},
+			Milestones: []milestones.Output{{
+				IID: 1, Title: "v1.0", State: "active", DueDate: "2026-06-01",
+				Expired: false, WebURL: "https://gl.example.com/m/1",
+			}},
 			Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
 		}
 		md := milestones.FormatListMarkdownString(out)
@@ -1133,14 +1149,17 @@ func TestFormatJob_Markdown(t *testing.T) {
 func TestFormatJob_ListMarkdown(t *testing.T) {
 	t.Run("with jobs", func(t *testing.T) {
 		out := jobs.ListOutput{
-			Jobs:       []jobs.Output{{ID: 1, Name: "test", Stage: "test", Status: "success", Duration: 10.0}},
+			Jobs: []jobs.Output{{
+				ID: 1, Name: "test", Stage: "test", Status: "success",
+				Duration: 10.0, WebURL: "https://gl.example.com/j/1",
+			}},
 			Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
 		}
 		md := jobs.FormatListMarkdown(out)
 		if !strings.Contains(md, "## Jobs (1)") {
 			t.Error(errMissingHeader)
 		}
-		if !strings.Contains(md, "[#1]") {
+		if !strings.Contains(md, "[#1](https://gl.example.com/j/1)") {
 			t.Error("missing job row")
 		}
 	})

--- a/internal/tools/memberroles/markdown.go
+++ b/internal/tools/memberroles/markdown.go
@@ -14,9 +14,11 @@ func FormatOutputMarkdown(o Output) string {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Member Role #%d: %s\n\n", o.ID, o.Name)
+	// A custom member role's name and description are typed by the group owner
+	// who created it.
+	fmt.Fprintf(&b, "## Member Role #%d: %s\n\n", o.ID, toolutil.EscapeMdHeading(o.Name))
 	if o.Description != "" {
-		fmt.Fprintf(&b, "- **Description**: %s\n", o.Description)
+		fmt.Fprintf(&b, "- **Description**: %s\n", toolutil.EscapeMdTableCell(o.Description))
 	}
 	if o.GroupID != 0 {
 		fmt.Fprintf(&b, "- **Group ID**: %d\n", o.GroupID)

--- a/internal/tools/members/markdown.go
+++ b/internal/tools/members/markdown.go
@@ -20,10 +20,10 @@ func FormatListMarkdownString(v ListOutput) string {
 	b.WriteString("| Username | Name | Access Level | State |\n")
 	b.WriteString("| --- | --- | --- | --- |\n")
 	for _, m := range v.Members {
-		username := toolutil.EscapeMdTableCell(m.Username)
-		if m.WebURL != "" {
-			username = fmt.Sprintf("[%s](%s)", username, m.WebURL)
-		}
+		// MdTitleLink escapes the label itself, so the raw username goes in:
+		// passing the already-escaped copy would escape it twice.
+		username := toolutil.MdTitleLink(m.Username, m.WebURL)
+		//gitlab:allow-unescaped m.State: a user state from GitLab's own closed set (active, blocked, deactivated, banned), never text anybody types.
 		fmt.Fprintf(
 			&b, "| %s | %s | %s | %s |\n",
 			username,
@@ -52,21 +52,25 @@ func FormatMarkdown(v Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Member: %s\n\n", toolutil.EscapeMdHeading(v.Username))
 	fmt.Fprintf(&b, toolutil.FmtMdID, v.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, v.Name)
-	fmt.Fprintf(&b, toolutil.FmtMdUsername, v.Username)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(v.Name))
+	fmt.Fprintf(&b, toolutil.FmtMdUsername, toolutil.EscapeMdTableCell(v.Username))
+	//gitlab:allow-unescaped v.State: a user state from GitLab's own closed set (active, blocked, deactivated, banned), never text anybody types.
 	fmt.Fprintf(&b, toolutil.FmtMdState, v.State)
 	fmt.Fprintf(&b, "- **Access Level**: %s (%d)\n", toolutil.AccessLevelDescription(gl.AccessLevelValue(v.AccessLevel)), v.AccessLevel)
 	if v.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, v.WebURL)
+		toolutil.WriteMdURL(&b, v.WebURL)
 	}
 	if v.Email != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdEmail, v.Email)
+		// GitLab validates an address with a regexp that forbids only '@' and
+		// whitespace, so '|' and '<' both pass.
+		fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(v.Email))
 	}
 	if v.MemberRole != nil {
-		fmt.Fprintf(&b, "- **Member Role**: %s (%d)\n", v.MemberRole.Name, v.MemberRole.ID)
+		fmt.Fprintf(&b, "- **Member Role**: %s (%d)\n", toolutil.EscapeMdTableCell(v.MemberRole.Name), v.MemberRole.ID)
 	}
 	if v.CreatedBy != nil {
-		fmt.Fprintf(&b, "- **Created By**: %s (@%s)\n", v.CreatedBy.Name, v.CreatedBy.Username)
+		fmt.Fprintf(&b, "- **Created By**: %s (@%s)\n",
+			toolutil.EscapeMdTableCell(v.CreatedBy.Name), toolutil.EscapeMdTableCell(v.CreatedBy.Username))
 	}
 	if v.ExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(v.ExpiresAt))

--- a/internal/tools/mergerequests/markdown.go
+++ b/internal/tools/mergerequests/markdown.go
@@ -33,19 +33,26 @@ func FormatMarkdown(mr Output) string {
 	}
 	fmt.Fprintf(&b, "## %s MR !%d: %s\n\n", titlePrefix, mr.IID, toolutil.EscapeMdHeading(mr.Title))
 	if path := mrProjectPath(mr); path != "" {
-		fmt.Fprintf(&b, "- **Project**: %s\n", path)
+		fmt.Fprintf(&b, "- **Project**: %s\n", toolutil.EscapeMdTableCell(path))
 	}
+	//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
 	fmt.Fprintf(&b, "- **State**: %s %s\n", toolutil.MRStateEmoji(mr.State), mr.State)
 	if mr.Draft {
 		fmt.Fprintf(&b, "- %s **Draft** merge request\n", toolutil.EmojiDraft)
 	}
-	fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n", mr.SourceBranch, mr.TargetBranch)
+	// A branch name is not an identifier: git check-ref-format forbids a space
+	// and the control bytes and permits '|', '<' and '>', so a pushable branch
+	// can end this row or open a tag in it.
+	fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n",
+		toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
 	if mr.DetailedMergeStatus != "" {
+		//gitlab:allow-unescaped mr.DetailedMergeStatus: a merge status GitLab computes from a fixed set (mergeable, ci_must_pass, conflict and the rest).
 		fmt.Fprintf(&b, "- **Merge Status**: %s\n", mr.DetailedMergeStatus)
 	}
 	writeMergeRequestPeopleAndLabels(&b, mr)
 	writeMergeRequestPipeline(&b, mr)
 	if mr.ChangesCount != "" {
+		//gitlab:allow-unescaped mr.ChangesCount: a changed-file count GitLab renders as a string, "3" or "1000+".
 		fmt.Fprintf(&b, "- **Changes**: %s files\n", mr.ChangesCount)
 	}
 	if mr.CreatedAt != "" {
@@ -58,7 +65,7 @@ func FormatMarkdown(mr Output) string {
 	if mr.Description != "" {
 		fmt.Fprintf(&b, "\n### Description\n\n%s%s\n", toolutil.WrapGFMBody(mr.Description), toolutil.RichContentHint(toolutil.DetectRichContent(mr.Description), mr.WebURL))
 	}
-	fmt.Fprintf(&b, "\n- **URL**: [%[1]s](%[1]s)\n", mr.WebURL)
+	toolutil.WriteMdURLNewline(&b, mr.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use gitlab_mr_review action 'changes_get' to see the diff of this MR",
@@ -122,19 +129,21 @@ func writeMergeRequestPeopleAndLabels(b *strings.Builder, mr Output) {
 		fmt.Fprintf(b, "- %s **Has Conflicts**\n", toolutil.EmojiWarning)
 	}
 	if author := userName(mr.Author); author != "" {
-		fmt.Fprintf(b, toolutil.FmtMdAuthorAt, author)
+		fmt.Fprintf(b, toolutil.FmtMdAuthorAt, toolutil.EscapeMdTableCell(author))
 	}
 	if names := userNames(mr.Assignees); len(names) > 0 {
-		fmt.Fprintf(b, "- **Assignees**: %s\n", strings.Join(prefixAt(names), ", "))
+		fmt.Fprintf(b, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(prefixAt(names), ", ")))
 	}
 	if names := userNames(mr.Reviewers); len(names) > 0 {
-		fmt.Fprintf(b, "- **Reviewers**: %s\n", strings.Join(prefixAt(names), ", "))
+		fmt.Fprintf(b, "- **Reviewers**: %s\n", toolutil.EscapeMdTableCell(strings.Join(prefixAt(names), ", ")))
 	}
 	if mr.Milestone != nil && mr.Milestone.Title != "" {
-		fmt.Fprintf(b, "- **Milestone**: %s\n", mr.Milestone.Title)
+		fmt.Fprintf(b, "- **Milestone**: %s\n", toolutil.EscapeMdTableCell(mr.Milestone.Title))
 	}
 	if len(mr.Labels) > 0 {
-		fmt.Fprintf(b, "- **Labels**: %s\n", strings.Join(mr.Labels, ", "))
+		// A label title is free text: GitLab's only rule on one is that it
+		// carries no comma.
+		fmt.Fprintf(b, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(mr.Labels, ", ")))
 	}
 }
 
@@ -143,7 +152,8 @@ func writeMergeRequestPipeline(b *strings.Builder, mr Output) {
 		return
 	}
 	if mr.Pipeline.WebURL != "" {
-		fmt.Fprintf(b, "- **Pipeline**: [#%d](%s)\n", mr.Pipeline.ID, mr.Pipeline.WebURL)
+		fmt.Fprintf(b, "- **Pipeline**: %s\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", mr.Pipeline.ID), mr.Pipeline.WebURL))
 		return
 	}
 	fmt.Fprintf(b, "- **Pipeline**: #%d\n", mr.Pipeline.ID)
@@ -163,7 +173,7 @@ func writeMergeRequestTerminalActor(b *strings.Builder, mr Output) {
 }
 
 func writeMergeRequestActorLine(b *strings.Builder, label, user, at string) {
-	fmt.Fprintf(b, "- **%s**: @%s", label, user)
+	fmt.Fprintf(b, "- **%s**: @%s", label, toolutil.EscapeMdTableCell(user))
 	if at != "" {
 		fmt.Fprintf(b, " on %s", toolutil.FormatTime(at))
 	}
@@ -195,8 +205,9 @@ func FormatListMarkdown(out ListOutput) string {
 		if mr.Draft {
 			draftTag = " " + toolutil.EmojiDraft
 		}
-		fmt.Fprintf(&b, "| [!%d](%s) | %s%s | %s %s | %s | %s | %s -> %s |\n",
-			mr.IID, mr.WebURL, toolutil.EscapeMdTableCell(mr.Title), draftTag, toolutil.MRStateEmoji(mr.State), mr.State, toolutil.EscapeMdTableCell(userName(mr.Author)), toolutil.EscapeMdTableCell(mrProjectPath(mr)), toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
+		//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
+		fmt.Fprintf(&b, "| %s | %s%s | %s %s | %s | %s | %s -> %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL), toolutil.EscapeMdTableCell(mr.Title), draftTag, toolutil.MRStateEmoji(mr.State), mr.State, toolutil.EscapeMdTableCell(userName(mr.Author)), toolutil.EscapeMdTableCell(mrProjectPath(mr)), toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -235,7 +246,7 @@ func FormatCommitsMarkdown(out CommitsOutput) string {
 	b.WriteString("| Short ID | Title | Author | Date |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, c := range out.Commits {
-		fmt.Fprintf(&b, "| [%s](%s) | %s | %s | %s |\n", c.ShortID, c.WebURL, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(c.ShortID, c.WebURL), toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -258,8 +269,9 @@ func FormatPipelinesMarkdown(out PipelinesOutput) string {
 	b.WriteString("| ID | Status | Source | Ref |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, p := range out.Pipelines {
-		fmt.Fprintf(&b, "| [#%d](%s) | %s %s | %s | %s |\n",
-			p.ID, p.WebURL, toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref))
+		//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
+		fmt.Fprintf(&b, "| %s | %s %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -297,8 +309,9 @@ func FormatParticipantsMarkdown(out ParticipantsOutput) string {
 	b.WriteString("| ID | Username | Name | State |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, p := range out.Participants {
-		fmt.Fprintf(&b, "| %d | [@%s](%s) | %s | %s |\n",
-			p.ID, toolutil.EscapeMdTableCell(p.Username), p.WebURL, toolutil.EscapeMdTableCell(p.Name), p.State)
+		//gitlab:allow-unescaped p.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
+		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n",
+			p.ID, toolutil.MdTitleLink("@"+p.Username, p.WebURL), toolutil.EscapeMdTableCell(p.Name), p.State)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -320,8 +333,9 @@ func FormatReviewersMarkdown(out ReviewersOutput) string {
 	b.WriteString("| ID | Username | Name | Review State | Assigned At |\n")
 	b.WriteString(toolutil.TblSep5Col)
 	for _, r := range out.Reviewers {
-		fmt.Fprintf(&b, "| %d | [@%s](%s) | %s | %s | %s |\n",
-			r.ID, toolutil.EscapeMdTableCell(r.Username), r.WebURL, toolutil.EscapeMdTableCell(r.Name), r.Review, toolutil.FormatTime(r.CreatedAt))
+		//gitlab:allow-unescaped r.Review: a review state, one of GitLab's fixed set (unreviewed, reviewed, requested_changes, approved).
+		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
+			r.ID, toolutil.MdTitleLink("@"+r.Username, r.WebURL), toolutil.EscapeMdTableCell(r.Name), r.Review, toolutil.FormatTime(r.CreatedAt))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -343,8 +357,9 @@ func FormatIssuesClosedMarkdown(out IssuesClosedOutput) string {
 	b.WriteString("| IID | Title | State | Author | Labels |\n")
 	b.WriteString(toolutil.TblSep5Col)
 	for _, issue := range out.Issues {
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s | %s | %s |\n",
-			issue.IID, issue.WebURL, toolutil.EscapeMdTableCell(issue.Title), issue.State, toolutil.EscapeMdTableCell(issues.AuthorName(issue)), strings.Join(issue.Labels, ", "))
+		//gitlab:allow-unescaped issue.State: an issue state, one of GitLab's fixed set (opened, closed).
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", issue.IID), issue.WebURL), toolutil.EscapeMdTableCell(issue.Title), issue.State, toolutil.EscapeMdTableCell(issues.AuthorName(issue)), toolutil.EscapeMdTableCell(strings.Join(issue.Labels, ", ")))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -360,18 +375,21 @@ func FormatIssuesClosedMarkdown(out IssuesClosedOutput) string {
 func FormatCreatePipelineMarkdown(p pipelines.Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s Pipeline #%d Created\n\n", toolutil.PipelineStatusEmoji(p.Status), p.ID)
+	//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
 	fmt.Fprintf(&b, "- **Status**: %s %s\n", toolutil.PipelineStatusEmoji(p.Status), p.Status)
 	if p.Source != "" {
+		//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
 		fmt.Fprintf(&b, "- **Source**: %s\n", p.Source)
 	}
 	if p.Ref != "" {
-		fmt.Fprintf(&b, "- **Ref**: %s\n", p.Ref)
+		fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(p.Ref))
 	}
 	if p.SHA != "" {
+		//gitlab:allow-unescaped p.SHA: a commit SHA, hexadecimal digits only.
 		fmt.Fprintf(&b, "- **SHA**: %s\n", p.SHA)
 	}
 	if p.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, p.WebURL)
+		toolutil.WriteMdURL(&b, p.WebURL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -386,11 +404,13 @@ func FormatTimeStatsMarkdown(ts TimeStatsOutput) string {
 	var b strings.Builder
 	b.WriteString("## Time Tracking Stats\n\n")
 	if ts.HumanTimeEstimate != "" {
+		//gitlab:allow-unescaped ts.HumanTimeEstimate: a duration GitLab renders from a count of seconds, "3d 4h 30m".
 		fmt.Fprintf(&b, "- **Estimate**: %s (%d seconds)\n", ts.HumanTimeEstimate, ts.TimeEstimate)
 	} else {
 		b.WriteString("- **Estimate**: not set\n")
 	}
 	if ts.HumanTotalTimeSpent != "" {
+		//gitlab:allow-unescaped ts.HumanTotalTimeSpent: a duration GitLab renders from a count of seconds, "3d 4h 30m".
 		fmt.Fprintf(&b, "- **Spent**: %s (%d seconds)\n", ts.HumanTotalTimeSpent, ts.TotalTimeSpent)
 	} else {
 		b.WriteString("- **Spent**: none\n")
@@ -413,13 +433,13 @@ func FormatRelatedIssuesMarkdown(out RelatedIssuesOutput) string {
 	b.WriteString("| IID | Title | State | Author | Labels |\n")
 	b.WriteString(toolutil.TblSep5Col)
 	for _, iss := range out.Issues {
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s | %s | %s |\n",
-			iss.IID,
-			iss.WebURL,
+		//gitlab:allow-unescaped iss.State: an issue state, one of GitLab's fixed set (opened, closed).
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", iss.IID), iss.WebURL),
 			toolutil.EscapeMdTableCell(iss.Title),
 			iss.State,
-			issues.AuthorName(iss),
-			strings.Join(iss.Labels, ", "))
+			toolutil.EscapeMdTableCell(issues.AuthorName(iss)),
+			toolutil.EscapeMdTableCell(strings.Join(iss.Labels, ", ")))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -435,14 +455,17 @@ func FormatRelatedIssuesMarkdown(out RelatedIssuesOutput) string {
 func FormatCreateTodoMarkdown(t CreateTodoOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Todo Created (#%d)\n\n", t.ID)
+	//gitlab:allow-unescaped t.ActionName: a to-do action, a gl.TodoAction GitLab picks from a fixed set.
 	fmt.Fprintf(&b, "- **Action**: %s\n", t.ActionName)
+	//gitlab:allow-unescaped t.TargetType: a to-do target type, a gl.TodoTargetType GitLab picks from a fixed set.
 	fmt.Fprintf(&b, "- **Type**: %s\n", t.TargetType)
 	if t.TargetTitle != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdTarget, t.TargetTitle)
+		fmt.Fprintf(&b, toolutil.FmtMdTarget, toolutil.EscapeMdTableCell(t.TargetTitle))
 	}
 	if t.TargetURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, t.TargetURL)
+		toolutil.WriteMdURL(&b, t.TargetURL)
 	}
+	//gitlab:allow-unescaped t.State: a to-do state GitLab picks from a fixed set (pending, done).
 	fmt.Fprintf(&b, toolutil.FmtMdState, t.State)
 	toolutil.WriteHints(
 		&b,
@@ -458,9 +481,11 @@ func FormatDependencyMarkdown(d DependencyOutput) string {
 	fmt.Fprintf(&b, "## MR Dependency (#%d)\n\n", d.ID)
 	if bmr := d.BlockingMergeRequest; bmr != nil {
 		fmt.Fprintf(&b, "- **Blocking MR**: !%d (ID: %d)\n", bmr.IID, bmr.ID)
-		fmt.Fprintf(&b, toolutil.FmtMdTitle, bmr.Title)
+		fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(bmr.Title))
+		//gitlab:allow-unescaped bmr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
 		fmt.Fprintf(&b, toolutil.FmtMdState, bmr.State)
-		fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n", bmr.SourceBranch, bmr.TargetBranch)
+		fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n",
+			toolutil.EscapeMdTableCell(bmr.SourceBranch), toolutil.EscapeMdTableCell(bmr.TargetBranch))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -485,6 +510,7 @@ func FormatDependenciesMarkdown(out DependenciesOutput) string {
 		if bmr := d.BlockingMergeRequest; bmr != nil {
 			iid, title, state = bmr.IID, bmr.Title, bmr.State
 		}
+		//gitlab:allow-unescaped state: the blocking merge request's state, read out of bmr.State a few lines above.
 		fmt.Fprintf(&b, "| %d | !%d | %s | %s |\n",
 			d.ID,
 			iid,

--- a/internal/tools/mergerequests/markdown_test.go
+++ b/internal/tools/mergerequests/markdown_test.go
@@ -1,0 +1,162 @@
+// markdown_test.go asserts that the merge request formatters contain the text
+// GitLab hands them, rather than letting it reshape the document around it.
+//
+// The rendering of ordinary values is covered by merge_requests_test.go; what
+// is here is the hostile half, and it asserts structure rather than comparing
+// against a golden string, so it keeps failing for the right reason after a
+// column is added or a label is reworded.
+package mergerequests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/issues"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
+)
+
+// hostileBranch is a branch name a person can create and push.
+//
+// It is not a contrivance: git check-ref-format forbids a space, a control
+// byte and the characters "~^:?*[" and backslash, and says nothing about the
+// pipe or the angle brackets, so GitLab accepts all three through the same
+// check. This server's own branch.create writes one.
+const hostileBranch = "feat|x<img src=q onerror=alert(1)>"
+
+// hostileTitle is what a person types into a merge request title, an issue
+// title or a label, none of which GitLab constrains to a character set. The
+// newline is the half that ends a table row.
+const hostileTitle = "Fix login | urgent\nsecond line"
+
+// assertTableRowsWellFormed fails when a row of a Markdown table carries a
+// different number of cells than the header above it, which is exactly what an
+// unescaped pipe or newline in a cell produces.
+func assertTableRowsWellFormed(t *testing.T, rendered string) {
+	t.Helper()
+	want := -1
+	for line := range strings.SplitSeq(rendered, "\n") {
+		if !strings.HasPrefix(line, "|") {
+			want = -1
+			continue
+		}
+		got := strings.Count(line, "|")
+		switch {
+		case want < 0:
+			want = got
+		case got != want:
+			t.Errorf("table row %q has %d pipes, want %d\n---\n%s", line, got, want, rendered)
+		}
+	}
+}
+
+// assertContained fails when text a person wrote reached the page able to
+// change the document around it.
+//
+// A raw '<' is the one that matters most: a renderer takes raw HTML ahead of
+// whatever surrounds it, so a title carrying an anchor tag arrives at a client
+// as a working link to a host that is not GitLab.
+func assertContained(t *testing.T, rendered string) {
+	t.Helper()
+	if strings.Contains(rendered, "<img") {
+		t.Errorf("rendered Markdown carries a raw tag\n---\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "&lt;img") {
+		t.Errorf("rendered Markdown does not entity-encode the angle bracket\n---\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "&#124;") {
+		t.Errorf("rendered Markdown does not encode the pipe\n---\n%s", rendered)
+	}
+}
+
+// hostileOutput is a merge request whose every free-text field carries the
+// characters the escapers exist for.
+func hostileOutput() Output {
+	return Output{
+		IID: 1, Title: hostileTitle, State: testStateOpened,
+		SourceBranch: hostileBranch, TargetBranch: hostileBranch,
+		Author:    &toolutil.BasicUserOutput{Username: hostileBranch},
+		Assignees: []*toolutil.BasicUserOutput{{Username: hostileBranch}},
+		Reviewers: []*toolutil.BasicUserOutput{{Username: hostileBranch}},
+		Labels:    []string{hostileTitle},
+		Milestone: &toolutil.MRMilestoneOutput{Title: hostileTitle},
+		WebURL:    "https://gitlab.example.com/g/p/-/merge_requests/1",
+	}
+}
+
+// TestFormatMarkdown_HostileBranchAndTitle_StayContained pins the detail view.
+//
+// It is a list of single-line values rather than a table, so the newline is
+// what breaks it: every value below has to arrive on the line the formatter
+// wrote for it, with no tag opened along the way.
+func TestFormatMarkdown_HostileBranchAndTitle_StayContained(t *testing.T) {
+	md := FormatMarkdown(hostileOutput())
+	assertContained(t, md)
+	for _, label := range []string{"**Source**", "**Assignees**", "**Reviewers**", "**Milestone**", "**Labels**"} {
+		t.Run(label, func(t *testing.T) {
+			line := lineWith(md, label)
+			if line == "" {
+				t.Fatalf("no %s line in\n---\n%s", label, md)
+			}
+			if strings.Contains(line, "\n") {
+				t.Errorf("%s line %q was split across lines", label, line)
+			}
+		})
+	}
+}
+
+// TestFormatListMarkdown_HostileBranchAndTitle_StayInOneCell pins the tables.
+//
+// A branch name and a title are cells here, so a pipe in either would add a
+// column to its row and shift every heading after it.
+func TestFormatListMarkdown_HostileBranchAndTitle_StayInOneCell(t *testing.T) {
+	mr := hostileOutput()
+	cases := []struct {
+		name     string
+		rendered string
+	}{
+		{name: "ListOutput", rendered: FormatListMarkdown(ListOutput{MergeRequests: []Output{mr}})},
+		{
+			name: "IssuesClosedOutput",
+			rendered: FormatIssuesClosedMarkdown(IssuesClosedOutput{Issues: []issues.Output{{
+				IID: 2, Title: hostileTitle, State: "opened", Labels: []string{hostileTitle},
+			}}}),
+		},
+		{
+			name: "DependenciesOutput",
+			rendered: FormatDependenciesMarkdown(DependenciesOutput{Dependencies: []DependencyOutput{{
+				ID: 3, BlockingMergeRequest: &BlockingMergeRequestOutput{IID: 4, Title: hostileTitle, State: "opened"},
+			}}}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertTableRowsWellFormed(t, tc.rendered)
+		})
+	}
+}
+
+// TestFormatDependencyMarkdown_HostileBranch_StaysContained pins the blocking
+// merge request detail, whose branches were rendered raw beside an escaped
+// title.
+func TestFormatDependencyMarkdown_HostileBranch_StaysContained(t *testing.T) {
+	md := FormatDependencyMarkdown(DependencyOutput{
+		ID: 3,
+		BlockingMergeRequest: &BlockingMergeRequestOutput{
+			IID: 4, Title: hostileTitle, State: "opened",
+			SourceBranch: hostileBranch, TargetBranch: hostileBranch,
+		},
+	})
+	assertContained(t, md)
+}
+
+// lineWith returns the single rendered line carrying label, which is how a
+// test asserts that a value stayed on the line written for it rather than
+// continuing onto lines of its own.
+func lineWith(rendered, label string) string {
+	for line := range strings.SplitSeq(rendered, "\n") {
+		if strings.Contains(line, label) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/tools/mergetrains/markdown.go
+++ b/internal/tools/mergetrains/markdown.go
@@ -27,13 +27,14 @@ func FormatListMarkdown(out ListOutput) string {
 	sb.WriteString("| ID | MR | Title | Branch | Status | User | Duration |\n")
 	sb.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
 	for _, t := range out.Trains {
-		mr := fmt.Sprintf("!%d", t.MergeRequest.IID)
-		if t.MergeRequest.WebURL != "" {
-			mr = fmt.Sprintf("[!%d](%s)", t.MergeRequest.IID, t.MergeRequest.WebURL)
-		}
+		mr := toolutil.MdTitleLink(fmt.Sprintf("!%d", t.MergeRequest.IID), t.MergeRequest.WebURL)
+		// A branch name is not an identifier: git check-ref-format permits
+		// '|', '<' and '>'.
+		//gitlab:allow-unescaped t.Status: a merge-train car state GitLab's own state machine writes (created, idle, stale, fresh, merging, merged).
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s | %s | %ds |\n",
 			t.ID, mr, toolutil.EscapeMdTableCell(t.MergeRequest.Title),
-			t.TargetBranch, t.Status, userName(t.User), t.Duration)
+			toolutil.EscapeMdTableCell(t.TargetBranch), t.Status,
+			toolutil.EscapeMdTableCell(userName(t.User)), t.Duration)
 	}
 	toolutil.WriteListSummary(&sb, len(out.Trains), out.Pagination)
 	toolutil.WritePagination(&sb, out.Pagination)
@@ -46,15 +47,15 @@ func FormatOutputMarkdown(out Output) string {
 	fmt.Fprintf(&sb, "## Merge Train #%d\n\n", out.ID)
 	sb.WriteString("| Property | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
+	//gitlab:allow-unescaped out.Status: a merge-train car state GitLab's own state machine writes (created, idle, stale, fresh, merging, merged).
 	fmt.Fprintf(&sb, "| Status | %s |\n", out.Status)
-	fmt.Fprintf(&sb, "| Target Branch | %s |\n", out.TargetBranch)
-	mr := fmt.Sprintf("!%d - %s", out.MergeRequest.IID, toolutil.EscapeMdTableCell(out.MergeRequest.Title))
-	if out.MergeRequest.WebURL != "" {
-		mr = fmt.Sprintf("[!%d](%s) - %s", out.MergeRequest.IID, out.MergeRequest.WebURL, toolutil.EscapeMdTableCell(out.MergeRequest.Title))
-	}
+	fmt.Fprintf(&sb, "| Target Branch | %s |\n", toolutil.EscapeMdTableCell(out.TargetBranch))
+	mr := fmt.Sprintf("%s - %s",
+		toolutil.MdTitleLink(fmt.Sprintf("!%d", out.MergeRequest.IID), out.MergeRequest.WebURL),
+		toolutil.EscapeMdTableCell(out.MergeRequest.Title))
 	fmt.Fprintf(&sb, "| Merge Request | %s |\n", mr)
 	if name := userName(out.User); name != "" {
-		fmt.Fprintf(&sb, "| User | %s |\n", name)
+		fmt.Fprintf(&sb, "| User | %s |\n", toolutil.EscapeMdTableCell(name))
 	}
 	if out.Pipeline != nil && out.Pipeline.ID > 0 {
 		fmt.Fprintf(&sb, "| Pipeline | #%d |\n", out.Pipeline.ID)

--- a/internal/tools/milestones/markdown.go
+++ b/internal/tools/milestones/markdown.go
@@ -2,6 +2,7 @@ package milestones
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -40,9 +41,10 @@ func FormatListMarkdownString(v ListOutput) string {
 			expired = "Yes"
 		}
 		fmt.Fprintf(
-			&b, "| [%d](%s) | %s | %s | %s | %s |\n",
-			m.IID, m.WebURL,
+			&b, "| %s | %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(strconv.FormatInt(m.IID, 10), m.WebURL),
 			toolutil.EscapeMdTableCell(m.Title),
+			//gitlab:allow-unescaped m.State: a milestone state, which GitLab returns as active or closed.
 			m.State,
 			due,
 			expired,
@@ -68,6 +70,7 @@ func FormatMarkdown(v Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Milestone: %s\n\n", toolutil.EscapeMdHeading(v.Title))
 	fmt.Fprintf(&b, "- **ID**: %d (IID: %d)\n", v.ID, v.IID)
+	//gitlab:allow-unescaped v.State: a milestone state, which GitLab returns as active or closed.
 	fmt.Fprintf(&b, toolutil.FmtMdState, v.State)
 	if v.Description != "" {
 		toolutil.WriteDescription(&b, v.Description)
@@ -80,7 +83,7 @@ func FormatMarkdown(v Output) string {
 	}
 	fmt.Fprintf(&b, "- **Expired**: %v\n", v.Expired)
 	if v.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, v.WebURL)
+		toolutil.WriteMdURL(&b, v.WebURL)
 	}
 	if v.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(v.CreatedAt))
@@ -111,11 +114,12 @@ func FormatIssuesMarkdownString(v MilestoneIssuesOutput) string {
 			created = issue.CreatedAt
 		}
 		fmt.Fprintf(
-			&b, "| [#%d](%s) | %s | %s | %s |\n",
-			issue.IID,
-			issue.WebURL,
+			&b, "| %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", issue.IID), issue.WebURL),
 			toolutil.EscapeMdTableCell(issue.Title),
+			//gitlab:allow-unescaped issue.State: an issue state, which GitLab returns as opened or closed.
 			issue.State,
+			//gitlab:allow-unescaped created: a creation timestamp formatted from a time.Time as RFC 3339, or the literal dash, in this table and in the merge request one below.
 			created,
 		)
 	}
@@ -149,10 +153,10 @@ func FormatMergeRequestsMarkdownString(v MilestoneMergeRequestsOutput) string {
 			created = mr.CreatedAt
 		}
 		fmt.Fprintf(
-			&b, "| [!%d](%s) | %s | %s | %s | %s | %s |\n",
-			mr.IID,
-			mr.WebURL,
+			&b, "| %s | %s | %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL),
 			toolutil.EscapeMdTableCell(mr.Title),
+			//gitlab:allow-unescaped mr.State: a merge request state, which GitLab returns as opened, closed, locked or merged.
 			mr.State,
 			toolutil.EscapeMdTableCell(mr.SourceBranch),
 			toolutil.EscapeMdTableCell(mr.TargetBranch),

--- a/internal/tools/modelregistry/markdown.go
+++ b/internal/tools/modelregistry/markdown.go
@@ -10,12 +10,14 @@ import (
 // FormatDownloadMarkdown formats a downloaded ML model package file as Markdown.
 func FormatDownloadMarkdown(o DownloadOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## ML Model Package: %s\n\n", o.Filename)
+	// Every one of these is echoed from the caller's own arguments: the
+	// project, the model version, the package path and the file name inside it.
+	fmt.Fprintf(&sb, "## ML Model Package: %s\n\n", toolutil.EscapeMdHeading(o.Filename))
 	sb.WriteString("| Field | Value |\n|---|---|\n")
-	fmt.Fprintf(&sb, "| Project | %s |\n", o.ProjectID)
-	fmt.Fprintf(&sb, "| Model Version | %s |\n", o.ModelVersionID)
-	fmt.Fprintf(&sb, "| Path | %s |\n", o.Path)
-	fmt.Fprintf(&sb, "| Filename | %s |\n", o.Filename)
+	fmt.Fprintf(&sb, "| Project | %s |\n", toolutil.EscapeMdTableCell(o.ProjectID))
+	fmt.Fprintf(&sb, "| Model Version | %s |\n", toolutil.EscapeMdTableCell(o.ModelVersionID))
+	fmt.Fprintf(&sb, "| Path | %s |\n", toolutil.EscapeMdTableCell(o.Path))
+	fmt.Fprintf(&sb, "| Filename | %s |\n", toolutil.EscapeMdTableCell(o.Filename))
 	fmt.Fprintf(&sb, "| Size | %d bytes |\n", o.SizeBytes)
 	sb.WriteString("\n_Content is base64-encoded in the structured JSON output._\n")
 	toolutil.WriteHints(

--- a/internal/tools/mrapprovals/markdown.go
+++ b/internal/tools/mrapprovals/markdown.go
@@ -67,6 +67,7 @@ func FormatStateMarkdown(s StateOutput) string {
 	for _, r := range s.Rules {
 		approved := toolutil.BoolEmoji(r.Approved)
 		approvedBy := strings.Join(userNames(r.ApprovedBy), ", ")
+		//gitlab:allow-unescaped r.RuleType: an approval rule type GitLab picks from a fixed set (regular, any_approver, code_owner, report_approver).
 		fmt.Fprintf(&b, "| %d | %s | %s | %d | %s | %s |\n", r.ID, toolutil.EscapeMdTableCell(r.Name), r.RuleType, r.ApprovalsRequired, approved, toolutil.EscapeMdTableCell(approvedBy))
 	}
 	toolutil.WriteHints(
@@ -106,6 +107,7 @@ func FormatConfigMarkdown(c ConfigOutput) string {
 	fmt.Fprintf(&b, "## MR Approval Configuration\n\n")
 	fmt.Fprintf(&b, "| Field | Value |\n| ----- | ----- |\n")
 	fmt.Fprintf(&b, "| MR | !%d |\n", c.IID)
+	//gitlab:allow-unescaped c.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
 	fmt.Fprintf(&b, "| State | %s |\n", c.State)
 	fmt.Fprintf(&b, "| Approved | %v |\n", c.Approved)
 	fmt.Fprintf(&b, "| Approvals Required | %d |\n", c.ApprovalsRequired)
@@ -131,7 +133,8 @@ func FormatConfigMarkdown(c ConfigOutput) string {
 func FormatRuleMarkdown(r RuleOutput) string {
 	var b strings.Builder
 	approved := toolutil.BoolEmoji(r.Approved)
-	fmt.Fprintf(&b, "## Approval Rule: %s\n\n", r.Name)
+	// An approval rule's name is free text a maintainer types.
+	fmt.Fprintf(&b, "## Approval Rule: %s\n\n", toolutil.EscapeMdHeading(r.Name))
 	fmt.Fprintf(&b, "| Field | Value |\n| ----- | ----- |\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", r.ID)
 	fmt.Fprintf(&b, "| Type | %s |\n", r.RuleType)

--- a/internal/tools/mrapprovalsettings/markdown.go
+++ b/internal/tools/mrapprovalsettings/markdown.go
@@ -7,12 +7,17 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// formatSetting renders one setting as the three cells of its row.
+//
+// The pipes in the result are the column separators this row is made of, so
+// the escaping goes on the one value that is not this package's own: the name
+// of the group a setting was inherited from.
 func formatSetting(s SettingOutput) string {
 	val := toolutil.BoolEmoji(s.Value)
 	locked := toolutil.BoolEmoji(s.Locked)
-	inherited := s.InheritedFrom
-	if inherited == "" {
-		inherited = "-"
+	inherited := "-"
+	if s.InheritedFrom != "" {
+		inherited = toolutil.EscapeMdTableCell(s.InheritedFrom)
 	}
 	return fmt.Sprintf("%s | %s | %s", val, locked, inherited)
 }

--- a/internal/tools/mrchanges/markdown.go
+++ b/internal/tools/mrchanges/markdown.go
@@ -26,7 +26,9 @@ func FormatOutputMarkdown(out Output) string {
 		case c.DeletedFile:
 			status = "deleted"
 		case c.RenamedFile:
-			status = "renamed from " + c.OldPath
+			// The old path is a repository path a committer chose, and git
+			// allows every byte but NUL and the separator inside a component.
+			status = "renamed from " + toolutil.EscapeMdTableCell(c.OldPath)
 		}
 		if c.Diff == "" && !c.DeletedFile {
 			truncated = append(truncated, c.NewPath)
@@ -67,6 +69,10 @@ func FormatDiffVersionsListMarkdown(out DiffVersionsListOutput) string {
 			baseSHA = baseSHA[:8]
 		}
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped v.State: a merge request diff state GitLab records, one of its own fixed set.
+			//gitlab:allow-unescaped short: the head commit SHA, hexadecimal digits git computed, truncated here.
+			//gitlab:allow-unescaped baseSHA: the base commit SHA, hexadecimal digits git computed, truncated here.
+			//gitlab:allow-unescaped v.CreatedAt: a timestamp this package formatted with time.Time.Format as RFC 3339.
 			v.ID, v.State, short, baseSHA, v.CreatedAt)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -78,14 +84,19 @@ func FormatDiffVersionsListMarkdown(out DiffVersionsListOutput) string {
 func FormatDiffVersionGetMarkdown(out DiffVersionOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Diff Version %d\n\n", out.ID)
+	//gitlab:allow-unescaped out.State: a merge request diff state GitLab records, one of its own fixed set.
 	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
+	//gitlab:allow-unescaped out.HeadCommitSHA: a commit SHA, hexadecimal digits git computed.
 	fmt.Fprintf(&b, "- **Head SHA**: %s\n", out.HeadCommitSHA)
+	//gitlab:allow-unescaped out.BaseCommitSHA: a commit SHA, hexadecimal digits git computed.
 	fmt.Fprintf(&b, "- **Base SHA**: %s\n", out.BaseCommitSHA)
+	//gitlab:allow-unescaped out.StartCommitSHA: a commit SHA, hexadecimal digits git computed.
 	fmt.Fprintf(&b, "- **Start SHA**: %s\n", out.StartCommitSHA)
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
 	}
 	if out.RealSize != "" {
+		//gitlab:allow-unescaped out.RealSize: GitLab's own count of the files in the diff, decimal digits with a trailing plus when the diff overflowed.
 		fmt.Fprintf(&b, "- **Real Size**: %s\n", out.RealSize)
 	}
 
@@ -98,6 +109,7 @@ func FormatDiffVersionGetMarkdown(out DiffVersionOutput) string {
 			if short == "" && len(c.ID) > 8 {
 				short = c.ID[:8]
 			}
+			//gitlab:allow-unescaped short: a commit SHA, hexadecimal digits git computed, truncated here.
 			fmt.Fprintf(&b, "| %s | %s | %s |\n",
 				short, toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.Title))
 		}
@@ -115,7 +127,7 @@ func FormatDiffVersionGetMarkdown(out DiffVersionOutput) string {
 			case d.DeletedFile:
 				status = "deleted"
 			case d.RenamedFile:
-				status = "renamed from " + d.OldPath
+				status = "renamed from " + toolutil.EscapeMdTableCell(d.OldPath)
 			}
 			fmt.Fprintf(&b, "| %s | %s |\n",
 				toolutil.EscapeMdTableCell(d.NewPath), status)

--- a/internal/tools/mrcontextcommits/markdown.go
+++ b/internal/tools/mrcontextcommits/markdown.go
@@ -19,7 +19,8 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	sb.WriteString("| SHA | Title | Author |\n")
 	sb.WriteString("|-----|-------|--------|\n")
 	for _, c := range out.Commits {
-		fmt.Fprintf(&sb, "| %s | %s | %s |\n", c.ShortID, toolutil.EscapeMdTableCell(c.Title), c.AuthorName)
+		//gitlab:allow-unescaped c.ShortID: an abbreviated commit SHA, hexadecimal by construction.
+		fmt.Fprintf(&sb, "| %s | %s | %s |\n", c.ShortID, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_commit_get` to view full details of a specific commit")
 	return toolutil.ToolResultWithMarkdown(sb.String())

--- a/internal/tools/mrdiscussions/markdown.go
+++ b/internal/tools/mrdiscussions/markdown.go
@@ -21,7 +21,7 @@ func noteAuthorUsername(n NoteOutput) string {
 func FormatNoteMarkdown(n NoteOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Discussion Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, noteAuthorUsername(n))
+	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(noteAuthorUsername(n)))
 	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
 	fmt.Fprintf(&b, "- **Resolved**: %v\n", n.Resolved)
 	fmt.Fprintf(&b, "\n%s\n", toolutil.WrapGFMBody(n.Body))

--- a/internal/tools/mrdraftnotes/markdown.go
+++ b/internal/tools/mrdraftnotes/markdown.go
@@ -14,12 +14,16 @@ func FormatOutputMarkdown(out Output) string {
 	fmt.Fprintf(&b, "- **Author ID**: %d\n", out.AuthorID)
 	fmt.Fprintf(&b, "- **MR ID**: %d\n", out.MergeRequestID)
 	if out.CommitID != "" {
+		//gitlab:allow-unescaped out.CommitID: a commit SHA, hexadecimal by construction.
 		fmt.Fprintf(&b, "- **Commit**: `%s`\n", out.CommitID)
 	}
 	if out.LineCode != "" {
-		fmt.Fprintf(&b, "- **Line Code**: `%s`\n", out.LineCode)
+		// GitLab builds a line code out of a file-path digest and two line
+		// numbers, but the digest is not verified here, so it is escaped.
+		fmt.Fprintf(&b, "- **Line Code**: `%s`\n", toolutil.EscapeMdTableCell(out.LineCode))
 	}
 	if out.DiscussionID != "" {
+		//gitlab:allow-unescaped out.DiscussionID: a discussion thread id, hexadecimal digits from GitLab's own digest.
 		fmt.Fprintf(&b, "- **Discussion**: %s\n", out.DiscussionID)
 	}
 	fmt.Fprintf(&b, "- **Resolve Discussion**: %v\n", out.ResolveDiscussion)
@@ -32,7 +36,7 @@ func FormatOutputMarkdown(out Output) string {
 		if line == 0 {
 			line = p.OldLine
 		}
-		fmt.Fprintf(&b, "- **Position**: `%s` line %d\n", path, line)
+		fmt.Fprintf(&b, "- **Position**: `%s` line %d\n", toolutil.EscapeMdTableCell(path), line)
 	}
 	fmt.Fprintf(&b, "\n### Body\n\n%s\n", toolutil.WrapGFMBody(out.Note))
 	toolutil.WriteHints(
@@ -64,6 +68,7 @@ func FormatListMarkdown(out ListOutput) string {
 		if len(commit) > 8 {
 			commit = commit[:8]
 		}
+		//gitlab:allow-unescaped commit: a commit SHA, hexadecimal by construction, truncated here.
 		fmt.Fprintf(&b, "| %d | %d | %s | %s |\n", d.ID, d.AuthorID, commit, toolutil.EscapeMdTableCell(note))
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/namespaces/markdown.go
+++ b/internal/tools/namespaces/markdown.go
@@ -23,7 +23,9 @@ func FormatListMarkdownString(out ListOutput) string {
 	fmt.Fprintf(&b, "## Namespaces (%d)\n\n", len(out.Namespaces))
 	toolutil.WriteListSummary(&b, len(out.Namespaces), out.Pagination)
 	for _, ns := range out.Namespaces {
-		fmt.Fprintf(&b, "- **%s** (ID: %d), kind: %s, path: `%s`\n", ns.Name, ns.ID, ns.Kind, ns.FullPath)
+		//gitlab:allow-unescaped ns.Kind: GitLab derives the kind from the namespace class and answers group or user, so this is a word the server chose.
+		fmt.Fprintf(&b, "- **%s** (ID: %d), kind: %s, path: `%s`\n",
+			toolutil.EscapeMdTableCell(ns.Name), ns.ID, ns.Kind, toolutil.EscapeMdTableCell(ns.FullPath))
 	}
 	b.WriteString(toolutil.FormatPagination(out.Pagination))
 	toolutil.WriteHints(&b, "Use `gitlab_namespace_get` to view details of a specific namespace")
@@ -38,23 +40,31 @@ func FormatMarkdown(out Output) *mcp.CallToolResult {
 // FormatMarkdownString renders a single namespace as a Markdown string.
 func FormatMarkdownString(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Namespace: %s\n\n", out.Name)
+	// For a user namespace GitLab keeps the name in step with the account
+	// holder's display name, which is free text; the paths are slugs a person
+	// chose, and every sibling that renders one escapes it.
+	fmt.Fprintf(&b, "## Namespace: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, "| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", out.ID)
-	fmt.Fprintf(&b, "| Name | %s |\n", out.Name)
-	fmt.Fprintf(&b, "| Path | %s |\n", out.Path)
-	fmt.Fprintf(&b, "| Full Path | %s |\n", out.FullPath)
+	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, "| Path | %s |\n", toolutil.EscapeMdTableCell(out.Path))
+	fmt.Fprintf(&b, "| Full Path | %s |\n", toolutil.EscapeMdTableCell(out.FullPath))
+	//gitlab:allow-unescaped out.Kind: GitLab derives the kind from the namespace class and answers group or user, so this is a word the server chose.
 	fmt.Fprintf(&b, "| Kind | %s |\n", out.Kind)
 	if out.ParentID > 0 {
 		fmt.Fprintf(&b, "| Parent ID | %d |\n", out.ParentID)
 	}
 	if out.WebURL != "" {
-		fmt.Fprintf(&b, "| Web URL | %s |\n", out.WebURL)
+		// GitLab builds this from the instance URL and the full path above, so
+		// it inherits whatever that path can hold.
+		fmt.Fprintf(&b, "| Web URL | %s |\n", toolutil.EscapeMdTableCell(out.WebURL))
 	}
 	if out.Plan != "" {
+		//gitlab:allow-unescaped out.Plan: one of GitLab's own seeded subscription names, such as free or ultimate, which no API lets a person write.
 		fmt.Fprintf(&b, "| Plan | %s |\n", out.Plan)
 	}
 	if out.TrialEndsOn != "" {
+		//gitlab:allow-unescaped out.TrialEndsOn: a date toOutput rendered from a gl.ISOTime with time.Format, so it holds digits and dashes.
 		fmt.Fprintf(&b, "| Trial Ends On | %s |\n", out.TrialEndsOn)
 	}
 	if out.MaxSeatsUsed != nil {

--- a/internal/tools/notifications/markdown.go
+++ b/internal/tools/notifications/markdown.go
@@ -18,9 +18,10 @@ func FormatMarkdown(out Output) *mcp.CallToolResult {
 func FormatMarkdownString(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Notification Settings\n\n")
+	//gitlab:allow-unescaped out.Level: a notification level GitLab picks from a fixed set (disabled, participating, watch, global, mention, custom).
 	fmt.Fprintf(&b, "- **Level**: %s\n", out.Level)
 	if out.NotificationEmail != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdEmail, out.NotificationEmail)
+		fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(out.NotificationEmail))
 	}
 	if out.Events != nil {
 		b.WriteString("\n### Custom Events\n\n")

--- a/internal/tools/orbit/markdown.go
+++ b/internal/tools/orbit/markdown.go
@@ -71,7 +71,10 @@ func FormatStatusMarkdown(out StatusOutput) string {
 			if component.Replicas != nil {
 				replicas = fmt.Sprintf("%d/%d", component.Replicas.Ready, component.Replicas.Desired)
 			}
-			fmt.Fprintf(&b, "| %s | %s | %s |\n", component.Name, component.Status, replicas)
+			// Both come back from the Knowledge Graph API as free strings, and
+			// nothing in this repository constrains either.
+			fmt.Fprintf(&b, "| %s | %s | %s |\n",
+				toolutil.EscapeMdTableCell(component.Name), toolutil.EscapeMdTableCell(component.Status), replicas)
 		}
 	}
 	toolutil.WriteHints(&b, "Use `gitlab_orbit_graph_status` to inspect indexing status for a namespace or project")
@@ -232,7 +235,9 @@ func writeKV(b *strings.Builder, key, value string) {
 	if value == "" {
 		return
 	}
-	fmt.Fprintf(b, "- %s: %s\n", key, value)
+	// The key is a literal at every call site; the value is whatever the
+	// Knowledge Graph API answered.
+	fmt.Fprintf(b, "- %s: %s\n", key, toolutil.EscapeMdTableCell(value))
 }
 
 // prettyAny returns a pretty-printed JSON string for any value, or

--- a/internal/tools/packages/markdown.go
+++ b/internal/tools/packages/markdown.go
@@ -16,13 +16,16 @@ func FormatPublishMarkdown(out PublishOutput) string {
 	fmt.Fprintf(&b, "## Package Published\n\n")
 	fmt.Fprintf(&b, "- **Package File ID**: %d\n", out.PackageFileID)
 	fmt.Fprintf(&b, "- **Package ID**: %d\n", out.PackageID)
-	fmt.Fprintf(&b, "- **File Name**: %s\n", out.FileName)
+	// The only validation on a package file name refuses a space and a leading
+	// tilde or at-sign, so a pipe and a '<' both survive.
+	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(out.FileName))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
 	if out.SHA256 != "" {
+		//gitlab:allow-unescaped out.SHA256: a SHA-256 digest, computed by GitLab for a published file and by crypto/sha256 here for a downloaded one, so hexadecimal either way.
 		fmt.Fprintf(&b, "- **SHA256**: %s\n", out.SHA256)
 	}
 	if out.URL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, out.URL)
+		toolutil.WriteMdURL(&b, out.URL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -37,7 +40,9 @@ func FormatPublishMarkdown(out PublishOutput) string {
 func FormatDownloadMarkdown(out DownloadOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Package Downloaded\n\n")
-	fmt.Fprintf(&b, "- **Output Path**: %s\n", out.OutputPath)
+	// The output path is the caller's own argument echoed back, before any
+	// canonicalization.
+	fmt.Fprintf(&b, "- **Output Path**: %s\n", toolutil.EscapeMdTableCell(out.OutputPath))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
 	if out.SHA256 != "" {
 		fmt.Fprintf(&b, "- **SHA256**: %s\n", out.SHA256)
@@ -84,7 +89,9 @@ func writePackageRow(b *strings.Builder, p ListItem, lastColumn string) {
 		p.ID,
 		toolutil.EscapeMdTableCell(p.Name),
 		toolutil.EscapeMdTableCell(p.Version),
+		//gitlab:allow-unescaped p.PackageType: the registry format GitLab stores the package under, one of its own enum values (generic, maven, npm and the rest).
 		p.PackageType,
+		//gitlab:allow-unescaped p.Status: a GitLab package status enum value (default, hidden, processing, error).
 		p.Status,
 		toolutil.EscapeMdTableCell(lastColumn),
 	)
@@ -170,6 +177,7 @@ func FormatFileListMarkdown(out FileListOutput) string {
 			f.PackageFileID,
 			toolutil.EscapeMdTableCell(f.FileName),
 			f.Size,
+			//gitlab:allow-unescaped sha: the leading characters of a SHA-256 digest, which is hexadecimal, so slicing it cannot split a rune.
 			sha,
 		)
 	}
@@ -188,16 +196,16 @@ func FormatPublishAndLinkMarkdown(out PublishAndLinkOutput) string {
 	fmt.Fprintf(&b, "## Package Published & Linked\n\n")
 	fmt.Fprintf(&b, "### Package\n\n")
 	fmt.Fprintf(&b, "- **Package File ID**: %d\n", out.Package.PackageFileID)
-	fmt.Fprintf(&b, "- **File Name**: %s\n", out.Package.FileName)
+	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(out.Package.FileName))
 	fmt.Fprintf(&b, fmtSizeBytes, out.Package.Size)
 	if out.Package.URL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, out.Package.URL)
+		toolutil.WriteMdURL(&b, out.Package.URL)
 	}
 	fmt.Fprintf(&b, "\n### Release Link\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ReleaseLink.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.ReleaseLink.Name)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.ReleaseLink.Name))
 	if out.ReleaseLink.URL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, out.ReleaseLink.URL)
+		toolutil.WriteMdURL(&b, out.ReleaseLink.URL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -232,7 +240,9 @@ func FormatPublishDirMarkdown(out PublishDirOutput) string {
 	if len(out.Errors) > 0 {
 		fmt.Fprintf(&b, "\n### Errors (%d)\n\n", len(out.Errors))
 		for _, e := range out.Errors {
-			fmt.Fprintf(&b, "- %s\n", e)
+			// Each is a local directory entry name plus a wrapped error whose
+			// text carries GitLab's own message.
+			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(e))
 		}
 	}
 	toolutil.WriteHints(

--- a/internal/tools/pages/markdown.go
+++ b/internal/tools/pages/markdown.go
@@ -14,14 +14,15 @@ func FormatPagesMarkdown(out Output) string {
 	var sb strings.Builder
 	sb.WriteString("## Pages Settings\n\n")
 	sb.WriteString("| Property | Value |\n|---|---|\n")
-	fmt.Fprintf(&sb, "| URL | %s |\n", out.URL)
+	fmt.Fprintf(&sb, "| URL | %s |\n", toolutil.EscapeMdTableCell(out.URL))
 	fmt.Fprintf(&sb, "| Unique Domain | %v |\n", out.IsUniqueDomainEnabled)
 	fmt.Fprintf(&sb, "| Force HTTPS | %v |\n", out.ForceHTTPS)
-	fmt.Fprintf(&sb, "| Primary Domain | %s |\n", out.PrimaryDomain)
+	fmt.Fprintf(&sb, "| Primary Domain | %s |\n", toolutil.EscapeMdTableCell(out.PrimaryDomain))
 	if len(out.Deployments) > 0 {
 		sb.WriteString("\n### Deployments\n\n| URL | Created | Path Prefix | Root Dir |\n|---|---|---|---|\n")
 		for _, d := range out.Deployments {
-			fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(d.URL, d.URL), toolutil.FormatTime(d.CreatedAt), d.PathPrefix, d.RootDirectory)
+			fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(d.URL, d.URL), toolutil.FormatTime(d.CreatedAt),
+				toolutil.EscapeMdTableCell(d.PathPrefix), toolutil.EscapeMdTableCell(d.RootDirectory))
 		}
 	}
 	toolutil.WriteHints(
@@ -35,17 +36,20 @@ func FormatPagesMarkdown(out Output) string {
 // FormatDomainMarkdown formats a single Pages domain for display.
 func FormatDomainMarkdown(out DomainOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Pages Domain: %s\n\n", out.Domain)
+	fmt.Fprintf(&sb, "## Pages Domain: %s\n\n", toolutil.EscapeMdHeading(out.Domain))
 	sb.WriteString("| Property | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, "| URL | %s |\n", toolutil.MdTitleLink(out.URL, out.URL))
 	fmt.Fprintf(&sb, "| Project | %s |\n", projectDisplay(out.ProjectID))
 	fmt.Fprintf(&sb, "| Verified | %v |\n", out.Verified)
 	fmt.Fprintf(&sb, "| Auto SSL | %v |\n", out.AutoSslEnabled)
 	if out.EnabledUntil != "" {
+		//gitlab:allow-unescaped out.EnabledUntil: a timestamp toDomainOutput formatted itself from a time.Time.
 		fmt.Fprintf(&sb, "| Enabled Until | %s |\n", out.EnabledUntil)
 	}
 	if out.Certificate.Subject != "" {
-		fmt.Fprintf(&sb, "| Cert Subject | %s |\n", out.Certificate.Subject)
+		// The subject is read out of a certificate whoever configured the
+		// domain supplied, so its common name is whatever they put in it.
+		fmt.Fprintf(&sb, "| Cert Subject | %s |\n", toolutil.EscapeMdTableCell(out.Certificate.Subject))
 		fmt.Fprintf(&sb, "| Cert Expired | %v |\n", out.Certificate.Expired)
 	}
 	toolutil.WriteHints(
@@ -64,7 +68,7 @@ func FormatDomainListMarkdown(out ListDomainsOutput) string {
 	var sb strings.Builder
 	sb.WriteString("## Pages Domains\n\n| Domain | URL | Verified | Auto SSL | Project |\n|---|---|---|---|---|\n")
 	for _, d := range out.Domains {
-		fmt.Fprintf(&sb, "| %s | %s | %v | %v | %s |\n", d.Domain, toolutil.MdTitleLink(d.URL, d.URL), d.Verified, d.AutoSslEnabled, projectDisplay(d.ProjectID))
+		fmt.Fprintf(&sb, "| %s | %s | %v | %v | %s |\n", toolutil.EscapeMdTableCell(d.Domain), toolutil.MdTitleLink(d.URL, d.URL), d.Verified, d.AutoSslEnabled, projectDisplay(d.ProjectID))
 	}
 	toolutil.WriteHints(
 		&sb,
@@ -82,7 +86,7 @@ func FormatAllDomainsMarkdown(out ListAllDomainsOutput) string {
 	var sb strings.Builder
 	sb.WriteString("## All Pages Domains\n\n| Domain | URL | Verified | Auto SSL | Project |\n|---|---|---|---|---|\n")
 	for _, d := range out.Domains {
-		fmt.Fprintf(&sb, "| %s | %s | %v | %v | %s |\n", d.Domain, toolutil.MdTitleLink(d.URL, d.URL), d.Verified, d.AutoSslEnabled, projectDisplay(d.ProjectID))
+		fmt.Fprintf(&sb, "| %s | %s | %v | %v | %s |\n", toolutil.EscapeMdTableCell(d.Domain), toolutil.MdTitleLink(d.URL, d.URL), d.Verified, d.AutoSslEnabled, projectDisplay(d.ProjectID))
 	}
 	toolutil.WriteHints(
 		&sb,

--- a/internal/tools/pipelines/markdown.go
+++ b/internal/tools/pipelines/markdown.go
@@ -37,8 +37,10 @@ func FormatListMarkdown(out ListOutput) string {
 		if len(sha) > 8 {
 			sha = sha[:8]
 		}
-		fmt.Fprintf(&b, "| [#%d](%s) | %s %s | %s | %s | %s |\n",
-			p.ID, p.WebURL, toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref), sha)
+		fmt.Fprintf(&b, "| %s | %s %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
+			//gitlab:allow-unescaped sha: the first characters of a commit SHA, which is hexadecimal.
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref), sha)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -54,15 +56,22 @@ func FormatListMarkdown(out ListOutput) string {
 func FormatDetailMarkdown(p DetailOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s Pipeline #%d: %s\n\n", toolutil.PipelineStatusEmoji(p.Status), p.ID, p.Status)
+	//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
 	fmt.Fprintf(&b, "- **IID**: %d\n", p.IID)
 	fmt.Fprintf(&b, "- **Source**: %s\n", p.Source)
-	fmt.Fprintf(&b, "- **Ref**: %s (tag: %v)\n", p.Ref, p.Tag)
+	// A ref is not an identifier: git check-ref-format permits '|', '<' and
+	// '>', so a pushable branch can end this line or open a tag in it.
+	fmt.Fprintf(&b, "- **Ref**: %s (tag: %v)\n", toolutil.EscapeMdTableCell(p.Ref), p.Tag)
+	//gitlab:allow-unescaped p.SHA: a commit SHA, hexadecimal digits only.
 	fmt.Fprintf(&b, "- **SHA**: %s\n", p.SHA)
 	if p.BeforeSHA != "" {
+		//gitlab:allow-unescaped p.BeforeSHA: the commit SHA the push started from, hexadecimal digits only.
 		fmt.Fprintf(&b, "- **Before SHA**: %s\n", p.BeforeSHA)
 	}
 	if p.Name != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdName, p.Name)
+		// The pipeline name comes from workflow:name in .gitlab-ci.yml, which
+		// is free text and interpolates CI variables besides.
+		fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(p.Name))
 	}
 	if p.Duration > 0 {
 		fmt.Fprintf(&b, "- **Duration**: %ds\n", p.Duration)
@@ -71,13 +80,16 @@ func FormatDetailMarkdown(p DetailOutput) string {
 		fmt.Fprintf(&b, "- **Queued**: %ds\n", p.QueuedDuration)
 	}
 	if p.Coverage != "" {
+		//gitlab:allow-unescaped p.Coverage: the average job coverage GitLab computes for the pipeline and serializes as a decimal number.
 		fmt.Fprintf(&b, "- **Coverage**: %s%%\n", p.Coverage)
 	}
 	if p.YamlErrors != "" {
-		fmt.Fprintf(&b, "- **YAML Errors**: %s\n", p.YamlErrors)
+		// GitLab quotes the user's own CI file back in this message, job and
+		// stage names included, and a Psych parse error carries "(<unknown>)".
+		fmt.Fprintf(&b, "- **YAML Errors**: %s\n", toolutil.EscapeMdTableCell(p.YamlErrors))
 	}
 	if p.User != nil && p.User.Username != "" {
-		fmt.Fprintf(&b, "- **User**: %s\n", p.User.Username)
+		fmt.Fprintf(&b, "- **User**: %s\n", toolutil.EscapeMdTableCell(p.User.Username))
 	}
 	if p.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(p.CreatedAt))
@@ -88,7 +100,7 @@ func FormatDetailMarkdown(p DetailOutput) string {
 	if p.FinishedAt != "" {
 		fmt.Fprintf(&b, "- **Finished**: %s\n", toolutil.FormatTime(p.FinishedAt))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, p.WebURL)
+	toolutil.WriteMdURL(&b, p.WebURL)
 	toolutil.WriteHints(
 		&b,
 		"Use gitlab_job action 'list' with this pipeline_id to see all jobs",
@@ -110,6 +122,7 @@ func FormatVariablesMarkdown(out VariablesOutput) string {
 	b.WriteString(toolutil.TblSep3Col)
 	for _, v := range out.Variables {
 		fmt.Fprintf(&b, "| %s | %s | %s |\n",
+			//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
 			toolutil.EscapeMdTableCell(v.Key), toolutil.EscapeMdTableCell(v.Value), v.VariableType)
 	}
 	toolutil.WriteHints(
@@ -201,6 +214,10 @@ func testSuiteSummaryOutputs(suites []TestSuiteSummaryOutput) []testSuiteMarkdow
 }
 
 // FormatWaitMarkdown renders the wait result as a Markdown summary.
+//
+//gitlab:allow-unescaped out.Pipeline.Status: the same pipeline status enum, reached through the pipeline the wait polled.
+//gitlab:allow-unescaped out.FinalStatus: the status the wait ended on, taken from that same pipeline.
+//gitlab:allow-unescaped out.WaitedFor: how long this server waited, rendered by time.Duration.String.
 func FormatWaitMarkdown(out WaitOutput) string {
 	var b strings.Builder
 	if out.TimedOut {

--- a/internal/tools/pipelineschedules/markdown.go
+++ b/internal/tools/pipelineschedules/markdown.go
@@ -82,9 +82,10 @@ func FormatListMarkdown(out ListOutput) string {
 func FormatVariableMarkdown(v VariableOutput) string {
 	var b strings.Builder
 	b.WriteString("## Pipeline Schedule Variable\n\n")
-	fmt.Fprintf(&b, "- **Key**: %s\n", v.Key)
-	fmt.Fprintf(&b, "- **Value**: %s\n", v.Value)
+	fmt.Fprintf(&b, "- **Key**: %s\n", toolutil.EscapeMdTableCell(v.Key))
+	fmt.Fprintf(&b, "- **Value**: %s\n", toolutil.EscapeMdTableCell(v.Value))
 	if v.VariableType != "" {
+		//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
 		fmt.Fprintf(&b, "- **Type**: %s\n", v.VariableType)
 	}
 	toolutil.WriteHints(
@@ -107,6 +108,8 @@ func FormatTriggeredPipelinesMarkdown(out TriggeredPipelinesListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, p := range out.Pipelines {
 		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s |\n",
+			//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
+			//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
 			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), p.IID, toolutil.EscapeMdTableCell(p.Ref), p.Status, p.Source)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/pipelinetriggers/markdown.go
+++ b/internal/tools/pipelinetriggers/markdown.go
@@ -71,8 +71,10 @@ func FormatRunOutputMarkdown(out RunOutput) string {
 	b.WriteString("## Pipeline Triggered\n\n")
 	b.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| Pipeline ID | %d |\n", out.ID)
+	//gitlab:allow-unescaped out.SHA: a commit SHA, hexadecimal by construction.
 	fmt.Fprintf(&b, "| SHA | %s |\n", out.SHA)
 	fmt.Fprintf(&b, "| Ref | %s |\n", toolutil.EscapeMdTableCell(out.Ref))
+	//gitlab:allow-unescaped out.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
 	fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
 	if out.WebURL != "" {
 		fmt.Fprintf(&b, "| URL | %s |\n", toolutil.MdTitleLink(fmt.Sprintf("Pipeline #%d", out.ID), out.WebURL))

--- a/internal/tools/projectaliases/markdown.go
+++ b/internal/tools/projectaliases/markdown.go
@@ -10,11 +10,12 @@ import (
 // FormatOutputMarkdown formats a single project alias as Markdown.
 func FormatOutputMarkdown(out Output) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Project Alias: %s\n\n", out.Name)
+	// An alias name is the string the caller of the create action supplied.
+	fmt.Fprintf(&sb, "## Project Alias: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&sb, "| Field | Value |\n")
 	fmt.Fprintf(&sb, "|-------|-------|\n")
 	fmt.Fprintf(&sb, "| ID | %d |\n", out.ID)
-	fmt.Fprintf(&sb, "| Name | `%s` |\n", out.Name)
+	fmt.Fprintf(&sb, "| Name | `%s` |\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&sb, "| Project ID | %d |\n", out.ProjectID)
 	toolutil.WriteHints(
 		&sb,
@@ -36,7 +37,7 @@ func FormatListMarkdown(out ListOutput) string {
 	fmt.Fprintf(&sb, "| ID | Name | Project ID |\n")
 	fmt.Fprintf(&sb, "|----|------|------------|\n")
 	for _, a := range out.Aliases {
-		fmt.Fprintf(&sb, "| %d | `%s` | %d |\n", a.ID, a.Name, a.ProjectID)
+		fmt.Fprintf(&sb, "| %d | `%s` | %d |\n", a.ID, toolutil.EscapeMdTableCell(a.Name), a.ProjectID)
 	}
 	return sb.String()
 }

--- a/internal/tools/projectdiscovery/markdown.go
+++ b/internal/tools/projectdiscovery/markdown.go
@@ -12,13 +12,14 @@ func FormatMarkdown(out ResolveOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Resolved GitLab Project\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
-	fmt.Fprintf(&b, toolutil.FmtMdPath, out.PathWithNamespace)
-	fmt.Fprintf(&b, toolutil.FmtMdURL, out.WebURL)
-	fmt.Fprintf(&b, "- **Default Branch**: %s\n", out.DefaultBranch)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, toolutil.FmtMdPath, toolutil.EscapeMdTableCell(out.PathWithNamespace))
+	toolutil.WriteMdURL(&b, out.WebURL)
+	fmt.Fprintf(&b, "- **Default Branch**: %s\n", toolutil.EscapeMdTableCell(out.DefaultBranch))
 	if out.Description != "" {
 		toolutil.WriteDescription(&b, out.Description)
 	}
+	//gitlab:allow-unescaped out.Visibility: a project visibility, a gl.VisibilityValue GitLab fills with private, internal or public.
 	fmt.Fprintf(&b, toolutil.FmtMdVisibility, out.Visibility)
 	fmt.Fprintf(&b, "\nUse `project_id: %d` or `project_id: \"%s\"` for subsequent operations.\n", out.ID, out.PathWithNamespace)
 	toolutil.WriteHints(

--- a/internal/tools/projectimportexport/markdown.go
+++ b/internal/tools/projectimportexport/markdown.go
@@ -47,10 +47,12 @@ func appendNonEmptyStatusRow(rows *[]statusRow, field, value string) {
 
 func projectImportExportStatusResult(title, name string, id int64, path string, rows []statusRow, hint string) *mcp.CallToolResult {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## %s: %s\n\n", title, name)
+	// The title is a literal at every call site; the project's name and path
+	// are what whoever created it chose.
+	fmt.Fprintf(&sb, "## %s: %s\n\n", title, toolutil.EscapeMdHeading(name))
 	sb.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, "| ID | %d |\n", id)
-	fmt.Fprintf(&sb, "| Path | %s |\n", path)
+	fmt.Fprintf(&sb, "| Path | %s |\n", toolutil.EscapeMdTableCell(path))
 	for _, row := range rows {
 		fmt.Fprintf(&sb, "| %s | %s |\n", row.Field, row.Value)
 	}

--- a/internal/tools/projectmirrors/markdown.go
+++ b/internal/tools/projectmirrors/markdown.go
@@ -14,30 +14,39 @@ func FormatOutputMarkdown(m Output) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Remote Mirror #%d\n\n", m.ID)
-	fmt.Fprintf(&b, "- **URL**: `%s`\n", m.URL)
+	// The mirror URL is whatever the maintainer configuring the mirror typed.
+	fmt.Fprintf(&b, "- **URL**: `%s`\n", toolutil.EscapeMdTableCell(m.URL))
 	fmt.Fprintf(&b, "- **Enabled**: %t\n", m.Enabled)
+	//gitlab:allow-unescaped m.UpdateStatus: a mirror update status GitLab picks from a fixed set (none, scheduled, started, finished, failed).
 	fmt.Fprintf(&b, "- **Status**: %s\n", m.UpdateStatus)
 	if m.AuthMethod != "" {
+		//gitlab:allow-unescaped m.AuthMethod: a mirror authentication method GitLab picks from a fixed set (password, ssh_public_key).
 		fmt.Fprintf(&b, "- **Auth Method**: %s\n", m.AuthMethod)
 	}
 	fmt.Fprintf(&b, "- **Only Protected Branches**: %t\n", m.OnlyProtectedBranches)
 	fmt.Fprintf(&b, "- **Keep Divergent Refs**: %t\n", m.KeepDivergentRefs)
 	if m.MirrorBranchRegex != "" {
-		fmt.Fprintf(&b, "- **Branch Regex**: `%s`\n", m.MirrorBranchRegex)
+		// A regex a maintainer types, where '|' is ordinary alternation.
+		fmt.Fprintf(&b, "- **Branch Regex**: `%s`\n", toolutil.EscapeMdTableCell(m.MirrorBranchRegex))
 	}
 	if len(m.HostKeys) > 0 {
 		b.WriteString("- **Host Keys**:\n")
 		for _, hk := range m.HostKeys {
+			//gitlab:allow-unescaped hk.FingerprintSHA256: a host key fingerprint GitLab derives from the key, base64 after a "SHA256:" prefix.
 			fmt.Fprintf(&b, "  - `%s`\n", hk.FingerprintSHA256)
 		}
 	}
 	if m.LastError != "" {
-		fmt.Fprintf(&b, "- **Last Error**: %s\n", m.LastError)
+		// GitLab quotes the remote's own output back in this field, so a
+		// hostile remote writes it.
+		fmt.Fprintf(&b, "- **Last Error**: %s\n", toolutil.EscapeMdTableCell(m.LastError))
 	}
 	if m.LastSuccessfulUpdateAt != "" {
+		//gitlab:allow-unescaped m.LastSuccessfulUpdateAt: a timestamp this package formatted itself, with time.Time.Format.
 		fmt.Fprintf(&b, "- **Last Successful Update**: %s\n", m.LastSuccessfulUpdateAt)
 	}
 	if m.LastUpdateAt != "" {
+		//gitlab:allow-unescaped m.LastUpdateAt: a timestamp this package formatted itself, with time.Time.Format.
 		fmt.Fprintf(&b, "- **Last Update**: %s\n", m.LastUpdateAt)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/projects/markdown.go
+++ b/internal/tools/projects/markdown.go
@@ -28,17 +28,18 @@ func FormatMarkdown(p Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Project: %s\n\n", toolutil.EscapeMdHeading(p.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, p.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdPath, p.PathWithNamespace)
+	fmt.Fprintf(&b, toolutil.FmtMdPath, toolutil.EscapeMdTableCell(p.PathWithNamespace))
+	//gitlab:allow-unescaped p.Visibility: a project visibility, a gl.VisibilityValue GitLab fills with private, internal or public.
 	fmt.Fprintf(&b, toolutil.FmtMdVisibility, p.Visibility)
-	fmt.Fprintf(&b, "- **Default Branch**: %s\n", p.DefaultBranch)
+	fmt.Fprintf(&b, "- **Default Branch**: %s\n", toolutil.EscapeMdTableCell(p.DefaultBranch))
 	if p.Description != "" {
 		toolutil.WriteDescription(&b, p.Description)
 	}
 	if p.Namespace != nil && p.Namespace.FullPath != "" {
-		fmt.Fprintf(&b, "- **Namespace**: %s\n", p.Namespace.FullPath)
+		fmt.Fprintf(&b, "- **Namespace**: %s\n", toolutil.EscapeMdTableCell(p.Namespace.FullPath))
 	}
 	if p.ForkedFromProject != nil && p.ForkedFromProject.PathWithNamespace != "" {
-		fmt.Fprintf(&b, "- **Forked From**: %s\n", p.ForkedFromProject.PathWithNamespace)
+		fmt.Fprintf(&b, "- **Forked From**: %s\n", toolutil.EscapeMdTableCell(p.ForkedFromProject.PathWithNamespace))
 	}
 	if p.Archived {
 		fmt.Fprintf(&b, "- %s **Archived**\n", toolutil.EmojiArchived)
@@ -53,22 +54,22 @@ func FormatMarkdown(p Output) string {
 		fmt.Fprintf(&b, "- **Open Issues**: %d\n", p.OpenIssuesCount)
 	}
 	if len(p.Topics) > 0 {
-		fmt.Fprintf(&b, "- **Topics**: %s\n", strings.Join(p.Topics, ", "))
+		fmt.Fprintf(&b, "- **Topics**: %s\n", toolutil.EscapeMdTableCell(strings.Join(p.Topics, ", ")))
 	}
 	if p.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(p.CreatedAt))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, p.WebURL)
+	toolutil.WriteMdURL(&b, p.WebURL)
 	if p.HTTPURLToRepo != "" {
-		fmt.Fprintf(&b, "- **HTTP Clone**: %s\n", p.HTTPURLToRepo)
+		fmt.Fprintf(&b, "- **HTTP Clone**: %s\n", toolutil.EscapeMdTableCell(p.HTTPURLToRepo))
 	}
 	if p.SSHURLToRepo != "" {
-		fmt.Fprintf(&b, "- **SSH Clone**: %s\n", p.SSHURLToRepo)
+		fmt.Fprintf(&b, "- **SSH Clone**: %s\n", toolutil.EscapeMdTableCell(p.SSHURLToRepo))
 	}
 	if p.MergeRequestTitleRegex != "" {
-		fmt.Fprintf(&b, "- **MR Title Regex**: `%s`\n", p.MergeRequestTitleRegex)
+		fmt.Fprintf(&b, "- **MR Title Regex**: `%s`\n", toolutil.EscapeMdTableCell(p.MergeRequestTitleRegex))
 		if p.MergeRequestTitleRegexDescription != "" {
-			fmt.Fprintf(&b, "- **MR Title Regex Description**: %s\n", p.MergeRequestTitleRegexDescription)
+			fmt.Fprintf(&b, "- **MR Title Regex Description**: %s\n", toolutil.EscapeMdTableCell(p.MergeRequestTitleRegexDescription))
 		}
 	}
 	if p.ProtectMergeRequestPipelines != nil && *p.ProtectMergeRequestPipelines {
@@ -89,9 +90,13 @@ func FormatMarkdown(p Output) string {
 func FormatDeleteMarkdown(out DeleteOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Project Deletion\n\n")
+	//gitlab:allow-unescaped out.Status: one of the three literals this package's own delete handlers write (already_scheduled, scheduled, success).
 	fmt.Fprintf(&b, toolutil.FmtMdStatus, out.Status)
-	fmt.Fprintf(&b, "- **Message**: %s\n", out.Message)
+	// The message is server-authored but interpolates the caller's own
+	// project_id, which nothing validates before it lands here.
+	fmt.Fprintf(&b, "- **Message**: %s\n", toolutil.EscapeMdTableCell(out.Message))
 	if out.MarkedForDeletionOn != "" {
+		//gitlab:allow-unescaped out.MarkedForDeletionOn: a date this package rendered itself, with time.Time.Format on the DateOnly layout.
 		fmt.Fprintf(&b, "- **Marked for deletion on**: %s\n", out.MarkedForDeletionOn)
 	}
 	if out.PermanentlyRemoved {
@@ -120,7 +125,7 @@ func FormatListMarkdown(out ListOutput) string {
 		if p.Archived {
 			archived = " " + toolutil.EmojiArchived
 		}
-		fmt.Fprintf(&b, "| %d | [%s](%s)%s | %s | %s | %d |\n", p.ID, toolutil.EscapeMdTableCell(p.Name), p.WebURL, archived, toolutil.EscapeMdTableCell(p.PathWithNamespace), p.Visibility, p.StarCount)
+		fmt.Fprintf(&b, "| %d | %s%s | %s | %s | %d |\n", p.ID, toolutil.MdTitleLink(p.Name, p.WebURL), archived, toolutil.EscapeMdTableCell(p.PathWithNamespace), p.Visibility, p.StarCount)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
@@ -279,7 +284,8 @@ func FormatListProjectUsersMarkdown(out ListProjectUsersOutput) string {
 	b.WriteString("| ID | Name | Username | State |\n")
 	b.WriteString("|---|---|---|---|\n")
 	for _, u := range out.Users {
-		fmt.Fprintf(&b, "| %d | %s | @%s | %s |\n", u.ID, u.Name, u.Username, u.State)
+		//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
+		fmt.Fprintf(&b, "| %d | %s | @%s | %s |\n", u.ID, toolutil.EscapeMdTableCell(u.Name), toolutil.EscapeMdTableCell(u.Username), u.State)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -300,7 +306,7 @@ func FormatListProjectGroupsMarkdown(out ListProjectGroupsOutput) string {
 	b.WriteString("| ID | Name | Full Path |\n")
 	b.WriteString("|---|---|---|\n")
 	for _, g := range out.Groups {
-		fmt.Fprintf(&b, "| %d | %s | %s |\n", g.ID, g.Name, g.FullPath)
+		fmt.Fprintf(&b, "| %d | %s | %s |\n", g.ID, toolutil.EscapeMdTableCell(g.Name), toolutil.EscapeMdTableCell(g.FullPath))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -320,7 +326,7 @@ func FormatListStarrersMarkdown(out ListProjectStarrersOutput) string {
 	b.WriteString("| User | Username | Starred Since |\n")
 	b.WriteString("|---|---|---|\n")
 	for _, s := range out.Starrers {
-		fmt.Fprintf(&b, "| %s | @%s | %s |\n", s.User.Name, s.User.Username, toolutil.FormatTime(s.StarredSince))
+		fmt.Fprintf(&b, "| %s | @%s | %s |\n", toolutil.EscapeMdTableCell(s.User.Name), toolutil.EscapeMdTableCell(s.User.Username), toolutil.FormatTime(s.StarredSince))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -338,6 +344,7 @@ func FormatShareProjectMarkdown(out ShareProjectOutput) string {
 		fmt.Fprintf(&b, "\n| Field | Value |\n")
 		b.WriteString("|---|---|\n")
 		fmt.Fprintf(&b, "| Group ID | %d |\n", out.GroupID)
+		//gitlab:allow-unescaped out.AccessRole: accessLevelName returns one of this package's six role literals, or "Level" and an integer.
 		fmt.Fprintf(&b, "| Access Role | %s |\n", out.AccessRole)
 	}
 	toolutil.WriteHints(
@@ -386,7 +393,8 @@ func FormatPushRuleMarkdown(out PushRuleOutput) string {
 		if val == "" {
 			val = "-"
 		}
-		fmt.Fprintf(&b, "| %s | %s |\n", r.name, val)
+		//gitlab:allow-unescaped r.name: every rule label in the slice above is a string literal written here.
+		fmt.Fprintf(&b, "| %s | %s |\n", r.name, toolutil.EscapeMdTableCell(val))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -453,21 +461,23 @@ func FormatApprovalRuleMarkdown(out ApprovalRuleOutput) string {
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
 	fmt.Fprintf(&b, "- **Approvals Required**: %d\n", out.ApprovalsRequired)
 	if out.RuleType != "" {
+		//gitlab:allow-unescaped out.RuleType: an approval rule type GitLab picks from a fixed set (regular, any_approver, code_owner, report_approver).
 		fmt.Fprintf(&b, "- **Rule Type**: %s\n", out.RuleType)
 	}
 	if out.ReportType != "" {
+		//gitlab:allow-unescaped out.ReportType: an approval report type GitLab picks from a fixed set (code_coverage, scan_finding, license_scanning, any_merge_request).
 		fmt.Fprintf(&b, "- **Report Type**: %s\n", out.ReportType)
 	}
 	fmt.Fprintf(&b, "- **Applies to all protected branches**: %s\n", boolIcon(out.AppliesToAllProtectedBranches))
 	fmt.Fprintf(&b, "- **Contains hidden groups**: %s\n", boolIcon(out.ContainsHiddenGroups))
 	if names := userNames(out.Users); len(names) > 0 {
-		fmt.Fprintf(&b, "- **Users**: %s\n", strings.Join(names, ", "))
+		fmt.Fprintf(&b, "- **Users**: %s\n", toolutil.EscapeMdTableCell(strings.Join(names, ", ")))
 	}
 	if names := groupNames(out.Groups); len(names) > 0 {
-		fmt.Fprintf(&b, "- **Groups**: %s\n", strings.Join(names, ", "))
+		fmt.Fprintf(&b, "- **Groups**: %s\n", toolutil.EscapeMdTableCell(strings.Join(names, ", ")))
 	}
 	if names := userNames(out.EligibleApprovers); len(names) > 0 {
-		fmt.Fprintf(&b, "- **Eligible Approvers**: %s\n", strings.Join(names, ", "))
+		fmt.Fprintf(&b, "- **Eligible Approvers**: %s\n", toolutil.EscapeMdTableCell(strings.Join(names, ", ")))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -489,6 +499,7 @@ func FormatListApprovalRulesMarkdown(out ListApprovalRulesOutput) string {
 	b.WriteString("| ID | Name | Type | Approvals | All Protected | Users | Groups |\n")
 	b.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
 	for _, r := range out.Rules {
+		//gitlab:allow-unescaped ruleType: the same approval rule type enum, or the dash this loop substitutes for an empty one.
 		ruleType := r.RuleType
 		if ruleType == "" {
 			ruleType = "-"
@@ -522,13 +533,16 @@ func FormatPullMirrorMarkdown(out PullMirrorOutput) string {
 	fmt.Fprintf(&b, "## Pull Mirror (ID: %d)\n\n", out.ID)
 	fmt.Fprintf(&b, "- **Enabled**: %s\n", boolIcon(out.Enabled))
 	if out.URL != "" {
-		fmt.Fprintf(&b, "- **URL**: %s\n", out.URL)
+		// The mirror source URL is whatever the maintainer configuring it typed.
+		fmt.Fprintf(&b, "- **URL**: %s\n", toolutil.EscapeMdTableCell(out.URL))
 	}
 	if out.UpdateStatus != "" {
+		//gitlab:allow-unescaped out.UpdateStatus: a mirror update status GitLab picks from a fixed set (none, scheduled, started, finished, failed).
 		fmt.Fprintf(&b, "- **Update Status**: %s\n", out.UpdateStatus)
 	}
 	if out.LastError != "" {
-		fmt.Fprintf(&b, "- **Last Error**: %s\n", out.LastError)
+		// GitLab quotes the remote's own output back in this field.
+		fmt.Fprintf(&b, "- **Last Error**: %s\n", toolutil.EscapeMdTableCell(out.LastError))
 	}
 	if out.LastSuccessfulUpdateAt != "" {
 		fmt.Fprintf(&b, "- **Last Successful Update**: %s\n", toolutil.FormatTime(out.LastSuccessfulUpdateAt))
@@ -540,7 +554,7 @@ func FormatPullMirrorMarkdown(out PullMirrorOutput) string {
 	fmt.Fprintf(&b, "- **Only Protected Branches**: %s\n", boolIcon(out.OnlyMirrorProtectedBranches))
 	fmt.Fprintf(&b, "- **Overwrite Diverged Branches**: %s\n", boolIcon(out.MirrorOverwritesDivergedBranches))
 	if out.MirrorBranchRegex != "" {
-		fmt.Fprintf(&b, "- **Branch Regex**: `%s`\n", out.MirrorBranchRegex)
+		fmt.Fprintf(&b, "- **Branch Regex**: `%s`\n", toolutil.EscapeMdTableCell(out.MirrorBranchRegex))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -555,8 +569,9 @@ func FormatRepositoryStorageMarkdown(out RepositoryStorageOutput) string {
 	var b strings.Builder
 	b.WriteString("## Repository Storage\n\n")
 	fmt.Fprintf(&b, "- **Project ID**: %d\n", out.ProjectID)
-	fmt.Fprintf(&b, "- **Disk Path**: %s\n", out.DiskPath)
-	fmt.Fprintf(&b, "- **Repository Storage**: %s\n", out.RepositoryStorage)
+	fmt.Fprintf(&b, "- **Disk Path**: %s\n", toolutil.EscapeMdTableCell(out.DiskPath))
+	// A storage shard name is an identifier the instance operator chose.
+	fmt.Fprintf(&b, "- **Repository Storage**: %s\n", toolutil.EscapeMdTableCell(out.RepositoryStorage))
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
 	}
@@ -599,8 +614,9 @@ func FormatTargetBranchRuleMarkdown(out TargetBranchRuleOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Target Branch Rule: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, "- **Source Pattern**: %s\n", out.Name)
-	fmt.Fprintf(&b, "- **Target Branch**: %s\n", out.TargetBranch)
+	// Both come straight off the caller's own create input.
+	fmt.Fprintf(&b, "- **Source Pattern**: %s\n", toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, "- **Target Branch**: %s\n", toolutil.EscapeMdTableCell(out.TargetBranch))
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
 	}

--- a/internal/tools/projectserviceaccounts/markdown.go
+++ b/internal/tools/projectserviceaccounts/markdown.go
@@ -19,11 +19,13 @@ func FormatMarkdownString(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Project Service Account: %s\n\n", toolutil.EscapeMdHeading(out.Username))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
-	fmt.Fprintf(&b, toolutil.FmtMdUsername, out.Username)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, out.Email)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
+	fmt.Fprintf(&b, toolutil.FmtMdUsername, toolutil.EscapeMdTableCell(out.Username))
+	// GitLab validates an address with a regexp that excludes whitespace and a
+	// second '@' and admits both '|' and '<'.
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(out.Email))
 	if out.UnconfirmedEmail != "" {
-		fmt.Fprintf(&b, "- **Unconfirmed email**: %s\n", out.UnconfirmedEmail)
+		fmt.Fprintf(&b, "- **Unconfirmed email**: %s\n", toolutil.EscapeMdTableCell(out.UnconfirmedEmail))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -59,21 +61,26 @@ func FormatPATMarkdownString(out PATOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Project Service Account Token: %s\n\n", toolutil.EscapeMdHeading(out.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, out.Name)
+	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, "- **Active**: %s\n", toolutil.BoolEmoji(out.Active))
 	fmt.Fprintf(&b, "- **Revoked**: %s\n", toolutil.BoolEmoji(out.Revoked))
+	//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): GitLab validates a token request against the scopes it knows and rejects anything else, so a scope is one of that fixed set.
 	fmt.Fprintf(&b, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	fmt.Fprintf(&b, "- **User ID**: %d\n", out.UserID)
 	if out.CreatedAt != "" {
+		//gitlab:allow-unescaped out.CreatedAt: toPATOutput formats the time client-go parsed, so this is an RFC 3339 timestamp this server wrote.
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, out.CreatedAt)
 	}
 	if out.LastUsedAt != "" {
+		//gitlab:allow-unescaped out.LastUsedAt: toPATOutput formats the time client-go parsed, so this is an RFC 3339 timestamp this server wrote.
 		fmt.Fprintf(&b, "- **Last used**: %s\n", out.LastUsedAt)
 	}
 	if out.ExpiresAt != "" {
+		//gitlab:allow-unescaped out.ExpiresAt: toPATOutput formats the date client-go parsed, so this is a YYYY-MM-DD date this server wrote.
 		fmt.Fprintf(&b, "- **Expires**: %s\n", out.ExpiresAt)
 	}
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the instance generates this credential from a URL-safe alphabet, and it has to reach the caller byte for byte.
 		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
 	}
 	toolutil.WriteHints(
@@ -95,6 +102,8 @@ func FormatListPATMarkdownString(out ListPATOutput) string {
 	}
 	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
 	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Active", "Revoked", "Scopes", "Expires"))
+	//gitlab:allow-unescaped strings.Join(token.Scopes, ", "): GitLab validates a token request against the scopes it knows and rejects anything else, so a scope is one of that fixed set.
+	//gitlab:allow-unescaped token.ExpiresAt: toPATOutput formats the date client-go parsed, so this is a YYYY-MM-DD date this server wrote.
 	for _, token := range out.Tokens {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %s |\n",
 			token.ID,

--- a/internal/tools/projectstoragemoves/markdown.go
+++ b/internal/tools/projectstoragemoves/markdown.go
@@ -13,14 +13,17 @@ func FormatOutputMarkdown(o Output) string {
 	fmt.Fprintf(&sb, "## Project Storage Move #%d\n\n", o.ID)
 	sb.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&sb, "| ID | %d |\n", o.ID)
+	//gitlab:allow-unescaped o.State: a storage move state GitLab picks from a fixed set (initial, scheduled, started, finished, failed and the rest).
 	fmt.Fprintf(&sb, "| State | %s |\n", o.State)
-	fmt.Fprintf(&sb, "| Source Storage | %s |\n", o.SourceStorageName)
-	fmt.Fprintf(&sb, "| Destination Storage | %s |\n", o.DestinationStorageName)
+	// A storage shard name is an identifier the instance operator chooses in
+	// gitlab.rb, so it is not a set this server can know.
+	fmt.Fprintf(&sb, "| Source Storage | %s |\n", toolutil.EscapeMdTableCell(o.SourceStorageName))
+	fmt.Fprintf(&sb, "| Destination Storage | %s |\n", toolutil.EscapeMdTableCell(o.DestinationStorageName))
 	if !o.CreatedAt.IsZero() {
 		fmt.Fprintf(&sb, "| Created At | %s |\n", o.CreatedAt.Format("2006-01-02 15:04:05"))
 	}
 	if o.Project != nil {
-		fmt.Fprintf(&sb, "| Project | %s (ID: %d) |\n", o.Project.PathWithNamespace, o.Project.ID)
+		fmt.Fprintf(&sb, "| Project | %s (ID: %d) |\n", toolutil.EscapeMdTableCell(o.Project.PathWithNamespace), o.Project.ID)
 	}
 	toolutil.WriteHints(
 		&sb,
@@ -40,8 +43,10 @@ func FormatListMarkdown(o ListOutput) string {
 		if m.Project != nil {
 			project = m.Project.PathWithNamespace
 		}
+		//gitlab:allow-unescaped m.State: a storage move state GitLab picks from a fixed set (initial, scheduled, started, finished, failed and the rest).
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s |\n",
-			m.ID, m.State, m.SourceStorageName, m.DestinationStorageName, project)
+			m.ID, m.State, toolutil.EscapeMdTableCell(m.SourceStorageName),
+			toolutil.EscapeMdTableCell(m.DestinationStorageName), toolutil.EscapeMdTableCell(project))
 	}
 	if o.Pagination.Page != 0 {
 		fmt.Fprintf(&sb, "\n_Page %d, %d moves shown._\n", o.Pagination.Page, len(o.Moves))

--- a/internal/tools/protectedenvs/markdown.go
+++ b/internal/tools/protectedenvs/markdown.go
@@ -13,7 +13,8 @@ func FormatOutputMarkdown(pe Output) string {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Environment: %s\n\n", pe.Name)
+	// An environment name is written in .gitlab-ci.yml or typed in the UI.
+	fmt.Fprintf(&b, "## Protected Environment: %s\n\n", toolutil.EscapeMdHeading(pe.Name))
 	fmt.Fprintf(&b, "- **Required Approvals**: %d\n\n", pe.RequiredApprovalCount)
 
 	if len(pe.DeployAccessLevels) > 0 {

--- a/internal/tools/protectedpackages/markdown.go
+++ b/internal/tools/protectedpackages/markdown.go
@@ -14,12 +14,16 @@ func FormatOutputMarkdown(r Output) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Package Protection Rule #%d\n\n", r.ID)
-	fmt.Fprintf(&b, "- **Pattern**: `%s`\n", r.PackageNamePattern)
+	// The pattern is free text this server's own create action passes through.
+	fmt.Fprintf(&b, "- **Pattern**: `%s`\n", toolutil.EscapeMdTableCell(r.PackageNamePattern))
+	//gitlab:allow-unescaped r.PackageType: the registry format GitLab stores the rule for, one of its own enum values (npm, pypi, maven and the rest).
 	fmt.Fprintf(&b, "- **Package Type**: %s\n", r.PackageType)
 	if r.MinimumAccessLevelForPush != "" {
+		//gitlab:allow-unescaped r.MinimumAccessLevelForPush: a protection rule access level GitLab picks from a fixed set (maintainer, owner, admin).
 		fmt.Fprintf(&b, "- **Min Push Level**: %s\n", r.MinimumAccessLevelForPush)
 	}
 	if r.MinimumAccessLevelForDelete != "" {
+		//gitlab:allow-unescaped r.MinimumAccessLevelForDelete: a protection rule access level GitLab picks from a fixed set (maintainer, owner, admin).
 		fmt.Fprintf(&b, "- **Min Delete Level**: %s\n", r.MinimumAccessLevelForDelete)
 	}
 	toolutil.WriteHints(

--- a/internal/tools/releaselinks/markdown.go
+++ b/internal/tools/releaselinks/markdown.go
@@ -12,7 +12,8 @@ func FormatOutputMarkdown(l Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Release Link: %s\n\n", toolutil.EscapeMdHeading(l.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, l.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdURL, l.URL)
+	toolutil.WriteMdURL(&b, l.URL)
+	//gitlab:allow-unescaped l.LinkType: a release link type GitLab picks from a fixed set (other, runbook, image, package).
 	fmt.Fprintf(&b, "- **Type**: %s\n", l.LinkType)
 	fmt.Fprintf(&b, "- **External**: %v\n", l.External)
 	toolutil.WriteHints(
@@ -37,7 +38,8 @@ func FormatBatchMarkdown(out CreateBatchOutput) string {
 	if len(out.Failed) > 0 {
 		fmt.Fprintf(&b, "\n### Failures (%d)\n\n", len(out.Failed))
 		for _, f := range out.Failed {
-			fmt.Fprintf(&b, "- %s\n", f)
+			// Each failure carries the link's own name and GitLab's message.
+			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(f))
 		}
 	}
 	toolutil.WriteHints(

--- a/internal/tools/releases/markdown.go
+++ b/internal/tools/releases/markdown.go
@@ -50,18 +50,20 @@ func milestoneTitles(ms []*toolutil.MilestoneOutput) []string {
 func FormatMarkdown(r Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Release: %s\n\n", toolutil.EscapeMdHeading(r.Name))
-	fmt.Fprintf(&b, "- **Tag**: %s\n", r.TagName)
+	// A tag name is a git ref, and check-ref-format permits '|', '<' and '>'.
+	fmt.Fprintf(&b, "- **Tag**: %s\n", toolutil.EscapeMdTableCell(r.TagName))
 	if r.Author != nil && r.Author.Username != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdAuthorAt, r.Author.Username)
+		fmt.Fprintf(&b, toolutil.FmtMdAuthorAt, toolutil.EscapeMdTableCell(r.Author.Username))
 	}
 	if webURL := releaseWebURL(r); webURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, webURL)
+		toolutil.WriteMdURL(&b, webURL)
 	}
 	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(r.CreatedAt))
 	if r.ReleasedAt != "" {
 		fmt.Fprintf(&b, "- **Released**: %s\n", toolutil.FormatTime(r.ReleasedAt))
 	}
 	if r.Commit != nil && r.Commit.ID != "" {
+		//gitlab:allow-unescaped r.Commit.ID: a commit SHA, hexadecimal by construction.
 		fmt.Fprintf(&b, "- **Commit**: %s\n", r.Commit.ID)
 	}
 	if r.UpcomingRelease {
@@ -100,10 +102,9 @@ func FormatListMarkdown(out ListOutput) string {
 		if released == "" {
 			released = r.CreatedAt
 		}
-		tag := toolutil.EscapeMdTableCell(r.TagName)
-		if webURL := releaseWebURL(r); webURL != "" {
-			tag = fmt.Sprintf("[%s](%s)", tag, webURL)
-		}
+		// The cell escaper leaves ']' alone, so a hand-built link's label could
+		// be closed from inside it by a tag holding one.
+		tag := toolutil.MdTitleLink(r.TagName, releaseWebURL(r))
 		var author string
 		if r.Author != nil {
 			author = r.Author.Username

--- a/internal/tools/repository/markdown.go
+++ b/internal/tools/repository/markdown.go
@@ -54,6 +54,7 @@ func FormatCompareMarkdown(out CompareOutput) string {
 		b.WriteString("| Short ID | Title | Author |\n")
 		b.WriteString(toolutil.TblSep3Col)
 		for _, c := range out.Commits {
+			//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which GitLab derives from the commit hash and is hexadecimal.
 			fmt.Fprintf(&b, toolutil.FmtRow3Str, c.ShortID, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName))
 		}
 	}
@@ -75,7 +76,7 @@ func FormatCompareMarkdown(out CompareOutput) string {
 		}
 	}
 	if out.WebURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURLNewline, out.WebURL)
+		toolutil.WriteMdURLNewline(&b, out.WebURL)
 	}
 	toolutil.WriteHints(
 		&b,
@@ -113,10 +114,13 @@ func FormatContributorsMarkdown(out ContributorsOutput) string {
 func FormatBlobMarkdown(out BlobOutput) string {
 	var b strings.Builder
 	b.WriteString("## Repository Blob\n\n")
-	fmt.Fprintf(&b, "- **SHA**: %s\n", out.SHA)
+	// The blob SHA is not GitLab's echo of anything it validated: it is the
+	// caller's own argument, filtered only by a remote endpoint answering 200.
+	fmt.Fprintf(&b, "- **SHA**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
 	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
 	switch out.ContentCategory {
 	case "image":
+		//gitlab:allow-unescaped out.ImageMIMEType: sniffed by http.DetectContentType on a branch that only runs when the result already begins with image/, so it is one of that function's own constants.
 		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", out.ImageMIMEType)
 		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
 	case "binary":
@@ -135,10 +139,13 @@ func FormatBlobMarkdown(out BlobOutput) string {
 func FormatRawBlobContentMarkdown(out RawBlobContentOutput) string {
 	var b strings.Builder
 	b.WriteString("## Repository Raw Blob Content\n\n")
-	fmt.Fprintf(&b, "- **SHA**: %s\n", out.SHA)
+	// The blob SHA is not GitLab's echo of anything it validated: it is the
+	// caller's own argument, filtered only by a remote endpoint answering 200.
+	fmt.Fprintf(&b, "- **SHA**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
 	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
 	switch out.ContentCategory {
 	case "image":
+		//gitlab:allow-unescaped out.ImageMIMEType: sniffed by http.DetectContentType on a branch that only runs when the result already begins with image/, so it is one of that function's own constants.
 		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", out.ImageMIMEType)
 		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
 	case "binary":
@@ -177,12 +184,15 @@ func rawBlobResult(out RawBlobContentOutput) *mcp.CallToolResult {
 func FormatArchiveMarkdown(out ArchiveOutput) string {
 	var b strings.Builder
 	b.WriteString("## Repository Archive\n\n")
-	fmt.Fprintf(&b, "- **Project**: %s\n", out.ProjectID)
-	fmt.Fprintf(&b, "- **Format**: %s\n", out.Format)
+	// Archive makes no API call at all, so all three are the caller's own
+	// arguments echoed back, format included: nothing checks it against the
+	// eight values its schema lists.
+	fmt.Fprintf(&b, "- **Project**: %s\n", toolutil.EscapeMdTableCell(out.ProjectID))
+	fmt.Fprintf(&b, "- **Format**: %s\n", toolutil.EscapeMdTableCell(out.Format))
 	if out.SHA != "" {
-		fmt.Fprintf(&b, "- **SHA/Ref**: %s\n", out.SHA)
+		fmt.Fprintf(&b, "- **SHA/Ref**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, out.URL)
+	toolutil.WriteMdURL(&b, out.URL)
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/tools/repositorysubmodules/markdown.go
+++ b/internal/tools/repositorysubmodules/markdown.go
@@ -23,7 +23,14 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 		if len(sha) > 8 {
 			sha = sha[:8]
 		}
-		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s |\n", s.Name, s.Path, sha, s.ResolvedProject)
+		// The name, the path and the resolved project all come out of the
+		// repository's own .gitmodules, so all three are text somebody typed:
+		// resolveProjectPath returns the substring after the colon of an
+		// SCP-style remote verbatim.
+		//gitlab:allow-unescaped sha: the object id of a submodule tree entry, hexadecimal by construction.
+		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s |\n",
+			toolutil.EscapeMdTableCell(s.Name), toolutil.EscapeMdTableCell(s.Path), sha,
+			toolutil.EscapeMdTableCell(s.ResolvedProject))
 	}
 	toolutil.WriteHints(&b, "Use `gitlab_read_repository_submodule_file` to view submodule content details")
 	return toolutil.ToolResultWithMarkdown(b.String())
@@ -42,10 +49,10 @@ func FormatReadMarkdown(out ReadOutput) *mcp.CallToolResult {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "## File from Submodule\n\n")
-	fmt.Fprintf(&b, "- **Submodule**: `%s`\n", out.SubmodulePath)
-	fmt.Fprintf(&b, "- **Resolved Project**: %s\n", out.ResolvedProject)
+	fmt.Fprintf(&b, "- **Submodule**: `%s`\n", toolutil.EscapeMdTableCell(out.SubmodulePath))
+	fmt.Fprintf(&b, "- **Resolved Project**: %s\n", toolutil.EscapeMdTableCell(out.ResolvedProject))
 	fmt.Fprintf(&b, "- **Commit**: `%s`\n", sha)
-	fmt.Fprintf(&b, "- **File**: `%s` (%d bytes)\n\n", out.FilePath, out.Size)
+	fmt.Fprintf(&b, "- **File**: `%s` (%d bytes)\n\n", toolutil.EscapeMdTableCell(out.FilePath), out.Size)
 	fmt.Fprintf(&b, "```%s\n%s\n```\n", ext, out.Content)
 	toolutil.WriteHints(&b, "Use `gitlab_update_repository_submodule` to change the commit SHA reference")
 	return toolutil.ToolResultWithMarkdown(b.String())
@@ -54,9 +61,15 @@ func FormatReadMarkdown(out ReadOutput) *mcp.CallToolResult {
 // FormatUpdateMarkdown formats the submodule update result as markdown.
 func FormatUpdateMarkdown(out UpdateOutput) *mcp.CallToolResult {
 	var b strings.Builder
+	// The title, the ident and the message are what a person wrote in the
+	// commit, and this package's own update action supplies the message.
+	//gitlab:allow-unescaped out.ShortID: an abbreviated commit SHA, hexadecimal by construction.
+	//gitlab:allow-unescaped out.ID: the commit SHA GitLab returned for the commit the update created, hexadecimal by construction.
 	fmt.Fprintf(&b, "## Submodule Updated\n\n- **Commit**: %s (%s)\n- **Title**: %s\n- **Author**: %s <%s>\n- **Message**: %s",
-		out.ShortID, out.ID, out.Title, out.AuthorName, out.AuthorEmail, out.Message)
+		out.ShortID, out.ID, toolutil.EscapeMdTableCell(out.Title), toolutil.EscapeMdTableCell(out.AuthorName),
+		toolutil.EscapeMdTableCell(out.AuthorEmail), toolutil.EscapeMdTableCell(out.Message))
 	if out.Status != "" {
+		//gitlab:allow-unescaped out.Status: a client-go BuildStateValue, one of a closed set of lowercase words.
 		fmt.Fprintf(&b, "\n- **Status**: %s", out.Status)
 	}
 	return toolutil.ToolResultWithMarkdown(b.String())

--- a/internal/tools/resourceevents/markdown.go
+++ b/internal/tools/resourceevents/markdown.go
@@ -7,6 +7,17 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
+// The values below reach a cell in this file with no escaper on them, because
+// each is a word GitLab picked from a fixed set rather than text anybody typed.
+// The five event kinds share them, so one declaration covers every table here.
+//
+//gitlab:allow-unescaped e.Action: a resource event action GitLab writes, either add or remove.
+//gitlab:allow-unescaped out.Action: a resource event action GitLab writes, either add or remove.
+//gitlab:allow-unescaped e.State: the state a state event recorded, one of GitLab's own set (closed, opened, merged).
+//gitlab:allow-unescaped out.State: the state a state event recorded, one of GitLab's own set (closed, opened, merged).
+//gitlab:allow-unescaped e.ResourceType: the kind of thing the event hangs on, which GitLab names Issue, MergeRequest or Epic.
+//gitlab:allow-unescaped out.ResourceType: the kind of thing the event hangs on, which GitLab names Issue, MergeRequest or Epic.
+
 // FormatLabelEventsMarkdown formats a list of label events.
 func FormatLabelEventsMarkdown(out ListLabelEventsOutput) string {
 	if len(out.Events) == 0 {
@@ -132,28 +143,35 @@ func FormatWeightEventsMarkdown(out ListWeightEventsOutput) string {
 	return sb.String()
 }
 
-// eventUsername returns the username of an event's user, or "" when absent.
+// eventUsername returns the username of an event's user as a table cell, or ""
+// when absent.
+//
+// This accessor and the three below exist only to fill the cells of this
+// file's tables, so each escapes what it returns rather than leaving the
+// question to a dozen call sites. A label name and the two titles are text a
+// person typed, and GitLab's only rule on a label name is that it holds no
+// comma.
 func eventUsername(u *EventUserOutput) string {
 	if u == nil {
 		return ""
 	}
-	return u.Username
+	return toolutil.EscapeMdTableCell(u.Username)
 }
 
-// labelName returns a label event label's name, or "" when absent.
+// labelName returns a label event label's name as a table cell, or "" when absent.
 func labelName(l *LabelEventLabelOutput) string {
 	if l == nil {
 		return ""
 	}
-	return l.Name
+	return toolutil.EscapeMdTableCell(l.Name)
 }
 
-// milestoneTitle returns a milestone's title, or "" when absent.
+// milestoneTitle returns a milestone's title as a table cell, or "" when absent.
 func milestoneTitle(m *MilestoneOutput) string {
 	if m == nil {
 		return ""
 	}
-	return m.Title
+	return toolutil.EscapeMdTableCell(m.Title)
 }
 
 // milestoneID returns a milestone's id, or 0 when absent.
@@ -164,12 +182,12 @@ func milestoneID(m *MilestoneOutput) int64 {
 	return m.ID
 }
 
-// iterationTitle returns an iteration's title, or "" when absent.
+// iterationTitle returns an iteration's title as a table cell, or "" when absent.
 func iterationTitle(it *IterationOutput) string {
 	if it == nil {
 		return ""
 	}
-	return it.Title
+	return toolutil.EscapeMdTableCell(it.Title)
 }
 
 // iterationID returns an iteration's id, or 0 when absent.

--- a/internal/tools/resourcegroups/markdown.go
+++ b/internal/tools/resourcegroups/markdown.go
@@ -17,6 +17,7 @@ func FormatListMarkdown(out ListOutput) string {
 	}
 	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Key", "Process Mode"))
 	for _, g := range out.Groups {
+		//gitlab:allow-unescaped g.ProcessMode: a resource group process mode GitLab picks from a fixed set (unordered, oldest_first, newest_first).
 		fmt.Fprintf(&sb, "| %d | %s | %s |\n", g.ID, toolutil.EscapeMdTableCell(g.Key), g.ProcessMode)
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_get_resource_group` to view details or edit process mode")
@@ -26,7 +27,9 @@ func FormatListMarkdown(out ListOutput) string {
 // FormatGroupMarkdown renders a single resource group summary.
 func FormatGroupMarkdown(g ResourceGroupItem) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Resource Group\n\n- **ID**: %d\n- **Key**: %s\n- **Process Mode**: %s\n", g.ID, g.Key, g.ProcessMode)
+	// The key is the resource_group name written in .gitlab-ci.yml.
+	fmt.Fprintf(&b, "## Resource Group\n\n- **ID**: %d\n- **Key**: %s\n- **Process Mode**: %s\n",
+		g.ID, toolutil.EscapeMdTableCell(g.Key), g.ProcessMode)
 	toolutil.WriteHints(&b, "Use `gitlab_list_resource_group_upcoming_jobs` to see upcoming jobs for this group")
 	return b.String()
 }
@@ -41,7 +44,8 @@ func FormatJobsMarkdown(out ListUpcomingJobsOutput) string {
 	}
 	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Status", "Stage"))
 	for _, j := range out.Jobs {
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, j.Stage)
+		//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
+		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, toolutil.EscapeMdTableCell(j.Stage))
 	}
 	toolutil.WriteHints(&sb, "Use job tools to view logs or retry specific jobs")
 	return sb.String()

--- a/internal/tools/runnercontrollers/markdown.go
+++ b/internal/tools/runnercontrollers/markdown.go
@@ -14,6 +14,7 @@ func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Runner Controller #%d\n\n", out.ID)
 	toolutil.WriteDescription(&b, out.Description)
+	//gitlab:allow-unescaped out.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
 	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
@@ -30,6 +31,7 @@ func FormatDetailsMarkdown(out DetailsOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Runner Controller #%d: Details\n\n", out.ID)
 	toolutil.WriteDescription(&b, out.Description)
+	//gitlab:allow-unescaped out.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
 	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
 	fmt.Fprintf(&b, "- **Connected**: %t\n", out.Connected)
 	if out.CreatedAt != "" {
@@ -54,6 +56,8 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| --- | --- | --- | --- |\n")
 	for _, rc := range out.Controllers {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n",
+			//gitlab:allow-unescaped rc.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
+			//gitlab:allow-unescaped rc.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 			rc.ID, toolutil.EscapeMdTableCell(rc.Description), rc.State, rc.CreatedAt)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/runnercontrollertokens/markdown.go
+++ b/internal/tools/runnercontrollertokens/markdown.go
@@ -16,6 +16,7 @@ func FormatOutputMarkdown(out Output) string {
 	fmt.Fprintf(&b, "- **Controller ID**: %d\n", out.RunnerControllerID)
 	toolutil.WriteDescription(&b, out.Description)
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the secret GitLab minted, which the reader has to copy back verbatim.
 		fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
 	}
 	if out.LastUsedAt != "" {
@@ -40,6 +41,8 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- |\n")
 	for _, t := range out.Tokens {
 		fmt.Fprintf(&b, "| %d | %d | %s | %s | %s |\n",
+			//gitlab:allow-unescaped t.LastUsedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
+			//gitlab:allow-unescaped t.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 			t.ID, t.RunnerControllerID, toolutil.EscapeMdTableCell(t.Description), t.LastUsedAt, t.CreatedAt)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/runners/markdown.go
+++ b/internal/tools/runners/markdown.go
@@ -15,6 +15,8 @@ func FormatOutputMarkdown(out Output) string {
 	b.WriteString(toolutil.TblSep2Col)
 	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
+	//gitlab:allow-unescaped out.RunnerType: a runner type GitLab picks from a fixed set (instance_type, group_type, project_type).
+	//gitlab:allow-unescaped out.Status: a runner status GitLab derives from when the runner last contacted it (online, offline, stale, never_contacted).
 	fmt.Fprintf(&b, "| Type | %s |\n", out.RunnerType)
 	fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
 	fmt.Fprintf(&b, "| Paused | %s |\n", toolutil.BoolEmoji(out.Paused))
@@ -36,12 +38,15 @@ func FormatDetailsMarkdown(out DetailsOutput) string {
 	b.WriteString(toolutil.TblSep2Col)
 	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
+	//gitlab:allow-unescaped out.RunnerType: a runner type GitLab picks from a fixed set (instance_type, group_type, project_type).
+	//gitlab:allow-unescaped out.Status: a runner status GitLab derives from when the runner last contacted it (online, offline, stale, never_contacted).
 	fmt.Fprintf(&b, "| Type | %s |\n", out.RunnerType)
 	fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
 	fmt.Fprintf(&b, "| Paused | %s |\n", toolutil.BoolEmoji(out.Paused))
 	fmt.Fprintf(&b, "| Shared | %s |\n", toolutil.BoolEmoji(out.IsShared))
 	fmt.Fprintf(&b, "| Online | %s |\n", toolutil.BoolEmoji(out.Online))
 	fmt.Fprintf(&b, "| Locked | %s |\n", toolutil.BoolEmoji(out.Locked))
+	//gitlab:allow-unescaped out.AccessLevel: a runner access level GitLab picks from a fixed set (not_protected, ref_protected), and refuses any other value on register and update.
 	fmt.Fprintf(&b, "| Access Level | %s |\n", out.AccessLevel)
 	fmt.Fprintf(&b, "| Run Untagged | %s |\n", toolutil.BoolEmoji(out.RunUntagged))
 	if len(out.TagList) > 0 {
@@ -83,6 +88,8 @@ func FormatListMarkdown(out ListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
 	for _, r := range out.Runners {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %t | %t |\n",
+			//gitlab:allow-unescaped r.RunnerType: the list rows carry the same runner type enum the single-runner table writes.
+			//gitlab:allow-unescaped r.Status: the list rows carry the same status enum the single-runner table writes.
 			r.ID, toolutil.EscapeMdTableCell(r.Name), r.RunnerType, r.Status, r.Paused, r.IsShared)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
@@ -106,7 +113,10 @@ func FormatJobListMarkdown(out JobListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
 	for _, j := range out.Jobs {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %.1fs |\n",
-			j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, j.Stage, toolutil.EscapeMdTableCell(j.Ref), j.Duration)
+			//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
+			// The stage name is written in .gitlab-ci.yml, and the jobs package
+			// escapes the same field in both of its tables.
+			j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, toolutil.EscapeMdTableCell(j.Stage), toolutil.EscapeMdTableCell(j.Ref), j.Duration)
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, "Use gitlab_job action 'get' with job_id for full job details")
@@ -117,6 +127,7 @@ func FormatJobListMarkdown(out JobListOutput) string {
 func FormatAuthTokenMarkdown(out AuthTokenOutput) string {
 	var b strings.Builder
 	b.WriteString("## Runner Authentication Token\n\n")
+	//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, which the reader has to copy back verbatim.
 	fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
 	if out.ExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
@@ -129,6 +140,7 @@ func FormatAuthTokenMarkdown(out AuthTokenOutput) string {
 func FormatRegTokenMarkdown(out AuthTokenOutput) string {
 	var b strings.Builder
 	b.WriteString("## Runner Registration Token\n\n")
+	//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, which the reader has to copy back verbatim.
 	fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
 	if out.ExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
@@ -148,7 +160,13 @@ func FormatManagerListMarkdown(out ManagerListOutput) string {
 	b.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
 	for _, m := range out.Managers {
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %s | %s |\n",
-			m.ID, toolutil.EscapeMdTableCell(m.SystemID), m.Version, m.Platform, m.Architecture, m.Status, m.IPAddress)
+			// The version, platform and architecture come out of the info
+			// payload the runner process posts, which GitLab length-checks and
+			// nothing else, and this server's own runner.register writes them.
+			//gitlab:allow-unescaped m.Status: a manager status GitLab derives from when the manager last contacted it (online, offline, stale, never_contacted).
+			//gitlab:allow-unescaped m.IPAddress: GitLab fills this from the address the manager connected from, never from the info payload beside it.
+			m.ID, toolutil.EscapeMdTableCell(m.SystemID), toolutil.EscapeMdTableCell(m.Version),
+			toolutil.EscapeMdTableCell(m.Platform), toolutil.EscapeMdTableCell(m.Architecture), m.Status, m.IPAddress)
 	}
 	toolutil.WriteHints(&b, "Use action 'get' with runner_id for full runner information")
 	return b.String()

--- a/internal/tools/search/markdown.go
+++ b/internal/tools/search/markdown.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/issues"
@@ -51,8 +52,9 @@ func FormatMRsMarkdown(out MergeRequestsOutput) string {
 	b.WriteString("| IID | Title | State | Author | Project | Source -> Target |\n")
 	b.WriteString(toolutil.TblSep6Col)
 	for _, mr := range out.MergeRequests {
-		fmt.Fprintf(&b, "| [!%d](%s) | %s | %s %s | %s | %s | %s -> %s |\n",
-			mr.IID, mr.WebURL,
+		//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
+		fmt.Fprintf(&b, "| %s | %s | %s %s | %s | %s | %s -> %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL),
 			toolutil.EscapeMdTableCell(mr.Title),
 			toolutil.MRStateEmoji(mr.State), mr.State,
 			toolutil.EscapeMdTableCell(mergerequests.AuthorName(mr)),
@@ -80,8 +82,9 @@ func FormatIssuesMarkdown(out IssuesOutput) string {
 	b.WriteString(toolutil.TblSep5Col)
 	for _, i := range out.Issues {
 		labels := strings.Join(i.Labels, ", ")
-		fmt.Fprintf(&b, "| [#%d](%s) | %s | %s %s | %s | %s |\n",
-			i.IID, i.WebURL,
+		//gitlab:allow-unescaped i.State: an issue state, one of GitLab's fixed set (opened, closed).
+		fmt.Fprintf(&b, "| %s | %s | %s %s | %s | %s |\n",
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", i.IID), i.WebURL),
 			toolutil.EscapeMdTableCell(i.Title),
 			toolutil.IssueStateEmoji(i.State), i.State,
 			toolutil.EscapeMdTableCell(issues.AuthorName(i)),
@@ -106,8 +109,8 @@ func FormatCommitsMarkdown(out CommitsOutput) string {
 	b.WriteString("| Short ID | Title | Author | Date |\n")
 	b.WriteString(toolutil.TblSep4Col)
 	for _, c := range out.Commits {
-		fmt.Fprintf(&b, "| [%s](%s) | %s | %s | %s |\n",
-			toolutil.EscapeMdTableCell(c.ShortID), c.WebURL,
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(c.ShortID, c.WebURL),
 			toolutil.EscapeMdTableCell(c.Title),
 			toolutil.EscapeMdTableCell(c.AuthorName),
 			toolutil.EscapeMdTableCell(c.CommittedDate))
@@ -135,8 +138,10 @@ func FormatMilestonesMarkdown(out MilestonesOutput) string {
 		if due == "" {
 			due = "\u2014"
 		}
-		fmt.Fprintf(&b, "| [%d](%s) | %s | %s | %s |\n",
-			m.IID, m.WebURL,
+		//gitlab:allow-unescaped m.State: a milestone state, one of GitLab's fixed set (active, closed).
+		//gitlab:allow-unescaped due: a due date the SDK's ISOTime rendered as digits and dashes, or the em dash substituted just above.
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+			toolutil.MdTitleLink(strconv.FormatInt(m.IID, 10), m.WebURL),
 			toolutil.EscapeMdTableCell(m.Title),
 			m.State,
 			due)
@@ -163,7 +168,9 @@ func FormatNotesMarkdown(out NotesOutput) string {
 	for _, n := range out.Notes {
 		fmt.Fprintf(&b, fmtTableRow4Col,
 			toolutil.EscapeMdTableCell(n.Author),
+			//gitlab:allow-unescaped n.NoteableType: the GitLab class a note hangs on (Issue, MergeRequest, Snippet, Commit, Epic), never text anybody types.
 			n.NoteableType,
+			//gitlab:allow-unescaped noteableRef(n.NoteableType, n.NoteableIID): that same class name and an integer IID, so the reference carries nothing a cell reacts to.
 			noteableRef(n.NoteableType, n.NoteableIID),
 			toolutil.EscapeMdTableCell(truncateBody(n.Body, 80)))
 	}
@@ -178,10 +185,9 @@ func FormatProjectsMarkdown(out ProjectsOutput) string {
 	rows := make([]searchResultRow, 0, len(out.Projects))
 	for _, p := range out.Projects {
 		rows = append(rows, searchResultRow{
-			fmt.Sprintf("[%s](%s)", toolutil.EscapeMdTableCell(p.Name), p.WebURL),
-			toolutil.EscapeMdTableCell(p.PathWithNamespace),
-			p.Visibility,
-			toolutil.EscapeMdTableCell(p.DefaultBranch),
+			Title:    p.Name,
+			TitleURL: p.WebURL,
+			Cells:    [3]string{p.PathWithNamespace, p.Visibility, p.DefaultBranch},
 		})
 	}
 	return formatSearchResultList("Project", len(out.Projects), out.Pagination, "No projects found.", "| Name | Path | Visibility | Default Branch |", rows,
@@ -189,7 +195,24 @@ func FormatProjectsMarkdown(out ProjectsOutput) string {
 		"Use gitlab_project action 'get' with the project path to see full details")
 }
 
-type searchResultRow [4]string
+// searchResultRow is one row of a four-column search result table, carried as
+// the values GitLab returned rather than as finished cells.
+//
+// Escaping them is [formatSearchResultList]'s job, so no caller can hand the
+// table a value that still has a pipe or an angle bracket in it. The callers
+// used to build the first column themselves as "[%s](%s)" around a
+// cell-escaped title, and the cell escaper leaves ']' alone: a snippet titled
+// "Fix login](http://attacker.invalid/x)" closed the label and pointed the
+// link at a host that is not GitLab, on this server's own instruction, since
+// the list carries HintPreserveLinks.
+type searchResultRow struct {
+	// Title and TitleURL are the first column: the result's name, linked to
+	// its page when GitLab returned one.
+	Title    string
+	TitleURL string
+	// Cells are the three remaining columns, in the order the header names them.
+	Cells [3]string
+}
 
 func formatSearchResultList(kind string, count int, pagination toolutil.PaginationOutput, emptyMessage, header string, rows []searchResultRow, hints ...string) string {
 	var b strings.Builder
@@ -204,7 +227,11 @@ func formatSearchResultList(kind string, count int, pagination toolutil.Paginati
 	b.WriteByte('\n')
 	b.WriteString(toolutil.TblSep4Col)
 	for _, row := range rows {
-		fmt.Fprintf(&b, fmtTableRow4Col, row[0], row[1], row[2], row[3])
+		fmt.Fprintf(&b, fmtTableRow4Col,
+			toolutil.MdTitleLink(row.Title, row.TitleURL),
+			toolutil.EscapeMdTableCell(row.Cells[0]),
+			toolutil.EscapeMdTableCell(row.Cells[1]),
+			toolutil.EscapeMdTableCell(row.Cells[2]))
 	}
 	toolutil.WritePagination(&b, pagination)
 	toolutil.WriteHints(&b, hints...)
@@ -216,10 +243,9 @@ func FormatSnippetsMarkdown(out SnippetsOutput) string {
 	rows := make([]searchResultRow, 0, len(out.Snippets))
 	for _, s := range out.Snippets {
 		rows = append(rows, searchResultRow{
-			fmt.Sprintf("[%s](%s)", toolutil.EscapeMdTableCell(s.Title), s.WebURL),
-			toolutil.EscapeMdTableCell(s.FileName),
-			s.Visibility,
-			toolutil.EscapeMdTableCell(s.Author),
+			Title:    s.Title,
+			TitleURL: s.WebURL,
+			Cells:    [3]string{s.FileName, s.Visibility, s.Author},
 		})
 	}
 	return formatSearchResultList("Snippet", len(out.Snippets), out.Pagination, "No snippets found.", "| Title | File | Visibility | Author |", rows,
@@ -239,8 +265,9 @@ func FormatUsersMarkdown(out UsersOutput) string {
 	b.WriteString("| Username | Name | State |\n")
 	b.WriteString(toolutil.TblSep3Col)
 	for _, u := range out.Users {
-		fmt.Fprintf(&b, "| [@%s](%s) | %s | %s |\n",
-			toolutil.EscapeMdTableCell(u.Username), u.WebURL,
+		//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
+		fmt.Fprintf(&b, "| %s | %s | %s |\n",
+			toolutil.MdTitleLink("@"+u.Username, u.WebURL),
 			toolutil.EscapeMdTableCell(u.Name),
 			u.State)
 	}
@@ -266,6 +293,7 @@ func FormatWikiMarkdown(out WikiOutput) string {
 		fmt.Fprintf(&b, "| %s | %s | %s |\n",
 			toolutil.EscapeMdTableCell(w.Title),
 			toolutil.EscapeMdTableCell(w.Slug),
+			//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
 			w.Format)
 	}
 	toolutil.WritePagination(&b, out.Pagination)

--- a/internal/tools/securefiles/markdown.go
+++ b/internal/tools/securefiles/markdown.go
@@ -28,6 +28,7 @@ func FormatListMarkdown(out ListOutput) string {
 	}
 	sb.WriteString("| ID | Name | Checksum Algorithm | Expires At |\n|----|------|-----------|-----------|\n")
 	for _, f := range out.Files {
+		//gitlab:allow-unescaped f.ChecksumAlgorithm: a digest algorithm name GitLab picks from a fixed set (sha256).
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", f.ID, toolutil.EscapeMdTableCell(f.Name), f.ChecksumAlgorithm, expiryOrDash(f.ExpiresAt))
 	}
 	toolutil.WritePagination(&sb, out.Pagination)
@@ -38,12 +39,17 @@ func FormatListMarkdown(out ListOutput) string {
 // FormatShowMarkdown formats a secure file as markdown.
 func FormatShowMarkdown(f SecureFileItem) string {
 	var b strings.Builder
+	//gitlab:allow-unescaped f.Checksum: a file digest GitLab computed, hexadecimal digits only.
+	//gitlab:allow-unescaped f.ChecksumAlgorithm: a digest algorithm name GitLab picks from a fixed set (sha256).
 	fmt.Fprintf(&b, "## Secure File\n\n- **ID**: %d\n- **Name**: %s\n- **Checksum**: %s\n- **Algorithm**: %s\n- **Created At**: %s\n- **Expires At**: %s\n",
-		f.ID, f.Name, f.Checksum, f.ChecksumAlgorithm, toolutil.FormatTimePtr(f.CreatedAt), toolutil.FormatTimePtr(f.ExpiresAt))
+		f.ID, toolutil.EscapeMdTableCell(f.Name), f.Checksum, f.ChecksumAlgorithm, toolutil.FormatTimePtr(f.CreatedAt), toolutil.FormatTimePtr(f.ExpiresAt))
 	if f.Metadata != nil {
 		m := f.Metadata
+		// Everything below is read out of the certificate whoever uploaded the
+		// file supplied, so its common names are whatever they put in it.
 		fmt.Fprintf(&b, "\n### Certificate Metadata\n\n- **ID**: %s\n- **Expires At**: %s\n- **Issuer CN**: %s\n- **Subject CN**: %s\n",
-			m.ID, toolutil.FormatTimePtr(m.ExpiresAt), m.Issuer.CN, m.Subject.CN)
+			toolutil.EscapeMdTableCell(m.ID), toolutil.FormatTimePtr(m.ExpiresAt),
+			toolutil.EscapeMdTableCell(m.Issuer.CN), toolutil.EscapeMdTableCell(m.Subject.CN))
 	}
 	toolutil.WriteHints(&b, "Use `gitlab_show_secure_file` to download this file")
 	return b.String()

--- a/internal/tools/securityattributes/markdown.go
+++ b/internal/tools/securityattributes/markdown.go
@@ -74,6 +74,7 @@ func FormatBulkUpdateMarkdown(out BulkUpdateOutput) string {
 	sb.WriteString(toolutil.EmojiSuccess + " Security attributes updated in bulk.\n\n")
 	sb.WriteString(fieldValueTableHeader)
 	sb.WriteString(fieldValueTableSeparator)
+	//gitlab:allow-unescaped out.Mode: a security attribute mode GitLab picks from a fixed set.
 	fmt.Fprintf(&sb, "| Mode | `%s` |\n", out.Mode)
 	fmt.Fprintf(&sb, "| Attributes | `%v` |\n", out.AttributeIDs)
 	if len(out.GroupIDs) > 0 {
@@ -95,6 +96,7 @@ func writeAttributeTable(sb *strings.Builder, out Output) {
 		fmt.Fprintf(sb, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
 	}
 	if out.EditableState != "" {
+		//gitlab:allow-unescaped out.EditableState: an editable state GitLab picks from a fixed set.
 		fmt.Fprintf(sb, "| Editable state | `%s` |\n", out.EditableState)
 	}
 	if out.SecurityCategory != nil {

--- a/internal/tools/securitycategories/markdown.go
+++ b/internal/tools/securitycategories/markdown.go
@@ -20,9 +20,11 @@ func FormatOutputMarkdown(out Output) string {
 	}
 	fmt.Fprintf(&sb, "| Multiple selection | %t |\n", out.MultipleSelection)
 	if out.EditableState != "" {
+		//gitlab:allow-unescaped out.EditableState: an editable state GitLab picks from a fixed set.
 		fmt.Fprintf(&sb, "| Editable state | `%s` |\n", out.EditableState)
 	}
 	if out.TemplateType != "" {
+		//gitlab:allow-unescaped out.TemplateType: a template type GitLab picks from a fixed set.
 		fmt.Fprintf(&sb, "| Template type | `%s` |\n", out.TemplateType)
 	}
 	if len(out.SecurityAttributes) > 0 {
@@ -34,7 +36,9 @@ func FormatOutputMarkdown(out Output) string {
 				&sb, "| `%d` | %s | `%s` | `%s` |\n",
 				attribute.ID,
 				toolutil.EscapeMdTableCell(attribute.Name),
+				//gitlab:allow-unescaped attribute.Color: a color GitLab validates as a hex literal.
 				attribute.Color,
+				//gitlab:allow-unescaped attribute.EditableState: an editable state GitLab picks from a fixed set.
 				attribute.EditableState,
 			)
 		}

--- a/internal/tools/securityfindings/markdown.go
+++ b/internal/tools/securityfindings/markdown.go
@@ -34,6 +34,7 @@ func FormatListMarkdown(out ListOutput) string {
 
 		fmt.Fprintf(
 			&sb, "| %s | %s | %s | %s | %s | %s | %s |\n",
+			//gitlab:allow-unescaped severityBadge(f.Severity): most answers are constants written here, and the fallback is a severity enum token GitLab spells as one bare word.
 			severityBadge(f.Severity),
 			toolutil.EscapeMdTableCell(f.Confidence),
 			toolutil.EscapeMdTableCell(name),

--- a/internal/tools/securityscanprofiles/markdown.go
+++ b/internal/tools/securityscanprofiles/markdown.go
@@ -12,7 +12,8 @@ import (
 func FormatMutationMarkdown(out MutationOutput) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "## Security Scan Profile\n\n%s\n\n", out.Message)
-	fmt.Fprintf(&sb, "- Profile: `%s`\n", out.SecurityScanProfileID)
+	// Echoed from the caller's own argument.
+	fmt.Fprintf(&sb, "- Profile: `%s`\n", toolutil.EscapeMdTableCell(out.SecurityScanProfileID))
 	if len(out.ProjectIDs) > 0 {
 		fmt.Fprintf(&sb, "- Projects: %s\n", joinInts(out.ProjectIDs))
 	}
@@ -27,7 +28,7 @@ func FormatMutationMarkdown(out MutationOutput) string {
 func FormatListProjectStatusesMarkdown(out ListProjectStatusesOutput) string {
 	var sb strings.Builder
 	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	fmt.Fprintf(&sb, "## Scan Profile Statuses: %s\n\n", out.ProjectFullPath)
+	fmt.Fprintf(&sb, "## Scan Profile Statuses: %s\n\n", toolutil.EscapeMdHeading(out.ProjectFullPath))
 
 	if len(out.Statuses) == 0 {
 		sb.WriteString("No scan profile statuses found.\n")

--- a/internal/tools/securitysettings/markdown.go
+++ b/internal/tools/securitysettings/markdown.go
@@ -41,7 +41,8 @@ func FormatGroupMarkdown(o GroupOutput) string {
 	if len(o.Errors) > 0 {
 		b.WriteString("\n**Errors**:\n")
 		for _, e := range o.Errors {
-			fmt.Fprintf(&b, "- %s\n", e)
+			// GitLab's own message about what it refused.
+			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(e))
 		}
 	}
 	toolutil.WriteHints(

--- a/internal/tools/snippets/markdown.go
+++ b/internal/tools/snippets/markdown.go
@@ -27,23 +27,25 @@ const hintUpdateSnippet = "Use action 'update' to modify a personal snippet; for
 // FormatMarkdown formats a single snippet as markdown.
 func FormatMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Snippet #%d: %s\n\n", out.ID, out.Title)
+	fmt.Fprintf(&b, "## Snippet #%d: %s\n\n", out.ID, toolutil.EscapeMdHeading(out.Title))
 	b.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", out.ID)
-	fmt.Fprintf(&b, "| Title | %s |\n", out.Title)
+	fmt.Fprintf(&b, "| Title | %s |\n", toolutil.EscapeMdTableCell(out.Title))
 	if out.FileName != "" {
-		fmt.Fprintf(&b, "| File Name | %s |\n", out.FileName)
+		fmt.Fprintf(&b, "| File Name | %s |\n", toolutil.EscapeMdTableCell(out.FileName))
 	}
 	if out.Description != "" {
 		fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
 	}
+	//gitlab:allow-unescaped out.Visibility: a snippet visibility GitLab answers as private, internal or public.
 	fmt.Fprintf(&b, "| Visibility | %s |\n", out.Visibility)
 	if out.Author != nil {
-		fmt.Fprintf(&b, "| Author | %s (@%s) |\n", out.Author.Name, out.Author.Username)
+		fmt.Fprintf(&b, "| Author | %s (@%s) |\n",
+			toolutil.EscapeMdTableCell(out.Author.Name), toolutil.EscapeMdTableCell(out.Author.Username))
 	}
 	if out.ProjectID != 0 {
 		if pp := extractProjectPath(out.WebURL); pp != "" {
-			fmt.Fprintf(&b, "| Project | %s |\n", pp)
+			fmt.Fprintf(&b, "| Project | %s |\n", toolutil.EscapeMdTableCell(pp))
 		} else {
 			fmt.Fprintf(&b, "| Project ID | %d |\n", out.ProjectID)
 		}
@@ -118,7 +120,10 @@ func FormatContentMarkdown(out ContentOutput) string {
 // FormatFileContentMarkdown formats snippet file content as markdown.
 func FormatFileContentMarkdown(out FileContentOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Snippet #%d File: %s (ref: %s)\n\n", out.SnippetID, out.FileName, out.Ref)
+	// Both are echoed from the caller's own arguments, and a git ref may hold
+	// '|', '<' and '>'.
+	fmt.Fprintf(&b, "## Snippet #%d File: %s (ref: %s)\n\n", out.SnippetID,
+		toolutil.EscapeMdHeading(out.FileName), toolutil.EscapeMdHeading(out.Ref))
 	b.WriteString(toolutil.MarkdownFencedBlock("", out.Content))
 	toolutil.WriteHints(
 		&b,

--- a/internal/tools/snippets/snippets.go
+++ b/internal/tools/snippets/snippets.go
@@ -235,8 +235,10 @@ func writeProjectSnippetTable(b *strings.Builder, snippets []Output) {
 	b.WriteString("|---|---|---|---|---|---|\n")
 	for _, s := range snippets {
 		proj := resolveProjectLabel(s)
+		//gitlab:allow-unescaped s.Visibility: a snippet visibility GitLab answers as private, internal or public.
 		fmt.Fprintf(b, "| %d | %s | %s | %s | @%s | %d |\n",
-			s.ID, toolutil.MdTitleLink(toolutil.EscapeMdTableCell(s.Title), s.WebURL), proj, s.Visibility, authorUsername(s.Author), len(s.Files))
+			s.ID, toolutil.MdTitleLink(s.Title, s.WebURL), toolutil.EscapeMdTableCell(proj), s.Visibility,
+			toolutil.EscapeMdTableCell(authorUsername(s.Author)), len(s.Files))
 	}
 }
 
@@ -257,7 +259,8 @@ func writeSimpleSnippetTable(b *strings.Builder, snippets []Output) {
 	b.WriteString("|---|---|---|---|---|\n")
 	for _, s := range snippets {
 		fmt.Fprintf(b, "| %d | %s | %s | @%s | %d |\n",
-			s.ID, toolutil.MdTitleLink(toolutil.EscapeMdTableCell(s.Title), s.WebURL), s.Visibility, authorUsername(s.Author), len(s.Files))
+			s.ID, toolutil.MdTitleLink(s.Title, s.WebURL), s.Visibility,
+			toolutil.EscapeMdTableCell(authorUsername(s.Author)), len(s.Files))
 	}
 }
 

--- a/internal/tools/systemhooks/markdown.go
+++ b/internal/tools/systemhooks/markdown.go
@@ -74,11 +74,14 @@ func FormatTestMarkdown(output TestOutput) *mcp.CallToolResult {
 	sb.WriteString("## Hook Test Event\n\n")
 	sb.WriteString("| Property | Value |\n")
 	sb.WriteString("|----------|-------|\n")
-	fmt.Fprintf(&sb, "| Event Name | %s |\n", e.EventName)
-	fmt.Fprintf(&sb, "| Name | %s |\n", e.Name)
-	fmt.Fprintf(&sb, "| Path | %s |\n", e.Path)
+	// A system hook event carries the name and path of whatever it fired about,
+	// both of which a person chose.
+	fmt.Fprintf(&sb, "| Event Name | %s |\n", toolutil.EscapeMdTableCell(e.EventName))
+	fmt.Fprintf(&sb, "| Name | %s |\n", toolutil.EscapeMdTableCell(e.Name))
+	fmt.Fprintf(&sb, "| Path | %s |\n", toolutil.EscapeMdTableCell(e.Path))
 	fmt.Fprintf(&sb, "| Project ID | %d |\n", e.ProjectID)
-	fmt.Fprintf(&sb, "| Owner | %s (%s) |\n", e.OwnerName, e.OwnerEmail)
+	fmt.Fprintf(&sb, "| Owner | %s (%s) |\n",
+		toolutil.EscapeMdTableCell(e.OwnerName), toolutil.EscapeMdTableCell(e.OwnerEmail))
 	toolutil.WriteHints(&sb, "Verify the hook is receiving events correctly")
 	return toolutil.ToolResultWithMarkdown(sb.String())
 }

--- a/internal/tools/tags/markdown.go
+++ b/internal/tools/tags/markdown.go
@@ -25,21 +25,25 @@ func formatTagNotFound(out tagNotFoundOutput) *mcp.CallToolResult {
 func FormatOutputMarkdownString(t Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Tag: %s\n\n", toolutil.EscapeMdHeading(t.Name))
+	//gitlab:allow-unescaped t.Target: the object id the tag resolves to, which GitLab reports as a hexadecimal SHA.
 	fmt.Fprintf(&b, toolutil.FmtMdTarget, t.Target)
 	fmt.Fprintf(&b, "- **Protected**: %v\n", t.Protected)
 	if t.Message != "" {
-		fmt.Fprintf(&b, "- **Message**: %s\n", t.Message)
+		// The annotated tag message is what whoever tagged typed, and this
+		// server's own tag.create writes it.
+		fmt.Fprintf(&b, "- **Message**: %s\n", toolutil.EscapeMdTableCell(t.Message))
 	}
 	if t.Commit != nil {
 		if t.Commit.ID != "" {
+			//gitlab:allow-unescaped t.Commit.ID: a commit SHA, hexadecimal by construction.
 			fmt.Fprintf(&b, "- **Commit SHA**: %s\n", t.Commit.ID)
 		}
 		if t.Commit.Message != "" {
-			fmt.Fprintf(&b, "- **Commit Message**: %s\n", t.Commit.Message)
+			fmt.Fprintf(&b, "- **Commit Message**: %s\n", toolutil.EscapeMdTableCell(t.Commit.Message))
 		}
 	}
 	if t.Release != nil && t.Release.Description != "" {
-		fmt.Fprintf(&b, "- **Release**: %s\n", t.Release.Description)
+		fmt.Fprintf(&b, "- **Release**: %s\n", toolutil.EscapeMdTableCell(t.Release.Description))
 	}
 	if t.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(t.CreatedAt))
@@ -89,21 +93,27 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 func FormatSignatureMarkdownString(out SignatureOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Tag Signature\n\n")
+	//gitlab:allow-unescaped out.SignatureType: a signing scheme GitLab names, one of PGP, SSH or X509.
 	fmt.Fprintf(&b, "- **Signature Type**: %s\n", out.SignatureType)
+	//gitlab:allow-unescaped out.VerificationStatus: a verification verdict GitLab computes, not text it stored.
 	fmt.Fprintf(&b, "- **Verification Status**: %s\n", out.VerificationStatus)
 	cert := out.X509Certificate
 	fmt.Fprintf(&b, "\n### X.509 Certificate\n\n")
-	fmt.Fprintf(&b, "- **Subject**: %s\n", cert.Subject)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, cert.Email)
+	// The subject and the email are read out of the signer's own certificate,
+	// which GitLab stores as parsed rather than validating.
+	fmt.Fprintf(&b, "- **Subject**: %s\n", toolutil.EscapeMdTableCell(cert.Subject))
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(cert.Email))
+	//gitlab:allow-unescaped cert.CertificateStatus: a GitLab certificate status, either good or revoked.
 	fmt.Fprintf(&b, toolutil.FmtMdStatus, cert.CertificateStatus)
 	if cert.SerialNumber != "" {
+		//gitlab:allow-unescaped cert.SerialNumber: GetSignature fills it from big.Int.String, so it holds decimal digits.
 		fmt.Fprintf(&b, "- **Serial Number**: %s\n", cert.SerialNumber)
 	}
 	issuer := cert.X509Issuer
 	fmt.Fprintf(&b, "\n### Issuer\n\n")
-	fmt.Fprintf(&b, "- **Subject**: %s\n", issuer.Subject)
+	fmt.Fprintf(&b, "- **Subject**: %s\n", toolutil.EscapeMdTableCell(issuer.Subject))
 	if issuer.CrlURL != "" {
-		fmt.Fprintf(&b, "- **CRL URL**: %s\n", issuer.CrlURL)
+		fmt.Fprintf(&b, "- **CRL URL**: %s\n", toolutil.EscapeMdTableCell(issuer.CrlURL))
 	}
 	toolutil.WriteHints(
 		&b,
@@ -163,7 +173,11 @@ func FormatListProtectedTagsMarkdownString(out ListProtectedTagsOutput) string {
 		for i, al := range t.CreateAccessLevels {
 			levels[i] = formatAccessLevelSummary(al)
 		}
-		fmt.Fprintf(&b, "| %s | %s |\n", toolutil.EscapeMdTableCell(t.Name), strings.Join(levels, ", "))
+		// GitLab's access-level description is a role name for a plain rule but
+		// a user's display name, a group's name or a deploy key's title for a
+		// granular one, and this file's detail formatter escapes the same field.
+		fmt.Fprintf(&b, "| %s | %s |\n", toolutil.EscapeMdTableCell(t.Name),
+			toolutil.EscapeMdTableCell(strings.Join(levels, ", ")))
 	}
 	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(

--- a/internal/tools/terraformstates/markdown.go
+++ b/internal/tools/terraformstates/markdown.go
@@ -26,8 +26,10 @@ func FormatListMarkdown(out ListOutput) string {
 // FormatStateMarkdown formats a single Terraform state as markdown.
 func FormatStateMarkdown(s StateItem) string {
 	var b strings.Builder
+	// The state's name is chosen by whoever ran terraform against it, and the
+	// download path is built around that name.
 	fmt.Fprintf(&b, "## Terraform State: %s\n\n- **Latest Serial**: %d\n- **Download Path**: %s\n",
-		s.Name, s.LatestSerial, s.DownloadPath)
+		toolutil.EscapeMdHeading(s.Name), s.LatestSerial, toolutil.EscapeMdTableCell(s.DownloadPath))
 	toolutil.WriteHints(
 		&b,
 		"Use `gitlab_lock_terraform_state` to lock this state",
@@ -39,7 +41,8 @@ func FormatStateMarkdown(s StateItem) string {
 // FormatLockMarkdown formats a lock/unlock result as markdown.
 func FormatLockMarkdown(out LockOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Terraform State Lock\n\n- **Success**: %v\n- **Message**: %s\n", out.Success, out.Message)
+	fmt.Fprintf(&b, "## Terraform State Lock\n\n- **Success**: %v\n- **Message**: %s\n",
+		out.Success, toolutil.EscapeMdTableCell(out.Message))
 	toolutil.WriteHints(&b, "Use `gitlab_get_terraform_state` to verify lock status")
 	return b.String()
 }

--- a/internal/tools/topics/markdown.go
+++ b/internal/tools/topics/markdown.go
@@ -34,16 +34,17 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 // FormatTopicMarkdown formats a single topic.
 func FormatTopicMarkdown(t TopicItem) *mcp.CallToolResult {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Topic: %s (ID: %d)\n\n", t.Name, t.ID)
+	// A topic's name and title are both free text an administrator types.
+	fmt.Fprintf(&sb, "## Topic: %s (ID: %d)\n\n", toolutil.EscapeMdHeading(t.Name), t.ID)
 	if t.Title != "" {
-		fmt.Fprintf(&sb, toolutil.FmtMdTitle, t.Title)
+		fmt.Fprintf(&sb, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(t.Title))
 	}
 	if t.Description != "" {
 		toolutil.WriteDescription(&sb, t.Description)
 	}
 	fmt.Fprintf(&sb, "- **Projects**: %d\n", t.TotalProjectsCount)
 	if t.AvatarURL != "" {
-		fmt.Fprintf(&sb, "- **Avatar**: %s\n", t.AvatarURL)
+		fmt.Fprintf(&sb, "- **Avatar**: %s\n", toolutil.EscapeMdTableCell(t.AvatarURL))
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_update_topic` to modify this topic")
 	return toolutil.ToolResultWithMarkdown(sb.String())

--- a/internal/tools/uploads/markdown.go
+++ b/internal/tools/uploads/markdown.go
@@ -11,12 +11,13 @@ import (
 func FormatUploadMarkdown(u UploadOutput) string {
 	var b strings.Builder
 	b.WriteString("## File Uploaded\n\n")
-	fmt.Fprintf(&b, "- **Alt**: %s\n", u.Alt)
-	fmt.Fprintf(&b, "- **URL**: %s\n", u.URL)
+	fmt.Fprintf(&b, "- **Alt**: %s\n", toolutil.EscapeMdTableCell(u.Alt))
+	fmt.Fprintf(&b, "- **URL**: %s\n", toolutil.EscapeMdTableCell(u.URL))
 	if u.FullURL != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdURL, u.FullURL)
+		toolutil.WriteMdURL(&b, u.FullURL)
 	}
-	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", u.Markdown)
+	// GitLab builds this snippet around the file name whoever uploaded it chose.
+	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", toolutil.EscapeMdTableCell(u.Markdown))
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/tools/uploads/uploads.go
+++ b/internal/tools/uploads/uploads.go
@@ -283,7 +283,11 @@ func DeleteBySecret(ctx context.Context, client *gitlabclient.Client, input Dele
 func UploadToolResult(u UploadOutput) *mcp.CallToolResult {
 	md := FormatUploadMarkdown(u)
 	if toolutil.IsImageFile(u.Alt) && u.FullURL != "" {
-		md += fmt.Sprintf("\n![%s](%s)\n", u.Alt, u.FullURL)
+		// An image embed is a link with a '!' in front, so both halves want the
+		// same escaping MdTitleLink gives a link, applied here because the
+		// helper writes no '!'.
+		md += fmt.Sprintf("\n![%s](%s)\n",
+			toolutil.EscapeMdLinkLabel(u.Alt), toolutil.EscapeMdLinkDestination(u.FullURL))
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/internal/tools/useremails/user_emails.go
+++ b/internal/tools/useremails/user_emails.go
@@ -220,7 +220,8 @@ func FormatListMarkdownString(out ListOutput) string {
 		if e.ConfirmedAt != "" {
 			confirmed = e.ConfirmedAt
 		}
-		fmt.Fprintf(&sb, "| %d | %s | %s |\n", e.ID, e.Email, confirmed)
+		//gitlab:allow-unescaped confirmed: a timestamp this package formatted itself, or the dash this loop substitutes.
+		fmt.Fprintf(&sb, "| %d | %s | %s |\n", e.ID, toolutil.EscapeMdTableCell(e.Email), confirmed)
 	}
 	return sb.String()
 }
@@ -230,8 +231,11 @@ func FormatMarkdownString(out Output) string {
 	var sb strings.Builder
 	sb.WriteString("## Email\n\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&sb, "- **Email**: %s\n", out.Email)
+	// GitLab validates an address with a regexp that forbids only '@' and
+	// whitespace, so '|' and '<' both pass.
+	fmt.Fprintf(&sb, "- **Email**: %s\n", toolutil.EscapeMdTableCell(out.Email))
 	if out.ConfirmedAt != "" {
+		//gitlab:allow-unescaped out.ConfirmedAt: a timestamp this package formatted itself from the time client-go parsed.
 		fmt.Fprintf(&sb, "- **Confirmed At**: %s\n", out.ConfirmedAt)
 	}
 	return sb.String()

--- a/internal/tools/usergpgkeys/user_gpg_keys.go
+++ b/internal/tools/usergpgkeys/user_gpg_keys.go
@@ -265,7 +265,9 @@ func FormatMarkdownString(o Output) string {
 	if len(keyPreview) > 80 {
 		keyPreview = keyPreview[:80] + "..."
 	}
-	fmt.Fprintf(&b, "- **Key**: `%s`\n", keyPreview)
+	// The preview is truncated rather than constrained, and an armored GPG
+	// block carries whatever the key's owner put in its user ID packet.
+	fmt.Fprintf(&b, "- **Key**: `%s`\n", toolutil.EscapeMdTableCell(keyPreview))
 	if o.CreatedAt != "" {
 		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(o.CreatedAt))
 	}

--- a/internal/tools/users/markdown.go
+++ b/internal/tools/users/markdown.go
@@ -26,16 +26,20 @@ func FormatMarkdownString(u Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## GitLab User: %s\n\n", toolutil.EscapeMdHeading(u.Name))
 	fmt.Fprintf(&b, toolutil.FmtMdID, u.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdUsername, u.Username)
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, u.Email)
+	fmt.Fprintf(&b, toolutil.FmtMdUsername, toolutil.EscapeMdTableCell(u.Username))
+	// GitLab validates an address with a regexp that excludes whitespace and a
+	// second '@' and admits both '|' and '<'.
+	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(u.Email))
+	//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned, ldap_blocked).
 	fmt.Fprintf(&b, toolutil.FmtMdState, u.State)
 	if u.Bio != "" {
-		fmt.Fprintf(&b, "- **Bio**: %s\n", u.Bio)
+		// A bio is free profile text, and GitLab allows newlines in it.
+		fmt.Fprintf(&b, "- **Bio**: %s\n", toolutil.EscapeMdTableCell(u.Bio))
 	}
 	fmt.Fprintf(&b, "- **Admin**: %v\n", u.IsAdmin)
-	fmt.Fprintf(&b, toolutil.FmtMdURL, u.WebURL)
+	toolutil.WriteMdURL(&b, u.WebURL)
 	if u.AvatarURL != "" {
-		fmt.Fprintf(&b, "- **Avatar**: %s\n", u.AvatarURL)
+		fmt.Fprintf(&b, "- **Avatar**: %s\n", toolutil.EscapeMdTableCell(u.AvatarURL))
 	}
 	if len(u.SCIMIdentities) > 0 {
 		b.WriteString("\n### SCIM Identities\n\n")
@@ -68,8 +72,9 @@ func FormatListMarkdownString(o ListOutput) string {
 	} else {
 		b.WriteString(toolutil.MarkdownTableHeader("ID", "Username", "Name", "Email", "State"))
 		for _, u := range o.Users {
-			fmt.Fprintf(&b, "| %d | [@%s](%s) | %s | %s | %s |\n",
-				u.ID, toolutil.EscapeMdTableCell(u.Username), u.WebURL,
+			//gitlab:allow-unescaped u.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned, ldap_blocked).
+			fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
+				u.ID, toolutil.MdTitleLink("@"+u.Username, u.WebURL),
 				toolutil.EscapeMdTableCell(u.Name),
 				toolutil.EscapeMdTableCell(u.Email), u.State)
 		}
@@ -93,12 +98,15 @@ func FormatStatusMarkdownString(o StatusOutput) string {
 	var b strings.Builder
 	b.WriteString("## User Status\n\n")
 	if o.Emoji != "" {
-		fmt.Fprintf(&b, "- **Emoji**: %s\n", o.Emoji)
+		// The status widget's emoji name is a plain string in the SDK, and this
+		// server's own set_user_status writes the field.
+		fmt.Fprintf(&b, "- **Emoji**: %s\n", toolutil.EscapeMdTableCell(o.Emoji))
 	}
 	if o.Message != "" {
-		fmt.Fprintf(&b, "- **Message**: %s\n", o.Message)
+		fmt.Fprintf(&b, "- **Message**: %s\n", toolutil.EscapeMdTableCell(o.Message))
 	}
 	if o.Availability != "" {
+		//gitlab:allow-unescaped o.Availability: a gl.AvailabilityValue, whose values are not_set and busy.
 		fmt.Fprintf(&b, "- **Availability**: %s\n", o.Availability)
 	}
 	if o.ClearStatusAt != "" {
@@ -121,9 +129,11 @@ func FormatSSHKeyMarkdownString(o SSHKeyOutput) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## SSH Key: %s\n\n", toolutil.EscapeMdHeading(o.Title))
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
-	fmt.Fprintf(&b, "- **Title**: %s\n", o.Title)
+	fmt.Fprintf(&b, "- **Title**: %s\n", toolutil.EscapeMdTableCell(o.Title))
+	//gitlab:allow-unescaped o.Key: GitLab stores only a public key it could parse, and this truncation stops inside the algorithm name and the base64 body, short of the free-text comment.
 	fmt.Fprintf(&b, "- **Key**: `%.40s...`\n", o.Key)
 	if o.UsageType != "" {
+		//gitlab:allow-unescaped o.UsageType: an SSH key usage GitLab picks from a fixed set (auth, signing, auth_and_signing).
 		fmt.Fprintf(&b, "- **Usage Type**: %s\n", o.UsageType)
 	}
 	if o.CreatedAt != "" {
@@ -151,6 +161,9 @@ func FormatSSHKeyListMarkdownString(o SSHKeyListOutput) string {
 		b.WriteString(toolutil.MarkdownTableHeader("ID", "Title", "Usage Type", "Created At", "Expires At"))
 		for _, k := range o.Keys {
 			fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
+				//gitlab:allow-unescaped k.UsageType: an SSH key usage GitLab picks from a fixed set (auth, signing, auth_and_signing).
+				//gitlab:allow-unescaped k.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
+				//gitlab:allow-unescaped k.ExpiresAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 				k.ID, toolutil.EscapeMdTableCell(k.Title), k.UsageType, k.CreatedAt, k.ExpiresAt)
 		}
 	}
@@ -202,6 +215,9 @@ func FormatContributionEventsMarkdownString(o ContributionEventsOutput) string {
 		for _, e := range o.Events {
 			target := toolutil.FormatTarget(e.TargetType, e.TargetIID, e.TargetTitle, e.TargetURL)
 			fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
+				//gitlab:allow-unescaped e.ActionName: a contribution-event action GitLab writes from its own vocabulary (opened, closed, pushed to and the rest).
+				//gitlab:allow-unescaped e.TargetType: the target's class name in GitLab, such as Issue, MergeRequest or Milestone.
+				//gitlab:allow-unescaped e.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
 				e.ID, e.ActionName, e.TargetType, target, e.CreatedAt)
 		}
 	}

--- a/internal/tools/users/user_admin.go
+++ b/internal/tools/users/user_admin.go
@@ -174,5 +174,6 @@ func FormatAdminActionMarkdownString(o AdminActionOutput) string {
 		toolutil.FmtMdID+
 		"- **Action**: %s\n"+
 		"- **Success**: %s %v\n",
+		//gitlab:allow-unescaped o.Action: one of the nine constants this file writes beside the request, never a value GitLab returned.
 		o.UserID, o.Action, toolutil.EmojiSuccess, o.Success)
 }

--- a/internal/tools/users/user_misc.go
+++ b/internal/tools/users/user_misc.go
@@ -320,6 +320,7 @@ func FormatUserActivitiesMarkdownString(o UserActivitiesOutput) string {
 		b.WriteString("|---|---|\n")
 		for _, a := range o.Activities {
 			fmt.Fprintf(&b, "| %s | %s |\n",
+				//gitlab:allow-unescaped a.LastActivityOn: a date this package formatted itself, with time.Time.Format on the ISO date layout.
 				toolutil.EscapeMdTableCell(a.Username), a.LastActivityOn)
 		}
 	}
@@ -344,6 +345,7 @@ func FormatUserMembershipsMarkdownString(o UserMembershipsOutput) string {
 		b.WriteString("|---|---|---|---|\n")
 		for _, m := range o.Memberships {
 			fmt.Fprintf(&b, "| %d | %s | %s | %d |\n",
+				//gitlab:allow-unescaped m.SourceType: GitLab names the membership source Project or Namespace, and nothing else.
 				m.SourceID, toolutil.EscapeMdTableCell(m.SourceName), m.SourceType, m.AccessLevel)
 		}
 	}
@@ -360,6 +362,7 @@ func FormatUserRunnerMarkdownString(o UserRunnerOutput) string {
 	var b strings.Builder
 	b.WriteString("## User Runner Created\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
+	//gitlab:allow-unescaped o.Token: the runner token GitLab minted, which the reader has to copy back verbatim.
 	fmt.Fprintf(&b, "- **Token**: %s\n", o.Token)
 	if o.TokenExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Token Expires At**: %s\n", toolutil.FormatTime(o.TokenExpiresAt))
@@ -377,7 +380,9 @@ func FormatDeleteUserIdentityMarkdownString(o DeleteUserIdentityOutput) string {
 		toolutil.FmtMdID+
 		"- **Provider**: %s\n"+
 		"- **Deleted**: %s %v\n",
-		o.UserID, o.Provider, toolutil.EmojiSuccess, o.Deleted)
+		// The provider is the caller's own argument echoed back, not a response
+		// field, so nothing in this repository constrains it.
+		o.UserID, toolutil.EscapeMdTableCell(o.Provider), toolutil.EmojiSuccess, o.Deleted)
 }
 
 // parseDate parses a YYYY-MM-DD string to time.Time, returning zero on failure.

--- a/internal/tools/users/user_service_accounts.go
+++ b/internal/tools/users/user_service_accounts.go
@@ -186,13 +186,13 @@ func FormatServiceAccountMarkdownString(out ServiceAccountOutput) string {
 	var sb strings.Builder
 	sb.WriteString("## Service Account\n\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&sb, "- **Username**: %s\n", out.Username)
-	fmt.Fprintf(&sb, "- **Name**: %s\n", out.Name)
+	fmt.Fprintf(&sb, "- **Username**: %s\n", toolutil.EscapeMdTableCell(out.Username))
+	fmt.Fprintf(&sb, "- **Name**: %s\n", toolutil.EscapeMdTableCell(out.Name))
 	if out.Email != "" {
-		fmt.Fprintf(&sb, "- **Email**: %s\n", out.Email)
+		fmt.Fprintf(&sb, "- **Email**: %s\n", toolutil.EscapeMdTableCell(out.Email))
 	}
 	if out.UnconfirmedEmail != "" {
-		fmt.Fprintf(&sb, "- **Unconfirmed Email**: %s\n", out.UnconfirmedEmail)
+		fmt.Fprintf(&sb, "- **Unconfirmed Email**: %s\n", toolutil.EscapeMdTableCell(out.UnconfirmedEmail))
 	}
 	return sb.String()
 }
@@ -217,16 +217,19 @@ func FormatCurrentUserPATMarkdownString(out CurrentUserPATOutput) string {
 	var sb strings.Builder
 	sb.WriteString("## Personal Access Token\n\n")
 	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&sb, "- **Name**: %s\n", out.Name)
+	fmt.Fprintf(&sb, "- **Name**: %s\n", toolutil.EscapeMdTableCell(out.Name))
 	fmt.Fprintf(&sb, "- **Active**: %v\n", out.Active)
+	//gitlab:allow-unescaped strings.Join(out.Scopes, ", "): token scopes, which GitLab refuses to store outside its own fixed set.
 	fmt.Fprintf(&sb, "- **Scopes**: %s\n", strings.Join(out.Scopes, ", "))
 	if out.Description != "" {
-		fmt.Fprintf(&sb, "- **Description**: %s\n", out.Description)
+		fmt.Fprintf(&sb, "- **Description**: %s\n", toolutil.EscapeMdTableCell(out.Description))
 	}
 	if out.ExpiresAt != "" {
+		//gitlab:allow-unescaped out.ExpiresAt: a date toolutil.NewPersonalTokenOutput formatted itself, on the ISO date layout.
 		fmt.Fprintf(&sb, "- **Expires At**: %s\n", out.ExpiresAt)
 	}
 	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: the secret GitLab minted, which the reader has to copy back verbatim.
 		fmt.Fprintf(&sb, "- **Token**: `%s`\n", out.Token)
 	}
 	return sb.String()

--- a/internal/tools/vulnerabilities/markdown.go
+++ b/internal/tools/vulnerabilities/markdown.go
@@ -56,7 +56,9 @@ func FormatGetMarkdown(out GetOutput) string {
 	v := out.Vulnerability
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "## Vulnerability: %s\n\n", v.Title)
+	// The title comes out of the security report artifact, which a repository's
+	// own CI job writes.
+	fmt.Fprintf(&sb, "## Vulnerability: %s\n\n", toolutil.EscapeMdHeading(v.Title))
 	writeVulnerabilitySummary(&sb, v)
 	writeVulnerabilityIdentifiers(&sb, v.Identifiers)
 	writeVulnerabilityDescription(&sb, v.Description)
@@ -86,11 +88,10 @@ func writeVulnerabilitySummary(sb *strings.Builder, v Item) {
 	}
 
 	if v.PrimaryID != nil {
-		id := v.PrimaryID.Name
-		if v.PrimaryID.URL != "" {
-			id = fmt.Sprintf("[%s](%s)", v.PrimaryID.Name, v.PrimaryID.URL)
-		}
-		fmt.Fprintf(sb, "| Primary Identifier | %s |\n", id)
+		// Both halves come out of the report's identifier object, so the name
+		// can close the label and the URL can close the destination.
+		fmt.Fprintf(sb, "| Primary Identifier | %s |\n",
+			toolutil.MdTitleLink(v.PrimaryID.Name, v.PrimaryID.URL))
 	}
 
 	if v.Location != nil {
@@ -145,16 +146,15 @@ func writeVulnerabilityIdentifiers(sb *strings.Builder, identifiers []Identifier
 }
 
 func writeVulnerabilityIdentifier(sb *strings.Builder, id IdentifierItem) {
-	name := toolutil.EscapeMdTableCell(id.Name)
-	if id.URL != "" {
-		name = fmt.Sprintf("[%s](%s)", toolutil.EscapeMdTableCell(id.Name), id.URL)
-	}
+	// The cell escaper neutralizes the pipe and the angle bracket and leaves
+	// ']' alone, so an identifier named "CWE-89](http://attacker.invalid/x)"
+	// closed the label and retargeted the link. MdTitleLink escapes both halves.
 	fmt.Fprintf(
 		sb, "| %s | %s | %s | %s |\n",
-		name,
+		toolutil.MdTitleLink(id.Name, id.URL),
 		toolutil.EscapeMdTableCell(id.ExternalType),
 		toolutil.EscapeMdTableCell(id.ExternalID),
-		id.URL,
+		toolutil.EscapeMdTableCell(id.URL),
 	)
 }
 
@@ -195,6 +195,8 @@ func FormatMutationMarkdown(out MutationOutput, action string) string {
 }
 
 // severityBadge returns an emoji + text badge for vulnerability severity.
+//
+//gitlab:allow-unescaped severityBadge(v.Severity): five of the six answers are constants written here, and the sixth is a VulnerabilitySeverity enum token, which GitLab spells as one bare word.
 func severityBadge(severity string) string {
 	switch strings.ToUpper(severity) {
 	case "CRITICAL":
@@ -213,11 +215,14 @@ func severityBadge(severity string) string {
 }
 
 // formatDate trims the time portion from ISO 8601 timestamps for display.
+// Slicing the first ten bytes shortens the value without saying anything about
+// what is in them, so the result is escaped: what arrives here is a GraphQL
+// field this package copies verbatim, and a cell is where it lands.
 func formatDate(ts string) string {
 	if len(ts) > 10 {
-		return ts[:10]
+		return toolutil.EscapeMdTableCell(ts[:10])
 	}
-	return ts
+	return toolutil.EscapeMdTableCell(ts)
 }
 
 // FormatSeverityCountMarkdown renders vulnerability severity counts as Markdown.

--- a/internal/tools/wikis/markdown.go
+++ b/internal/tools/wikis/markdown.go
@@ -25,10 +25,11 @@ func formatWikiNotFound(out wikiNotFoundOutput) *mcp.CallToolResult {
 func FormatOutputMarkdownString(w Output) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## Wiki: %s\n\n", toolutil.EscapeMdHeading(w.Title))
-	fmt.Fprintf(&b, "- **Slug**: %s\n", w.Slug)
+	fmt.Fprintf(&b, "- **Slug**: %s\n", toolutil.EscapeMdTableCell(w.Slug))
+	//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
 	fmt.Fprintf(&b, "- **Format**: %s\n", w.Format)
 	if w.Encoding != "" {
-		fmt.Fprintf(&b, "- **Encoding**: %s\n", w.Encoding)
+		fmt.Fprintf(&b, "- **Encoding**: %s\n", toolutil.EscapeMdTableCell(w.Encoding))
 	}
 	if w.Content != "" {
 		fmt.Fprintf(&b, "\n### Content\n\n%s\n", toolutil.WrapGFMBody(w.Content))
@@ -59,6 +60,7 @@ func FormatListMarkdownString(out ListOutput) string {
 			&b, "| %s | %s | %s |\n",
 			toolutil.EscapeMdTableCell(w.Title),
 			toolutil.EscapeMdTableCell(w.Slug),
+			//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
 			w.Format,
 		)
 	}
@@ -79,13 +81,14 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 func FormatAttachmentMarkdownString(o AttachmentOutput) string {
 	var b strings.Builder
 	b.WriteString("## Wiki Attachment Uploaded\n\n")
-	fmt.Fprintf(&b, "- **File Name**: %s\n", o.FileName)
-	fmt.Fprintf(&b, "- **File Path**: %s\n", o.FilePath)
+	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(o.FileName))
+	fmt.Fprintf(&b, "- **File Path**: %s\n", toolutil.EscapeMdTableCell(o.FilePath))
 	if o.Branch != "" {
-		fmt.Fprintf(&b, "- **Branch**: %s\n", o.Branch)
+		fmt.Fprintf(&b, "- **Branch**: %s\n", toolutil.EscapeMdTableCell(o.Branch))
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdURL, o.URL)
-	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", o.Markdown)
+	toolutil.WriteMdURL(&b, o.URL)
+	// GitLab builds this snippet around the file name whoever uploaded it chose.
+	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", toolutil.EscapeMdTableCell(o.Markdown))
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/tools/workitems/markdown.go
+++ b/internal/tools/workitems/markdown.go
@@ -13,23 +13,30 @@ import (
 func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 	wi := out.WorkItem
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Work Item #%d: %s\n\n", wi.IID, wi.Title)
-	fmt.Fprintf(&sb, "- **Type**: %s\n", wi.Type)
+	fmt.Fprintf(&sb, "## Work Item #%d: %s\n\n", wi.IID, toolutil.EscapeMdHeading(wi.Title))
+	// The type name is a GraphQL String rather than an enum, and this file's
+	// own type table already escapes the same value.
+	fmt.Fprintf(&sb, "- **Type**: %s\n", toolutil.EscapeMdTableCell(wi.Type))
+	//gitlab:allow-unescaped wi.State: a work item state from the GraphQL WorkItemState enum (OPEN, CLOSED), never text anybody types.
 	fmt.Fprintf(&sb, toolutil.FmtMdState, wi.State)
 	if wi.Status != "" {
-		fmt.Fprintf(&sb, "- **Status**: %s\n", wi.Status)
+		// The status widget carries the display name of a status in the
+		// namespace's lifecycle, which an administrator can create and rename.
+		fmt.Fprintf(&sb, "- **Status**: %s\n", toolutil.EscapeMdTableCell(wi.Status))
 	}
 	if wi.Author != "" {
-		fmt.Fprintf(&sb, toolutil.FmtMdAuthor, wi.Author)
+		fmt.Fprintf(&sb, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(wi.Author))
 	}
 	if len(wi.Assignees) > 0 {
-		fmt.Fprintf(&sb, "- **Assignees**: %s\n", strings.Join(wi.Assignees, ", "))
+		fmt.Fprintf(&sb, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(wi.Assignees, ", ")))
 	}
 	if len(wi.Labels) > 0 {
-		fmt.Fprintf(&sb, "- **Labels**: %s\n", strings.Join(wi.Labels, ", "))
+		// A label title is free text: GitLab's only rule on one is that it
+		// carries no comma.
+		fmt.Fprintf(&sb, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(wi.Labels, ", ")))
 	}
 	if wi.WebURL != "" {
-		fmt.Fprintf(&sb, "- **URL**: %s\n", wi.WebURL)
+		toolutil.WriteMdURL(&sb, wi.WebURL)
 	}
 	if wi.Description != "" {
 		fmt.Fprintf(&sb, "\n### Description\n\n%s\n", wi.Description)
@@ -39,7 +46,8 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 		sb.WriteString("| IID | Link Type | Path |\n")
 		sb.WriteString("|-----|-----------|------|\n")
 		for _, li := range wi.LinkedItems {
-			fmt.Fprintf(&sb, "| %d | %s | %s |\n", li.IID, li.LinkType, li.Path)
+			//gitlab:allow-unescaped li.LinkType: a link type from GitLab's own closed set (blocks, is_blocked_by, relates_to).
+			fmt.Fprintf(&sb, "| %d | %s | %s |\n", li.IID, li.LinkType, toolutil.EscapeMdTableCell(li.Path))
 		}
 	}
 	if len(wi.Children) > 0 {
@@ -47,7 +55,7 @@ func FormatGetMarkdown(out GetOutput) *mcp.CallToolResult {
 		sb.WriteString("| IID | Path |\n")
 		sb.WriteString("|-----|------|\n")
 		for _, c := range wi.Children {
-			fmt.Fprintf(&sb, "| %d | %s |\n", c.IID, c.Path)
+			fmt.Fprintf(&sb, "| %d | %s |\n", c.IID, toolutil.EscapeMdTableCell(c.Path))
 		}
 	}
 	toolutil.WriteHints(&sb, "Use `gitlab_update_work_item` to modify this work item")
@@ -72,7 +80,8 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	sb.WriteString("|-----|------|-------|--------|-------|--------|\n")
 	for _, wi := range out.WorkItems {
 		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s | %s |\n",
-			wi.IID, wi.Type, wi.State, wi.Status, toolutil.EscapeMdTableCell(wi.Title), wi.Author)
+			wi.IID, toolutil.EscapeMdTableCell(wi.Type), wi.State, toolutil.EscapeMdTableCell(wi.Status),
+			toolutil.EscapeMdTableCell(wi.Title), toolutil.EscapeMdTableCell(wi.Author))
 	}
 	if out.Pagination.HasNextPage {
 		fmt.Fprintf(&sb, "\n> Next page cursor: `%s`\n", out.Pagination.EndCursor)

--- a/internal/tools/workitems/work_items_test.go
+++ b/internal/tools/workitems/work_items_test.go
@@ -837,7 +837,9 @@ func TestFormatGetMarkdown_FullPopulated(t *testing.T) {
 		"**Author**: alice",
 		"**Assignees**: bob, carol",
 		"**Labels**: bug, urgent",
-		"**URL**: https://gitlab.example.com/work_items/42",
+		// The URL line is now the shared clickable one, as every other domain
+		// writes it.
+		"**URL**: [https://gitlab.example.com/work_items/42](https://gitlab.example.com/work_items/42)",
 		testSectionDesc,
 		"A very detailed description.",
 	}
@@ -965,7 +967,7 @@ func TestFormatGetMarkdown_OnlyWebURL(t *testing.T) {
 	}}
 	result := FormatGetMarkdown(out)
 	text := extractText(t, result)
-	if !strings.Contains(text, "**URL**: https://example.com/wi/1") {
+	if !strings.Contains(text, "**URL**: [https://example.com/wi/1](https://example.com/wi/1)") {
 		t.Errorf("missing URL: %s", text)
 	}
 }

--- a/internal/tools/workitemsavedviews/markdown.go
+++ b/internal/tools/workitemsavedviews/markdown.go
@@ -11,7 +11,8 @@ import (
 // FormatGetMarkdown renders one saved view, filters included.
 func FormatGetMarkdown(out GetOutput) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Saved View: %s\n\n", out.SavedView.Name)
+	// A saved view's name is free text whoever saved it typed.
+	fmt.Fprintf(&sb, "## Saved View: %s\n\n", toolutil.EscapeMdHeading(out.SavedView.Name))
 	writeViewDetails(&sb, out.SavedView)
 	if out.SavedView.Filters != nil {
 		fmt.Fprintf(&sb, "\n### Filters\n\n```json\n%s\n```\n", prettyJSON(out.SavedView.Filters))
@@ -27,7 +28,7 @@ func FormatGetMarkdown(out GetOutput) string {
 func FormatListMarkdown(out ListOutput) string {
 	var sb strings.Builder
 	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	fmt.Fprintf(&sb, "## Saved Views: %s\n\n", out.NamespacePath)
+	fmt.Fprintf(&sb, "## Saved Views: %s\n\n", toolutil.EscapeMdHeading(out.NamespacePath))
 
 	if len(out.SavedViews) == 0 {
 		sb.WriteString("No saved views found.\n")
@@ -67,14 +68,16 @@ func FormatMutateMarkdown(out MutateOutput) string {
 func writeViewDetails(sb *strings.Builder, view Item) {
 	fmt.Fprintf(sb, "- **ID**: %d\n", view.ID)
 	if view.GID != "" {
+		//gitlab:allow-unescaped view.GID: a GraphQL global id GitLab mints, gid://gitlab/ and a type name and a number.
 		fmt.Fprintf(sb, "- **Global ID**: `%s`\n", view.GID)
 	}
 	if view.Description != "" {
-		fmt.Fprintf(sb, "- **Description**: %s\n", view.Description)
+		fmt.Fprintf(sb, "- **Description**: %s\n", toolutil.EscapeMdTableCell(view.Description))
 	}
 	fmt.Fprintf(sb, "- **Private**: %v\n", view.IsPrivate)
 	fmt.Fprintf(sb, "- **Subscribed**: %v\n", view.Subscribed)
 	if view.Sort != "" {
+		//gitlab:allow-unescaped view.Sort: a work item sort key GitLab picks from its own enum (CREATED_DESC, TITLE_ASC and the rest).
 		fmt.Fprintf(sb, "- **Sort**: %s\n", view.Sort)
 	}
 }

--- a/internal/toolutil/errors.go
+++ b/internal/toolutil/errors.go
@@ -275,6 +275,8 @@ func (e *DetailedError) Error() string {
 // tool results. Includes all available context for diagnostics.
 func (e *DetailedError) Markdown() string {
 	var b strings.Builder
+	//gitlab:allow-unescaped e.Domain: the tool domain the handler named when it built the error, compiled in rather than read from GitLab.
+	//gitlab:allow-unescaped e.Action: the action the handler named when it built the error, compiled in rather than read from GitLab.
 	fmt.Fprintf(&b, "## "+EmojiCross+" Error: %s/%s\n\n", e.Domain, e.Action)
 	fmt.Fprintf(&b, "**Message**: %s\n", e.Message)
 	if e.GitLabStatus > 0 {

--- a/internal/toolutil/label_markdown.go
+++ b/internal/toolutil/label_markdown.go
@@ -35,7 +35,9 @@ func FormatLabelMarkdown(label LabelMarkdown, opts LabelMarkdownOptions) string 
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s: %s\n\n", opts.DetailTitle, EscapeMdHeading(label.Name))
 	fmt.Fprintf(&b, FmtMdID, label.ID)
-	fmt.Fprintf(&b, "- **Color**: %s\n", label.Color)
+	// Escaped rather than declared, because this file's own list table escapes
+	// the same field, and one value should not carry two answers.
+	fmt.Fprintf(&b, "- **Color**: %s\n", EscapeMdTableCell(label.Color))
 	if label.Description != "" {
 		if opts.EscapeDescription {
 			fmt.Fprintf(&b, FmtMdDescription, EscapeMdTableCell(label.Description))
@@ -59,6 +61,7 @@ func FormatLabelMarkdown(label LabelMarkdown, opts LabelMarkdownOptions) string 
 // FormatLabelListMarkdown renders project or group labels as a paginated table.
 func FormatLabelListMarkdown(labels []LabelMarkdown, pagination PaginationOutput, opts LabelMarkdownOptions) string {
 	var b strings.Builder
+	//gitlab:allow-unescaped opts.ListTitle: the section heading the labels and grouplabels packages supply as a constant, never a value read from GitLab.
 	fmt.Fprintf(&b, "## %s (%d)\n\n", opts.ListTitle, pagination.TotalItems)
 	WriteListSummary(&b, len(labels), pagination)
 	if len(labels) == 0 {

--- a/internal/toolutil/markdown.go
+++ b/internal/toolutil/markdown.go
@@ -53,8 +53,7 @@ const (
 	FmtMdTarget      = "- **Target**: %s\n"
 	FmtMdCreated     = "- **Created**: %s\n"
 	FmtMdUpdated     = "- **Updated**: %s\n"
-	FmtMdURL         = "- **URL**: [%[1]s](%[1]s)\n"
-	FmtMdURLNewline  = "\n- **URL**: [%[1]s](%[1]s)\n"
+	fmtMdURLLine     = "- **URL**: %s\n"
 	FmtMdAuthorAt    = "- **Author**: @%s\n"
 	FmtMdAuthor      = "- **Author**: %s\n"
 	FmtMdSectionText = "\n%s\n"
@@ -117,6 +116,26 @@ const (
 	EmojiNew          = "\U0001F195"   // 🆕
 	EmojiHand         = "\u270B"       // ✋
 )
+
+// WriteMdURL appends the "- **URL**: ..." line, rendering url as a link whose
+// label and destination are the same address.
+//
+// It replaces a pair of format constants that read "- **URL**: [%[1]s](%[1]s)"
+// and were used at 31 call sites. One value filling both halves of a link is a
+// shape no argument can be escaped into safely, so each of those call sites
+// hand-wrote a link with nothing in front of it, and the audit flagged every
+// one of them twice. Escaping belongs here, once, rather than in a decision
+// each of 22 packages makes for itself.
+func WriteMdURL(b *strings.Builder, url string) {
+	fmt.Fprintf(b, fmtMdURLLine, MdTitleLink(url, url))
+}
+
+// WriteMdURLNewline appends the same line as [WriteMdURL], preceded by a blank
+// line, for a formatter that closes a section with it.
+func WriteMdURLNewline(b *strings.Builder, url string) {
+	b.WriteString("\n")
+	WriteMdURL(b, url)
+}
 
 // WritePagination appends a newline-wrapped pagination summary to the builder.
 func WritePagination(b *strings.Builder, p PaginationOutput) {
@@ -293,10 +312,12 @@ func FormatStorageMoveCollectionMarkdown[T any](moves []T, pagination Pagination
 }
 
 func storageMoveEntityCell(entity StorageMoveEntityMarkdown, includeID bool) string {
-	name := EscapeMdTableCell(entity.Name)
-	if entity.URL != "" {
-		name = fmt.Sprintf("[%s](%s)", name, entity.URL)
-	}
+	// The name is a group name or a snippet title, and the cell escaper leaves
+	// the brackets alone, so a title of "Fix login](http://attacker.invalid/x)"
+	// closed the label of the link written around it here. MdTitleLink escapes
+	// both halves and returns the bare escaped name when there is no URL,
+	// which is the shape this used to build by hand.
+	name := MdTitleLink(entity.Name, entity.URL)
 	if includeID {
 		return fmt.Sprintf("%s (ID: %d)", name, entity.ID)
 	}
@@ -367,7 +388,9 @@ func FormatCICDVariableMarkdown(v CICDVariableMarkdown, opts CICDVariableMarkdow
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## %s: %s\n\n", opts.Title, v.Key)
+	// A CI/CD variable key is held to word characters by GitLab, but this same
+	// file escapes the field in its list table, so it is escaped here too.
+	fmt.Fprintf(&b, "## %s: %s\n\n", opts.Title, EscapeMdHeading(v.Key))
 	b.WriteString(TblFieldValue)
 	fmt.Fprintf(&b, "| Type | %s |\n", EscapeMdTableCell(v.VariableType))
 	fmt.Fprintf(&b, "| Protected | %s |\n", BoolEmoji(v.Protected))
@@ -614,6 +637,7 @@ func FormatDiscussionListMarkdown(discussions []DiscussionMarkdown, opts Discuss
 		WriteListSummary(&b, len(discussions), opts.Pagination)
 	}
 	for _, discussion := range discussions {
+		//gitlab:allow-unescaped discussion.ID: a discussion thread id, hexadecimal digits from the REST digest or from the numeric half of a GraphQL global id.
 		fmt.Fprintf(&b, "### Discussion %s\n", discussion.ID)
 		writeDiscussionNotes(&b, discussion.Notes)
 		b.WriteString("\n")
@@ -664,7 +688,7 @@ func FormatDiscussionNoteMarkdown(note DiscussionNoteMarkdown, hints ...string) 
 	var b strings.Builder
 	b.WriteString("## Note\n\n")
 	fmt.Fprintf(&b, FmtMdID, note.ID)
-	fmt.Fprintf(&b, FmtMdAuthorAt, note.Author)
+	fmt.Fprintf(&b, FmtMdAuthorAt, EscapeMdTableCell(note.Author))
 	b.WriteString("- **Body**:\n\n")
 	b.WriteString(WrapGFMBody(note.Body))
 	b.WriteString("\n")
@@ -800,7 +824,10 @@ func FormatTemplateListMarkdown(templates []TemplateMarkdown, pagination Paginat
 // code block.
 func FormatTemplateContentMarkdown(title, name, language, content string, hints ...string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## %s: %s\n\n", title, name)
+	//gitlab:allow-unescaped title: the template family label NewTemplateRenderer was built with, a constant at every call site.
+	// On an instance with custom file templates the set is served out of a
+	// designated project, so the name is a repository file name somebody chose.
+	fmt.Fprintf(&b, "## %s: %s\n\n", title, EscapeMdHeading(name))
 	fence := MarkdownCodeFence(content)
 	fmt.Fprintf(&b, "%s%s\n", fence, sanitizeFenceInfo(language))
 	b.WriteString(content)
@@ -954,7 +981,7 @@ type NoteMarkdownOptions struct {
 func FormatNoteMarkdown(note NoteMarkdown, opts NoteMarkdownOptions) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s #%d\n\n", opts.Title, note.ID)
-	fmt.Fprintf(&b, FmtMdAuthor, note.Author)
+	fmt.Fprintf(&b, FmtMdAuthor, EscapeMdTableCell(note.Author))
 	fmt.Fprintf(&b, FmtMdCreated, FormatTime(note.CreatedAt))
 	if note.System {
 		b.WriteString("- **System note**\n")
@@ -969,7 +996,7 @@ func FormatNoteMarkdown(note NoteMarkdown, opts NoteMarkdownOptions) string {
 		}
 		fmt.Fprintf(&b, "- **Resolvable**: %s\n", resolved)
 		if note.ResolvedBy != "" {
-			fmt.Fprintf(&b, "- **Resolved By**: @%s\n", note.ResolvedBy)
+			fmt.Fprintf(&b, "- **Resolved By**: @%s\n", EscapeMdTableCell(note.ResolvedBy))
 		}
 	}
 	fmt.Fprintf(&b, FmtMdSectionText, WrapGFMBody(note.Body))

--- a/internal/toolutil/markdown_test.go
+++ b/internal/toolutil/markdown_test.go
@@ -3,7 +3,6 @@ package toolutil
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1136,25 +1135,44 @@ func TestAppendResourceLink_NoOp(t *testing.T) {
 	})
 }
 
-// TestFmtMdURL_ClickableLinkFormat verifies that FmtMdURL produces
+// TestWriteMdURL_ClickableLinkFormat verifies that WriteMdURL produces
 // a Markdown clickable link [url](url) instead of a plain URL.
-func TestFmtMdURL_ClickableLinkFormat(t *testing.T) {
-	url := "https://gitlab.example.com/project"
-	result := fmt.Sprintf(FmtMdURL, url)
+func TestWriteMdURL_ClickableLinkFormat(t *testing.T) {
+	var b strings.Builder
+	WriteMdURL(&b, "https://gitlab.example.com/project")
 	want := "- **URL**: [https://gitlab.example.com/project](https://gitlab.example.com/project)\n"
-	if result != want {
-		t.Errorf("FmtMdURL =\n%q\nwant:\n%q", result, want)
+	if b.String() != want {
+		t.Errorf("WriteMdURL =\n%q\nwant:\n%q", b.String(), want)
 	}
 }
 
-// TestFmtMdURLNewline_ClickableLinkFormat verifies that FmtMdURLNewline
+// TestWriteMdURLNewline_ClickableLinkFormat verifies that WriteMdURLNewline
 // produces a clickable link with a leading newline.
-func TestFmtMdURLNewline_ClickableLinkFormat(t *testing.T) {
-	url := "https://gitlab.example.com/project"
-	result := fmt.Sprintf(FmtMdURLNewline, url)
+func TestWriteMdURLNewline_ClickableLinkFormat(t *testing.T) {
+	var b strings.Builder
+	WriteMdURLNewline(&b, "https://gitlab.example.com/project")
 	want := "\n- **URL**: [https://gitlab.example.com/project](https://gitlab.example.com/project)\n"
-	if result != want {
-		t.Errorf("FmtMdURLNewline =\n%q\nwant:\n%q", result, want)
+	if b.String() != want {
+		t.Errorf("WriteMdURLNewline =\n%q\nwant:\n%q", b.String(), want)
+	}
+}
+
+// TestWriteMdURL_HostileURL_CannotEndTheLink verifies that a URL cannot close
+// the destination this helper wrote around it.
+//
+// The pair of constants this helper replaced put one value in both halves of a
+// link, which is why every call site rendered a URL with nothing in front of
+// it. A destination holding ')' ended the link early and left the rest of the
+// address as prose, and a label holding '<' opened raw HTML inside it.
+func TestWriteMdURL_HostileURL_CannotEndTheLink(t *testing.T) {
+	var b strings.Builder
+	WriteMdURL(&b, "https://gitlab.example.com/x)<img src=q>")
+	got := b.String()
+	if strings.Contains(got, ")<") {
+		t.Errorf("WriteMdURL = %q, which lets the destination end early", got)
+	}
+	if !strings.Contains(got, "%29") || !strings.Contains(got, "%3C") {
+		t.Errorf("WriteMdURL = %q, want the parenthesis and angle bracket percent-encoded", got)
 	}
 }
 
@@ -1387,6 +1405,15 @@ func TestWriteDiscussionNotes_BodyCannotForgeStructure(t *testing.T) {
 			name:    "body carrying a control sequence",
 			body:    "ok\x1b[2J",
 			wantNot: []string{"\x1b"},
+		},
+		{
+			// A note with no body at all still gets its author line, and no
+			// quote block under it: an indented empty line there reads as the
+			// start of a code block rather than as part of the list item.
+			name:     "no body",
+			body:     "",
+			wantHave: []string{"**@attacker**"},
+			wantNot:  []string{"  >"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/toolutil/not_found.go
+++ b/internal/toolutil/not_found.go
@@ -20,6 +20,7 @@ import (
 // at INFO level instead of ERROR.
 func NotFoundResult(resource, identifier string, hints ...string) *mcp.CallToolResult {
 	var b strings.Builder
+	//gitlab:allow-unescaped resource: the resource label the calling formatter passes as a constant, "User" or "Project Badge" rather than anything read from GitLab.
 	fmt.Fprintf(&b, "## %s %s Not Found\n\n", EmojiQuestion, resource)
 	fmt.Fprintf(&b, "The %s **%s** does not exist or is not accessible with your current permissions.\n\n", strings.ToLower(resource), identifier)
 	WriteHints(&b, hints...)

--- a/internal/toolutil/template_markdown.go
+++ b/internal/toolutil/template_markdown.go
@@ -66,12 +66,15 @@ type TemplateDetailMarkdown struct {
 // FormatTemplateDetailMarkdown renders a shared template detail layout.
 func FormatTemplateDetailMarkdown(detail TemplateDetailMarkdown) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, FmtMdH2, detail.Title)
+	// The project-template endpoints also serve issue and merge-request
+	// description templates, whose name is a file in .gitlab/issue_templates
+	// named by whoever pushed it.
+	fmt.Fprintf(&b, FmtMdH2, EscapeMdHeading(detail.Title))
 	if detail.Key != "" {
-		fmt.Fprintf(&b, "- **Key**: %s\n", detail.Key)
+		fmt.Fprintf(&b, "- **Key**: %s\n", EscapeMdTableCell(detail.Key))
 	}
 	if detail.Nickname != "" {
-		fmt.Fprintf(&b, "- **Nickname**: %s\n", detail.Nickname)
+		fmt.Fprintf(&b, "- **Nickname**: %s\n", EscapeMdTableCell(detail.Nickname))
 	}
 	if detail.Popular {
 		b.WriteString("- **Popular**: Yes\n")
@@ -106,9 +109,12 @@ func writeTemplateDetailList(b *strings.Builder, label string, values []string, 
 	if len(values) == 0 {
 		return
 	}
+	// The permissions, conditions and limitations arrays come back as the API
+	// sent them, and nothing this server controls constrains their contents.
+	joined := EscapeMdTableCell(strings.Join(values, ", "))
 	if plain {
-		fmt.Fprintf(b, "**%s**: %s\n", label, strings.Join(values, ", "))
+		fmt.Fprintf(b, "**%s**: %s\n", label, joined)
 		return
 	}
-	fmt.Fprintf(b, "- **%s**: %s\n", label, strings.Join(values, ", "))
+	fmt.Fprintf(b, "- **%s**: %s\n", label, joined)
 }

--- a/internal/toolutil/text.go
+++ b/internal/toolutil/text.go
@@ -264,7 +264,8 @@ func RichContentHint(features, webURL string) string {
 	if features == "" || webURL == "" {
 		return ""
 	}
-	return fmt.Sprintf("\n> **Contains**: %s. [View in GitLab](%s) for full rendering.\n", features, webURL)
+	return fmt.Sprintf("\n> **Contains**: %s. %s for full rendering.\n",
+		features, MdTitleLink("View in GitLab", webURL))
 }
 
 // EscapeMdHeading sanitizes a user-controlled string that will be interpolated

--- a/internal/toolutil/time_helpers.go
+++ b/internal/toolutil/time_helpers.go
@@ -20,8 +20,19 @@ func ParseOptionalTime(s string) *time.Time {
 }
 
 // FormatTime converts an RFC3339 timestamp string to a human-readable format
-// ("2 Jan 2006 15:04 UTC"). Returns the original string unchanged if parsing
-// fails, so existing callers remain safe.
+// ("2 Jan 2006 15:04 UTC"), falling back to the date-only layout and then to
+// the string it was given.
+//
+// Every one of this function's callers writes the result straight into
+// Markdown, so the fallback runs it through [EscapeMdTableCell] rather than
+// returning it as it arrived. A value that reaches the fallback is by
+// definition not a timestamp, which leaves only two ways to get there: a field
+// this server formatted itself and a field carrying whatever GitLab put in it.
+// Returning the second verbatim put a pipe, a newline and a '<' into a table
+// cell from 155 call sites, and telling each of those call sites to escape a
+// timestamp would have taught the next reader that a date needs escaping.
+// Escaping here costs nothing that renders: neither layout's output contains
+// any character the escaper touches.
 func FormatTime(s string) string {
 	if s == "" {
 		return ""
@@ -34,7 +45,7 @@ func FormatTime(s string) string {
 	if err == nil {
 		return t.Format("2 Jan 2006")
 	}
-	return s
+	return EscapeMdTableCell(s)
 }
 
 // FormatTimePtr renders an optional *time.Time as RFC 3339, or "" when nil.

--- a/internal/toolutil/time_helpers_test.go
+++ b/internal/toolutil/time_helpers_test.go
@@ -43,13 +43,31 @@ func TestFormatTime_Empty(t *testing.T) {
 	}
 }
 
-// TestFormatTime_InvalidFormat verifies that FormatTime returns the original
-// string verbatim when it cannot be parsed as RFC 3339.
+// TestFormatTime_InvalidFormat verifies that FormatTime returns the string it
+// was given when it cannot be parsed as a timestamp, unchanged for a value
+// that renders as itself.
 func TestFormatTime_InvalidFormat(t *testing.T) {
 	input := "not-a-date"
 	got := FormatTime(input)
 	if got != input {
 		t.Errorf("FormatTime(%q) = %q, want original input", input, got)
+	}
+}
+
+// TestFormatTime_InvalidFormat_ContainsTheValue verifies that a value reaching
+// the fallback cannot change the shape of the Markdown it is written into.
+//
+// Only a value that is not a timestamp gets this far, so the fallback is the
+// one branch of this function that can be handed text somebody wrote. Every
+// caller writes the result into a table cell or a list item, and the pipe, the
+// newline and the '<' each end or reshape one.
+func TestFormatTime_InvalidFormat_ContainsTheValue(t *testing.T) {
+	got := FormatTime("a | b\nc <img src=x>")
+	if strings.ContainsAny(got, "|\n<") {
+		t.Errorf("FormatTime() = %q, which still carries a pipe, a newline or a '<'", got)
+	}
+	if !strings.Contains(got, "&#124;") || !strings.Contains(got, "&lt;") {
+		t.Errorf("FormatTime() = %q, want the pipe and the angle bracket as entities", got)
 	}
 }
 

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -69,10 +69,24 @@ function inlineLinks(line) {
 	const targets = [];
 	const pattern = /!?\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
 	let match;
-	while ((match = pattern.exec(line)) !== null) {
+	const prose = withoutCodeSpans(line);
+	while ((match = pattern.exec(prose)) !== null) {
 		targets.push(match[1]);
 	}
 	return targets;
+}
+
+// withoutCodeSpans blanks the contents of every backtick span, keeping the line
+// the same length so a reported column still points at the right place.
+//
+// Text inside a code span is quoted, not linked: prose about a formatter that
+// must not hand-write `[%s](%s)` was read as a link to a file named `%s` and
+// failed this check, which is the checker being wrong about Markdown rather
+// than the sentence being wrong about the code.
+function withoutCodeSpans(line) {
+	return line.replace(/(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/g, (span, fence, body) =>
+		fence + " ".repeat(body.length) + fence,
+	);
 }
 
 function checkTarget(file, line, rawTarget) {


### PR DESCRIPTION
Every Markdown formatter in this server interpolates GitLab-authored text into a table cell, a heading or a link, and nothing checked that any of them escaped it. The rule existed, it was written down, and it was enforced by whoever happened to review the diff. This adds the gate that enforces it instead, and then walks everything the gate found.

`cmd/audit_md_escaping` loads the whole program with the type checker rather than pattern-matching the source, which is what lets it follow a format string held in a named constant and resolve a document assembled from fragments. It parses each template with `fmt`'s real grammar, so an explicit argument index such as `%[1]s` is paired with the expression it actually names, and it classifies each verb by the Markdown context of the line it sits on: a table cell, a heading, a list item, a link label, a link destination. Then it asks whether the expression reaching that verb passed through an escaper appropriate to the context. `make check-md-escaping` is the gate, `make audit-md-escaping` writes the work list, and `make analyze` runs it as its ninth check.

The single highest-leverage finding was not in a formatter at all. `toolutil.FormatTime` tries RFC3339, then a date, and returns its input verbatim when neither parses, so 151 of the flagged sites were a GitLab-authored string reaching a cell through a function nobody thought of as a sink. One edit at that fallback cleared all of them.

The rest is the sweep: the escaper applied wherever the audit found a raw interpolation, hand-built `[text](url)` pairs replaced with `toolutil.MdTitleLink` so both halves are escaped, and headings run through `EscapeMdHeading` so a name cannot promote or demote the heading level it lands in. Regression tests cover the hostile shapes: a pipe and a newline in one value staying inside one cell, and a title of the form `Fix login](http://example.invalid/x)` failing to close the label and open a destination of its own.

An exemption is a comment in the source next to the call it excuses, in the same shape `audit_readonly_graphql` already uses, and the audit reports one that no longer matches anything so a stale exemption cannot quietly widen the gate.

Closes https://github.com/jmrplens/gitlab-mcp-server/issues/563

