### PR TITLE
docs(upstream): record the second batch and what the maintainers asked us to hold back

### DIFF
--- a/.github/skills/upstream-contribution/SKILL.md
+++ b/.github/skills/upstream-contribution/SKILL.md
@@ -77,11 +77,13 @@ Putting the reference only at the bottom is what went wrong on 2026-09-09. A cod
 
 ## Batch, do not drip
 
-**One merge request per struct is the wrong shape, and the maintainers said so.** The request, in their words on [!3053](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3053): create an issue with the missing fields, keep updating it until there is a good point to send merge requests that may be a bit larger, so they can approve chunks ahead of time and then only check that the merge request matches the chunk. Three maintainers cannot validate a stream of small ones, and they will tell you the descriptions read as machine-written, which is true and is not the complaint: the complaint is the count.
+**One merge request per struct is the wrong shape, and the maintainers said so.** The request, in their words on [!3053](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3053): create an issue with the missing fields, keep updating it until there is a good point to send merge requests that may be a bit larger, so they can approve chunks ahead of time and then only check that the merge request matches the chunk.
 
 So the loop is: keep 2300 current, ask the maintainers which chunks they are happy to pre-approve, and send **one merge request per approved chunk**, not per struct. Nothing goes out that the issue does not already describe.
 
-Two consequences worth keeping. **Never have more open than they asked for**; if in doubt, ask on the issue before opening anything. And **say plainly how the work is produced** when asked, along with what that does and does not guarantee: the entity, line and condition are read out of a booted GitLab rather than recalled, and each is checked against current `master`, which narrows what a reviewer must distrust without pretending it removes the review.
+**What actually stung was the burst, not the count.** Asked directly, the same maintainer said there was no reason to close the ones already in front of reviewers, that they would get through them, and that he was reacting to a second large set of pings arriving on top of an overnight one. So the rule to follow is about the rate at which you demand attention, not a ceiling on open merge requests: batch the work, and above all do not fire a round of `@gitlab-bot ready` commands in one sitting. Offering to withdraw work already under review was the wrong instinct and was declined.
+
+**Say plainly how the work is produced** when asked, along with what that does and does not guarantee: the entity, line and condition are read out of a booted GitLab rather than recalled, and each is checked against current `master`, which narrows what a reviewer must distrust without pretending it removes the review. They will notice on their own, and being told is better than being reassured.
 
 Two separate mechanisms read that line, and confusing them is what produced the wrong rule this replaces.
 

--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -929,20 +929,100 @@ GitLab says each of its Grape entities exposes. Each finding carries
 key added to the fixture of an existing test.
 
 **The gap is usually in GitLab's own documentation too, and that is a second
