### PR TITLE
test(e2e): let the Docker fixture run on another host, on IPv4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,21 @@ ORBIT_FIXTURES_INDEXER_TIMEOUT ?= 600
 # cross-entity CI/MR data. Adds ~5 min of mirror time on first run.
 ORBIT_FIXTURES_MIRROR ?= false
 E2E_DOCKER_ENTERPRISE_TIMEOUT ?= 3600s
+# Where the e2e Docker fixture is reached from the machine running the suite.
+# Docker itself follows DOCKER_HOST or the active context, so the fixture can
+# run on another host: `DOCKER_HOST=ssh://truenas
+# E2E_DOCKER_GITLAB_URL=http://192.168.0.40:8929 make test-e2e-docker`. GitLab's
+# own idea of its URL (external_url, and the registry's beside it) follows the
+# same value, so the web_url fields it answers with are the ones the tests
+# reach. Bitbucket is published on loopback by default and has to be bound to
+# the LAN (E2E_BITBUCKET_BIND=0.0.0.0) when the fixture is remote.
+E2E_DOCKER_GITLAB_URL ?= http://localhost:8929
+E2E_DOCKER_REGISTRY_URL ?= $(patsubst %:8929,%:5050,$(E2E_DOCKER_GITLAB_URL))
+E2E_DOCKER_BITBUCKET_URL ?= http://localhost:7990
+E2E_BITBUCKET_BIND ?= 127.0.0.1
+export E2E_GITLAB_EXTERNAL_URL = $(E2E_DOCKER_GITLAB_URL)
+export E2E_REGISTRY_EXTERNAL_URL = $(E2E_DOCKER_REGISTRY_URL)
+export E2E_BITBUCKET_BIND
 
 # Read version from VERSION file (single source of truth)
 VERSION := $(strip $(file < VERSION))
@@ -242,11 +257,11 @@ test-e2e-docker: ensure-gotestsum
 	@openssl rand -hex 16 > test/e2e/.bitbucket-admin-pass
 	E2E_BITBUCKET_ADMIN_PASSWORD=$$(cat test/e2e/.bitbucket-admin-pass) docker compose -f test/e2e/docker-compose.yml --profile bitbucket up -d
 	@echo "=== Waiting for GitLab readiness ==="
-	./test/e2e/scripts/wait-for-gitlab.sh http://localhost:8929 600
+	./test/e2e/scripts/wait-for-gitlab.sh $(E2E_DOCKER_GITLAB_URL) 600
 	@echo "=== Setting up test user and token ==="
 	@set -e; \
 	for attempt in 1 2 3; do \
-		if ./test/e2e/scripts/setup-gitlab.sh http://localhost:8929; then \
+		if ./test/e2e/scripts/setup-gitlab.sh $(E2E_DOCKER_GITLAB_URL); then \
 			break; \
 		fi; \
 		if [ "$$attempt" -eq 3 ]; then \
@@ -257,9 +272,9 @@ test-e2e-docker: ensure-gotestsum
 		sleep 5; \
 	done
 	@echo "=== Registering GitLab Runner ==="
-	./test/e2e/scripts/register-runner.sh http://localhost:8929
+	./test/e2e/scripts/register-runner.sh $(E2E_DOCKER_GITLAB_URL)
 	@echo "=== Provisioning Bitbucket import fixture ==="
-	E2E_BITBUCKET_ADMIN_PASSWORD=$$(cat test/e2e/.bitbucket-admin-pass) ./test/e2e/scripts/setup-bitbucket.sh http://localhost:7990
+	E2E_BITBUCKET_ADMIN_PASSWORD=$$(cat test/e2e/.bitbucket-admin-pass) ./test/e2e/scripts/setup-bitbucket.sh $(E2E_DOCKER_BITBUCKET_URL)
 	@echo "=== Running E2E tests ==="
 	$(call MKDIR_P,$(E2E_REPORT_DIR))
 	@set +e; \
@@ -288,11 +303,11 @@ test-e2e-docker-enterprise: ensure-gotestsum
 	  if [ -z "$$activation_code" ] && [ -s "$${E2E_ENTERPRISE_LICENSE_FILE:-test/e2e/.enterprise-license}" ]; then echo "    Reusing cached Enterprise license during setup"; fi; \
 	  GITLAB_IMAGE=$${GITLAB_IMAGE:-gitlab/gitlab-ee:latest} GITLAB_ACTIVATION_CODE="$$activation_code" docker compose -f test/e2e/docker-compose.yml up -d
 	@echo "=== Waiting for GitLab readiness ==="
-	./test/e2e/scripts/wait-for-gitlab.sh http://localhost:8929 600
+	./test/e2e/scripts/wait-for-gitlab.sh $(E2E_DOCKER_GITLAB_URL) 600
 	@echo "=== Setting up test user, token, and Enterprise license ==="
 	@set -e; \
 	for attempt in 1 2 3; do \
-		if GITLAB_ENTERPRISE=true ./test/e2e/scripts/setup-gitlab.sh http://localhost:8929; then \
+		if GITLAB_ENTERPRISE=true ./test/e2e/scripts/setup-gitlab.sh $(E2E_DOCKER_GITLAB_URL); then \
 			break; \
 		fi; \
 		if [ "$$attempt" -eq 3 ]; then \
