### PR TITLE
refactor(bench): find go.mod through cmdutil, not the surface reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,20 +467,20 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,219 |     255,716 |
-| Unit tests (`_test.go`)  |       714 |     417,969 |
-| End-to-end tests         |       246 |      66,271 |
-| **Total**                | **2,179** | **739,956** |
+| Source (`.go`, non-test) |     1,219 |     255,627 |
+| Unit tests (`_test.go`)  |       714 |     417,624 |
+| End-to-end tests         |       246 |      66,251 |
+| **Total**                | **2,179** | **739,502** |
 
 ### Functions
 
 | Category                        |  Count |
 | ------------------------------- | -----: |
-| Source functions                |  9,439 |
+| Source functions                |  9,434 |
 | . Exported (public)             |  2,940 |
-| . Unexported (private)          |  6,499 |
-| Unit test functions (`TestXxx`) | 14,272 |
-| Subtests (`t.Run(...)`)         |  5,697 |
+| . Unexported (private)          |  6,494 |
+| Unit test functions (`TestXxx`) | 14,265 |
+| Subtests (`t.Run(...)`)         |  5,691 |
 | End-to-end test functions       |    603 |
 
 ### Ratios worth noting
@@ -490,14 +490,14 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.63× more tests than code |
 | Average source file length         |                 ~210 lines |
 | Average test file length           |                 ~585 lines |
-| Comment lines in source            |  45,686 (~17.9% of source) |
+| Comment lines in source            |  45,633 (~17.9% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
 
 | Pattern                            | Count |
 | ---------------------------------- | ----: |
-| `if err != nil` checks             | 7,739 |
+| `if err != nil` checks             | 7,733 |
 | `defer` statements                 | 1,354 |
 | `struct` types defined             | 3,099 |
 | `//nolint` suppressions            |   323 |
@@ -522,8 +522,8 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Fact                                 | Value                                                                                                |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Source code printed at 55 lines/page | ~4,649 pages of A4                                                                                   |
-| Source lines mentioning `"gitlab"`   | 14,773 (impossible to avoid)                                                                         |
+| Source code printed at 55 lines/page | ~4,647 pages of A4                                                                                   |
+| Source lines mentioning `"gitlab"`   | 14,762 (impossible to avoid)                                                                         |
 | Longest function name in source      | `assertDynamicCompatibilityPolicyOwnedByActionCompat` (51 chars)                                     |
 | Longest test function name           | `TestRequiredMissingAndUnknownParamNames_SchemaValidation_ReturnsSortedMissingAndUnknown` (87 chars) |
 

--- a/cmd/bench_resources/main.go
+++ b/cmd/bench_resources/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/mcpsurface"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 )
 
 // Default output locations, all relative to the module root. The record lives
@@ -215,8 +215,15 @@ var getwd = os.Getwd
 // in a mode that renders nothing: the mode returns before the record is read
 // or a chart is drawn. What it still needs is a binary, since building one is
 // the one thing here that does read the checkout.
+//
+// The walk comes from [cmdutil.RepositoryRoot] rather than from
+// cmd/internal/mcpsurface, whose ProjectRoot is the same loop: this harness
+// measures the shipped binary as a black box and lists no surface of its own,
+// so taking the walk from the surface reader would compile the whole tool
+// catalog into it for fifteen lines of directory walking, and every catalog
+// change would rebuild a command that never asks the catalog anything.
 func locateRoot(opts options) (string, error) {
-	root, err := mcpsurface.ProjectRoot()
+	root, err := cmdutil.RepositoryRoot(".")
 	if err == nil {
 		return root, nil
 	}

--- a/cmd/bench_resources/render_test.go
+++ b/cmd/bench_resources/render_test.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jmrplens/gitlab-mcp-server/v2/cmd/internal/mcpsurface"
+	"github.com/jmrplens/gitlab-mcp-server/v2/internal/cmdutil"
 )
 
 // projectRootForTest resolves the module root for tests that read committed
-// files.
-func projectRootForTest() (string, error) { return mcpsurface.ProjectRoot() }
+// files, through the same walker the command uses.
+func projectRootForTest() (string, error) { return cmdutil.RepositoryRoot(".") }
 
 // TestWriteCharts_WritesAPairPerFigure verifies every figure is written in
 // both schemes, named so the Markdown page's <picture> can find them, and that

--- a/cmd/internal/mcpsurface/surface.go
+++ b/cmd/internal/mcpsurface/surface.go
@@ -2,12 +2,10 @@ package mcpsurface
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"sort"
 	"sync"
 
@@ -371,19 +369,22 @@ func Prompts(client *gitlabclient.Client) []*mcp.Prompt {
 
 // ProjectRoot walks up from the working directory to the directory holding
 // go.mod, so a generator works from anywhere in the repository.
+//
+// The walk itself is [cmdutil.RepositoryRoot]: this used to be a second copy
+// of the same loop, differing only in its error text, and a command that
+// wanted nothing but the root had to import this package and with it the whole
+// tool catalog. What stays here is the wording its callers report, which their
+// tests assert on: the working directory is resolved here rather than passed
+// as "." so that failure still names the step, and a walk that reaches the
+// filesystem root is still reported as a missing project root.
 func ProjectRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get working directory: %w", err)
 	}
-	for {
-		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", errors.New("could not find project root (no go.mod found)")
-		}
-		dir = parent
+	root, err := cmdutil.RepositoryRoot(dir)
+	if err != nil {
+		return "", fmt.Errorf("could not find project root: %w", err)
 	}
+	return root, nil
 }


