### PR TITLE
docs(upstream): record the merge requests that landed and the versions carrying them

### DIFF
--- a/docs/development/upstream-bugs.md
+++ b/docs/development/upstream-bugs.md
@@ -826,13 +826,18 @@ of change whose test is one assertion on the built URL.
   where the maintainers had said there was no good way to detect this drift.
   Every merge request references it with a non-closing `Related to`, so the
   first merge does not close the umbrella.
-- **In review**: `!3041`, `!3043`, `!3044`, `!3045` and `!3047` are open.
+- **In review**: `!3041`, `!3044`, `!3048`, `!3049`, `!3050`, `!3051`, `!3052`
+  and `!3053` are open.
 - **Merged**: `!3042` (`BroadcastMessage.Color`) in **v3.1.0**, tagged on
   2026-09-09 eighteen minutes after the merge; then `!3040`
   (`Appearance.SiteName`) and `!3046` (the `GroupSCIMIdentity` json tag) in
-  **v3.2.0** the same day. Do not read a merge as a release: `!3040` sat
+  **v3.2.0** the same day; then `!3043` (`Agent.IsReceptive`) and `!3045`
+  (`SecureFile.FileExtension`) in **v3.3.0**, and `!3047`
+  (`GroupServiceAccount.PublicEmail` and `UnconfirmedEmail`) in **v3.4.0**,
+  all on 2026-09-10. Do not read a merge as a release: `!3040` sat
   merged and in no tag for hours, so the version is read from which tags
-  contain the merge commit rather than from the newest tag.
+  contain the merge commit rather than from the newest tag. Six releases in
+  two days is why: the newest tag was wrong for five of these six.
 - **Blocking**: no.
 - **Workaround**: yes. Each field is read from the captured response beside
   the SDK's decode, through the readers in `internal/toolutil/sent_shapes.go`.


### PR DESCRIPTION
## Description

Three of the five merge requests the register called open had already merged, and the in-review list predated the second batch, so it named five where eight are open.

The versions come from asking which tags contain each merge commit, not from the newest tag, which is the rule this section already states. That rule earned its place again: six client-go releases went out in two days, and the newest tag was the wrong answer for five of the six merge requests.

## Related Issue

No single issue: this is the permanent register for the 1:1 field review, whose upstream half is tracked in <https://gitlab.com/gitlab-org/api/client-go/-/issues/2300>.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [x] Documentation update
- [ ] CI / build / tooling

## Changes Made

- Moves the cluster agent receptive flag and the secure file extension to merged in client-go v3.3.0, and the two service account address fields in v3.4.0.
- Corrects the in-review list to the eight that are actually open.
- Records why the merge-is-not-a-release note keeps mattering.

## How to Test

Read the section: every merge request named as merged carries the version whose tag contains its merge commit.

## Breaking Changes / Migration Notes

N/A. Documentation only.

## Checklist

### Code Quality

- [x] No code changed

### Testing

- [x] No code changed, so no test changes

### Documentation

- [x] The register is the documentation
- [x] Markdown lint and the table formatter both pass
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Security

- [x] No secrets, tokens, or credentials


