### PR TITLE
docs(adr-0018): correct what publishes the catalog, and pin the citation

### DIFF
--- a/docs/development/adr/adr-0018-authorization-admits-per-action-gating.md
+++ b/docs/development/adr/adr-0018-authorization-admits-per-action-gating.md
@@ -95,9 +95,12 @@ decision here does not rest on that stricter reading, since nothing in any
 revision sanctions the partially anonymous surface either.
 
 Revision 2026-07-28 removed the `initialize` handshake, so the question now
-concerns `server/discover`, which servers **MUST** implement and which the
-specification nowhere requires to be anonymous; this deployment authenticates
-it like every other method.
+concerns `server/discover`. A server **implementing that revision** must
+implement the method, though calling it stays optional for the client, and
+nothing in the specification requires it to be served anonymously; this
+deployment authenticates it like every other method. The requirement is scoped
+to that revision on purpose: it says nothing about a server still speaking an
+initialization-era revision, and this one speaks several.
 
 **The catalog is published unauthenticated, and not by the mechanism this once
 named.** A Server Card under SEP-2127 deliberately carries no primitives: the
@@ -176,8 +179,10 @@ without executing.
 - NEG-004: VerifyMCP's score does not move. Six of its seven categories need
   an unauthenticated `server/discover` and `tools/list`, which this ADR
   declines to provide. The catalog those categories are looking for is at
-  `/server-card`, unauthenticated, and a scorer that reads only the JSON-RPC
-  surface will not find it.
+  `/.well-known/mcp/server-card.json`, unauthenticated, and a scorer that
+  reads only the JSON-RPC surface will not find it. VerifyMCP's own remedy is
+  to claim the listing and supply a read-only token, which is exactly the
+  `read_api` credential this ADR admits.
 
 ### Neutral
 

--- a/docs/development/adr/adr-0018-authorization-admits-per-action-gating.md
+++ b/docs/development/adr/adr-0018-authorization-admits-per-action-gating.md
@@ -72,21 +72,53 @@ action.**
   write, and `read_api` alone for one that cannot.
 
 **`tools/list` stays authenticated.** The MCP authorization specification
-(checked against 2025-11-25 and 2026-07-28) states that MCP servers "**MUST**
-validate access tokens before processing the request … and take all necessary
-steps to ensure no data is returned to unauthorized parties" (Authorization —
-Security Considerations, Access Token Privilege Restriction), and the
-Streamable HTTP binding adds that servers "**SHOULD** implement proper
-authentication for all connections". No revision carves out a method that may
-be served anonymously. Authorization is optional for a server as a whole; a
-server that requires it has no sanctioned partially anonymous surface.
+(checked against 2025-06-18, 2025-11-25, 2026-07-28 and the draft) states that
+MCP servers "**MUST** validate access tokens before processing the request …
+and take all necessary steps to ensure no data is returned to unauthorized
+parties" (Authorization — Security Considerations, Access Token Privilege
+Restriction), and the Streamable HTTP binding adds that servers "**SHOULD**
+implement proper authentication for all connections". No revision carves out a
+method that may be served anonymously. Authorization is optional for a server
+as a whole; a server that requires it has no sanctioned partially anonymous
+surface.
+
+Two things about that citation are worth pinning, because getting either wrong
+reopens a settled question. **The sentence was never removed**: it dates from
+the 2025-03 rewrite and stands unchanged in every revision above. In 2026-07-28
+it moved file rather than disappearing, because that revision split
+`basic/authorization.mdx` into a directory; fetching the old single-file path
+against 2026-07-28 returns 404, and reading that 404 as "the rule is gone" is
+the specific mistake to avoid. And the sentence sits under a heading about
+audience validation, so read strictly it governs a token that **was** presented
+rather than literally forbidding an answer to a request carrying none; the
+decision here does not rest on that stricter reading, since nothing in any
+revision sanctions the partially anonymous surface either.
 
 Revision 2026-07-28 removed the `initialize` handshake, so the question now
 concerns `server/discover`, which servers **MUST** implement and which the
 specification nowhere requires to be anonymous; this deployment authenticates
