### PR TITLE
fix(security): read the line numbers GitLab sends as the strings they are

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,221 |     255,727 |
-| Unit tests (`_test.go`)  |       715 |     417,329 |
-| End-to-end tests         |       246 |      66,268 |
-| **Total**                | **2,182** | **739,324** |
+| Source (`.go`, non-test) |     1,221 |     255,764 |
+| Unit tests (`_test.go`)  |       715 |     417,507 |
+| End-to-end tests         |       246 |      66,271 |
+| **Total**                | **2,182** | **739,542** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  9,437 |
+| Source functions                |  9,440 |
 | . Exported (public)             |  2,938 |
-| . Unexported (private)          |  6,499 |
-| Unit test functions (`TestXxx`) | 14,256 |
-| Subtests (`t.Run(...)`)         |  5,687 |
+| . Unexported (private)          |  6,502 |
+| Unit test functions (`TestXxx`) | 14,260 |
+| Subtests (`t.Run(...)`)         |  5,690 |
 | End-to-end test functions       |    603 |
 
 ### Ratios worth noting
@@ -490,14 +490,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~209 lines |
 | Average test file length           |                 ~584 lines |
-| Comment lines in source            |  45,468 (~17.8% of source) |
+| Comment lines in source            |  45,506 (~17.8% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,734 |
+| `if err != nil` checks             | 7,736 |
 | `defer` statements                 | 1,361 |
 | `struct` types defined             | 3,099 |
 | `//nolint` suppressions            |   321 |
@@ -522,8 +522,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,649 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 14,769 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,650 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 14,778 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/docs/development/request-inventory.json
+++ b/docs/development/request-inventory.json
@@ -3820,6 +3820,7 @@
         "adjacentWorkItemId",
         "childrenIds",
         "id",
+        "parentId",
         "relativePosition"
       ]
     },

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,8 +18,8 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,859 |
-| Unit test functions                                   | 14,256 |
+| Total test functions                                  | 14,863 |
+| Unit test functions                                   | 14,260 |
 | E2E test functions                                    |    603 |
 | cmd test functions                                    |  2,871 |
 | Test files (internal/)                                |    520 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,856 | 79.8% |
+| `TestFunc_Scenario` (2-part)           | 11,858 | 79.8% |
 | `TestFunc` (no underscore)             |    980 |  6.6% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,023 | 13.6% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,025 | 13.6% |
 
 ## Test Distribution
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,442 |        145 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            340 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (177) |          8,603 |        359 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (177) |          8,607 |        359 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            603 |        240 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
 | cmd packages            |          2,871 |        195 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,859** |    **955** |                                                                                                 |
+| **Total**               |     **14,863** |    **955** |                                                                                                 |
 
 ### Core Packages
 
@@ -84,7 +84,7 @@
 
 | Sub-package       | Tests | Coverage | Tools |
 | ----------------- | ----: | -------: | ----: |
-| projects          |   391 |   100.0% |    57 |
+| projects          |   393 |   100.0% |    57 |
 | groups            |   249 |   100.0% |    37 |
 | mergerequests     |   245 |   100.0% |    30 |
 | issues            |   223 |   100.0% |    21 |
@@ -249,7 +249,7 @@
 | projectimportexport     |        40 |          1 |    99.6% |         5 |
 | projectiterations       |        18 |          1 |   100.0% |         1 |
 | projectmirrors          |        63 |          2 |   100.0% |         7 |
-| projects                |       391 |          6 |   100.0% |        57 |
+| projects                |       393 |          6 |   100.0% |        57 |
 | projectserviceaccounts  |        11 |          2 |   100.0% |         8 |
 | projectstatistics       |         8 |          2 |   100.0% |         1 |
 | projectstoragemoves     |        19 |          2 |   100.0% |         6 |
@@ -270,7 +270,7 @@
 | securefiles             |        28 |          2 |   100.0% |         4 |
 | securityattributes      |        24 |          1 |   100.0% |         5 |
 | securitycategories      |        16 |          1 |   100.0% |         3 |
