### PR TITLE
fix(projects): answer a project with no push rules instead of dereferencing nil

### DIFF
--- a/internal/tools/projects/projects.go
+++ b/internal/tools/projects/projects.go
@@ -3280,9 +3280,11 @@ func GetPushRules(ctx context.Context, client *gitlabclient.Client, input GetPus
 			"reading push rules requires Premium/Ultimate licensing and at least Maintainer role on the project")
 	}
 	// A project whose rules were deleted is answered with null and a 200, not
-	// a 404, so it arrives here as no rule and no error.
+	// a 404, so it arrives here as no rule and no error. It is reported as a
+	// not-found, which is what it is and what a caller polling for the delete
+	// to land looks for.
 	if rule == nil {
-		return PushRuleOutput{}, errors.New("projectGetPushRules: no push rules are configured on this project. Use gitlab_project_add_push_rule to create one")
+		return PushRuleOutput{}, errors.New("projectGetPushRules: push rules not found: none are configured on this project. Use gitlab_project_add_push_rule to create one")
 	}
 	return pushRuleOutputFromGL(rule), nil
 }

--- a/internal/tools/projects/projects.go
+++ b/internal/tools/projects/projects.go
@@ -3228,7 +3228,15 @@ type PushRuleOutput struct {
 }
 
 // pushRuleOutputFromGL maps push rule output from gl between API and evaluator models.
+//
+// A nil rule maps to the zero output rather than a dereference: GitLab answers
+// a project whose rules were deleted with a body of null and a 200, which
+// client-go hands back as a nil rule and no error, and the get handler used
+// to take the whole process down on it.
 func pushRuleOutputFromGL(r *gl.ProjectPushRules) PushRuleOutput {
+	if r == nil {
+		return PushRuleOutput{}
+	}
 	out := PushRuleOutput{
 		ID:                         r.ID,
 		ProjectID:                  r.ProjectID,
@@ -3270,6 +3278,11 @@ func GetPushRules(ctx context.Context, client *gitlabclient.Client, input GetPus
 		}
 		return PushRuleOutput{}, toolutil.WrapErrWithStatusHint("projectGetPushRules", err, http.StatusForbidden,
 			"reading push rules requires Premium/Ultimate licensing and at least Maintainer role on the project")
+	}
+	// A project whose rules were deleted is answered with null and a 200, not
+	// a 404, so it arrives here as no rule and no error.
+	if rule == nil {
+		return PushRuleOutput{}, errors.New("projectGetPushRules: no push rules are configured on this project. Use gitlab_project_add_push_rule to create one")
 	}
 	return pushRuleOutputFromGL(rule), nil
 }

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -2738,8 +2738,8 @@ func TestGetPushRules_NoRulesConfigured_SaysSoInsteadOfPanicking(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a project with no push rules, got nil")
 	}
-	if !strings.Contains(err.Error(), "no push rules are configured") {
-		t.Errorf("error = %q, want it to say no push rules are configured", err)
+	if !strings.Contains(err.Error(), "push rules not found") {
+		t.Errorf("error = %q, want it to say the push rules were not found", err)
 	}
 }
 

--- a/internal/tools/projects/projects_test.go
+++ b/internal/tools/projects/projects_test.go
@@ -2720,6 +2720,39 @@ func TestGetPushRules_NotFound(t *testing.T) {
 	}
 }
 
+// TestGetPushRules_NoRulesConfigured_SaysSoInsteadOfPanicking pins the answer
+// to a project whose push rules were deleted. GitLab answers that GET with a
+// body of null and a 200, which client-go hands back as a nil rule and no
+// error; the handler used to dereference it, and in the in-process e2e suite
+// that took the whole test binary down with every test running beside it.
+func TestGetPushRules_NoRulesConfigured_SaysSoInsteadOfPanicking(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == pathPushRules42 {
+			testutil.RespondJSON(w, http.StatusOK, `null`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	_, err := GetPushRules(context.Background(), client, GetPushRulesInput{ProjectID: "42"})
+	if err == nil {
+		t.Fatal("expected an error for a project with no push rules, got nil")
+	}
+	if !strings.Contains(err.Error(), "no push rules are configured") {
+		t.Errorf("error = %q, want it to say no push rules are configured", err)
+	}
+}
+
+// TestPushRuleOutputFromGL_Nil_MapsToTheZeroOutput covers the mapper's own
+// guard, reachable from the add and edit handlers should GitLab ever answer
+// one of them with null as it does the get.
+func TestPushRuleOutputFromGL_Nil_MapsToTheZeroOutput(t *testing.T) {
+	out := pushRuleOutputFromGL(nil)
+	if out.ID != 0 || out.ProjectID != 0 || out.CommitMessageRegex != "" || out.MaxFileSize != 0 || out.CreatedAt != "" {
+		t.Errorf("pushRuleOutputFromGL(nil) = %+v, want the zero output", out)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FormatPushRuleMarkdown test
 // ---------------------------------------------------------------------------.


### PR DESCRIPTION
The licensed Enterprise e2e run found this one: `TestIndividual_PushRules/Delete` and `TestMeta_PushRules/Meta/PushRule/Delete` read the rules back after deleting them, and the process died with a nil dereference in `pushRuleOutputFromGL`. GitLab answers that GET with a body of `null` and a 200, not a 404, so client-go hands back a nil rule and no error, and the handler took the nil for a rule.

## What changes

`GetPushRules` answers a nil rule with an error saying no push rules are configured, carrying the same hint the 404 branch already gives, and `pushRuleOutputFromGL` maps nil to the zero output so the add and edit paths cannot meet the same end should GitLab ever answer them the same way.

## Why it matters beyond the suite

The shipped binary survives this through `recoverPanics`, which turns the panic into a JSON-RPC internal error, so a caller saw "internal error" where the answer is "this project has no push rules". The in-process e2e suite has no such backstop: the panic killed the test binary and 22 tests running beside it were reported as unknown, which is how one nil hid the rest of the Enterprise run.

## Verification

Two unit tests: the get handler against a mock answering `null`, and the mapper against nil. `internal/tools/projects` stays at 100% and lint-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented crashes when GitLab returns no push rule data.
  - Push-rule requests now return a clear error when no rules are configured.
  - Improved handling of empty or missing push-rule responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->