### PR TITLE
refactor(eval): assemble the evaluated catalogs the way the server does

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,221 |     255,764 |
-| Unit tests (`_test.go`)  |       715 |     417,507 |
-| End-to-end tests         |       246 |      66,271 |
-| **Total**                | **2,182** | **739,542** |
+| Source (`.go`, non-test) |     1,221 |     255,756 |
+| Unit tests (`_test.go`)  |       715 |     417,369 |
+| End-to-end tests         |       246 |      66,251 |
+| **Total**                | **2,182** | **739,376** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  9,440 |
+| Source functions                |  9,437 |
 | . Exported (public)             |  2,938 |
-| . Unexported (private)          |  6,502 |
-| Unit test functions (`TestXxx`) | 14,260 |
-| Subtests (`t.Run(...)`)         |  5,690 |
+| . Unexported (private)          |  6,499 |
+| Unit test functions (`TestXxx`) | 14,257 |
+| Subtests (`t.Run(...)`)         |  5,687 |
 | End-to-end test functions       |    603 |
 
 ### Ratios worth noting
@@ -490,15 +490,15 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~209 lines |
 | Average test file length           |                 ~584 lines |
-| Comment lines in source            |  45,506 (~17.8% of source) |
+| Comment lines in source            |  45,501 (~17.8% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,736 |
-| `defer` statements                 | 1,361 |
+| `if err != nil` checks             | 7,734 |
+| `defer` statements                 | 1,362 |
 | `struct` types defined             | 3,099 |
 | `//nolint` suppressions            |   321 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
@@ -523,7 +523,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~4,650 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 14,778 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 14,772 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,221 |     255,756 |
-| Unit tests (`_test.go`)  |       715 |     417,369 |
+| Source (`.go`, non-test) |     1,221 |     255,778 |
+| Unit tests (`_test.go`)  |       715 |     417,499 |
 | End-to-end tests         |       246 |      66,251 |
-| **Total**                | **2,182** | **739,376** |
+| **Total**                | **2,182** | **739,528** |
 
 ### Functions
 
@@ -479,8 +479,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Source functions                |  9,437 |
 | . Exported (public)             |  2,938 |
 | . Unexported (private)          |  6,499 |
-| Unit test functions (`TestXxx`) | 14,257 |
-| Subtests (`t.Run(...)`)         |  5,687 |
+| Unit test functions (`TestXxx`) | 14,260 |
+| Subtests (`t.Run(...)`)         |  5,689 |
 | End-to-end test functions       |    603 |
 
 ### Ratios worth noting
@@ -490,17 +490,17 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~209 lines |
 | Average test file length           |                 ~584 lines |
-| Comment lines in source            |  45,501 (~17.8% of source) |
+| Comment lines in source            |  45,518 (~17.8% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,734 |
+| `if err != nil` checks             | 7,735 |
 | `defer` statements                 | 1,362 |
 | `struct` types defined             | 3,099 |
-| `//nolint` suppressions            |   321 |
+| `//nolint` suppressions            |   323 |
 | `TODO` / `FIXME` / `HACK` comments |     2 |
 
 ### Project
@@ -523,7 +523,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Source code printed at 55 lines/page | ~4,650 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 14,772 (impossible to avoid)                                                                         |
+| Source lines mentioning `"gitlab"`   | 14,773 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/eval_mcp_surfaces/internal/evaluator/doc.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/doc.go
@@ -14,6 +14,17 @@
 //  4. Results are aggregated into a Markdown report and optional trace
 //     artifacts.
 //
+// # The evaluated surface
+//
+// The catalog a model is scored against is assembled by the same functions
+// cmd/server assembles its own with: dynamiccatalog.Build for the dynamic
+// surface and tools.SharedMetaCatalog for the meta surface, both given a
+// config.ServerConfig built from --server-mode. Assembling an equivalent
+// catalog here instead would measure a surface the product does not serve:
+// the filters and the standalone actions have an order, and the bookkeeping
+// they produce is what tells a model that a withheld write exists and is not
+// available, rather than that the server cannot do it at all.
+//
 // # Public API
 //
 // [Run] is the CLI entry point. [AllEvalCases], [CaseByID], [CasesByPreset],

--- a/cmd/eval_mcp_surfaces/internal/evaluator/doc.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/doc.go
@@ -25,6 +25,15 @@
 // they produce is what tells a model that a withheld write exists and is not
 // available, rather than that the server cannot do it at all.
 //
+// The catalog is what this mirrors, and only the catalog. cmd/server runs one
+// further pass after registration, over the tools registered outside the
+// catalog: in read-only mode it removes every registered tool without a
+// read-only hint, and in safe mode it wraps the rest with previews. The meta
+// surface registers the gitlab_interactive_* creation flows that way, so in a
+// read-only or safe-mode meta evaluation those flows keep their real handlers
+// here while the product would have withdrawn or previewed them. Closing that
+// means the pass moving out of cmd/server, not a second copy of it here.
+//
 // # Public API
 //
 // [Run] is the CLI entry point. [AllEvalCases], [CaseByID], [CasesByPreset],

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamiccatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -400,18 +401,22 @@ func newCatalogSession(client *gitlabclient.Client, toolSurface, serverMode stri
 	return session, closeSession, err
 }
 
-// applyEvalServerMode applies the protective server mode to the catalog the
-// evaluated model will see, using the same catalog transforms the server
-// applies for GITLAB_MCP_READ_ONLY and GITLAB_MCP_SAFE_MODE. Both act per action, so
-// evaluating them means evaluating a different catalog, not a different client.
-func applyEvalServerMode(catalog *actioncatalog.Catalog, serverMode string) *actioncatalog.Catalog {
-	switch serverMode {
-	case ServerModeReadOnly:
-		return catalog.FilterReadOnlyActions()
-	case ServerModeSafe:
-		return catalog.WithSafeModePreviews()
-	default:
-		return catalog
+// evalServerConfig describes the deployment the evaluated catalog is assembled
+// for, so the assemblers the server itself uses can be handed the same
+// configuration a server would receive.
+//
+// The tier is the one thing this has to state rather than pass through:
+// [edition.TierForEnterprise] is the mapping the catalog builders apply to the
+// legacy binary "enterprise" notion, so an enterprise client evaluates the
+// Ultimate catalog and a Community one the Free catalog, exactly as before.
+// GITLAB_MCP_READ_ONLY and GITLAB_MCP_SAFE_MODE both act per action, so
+// evaluating either means evaluating a different catalog, not a different
+// client.
+func evalServerConfig(client *gitlabclient.Client, serverMode string) *config.ServerConfig {
+	return &config.ServerConfig{
+		Tier:     edition.TierForEnterprise(client.IsEnterprise()),
+		ReadOnly: serverMode == ServerModeReadOnly,
+		SafeMode: serverMode == ServerModeSafe,
 	}
 }
 
@@ -434,31 +439,37 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface, serverMode st
 			return completionHandler.Complete(ctx, req)
 		},
 	})
+	cfg := evalServerConfig(client, serverMode)
 	var surfaceCatalog *actioncatalog.Catalog
 	switch toolSurface {
 	case config.ToolSurfaceDynamic:
-		actionCatalog, catalogErr := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Enterprise: client.IsEnterprise(), IncludeMCP: true})
+		// dynamiccatalog.Build is the assembler cmd/server uses, in the order
+		// it uses it: the filters run before the standalone actions join, so
+		// no narrowed action is left behind them, and safe-mode previews come
+		// last over the whole catalog, so a standalone write is previewed like
+		// any other. Assembling an equivalent catalog here was what the e2e
+		// suite did before this package existed, and a test that builds its
+		// own copy of the thing under test is testing the copy.
+		actionCatalog, withheld, catalogErr := dynamiccatalog.Build(client, cfg)
 		if catalogErr != nil {
 			return nil, nil, nil, nil, fmt.Errorf(errBuildActionCatalog, catalogErr)
 		}