-| securityfindings        |        23 |          1 |   100.0% |         1 |
+| securityfindings        |        24 |          1 |   100.0% |         1 |
 | securityscanprofiles    |        17 |          1 |   100.0% |         3 |
 | securitysettings        |        32 |          3 |   100.0% |         3 |
 | settings                |        17 |          1 |    94.4% |         2 |
@@ -289,12 +289,12 @@
 | useremails              |        24 |          2 |   100.0% |         6 |
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       210 |          7 |   100.0% |        38 |
-| vulnerabilities         |        65 |          3 |   100.0% |         8 |
+| vulnerabilities         |        66 |          3 |   100.0% |         8 |
 | waitpoll                |        13 |          1 |    99.2% |         0 |
 | wikis                   |        61 |          2 |   100.0% |         6 |
 | workitems               |       120 |          3 |   100.0% |         6 |
 | workitemsavedviews      |        52 |          4 |   100.0% |         7 |
-| **Total**               | **8,603** |    **359** |          | **1,187** |
+| **Total**               | **8,607** |    **359** |          | **1,187** |
 
 </details>
 

--- a/internal/tools/securityfindings/security_findings.go
+++ b/internal/tools/securityfindings/security_findings.go
@@ -183,6 +183,15 @@ func lineNumber(s string) int {
 	return n
 }
 
+// lowercased spells filter values the way GitLab's finder looks them up.
+func lowercased(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = strings.ToLower(strings.TrimSpace(v))
+	}
+	return out
+}
+
 // gqlVulnerabilityRef holds a reference to a vulnerability.
 type gqlVulnerabilityRef struct {
 	ID    string `json:"id"`
@@ -325,14 +334,19 @@ func List(ctx context.Context, client *gitlabclient.Client, input ListInput) (Li
 			"pipelineIID": input.PipelineIID,
 		},
 	)
