### PR TITLE
docs(upstream): record what landed, what is approved and the service account gap

### DIFF
--- a/.github/skills/upstream-contribution/SKILL.md
+++ b/.github/skills/upstream-contribution/SKILL.md
@@ -65,7 +65,20 @@ Answer the breaking-change heading honestly rather than with a flat "no". Correc
 
 Say the gap was found while developing this MCP server and link the repository: the backlink is the point of contributing from here.
 
-Reference a related issue **only** if it already carries a `type::` label, and only at the start of a line with one of `related to`, `relates to`, `relate to`, `contributes to`, `contribute to`, `closes`, `close`, `see`. GitLab's `apply_labels_from_related_issue.rb` copies the first `type::` label off the issue and re-fires when the description is edited. `fixes`, `resolves` and `updates` are **not** in that list, and merge requests using them merged with no `type::` label ever.
+**Always reference the drift issue.** Every merge request that comes out of the field-by-field review carries this line, on a line of its own, at the end of the description:
+
+```text
+Related to https://gitlab.com/gitlab-org/api/client-go/-/issues/2300
+```
+
+Issue 2300 is the umbrella: it publishes the method, the per-struct lists of fields GitLab sends that the library does not model, and the table of what has been sent so far. `Related to` is deliberate and `Closes` would be wrong, because the umbrella has to survive the first merge rather than be closed by it.
+
+Two separate mechanisms read that line, and confusing them is what produced the wrong rule this replaces.
+
+- **`apply_labels_from_related_issue.rb`** copies the first `type::` label off the referenced issue, and only onto a merge request that carries none, so a label already asked for by comment is not overwritten. It re-fires whenever the description is edited. The reference must start a line with one of `related to`, `relates to`, `relate to`, `contributes to`, `contribute to`, `closes`, `close`, `see`; `fixes`, `resolves` and `updates` are **not** in that list, and merge requests using them merged with no `type::` label ever. Issue 2300 carries no `type::` label of its own, having been opened by an account that cannot set labels, so referencing it copies nothing.
+- **The contributor platform** applies a `linked-issue` label of its own a few minutes after creation, when the merge request's GraphQL `linked_work_items` connection is non-empty. A `MENTIONED` link is enough; it does not have to be `CLOSES`. That label is what carries the linked-issue point bonus, which is why one umbrella issue referenced from every merge request scores nearly the same as opening a throwaway issue per merge request, and reads as evidence rather than as noise.
+
+`CONTRIBUTING.md` asks for no issue before a merge request, and a maintainer has said per-merge-request issues are noise. One well-evidenced umbrella is the shape that satisfies both.
 
 ### 5. Do not set fields the account cannot set
 
@@ -109,12 +122,62 @@ Expect `danger-review` and `autolabels` to fail: both are `allow_failure: true`.
 In this order.
 
 1. **Fix the title** if it has no conventional prefix, or has one with no file scope. Title and description are the two fields the author may still edit.
-2. **Fix the description** if it is missing the three headings or the backlink, keeping every piece of evidence it already carries. This comes **before** the label command, not after: editing a description re-fires `apply_labels_from_related_issue.rb`, so a merge request that references an issue would have its `type::` label re-derived on top of the one just asked for.
+2. **Fix the description** if it is missing the three headings, the backlink or the `Related to` line for issue 2300, keeping every piece of evidence it already carries. Do it **before** the label command: editing a description re-fires `apply_labels_from_related_issue.rb`, and although that script only labels a merge request carrying no `type::` label at all, and so cannot overwrite one already asked for, doing the edit first removes the question entirely.
 3. **Ask for the label**: post `@gitlab-bot label ~"type::feature"` (or `~"type::bug"`) as a comment, with the command at the start of its own line. `command_mr_label.rb` accepts it from the resource author, and its allowed scopes include `type`. The rate limit is the module default of 60 per hour keyed on the actor.
    Pick by what should ship: `type::feature` cuts a minor, `type::bug` a patch, `type::maintenance` cuts nothing. There is no urgency — an unlabelled merge request still merges and still ships under "Other Changes", and the analyzer reads labels through the API at release time, so a label added later still counts.
 4. **Ask for review, naming a code owner**: post `@gitlab-bot ready @<code owner>`. `command_mr_request_review.rb` reacts to the author's own note and emits `/ready`, the `workflow::ready for review` label and `/request_review`; with arguments it requests exactly those users. This is the only mechanism by which a non-member gets a chosen name onto the reviewer field. Posted **bare** it picks a random GitLab-wide merge request coach, who is usually not one of the four code owners.
    One ready command per merge request per hour: the limit is 1 for a non-member and the cache key is the actor **plus** the merge request path, so several merge requests can be readied within the same hour and a misfire costs an hour on that one only.
 5. **Then stop.** One approval is required and this account cannot approve; the fork pipeline is already green and needs no maintainer to start it. Do not re-post `ready` if nothing happens — it is rate-limited and would only re-request the same person, and `gitlab-bot` nudges an unattended merge request on its own.
