### PR TITLE
fix(test): give the polling-transition test a budget two polls fit in

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ and is never logged. Full details: [PRIVACY.md](PRIVACY.md).
 | Category                 |     Files |       Lines |
 | ------------------------ | --------: | ----------: |
 | Source (`.go`, non-test) |     1,246 |     267,003 |
-| Unit tests (`_test.go`)  |       735 |     437,467 |
+| Unit tests (`_test.go`)  |       735 |     437,473 |
 | End-to-end tests         |       246 |      66,458 |
-| **Total**                | **2,227** | **770,928** |
+| **Total**                | **2,227** | **770,934** |
 
 ### Functions
 

--- a/internal/tools/pipelines/wait_test.go
+++ b/internal/tools/pipelines/wait_test.go
@@ -181,11 +181,17 @@ func TestWait_PollingTransition(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
+	// 200 for the same reason TestWait_Timeout asks for it, and it is the whole
+	// budget rather than a margin: the seconds here are milliseconds, so this is
+	// 200ms for two loopback round-trips, and a CI runner under load spends more
+	// than that on one. At 60 the test asserted that Wait polls twice while
+	// giving it a budget a single poll could exhaust, and it failed exactly that
+	// way (PollCount = 1, FinalStatus = ""). Do not trim it back.
 	out, err := Wait(context.Background(), nil, client, WaitInput{
 		ProjectID:       "42",
 		PipelineID:      10,
 		IntervalSeconds: 5,
-		TimeoutSeconds:  60,
+		TimeoutSeconds:  200,
 	})
 	if err != nil {
 		t.Fatalf("Wait() unexpected error: %v", err)


### PR DESCRIPTION
## Description

`TestWait_PollingTransition` asserts that `Wait` polls at least twice, and gave it a timeout a single poll could exhaust.

Under `useFastPipelinePollDuration` the seconds in `WaitInput` are milliseconds, so `TimeoutSeconds: 60` is a 60ms budget for two loopback round-trips. A loaded CI runner spends more than that on one, and it failed exactly that way on PR 684, a branch that changes no Go code at all: `PollCount = 1, want >= 2` and `FinalStatus = "", want "success"`.

`TestWait_Timeout` in the same file was raised from 20 to 200 for this reason and carries the comment saying so. This is the same fix applied to the one other test in the millisecond regime that was still tight. The third, `TestWait_ContextCanceledDuringPoll`, already asks for 300.

Stacked on #685 rather than opened against main, because that PR regenerates the same README stats rows this one moves, so two independent branches would conflict there for whichever merged second.

## Related Issue

No issue: a flake found in CI on an unrelated pull request.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `TimeoutSeconds` 60 to 200 in `TestWait_PollingTransition`, with a comment saying why the number is the whole budget rather than a margin.
- README stats rows regenerated for the six added comment lines.

## How to Test

`RGO_DIR="$PWD" /root/.claude/bin/rgo 'go test ./internal/tools/pipelines/ -run "TestWait" -count=30'` passes. That is what I ran: 30 consecutive iterations, green.

## Breaking Changes / Migration Notes

N/A

## Checklist

### Code Quality

- [x] `golangci-lint run ./internal/tools/pipelines/` clean
- [x] Follows the conventions in `CLAUDE.md`

### Testing

- [x] 30 consecutive runs of the `TestWait` set pass
- [x] No production code touched

### Documentation

- [x] README stats regenerated
- [x] Commit message follows Conventional Commits

### Security

- [x] No secrets, tokens or credentials