### PR TITLE
fix(telemetry): name the action registration bound to an individual tool

### DIFF
--- a/internal/tools/catalog_identity.go
+++ b/internal/tools/catalog_identity.go
@@ -52,15 +52,32 @@ func NewCallIdentifier(catalog *actioncatalog.Catalog, surface string) mcpotel.C
 	}
 	origin := catalog.SharedOrigin()
 	if origin == nil {
-		return newCallIdentifier(catalog.Actions(), surface)
+		return newCallIdentifier(identifierActions(catalog, surface), surface)
 	}
 	// The identifier reads names and IDs only, so every server bound to one
 	// shared catalog can use one; built from the origin, whose actions carry
 	// the same names, so the maps hold nothing bound to a credential.
 	key := identifierKey{origin: origin, surface: surface}
 	return sharedIdentifiers.Load(key, func() mcpotel.CallIdentifier {
-		return newCallIdentifier(origin.Actions(), surface)
+		return newCallIdentifier(identifierActions(origin, surface), surface)
 	})
+}
+
+// identifierActions lists a catalog's actions in the order the surface's
+// resolver reads them.
+//
+// Only the individual surface cares. Several actions can declare one
+// individual tool name, registration binds it to the first of them in
+// [individualRegistrationOrder], and the resolver must name that same action.
+// It read them sorted by canonical ID and kept the last, which put every call to
+// gitlab_commit_list under repository.file_history and every call to
+// gitlab_user_current under user.me. The meta and dynamic resolvers key on
+// canonical IDs, which are unique, so they keep the catalog's own order.
+func identifierActions(catalog *actioncatalog.Catalog, surface string) []actioncatalog.Action {
+	if surface == config.ToolSurfaceIndividual {
+		return individualRegistrationOrder(catalog)
+	}
+	return catalog.Actions()
 }
 
 // identifierKey names one shared identifier: the shared catalog it resolves
@@ -102,12 +119,22 @@ func newCallIdentifier(actions []actioncatalog.Action, surface string) mcpotel.C
 // Nothing here decodes arguments, and that is worth stating: this is the
 // surface with roughly a thousand tools, and its tools carry no action field at
 // all, so a decode would be pure waste on every call.