-it like every other method. The catalog is published instead through the
-mechanism designed for it: the server card at `/server-card`, unauthenticated,
-carrying every tool, resource, template and prompt with its schemas.
+it like every other method.
+
+**The catalog is published unauthenticated, and not by the mechanism this once
+named.** A Server Card under SEP-2127 deliberately carries no primitives: the
+SEP says it "intentionally omits primitive definitions (tools, resources, and
+prompts)", because what a server exposes "can vary by authenticated user,
+session, configuration, feature flags, deployment state", leaving "no viable
+substitute for runtime listing … with the logged-in user's identity". So a
+conformant card answers nothing about the catalog by design, and no scanner
+should be helped by enriching one. What does publish the catalog here is the
+**earlier SEP-1649 shape**, which this server still serves unauthenticated (2
+tools with their schemas, 37 prompts, 8 resources and 37 resource templates)
+and which a deployment reaches at `/.well-known/mcp/server-card.json`. Anyone
+comparing this deployment against the specification should hold the two apart:
+the conformant card is small on purpose, and the enumerating document is the
+older thing that happens to answer the question a directory asks.
+
+Practice agrees with the reading. Of 31 public remote MCP endpoints probed on
+2026-09-10, the 26 that require a credential refuse `tools/list` with 401,
+GitLab's own `gitlab.com/api/v4/mcp` among them; the five that answer it
+anonymously answer `tools/call` anonymously too. Nothing in the sample lists
+without executing.
 
 ## Consequences
 


### PR DESCRIPTION
## Description

Closing the question of whether the hosted endpoint should answer `tools/list` without a credential. The answer is no, it stays authenticated, and this corrects the record that decision rests on.

Nothing about the served surface changes. ADR-0018 is the only file touched.

## What was wrong

The ADR said the catalog is published by "the server card at `/server-card`, carrying every tool, resource, template and prompt with its schemas". A Server Card under SEP-2127 carries no primitives at all. The SEP says it intentionally omits them, because what a server exposes varies by user, session, configuration, flags and deployment state, leaving no substitute for runtime listing with the caller's identity.

So a conformant card answers nothing about the catalog, by design, and nobody should be tempted to enrich one to satisfy a scanner. What does publish the catalog unauthenticated is the earlier SEP-1649 shape this server still serves at `/.well-known/mcp/server-card.json`: 2 tools with their schemas, 37 prompts, 8 resources, 37 resource templates.

## What was nearly wrong

I reported earlier in this investigation that the "MUST validate access tokens before processing the request" sentence has zero occurrences in revision 2026-07-28, and therefore that the rule no longer applies to the revision our SDK speaks. That was false, and the way it was false is worth recording rather than quietly correcting.

2026-07-28 split `basic/authorization.mdx` into a directory. Fetching the old single-file path against that revision returns 404, and I read the 404 as absence. The sentence is at `basic/authorization/security-considerations.mdx:120`, unchanged since the 2025-03 rewrite, and present in 2025-06-18, 2025-11-25, 2026-07-28 and the draft alike.

The ADR now names all four revisions and says why the file moved, so the next reader who fetches the old path and gets a 404 has the answer in front of them instead of reopening the decision.

It also records the honest limit of the citation: the sentence sits under a heading about audience validation, so read strictly it governs a token that was presented rather than literally forbidding an answer to a request carrying none. The decision does not rest on the stronger reading, because nothing in any revision sanctions a partially anonymous surface either.

## What was added

What other servers actually do, because a rule nobody follows is worth knowing about before leaning on it. Of 31 public remote MCP endpoints probed on 2026-09-10, the 26 that require a credential refuse `tools/list` with 401, GitLab's own `gitlab.com/api/v4/mcp` among them. The five that answer it anonymously answer `tools/call` anonymously too. Nothing in the sample lists without executing.

## What this does not change

A `read_api` token is admitted and served a read-only surface, which is what ADR-0018 exists for, and that is unchanged and still proven on the wire by `TestOAuth_ReadAPITokenIsAdmitted` in `test/e2e/http`.

## Type of Change

- [x] Documentation

## How to Test

1. `npx markdownlint-cli2 docs/development/adr/adr-0018-authorization-admits-per-action-gating.md` passes.
2. The claims are checkable from outside: `curl -s -o /dev/null -w '%{http_code}' https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/main/docs/specification/2026-07-28/basic/authorization.mdx` answers 404, and the same fetch of `basic/authorization/security-considerations.mdx` carries the sentence at line 120.
3. `curl -s https://mcp.jmrp.io/gitlab/server-card | jq keys` lists no primitive key; the same fetch of `/gitlab/.well-known/mcp/server-card.json` carries `tools`, `prompts`, `resources` and `resourceTemplates`.

## Checklist

- [x] Markdown lints clean
- [x] No generated artifact reads `docs/development/adr/`, so nothing needs regenerating
- [x] Commit message follows Conventional Commits