@@ -303,7 +318,7 @@ test-e2e-docker-enterprise: ensure-gotestsum
 		sleep 5; \
 	done
 	@echo "=== Registering GitLab Runner ==="
-	./test/e2e/scripts/register-runner.sh http://localhost:8929
+	./test/e2e/scripts/register-runner.sh $(E2E_DOCKER_GITLAB_URL)
 	@echo "=== Running Enterprise E2E tests ==="
 	@$(call MKDIR_P,$(E2E_REPORT_DIR))
 	@set +e; \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -109,6 +109,29 @@ Or use the Makefile target:
 make test-e2e-docker
 ```
 
+### Running the fixture on another host
+
+The containers need about 5 GB and a few cores for ten minutes of boot, which
+is a poor fit for a busy workstation. Docker follows `DOCKER_HOST` (or the
+active context), so the whole fixture can run elsewhere while the suite runs
+here; the Makefile only has to know where GitLab is reachable from this
+machine:
+
+```bash
+DOCKER_HOST=ssh://truenas \
+E2E_DOCKER_GITLAB_URL=http://192.168.0.40:8929 \
+E2E_DOCKER_BITBUCKET_URL=http://192.168.0.40:7990 \
+E2E_BITBUCKET_BIND=0.0.0.0 \
+make test-e2e-docker          # or test-e2e-docker-enterprise
+```
+
+`E2E_DOCKER_GITLAB_URL` is also handed to the container as its `external_url`
+(the registry's follows on port 5050), so the `web_url` fields GitLab answers
+with name the address the tests reach. Bitbucket is published on loopback by
+default and has to be bound to the remote host's LAN address for the setup
+script and the import test to reach it. The published ports are then open on
+that host's network: use it on a LAN you trust.
+
 ### Docker Enterprise Mode
 
 Enterprise mode uses the same Docker topology with the EE image and a local

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -1,3 +1,12 @@
+# IPv4 only, whatever the daemon's default is. A host whose Docker enables IPv6
+# on new networks (TrueNAS SCALE does, with a fdd0::/48 pool) hands every
+# service an IPv6 address as well, GitLab resolves e2e-fixture to that one
+# first, and the hook test fails with "Failed to open TCP connection to
+# fdd0:0:0:3::2:8080" against a fixture nothing reaches over IPv6.
+networks:
+  default:
+    enable_ipv6: false
+
 services:
   gitlab:
     image: ${GITLAB_IMAGE:-gitlab/gitlab-ce:latest}

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       GITLAB_ACTIVATION_CODE: ${GITLAB_ACTIVATION_CODE:-}
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://localhost:8929'
+        external_url '${E2E_GITLAB_EXTERNAL_URL:-http://localhost:8929}'
         nginx['listen_port'] = 80
         nginx['listen_https'] = false
         gitlab_rails['monitoring_whitelist'] = ['0.0.0.0/0', '::/0']
@@ -33,7 +33,7 @@ services:
         # (gitlab_registry_tag_protection_*) can be exercised end-to-end instead
         # of skipped. The protection-rules API is DB-backed and does not require
         # pushing images, so no TLS or client access to :5050 is needed.
-        registry_external_url 'http://localhost:5050'
+        registry_external_url '${E2E_REGISTRY_EXTERNAL_URL:-http://localhost:5050}'
         registry['enable'] = true
         gitlab_rails['registry_enabled'] = true
         registry_nginx['listen_port'] = 5050
@@ -115,7 +115,10 @@ services:
     container_name: e2e-bitbucket
     profiles: ["bitbucket"]
     ports:
-      - "127.0.0.1:7990:7990"
+      # Loopback by default: nothing but the setup script and the import test
+      # on this machine should reach it. A fixture running on another host is
+      # bound to that host's LAN address instead (E2E_BITBUCKET_BIND=0.0.0.0).
+      - "${E2E_BITBUCKET_BIND:-127.0.0.1}:7990:7990"
     environment:
       SEARCH_ENABLED: "false"
       JVM_MAXIMUM_MEMORY: "1024m"


### PR DESCRIPTION
The containers of the e2e Docker fixture need about 5 GB and a few cores for ten minutes of boot, which is a poor fit for the workstation that runs the suite, so they belong on the TrueNAS box beside the Go compile that already runs there. Docker follows `DOCKER_HOST`, but the two Docker targets and the compose file spelled `localhost` for GitLab, the registry and Bitbucket.

## What changes

The address the suite reaches GitLab at is `E2E_DOCKER_GITLAB_URL`, handed to the container as its `external_url` (the registry's follows on port 5050) so the `web_url` fields GitLab answers with name the address the tests reach; Bitbucket's address and bind are their own variables, and loopback stays the default everywhere. The compose network declares `enable_ipv6: false`: a daemon that enables IPv6 on new networks, as TrueNAS SCALE does with a `fdd0::/48` pool, handed every service an IPv6 address, GitLab resolved `e2e-fixture` to that one first, and the group hook test failed against a fixture nothing reaches over IPv6. `test/e2e/README.md` documents the remote form.

## Verification

The first licensed Enterprise run with the fixture on truenas went through boot, activation, setup and runner registration over `DOCKER_HOST=ssh://truenas`; it is what found the two server defects fixed below this layer and the IPv6 resolution fixed here. `make -n` shows the substituted URLs and `docker compose config` renders the interpolated `external_url`, registry URL and Bitbucket bind.