+
+## The same gap is usually in GitLab's own documentation
+
+A field client-go does not model is often a field GitLab never documented either, and the merge request is not finished until both are sent. This is not a guess: cross-checking the eight fields of the first tranche against `doc/api/`, two of them, `is_receptive` and `file_extension`, appeared nowhere on their page. A code owner asked for exactly this on [!3045](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3045) rather than opening it himself, so offering it unprompted saves a round trip.
+
+**Check before assuming.** Read the page from `gitlab-org/gitlab` (project `278964`) and grep for the field. Do not trust the page's title to name the field's home: the service account page is `doc/api/service_accounts.md`, not `user_service_accounts.md`, and a wrong path answers 404 rather than "absent".
+
+**Where the change goes.** Branch on the community fork `gitlab-community/gitlab-org/gitlab` (project `41372369`, default branch `master`, developer access), and open the merge request against `gitlab-org/gitlab` `master` with `target_project_id`. One file, one commit, `remove_source_branch` and `allow_collaboration` both on.
+
+Four rules the two merge requests sent so far were shaped by.
+
+1. **Every example, not the one that prompted it.** `doc/api/secure_files.md` had four example responses and all four predated the field. Fixing one and leaving three is a worse page than before, because now they disagree.
+2. **The attribute table counts as documentation.** `doc/api/cluster_agents.md` documents its responses twice, in a table and in an example, and a field missing from the table is missing whichever the reader trusts. That page needed three tables and four examples.
+3. **Other entities share the page.** The cluster agents page also documents agent tokens and receptive URL configurations, which are different Grape entities and must not gain the field. Identify the right objects by something structural (the agent examples are the ones carrying `config_project`), never by position.
+4. **Put the field where the entity exposes it, and keep the table aligned.** Read the order off `gitlab-api-live.json`. In a table, keep the new cell no wider than the column already is, or every other row has to be re-padded and a three-line change becomes a whole-table diff.
+
+**Two traps in that record, both of which have already produced a wrong published claim.** Its per-field gate key is `conditions`, a **list**, not `condition`: reading it as `condition` reports every field as unconditional and never errors, which is how upstream issue 2300 came to claim that all six `API::Entities::ServiceAccount` fields are unconditional when `unconfirmed_email` is gated on `unconfirmed_email.present?`. And the record is a pin taken at one release, so it lags master and will not know a field or route added since. Before writing a conditionality claim into a public description, confirm it against GitLab's current Ruby, and say "sent only when …" rather than nothing when a field is gated: a documented field a reader cannot find in a response is a bug report waiting to be filed.
+
+Validate before pushing: parse every ` ```json ` block on the page and assert the field is present in exactly the objects that should have it and absent from the rest. A trailing comma left behind by hand-editing is invisible in review and breaks the example for anyone who copies it.
+
+**A new merge request there reports empty for a while.** `prepared_at` is null until a background job fetches the fork ref and builds the diff, and until then the API answers 0 commits and 0 changed files. That is preparation lag on a repository that size, not a failed push: confirm the work from the branch tip on the fork instead.
+
+Finally, link both ways: a note on the client-go merge request naming the documentation one, and the client-go merge request named in the documentation description as where the gap was found.
+
+## Keep issue 2300 current
+
+The umbrella issue carries a table of what has been sent, and a table that lags is worse than no table: a maintainer reading "open" about something merged a week ago learns that nothing here is maintained. Update it at both moments, not only at the end.
+
+**When the merge request is published**, add its row: the merge request link, the struct, the field or fields, and `open`. A merge request that exists and is not in the table is invisible to anyone reading the issue.
+
+**When it merges**, change the row to say which release carries it, and read that from the repository rather than assuming. A merge and a tag are different events: `!3040` was merged and in no tag for hours, and saying "released in v3.1.0" because that was the newest tag would have been false. Ask which tags contain the merge commit:
+
+```bash
+curl -s --header "PRIVATE-TOKEN: $TOKEN" \
+  "https://gitlab.com/api/v4/projects/gitlab-org%2Fapi%2Fclient-go/repository/commits/<merge_commit_sha>/refs?type=tag"
+```
+
+An empty answer means merged and unreleased, which the row should say in those words.
+
+Update the issue by rewriting its description through the API (`PUT /projects/:id/issues/2300`), not by commenting: the table is the document, and a correction buried in a comment thread leaves the wrong table at the top.
+
+**Read, modify, write. Never PUT a locally held copy.** Contributor success prepends an `<!--IssueSummary start-->` block to the description shortly after the issue is created, and it is not visible in anything written here. A blind PUT of the local file deletes it. Fetch the description, replace the exact region being changed, refuse to write if the anchor does not appear exactly once, and check the block survived in the response. The first correction made from here did wipe it, and the only reason nothing was lost is that the automation put it back.
+
+Re-read the state of every merge request in the table while doing this, not just the one that prompted the update. Two of them changed state during the single session that opened the issue.
+
+**Nothing in the issue sidebar is ours to set, and the labels arrive on their own.** Labels, assignees, milestone, weight, iteration, dates and health status are all dropped silently for a non-member exactly as `reviewer_ids` is on a merge request: the PUT answers 200 and `labels` comes back empty. There is no issue equivalent of the merge request escape hatch either, since `triage/processor/community/` holds `command_mr_label.rb` and no `command_issue_label.rb`; `command_issue_help.rb` is the only issue command.
+
+Do not reach for the "Label this issue" link in the `IssueSummary` block either, at least not first. An `untriaged-issues` triage policy runs a model over the issue and labels it about fifteen minutes after creation: issue 2300 was opened at 14:08 and had `type::maintenance`, `backend` and `automation:ml` at 14:23, with no action from anybody. It publishes its confidence per label and applies only the high ones, so it took type at 80 and backend at 75 and declined `group::source code` at 40, `Category:Source Code Management` at 35 and `maintenance::refactor` at 55, which is the right call: the first two would have routed a Go client library issue to the source code management team. **Wait for it, then correct only what it got wrong.** Expect `ai-quick-win-labeller-gitlab-org` to comment "Could not start processing due to this error: You have insufficient permissions"; that is a failure on their side and costs nothing but the `quick win` label.
+
+Subscription needs nothing: the author is subscribed on creation.
 
 ## What actually moves a merge request
 
@@ -132,7 +195,9 @@ go get gitlab.com/gitlab-org/api/client-go/v3@latest
 go mod tidy
 ```
 