+	// severity and reportType are plain String arguments on this field, not
+	// the enums the vulnerability queries take, and GitLab looks the values up
+	// in its own lowercase enums (Security::Finding.severities.fetch_values,
+	// Security::Scan.by_scan_types): CRITICAL or SAST as spelled everywhere
+	// else in this server is a KeyError there and comes back as a 500.
 	if len(input.Severity) > 0 {
-		vars["severity"] = input.Severity
+		vars["severity"] = lowercased(input.Severity)
 	}
 	if len(input.Scanner) > 0 {
 		vars["scanner"] = input.Scanner
 	}
 	if len(input.ReportType) > 0 {
-		vars["reportType"] = input.ReportType
+		vars["reportType"] = lowercased(input.ReportType)
 	}
 	if len(input.State) > 0 {
 		vars["state"] = input.State

--- a/internal/tools/securityfindings/security_findings.go
+++ b/internal/tools/securityfindings/security_findings.go
@@ -3,6 +3,8 @@ package securityfindings
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
@@ -157,13 +159,28 @@ type gqlIdentifier struct {
 	URL          string `json:"url"`
 }
 
+// gqlLocation is the location a finding reports. GitLab types startLine and
+// endLine as String on every location type in the pinned schema, and a live
+// instance sends them quoted; an int here made the whole response fail to
+// decode.
 type gqlLocation struct {
 	File      string `json:"file"`
 	Path      string `json:"path"`
 	Image     string `json:"image"`
-	StartLine int    `json:"startLine"`
-	EndLine   int    `json:"endLine"`
+	StartLine string `json:"startLine"`
+	EndLine   string `json:"endLine"`
 	BlobPath  string `json:"blobPath"`
+}
+
+// lineNumber reads the line GitLab spells as a string. A value that is not a
+// number, which the schema allows, reads as no line rather than an error, since
+// a finding is worth reporting whether or not its line parsed.
+func lineNumber(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // gqlVulnerabilityRef holds a reference to a vulnerability.
@@ -240,8 +257,8 @@ func nodeToItem(n gqlFindingNode) FindingItem {
 	if n.Location != nil {
 		loc := &LocationItem{
 			File:      n.Location.File,
-			StartLine: n.Location.StartLine,
-			EndLine:   n.Location.EndLine,
+			StartLine: lineNumber(n.Location.StartLine),
+			EndLine:   lineNumber(n.Location.EndLine),
 			BlobPath:  n.Location.BlobPath,
 		}
 		if loc.File == "" && n.Location.Path != "" {

--- a/internal/tools/securityfindings/security_findings_test.go
+++ b/internal/tools/securityfindings/security_findings_test.go
@@ -179,6 +179,7 @@ func TestList_WithFilters(t *testing.T) {
 					}
 				})
 			}
+			assertLowercasedOnTheWire(t, vars)
 			testutil.RespondGraphQL(w, http.StatusOK, `{
 				"project": {
 					"pipeline": {
@@ -207,6 +208,34 @@ func TestList_WithFilters(t *testing.T) {
 	}
 	if len(out.Findings) != 0 {
 		t.Errorf("expected 0 findings, got %d", len(out.Findings))
+	}
+}
+
+// assertLowercasedOnTheWire pins that severity and reportType reach GitLab in
+// lowercase: they are String arguments GitLab looks up in its own lowercase
+// enums, and the licensed run met a 500 for CRITICAL and SAST. It runs on the
+// mock's goroutine, so it reports and never aborts.
+func assertLowercasedOnTheWire(t *testing.T, vars map[string]any) {
+	t.Helper()
+	for _, tc := range []struct {
+		key  string
+		want []string
+	}{
+		{key: "severity", want: []string{"high", "critical"}},
+		{key: "reportType", want: []string{"sast"}},
+	} {
+		t.Run(tc.key+" is lowercased on the wire", func(t *testing.T) {
+			got, _ := vars[tc.key].([]any)
+			if len(got) != len(tc.want) {
+				t.Errorf("%s = %v, want %v", tc.key, vars[tc.key], tc.want)
+				return
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("%s[%d] = %v, want %q", tc.key, i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }
 

--- a/internal/tools/securityfindings/security_findings_test.go
+++ b/internal/tools/securityfindings/security_findings_test.go
@@ -31,8 +31,8 @@ const sampleFindingNode = `{
   ],
   "location": {
     "file": "src/app.js",
-    "startLine": 42,
-    "endLine": 42,
+    "startLine": "42",
+    "endLine": "42",
     "blobPath": "/src/app.js"
   },
   "state": "DETECTED",
@@ -803,5 +803,29 @@ func TestList_NullProject(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing/proj") {
 		t.Errorf("error = %q, want contains project path", err.Error())
+	}
+}
+
+// TestLineNumber_ReadsGitLabsStringAndTakesNothingElseForALine pins how the
+// line a location carries is read. GitLab types startLine and endLine as
+// String, and the licensed e2e run found a live instance sending them quoted
+// while the response struct expected an int, which failed the whole decode.
+func TestLineNumber_ReadsGitLabsStringAndTakesNothingElseForALine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "a quoted number", in: "42", want: 42},
+		{name: "a number with spaces around it", in: " 7 ", want: 7},
+		{name: "an empty string", in: "", want: 0},
+		{name: "a value that is not a number", in: "n/a", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lineNumber(tt.in); got != tt.want {
+				t.Errorf("lineNumber(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/tools/vulnerabilities/vulnerabilities.go
+++ b/internal/tools/vulnerabilities/vulnerabilities.go
@@ -3,6 +3,8 @@ package vulnerabilities
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v2"
 
@@ -214,13 +216,28 @@ type gqlScanner struct {
 	Vendor string `json:"vendor"`
 }
 
+// gqlLocation is the location a finding reports. GitLab types startLine and
+// endLine as String on every location type (VulnerabilityLocationSast and its
+// siblings in the pinned schema), and a live instance sends them quoted; an
+// int here made the whole response fail to decode.
 type gqlLocation struct {
 	File      string `json:"file"`
 	Path      string `json:"path"`
 	Image     string `json:"image"`
-	StartLine int    `json:"startLine"`
-	EndLine   int    `json:"endLine"`
+	StartLine string `json:"startLine"`
+	EndLine   string `json:"endLine"`
 	BlobPath  string `json:"blobPath"`
+}
+
+// lineNumber reads the line GitLab spells as a string. A value that is not a
+// number, which the schema allows, reads as no line rather than an error, since
+// a finding is worth reporting whether or not its line parsed.
+func lineNumber(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 type gqlProject struct {
@@ -308,8 +325,8 @@ func nodeToItem(n gqlVulnerabilityNode) Item {
 	if n.Location != nil {
 		loc := &LocationItem{
 			File:      n.Location.File,
-			StartLine: n.Location.StartLine,
-			EndLine:   n.Location.EndLine,
+			StartLine: lineNumber(n.Location.StartLine),
+			EndLine:   lineNumber(n.Location.EndLine),
 			BlobPath:  n.Location.BlobPath,
 		}
 		if loc.File == "" && n.Location.Path != "" {

--- a/internal/tools/vulnerabilities/vulnerabilities_test.go
+++ b/internal/tools/vulnerabilities/vulnerabilities_test.go
@@ -36,8 +36,8 @@ const sampleVulnNode = `{
   },
   "location": {
     "file": "app/controllers/sessions_controller.rb",
-    "startLine": 42,
-    "endLine": 42,
+    "startLine": "42",
+    "endLine": "42",
     "blobPath": "/project/-/blob/main/app/controllers/sessions_controller.rb"
   }
 }`
@@ -72,8 +72,8 @@ const sampleVulnGetNode = `{
   },
   "location": {
     "file": "app/controllers/sessions_controller.rb",
-    "startLine": 42,
-    "endLine": 42,
+    "startLine": "42",
+    "endLine": "42",
     "blobPath": "/project/-/blob/main/app/controllers/sessions_controller.rb"
   },
   "project": {
@@ -1206,4 +1206,28 @@ func containsStr(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// TestLineNumber_ReadsGitLabsStringAndTakesNothingElseForALine pins how the
+// line a location carries is read. GitLab types startLine and endLine as
+// String, and the licensed e2e run found a live instance sending them quoted
+// while the response struct expected an int, which failed the whole decode.
+func TestLineNumber_ReadsGitLabsStringAndTakesNothingElseForALine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "a quoted number", in: "42", want: 42},
+		{name: "a number with spaces around it", in: " 7 ", want: 7},
+		{name: "an empty string", in: "", want: 0},
+		{name: "a value that is not a number", in: "n/a", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lineNumber(tt.in); got != tt.want {
+				t.Errorf("lineNumber(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
 }

--- a/test/e2e/suite/enterprise_ee_test.go
+++ b/test/e2e/suite/enterprise_ee_test.go
@@ -1348,10 +1348,10 @@ func TestMeta_StorageMoves(t *testing.T) {
 // gitlab_security_finding meta-tool.
 // Requires GitLab Premium/Ultimate (GITLAB_ENTERPRISE=true).
 //
-// Its fixture is a fresh project with no pipeline, so an empty listing is the
-// correct answer and these subtests can only show that the action routes and
-// that its filters are accepted. That is deliberately not enough to catch a
-// refused GraphQL document, which also answers empty and without an error: the
+// Its fixture is a fresh project with no pipeline, so a not-found naming the
+// pipeline is the correct answer and these subtests can only show that the
+// action routes, refuses a pipeline it cannot find, and accepts its filters.
+// That is deliberately not enough to catch a refused GraphQL document: the
 // assertion that the findings really come back lives in
 // [TestMeta_VulnerabilityLifecycle], which owns a pipeline that publishes
 // three CRITICAL SAST findings.
@@ -1364,20 +1364,23 @@ func TestMeta_SecurityFindings(t *testing.T) {
 	ctx := context.Background()
 	proj := createProjectMeta(ctx, t, sess.meta)
 
+	// The fixture has no pipeline, so the one right answer to pipeline 1 is a
+	// not-found that names it: the action refuses a pipeline it cannot find
+	// rather than answering an empty page a caller would read as no findings.
 	t.Run("Meta/SecurityFinding/List", func(t *testing.T) {
-		out, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
+		_, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
 			"action": "list",
 			"params": map[string]any{
 				"project_path": proj.Path,
 				"pipeline_iid": "1",
 			},
 		})
-		requirePremiumFeature(t, err, "security findings")
-		t.Logf("Security findings: %d", len(out.Findings))
+		requireTruef(t, isNotFoundError(err), "security findings of a project with no pipeline: want a not-found naming the pipeline, got %v", err)
+		t.Logf("Security findings for a missing pipeline: %v", err)
 	})
 
 	t.Run("Meta/SecurityFinding/ListFiltered", func(t *testing.T) {
-		out, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
+		_, err := callToolOn[securityfindings.ListOutput](ctx, sess.meta, "gitlab_security_finding", map[string]any{
 			"action": "list",
 			"params": map[string]any{
 				"project_path": proj.Path,
@@ -1387,8 +1390,8 @@ func TestMeta_SecurityFindings(t *testing.T) {
 				"first":        10,
 			},
 		})
-		requireNoError(t, err, "security findings list with filters")
-		t.Logf("Filtered security findings: %d", len(out.Findings))
+		requireTruef(t, isNotFoundError(err), "filtered security findings of a project with no pipeline: want a not-found naming the pipeline, got %v", err)
+		t.Logf("Filtered security findings for a missing pipeline: %v", err)
 	})
 }
 


### PR DESCRIPTION
The licensed Enterprise run on truenas, with the two server defects below this layer fixed, still failed every vulnerability and security-finding call that carried a located finding: `json: cannot unmarshal string into Go struct field ...location.startLine of type int`. GitLab types `startLine` and `endLine` as `String` on every location type, the pinned schema in `internal/graphqlschema` says so, and a live Ultimate instance sends them quoted; the response structs of both tools declared them as `int`, so the whole response failed to decode. The test transport validates documents and variables against the schema and cannot see a response shape, which is the gap this fell through.

## What changes

`gqlLocation` in `internal/tools/vulnerabilities` and `internal/tools/securityfindings` reads the two lines as strings and parses them into the published `start_line` and `end_line`, which stay integers, so no output schema, snapshot or document moves. A value that is not a number reads as no line rather than an error, since a finding is worth reporting whether or not its line parsed.

`TestMeta_SecurityFindings` in the Enterprise suite expected an empty page for pipeline 1 of a project that has no pipeline; the action refuses a pipeline it cannot find, which is the right answer, so the test now expects that not-found.

The third run then failed exactly one case, the filtered listing of `TestMeta_VulnerabilityLifecycle`, with a 500 from GitLab. `securityReportFindings` takes `severity` and `reportType` as plain `[String!]`, not the enums the vulnerability queries take, and GitLab's finder looks the values up in its own lowercase enums (`Security::Finding.severities.fetch_values`, `Security::Scan.by_scan_types`), so `CRITICAL` and `SAST` raised there. The handler now lowercases both on the wire, the input keeps the spelling every other tool documents, and the filters test asserts what reaches the mock.

## Verification

Both packages at 100% with the fixtures requoted and a table test on the parser; lint clean; the Enterprise half of the suite vets and lints under its tags. The Enterprise run that follows this layer is what proves it against the instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Security findings and vulnerability locations now handle GitLab’s string-formatted line numbers correctly.
  - Security findings filters now work consistently regardless of capitalization or extra surrounding spaces.
  - Security-finding lookups now correctly report when no pipeline is available.

- **Documentation**
  - Refreshed project and test statistics to reflect the current codebase.

- **Tests**
  - Expanded coverage for filter normalization, line-number handling, and pipeline-related responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->