-		actionCatalog, catalogErr = dynamictools.AddStandaloneCatalog(actionCatalog, client, dynamictools.StandaloneOptions{})
-		if catalogErr != nil {
-			return nil, nil, nil, nil, fmt.Errorf("add standalone dynamic catalog: %w", catalogErr)
-		}
-		actionCatalog = applyEvalServerMode(actionCatalog, serverMode)
 		surfaceCatalog = actionCatalog
-		dynamictools.RegisterCatalogFindExecuteTools(server, actionCatalog)
+		// The bookkeeping is the point of building it this way: without it the
+		// evaluated model reads a narrowed action as absent rather than as
+		// withheld, and scores a capability the deployment has.
+		dynamictools.RegisterCatalogFindExecuteTools(server, actionCatalog,
+			dynamictools.WithWithheldActions(withheld.ByTokenScope, withheld.ByOperator))
 		routes = dynamicValidationRoutes(actionCatalog.ActionMaps())
 	case config.ToolSurfaceMeta:
-		actionCatalog, catalogErr := tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Enterprise: client.IsEnterprise(), IncludeMCP: true})
+		filteredCatalog, _, catalogErr := tools.SharedMetaCatalog(client, cfg)
 		if catalogErr != nil {
 			return nil, nil, nil, nil, fmt.Errorf(errBuildActionCatalog, catalogErr)
 		}