-Then retire the workaround this project carried for the gap (a captured-response read under [ADR-0021](../../../docs/development/adr/adr-0021-captured-response-for-fields-the-sdk-does-not-model.md), or a request built by hand) and mark the `docs/development/upstream-bugs.md` entry merged with the version that carries it.
+Then retire the workaround this project carried for the gap (a captured-response read under [ADR-0021](../../../docs/development/adr/adr-0021-captured-response-for-fields-the-sdk-does-not-model.md), or a request built by hand), mark the `docs/development/upstream-bugs.md` entry merged with the version that carries it, and update the row in issue 2300 as "Keep issue 2300 current" describes.
+
+Wait before bumping: several merge requests land across several releases, so batch the version bump rather than raising the pin per merge.
 
 ## Validation checklist
 
@@ -140,9 +205,13 @@ Then retire the workaround this project carried for the gap (a captured-response
 - [ ] Branch pushed to the community fork, merge request opened against project 65271576
 - [ ] Conventional prefix **with the API file as scope** on the title, and a prefix on every commit
 - [ ] Description uses the project's three `##` headings, names this MCP server as where the gap was found, and links it
+- [ ] Description ends with `Related to https://gitlab.com/gitlab-org/api/client-go/-/issues/2300` on its own line, never `Closes`
+- [ ] Row added to issue 2300's table once the merge request is published, and corrected with the release once it merges
 - [ ] No reviewer requested by hand, `@GitLabDuo` included: that one is permanent once made
 - [ ] Field placed in API-documentation order, `int64`/`any`, `PathEscape` where a path parameter is interpolated
 - [ ] Every public symbol carries a name-first comment ending in a `// GitLab API docs:` link
 - [ ] Test asserts the new field, starts with `t.Parallel()`, uses testify
 - [ ] `make reviewable` passes
 - [ ] `type::` label asked for by comment, then `@gitlab-bot ready @<code owner>`
+- [ ] `doc/api/` checked for the same field, and a documentation merge request opened against `gitlab-org/gitlab` when it is missing, covering every example **and** every attribute table on the page
+- [ ] The two merge requests link to each other

--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -816,12 +816,17 @@ of change whose test is one assertion on the built URL.
 ### Response structs that miss a field GitLab sends unconditionally
 
 - **Reported**: yes, one merge request per struct, linked below.
-- **In review**: yes, the same merge requests.
-- **Merged**: not yet.
+- **In review**: yes, the same merge requests. `!3046` is approved and waiting
+  to be merged; the rest are open.
+- **Merged**: `!3042` (`BroadcastMessage.Color`), in **v3.1.0**, tagged on
+  2026-09-09 eighteen minutes after the merge. The others not yet.
 - **Blocking**: no.
 - **Workaround**: yes. Each field is read from the captured response beside
   the SDK's decode, through the readers in `internal/toolutil/sent_shapes.go`.
   Each retires when its merge request lands and the pin moves.
+  The pin is deliberately **not** moved once per merge: several of these will
+  land in quick succession, so the bump and the workarounds it retires are
+  taken together rather than one release at a time.
 
 **What**: one field per struct, each exposed by the rendering entity with no
 condition at all, so every response of every endpoint that renders it carries
@@ -884,6 +889,24 @@ the field and the SDK drops it. Every entity reference is to the tag
   The SDK's own fixtures used the wrong key too, so its tests were green
   against a response GitLab never sends.
   [gitlab-org/api/client-go!3046](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3046).
+- `GroupServiceAccount` (`group_serviceaccounts.go`) has neither
+  `public_email` nor `unconfirmed_email`. All four group service account
+  endpoints render `Entities::ServiceAccount`, which inherits `UserSafe`:
+  [lib/api/entities/user_safe.rb](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.3.1-ee/lib/api/entities/user_safe.rb)
+  exposes `public_email` on line 10 unconditionally, and
+  [lib/api/entities/service_account.rb](https://gitlab.com/gitlab-org/gitlab/-/blob/v19.3.1-ee/lib/api/entities/service_account.rb)
+  exposes `unconfirmed_email` on line 7 when one is pending.
+  [gitlab-org/api/client-go!3047](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3047).
+  This one is worth reading for what it says about the SDK rather than about
+  the field: the same GitLab entity is modelled by three structs, and they
+  disagree. The project-scope `ServiceAccount` already carries
+  `unconfirmed_email` while the group-scope one carries neither, which is why
+  `internal/tools/projectserviceaccounts` reads that key from the SDK and
+  `internal/tools/groupserviceaccounts` reads it from the capture. Two gaps
+  next to it are not covered by that merge request and are worth a second:
+  `ProjectServiceAccount` and the instance-scope `ServiceAccount` are both
+  missing `public_email` too, and no scope wraps
+  `GET /…/service_accounts/:user_id` at all.
 
 **How we found it**: the sent dimension of the 1:1 audit
 (`shapes.typed.unsurfaced` in `go run ./cmd/audit_1to1/ -scope=paths`), whose

--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -815,11 +815,21 @@ of change whose test is one assertion on the built URL.
 
 ### Response structs that miss a field GitLab sends unconditionally
 
-- **Reported**: yes, one merge request per struct, linked below.
-- **In review**: yes, the same merge requests. `!3046` is approved and waiting
-  to be merged; the rest are open.
-- **Merged**: `!3042` (`BroadcastMessage.Color`), in **v3.1.0**, tagged on
-  2026-09-09 eighteen minutes after the merge. The others not yet.
+- **Reported**: yes, one merge request per struct, linked below, plus one
+  umbrella issue,
+  [gitlab-org/api/client-go#2300](https://gitlab.com/gitlab-org/api/client-go/-/issues/2300),
+  which publishes the method and the whole measurement and answers
+  [issue 2269](https://gitlab.com/gitlab-org/api/client-go/-/issues/2269),
+  where the maintainers had said there was no good way to detect this drift.
+  Every merge request references it with a non-closing `Related to`, so the
+  first merge does not close the umbrella.
+- **In review**: `!3041`, `!3043`, `!3044`, `!3045` and `!3047` are open.
+- **Merged**: `!3042` (`BroadcastMessage.Color`) in **v3.1.0**, tagged on
+  2026-09-09 eighteen minutes after the merge; then `!3040`
+  (`Appearance.SiteName`) and `!3046` (the `GroupSCIMIdentity` json tag) in
+  **v3.2.0** the same day. Do not read a merge as a release: `!3040` sat
+  merged and in no tag for hours, so the version is read from which tags
+  contain the merge commit rather than from the newest tag.
 - **Blocking**: no.
 - **Workaround**: yes. Each field is read from the captured response beside
   the SDK's decode, through the readers in `internal/toolutil/sent_shapes.go`.
@@ -916,6 +926,22 @@ GitLab says each of its Grape entities exposes. Each finding carries
 
 **Effort**: trivial per struct. One additive field with a `json` tag, and one
 key added to the fixture of an existing test.
+
+**The gap is usually in GitLab's own documentation too, and that is a second
+merge request.** A code owner asked for it on `!3045` rather than opening it
+himself, so cross-checking all eight fields against `doc/api/` was worth doing:
+two of the eight, `file_extension` and `is_receptive`, appeared nowhere on
+their page, and a third page showed `public_email` in none of its fourteen
+example responses. Three documentation merge requests went to
+`gitlab-org/gitlab` from its own
+[community fork](https://gitlab.com/gitlab-community/gitlab-org/gitlab):
+[!254507](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254507),
+[!254511](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254511) and
+[!254519](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254519).
+`.github/skills/upstream-contribution/SKILL.md` carries the procedure and the
+traps: every example on a page rather than the one that prompted it, the
+response attribute tables as well as the examples, and the other entities
+sharing the page that must not gain the field.
 
 **Where these merge requests come from**: the
 [community fork](https://gitlab.com/gitlab-community/gitlab-org/api/client-go),


### PR DESCRIPTION
The register was behind by three facts, and it is the one place that answers what a workaround here is waiting on.

`BroadcastMessage.Color` is merged upstream and shipped in client-go v3.1.0, tagged eighteen minutes after the merge. The SCIM tag correction is approved and waiting. And `GroupServiceAccount` is a new entry.

That last one is the interesting one, because the missing field is the smaller half of what it shows. All four group service account endpoints render the same entity, which exposes `public_email` unconditionally and `unconfirmed_email` when one is pending, and the struct carries neither. The project-scope struct already carries `unconfirmed_email`, so the same GitLab entity is modeled three times in the SDK and the three disagree. That is why `projectserviceaccounts` reads the key from client-go while `groupserviceaccounts` reads it from the captured response, an asymmetry that reads like a mistake here until you look upstream.

Two adjacent gaps are recorded and deliberately not folded into that merge request: `ProjectServiceAccount` and the instance-scope `ServiceAccount` are missing `public_email` as well, and no scope wraps the single-account GET at all.

The pin stays where it is. Several of these will land close together, so the bump and the workarounds it retires are worth taking in one pass rather than one per release, and the register now says so where the next reader will look.