### PR TITLE
fix(quality): clear the five open Sonar findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,241 |     265,165 |
+| Source (`.go`, non-test) |     1,241 |     265,164 |
 | Unit tests (`_test.go`)  |       728 |     434,390 |
 | End-to-end tests         |       246 |      66,332 |
-| **Total**                | **2,215** | **765,887** |
+| **Total**                | **2,215** | **765,886** |
 
 ### Functions
 
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~214 lines |
 | Average test file length           |                 ~597 lines |
-| Comment lines in source            |  49,291 (~18.6% of source) |
+| Comment lines in source            |  49,300 (~18.6% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns

--- a/cmd/internal/docgen/write_test.go
+++ b/cmd/internal/docgen/write_test.go
@@ -252,7 +252,7 @@ func TestWriteReport_StdoutIsClosed_ReturnsTheWriteError(t *testing.T) {
 	os.Stdout = file
 	t.Cleanup(func() { os.Stdout = previous })
 
-	if writeErr := WriteReport("-", []byte("{}\n")); writeErr == nil {
+	if WriteReport("-", []byte("{}\n")) == nil {
 		t.Error("WriteReport(-) error = nil, want the closed-file write error")
 	}
 }

--- a/docs/development/repository-settings.md
+++ b/docs/development/repository-settings.md
@@ -62,11 +62,15 @@ the source.
 gh api repos/jmrplens/gitlab-mcp-server/releases/latest --jq '{tag: .tag_name, immutable}'
 ```
 
-**Current state.** Not enabled. `v2.7.5` and every release before it report
-`"immutable": false`.
+**Current state.** Enabled, as of 2026-09-10. The check above answers about a
+release rather than about the setting, so it keeps reporting the old state until
+a release is published under it: `v2.7.5` and everything before it predate the
+change and stay mutable. 3.0.0 is the first release the setting covers, and it
+is the one to check the field on. Nothing in the repository API reports the
+toggle itself, so this page is the record.
 
-**Caveat.** The setting is not retroactive. Releases published before it is
-turned on stay mutable forever, so enabling it protects future releases only.
+**Caveat.** The setting is not retroactive. Releases published before it was
+turned on stay mutable forever, so it protects future releases only.
 Nothing in the workflow needs to change: GoReleaser already creates the release
 as a draft and a later step publishes it, which is the shape the feature
 requires.

--- a/internal/testutil/captured_test.go
+++ b/internal/testutil/captured_test.go
@@ -79,7 +79,7 @@ func TestAssertCapturedDecodeFailure_ReportsAnythingElse(t *testing.T) {
 				Call: func() error { return testCase.err },
 			})
 
-			if reported := len(reporter.reported) == 1; reported != testCase.wantReport {
+			if (len(reporter.reported) == 1) != testCase.wantReport {
 				t.Errorf("reported = %v, want %t", reporter.reported, testCase.wantReport)
 			}
 			if testCase.wantReport && !strings.Contains(reporter.reported[0], "want the capture's decode failure") {

--- a/internal/tools/branchrules/branch_rules.go
+++ b/internal/tools/branchrules/branch_rules.go
@@ -168,9 +168,14 @@ type gqlBranchRuleNode struct {
 	} `json:"externalStatusChecks"`
 }
 
-// branchRuleNode is what the list decodes a node as: either edition's shape,
-// each knowing how to become the one output item.
-type branchRuleNode interface {
+// branchRuleConverter is what the list decodes a node as: either edition's
+// shape, each knowing how to become the one output item. It is named for the
+// role it fills rather than for the shape it admits, which is the convention
+// the rest of this repository follows for an interface with one method
+// (promptAdder, errorReporter, modelProvider); the previous spelling named the
+// shape, and a reader met a constraint whose name did not say what the generic
+// code was going to do with it.
+type branchRuleConverter interface {
 	item() BranchRuleItem
 }
 
@@ -276,7 +281,7 @@ func List(ctx context.Context, client *gitlabclient.Client, input ListInput) (Li
 // Building the variables here rather than in the caller is what keeps the check
 // honest: the pair is checked against the document this call will actually
 // send, not against the one a tier decision happened to pick first.
-func listWith[N branchRuleNode](ctx context.Context, client *gitlabclient.Client, query string, input ListInput) (ListOutput, error) {
+func listWith[N branchRuleConverter](ctx context.Context, client *gitlabclient.Client, query string, input ListInput) (ListOutput, error) {
 	vars, err := input.Variables(query)
 	if err != nil {
 		return ListOutput{}, fmt.Errorf("list_branch_rules: %w", err)
@@ -290,19 +295,19 @@ func listWith[N branchRuleNode](ctx context.Context, client *gitlabclient.Client
 //
 // Pagination is the forward half alone, because both documents select that
 // half alone: Project.branchRules accepts first and after and nothing else.
-type gqlBranchRulesConnection[N branchRuleNode] struct {
+type gqlBranchRulesConnection[N branchRuleConverter] struct {
 	Nodes    []N                                `json:"nodes"`
 	PageInfo toolutil.GraphQLRawForwardPageInfo `json:"pageInfo"`
 }
 
 // gqlProjectBranchRules wraps the branch rules connection inside a project.
-type gqlProjectBranchRules[N branchRuleNode] struct {
+type gqlProjectBranchRules[N branchRuleConverter] struct {
 	BranchRules gqlBranchRulesConnection[N] `json:"branchRules"`
 }
 
 // gqlResponse is the GraphQL response envelope for branch rules, with each
 // node decoded as N.
-type gqlResponse[N branchRuleNode] struct {
+type gqlResponse[N branchRuleConverter] struct {
 	Data struct {
 		Project *gqlProjectBranchRules[N] `json:"project"`
 	} `json:"data"`
@@ -310,7 +315,7 @@ type gqlResponse[N branchRuleNode] struct {
 }
 
 // doGraphQLList executes a branch rules GraphQL query and returns the output.
-func doGraphQLList[N branchRuleNode](ctx context.Context, client *gitlabclient.Client, query string, vars map[string]any, projectPath string) (ListOutput, error) {
+func doGraphQLList[N branchRuleConverter](ctx context.Context, client *gitlabclient.Client, query string, vars map[string]any, projectPath string) (ListOutput, error) {
 	var resp gqlResponse[N]
 
 	_, err := client.GL().GraphQL.Do(gl.GraphQLQuery{

--- a/internal/tools/mergerequests/action_specs.go
+++ b/internal/tools/mergerequests/action_specs.go
@@ -423,17 +423,11 @@ func mergeRequestOptions(actionName, individualTool string) toolutil.ActionSpecO
 			toolutil.SchemaApproverIDsOverride("approver_ids"),
 			toolutil.SchemaApproverIDsOverride("approved_by_ids"),
 		}
-	case "list_global":
-		options.InputSchemaOverrides = []toolutil.InputSchemaOverride{
-			toolutil.SchemaPropertyOverride("state", map[string]any{"enum": []any{"opened", "closed", "locked", "merged", "all"}}),
-			toolutil.SchemaPropertyOverride("scope", map[string]any{"enum": []any{"created_by_me", "assigned_to_me", "all"}}),
-			toolutil.SchemaPropertyOverride("order_by", map[string]any{"enum": []any{"created_at", "updated_at"}}),
-			toolutil.SchemaPropertyOverride("wip", map[string]any{"enum": []any{"yes", "no"}}),
-			toolutil.SchemaPropertyOverride("view", map[string]any{"enum": []any{"simple"}}),
-			toolutil.SchemaApproverIDsOverride("approver_ids"),
-			toolutil.SchemaApproverIDsOverride("approved_by_ids"),
-		}
-	case "list_group":
+	// The global and group listings take the same overrides, and their enums
+	// differ from the project listing's in one value: neither accepts title as
+	// an order_by. Spelling them once says they agree on purpose, where two
+	// identical blocks left a reader comparing seven lines by eye to find out.
+	case "list_global", "list_group":
 		options.InputSchemaOverrides = []toolutil.InputSchemaOverride{
 			toolutil.SchemaPropertyOverride("state", map[string]any{"enum": []any{"opened", "closed", "locked", "merged", "all"}}),
 			toolutil.SchemaPropertyOverride("scope", map[string]any{"enum": []any{"created_by_me", "assigned_to_me", "all"}}),

--- a/internal/tools/search/search_test.go
+++ b/internal/tools/search/search_test.go
@@ -2478,7 +2478,7 @@ func TestSnippets_AuthorAndTimestamps_AreCopiedOnlyWhenSent(t *testing.T) {
 			if snippet.Author != tt.wantAuthor {
 				t.Errorf("Author = %q, want %q", snippet.Author, tt.wantAuthor)
 			}
-			if gotTimestamp := snippet.CreatedAt != "" && snippet.UpdatedAt != ""; gotTimestamp != tt.wantTimestamp {
+			if (snippet.CreatedAt != "" && snippet.UpdatedAt != "") != tt.wantTimestamp {
 				t.Errorf("timestamps = %q/%q, want them set: %t", snippet.CreatedAt, snippet.UpdatedAt, tt.wantTimestamp)
 			}
 			if snippet.Title != "scratch" {


### PR DESCRIPTION
## Description

SonarCloud reports five open issues on `main`. This closes all five, and the last one is the only one worth reading about.

Three are S8193 and are the shape the Geo layer already fixed: an `if` statement that names its condition in an initializer and then compares that name, which makes a reader carry a variable to the next line for nothing.

S1871 is a duplicated branch. The global and the group merge request listings each declared seven identical schema overrides in a case block of their own, so nothing in the source said whether they agree by accident or on purpose, and a reader had to compare seven lines by eye to find out. They now share one case, with a comment saying what they agree on and how they differ from the project listing, which is a single `order_by` value.

S8196 names `branchRuleNode`, a one-method interface used only as a generic constraint. My first reading was that the rule does not apply here, on the ground that the `-er` convention in Effective Go is about interfaces a caller holds a value of, while a constraint is conventionally named after the type set it admits, the way `cmp.Ordered` is. **That reading was wrong, and this repository's own code is what settles it.** `promptAdder`, `errorReporter`, `tempDirReporter`, `requestReporter`, `embedReporter`, `graphQLReporter`, `legacyReporter`, `registrar` and `modelProvider` are every other one-method interface in the tree, and every one of them is an agent noun. `modelProvider` settles the second half of the question too, because its method is `callOnce`: the house convention names the **role**, not the method. `branchRuleNode` named the shape it admits, said nothing about what the generic code was going to do with it, and was the only departure from that convention in the tree.

## Related Issue

No single issue: these are the five findings SonarCloud has open against `main`, which are being cleared before the 3.0.0 tag.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional change)
- [ ] Documentation update
- [ ] CI / build / tooling

## Changes Made

- Compares the condition directly in three tests, in `internal/tools/search`, `cmd/internal/docgen` and `internal/testutil`.
- Merges the global and group merge request listing cases, which declared the same seven schema overrides twice.
- Renames `branchRuleNode` to `branchRuleConverter`, matching the agent-noun convention every other one-method interface here already follows, and records in its doc comment why the name describes the role rather than the shape.
- Carries one unrelated documentation commit: `docs/development/repository-settings.md` said immutable releases was not enabled, which is no longer true, and it implied the check answers about the setting when it answers about a release.

## A flake seen on this branch, and why it is not from this change

The first run of the Linux leg failed on `TestServeHTTP_APooledCatalogThatCannotBeBuilt_IsEvicted`, which asserts that a failed catalog build is evicted rather than cached. It is filed separately as issue 672 with the evidence: the test passes 20 out of 20 in isolation, nothing here reaches the pool or the readiness gate, and the cross-platform matrix was green on the previous seven runs of `main`. The eviction appears to complete after the response is written, so a loaded runner can slip the second request in ahead of it.

## How to Test

1. `go build ./... && go test ./internal/tools/search/ ./cmd/internal/docgen/ ./internal/testutil/ ./internal/tools/mergerequests/ ./internal/tools/branchrules/ ./internal/tools/ -count=1`.
2. `golangci-lint run --build-tags e2e` on those packages.
3. The catalog is unchanged by the merged case: `make check-action-catalog-manifest` and the tool snapshots both pass without regeneration, which is the evidence that the two listings really did declare the same overrides.

## Breaking Changes / Migration Notes

N/A. Every change is to an unexported name, a test, or a case block that produces the same catalog.

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...`
- [x] Consolidated Go analysis passes on changed packages
- [x] Code is formatted: `make analyze-fix`
- [x] Follows idiomatic Go patterns and the conventions documented in `CLAUDE.md` / `.github/instructions/`

### Testing

- [x] All existing tests pass
- [ ] New tests added for new functionality (no new functionality)
- [x] Coverage on modified packages is unchanged
- [x] Edge cases and error scenarios covered
- [ ] If applicable, E2E tests updated/added under `test/e2e/suite/`

### Documentation

- [x] Doc comments added for exported types/functions (godoc)
- [ ] `docs/` updated if public API or behavior changed (no behavior changed)
- [x] `README.md` statistics regenerated
- [ ] If introducing/removing a tool: `docs/tools/{domain}.md` and tool counts updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [x] No secrets, tokens, or credentials in code, tests, fixtures, or logs
- [x] Input validation for user-provided parameters
- [x] Error messages do not leak sensitive information
- [x] No new dependencies with known vulnerabilities