-		actionCatalog = applyEvalServerMode(actionCatalog, serverMode)
-		surfaceCatalog = actionCatalog
-		tools.RegisterMetaCatalog(server, actionCatalog)
+		surfaceCatalog = filteredCatalog
+		tools.RegisterMetaCatalog(server, filteredCatalog)
 		tools.RegisterMetaStandaloneTools(server, client)
-		routes = actionCatalog.ActionMaps()
+		routes = filteredCatalog.ActionMaps()
 	default:
 		return nil, nil, nil, nil, fmt.Errorf("unsupported tool surface %q", toolSurface)
 	}

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions.go
@@ -420,6 +420,16 @@ func evalServerConfig(client *gitlabclient.Client, serverMode string) *config.Se
 	}
 }
 
+// Test seams, the pair cmd/server keeps for the same two assemblers. Neither
+// can fail from any input the evaluator takes: both assemble the ActionSpecs
+// compiled into this binary, and the filter they apply adds groups the base
+// catalog already validated. The branches reporting their failure exist for
+// the day one of those facts changes, and would otherwise never run.
+var (
+	buildDynamicCatalog = dynamiccatalog.Build    //nolint:gochecknoglobals // test seam
+	sharedMetaCatalog   = tools.SharedMetaCatalog //nolint:gochecknoglobals // test seam
+)
+
 // buildCatalogSession constructs the request parameters from the input.
 func buildCatalogSession(client *gitlabclient.Client, toolSurface, serverMode string) (session *mcp.ClientSession, closeSession func(), mcpTools []*mcp.Tool, routes map[string]toolutil.ActionMap, err error) {
 	completionHandler := completions.NewHandler(client)
@@ -450,7 +460,7 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface, serverMode st
 		// any other. Assembling an equivalent catalog here was what the e2e
 		// suite did before this package existed, and a test that builds its
 		// own copy of the thing under test is testing the copy.
-		actionCatalog, withheld, catalogErr := dynamiccatalog.Build(client, cfg)
+		actionCatalog, withheld, catalogErr := buildDynamicCatalog(client, cfg)
 		if catalogErr != nil {
 			return nil, nil, nil, nil, fmt.Errorf(errBuildActionCatalog, catalogErr)
 		}
@@ -462,7 +472,7 @@ func buildCatalogSession(client *gitlabclient.Client, toolSurface, serverMode st
 			dynamictools.WithWithheldActions(withheld.ByTokenScope, withheld.ByOperator))
 		routes = dynamicValidationRoutes(actionCatalog.ActionMaps())
 	case config.ToolSurfaceMeta:
-		filteredCatalog, _, catalogErr := tools.SharedMetaCatalog(client, cfg)
+		filteredCatalog, _, catalogErr := sharedMetaCatalog(client, cfg)
 		if catalogErr != nil {
 			return nil, nil, nil, nil, fmt.Errorf(errBuildActionCatalog, catalogErr)
 		}

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
@@ -575,6 +575,46 @@ func TestBuildCatalogSession_ServerModeShapesDynamicSurface(t *testing.T) {
 	}
 }
 
