### PR TITLE
fix(epicissues): move the child under its parent the way GitLab accepts

### DIFF
--- a/internal/tools/epicissues/epic_issues.go
+++ b/internal/tools/epicissues/epic_issues.go
@@ -84,39 +84,23 @@ mutation($id: WorkItemID!) {
 }
 `
 
+// mutationReorderChild moves one child among its siblings. The item updated
+// is the child, with the epic as parentId: GitLab refuses relativePosition
+// combined with childrenIds ("Relative position cannot be combined with
+// childrenIds"), so the parent cannot be told which child moves. The mutation
+// answers with the child alone; the epic's children are listed afterwards.
 const mutationReorderChild = `
-mutation($id: WorkItemID!, $childrenIds: [WorkItemID!]!, $adjacentWorkItemId: WorkItemID!, $relativePosition: RelativePositionType!) {
+mutation($id: WorkItemID!, $parentId: WorkItemID!, $adjacentWorkItemId: WorkItemID!, $relativePosition: RelativePositionType!) {
   workItemUpdate(input: {
     id: $id
     hierarchyWidget: {
-      childrenIds: $childrenIds
+      parentId: $parentId
       adjacentWorkItemId: $adjacentWorkItemId
       relativePosition: $relativePosition
     }
   }) {
     workItem {
       id
-      widgets {
-        ... on WorkItemWidgetHierarchy {
-          children(first: 100) {
-            nodes {
-              id
-              iid
-              title
-              state
-              webUrl
-              createdAt
-              updatedAt
-              author { username }
-              widgets {
-                ... on WorkItemWidgetLabels {
-                  labels { nodes { title } }
-                }
-              }
-            }
-          }
-        }
-      }
     }
     errors
   }
@@ -504,12 +488,14 @@ func UpdateOrder(ctx context.Context, client *gitlabclient.Client, input UpdateI
 			hintEpicGIDResolution)
 	}
 
+	// The child is the item updated and the epic is its parentId; see the
+	// comment on mutationReorderChild for why the parent cannot be the target.
 	var resp gqlMutationResponse
 	_, err = client.GL().GraphQL.Do(gl.GraphQLQuery{
 		Query: mutationReorderChild,
 		Variables: map[string]any{
-			"id":                 epicGID,
-			"childrenIds":        []string{input.ChildID},
+			"id":                 input.ChildID,
+			"parentId":           epicGID,
 			"adjacentWorkItemId": input.AdjacentID,
 			"relativePosition":   pos,
 		},
@@ -523,19 +509,7 @@ func UpdateOrder(ctx context.Context, client *gitlabclient.Client, input UpdateI
 		return ListOutput{}, fmt.Errorf("epicIssueUpdate: %s", resp.Data.WorkItemUpdate.Errors[0])
 	}
 
-	var children []ChildOutput
-	if resp.Data.WorkItemUpdate.WorkItem != nil {
-		for _, w := range resp.Data.WorkItemUpdate.WorkItem.Widgets {
-			if w.Children != nil {
-				for _, n := range w.Children.Nodes {
-					children = append(children, nodeToChildOutput(n))
-				}
-			}
-		}
-	}
-	if len(children) == 0 {
-		return List(ctx, client, ListInput{FullPath: input.FullPath, IID: input.IID})
-	}
-
-	return ListOutput{Issues: children}, nil
+	// The mutation answers with the child that moved, not with the epic's
+	// children, so the order the caller asked about is read back from the epic.
+	return List(ctx, client, ListInput{FullPath: input.FullPath, IID: input.IID})
 }

--- a/internal/tools/epicissues/epic_issues_test.go
+++ b/internal/tools/epicissues/epic_issues_test.go
@@ -124,12 +124,25 @@ const gqlRemoveParentData = `{
   }
 }`
 
-const gqlReorderData = `{
+// gqlReorderAck is what the reorder mutation answers with: the child that
+// moved, and nothing about its siblings. The epic's children are read back
+// with the list query afterwards.
+const gqlReorderAck = `{
   "workItemUpdate": {
+    "workItem": {"id": "gid://gitlab/WorkItem/10"},
+    "errors": []
+  }
+}`
+
+// gqlChildrenReordered is the epic's children as the list query answers them
+// after 10 was moved before 20.
+const gqlChildrenReordered = `{
+  "namespace": {
     "workItem": {
       "id": "gid://gitlab/WorkItem/1",
       "widgets": [{
         "children": {
+          "pageInfo": {"hasNextPage": false, "hasPreviousPage": false, "endCursor": "", "startCursor": ""},
           "nodes": [
             {
               "id": "gid://gitlab/WorkItem/20",
@@ -156,8 +169,7 @@ const gqlReorderData = `{
           ]
         }
       }]
-    },
-    "errors": []
+    }
   }
 }`
 
@@ -184,6 +196,27 @@ func resolveHandler(childPath string) http.HandlerFunc {
 		} else {
 			testutil.RespondGraphQL(w, http.StatusOK, gqlWorkItemGIDData)
 		}
+	}
+}
+
+// reorderAck answers the reorder mutation with the moved child when the
+// variables carry the values in want and no childrenIds, and with a mutation
+// error otherwise, so a document that drifts back to naming the children
+// beside relativePosition fails here the way GitLab fails it.
+func reorderAck(want map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars, _ := testutil.ParseGraphQLVariables(r)
+		if _, forbidden := vars["childrenIds"]; forbidden {
+			testutil.RespondGraphQL(w, http.StatusOK, gqlMutationErrors)
+			return
+		}
+		for name, value := range want {
+			if vars[name] != value {
+				testutil.RespondGraphQL(w, http.StatusOK, gqlMutationErrors)
+				return
+			}
+		}
+		testutil.RespondGraphQL(w, http.StatusOK, gqlReorderAck)
 	}
 }
 
@@ -811,12 +844,22 @@ func TestUpdateOrder(t *testing.T) {
 				ChildID: "gid://gitlab/WorkItem/10", AdjacentID: "gid://gitlab/WorkItem/20",
 				RelativePosition: "BEFORE",
 			},
+			// Three documents reach the mock: the GID resolution, the mutation,
+			// and the listing that reads the order back. The list query also
+			// says "workItem(iid", so its own, longer key has to be present or
+			// it would be answered as a resolution.
 			handler: graphqlMux(map[string]http.HandlerFunc{
 				"workItem(iid": func(w http.ResponseWriter, _ *http.Request) {
 					testutil.RespondGraphQL(w, http.StatusOK, gqlWorkItemGIDData)
 				},
-				"workItemUpdate(": func(w http.ResponseWriter, _ *http.Request) {
-					testutil.RespondGraphQL(w, http.StatusOK, gqlReorderData)
+				// The child is the item updated and the epic its parent; a
+				// document that named childrenIds beside relativePosition is
+				// what GitLab refused.
+				"workItemUpdate(": reorderAck(map[string]string{
+					"id": "gid://gitlab/WorkItem/10", "parentId": "gid://gitlab/WorkItem/1", "relativePosition": "BEFORE",
+				}),
+				"WorkItemWidgetHierarchy": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusOK, gqlChildrenReordered)
 				},
 			}),
 			check: func(t *testing.T, out ListOutput) {
@@ -843,8 +886,9 @@ func TestUpdateOrder(t *testing.T) {
 				"workItem(iid": func(w http.ResponseWriter, _ *http.Request) {
 					testutil.RespondGraphQL(w, http.StatusOK, gqlWorkItemGIDData)
 				},
-				"workItemUpdate(": func(w http.ResponseWriter, _ *http.Request) {
-					testutil.RespondGraphQL(w, http.StatusOK, gqlReorderData)
+				"workItemUpdate(": reorderAck(map[string]string{"relativePosition": "AFTER"}),
+				"WorkItemWidgetHierarchy": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusOK, gqlChildrenMultiple)
 				},
 			}),
 			check: func(t *testing.T, out ListOutput) {
@@ -865,8 +909,9 @@ func TestUpdateOrder(t *testing.T) {
 				"workItem(iid": func(w http.ResponseWriter, _ *http.Request) {
 					testutil.RespondGraphQL(w, http.StatusOK, gqlWorkItemGIDData)
 				},
-				"workItemUpdate(": func(w http.ResponseWriter, _ *http.Request) {
-					testutil.RespondGraphQL(w, http.StatusOK, gqlReorderData)
+				"workItemUpdate(": reorderAck(map[string]string{"relativePosition": "BEFORE"}),
+				"WorkItemWidgetHierarchy": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusOK, gqlChildrenMultiple)
 				},
 			}),
 			check: func(t *testing.T, out ListOutput) {
@@ -875,6 +920,29 @@ func TestUpdateOrder(t *testing.T) {
 					t.Fatalf("got %d issues, want 2", len(out.Issues))
 				}
 			},
+		},
+		{
+			// The move is done and GitLab acknowledged it; what fails is reading
+			// the order back, which is reported as the listing's own error so a
+			// caller does not retry a reorder that already happened.
+			name: "reports the listing's error when reading the order back fails",
+			input: UpdateInput{
+				FullPath: testFullPath, IID: 1,
+				ChildID: "gid://gitlab/WorkItem/10", AdjacentID: "gid://gitlab/WorkItem/20",
+				RelativePosition: "BEFORE",
+			},
+			handler: graphqlMux(map[string]http.HandlerFunc{
+				"workItem(iid": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusOK, gqlWorkItemGIDData)
+				},
+				"workItemUpdate(": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusOK, gqlReorderAck)
+				},
+				"WorkItemWidgetHierarchy": func(w http.ResponseWriter, _ *http.Request) {
+					testutil.RespondGraphQL(w, http.StatusInternalServerError, `{"message":"boom"}`)
+				},
+			}),
+			wantErr: "epicIssueList",
 		},
 		{
 			name:    "returns error when full_path is empty",


### PR DESCRIPTION
The licensed Enterprise e2e run failed `TestMeta_EpicIssues/EpicIssueUpdate_Reorder` with GitLab's own words: "Relative position cannot be combined with childrenIds". The reorder mutation updated the epic with `hierarchyWidget{childrenIds, adjacentWorkItemId, relativePosition}`, a document the pinned schema accepts and the instance refuses, which is the class of defect the schema check cannot see.

## What changes

The item updated is the child, with the epic as `parentId` beside `adjacentWorkItemId` and `relativePosition`, which is the shape GitLab's own frontend sends when an item is dragged in the tree. That answer names the child alone, so the handler reads the epic's children back with the list query it already had, and answers the order the caller asked about.

## Verification

The three reorder cases now drive a mock that refuses any document carrying `childrenIds` and checks the child, parent and position variables, and a fourth case pins that a listing that fails after an acknowledged move is reported as the listing's error, so a caller does not retry a reorder that already happened. `internal/tools/epicissues` stays at 100% and lint-clean; the test transport validated the new document and its variables against the pinned schema.