-merge request.** A code owner asked for it on `!3045` rather than opening it
-himself, so cross-checking all eight fields against `doc/api/` was worth doing:
-two of the eight, `file_extension` and `is_receptive`, appeared nowhere on
-their page, and a third page showed `public_email` in none of its fourteen
-example responses. Three documentation merge requests went to
-`gitlab-org/gitlab` from its own
+merge request.** A code owner asked for it on
+[!3045](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3045)
+rather than opening it himself, so cross-checking all eight fields against
+`doc/api/` was worth doing: two of the eight, `file_extension` and
+`is_receptive`, appeared nowhere on their page, and a third page showed
+`public_email` in none of its fourteen example responses. Nine documentation
+merge requests have gone to `gitlab-org/gitlab` from its own
 [community fork](https://gitlab.com/gitlab-community/gitlab-org/gitlab):
 [!254507](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254507),
-[!254511](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254511) and
-[!254519](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254519).
+[!254511](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254511),
+[!254519](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254519),
+[!254538](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254538),
+[!254540](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254540),
+[!254542](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254542),
+[!254543](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254543),
+[!254547](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254547) and
+[!254552](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/254552).
 `.github/skills/upstream-contribution/SKILL.md` carries the procedure and the
 traps: every example on a page rather than the one that prompted it, the
 response attribute tables as well as the examples, and the other entities
 sharing the page that must not gain the field.
+
+Three of those nine fixed a documentation defect found on the way rather than
+the field that prompted them: three `fingerprint_sha256` keys on the deploy
+keys page had lost their name and sat as `""`, one snippet example's `raw_url`
+pointed at a different snippet, and the packages page showed a `pipelines`
+array inside `versions` where the entity exposes a single `pipeline` and omits
+`tags`.
+
+**The second batch, and the cadence a maintainer asked for.** Six more merge
+requests carry the structs behind the fields this server published in the
+member and Geo tranches:
+[!3048](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3048)
+(`Hook`),
+[!3049](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3049)
+(both deploy key structs),
+[!3050](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3050)
+(both event structs),
+[!3051](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3051)
+(`Namespace`),
+[!3052](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3052)
+(`Package`, plus the `GetProjectPackage` wrapper the versions field needs and
+which the library did not have) and
+[!3053](https://gitlab.com/gitlab-org/api/client-go/-/merge_requests/3053)
+(`Snippet`).
+
+On the last of those, a code owner asked to stop opening one merge request per
+struct: keep an issue with the missing fields, update it, and send larger merge
+requests once a chunk is pre-approved, so three maintainers validate a chunk
+rather than a stream. That is now the rule, and the umbrella issue they were
+asking for already existed as issue 2300, referenced from every one of these in
+a `Related to` line at the bottom where a reviewer never looks. Nothing further
+goes upstream until they say which chunks they want.
+
+**Four findings from that batch that are not merge requests**, because sending
+them would have been wrong:
+
+- `projects_with_write_access` and `projects_with_readonly_access` are gated on
+  presenter options that `lib/api/deploy_keys.rb` passes on `GET /deploy_keys`
+  alone, so the project-scope routes never send them. `InstanceDeployKey` is
+  already correct and `ProjectDeployKey` must not gain them.
+- `Package.project_id` and `project_path` are already modelled, on
+  `GroupPackage`, which embeds `Package` and is what `ListGroupPackages`
+  returns. Adding them to `Package` would shadow those.
+- `ContributionEvent.Title`, `ProjectEvent.Title` and `ProjectEvent.Data` are
+  phantoms: `API::Entities::Event` exposes no `title` and no `data`. Removing
+  them is a breaking change, so it is recorded rather than done.
+- `PackagePipeline` is missing `iid`, `project_id` and `source` of the eleven
+  keys `API::Entities::Package::Pipeline` exposes.
+
+**Three more gaps are recorded and not yet sent**, held back by the batching
+the maintainer asked for above. Each is a field this server now reads from the
+captured response, so each carries a live workaround:
+
+- `PendingInvite` has no `invite_token`, which
+  `lib/api/entities/invitation.rb` exposes with no condition. The same struct
+  declares an `ID` the entity does not expose, which the audit already reports
+  as a phantom in the other direction, so one merge request settles both.
+- `BillableGroupMember` has no `public_email` and no `locked`, both exposed
+  unconditionally through the `UserBasic` that
+  `ee/lib/api/entities/billable_member.rb` inherits (`locked` through
+  `access_locked?`).
+- `AccessRequest` is missing six unconditional fields, `public_email`,
+  `locked`, `avatar_url` and `web_url` from the merged `UserBasic`, and
+  `expires_at` and `membership_state` from the `Member` that
+  `lib/api/entities/access_requester.rb` inherits. The conditional ones,
+  `created_by`, `email`, both identities, `override` and `member_role`, belong
+  in the same merge request as a second group.
+
+One lead rather than a finding, because nothing has measured it: the record's
+`API::Entities::MemberRole` exposes about fifty permission flags where
+`gl.MemberRole` and this server's own member role output mirror twenty-two. The
+audit's nested comparison does not reach that object, so it is unmeasured
+rather than measured and clean.
 
 **Where these merge requests come from**: the
 [community fork](https://gitlab.com/gitlab-community/gitlab-org/api/client-go),


### PR DESCRIPTION
## Description

The permanent register had fallen behind what actually went upstream today. This brings it current and, more usefully, records the things that are deliberately not merge requests.

Six more client-go merge requests carry the structs behind the member and Geo tranches, and the documentation half has grown from three to nine. Three of those nine fixed a defect found on the way rather than the field that prompted them: three `fingerprint_sha256` keys sitting as `""`, a snippet example whose `raw_url` pointed at a different snippet, and a packages page showing a `pipelines` array where the entity exposes a single `pipeline`. That is worth recording before anyone assumes a doc page is right.

A code owner then asked us to stop opening one merge request per struct and to send larger ones from a pre-approved chunk of the umbrella issue. Nothing further goes upstream until they say which chunks they want, so the three member-family gaps that would have gone next are recorded here instead, each with the entity and line that proves it.

## Related Issue

No single issue: this is the register for the continuing 1:1 field review, whose upstream half is tracked in <https://gitlab.com/gitlab-org/api/client-go/-/issues/2300>.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [x] Documentation update
- [ ] CI / build / tooling

## Changes Made

- Records the second batch of client-go merge requests, one per struct, and the cadence change the maintainer asked for.
- Grows the documentation list from three merge requests to nine, and notes the three that fixed something other than what prompted them.
- Records four findings from that batch that are deliberately **not** merge requests: two would publish a field the endpoint never sends (the deploy key project lists, gated on options only the instance route passes), one is already modelled on the struct that embeds it (`Package.project_id` on `GroupPackage`), and one is a phantom whose removal would break callers (`title` and `data` on the event structs).
- Records three gaps held back by the batching request, with the entity and line for each.
- Names one lead rather than a finding: `API::Entities::MemberRole` exposes about fifty permission flags where the struct mirrors twenty-two, and the audit's nested comparison does not reach it, so it is unmeasured rather than clean.
- Links a `!3045` reference that was left bare, which the repository's own convention forbids.

## How to Test

1. Read the diff: it is one file.
2. `npx markdownlint-cli2 docs/development/upstream-bugs.md` and `make check-doc-links`.
3. Every merge request reference in the change is a full link rather than a bare `!NNN`.

## Breaking Changes / Migration Notes

N/A. Documentation only.

## Checklist

### Code Quality

- [x] No code changed
- [x] Follows the conventions documented in `CLAUDE.md`

### Testing

- [x] Not applicable: no code changed
- [x] `make check-stats` and `make check-doc-links` pass

### Documentation

- [x] `docs/development/upstream-bugs.md` follows its own entry schema, links every tracker item with a full URL, and keeps entries rather than deleting them
- [x] Commit message follows Conventional Commits

### Security

- [x] No secrets, tokens, or credentials