+// TestBuildCatalogSession_ReadOnlyDynamicNamesTheCauseOfAWithheldAction
+// verifies the evaluated dynamic surface answers a write the protective mode
+// withheld by naming the cause, not by calling the action unknown.
+//
+// The catalog is assembled by dynamiccatalog.Build, which is what cmd/server
+// assembles, so the bookkeeping FilterActionCatalog produces reaches the
+// registry through WithWithheldActions. While the evaluator assembled its own
+// catalog that bookkeeping did not exist, and the evaluated model read
+// "unknown action ... Did you mean" — an answer whose suggestions are all real
+// read-only actions, so it reads as "this server cannot do that" for a
+// capability the deployment has and this session merely may not use. Scoring a
+// model against that answer measures a surface the product never serves.
+func TestBuildCatalogSession_ReadOnlyDynamicNamesTheCauseOfAWithheldAction(t *testing.T) {
+	client := newEvalTestClient(t, false)
+
+	session, closeSession, _, _, err := buildCatalogSession(client, config.ToolSurfaceDynamic, ServerModeReadOnly)
+	if err != nil {
+		t.Fatalf("buildCatalogSession(dynamic, read-only) error = %v", err)
+	}
+	defer closeSession()
+
+	result, callErr := session.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      dynamicExecuteActionTool,
+		Arguments: map[string]any{"action": "issue.create", "params": map[string]any{}},
+	})
+	if callErr != nil {
+		t.Fatalf("CallTool(%s) error = %v", dynamicExecuteActionTool, callErr)
+	}
+	if !result.IsError {
+		t.Fatalf("CallTool(%s, issue.create) succeeded in read-only mode", dynamicExecuteActionTool)
+	}
+	answer := callToolResultText(result)
+	if !strings.Contains(answer, "exists but is not available") {
+		t.Errorf("read-only answer = %q, want the withheld cause", answer)
+	}
+	if strings.Contains(answer, "Did you mean") {
+		t.Errorf("read-only answer = %q, want the withheld cause rather than an unknown-action guess", answer)
+	}
+}
+
 // hasEvalRoute reports whether any tool in routes exposes the action id, which
 // dynamic routes key by canonical ID and meta routes key by action name.
 func hasEvalRoute(routes map[string]toolutil.ActionMap, actionID string) bool {

--- a/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
+++ b/cmd/eval_mcp_surfaces/internal/evaluator/sessions_test.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +16,8 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -575,7 +578,7 @@ func TestBuildCatalogSession_ServerModeShapesDynamicSurface(t *testing.T) {
 	}
 }
 
-// TestBuildCatalogSession_ReadOnlyDynamicNamesTheCauseOfAWithheldAction
+// TestBuildCatalogSession_ReadOnlyDynamic_NamesTheCauseOfAWithheldAction
 // verifies the evaluated dynamic surface answers a write the protective mode
 // withheld by naming the cause, not by calling the action unknown.
 //
