### PR TITLE
fix(config): say 3.1.0, not v3, as the release that drops the old variable names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,7 +447,7 @@ Every variable this server defines carries the prefix, with no exception for
 a name that already began with `GITLAB_`: the switches that did (`GITLAB_TIER`,
 `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, `GITLAB_IGNORE_SCOPES`,
 `GITLAB_SKIP_TLS_VERIFY`) and `YOLO_MODE` were renamed in 2.8.0, and the old
-spellings keep working until v3 with the same startup warning, resolved through
+spellings keep working until 3.1.0 with the same startup warning, resolved through
 `config.LegacyEnvName`. Only three groups stay bare, because prefixing them
 would be wrong rather than churn: `GITLAB_URL` and `GITLAB_TOKEN` (GitLab's own
 convention, and what a user already has in the environment, so they are never

--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
-| Source (`.go`, non-test) |     1,243 |     266,330 |
-| Unit tests (`_test.go`)  |       732 |     436,532 |
+| Source (`.go`, non-test) |     1,243 |     266,336 |
+| Unit tests (`_test.go`)  |       732 |     436,538 |
 | End-to-end tests         |       246 |      66,458 |
-| **Total**                | **2,221** | **769,320** |
+| **Total**                | **2,221** | **769,332** |
 
 ### Functions
 
@@ -490,7 +490,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Test lines vs source lines         | 1.64× more tests than code |
 | Average source file length         |                 ~214 lines |
 | Average test file length           |                 ~596 lines |
-| Comment lines in source            |  49,749 (~18.7% of source) |
+| Comment lines in source            |  49,755 (~18.7% of source) |
 | Test functions per source function |                       1.5× |
 
 ### Code patterns
@@ -516,7 +516,7 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Record              | File                                    |
 | ------------------- | --------------------------------------- |
 | Longest source file | `cmd/server/main.go`. 4,667 lines       |
-| Longest test file   | `cmd/server/main_test.go`. 10,658 lines |
+| Longest test file   | `cmd/server/main_test.go`. 10,664 lines |
 
 ### Because why not
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -555,7 +555,7 @@ FLAGS
 
 ENVIRONMENT VARIABLES (stdio mode)
   Settings this project defines are read as GITLAB_MCP_<NAME>. The unprefixed
-  spelling of a renamed variable still works and is removed in v3; when both
+  spelling of a renamed variable still works and is removed in 3.1.0; when both
   are set the prefixed one wins and a warning names the one being ignored.
   GITLAB_URL and GITLAB_TOKEN keep their bare names, and so does every OTEL_*
   variable, which the OpenTelemetry exporters read themselves.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -10097,7 +10097,13 @@ func TestApplyLocalFilesystemPolicy_FollowsTheParsedFlag_NotTheArgumentScan(t *t
 //
 // The warning is what makes the rename a migration rather than a permanent
 // shim: an old name that keeps working and says nothing is one nobody moves off
-// before v3 removes it under them.
+// before the release that removes it does so under them.
+//
+// The removal version is asserted rather than left to the message, because it
+// moved once already: it was to be 3.0.0 and is 3.1.0, since a 2.7.5 deployment
+// updates itself into 3.0.0 with nobody reading a release note. A warning that
+// names the wrong release is worse than none, so it is pinned here as well as
+// where the text is built.
 func TestLogDeprecatedEnvNames_WarnsThroughTheConfiguredLogger(t *testing.T) {
 	// The prefixed name is cleared rather than assumed absent: another test in
 	// this package passes -log-level, and that flag writes the prefixed
@@ -10115,7 +10121,7 @@ func TestLogDeprecatedEnvNames_WarnsThroughTheConfiguredLogger(t *testing.T) {
 
 	logDeprecatedEnvNames()
 
-	for _, want := range []string{"LOG_LEVEL", config.EnvPrefix + "LOG_LEVEL", "v3"} {
+	for _, want := range []string{"LOG_LEVEL", config.EnvPrefix + "LOG_LEVEL", "3.1.0"} {
 		t.Run(want, func(t *testing.T) {
 			if !strings.Contains(logged.String(), want) {
 				t.Errorf("the startup warning does not mention %q: %s", want, logged.String())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,7 +110,7 @@ gitlab-mcp-server
 
 Most flags on this page fall back to an environment variable when they are not
 passed, and the settings this project defines are named `GITLAB_MCP_<NAME>`
-from 2.8.0. The unprefixed spelling still works and is removed in v3; when
+from 2.8.0. The unprefixed spelling still works and is removed in 3.1.0; when
 both are set the prefixed one wins and a startup warning names the one being
 ignored. `GITLAB_URL`, `GITLAB_TOKEN`, the `GITLAB_`-prefixed switches and
 every `OTEL_*` variable keep their bare names. The flags with no variable at

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,19 +21,19 @@ or `RATE_LIMIT_RPS` may already be owned by something else there, and the
 collision is silent: the server reads a value nobody gave it and behaves in a
 way nobody configured.
 
-The unprefixed spelling still works and is removed in v3. When both are set the
+The unprefixed spelling still works and is removed in 3.1.0. When both are set the
 prefixed one wins, and a warning at startup names the one being ignored.
 
-The switches that already began with `GITLAB_` were renamed as well, so that every variable of this server reads alike: `GITLAB_TIER`, `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, `GITLAB_IGNORE_SCOPES` and `GITLAB_SKIP_TLS_VERIFY` are now `GITLAB_MCP_TIER`, `GITLAB_MCP_READ_ONLY`, `GITLAB_MCP_SAFE_MODE`, `GITLAB_MCP_IGNORE_SCOPES` and `GITLAB_MCP_SKIP_TLS_VERIFY`, and `YOLO_MODE` is `GITLAB_MCP_YOLO_MODE`. The old spellings keep working until v3 with the same warning. `GITLAB_ENTERPRISE`, deprecated before this in favour of the tier, stays as it is.
+The switches that already began with `GITLAB_` were renamed as well, so that every variable of this server reads alike: `GITLAB_TIER`, `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, `GITLAB_IGNORE_SCOPES` and `GITLAB_SKIP_TLS_VERIFY` are now `GITLAB_MCP_TIER`, `GITLAB_MCP_READ_ONLY`, `GITLAB_MCP_SAFE_MODE`, `GITLAB_MCP_IGNORE_SCOPES` and `GITLAB_MCP_SKIP_TLS_VERIFY`, and `YOLO_MODE` is `GITLAB_MCP_YOLO_MODE`. The old spellings keep working until 3.1.0 with the same warning. They were to have gone in 3.0.0 and were held back one release, because 2.7.5 carries a self-updater and 3.0.0 does not: a 2.7.5 deployment updates itself into 3.0.0 with nobody reading a release note, so removing them there would break those deployments in silence. `GITLAB_ENTERPRISE`, deprecated before this in favour of the tier, stays as it is.
 
 Some names stay bare on purpose:
 
-| Names                        | Why they were not renamed                                                                                                                                                                                         |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITLAB_URL`, `GITLAB_TOKEN` | GitLab's own convention. Every existing configuration sets them, and they are the two most likely to be written into a client configuration from memory                                                           |
-| `OTEL_*`                     | Owned by the OpenTelemetry specification. The exporters read those names themselves and would never see a prefixed spelling                                                                                       |
-| `AUTOPILOT`                  | A convention other agent tooling sets, honored as an alias of `GITLAB_MCP_YOLO_MODE` and never warned about. The setting itself is ours and carries the prefix; its old spelling `YOLO_MODE` still works until v3 |
-| `EVAL_SURFACE_*`             | The surface evaluator's own variables, set by `make` targets in this repository. They never appear beside another tool's variables in a user's shell                                                              |
+| Names                        | Why they were not renamed                                                                                                                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`, `GITLAB_TOKEN` | GitLab's own convention. Every existing configuration sets them, and they are the two most likely to be written into a client configuration from memory                                                              |
+| `OTEL_*`                     | Owned by the OpenTelemetry specification. The exporters read those names themselves and would never see a prefixed spelling                                                                                          |
+| `AUTOPILOT`                  | A convention other agent tooling sets, honored as an alias of `GITLAB_MCP_YOLO_MODE` and never warned about. The setting itself is ours and carries the prefix; its old spelling `YOLO_MODE` still works until 3.1.0 |
+| `EVAL_SURFACE_*`             | The surface evaluator's own variables, set by `make` targets in this repository. They never appear beside another tool's variables in a user's shell                                                                 |
 
 The tables below always give the name to set, so read the name rather than
 deriving it.

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -18,7 +18,7 @@ or `RATE_LIMIT_RPS` may already be owned by something else there, and the
 collision is silent: the server reads a value nobody gave it and behaves in a
 way nobody configured.
 
-The unprefixed spelling still works and is removed in v3. When both are set the
+The unprefixed spelling still works and is removed in 3.1.0. When both are set the
 prefixed one wins, and a warning at startup names the one being ignored.
 
 The switches that already began with `GITLAB_` were renamed as well, so that every variable of this server reads alike: `GITLAB_TIER`, `GITLAB_READ_ONLY`, `GITLAB_SAFE_MODE`, `GITLAB_IGNORE_SCOPES` and `GITLAB_SKIP_TLS_VERIFY` are now `GITLAB_MCP_TIER`, `GITLAB_MCP_READ_ONLY`, `GITLAB_MCP_SAFE_MODE`, `GITLAB_MCP_IGNORE_SCOPES` and `GITLAB_MCP_SKIP_TLS_VERIFY`, and `YOLO_MODE` is `GITLAB_MCP_YOLO_MODE`. The old spellings keep working with the same warning.
@@ -27,12 +27,12 @@ Two names are gone rather than renamed, both deprecated in 2.7.5 and removed in 
 
 Some names stay bare on purpose:
 
-| Names                        | Why they were not renamed                                                                                                                                                                                         |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GITLAB_URL`, `GITLAB_TOKEN` | GitLab's own convention. Every existing configuration sets them, and they are the two most likely to be written into a client configuration from memory                                                           |
-| `OTEL_*`                     | Owned by the OpenTelemetry specification. The exporters read those names themselves and would never see a prefixed spelling                                                                                       |
-| `AUTOPILOT`                  | A convention other agent tooling sets, honored as an alias of `GITLAB_MCP_YOLO_MODE` and never warned about. The setting itself is ours and carries the prefix; its old spelling `YOLO_MODE` still works until v3 |
-| `EVAL_SURFACE_*`             | The surface evaluator's own variables, set by `make` targets in this repository. They never appear beside another tool's variables in a user's shell                                                              |
+| Names                        | Why they were not renamed                                                                                                                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GITLAB_URL`, `GITLAB_TOKEN` | GitLab's own convention. Every existing configuration sets them, and they are the two most likely to be written into a client configuration from memory                                                              |
+| `OTEL_*`                     | Owned by the OpenTelemetry specification. The exporters read those names themselves and would never see a prefixed spelling                                                                                          |
+| `AUTOPILOT`                  | A convention other agent tooling sets, honored as an alias of `GITLAB_MCP_YOLO_MODE` and never warned about. The setting itself is ours and carries the prefix; its old spelling `YOLO_MODE` still works until 3.1.0 |
+| `EVAL_SURFACE_*`             | The surface evaluator's own variables, set by `make` targets in this repository. They never appear beside another tool's variables in a user's shell                                                                 |
 
 The tables below always give the name to set, so read the name rather than
 deriving it. The renamed set is `internal/config.PrefixedEnvNames()`; a name

--- a/internal/clientcompat/client_compat.go
+++ b/internal/clientcompat/client_compat.go
@@ -29,7 +29,7 @@ const (
 // envDisable is the environment kill-switch: GITLAB_MCP_CLIENT_COMPAT=off
 // disables the middleware entirely (both stdio and HTTP modes read the process
 // env). Read through [config.Getenv], so the deprecated CLIENT_COMPAT spelling
-// keeps working until v3.
+// keeps working until 3.1.0.
 const envDisable = "CLIENT_COMPAT"
 
 // Enabled reports whether the compatibility middleware should be installed.

--- a/internal/config/env_name.go
+++ b/internal/config/env_name.go
@@ -19,8 +19,14 @@ import (
 const EnvPrefix = "GITLAB_MCP_"
 
 // prefixedNames are the variables that gained EnvPrefix in 2.8.0 and still
-// answer to their old name. The old spelling is removed in v3, which is the
-// release that renumbers anyway when client-go does.
+// answer to their old name. The old spelling is removed in 3.1.0.
+//
+// It was to have gone in 3.0.0, the release that renumbers when client-go
+// does, and it was held back one release on purpose: 2.7.5 still carries a
+// self-updater and 3.0.0 does not, so a 2.7.5 deployment updates itself into
+// 3.0.0 without anyone reading a release note. Removing the old spellings in
+// the release that arrives unannounced would break those deployments in
+// silence. 3.1.0 is the first version nobody is carried into.
 //
 // Every variable this server defines is on this list; the rule has no
 // exception for a name that already began with GITLAB_. Two names stay bare
@@ -168,7 +174,7 @@ func DeprecatedEnvWarnings() []string {
 				" are set; "+EnvPrefix+name+" is being used and "+legacy+" is ignored")
 			continue
 		}
-		warnings = append(warnings, legacy+" is deprecated and will be removed in v3; rename it to "+EnvPrefix+name)
+		warnings = append(warnings, legacy+" is deprecated and will be removed in 3.1.0; rename it to "+EnvPrefix+name)
 	}
 	return warnings
 }

--- a/internal/config/env_name_test.go
+++ b/internal/config/env_name_test.go
@@ -112,7 +112,7 @@ func TestDeprecatedEnvWarnings_ReportWhatWasRead(t *testing.T) {
 			env:         map[string]string{"AUTH_MODE": "oauth"},
 			read:        []string{"AUTH_MODE", "AUTH_MODE"},
 			wantCount:   1,
-			wantMention: []string{"AUTH_MODE", EnvPrefix + "AUTH_MODE", "v3"},
+			wantMention: []string{"AUTH_MODE", EnvPrefix + "AUTH_MODE", "3.1.0"},
 		},
 		{
 			name:        "both set says which one is ignored",
@@ -196,7 +196,7 @@ func TestGetenv_RenamedGitLabSwitch_FallsBackToItsOldSpelling(t *testing.T) {
 		{
 			name: "only the old spelling set", old: "premium", new: "",
 			want:        "premium",
-			wantWarning: "GITLAB_TIER is deprecated and will be removed in v3; rename it to GITLAB_MCP_TIER",
+			wantWarning: "GITLAB_TIER is deprecated and will be removed in 3.1.0; rename it to GITLAB_MCP_TIER",
 		},
 		{
 			name: "both set, the prefixed one wins", old: "premium", new: "ultimate",

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -52,7 +52,7 @@ or `RATE_LIMIT_RPS` may already be owned by something else there, and the
 collision is silent: the server reads a value nobody gave it and behaves in a
 way nobody configured.
 
-The unprefixed spelling still works and is removed in v3. When both are set the
+The unprefixed spelling still works and is removed in 3.1.0. When both are set the
 prefixed one wins, and a warning at startup names the one being ignored.
 
 Some names stay bare on purpose:


### PR DESCRIPTION
## Description

The startup warning read `will be removed in v3`, and 3.0.0 **is** v3. Shipped as it stood, the release where the old spellings still work would have told every operator they had been removed in the version they were running. The same claim was in the curated help text, four reference pages, the documentation site and this project's own context file.

Holding the shims one more release is a decision, not an oversight. 2.7.5 carries a self-updater and 3.0.0 does not, so a 2.7.5 deployment updates itself into 3.0.0 **with nobody reading a release note**. Removing the old names in the release that arrives unannounced would break those deployments in silence, and the operator's first sign would be a server behaving as though it had been configured by nobody. 3.1.0 is the first version nobody is carried into, so that is where they go.

## Related Issue

Refs the environment-variable section of the v2 deprecation tracker, <https://github.com/jmrplens/gitlab-mcp-server/issues/366>, whose other two sections are already done: `META_TOOLS` and `GITLAB_ENTERPRISE` are gone from the source and the flat copies in the group Datadog output are gone.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [x] Documentation update
- [ ] CI / build / tooling

## Changes Made

- Corrects the startup warning, which is the only operator-facing statement of the removal version.
- Corrects the same claim in the curated help text, the environment, CLI and configuration references, the site's configuration page and `CLAUDE.md`.
- Records **why** the removal moved, at the list it is driven from and in the configuration reference, so the next reader does not restore the earlier plan.
- Updates the two tests that pinned the word rather than loosening them, and says in the one in `cmd/server` why the version is asserted at all: it moved once, and a warning naming the wrong release is worse than no warning.

## How to Test

1. `GITLAB_TIER=premium ./gitlab-mcp-server --version` style startup: the warning names 3.1.0 and the variable still works.
2. `go test ./internal/config/ ./cmd/server/ -count=1`.
3. `grep -rn "removed in v3" .` finds nothing outside the two comments that describe what 3.0.0 genuinely did remove.

## Breaking Changes / Migration Notes

N/A, and that is the point: nothing is removed in 3.0.0 that was not already removed. The removal of the unprefixed spellings moves to 3.1.0.

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...`
- [x] Consolidated Go analysis passes on changed packages
- [x] Code is formatted: `make analyze-fix`
- [x] Follows idiomatic Go patterns and the conventions documented in `CLAUDE.md` / `.github/instructions/`

### Testing

- [x] All existing tests pass
- [x] The two tests that pin the removal version are updated, not loosened
- [x] Edge cases and error scenarios covered
- [ ] If applicable, E2E tests updated/added under `test/e2e/suite/`

### Documentation

- [x] Doc comments updated where the plan is recorded
- [x] `docs/` updated: environment, CLI and configuration references
- [x] `README.md` and the Starlight site updated
- [ ] If introducing/removing a tool: `docs/tools/{domain}.md` and tool counts updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [x] No secrets, tokens, or credentials in code, tests, fixtures, or logs
- [x] Input validation for user-provided parameters
- [x] Error messages do not leak sensitive information
- [x] No new dependencies with known vulnerabilities


