### PR TITLE
refactor: use the expression in the condition where a variable named it once

### DIFF
--- a/cmd/audit_graphql_documents/drift.go
+++ b/cmd/audit_graphql_documents/drift.go
@@ -216,7 +216,7 @@ func (w *coordinateWalker) inputType(name string) {
 
 // namedType records a type by name, without descending into it.
 func (w *coordinateWalker) namedType(name string) {
-	if definition := w.definition(name); definition != nil {
+	if w.definition(name) != nil {
 		w.record(coordinate{typeName: name})
 	}
 }

--- a/internal/testutil/request_inventory_test.go
+++ b/internal/testutil/request_inventory_test.go
@@ -281,7 +281,7 @@ func TestReleaseRecorders_AnOpenShard_IsClosedAndForgotten(t *testing.T) {
 	if rec.file != nil {
 		t.Error("releaseRecorders() left the shard open, so the directory holding it cannot be removed on Windows")
 	}
-	if again := inventoryRecorder(); again == rec {
+	if inventoryRecorder() == rec {
 		t.Error("releaseRecorders() left the released recorder in the registry, so a later run would write through a closed file")
 	}
 }
@@ -414,7 +414,7 @@ func TestInventoryRecorder_Environment_DecidesWhetherRecordingHappens(t *testing
 	if first == nil {
 		t.Fatal("inventoryRecorder() = nil with a directory set")
 	}
-	if second := inventoryRecorder(); second != first {
+	if inventoryRecorder() != first {
 		t.Error("inventoryRecorder() built a second recorder for the same directory")
 	}
 }
@@ -433,7 +433,7 @@ func TestRecordingHandler_RecordingOff_ReturnsTheHandlerUnchanged(t *testing.T) 
 	t.Setenv(InventoryDirEnv, "")
 	var handler http.Handler = inertHandler{}
 
-	if wrapped := recordingHandler(t, handler); wrapped != handler {
+	if recordingHandler(t, handler) != handler {
 		t.Error("recordingHandler wrapped the handler with recording off")
 	}
 }


### PR DESCRIPTION
SonarCloud flagged four S8193 findings on main once the two stacks had landed: an assignment in an if statement whose variable is used only in the condition. Three are assertions in the request-inventory tests (`inventoryRecorder()` and `recordingHandler()` compared with what a previous call returned) and one is the named-type check of the GraphQL coordinate walker in `cmd/audit_graphql_documents`.

## What changes

The four conditions test the expression directly. No behaviour changes; the tests and the walker read the same values.

## Verification

`internal/testutil` and `cmd/audit_graphql_documents` tests and lint on truenas; the quality gate on main was already OK, and this clears its new-code smells.