+//
+// The first action to declare a name keeps it, and the name is trimmed, both
+// because that is what registration does with the same field: the actions
+// arrive in registration order, and a name two of them declare belongs to the
+// one whose handler was registered.
 func individualIdentifier(actions []actioncatalog.Action) mcpotel.CallIdentifier {
 	byTool := make(map[string]mcpotel.Identity, len(actions))
 	for _, action := range actions {
-		if name := action.IndividualTool.Name; name != "" {
-			byTool[name] = mcpotel.Identity{ActionID: string(action.ID), Domain: action.Domain}
+		name := strings.TrimSpace(action.IndividualTool.Name)
+		if name == "" {
+			continue
 		}
+		if _, taken := byTool[name]; taken {
+			continue
+		}
+		byTool[name] = mcpotel.Identity{ActionID: string(action.ID), Domain: action.Domain}
 	}
 	return mcpotel.IdentifierFunc(func(toolName string, _ any) (mcpotel.Identity, bool) {
 		identity, ok := byTool[toolName]

--- a/internal/tools/catalog_identity_test.go
+++ b/internal/tools/catalog_identity_test.go
@@ -1,10 +1,16 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/config"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/mcpotel"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/actioncatalog"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
@@ -443,4 +449,133 @@ func TestNewCallIdentifier_MetaCallWithoutAnAction_StillNamesTheDomain(t *testin
 			}
 		})
 	}
+}
+
+// TestNewCallIdentifier_IndividualNameBelongsToTheRegisteredAction verifies
+// that when two actions declare one individual tool name, the resolver names
+// the action whose projection registration kept.
+//
+// alpha is declared before beta and sorts before it, so registration keeps
+// alpha while a resolver reading the actions by canonical ID and keeping the
+// last would name beta. The two carry different descriptions, which is how the
+// test reads, from the served tool list, which of them registration kept.
+func TestNewCallIdentifier_IndividualNameBelongsToTheRegisteredAction(t *testing.T) {
+	spec := func(actionName, description string) toolutil.ActionSpec {
+		return toolutil.NewActionSpec(actionName, toolutil.RouteAction(nil,
+			func(_ context.Context, _ *gitlabclient.Client, _ struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			}), toolutil.ActionSpecOptions{
+			ReadOnly:       true,
+			OwnerPackage:   "tools",
+			IndividualTool: toolutil.IndividualToolSpec{Name: "gitlab_test_shared", Title: "Shared", Description: description},
+		})
+	}
+	catalog := testIndividualCatalog(t, spec("alpha", "Alpha."), spec("beta", "Beta."))
+
+	registered := registeredIndividualTools(t, catalog)
+	identity, ok := NewCallIdentifier(catalog, config.ToolSurfaceIndividual).Identify("gitlab_test_shared", nil)
+	if !ok {
+		t.Fatal("gitlab_test_shared resolved to nothing")
+	}
+	action, found := catalog.Action(actioncatalog.ActionID(identity.ActionID))
+	if !found {
+		t.Fatalf("resolved action %q is not in the catalog", identity.ActionID)
+	}
+	if got, want := action.IndividualTool.Description, registered["gitlab_test_shared"].Description; got != want {
+		t.Fatalf("resolved %s (%q), but registration served %q", identity.ActionID, got, want)
+	}
+}
+
+// ambiguousIndividualToolOwners names every individual tool that more than one
+// action declares, with the action registration binds it to. The siblings are
+// deliberate: each is one handler projected under a second meta name, and the
+// individual surface serves it once.
+var ambiguousIndividualToolOwners = map[string]string{
+	// repository.file_history is the same commits.List under a path-scoped name.
+	"gitlab_commit_list": "repository.commit_list",
+	// issue.list_group is the same issues.ListGroup; the group surface owns
+	// the individual tool's description.
+	"gitlab_issue_list_group": "group.issues",
+	// user.me is the same users.Current under a friendlier name.
+	"gitlab_user_current": "user.current",
+}
+
+// TestNewCallIdentifier_AmbiguousIndividualNamesResolveToTheirOwner verifies,
+// on the real catalog and every licensing tier, that each individual tool name
+// several actions declare resolves to the action registration binds it to.
+//
+// The siblings project identical tools, so nothing a client can see tells them
+// apart and the served tool list cannot be the oracle here, as it is for the
+// synthetic catalog above: the owners are declared instead. A name declared
+// twice that is missing from the declaration fails, and so does a declaration
+// no tier needs any more, so a new sibling is a decision rather than a
+// telemetry label chosen by sort order.
+func TestNewCallIdentifier_AmbiguousIndividualNamesResolveToTheirOwner(t *testing.T) {
+	needed := make(map[string]bool)
+	for _, tier := range []edition.Tier{edition.Free, edition.Premium, edition.Ultimate} {
+		t.Run(tier.String(), func(t *testing.T) {
+			for _, name := range checkAmbiguousIndividualOwners(t, tier) {
+				needed[name] = true
+			}
+		})
+	}
+	for name := range ambiguousIndividualToolOwners {
+		if !needed[name] {
+			t.Errorf("ambiguousIndividualToolOwners declares %s, which no tier declares twice any more", name)
+		}
+	}
+}
+
+// checkAmbiguousIndividualOwners resolves every individual tool name the tier's
+// catalog declares more than once, reports each that does not resolve to its
+// declared owner, and returns the names it found declared more than once.
+func checkAmbiguousIndividualOwners(t *testing.T, tier edition.Tier) []string {
+	t.Helper()
+	catalog, err := BuildActionCatalog(nil, ActionCatalogOptions{Tier: tier, IncludeMCP: true})
+	if err != nil {
+		t.Fatalf("BuildActionCatalog(%s) error = %v", tier, err)
+	}
+	identifier := NewCallIdentifier(catalog, config.ToolSurfaceIndividual)
+	var ambiguous []string
+	for name, count := range declaredIndividualNames(catalog) {
+		if count < 2 {
+			continue
+		}
+		ambiguous = append(ambiguous, name)
+		owner, known := ambiguousIndividualToolOwners[name]
+		if !known {
+			t.Errorf("%s is declared by %d actions and has no owner in ambiguousIndividualToolOwners", name, count)
+			continue
+		}
+		if identity, ok := identifier.Identify(name, nil); !ok || identity.ActionID != owner {
+			t.Errorf("%s resolved to %q, want %q", name, identity.ActionID, owner)
+		}
+	}
+	return ambiguous
+}
+
+// declaredIndividualNames counts the actions that declare each individual tool
+// name, trimmed as registration trims it.
+func declaredIndividualNames(catalog *actioncatalog.Catalog) map[string]int {
+	declared := make(map[string]int)
+	for _, action := range catalog.Actions() {
+		if name := strings.TrimSpace(action.IndividualTool.Name); name != "" {
+			declared[name]++
+		}
+	}
+	return declared
+}
+
+// registeredIndividualTools registers catalog on a fresh server with the
+// options cmd/server registers the individual surface with, and returns the
+// served tools by name.
+func registeredIndividualTools(t *testing.T, catalog *actioncatalog.Catalog) map[string]*mcp.Tool {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, &mcp.ServerOptions{PageSize: 2000, SchemaCache: testSchemaCache})
+	RegisterIndividualCatalogTools(server, catalog, IndividualCatalogRegisterOptions{IncludeStandaloneUtilities: true})
+	tools := make(map[string]*mcp.Tool)
+	for _, tool := range listToolsFromServer(t, server) {
+		tools[tool.Name] = tool
+	}
+	return tools
 }

