### PR TITLE
fix(site): pin js-yaml past the advisory the current pin is vulnerable to

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   brace-expansion@>=3.0.0 <5.0.9: 5.0.9
   fast-uri@<3.1.6: 3.1.6
   ip-address@<10.3.1: 10.3.1
-  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  js-yaml@>=4.0.0 <4.3.2: 4.3.2
 
 importers:
 
@@ -2456,8 +2456,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -3980,7 +3980,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       picomatch: 4.0.7
       retext-smartypants: 6.2.0
       shiki: 4.4.3
@@ -3991,7 +3991,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       picomatch: 4.0.7
       retext-smartypants: 6.2.0
       shiki: 4.4.3
@@ -4101,7 +4101,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.4.0(typescript@6.0.3)
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       klona: 2.0.6
       magic-string: 1.2.3
       mdast-util-directive: 3.1.0(supports-color@10.2.2)
@@ -5227,7 +5227,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       jsonc-parser: 3.3.1
       magic-string: 1.2.3
       magicast: 0.5.4
@@ -5481,7 +5481,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -6512,7 +6512,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -26,8 +26,13 @@ overrides:
   # dev/build deps only (pa11y-ci > puppeteer > socks-proxy-agent > socks).
   "ip-address@<10.3.1": 10.3.1
   # js-yaml quadratic CPU consumption in !!omap resolution (GHSA-5p4m-2wfm-xmqj,
-  # CVE-2026-59870); build deps only (@astrojs/internal-helpers and friends).
-  "js-yaml@>=4.0.0 <4.3.1": 4.3.1
+  # CVE-2026-59870), and then maxTotalMergeKeys not bounding CPU for empty
+  # merge sources (GHSA-2883-xcg3-v3hh), which the 4.3.1 this line used to pin
+  # is itself vulnerable to. Build deps only (@astrojs/internal-helpers and
+  # friends). 4.3.2 is the v4-legacy tag: the 4.x line is what Astro depends
+  # on, and pinning 5.x onto it is a major bump an advisory fix should not drag
+  # in.
+  "js-yaml@>=4.0.0 <4.3.2": 4.3.2
 
 auditConfig:
   ignoreGhsas:
@@ -36,6 +41,12 @@ auditConfig:
     # Dev-only path (pa11y-ci > puppeteer > @puppeteer/browsers). Remove this
     # exception once extract-zip publishes a fixed release.
     - GHSA-jmr9-qjv8-65gv
+    # extract-zip arbitrary file writes through symlink archive entries: the
+    # same package, the same dev-only path, and the same absence of anywhere to
+    # go. This one records no patched version at all, and 2.0.1 is still the
+    # last release published. Both exceptions retire together, on the release
+    # that fixes either.
+    - GHSA-7pqw-9j4j-h8q3
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
The site dependency audit is red on every open pull request, and has been since before any of them opened. It is not a required check, so it has been failing quietly.

Two high advisories, and only one of them has anywhere to go.

`js-yaml` is pinned at 4.3.1 for an earlier advisory, and GHSA-2883-xcg3-v3hh covers everything below 4.3.2, so the pin that answered one advisory is the version the next one names. I moved it to 4.3.2, which is the `v4-legacy` tag: the 4.x line is what Astro depends on, and a major bump is not what an advisory fix should drag in.

The other is `extract-zip` again, a second symlink advisory on the same dev-only path through `pa11y-ci` and `puppeteer`. This one records no patched version at all and 2.0.1 is still the last release published, so it joins the exception the first one already has. Both retire on the release that fixes either.

I verified both halves: `pnpm audit --audit-level=high` now reports two high, both ignored, and exits zero, and the site builds its 105 pages with the new resolution.
