### PR TITLE
chore(sonar): declare the destination guard's addresses as intended

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -276,18 +276,28 @@ sonar.issue.ignore.multicriteria.g9.ruleKey=go:S4036
 sonar.issue.ignore.multicriteria.g9.resourceKey=**/bench_resources/*.go
 
 # S1313: "Make sure using this hardcoded IP address is safe here".
-# internal/gitlab/destination.go is the outbound destination guard, and the five
-# addresses it names are the thing being guarded against: the four cloud
-# instance-metadata endpoints and RFC 6598 shared address space. Naming them is
-# not a shortcut around configuration, it is the specification of the rule.
+# internal/gitlab/destination.go is the outbound destination guard, and what it
+# writes down is the thing being guarded against rather than anywhere it
+# connects. Naming it is the specification of the rule, not a shortcut around
+# configuration. The rule flags two different kinds of constant here, and they
+# are worth separating because the argument differs:
 #
-# The rule's own rationale does not reach this file. It warns that a hardcoded
-# address makes software inflexible and can disclose infrastructure. Neither
-# applies: these addresses are fixed by the cloud providers rather than by any
-# deployment, none of them belongs to this project or to anyone running it, and
-# every one is published in the vendors' own documentation. An operator cannot
-# usefully configure them, because a deployment that could point the metadata
-# list somewhere else could point it at nothing and turn the guard off.
+#   - Four addresses that the cloud providers define, each an instance-metadata
+#     or container-credentials endpoint, each published in that vendor's own
+#     documentation.
+#   - One prefix that a standard defines: RFC 6598 shared address space,
+#     100.64.0.0/10, which service providers and carrier-grade NAT deployments
+#     draw internal addresses from. It is not a metadata endpoint and no vendor
+#     owns it. The guard has to name it because netip.Addr.IsPrivate covers
+#     RFC 1918 and RFC 4193 only, so nothing in the standard library recognises
+#     it.
+#
+# The rule's own rationale reaches neither kind. It warns that a hardcoded
+# address makes software inflexible and can disclose infrastructure. None of
+# these belongs to this project or to anyone running it, and none of them says
+# anything about where this server is deployed. An operator cannot usefully
+# configure them either: a deployment that could point the metadata list
+# somewhere else could point it at nothing and turn the guard off.
 #
 # There is also no version of this the rule would accept. It flags the literal,
 # so moving the addresses behind a parsed string table keeps them; building them

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -175,7 +175,7 @@ sonar.cpd.exclusions=internal/tools/groupsaml/group_saml.go,internal/tools/*/act
 # S3776: "Refactor this method to reduce its Cognitive Complexity"
 # Test helper functions that verify multiple fields of API responses naturally
 # have higher complexity. Splitting them reduces test readability.
-sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7,g8,g9
+sonar.issue.ignore.multicriteria=t1,t2,t3,t4,g1,g2,g4,g5,g6,g7,g8,g9,g10
 
 # S1192 — duplicated string literals in tests
 sonar.issue.ignore.multicriteria.t1.ruleKey=go:S1192
@@ -274,4 +274,28 @@ sonar.issue.ignore.multicriteria.g8.resourceKey=**/prompts/exclusion.go
 # is only consulted when /proc is unavailable.
 sonar.issue.ignore.multicriteria.g9.ruleKey=go:S4036
 sonar.issue.ignore.multicriteria.g9.resourceKey=**/bench_resources/*.go
+
+# S1313: "Make sure using this hardcoded IP address is safe here".
+# internal/gitlab/destination.go is the outbound destination guard, and the five
+# addresses it names are the thing being guarded against: the four cloud
+# instance-metadata endpoints and RFC 6598 shared address space. Naming them is
+# not a shortcut around configuration, it is the specification of the rule.
+#
+# The rule's own rationale does not reach this file. It warns that a hardcoded
+# address makes software inflexible and can disclose infrastructure. Neither
+# applies: these addresses are fixed by the cloud providers rather than by any
+# deployment, none of them belongs to this project or to anyone running it, and
+# every one is published in the vendors' own documentation. An operator cannot
+# usefully configure them, because a deployment that could point the metadata
+# list somewhere else could point it at nothing and turn the guard off.
+#
+# There is also no version of this the rule would accept. It flags the literal,
+# so moving the addresses behind a parsed string table keeps them; building them
+# from octets to defeat the matcher would obfuscate the one part of that file a
+# reviewer most needs to read. The file already argues, in its own comment, why
+# the four are named one by one rather than derived from their enclosing ranges:
+# tier A applies to every client and every hop, and a rule that broad has to be
+# as narrow as it can be.
+sonar.issue.ignore.multicriteria.g10.ruleKey=go:S1313
+sonar.issue.ignore.multicriteria.g10.resourceKey=**/gitlab/destination.go
 


### PR DESCRIPTION
## Description

SonarCloud opened five findings on `main` the moment the outbound destination guard landed, all `go:S1313`, all on the same file: the four cloud instance-metadata endpoints and RFC 6598 shared address space.

They are the specification of the guard rather than a shortcut around configuration. The addresses are fixed by the cloud providers, none of them belongs to this project or to anyone running it, and every one is published in the vendors' own documentation. An operator cannot usefully configure them either: a deployment that could point the metadata list somewhere else could point it at nothing and turn the guard off.

There is also no version of the file the rule would accept. It flags the literal, so a parsed string table keeps it, and building the addresses from octets to defeat the matcher would obfuscate the part of that file a reviewer most needs to read.

This goes in `sonar-project.properties`, beside the TLS-skip and PATH entries, because that is where this project already keeps its argued exclusions. Marking the five in the web interface would leave the reasoning unversioned and unreviewable.

## Related Issue

No issue: this is the analyser's response to what landed in the destination-guard change.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [x] CI / build / tooling

## Changes Made

- Adds a `g10` exclusion for `go:S1313` scoped to the destination guard alone, with the reasoning stated in the file's own style.

## How to Test

1. After this merges, the project's open-issue count returns to zero.
2. The scope is one file, so the rule keeps applying to every other address literal in the tree.

## Breaking Changes / Migration Notes

N/A. Analyser configuration only, no code change.

## Checklist

### Code Quality

- [x] No code changed
- [x] Follows the conventions documented in `CLAUDE.md`

### Testing

- [x] No code changed, so no test changes

### Documentation

- [x] The reasoning is in the configuration file, which is where this project documents its exclusions
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [x] The exclusion narrows to one file and one rule, so no other address literal stops being checked