--- a/internal/tools/individual_catalog.go
+++ b/internal/tools/individual_catalog.go
@@ -71,6 +71,29 @@ func RegisterIndividualCatalogTools(server *mcp.Server, catalog *actioncatalog.C
 	}
 }
 
+// individualRegistrationOrder lists the catalog's actions in the order
+// [RegisterIndividualCatalogTools] visits them: groups by tool name, then each
+// group's actions as declared, leaving out the groups no registration projects.
+//
+// The order decides which action an individual tool name belongs to. A name can
+// be declared by more than one action on purpose: gitlab_issue_list_group is
+// projected from issue.list_group and group.issues, gitlab_commit_list from
+// repository.commit_list and repository.file_history, gitlab_user_current from
+// user.current and user.me. Registration binds the name to the first of them in
+// this order, so a reader that maps a tool name back to an action has to walk
+// the same order and keep the first, or it names an action whose handler never
+// ran under that name.
+func individualRegistrationOrder(catalog *actioncatalog.Catalog) []actioncatalog.Action {
+	projected := IndividualCatalogRegisterOptions{IncludeStandaloneUtilities: true}
+	var actions []actioncatalog.Action
+	for _, group := range catalog.Groups() {
+		if individualCatalogGroupEligible(group, projected) {
+			actions = append(actions, group.ActionsInOrder()...)
+		}
+	}
+	return actions
+}
+
 // registerIndividualCatalogGroup projects every action in a single
 // catalog group onto the server. Groups failing the surface or edition
 // gate are silently skipped. The group's [actioncatalog.Group.FormatResult]


### PR DESCRIPTION
Three individual tool names are each declared by two catalog actions on purpose, one handler projected under a second meta name: `gitlab_commit_list` from `repository.commit_list` and `repository.file_history`, `gitlab_issue_list_group` from `group.issues` and `issue.list_group`, and `gitlab_user_current` from `user.current` and `user.me`. Registration serves each name once and binds it to the first declaring action in its own walk (groups by tool name, actions as declared). The call identifier read the actions sorted by canonical ID and kept the last, so every call to those three tools on the individual surface was recorded under the sibling whose handler was never registered.

The identifier now walks the order registration walks and keeps the first name, trimmed as registration trims it. The meta and dynamic resolvers key on canonical IDs and are unchanged.

A synthetic catalog pins the mechanism against the served tool list, with two actions declaring one name under different descriptions. The real siblings project identical tools, so no client-visible output tells them apart; their owners are declared in a table the test holds on every tier, which also fails on a new name declared twice without an owner and on a declaration no tier needs any more.

The e2e coverage recorder now being designed would resolve calls through this identifier, so it has to agree with registration first.