### PR DESCRIPTION
The benchmark harness measures the shipped server binary as a black box: it starts a real process against a stub GitLab over a real socket, times it, and draws the published charts. It lists no MCP surface of its own. Yet the one symbol it took from `cmd/internal/mcpsurface` was `ProjectRoot`, fifteen lines of walking upward to find `go.mod`, and that single import linked the whole tool catalog into it.

I measured the cost before changing anything: `go list -deps ./cmd/bench_resources` counted 194 packages of this module, of which 183 arrive only through `mcpsurface`. Every catalog change rebuilt the largest binary in `cmd/` for a directory walk it could do itself. After this change it links 11: `internal/cmdutil` for the walk, plus `cmd/internal/docgen`, `internal/toolutil` and `internal/config`, which the rendering, fairness and target code genuinely use.

This is item 3 of the `cmd/` consolidation plan, and its layer sits on `consolidate-mcpsurface`.

## What changes

`cmd/bench_resources` calls `cmdutil.RepositoryRoot(".")` and drops its `mcpsurface` import; `render_test.go`'s `projectRootForTest` does the same, so tests and command resolve the root through one walker. `locateRoot` only tests `err == nil` before falling back to the working directory, so nothing about its behaviour moves with the error text.

`mcpsurface.ProjectRoot` stays for its own callers (`gen_llms`, `gen_lhm_manifest`) and now delegates to `cmdutil.RepositoryRoot` instead of carrying a second copy of the same loop. It keeps the two things its callers' tests read: it resolves the working directory itself, so that failure still reports `get working directory`, and it still reports a walk that reached the filesystem root as `could not find project root`. The plan called for a bare one-line wrapper over `RepositoryRoot(".")`; that spelling fails `TestRun_RequiresProjectRoot` and `TestWriteGeneratedFile_RequiresProjectRoot` in `cmd/gen_llms`, which assert on that wording, so I kept the wording and shared the loop, which is what the item was for.

I left `gen_brand.repoRoot` and `gen_icon_webp.repoRoot` alone, as the plan's `keep_apart` requires: both commands import nothing from this module today, and `gen_brand` runs first in `update-all` because later generators compile what it writes.

## Verification

`gofmt -l` is silent on the touched directories. `go build ./...` passes; `go test -count=1` over `./cmd/...` and `./internal/...` reports no failure, and `cmd/bench_resources`, `cmd/internal/mcpsurface` and `internal/cmdutil` are each at 100% of statements. `golangci-lint` is clean on all three.

Every committed generated artifact comes back byte-identical: `make check-llms`, `make check-footprint`, `make check-lhm-manifest`, `make check-action-catalog-manifest` and `go run ./cmd/gen_request_inventory/ -check` (over freshly recorded shards) all pass without regeneration, and `make check-testing-docs` is up to date. The only regenerated file is `README.md`'s stats block, which moves by the eight comment lines this adds.
