### PR TITLE
fix(meta): stop an alias from rewriting an action the tool routes

### DIFF
--- a/internal/tools/actioncompat/action_aliases.go
+++ b/internal/tools/actioncompat/action_aliases.go
@@ -20,7 +20,6 @@ const (
 	actionBranchProtect                  = "branch.protect"
 	actionExternalStatusCheckListProject = "external_status_check.list_project"
 	actionFeatureFlagUserListList        = "feature_flags.ff_user_list_list"
-	actionGroupEpicBoardList             = "group.epic_board_list"
 	actionGroupEpicDiscussionUpdateNote  = "group.epic_discussion_update_note"
 	actionGroupEpicDiscussionDeleteNote  = "group.epic_discussion_delete_note"
 	actionGroupLabelUpdate               = "group.group_label_update"
@@ -104,7 +103,6 @@ func defaultActionAliases() []ActionAlias {
 		compatActionAlias("branch.protected_list", "branch.get_protected"),
 		compatActionAlias("branch.update_protection", "branch.update_protected"),
 		compatActionAlias("enterprise_user.group_list", "enterprise_user.list"),
-		compatActionAlias("external_status_check.list_project_checks", actionExternalStatusCheckListProject),
 		compatActionAlias("feature_flag.list", "feature_flags.feature_flag_list"),
 		compatActionAlias("geo.node_list", "geo.list"),
 		compatActionAlias("gitlab_server.health_check", "server.health_check"),
@@ -119,10 +117,8 @@ func defaultActionAliases() []ActionAlias {
 		compatActionAlias("gitlab_issue.create", "issue.create"),
 		compatActionAlias("gitlab_issue.delete", "issue.delete"),
 		compatActionAlias("group.custom_member_roles_list", "member_role.list_group"),
-		compatActionAlias("group.group_board_list", actionGroupEpicBoardList),
 		compatActionAlias("group.epic_discussion_note_update", actionGroupEpicDiscussionUpdateNote),
 		compatActionAlias("group.epic_discussion_note_delete", actionGroupEpicDiscussionDeleteNote),
-		compatActionAlias("group.ldap_link_delete", "group.ldap_link_delete_for_provider"),
 		compatActionAlias("issue.note.create", "issue.note_create"),
 		compatActionAlias("issue.note.delete", "issue.note_delete"),
 		compatActionAlias("issue.note.get", "issue.note_get"),

--- a/internal/tools/actioncompat/apply_test.go
+++ b/internal/tools/actioncompat/apply_test.go
@@ -179,7 +179,6 @@ func TestNormalizeActionAlias_UsesCompatibilityPolicy(t *testing.T) {
 		"gitlab_package/publish_directory":      "package.publish_directory",
 		"gitlab_release/create":                 "release.create",
 		"gitlab_release_link/link_create_batch": "release.link_create_batch",
-		"group.group_board_list":                "group.epic_board_list",
 		"group.epic_discussion_note_update":     "group.epic_discussion_update_note",
 		"group.epic_discussion_note_delete":     "group.epic_discussion_delete_note",
 		"service_account.delete":                "group.service_account_delete",

--- a/internal/tools/dynamic/alias_audit.go
+++ b/internal/tools/dynamic/alias_audit.go
@@ -31,9 +31,10 @@ type CatalogDiscoveryFinding struct {
 }
 
 // AuditDefaultActionAliases returns governance findings for catalog-projected
-// compatibility aliases. It reports duplicate alias/canonical pairs, aliases
-// that map to missing canonical actions when a catalog is provided, and
-// ambiguous aliases that resolve to multiple canonical IDs.
+// compatibility aliases. It reports duplicate alias/canonical pairs, and when a
+// catalog is provided, aliases that map to missing canonical actions and
+// aliases spelled like another action's canonical ID; and ambiguous aliases
+// that resolve to multiple canonical IDs.
 //
 // Severity levels in the returned AliasAuditFinding values are interpreted as
 // follows: "error" for definite violations, "warning" for ambiguous alias
@@ -173,6 +174,13 @@ func detectAliasErrors(aliases []actionAlias, canonicalIDs map[string]struct{}, 
 		if validateCanonicalTarget {
 			if _, ok := canonicalIDs[alias.Canonical]; !ok {
 				findings = append(findings, aliasFinding("error", "non_canonical_target", alias, "alias target is not present in the canonical action catalog"))
+			}
+			// An alias spelled like another action's canonical ID never
+			// reaches its target, since execution resolves the canonical ID
+			// first, and what it does instead is offer that other action's
+			// name as a way to find this one.
+			if _, ok := canonicalIDs[alias.Alias]; ok && alias.Alias != alias.Canonical {
+				findings = append(findings, aliasFinding("error", "alias_names_another_action", alias, "alias is the canonical ID of another action"))
 			}
 		}
 		if !alias.searchable() {

--- a/internal/tools/dynamic/alias_audit_test.go
+++ b/internal/tools/dynamic/alias_audit_test.go
@@ -18,6 +18,7 @@ func TestAuditActionAliases_ReportsGovernanceFindings(t *testing.T) {
 	group := actioncatalog.NewGroup(actioncatalog.GroupOptions{ToolName: "gitlab_project"})
 	route := toolutil.Route(func(_ context.Context, _ map[string]any) (any, error) { return struct{}{}, nil })
 	group.SetAction(actioncatalog.Action{Name: "get", Route: route})
+	group.SetAction(actioncatalog.Action{Name: "list", Route: route})
 	if err := catalog.AddGroup(group); err != nil {
 		t.Fatalf("AddGroup() error = %v", err)
 	}
@@ -26,6 +27,7 @@ func TestAuditActionAliases_ReportsGovernanceFindings(t *testing.T) {
 		{Alias: "project.lookup", Canonical: "project.get"},
 		{Alias: "project.lookup", Canonical: "project.get"},
 		{Alias: "project.get", Canonical: "project.get"},
+		{Alias: "project.list", Canonical: "project.get"},
 		{Alias: "project.missing", Canonical: "project.missing"},
 		{Alias: "project.compat", Canonical: "project.get", Source: aliasSourceDeprecated},
 		{Alias: "project.ambiguous", Canonical: "project.get"},
@@ -35,6 +37,7 @@ func TestAuditActionAliases_ReportsGovernanceFindings(t *testing.T) {
 	findings := auditActionAliases(catalog, aliases)
 	wantProblems := []string{
 		"alias_equals_canonical",
+		"alias_names_another_action",
 		"ambiguous_compatibility_alias",
 		"duplicate_alias",
 		"non_canonical_target",

--- a/internal/tools/dynamic/register_test.go
+++ b/internal/tools/dynamic/register_test.go
@@ -1446,7 +1446,6 @@ func TestDescribe_CanonicalizesObservedModelAliases(t *testing.T) {
 		"project.member_remove":                     "project.member_delete",
 		"project_member.remove":                     "project.member_delete",
 		"webhook.add":                               "project.hook_add",
-		"group.ldap_link_delete":                    "group.ldap_link_delete_for_provider",
 		"release.create_link":                       "release.link_create",
 		"package.list_project":                      "package.list",
 	}

--- a/internal/tools/meta_tool_test.go
+++ b/internal/tools/meta_tool_test.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/projects"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/uploads"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
@@ -111,6 +113,85 @@ func TestMakeMetaHandler_ValidAction(t *testing.T) {
 	}
 	if result != "42" {
 		t.Errorf("expected 42, got %v", result)
+	}
+}
+
+// TestMetaCatalog_GroupBoardListAsksForTheIssueBoardsOnEveryTier verifies that
+// gitlab_group/group_board_list requests the group's issue boards on every
+// licensing tier.
+//
+// A licensed catalog also routes epic_board_list on gitlab_group, and an alias
+// mapping the first name to the second used to send the call to
+// /groups/:id/epic_boards on Premium and Ultimate. The mock answers any path
+// and records the one asked, so the test fails on the request rather than on a
+// rendering.
+func TestMetaCatalog_GroupBoardListAsksForTheIssueBoardsOnEveryTier(t *testing.T) {
+	for _, tier := range []edition.Tier{edition.Free, edition.Premium, edition.Ultimate} {
+		t.Run(tier.String(), func(t *testing.T) {
+			var asked atomic.Value
+			client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				asked.Store(r.URL.Path)
+				testutil.RespondJSON(w, http.StatusOK, `[]`)
+			}))
+			catalog, err := BuildActionCatalog(client, ActionCatalogOptions{Tier: tier})
+			if err != nil {
+				t.Fatalf("BuildActionCatalog(%s) error = %v", tier, err)
+			}
+			handler := toolutil.MakeMetaHandler("gitlab_group", catalog.ActionMaps()["gitlab_group"], markdownForResult)
+
+			result, _, err := handler(context.Background(), nil, MetaToolInput{Action: "group_board_list", Params: map[string]any{"group_id": "7"}})
+			if err != nil {
+				t.Fatalf(fmtUnexpectedErr, err)
+			}
+			if result != nil && result.IsError {
+				t.Fatalf("group_board_list returned a tool error: %#v", result.Content)
+			}
+			if got, _ := asked.Load().(string); got != "/api/v4/groups/7/boards" {
+				t.Fatalf("group_board_list asked GitLab for %q, want /api/v4/groups/7/boards", got)
+			}
+		})
+	}
+}
+
+// sameHandlerActionAliases lists the aliases of the meta alias table whose name
+// is also an action of its own because both names are registered with one
+// handler, so rewriting one into the other changes nothing a caller can see.
+var sameHandlerActionAliases = map[string]string{
+	// user.me is user.current registered under a friendlier name: both route
+	// to users.Current.
+	"me": "current",
+}
+
+// TestActionAliasTable_SpellsNoActionOfItsOwn verifies that no entry of the
+// meta alias table is the name of a different action, on any licensing tier.
+//
+// An alias is another spelling of one action. A name the catalog routes as an
+// action of its own, or a canonical ID, is not a spelling of anything else:
+// rewriting it runs a handler the caller did not name, which is what
+// group_board_list did on a licensed instance until the dispatcher stopped
+// rewriting routed names. The dispatcher guard keeps the meta surface safe
+// either way; this keeps the table honest for the evaluator, which applies it
+// without knowing the catalog.
+func TestActionAliasTable_SpellsNoActionOfItsOwn(t *testing.T) {
+	for _, tier := range []edition.Tier{edition.Free, edition.Premium, edition.Ultimate} {
+		t.Run(tier.String(), func(t *testing.T) {
+			catalog, err := BuildActionCatalog(nil, ActionCatalogOptions{Tier: tier, IncludeMCP: true})
+			if err != nil {
+				t.Fatalf("BuildActionCatalog(%s) error = %v", tier, err)
+			}
+			names := make(map[string]struct{})
+			for _, action := range catalog.Actions() {
+				names[string(action.ID)] = struct{}{}
+				names[action.Name] = struct{}{}
+			}
+			for name := range names {
+				target, ok := toolutil.ActionAliasTarget(name)
+				if !ok || target == name || sameHandlerActionAliases[name] == target {
+					continue
+				}
+				t.Errorf("alias %q -> %q: %q is an action of its own", name, target, name)
+			}
+		})
 	}
 }
 

--- a/internal/toolutil/meta_tool.go
+++ b/internal/toolutil/meta_tool.go
@@ -186,7 +186,6 @@ var commonActionAliases = map[string]string{
 	"project_member.get":                         "project.member_get",
 	"project_member.remove":                      actionProjectMemberDelete,
 	"project_member.update":                      actionProjectMemberEdit,
-	"external_status_check.list_project_checks":  actionExternalStatusCheckListProject,
 	"feature_flag_user_list.create":              "feature_flags.ff_user_list_create",
 	"feature_flag_user_list.delete":              "feature_flags.ff_user_list_delete",
 	"feature_flag_user_list.get":                 "feature_flags.ff_user_list_get",
@@ -231,7 +230,6 @@ var commonActionAliases = map[string]string{
 	"issue_note.list":                            "issue.note_list",
 	"issue_note.update":                          "issue.note_update",
 	"gitlab_interactive_issue.create":            "interactive.issue_create",
-	"group_board_list":                           "epic_board_list",
 	"epic_discussion_note_update":                "epic_discussion_update_note",
 	"epic_discussion_note_delete":                "epic_discussion_delete_note",
 	"variable.create":                            "ci_variable.create",
@@ -240,16 +238,36 @@ var commonActionAliases = map[string]string{
 
 // NormalizeActionAlias returns the canonical action name for common shortened
 // action spellings when the canonical action exists on the target meta-tool.
+//
+// An action the tool routes is returned as it is. An alias is another spelling
+// of one action, and a name the tool already routes is an action of its own:
+// rewriting it runs a different handler than the one the caller named. That is
+// what group_board_list did on a licensed instance, where epic_board_list also
+// exists on gitlab_group and the alias turned a request for the group's issue
+// boards into its epic boards.
 func NormalizeActionAlias(action string, routes ActionMap) string {
 	if action == "" {
 		return action
 	}
-	if canonical, ok := commonActionAliases[action]; ok {
+	if _, routed := routes[action]; routed {
+		return action
+	}
+	if canonical, ok := ActionAliasTarget(action); ok {
 		if _, exists := routes[canonical]; exists {
 			return canonical
 		}
 	}
 	return action
+}
+
+// ActionAliasTarget reports the action a common alias spelling stands for,
+// whatever tool it is sent to. [NormalizeActionAlias] decides whether a call
+// is rewritten; this is only the table's lookup, and it is exported so a test
+// holding the whole catalog can prove that no alias is the name of an action
+// of its own.
+func ActionAliasTarget(action string) (string, bool) {
+	canonical, ok := commonActionAliases[action]
+	return canonical, ok
 }
 
 // NormalizeActionAliasForParams returns the canonical action name for aliases

--- a/internal/toolutil/meta_tool_test.go
+++ b/internal/toolutil/meta_tool_test.go
@@ -1318,6 +1318,42 @@ func TestMakeMetaHandler_ActionAlias(t *testing.T) {
 	}
 }
 
+// TestMakeMetaHandler_RoutedActionIsNeverRewrittenByAnAlias verifies that an
+// action the tool routes runs its own handler even when the alias table maps
+// its name to another action the tool also routes.
+//
+// "me" is an alias of "current". With both routed, a call naming "me" must run
+// the "me" route; with only "current" routed, the alias still resolves. The
+// first half is the shape that sent gitlab_group/group_board_list to the epic
+// boards on a licensed instance, where both actions exist.
+func TestMakeMetaHandler_RoutedActionIsNeverRewrittenByAnAlias(t *testing.T) {
+	route := func(result string) ActionRoute {
+		return Route(func(_ context.Context, _ map[string]any) (any, error) {
+			return testOutput{Result: result}, nil
+		})
+	}
+	tests := map[string]struct {
+		routes ActionMap
+		want   string
+	}{
+		"both routed, the named one runs": {routes: ActionMap{"me": route("me"), "current": route("current")}, want: "me"},
+		"only the canonical routed":       {routes: ActionMap{"current": route("current")}, want: "current"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			handler := MakeMetaHandler("gitlab_user", tc.routes, nil)
+			_, raw, err := handler(context.Background(), &mcp.CallToolRequest{}, MetaToolInput{Action: "me"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out, ok := raw.(testOutput)
+			if !ok || out.Result != tc.want {
+				t.Fatalf("raw = %#v, want the %q route", raw, tc.want)
+			}
+		})
+	}
+}
+
 // TestMakeMetaHandler_EnvironmentGetByNameUsesProtectedGet verifies that a
 // named protected environment fetch is not routed to the numeric environment
 // get action when models send the generic get action.
@@ -1399,7 +1435,6 @@ func TestNormalizeActionAlias_DynamicCompatibilityAliases(t *testing.T) {
 		"merge_request.spent_time_reset":     {},
 		"issue.note_create":                  {},
 		"interactive.issue_create":           {},
-		"epic_board_list":                    {},
 		"epic_discussion_update_note":        {},
 		"epic_discussion_delete_note":        {},
 	}
@@ -1466,7 +1501,6 @@ func TestNormalizeActionAlias_DynamicCompatibilityAliases(t *testing.T) {
 		"issue_note.list":                            "issue.note_list",
 		"issue_note.update":                          "issue.note_update",
 		"gitlab_interactive_issue.create":            "interactive.issue_create",
-		"group_board_list":                           "epic_board_list",
 		"epic_discussion_note_update":                "epic_discussion_update_note",
 		"epic_discussion_note_delete":                "epic_discussion_delete_note",
 	}


### PR DESCRIPTION
On a licensed instance, `gitlab_group` with `action: group_board_list` returned the group's epic boards instead of its issue boards. The meta alias table mapped `group_board_list` to `epic_board_list`, and `NormalizeActionAlias` rewrote any aliased name whose target the tool routed without asking whether the name was itself one of the tool's actions. On Free `epic_board_list` does not exist, so only Premium and Ultimate were affected. A test against the real catalog reproduces it: before this change the call asked GitLab for `/api/v4/groups/7/epic_boards` on both licensed tiers.

The dispatcher now returns a routed action unchanged, and the entry is removed. Three dynamic compatibility aliases had the same shape, each spelled like the canonical ID of a different action (`group.group_board_list`, `group.ldap_link_delete`, `external_status_check.list_project_checks`). Execution was already safe there because the registry resolves a canonical ID before an alias, but search offered each name as a way to reach the other action, and the surface evaluator scored a call to one as a call to the other. They are removed, with the matching meta table entry.

Two checks keep the class out: the dynamic alias audit now reports an alias spelled like another action's canonical ID as an error, which `cmd/audit_dynamic_aliases` already fails CI on, and a test holds every entry of the meta table against the catalog on Free, Premium and Ultimate, with `me`/`current` as the one declared exception (one handler registered under two names).