@@ -587,7 +590,7 @@ func TestBuildCatalogSession_ServerModeShapesDynamicSurface(t *testing.T) {
 // read-only actions, so it reads as "this server cannot do that" for a
 // capability the deployment has and this session merely may not use. Scoring a
 // model against that answer measures a surface the product never serves.
-func TestBuildCatalogSession_ReadOnlyDynamicNamesTheCauseOfAWithheldAction(t *testing.T) {
+func TestBuildCatalogSession_ReadOnlyDynamic_NamesTheCauseOfAWithheldAction(t *testing.T) {
 	client := newEvalTestClient(t, false)
 
 	session, closeSession, _, _, err := buildCatalogSession(client, config.ToolSurfaceDynamic, ServerModeReadOnly)
@@ -612,6 +615,133 @@ func TestBuildCatalogSession_ReadOnlyDynamicNamesTheCauseOfAWithheldAction(t *te
 	}
 	if strings.Contains(answer, "Did you mean") {
 		t.Errorf("read-only answer = %q, want the withheld cause rather than an unknown-action guess", answer)
+	}
+}
+
+// errEvalCatalogSeam is returned by the assembler seams below, so the failure
+// the session reports can be matched rather than pattern-matched on text.
+var errEvalCatalogSeam = errors.New("catalog assembler refused")
+
+// TestBuildCatalogSession_AssemblerFails_ReportsTheCatalogError verifies both
+// surfaces report the assembler's failure instead of building a session on a
+// catalog that was never assembled.
+//
+// Neither assembler can fail from any input the evaluator takes: both build the
+// ActionSpecs compiled into this binary, and the filter they apply adds groups
+// the base catalog already validated. That is exactly why the seams exist. The
+// branch has to hold the error rather than swallow it, because the evaluator
+// would otherwise score a model against an empty surface and report the score
+// as if the surface were the product's.
+func TestBuildCatalogSession_AssemblerFails_ReportsTheCatalogError(t *testing.T) {
+	cases := []struct {
+		name        string
+		toolSurface string
+		install     func(*testing.T)
+	}{
+		{
+			name:        "dynamic",
+			toolSurface: config.ToolSurfaceDynamic,
+			install: func(t *testing.T) {
+				t.Helper()
+				original := buildDynamicCatalog
+				buildDynamicCatalog = func(*gitlabclient.Client, *config.ServerConfig) (*actioncatalog.Catalog, tools.WithheldActions, error) {
+					return nil, tools.WithheldActions{}, errEvalCatalogSeam
+				}
+				t.Cleanup(func() { buildDynamicCatalog = original })
+			},
+		},
+		{
+			name:        "meta",
+			toolSurface: config.ToolSurfaceMeta,
+			install: func(t *testing.T) {
+				t.Helper()
+				original := sharedMetaCatalog
+				sharedMetaCatalog = func(*gitlabclient.Client, *config.ServerConfig) (*actioncatalog.Catalog, tools.WithheldActions, error) {
+					return nil, tools.WithheldActions{}, errEvalCatalogSeam
+				}
+				t.Cleanup(func() { sharedMetaCatalog = original })
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.install(t)
+			client := newEvalTestClient(t, false)
+			session, closeSession, _, _, err := buildCatalogSession(client, testCase.toolSurface, ServerModeDefault)
+			if closeSession != nil {
+				closeSession()
+			}
+			if session != nil {
+				t.Error("buildCatalogSession returned a session over a catalog that failed to assemble")
+			}
+			if !errors.Is(err, errEvalCatalogSeam) {
+				t.Fatalf("buildCatalogSession error = %v, want the assembler failure", err)
+			}
+			if !strings.Contains(err.Error(), "build action catalog") {
+				t.Errorf("buildCatalogSession error = %q, want it to name the step that failed", err)
+			}
+		})
+	}
+}
+
+// TestBuildCatalogSession_UnknownSurface_IsRefused verifies a tool surface the
+// evaluator has no assembler for is an error rather than a session with no
+// tools, which would score every case as a model failure.
+func TestBuildCatalogSession_UnknownSurface_IsRefused(t *testing.T) {
+	client := newEvalTestClient(t, false)
+
+	session, closeSession, _, _, err := buildCatalogSession(client, "individual", ServerModeDefault)
+	if closeSession != nil {
+		closeSession()
+	}
+	if session != nil {
+		t.Error("buildCatalogSession returned a session for an unsupported surface")
+	}
+	if err == nil || !strings.Contains(err.Error(), `unsupported tool surface "individual"`) {
+		t.Fatalf("buildCatalogSession error = %v, want the surface named", err)
+	}
+}
+
+// TestEvalServerConfig_ServerModes_ShareOneBaseAndDifferByFilter verifies the
+// memoization the shared assemblers apply keys the evaluated catalogs apart by
+// server mode, and reuses one catalog per mode.
+//
+// A single evaluator process builds a session per --server-mode against one
+// client, so all three configurations meet in the one cache
+// [tools.ShareCatalog] keeps. Two modes colliding on a key would serve the
+// unrestricted catalog to a protective run, and every case would then be scored
+// against a surface the product does not serve for that mode; a mode failing to
+// memoize would rebuild a thousand actions per session for nothing. The route
+// assertions elsewhere in this file would catch the collision, but not this
+// way: they would report a scoring difference and leave the cause to guesswork.
+func TestEvalServerConfig_ServerModes_ShareOneBaseAndDifferByFilter(t *testing.T) {
+	client := newEvalTestClient(t, false)
+
+	origins := make(map[string]*actioncatalog.Catalog, 3)
+	for _, mode := range []string{ServerModeDefault, ServerModeReadOnly, ServerModeSafe} {
+		t.Run(mode, func(t *testing.T) {
+			catalog, _, err := buildDynamicCatalog(client, evalServerConfig(client, mode))
+			if err != nil {
+				t.Fatalf("buildDynamicCatalog(%s) error = %v", mode, err)
+			}
+			origin := catalog.SharedOrigin()
+			if origin == nil {
+				t.Fatalf("catalog for %s is not shared: every session of this mode would rebuild it", mode)
+			}
+			again, _, againErr := buildDynamicCatalog(client, evalServerConfig(client, mode))
+			if againErr != nil {
+				t.Fatalf("buildDynamicCatalog(%s) second call error = %v", mode, againErr)
+			}
+			if again.SharedOrigin() != origin {
+				t.Errorf("%s assembled a second catalog; the shared one was not reused", mode)
+			}
+			for otherMode, otherOrigin := range origins {
+				if otherOrigin == origin {
+					t.Errorf("%s and %s share one catalog; one of them is evaluated against the other's surface", mode, otherMode)
+				}
+			}
+			origins[mode] = origin
+		})
 	}
 }
 

--- a/cmd/internal/mcpsurface/surface.go
+++ b/cmd/internal/mcpsurface/surface.go
@@ -99,7 +99,10 @@ func Session(setup func(*mcp.Server)) (session *mcp.ClientSession, cleanup func(
 // It delegates to [dynamiccatalog.Build] with a configuration that narrows
 // nothing, so the generators describe the catalog the server assembles rather
 // than a second assembly of the same parts: an unconfigured deployment is what
-// a generated artifact must describe, and there is one assembler for it.
+// a generated artifact must describe, and this is the function cmd/server
+// calls to assemble it. Several audit commands and the e2e suite still put
+// their own copy together; each one that moves onto this package is one fewer
+// surface that can drift from the served one without a test noticing.
 //
 // Assembly reads only the ActionSpecs compiled into this binary, so a failure
 // means the committed catalog is malformed, which no generator run can fix and

--- a/cmd/internal/mcpsurface/surface.go
+++ b/cmd/internal/mcpsurface/surface.go
@@ -13,12 +13,13 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/auditshared"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/edition"
 	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v2/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/prompts"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/resources"
-	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/actioncatalog"
 	dynamictools "github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamic"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/tools/dynamiccatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v2/internal/toolutil"
 )
 
@@ -95,12 +96,18 @@ func Session(setup func(*mcp.Server)) (session *mcp.ClientSession, cleanup func(
 // find/execute surface, including the standalone actions that are not part of
 // any domain meta-tool. enterprise selects the Premium/Ultimate catalog.
 //
-// Both steps assemble the ActionSpecs compiled into this binary, so a failure
+// It delegates to [dynamiccatalog.Build] with a configuration that narrows
+// nothing, so the generators describe the catalog the server assembles rather
+// than a second assembly of the same parts: an unconfigured deployment is what
+// a generated artifact must describe, and there is one assembler for it.
+//
+// Assembly reads only the ActionSpecs compiled into this binary, so a failure
 // means the committed catalog is malformed, which no generator run can fix and
 // every caller would only print.
 func DynamicCatalog(client *gitlabclient.Client, enterprise bool) *actioncatalog.Catalog {
-	catalog := cmdutil.Must(tools.BuildActionCatalog(client, tools.ActionCatalogOptions{Enterprise: enterprise, IncludeMCP: true}))
-	return cmdutil.Must(dynamictools.AddStandaloneCatalog(catalog, client, dynamictools.StandaloneOptions{}))
+	catalog, _, err := dynamiccatalog.Build(client, &config.ServerConfig{Tier: edition.TierForEnterprise(enterprise)})
+	cmdutil.MustDo(err)
+	return catalog
 }
 
 // DynamicTools returns the visible two-tool dynamic catalog from a real MCP

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,860 |
-| Unit test functions                                   | 14,257 |
+| Total test functions                                  | 14,863 |
+| Unit test functions                                   | 14,260 |
 | E2E test functions                                    |    603 |
-| cmd test functions                                    |  2,872 |
+| cmd test functions                                    |  2,875 |
 | Test files (internal/)                                |    520 |
 | Test files (cmd/)                                     |    195 |
 | Test files (test/e2e/)                                |    240 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,857 | 79.8% |
+| `TestFunc_Scenario` (2-part)           | 11,856 | 79.8% |
 | `TestFunc` (no underscore)             |    980 |  6.6% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,023 | 13.6% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,027 | 13.6% |
 
 ## Test Distribution
 
@@ -49,8 +49,8 @@
 | Tools orchestration     |            340 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
 | Tool sub-packages (177) |          8,603 |        359 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            603 |        240 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,872 |        195 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,860** |    **955** |                                                                                                 |
+| cmd packages            |          2,875 |        195 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,863** |    **955** |                                                                                                 |
 
 ### Core Packages
 

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -18,10 +18,10 @@
 
 | Metric                                                |  Value |
 | ----------------------------------------------------- | -----: |
-| Total test functions                                  | 14,863 |
-| Unit test functions                                   | 14,260 |
+| Total test functions                                  | 14,860 |
+| Unit test functions                                   | 14,257 |
 | E2E test functions                                    |    603 |
-| cmd test functions                                    |  2,871 |
+| cmd test functions                                    |  2,872 |
 | Test files (internal/)                                |    520 |
 | Test files (cmd/)                                     |    195 |
 | Test files (test/e2e/)                                |    240 |
@@ -35,9 +35,9 @@
 
 | Pattern                                |  Count |     % |
 | -------------------------------------- | -----: | ----: |
-| `TestFunc_Scenario` (2-part)           | 11,858 | 79.8% |
+| `TestFunc_Scenario` (2-part)           | 11,857 | 79.8% |
 | `TestFunc` (no underscore)             |    980 |  6.6% |
-| `TestFunc_Scenario_Expected` (3+ part) |  2,025 | 13.6% |
+| `TestFunc_Scenario_Expected` (3+ part) |  2,023 | 13.6% |
 
 ## Test Distribution
 
@@ -47,10 +47,10 @@
 | ----------------------- | -------------: | ---------: | ----------------------------------------------------------------------------------------------- |
 | Core packages           |          2,442 |        145 | shared runtime packages such as config, GitLab client, OAuth, resources, prompts, and utilities |
 | Tools orchestration     |            340 |         16 | registration, meta-tool dispatch, safe mode, validation, markdown, and routing tests            |
-| Tool sub-packages (177) |          8,607 |        359 | domain-specific GitLab tool handlers                                                            |
+| Tool sub-packages (177) |          8,603 |        359 | domain-specific GitLab tool handlers                                                            |
 | E2E integration         |            603 |        240 | build-tagged; only test/e2e/suite and test/e2e/orbit need a real instance                       |
-| cmd packages            |          2,871 |        195 | server entry point and developer command utilities                                              |
-| **Total**               |     **14,863** |    **955** |                                                                                                 |
+| cmd packages            |          2,872 |        195 | server entry point and developer command utilities                                              |
+| **Total**               |     **14,860** |    **955** |                                                                                                 |
 
 ### Core Packages
 
@@ -84,7 +84,7 @@
 
 | Sub-package       | Tests | Coverage | Tools |
 | ----------------- | ----: | -------: | ----: |
-| projects          |   393 |   100.0% |    57 |
+| projects          |   391 |   100.0% |    57 |
 | groups            |   249 |   100.0% |    37 |
 | mergerequests     |   245 |   100.0% |    30 |
 | issues            |   223 |   100.0% |    21 |
@@ -249,7 +249,7 @@
 | projectimportexport     |        40 |          1 |    99.6% |         5 |
 | projectiterations       |        18 |          1 |   100.0% |         1 |
 | projectmirrors          |        63 |          2 |   100.0% |         7 |
-| projects                |       393 |          6 |   100.0% |        57 |
+| projects                |       391 |          6 |   100.0% |        57 |
 | projectserviceaccounts  |        11 |          2 |   100.0% |         8 |
 | projectstatistics       |         8 |          2 |   100.0% |         1 |
 | projectstoragemoves     |        19 |          2 |   100.0% |         6 |
@@ -270,7 +270,7 @@
 | securefiles             |        28 |          2 |   100.0% |         4 |
 | securityattributes      |        24 |          1 |   100.0% |         5 |
 | securitycategories      |        16 |          1 |   100.0% |         3 |
-| securityfindings        |        24 |          1 |   100.0% |         1 |
+| securityfindings        |        23 |          1 |   100.0% |         1 |
 | securityscanprofiles    |        17 |          1 |   100.0% |         3 |
 | securitysettings        |        32 |          3 |   100.0% |         3 |
 | settings                |        17 |          1 |    94.4% |         2 |
@@ -289,12 +289,12 @@
 | useremails              |        24 |          2 |   100.0% |         6 |
 | usergpgkeys             |        44 |          2 |   100.0% |         8 |
 | users                   |       210 |          7 |   100.0% |        38 |
-| vulnerabilities         |        66 |          3 |   100.0% |         8 |
+| vulnerabilities         |        65 |          3 |   100.0% |         8 |
 | waitpoll                |        13 |          1 |    99.2% |         0 |
 | wikis                   |        61 |          2 |   100.0% |         6 |
 | workitems               |       120 |          3 |   100.0% |         6 |
 | workitemsavedviews      |        52 |          4 |   100.0% |         7 |
-| **Total**               | **8,607** |    **359** |          | **1,187** |
+| **Total**               | **8,603** |    **359** |          | **1,187** |
 
 </details>
 


### PR DESCRIPTION
The surface evaluator scored models against a catalog it assembled itself, in an order the shipped binary does not use and without the bookkeeping that `internal/tools/dynamiccatalog` was created to end. I have made it call the same two assemblers `cmd/server` calls, and made `cmd/internal/mcpsurface` call one of them too, so neither puts its own copy of the dynamic catalog together any more. Several audit commands and the e2e suite still do, which is separate work; nothing here claims otherwise.

The defect this fixes is small and precisely the one that package documents. `--server-mode=read-only` withholds every mutating action; the evaluator then registered `gitlab_execute_action` with no `WithWithheldActions`, so a model asking for `issue.create` was told `unknown action "issue.create". Did you mean ...` with a list of real read-only actions. The product answers `action "issue.create" exists but is not available: this deployment is configured to withhold it`. The first answer reads as "this server cannot do that", so the evaluator was measuring a model against an answer no deployment serves, and any read-only or safe-mode score was a score of the copy. Two smaller order differences went with it: the read-only filter now runs before the standalone actions join rather than after, and safe-mode previews are applied over the complete catalog, so a standalone write (the interactive creation flows among them) is previewed instead of keeping its real handler.

## What changes

`buildCatalogSession` builds a `config.ServerConfig` from `--server-mode` and the client's licence tier, then calls `dynamiccatalog.Build` for the dynamic surface and `tools.SharedMetaCatalog` for the meta surface, passing the returned withheld lists to `RegisterCatalogFindExecuteTools`. That is `cmd/server/main.go`'s `registerConfiguredToolSurfaceWithCatalog` line for line. The private `applyEvalServerMode` transform is deleted.

The tier is the one thing the evaluator has to state rather than pass through, and it is stated where it can be read: `edition.TierForEnterprise(client.IsEnterprise())` is the mapping the catalog builders already apply to the legacy binary "enterprise" notion, so an enterprise client keeps evaluating the Ultimate catalog and a Community one the Free catalog.

`mcpsurface.DynamicCatalog` becomes a thin wrapper over `dynamiccatalog.Build` with a configuration that narrows nothing, which is what its callers were building by hand. The generated artifacts are unchanged by it, which the verification below checks rather than assumes.

Both assemblers are reached through a package-level seam, the pair `cmd/server` and both callee packages already keep for them: neither can fail from any input the evaluator takes, so the branch that has to hold the error rather than build a session over a catalog that was never assembled had never run. It runs now, together with the unsupported-surface refusal, and one more test names the memoization the shared assemblers apply, since one process builds a session per `--server-mode` against one client and a key collision there would evaluate a protective mode against the unrestricted surface.

A regression test drives the read-only dynamic session over a real MCP round-trip and asserts the answer names the cause instead of guessing at a typo. `evaluator/doc.go` gains a short section saying the evaluated surface is the server's own assembly, why building an equivalent one measures the wrong thing, and what it still does not mirror: `cmd/server` runs a visibility pass after registration that withdraws or previews the tools registered outside the catalog, and the evaluator has no equivalent, so the `gitlab_interactive_*` flows keep their real handlers in a protective meta evaluation. That gap is older than this branch, and closing it means moving that pass out of `cmd/server` rather than copying it here.

## Verification

`rgo go build ./...`; `rgo go test ./cmd/eval_mcp_surfaces/... ./cmd/internal/mcpsurface/ ./cmd/server/... ./internal/tools/dynamiccatalog/ -count=1 -cover` — all pass, with `cmd/internal/mcpsurface` and `internal/tools/dynamiccatalog` at 100.0% and `cmd/server` at 99.8%. `buildCatalogSession` goes from 85.1% to 91.5% of statements; what is left uncovered in it are the SDK connect failures, which predate this branch, and the package holds its 93.6% baseline, whose gap sits in functions this branch does not touch and that need a live GitLab. `rgo golangci-lint run` over both touched trees is clean, `gofmt -l` prints nothing.

Every committed generated artifact had to come back byte-identical, since `mcpsurface` feeds the generators: `make check-llms`, `make check-footprint`, `make check-lhm-manifest`, `make check-action-catalog-manifest` and `go run ./cmd/gen_request_inventory/ -check` all pass with no regeneration (the request inventory was re-recorded from a full unit-suite run first, since the gate needs the shards). `make check-test-file-names`, `make check-test-goroutines` and `make check-test-subtests` pass, `make check-stats` and `make check-testing-docs` pass on the regenerated artifacts, and `godoc_tool audit --include-tests` reports nothing in either touched package beyond one finding that is present on `main`.
