### PR TITLE
test(e2e/http): let the kernel pick the shutdown harness's port, and read it back

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,221 |     255,727 |
-| Unit tests (`_test.go`)  |       715 |     417,324 |
-| End-to-end tests         |       246 |      66,251 |
-| **Total**                | **2,182** | **739,302** |
+| Unit tests (`_test.go`)  |       715 |     417,329 |
+| End-to-end tests         |       246 |      66,268 |
+| **Total**                | **2,182** | **739,324** |
 
 ### Functions
 
@@ -497,7 +497,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,733 |
+| `if err != nil` checks             | 7,734 |
 | `defer` statements                 | 1,361 |
 | `struct` types defined             | 3,099 |
 | `//nolint` suppressions            |   321 |

--- a/test/e2e/http/shutdown_test.go
+++ b/test/e2e/http/shutdown_test.go
@@ -151,11 +151,18 @@ type shutdownServer struct {
 
 // shutdownStartServer launches the binary with the given flags and waits for
 // /health, leaving the process reachable by signal.
+//
+// The port is the kernel's choice and read back from the server's own log,
+// the way startServer does it. This file used to reserve one with freePort
+// and hand the number over, and on Windows the port a listener has just
+// released is not always free again by the time the next bind asks for it:
+// the server died with "Only one usage of each socket address" and the test
+// reported that it never became healthy.
 func shutdownStartServer(t *testing.T, flags ...string) *shutdownServer {
 	t.Helper()
 
 	bin := serverBinary(t)
-	addr := "127.0.0.1:" + itoa(freePort(t))
+	addr := "127.0.0.1:" + itoa(ephemeralPort)
 
 	args := append([]string{"--http", "--http-addr=" + addr}, flags...)
 	// Not exec.CommandContext: its cancellation is a kill, and this file needs
@@ -181,11 +188,7 @@ func shutdownStartServer(t *testing.T, flags ...string) *shutdownServer {
 		defer mu.Unlock()
 		return out.String()
 	}
-	srv := &shutdownServer{
-		probe: &server{baseURL: "http://" + addr, logs: logs},
-		cmd:   cmd,
-		logs:  logs,
-	}
+	srv := &shutdownServer{cmd: cmd, logs: logs}
 
 	t.Cleanup(func() {
 		// Whatever the test concluded, nothing is left running: a server that
@@ -194,6 +197,20 @@ func shutdownStartServer(t *testing.T, flags ...string) *shutdownServer {
 		_ = cmd.Process.Kill()
 		_ = srv.wait()
 	})
+
+	// The reaping is once-guarded, so the goroutine that publishes the exit
+	// for the address wait and the test's own terminateAndWait share one
+	// Wait and both see its result.
+	exited := make(chan struct{})
+	go func() {
+		_ = srv.wait()
+		close(exited)
+	}()
+	bound, err := awaitListenAddr(logs, exited)
+	if err != nil {
+		t.Fatalf("starting the server: %v", err)
+	}
+	srv.probe = &server{baseURL: "http://" + bound, logs: logs}
 
 	waitHealthy(t, srv.probe)
 	return srv


### PR DESCRIPTION
The Windows leg of the stack's CI failed once in `test/e2e/http` with `TestHealth_Draining_AnswersServiceUnavailableBeforeTheListenerCloses` reporting that the server never became healthy, and the server's own log said why: `bind: Only one usage of each socket address (protocol/network address/port) is normally permitted`. The shutdown harness reserved a port with `freePort` and handed the number to the binary, and on Windows a port a listener has just released is not always free again by the time the next bind asks for it.

## What changes

`shutdownStartServer` asks for port 0 and reads the address the server logs, through the same `awaitListenAddr` that `startServer` already uses, so the kernel makes the choice and nothing can be handed a port that is still closing. The reaping is once-guarded, so the goroutine that publishes the exit for the address wait and the test's own `terminateAndWait` share one `Wait` and both see its result.

## Verification

`go vet -tags httpe2e` and `golangci-lint --build-tags httpe2e` on the module, and the Shutdown, Health and Drain tests green locally. The same class of fix as the `refusedDial` transport in `cmd/gen_api_shapes`: the test reaches the condition by construction rather than by racing the port allocator.
