### PR TITLE
fix(tools): stop rendering credentials in tool Markdown

### DIFF
--- a/internal/prompts/prompt_audit.go
+++ b/internal/prompts/prompt_audit.go
@@ -778,9 +778,9 @@ func writeFullWebhooksSection(b *strings.Builder, webhooks []*gl.ProjectHook) {
 	if len(webhooks) > 0 {
 		b.WriteString("\n| URL | Push | MR | Issues | SSL |\n|-----|------|-----|--------|-----|\n")
 		for _, h := range webhooks {
-			// Escaped outside the truncation, so no entity is cut in half.
+			// Escaped outside the redaction, so no entity is cut in half.
 			fmt.Fprintf(b, "| %s | %s | %s | %s | %s |\n",
-				mdInline(maskURL(h.URL)), toolutil.BoolEmoji(h.PushEvents), toolutil.BoolEmoji(h.MergeRequestsEvents),
+				mdInline(toolutil.RedactURLToOrigin(h.URL)), toolutil.BoolEmoji(h.PushEvents), toolutil.BoolEmoji(h.MergeRequestsEvents),
 				toolutil.BoolEmoji(h.IssuesEvents), toolutil.BoolEmoji(h.EnableSSLVerification))
 		}
 	}
@@ -859,12 +859,4 @@ func formatBytes(bytes int64) string {
 	default:
 		return fmt.Sprintf("%d B", bytes)
 	}
-}
-
-// maskURL masks the path portion of a webhook URL for security.
-func maskURL(u string) string {
-	if len(u) <= 30 {
-		return u
-	}
-	return u[:30] + "..."
 }

--- a/internal/prompts/prompt_audit_test.go
+++ b/internal/prompts/prompt_audit_test.go
@@ -672,16 +672,37 @@ func TestFormatBytes(t *testing.T) {
 	}
 }
 
-// TestMaskURL verifies MaskURL.
-func TestMaskURL(t *testing.T) {
-	short := "http://example.com"
-	if got := maskURL(short); got != short {
-		t.Errorf("maskURL short = %q, want %q", got, short)
+// TestWriteFullWebhooksSection_URLWithCredentials_RendersOriginOnly verifies
+// that a webhook row names the host it posts to and nothing else: no userinfo,
+// no path, no query.
+//
+// It matters because the row used to be the first thirty characters of the
+// URL, which is long enough to spell a userinfo out in full, and because a
+// hook's path is routinely the secret (a Slack-style endpoint is a public host
+// plus an unguessable path).
+func TestWriteFullWebhooksSection_URLWithCredentials_RendersOriginOnly(t *testing.T) {
+	hooks := []*gl.ProjectHook{
+		{URL: "https://hookuser:hookpass@hooks.example.com/services/T000/B000/SECRETPATHVALUE"},
+		{URL: "https://short.example.com/?token=querysecret"},
 	}
-	long := "https://very-long-webhook-url.example.com/path/to/endpoint"
-	got := maskURL(long)
-	if len(got) > 34 || !strings.HasSuffix(got, "...") {
-		t.Errorf("maskURL long = %q, expected truncated with ...", got)
+
+	var b strings.Builder
+	writeFullWebhooksSection(&b, hooks)
+	got := b.String()
+
+	for _, secret := range []string{"hookpass", "hookuser", "SECRETPATHVALUE", "B000", "querysecret"} {
+		t.Run("withholds "+secret, func(t *testing.T) {
+			if strings.Contains(got, secret) {
+				t.Errorf("webhook section leaked %q:\n%s", secret, got)
+			}
+		})
+	}
+	for _, want := range []string{"https://hooks.example.com/...", "https://short.example.com/..."} {
+		t.Run("renders "+want, func(t *testing.T) {
+			if !strings.Contains(got, want) {
+				t.Errorf("webhook section missing redacted origin %q:\n%s", want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/health/health.go
+++ b/internal/tools/health/health.go
@@ -52,22 +52,6 @@ func SetServerInfo(info ServerInfo) {
 	serverInfo = info
 }
 
-// publicBaseURL renders base with the three parts a secret can hide in
-// removed: the userinfo, the query and the fragment. What survives is the
-// scheme, the host and the path, which is what identifies the instance and
-// all this diagnostics field was ever meant to report.
-//
-// GITLAB_URL is validated for scheme and host only, so an operator may
-// configure any of the three (a proxy credential in the userinfo is the
-// realistic one), and this value is handed to whichever MCP client called the
-// tool and copied into whatever it logs. client-go builds its own error text
-// the same way, from scheme, host and path (gitlab.go, ErrorResponse.Error),
-// so this leaves the two agreeing rather than the field being the one place
-// that says more.
-func publicBaseURL(base *url.URL) string {
-	return base.Scheme + "://" + base.Host + base.EscapedPath()
-}
-
 // withoutUserinfo removes user from text, for the error strings that come
 // back from a request made against a base URL carrying one.
 //
@@ -117,8 +101,11 @@ func Check(ctx context.Context, client *gitlabclient.Client, _ Input) (Output, e
 
 	base := client.GL().BaseURL()
 
+	// GITLAB_URL is validated for scheme and host only, so an operator may
+	// configure a userinfo, a query or a fragment, and this value is handed to
+	// whichever MCP client called the tool and copied into whatever it logs.
 	out := Output{
-		GitLabURL:        publicBaseURL(base),
+		GitLabURL:        toolutil.RedactURL(base),
 		MCPServerVersion: serverInfo.Version,
 		Author:           serverInfo.Author,
 		Department:       serverInfo.Department,

--- a/internal/tools/health/health_test.go
+++ b/internal/tools/health/health_test.go
@@ -578,12 +578,13 @@ func healthSpecByName(t *testing.T, specs []toolutil.ActionSpec, name string) to
 // Diagnostics never carry the secrets a base URL can hide
 // ---------------------------------------------------------------------------.
 
-// TestPublicBaseURL_URLCarryingSecrets_KeepsOnlySchemeHostAndPath verifies that
-// the reported instance URL is reduced to the parts that identify the instance.
+// TestCheck_URLCarryingSecrets_KeepsOnlySchemeHostAndPath verifies that the
+// reported instance URL is reduced to the parts that identify the instance.
 // GITLAB_URL is validated for scheme and host alone, so userinfo, a query and a
 // fragment are all configurable, and this value ends up in a tool result and in
-// whatever the client logs.
-func TestPublicBaseURL_URLCarryingSecrets_KeepsOnlySchemeHostAndPath(t *testing.T) {
+// whatever the client logs. The rule now lives in toolutil.RedactURL, which
+// this tool and the webhook audit prompt share.
+func TestCheck_URLCarryingSecrets_KeepsOnlySchemeHostAndPath(t *testing.T) {
 	cases := []struct {
 		name string
 		raw  string
@@ -603,8 +604,8 @@ func TestPublicBaseURL_URLCarryingSecrets_KeepsOnlySchemeHostAndPath(t *testing.
 			if err != nil {
 				t.Fatalf("url.Parse(%q): %v", tc.raw, err)
 			}
-			if got := publicBaseURL(parsed); got != tc.want {
-				t.Errorf("publicBaseURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			if got := toolutil.RedactURL(parsed); got != tc.want {
+				t.Errorf("toolutil.RedactURL(%q) = %q, want %q", tc.raw, got, tc.want)
 			}
 		})
 	}

--- a/internal/tools/instancevariables/instance_variables_test.go
+++ b/internal/tools/instancevariables/instance_variables_test.go
@@ -259,7 +259,7 @@ func TestFormatOutputMarkdown(t *testing.T) {
 	if !strings.Contains(md, "secret") {
 		t.Error("expected value in output when not masked")
 	}
-	if !strings.Contains(md, "true") {
+	if !strings.Contains(md, "| Protected | "+toolutil.BoolEmoji(true)+" |") {
 		t.Error("expected Protected=true in output")
 	}
 }
@@ -706,12 +706,12 @@ func TestFormatOutputMarkdown_FullUnmasked(t *testing.T) {
 
 	for _, want := range []string{
 		"## Instance Variable: DB_HOST",
-		"**Type**: env_var",
-		"**Protected**: true",
-		"**Masked**: false",
-		"**Raw**: true",
-		"**Description**: Database host",
-		"**Value**: localhost",
+		"| Type | env_var |",
+		"| Protected | " + toolutil.BoolEmoji(true) + " |",
+		"| Masked | " + toolutil.BoolEmoji(false) + " |",
+		"| Raw | " + toolutil.BoolEmoji(true) + " |",
+		"| Description | Database host |",
+		"| Value | localhost |",
 	} {
 		t.Run(want, func(t *testing.T) {
 			if !strings.Contains(md, want) {
@@ -731,11 +731,65 @@ func TestFormatOutputMarkdown_NoDescription(t *testing.T) {
 		VariableType: "env_var",
 	})
 
-	if strings.Contains(md, "**Description**") {
+	if strings.Contains(md, "| Description |") {
 		t.Error("should not contain Description when empty")
 	}
-	if !strings.Contains(md, "**Value**: val") {
+	if !strings.Contains(md, "| Value | val |") {
 		t.Errorf("expected value in output:\n%s", md)
+	}
+}
+
+// TestFormatOutputMarkdown_HiddenVariable_WithholdsTheValue verifies that an
+// instance variable GitLab marks hidden has its value withheld from the card,
+// and that the flag itself is reported.
+//
+// It matters because hidden is the stronger of GitLab's two secrecy flags: a
+// variable created with masked_and_hidden is never shown again in GitLab's own
+// UI, and the API still answers an administrator's read with the value. The
+// card asked only whether the variable was masked, so a hidden-but-unmasked
+// variable was printed in full, which is the one shape the flag exists for.
+func TestFormatOutputMarkdown_HiddenVariable_WithholdsTheValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		variable   Output
+		wantHidden bool
+	}{
+		{
+			name:       "hidden and not masked",
+			variable:   Output{Key: "DEPLOY_KEY", Value: "s3cret-value", VariableType: "env_var", Hidden: true},
+			wantHidden: true,
+		},
+		{
+			name:       "masked and hidden",
+			variable:   Output{Key: "DEPLOY_KEY", Value: "s3cret-value", VariableType: "env_var", Masked: true, Hidden: true},
+			wantHidden: true,
+		},
+		{
+			name:       "neither is still printed",
+			variable:   Output{Key: "DEPLOY_KEY", Value: "s3cret-value", VariableType: "env_var"},
+			wantHidden: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			md := FormatOutputMarkdown(tc.variable)
+			switch {
+			case tc.wantHidden:
+				if strings.Contains(md, "s3cret-value") {
+					t.Errorf("hidden variable rendered its value:\n%s", md)
+				}
+				if !strings.Contains(md, "| Value | [masked] |") {
+					t.Errorf("hidden variable missing the withheld marker:\n%s", md)
+				}
+				if !strings.Contains(md, "| Hidden |") {
+					t.Errorf("hidden variable does not report the flag:\n%s", md)
+				}
+			default:
+				if !strings.Contains(md, "| Value | s3cret-value |") {
+					t.Errorf("readable variable lost its value:\n%s", md)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/tools/instancevariables/markdown.go
+++ b/internal/tools/instancevariables/markdown.go
@@ -1,38 +1,19 @@
 package instancevariables
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
 // FormatOutputMarkdown renders a single instance CI/CD variable as Markdown.
+//
+// Hidden is the second half of the guard and was missing: GitLab lets an
+// instance variable be created with the value hidden from every later reader,
+// and it sends that value back to an administrator's own request, so a card
+// that asked only whether the variable was masked printed it. The shared
+// renderer this delegates to has held both halves since hidden variables
+// existed, and it reports the flag as well, which the card did not.
 func FormatOutputMarkdown(v Output) string {
-	if v.Key == "" {
-		return ""
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Instance Variable: %s\n\n", toolutil.EscapeMdHeading(v.Key))
-	//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
-	fmt.Fprintf(&b, "- **Type**: %s\n", v.VariableType)
-	fmt.Fprintf(&b, "- **Protected**: %t\n", v.Protected)
-	fmt.Fprintf(&b, "- **Masked**: %t\n", v.Masked)
-	fmt.Fprintf(&b, "- **Raw**: %t\n", v.Raw)
-	if v.Description != "" {
-		toolutil.WriteDescription(&b, v.Description)
-	}
-	if !v.Masked {
-		fmt.Fprintf(&b, "- **Value**: %s\n", toolutil.EscapeMdTableCell(v.Value))
-	} else {
-		b.WriteString("- **Value**: [masked]\n")
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'update' to change this variable",
-		"Use action 'delete' to remove this variable",
-	)
-	return b.String()
+	return toolutil.FormatCICDVariableDetailMarkdown(toMarkdownVariable(v), "Instance Variable", false)
 }
 
 // FormatListMarkdown renders a paginated list of instance CI/CD variables as a Markdown table.
@@ -44,8 +25,12 @@ func FormatListMarkdown(out ListOutput) string {
 	)
 }
 
+// toMarkdownVariable maps an instance variable onto the shared view model.
+// Hidden travels with Masked because the shared renderer withholds the value
+// for either: a variable created with masked_and_hidden is never shown again
+// in GitLab's own UI, whether or not it is also masked.
 func toMarkdownVariable(v Output) toolutil.CICDVariableMarkdown {
-	flags := toolutil.CICDVariableFlags{Protected: v.Protected, Masked: v.Masked, Raw: v.Raw}
+	flags := toolutil.CICDVariableFlags{Protected: v.Protected, Masked: v.Masked, Hidden: v.Hidden, Raw: v.Raw}
 	return toolutil.NewCICDVariableMarkdown(v.Key, v.Value, v.VariableType, flags, "", v.Description)
 }
 

--- a/internal/tools/pipelinetriggers/markdown.go
+++ b/internal/tools/pipelinetriggers/markdown.go
@@ -7,14 +7,57 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// triggerTokenPrefix is the marker GitLab puts in front of every pipeline
+// trigger token it mints.
+const triggerTokenPrefix = "glptt-"
+
+// shownTokenChars is how much of the secret part of a trigger token the get
+// and list cards reveal: enough to tell two tokens apart at a glance, and far
+// too little to run a pipeline with.
+const shownTokenChars = 4
+
+// maskTriggerToken renders the prefix of a pipeline trigger token: GitLab's
+// own "glptt-" marker when the token carries one, plus four characters of the
+// secret after it, and an ellipsis for the rest.
+//
+// GitLab returns the whole token from the get and the list endpoints as well
+// as from the create one, so printing it in full was this server's choice, and
+// on a list it repeated a live credential once per row into text a model
+// reads, keeps in its context and may quote back. A token too short to have a
+// prefix and four characters is withheld entirely rather than revealed by the
+// arithmetic.
+func maskTriggerToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	shown := shownTokenChars
+	if strings.HasPrefix(token, triggerTokenPrefix) {
+		shown += len(triggerTokenPrefix)
+	}
+	if len(token) <= shown {
+		return toolutil.RedactedPlaceholder
+	}
+	return token[:shown] + "..."
+}
+
 // FormatTriggerMarkdown formats a single pipeline trigger as markdown.
+//
+// The token is written in full only on the result that mints it. A get or an
+// update answers with the same Go type and prints the prefix alone.
 func FormatTriggerMarkdown(out Output) string {
 	var b strings.Builder
 	b.WriteString("## Pipeline Trigger\n\n")
 	b.WriteString("| Field | Value |\n|---|---|\n")
 	fmt.Fprintf(&b, "| ID | %d |\n", out.ID)
 	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
-	fmt.Fprintf(&b, "| Token | %s |\n", toolutil.EscapeMdTableCell(out.Token))
+	if out.Token != "" {
+		token := out.Token
+		if !out.minted {
+			token = maskTriggerToken(out.Token)
+		}
+		//gitlab:allow-unescaped token: a token GitLab minted, a fixed prefix and URL-safe characters, inside a code span so the reader can copy it back verbatim.
+		fmt.Fprintf(&b, "| Token | `%s` |\n", token)
+	}
 	if out.Owner != nil && out.Owner.Name != "" {
 		fmt.Fprintf(&b, "| Owner | %s |\n", toolutil.EscapeMdTableCell(out.Owner.Name))
 	}
@@ -27,12 +70,15 @@ func FormatTriggerMarkdown(out Output) string {
 	if out.ExpiresAt != "" {
 		fmt.Fprintf(&b, "| Expires At | %s |\n", toolutil.FormatTime(out.ExpiresAt))
 	}
-	toolutil.WriteHints(
-		&b,
+	hints := []string{
 		"Use the selected tool surface's pipeline-trigger update action with the same project_id and trigger_id to modify this trigger",
 		"Use the selected tool surface's pipeline-trigger run action with the same project_id, ref, and this token to execute a pipeline",
 		"Use the selected tool surface's pipeline-trigger delete action with the same project_id, trigger_id, and explicit confirm=true to remove this trigger",
-	)
+	}
+	if !out.minted && out.Token != "" {
+		hints[1] = "Only the prefix of the token is shown here. Read the full value from this result's structured output, or use the pipeline-trigger create action to mint a new trigger, before calling the pipeline-trigger run action"
+	}
+	toolutil.WriteHints(&b, hints...)
 	return b.String()
 }
 
@@ -51,10 +97,14 @@ func FormatListTriggersMarkdown(out ListOutput) string {
 		if t.Owner != nil {
 			owner = t.Owner.Name
 		}
+		// A list answers with every trigger a project has, so the old row wrote
+		// one live credential per line into the model's context. GitLab sends
+		// them; publishing them was ours.
+		//gitlab:allow-unescaped maskTriggerToken(t.Token): the prefix of a token GitLab minted, a fixed marker and URL-safe characters.
 		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
 			t.ID,
 			toolutil.EscapeMdTableCell(t.Description),
-			toolutil.EscapeMdTableCell(t.Token),
+			maskTriggerToken(t.Token),
 			toolutil.EscapeMdTableCell(owner),
 			toolutil.FormatTime(t.LastUsed))
 	}
@@ -62,6 +112,7 @@ func FormatListTriggersMarkdown(out ListOutput) string {
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,
+		"The Token column shows each token's prefix only. Read the full value from this result's structured output when a pipeline-trigger run action needs one",
 		"Use the selected tool surface's pipeline-trigger get action with the same project_id and trigger_id for full details",
 		"Use the selected tool surface's pipeline-trigger create action with project_id to add a new pipeline trigger",
 	)

--- a/internal/tools/pipelinetriggers/pipeline_triggers.go
+++ b/internal/tools/pipelinetriggers/pipeline_triggers.go
@@ -28,6 +28,14 @@ type Output struct {
 	UpdatedAt   string      `json:"updated_at,omitempty"`
 	LastUsed    string      `json:"last_used,omitempty"`
 	ExpiresAt   string      `json:"expires_at,omitempty"`
+
+	// minted says this value is the answer to the call that created the token,
+	// which is the one card that prints it in full; every other card prints the
+	// prefix alone. It is unexported so that nothing about the published shape
+	// moves: GitLab returns the token from get and from list too, and the 1:1
+	// policy keeps it on the structured output of all three. What changes is
+	// only how much of it this server writes into the Markdown a model reads.
+	minted bool
 }
 
 // ListOutput represents a paginated list of pipeline triggers.
@@ -210,7 +218,9 @@ func CreateTrigger(ctx context.Context, client *gitlabclient.Client, input Creat
 	if err != nil {
 		return Output{}, toolutil.WrapErr("pipeline_trigger_create", err)
 	}
-	return convertTrigger(t, extra), nil
+	out := convertTrigger(t, extra)
+	out.minted = true
+	return out, nil
 }
 
 // UpdateTrigger updates a pipeline trigger.

--- a/internal/tools/pipelinetriggers/pipeline_triggers_test.go
+++ b/internal/tools/pipelinetriggers/pipeline_triggers_test.go
@@ -177,6 +177,120 @@ func TestCreateTrigger_Success(t *testing.T) {
 	}
 }
 
+// TestCreateTrigger_MintedToken_IsRenderedInFull verifies that the one card
+// that answers the call which mints a trigger token prints that token whole.
+//
+// It matters because the value is unobtainable anywhere else in a usable form
+// once the get and the list cards stop printing it, so masking every card
+// would have left the create action useless.
+func TestCreateTrigger_MintedToken_IsRenderedInFull(t *testing.T) {
+	const token = "glptt-mintedsecret0123456789"
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v4/projects/1/triggers", func(w http.ResponseWriter, r *http.Request) {
+		testutil.RespondJSON(w, http.StatusCreated, `{"id":11,"description":"test trigger","token":"`+token+`"}`)
+	})
+	client := testutil.NewTestClient(t, mux)
+
+	out, err := CreateTrigger(context.Background(), client, CreateInput{ProjectID: "1", Description: "test trigger"})
+	if err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	md := FormatTriggerMarkdown(out)
+	if !strings.Contains(md, "| Token | `"+token+"` |") {
+		t.Errorf("create card missing the minted token in a code span:\n%s", md)
+	}
+}
+
+// TestGetTrigger_ExistingToken_IsRenderedByPrefixOnly verifies that the card a
+// get answers with prints the token's prefix and never the whole secret.
+//
+// It matters because GitLab returns the token from the get endpoint too, so
+// printing it was this server's own choice, and the value reached the model as
+// a usable credential on every read of a trigger somebody else created.
+func TestGetTrigger_ExistingToken_IsRenderedByPrefixOnly(t *testing.T) {
+	const token = "glptt-storedsecret0123456789"
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/projects/1/triggers/10", func(w http.ResponseWriter, r *http.Request) {
+		testutil.RespondJSON(w, http.StatusOK, `{"id":10,"description":"deploy","token":"`+token+`"}`)
+	})
+	client := testutil.NewTestClient(t, mux)
+
+	out, err := GetTrigger(context.Background(), client, GetInput{ProjectID: "1", TriggerID: 10})
+	if err != nil {
+		t.Fatalf(fmtUnexpErr, err)
+	}
+	if out.Token != token {
+		t.Errorf("structured output = %q, want the token GitLab sent kept for 1:1 parity", out.Token)
+	}
+	md := FormatTriggerMarkdown(out)
+	if strings.Contains(md, token) {
+		t.Errorf("get card rendered the whole token:\n%s", md)
+	}
+	if !strings.Contains(md, "| Token | `glptt-stor...` |") {
+		t.Errorf("get card missing the masked token prefix:\n%s", md)
+	}
+	if !strings.Contains(md, "Only the prefix of the token is shown here") {
+		t.Errorf("get card missing the hint naming where the full value is:\n%s", md)
+	}
+}
+
+// TestFormatListTriggersMarkdown_Tokens_AreRenderedByPrefixOnly verifies that a
+// list of triggers writes no usable credential into its table.
+//
+// It matters because a list answers with every trigger a project has, so the
+// old row printed one live token per line into text a model keeps in context.
+func TestFormatListTriggersMarkdown_Tokens_AreRenderedByPrefixOnly(t *testing.T) {
+	const tokenA = "glptt-aaaasecret0123456789"
+	const tokenB = "glptt-bbbbsecret0123456789"
+	md := FormatListTriggersMarkdown(ListOutput{
+		Triggers: []Output{
+			{ID: 1, Description: "A", Token: tokenA},
+			{ID: 2, Description: "B", Token: tokenB},
+		},
+		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
+	})
+
+	for _, token := range []string{tokenA, tokenB} {
+		t.Run(token, func(t *testing.T) {
+			if strings.Contains(md, token) {
+				t.Errorf("list rendered the whole token %q:\n%s", token, md)
+			}
+		})
+	}
+	for _, want := range []string{"glptt-aaaa...", "glptt-bbbb..."} {
+		t.Run(want, func(t *testing.T) {
+			if !strings.Contains(md, want) {
+				t.Errorf("list missing the masked prefix %q:\n%s", want, md)
+			}
+		})
+	}
+}
+
+// TestMaskTriggerToken_TokenShapes_RevealNoMoreThanThePrefix verifies the
+// masking rule itself: GitLab's marker plus four characters, an empty token
+// rendered as nothing, and a token too short to spare four characters
+// withheld whole rather than revealed by the arithmetic.
+func TestMaskTriggerToken_TokenShapes_RevealNoMoreThanThePrefix(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "prefixed token", token: "glptt-abcdef123456", want: "glptt-abcd..."},
+		{name: "unprefixed token", token: "abcdef123456", want: "abcd..."},
+		{name: "exactly the revealed length", token: "glptt-abcd", want: toolutil.RedactedPlaceholder},
+		{name: "shorter than the revealed length", token: "abc", want: toolutil.RedactedPlaceholder},
+		{name: "empty", token: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := maskTriggerToken(tc.token); got != tc.want {
+				t.Errorf("maskTriggerToken(%q) = %q, want %q", tc.token, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestCreateTrigger_MissingDescription verifies CreateTrigger when missing description.
 func TestCreateTrigger_MissingDescription(t *testing.T) {
 	client := testutil.NewTestClient(t, http.NewServeMux())
@@ -845,7 +959,7 @@ func TestFormatTriggerMarkdown_AllFields(t *testing.T) {
 	md := FormatTriggerMarkdown(Output{
 		ID:          10,
 		Description: "deploy trigger",
-		Token:       "abc123",
+		Token:       "glptt-abc123def456",
 		Owner:       &UserOutput{ID: 1, Name: "Admin"},
 		CreatedAt:   "2026-01-01T00:00:00Z",
 		UpdatedAt:   "2026-06-01T00:00:00Z",
@@ -856,7 +970,7 @@ func TestFormatTriggerMarkdown_AllFields(t *testing.T) {
 		"## Pipeline Trigger",
 		"| ID | 10 |",
 		"deploy trigger",
-		"abc123",
+		"glptt-abc1...",
 		"Admin",
 		"1 Jan 2026 00:00 UTC",
 		"1 Dec 2026 00:00 UTC",
@@ -900,8 +1014,8 @@ func TestFormatTriggerMarkdown_MinimalFields(t *testing.T) {
 func TestFormatListTriggersMarkdown_DetailedContent(t *testing.T) {
 	out := ListOutput{
 		Triggers: []Output{
-			{ID: 1, Description: "Trigger A", Token: "tokA", Owner: &UserOutput{Name: "admin"}, LastUsed: "2026-01-01T00:00:00Z"},
-			{ID: 2, Description: "Trigger B", Token: "tokB", Owner: &UserOutput{Name: "user1"}, LastUsed: ""},
+			{ID: 1, Description: "Trigger A", Token: "glptt-tokAsecretvalue", Owner: &UserOutput{Name: "admin"}, LastUsed: "2026-01-01T00:00:00Z"},
+			{ID: 2, Description: "Trigger B", Token: "glptt-tokBsecretvalue", Owner: &UserOutput{Name: "user1"}, LastUsed: ""},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
@@ -914,8 +1028,8 @@ func TestFormatListTriggersMarkdown_DetailedContent(t *testing.T) {
 		"| 2 |",
 		"Trigger A",
 		"Trigger B",
-		"tokA",
-		"tokB",
+		"glptt-tokA...",
+		"glptt-tokB...",
 		"admin",
 		"user1",
 	} {

--- a/internal/tools/repositorysubmodules/list.go
+++ b/internal/tools/repositorysubmodules/list.go
@@ -23,7 +23,9 @@ type ListInput struct {
 }
 
 // SubmoduleEntry represents a single submodule with its configuration and
-// current commit pointer.
+// current commit pointer. URL is the remote as .gitmodules writes it with any
+// credentials removed ([redactRemote]); ResolvedProject is the project path it
+// names, and carries no credentials either ([resolveProjectPath]).
 type SubmoduleEntry struct {
 	Name            string `json:"name"`
 	Path            string `json:"path"`
@@ -108,7 +110,7 @@ func parseGitmodules(content string) []SubmoduleEntry {
 			case "path":
 				current.Path = val
 			case "url":
-				current.URL = val
+				current.URL = redactRemote(val)
 				current.ResolvedProject = resolveProjectPath(val)
 			}
 		}
@@ -132,13 +134,24 @@ func parseKeyValue(line string) (key, value string, ok bool) {
 //   - git@host:group/project.git
 //   - https://host/group/project.git
 //   - ssh://git@host/group/project.git
+//
+// The SCP branch is taken on the absence of a scheme and not on the presence
+// of an "@" and a ":", which every credentialed https remote also has. Read
+// the old way, "https://user:password@host/group/project.git" split on its
+// first colon and resolved to "/user:password@host/group/project", so the
+// password was rendered into the submodule table as the project name. What a
+// scheme introduces is parsed with net/url, whose User is dropped and never
+// read.
 func resolveProjectPath(rawURL string) string {
-	if strings.Contains(rawURL, "@") && strings.Contains(rawURL, ":") && !strings.HasPrefix(rawURL, "ssh://") {
-		// SCP-style: git@host:path.git
-		parts := strings.SplitN(rawURL, ":", 2)
-		if len(parts) == 2 {
-			return strings.TrimSuffix(strings.TrimPrefix(parts[1], "/"), ".git")
+	if !strings.Contains(rawURL, "://") {
+		// SCP-style: [user@]host:path.git, and the userinfo goes first so that
+		// a password written where ssh would never accept one cannot survive
+		// the colon split either.
+		remote := withoutSCPUserinfo(rawURL)
+		if _, path, found := strings.Cut(remote, ":"); found {
+			return strings.TrimSuffix(strings.TrimPrefix(path, "/"), ".git")
 		}
+		return strings.TrimSuffix(strings.TrimPrefix(remote, "/"), ".git")
 	}
 
 	u, err := url.Parse(rawURL)
@@ -147,6 +160,47 @@ func resolveProjectPath(rawURL string) string {
 	}
 	path := strings.TrimPrefix(u.Path, "/")
 	return strings.TrimSuffix(path, ".git")
+}
+
+// withoutSCPUserinfo removes the credentials from an SCP-style remote,
+// "[user[:password]@]host:path". A bare "git@" is left alone: it is the ssh
+// account every such remote is written with and identifies nobody, while a
+// userinfo carrying a colon carries a password.
+func withoutSCPUserinfo(remote string) string {
+	authority, _, _ := strings.Cut(remote, "/")
+	at := strings.LastIndex(authority, "@")
+	if at < 0 {
+		return remote
+	}
+	if !strings.Contains(authority[:at], ":") {
+		return remote
+	}
+	return remote[at+1:]
+}
+
+// redactRemote removes the credentials a .gitmodules remote can carry before
+// the remote is published on the output. The file is part of the repository,
+// so whoever can push chooses the text, and a submodule pinned through
+// "https://user:password@host/group/project.git" would otherwise hand that
+// password to the model in the structured result beside the table.
+//
+// Only the userinfo goes: the host and the path are what identify the
+// submodule, which is the whole point of reporting the remote.
+func redactRemote(rawURL string) string {
+	if !strings.Contains(rawURL, "://") {
+		return withoutSCPUserinfo(rawURL)
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		// A remote carrying a scheme that will not parse is not something this
+		// can judge, so nothing of it is published.
+		return ""
+	}
+	if u.User == nil {
+		return rawURL
+	}
+	u.User = nil
+	return u.String()
 }
 
 // enrichSubmoduleCommitSHAs walks the repository tree to find nodes of type

--- a/internal/tools/repositorysubmodules/list_test.go
+++ b/internal/tools/repositorysubmodules/list_test.go
@@ -135,6 +135,109 @@ func TestResolveProjectPath(t *testing.T) {
 	}
 }
 
+// TestParseGitmodules_RemoteWithCredentials_PublishesNeither verifies that a
+// submodule remote carrying a password reaches neither the resolved project
+// path nor the url field the tool publishes.
+//
+// It matters because .gitmodules is part of the repository, so whoever can
+// push chooses its text, and the old resolver took its SCP branch on the
+// presence of an "@" and a ":" -- which every credentialed https remote also
+// has. "https://user:password@host/group/project.git" split on the colon of
+// its own scheme and resolved to "/user:password@host/group/project", which
+// the submodule table then printed as the project name.
+func TestParseGitmodules_RemoteWithCredentials_PublishesNeither(t *testing.T) {
+	cases := []struct {
+		name         string
+		remote       string
+		wantResolved string
+		wantURL      string
+	}{
+		{
+			name:         "https with password",
+			remote:       "https://ciuser:s3cretpw@gitlab.example.com/group/project.git",
+			wantResolved: "group/project",
+			wantURL:      "https://gitlab.example.com/group/project.git",
+		},
+		{
+			name:         "https with username only",
+			remote:       "https://ciuser@gitlab.example.com/group/project.git",
+			wantResolved: "group/project",
+			wantURL:      "https://gitlab.example.com/group/project.git",
+		},
+		{
+			name:         "ssh scheme with password",
+			remote:       "ssh://ciuser:s3cretpw@gitlab.example.com/group/project.git",
+			wantResolved: "group/project",
+			wantURL:      "ssh://gitlab.example.com/group/project.git",
+		},
+		{
+			name:         "scp style with password",
+			remote:       "ciuser:s3cretpw@gitlab.example.com:group/project.git",
+			wantResolved: "group/project",
+			wantURL:      "gitlab.example.com:group/project.git",
+		},
+		{
+			name:         "scp style ssh account is kept",
+			remote:       "git@gitlab.example.com:group/project.git",
+			wantResolved: "group/project",
+			wantURL:      "git@gitlab.example.com:group/project.git",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := parseGitmodules("[submodule \"lib\"]\n\tpath = lib\n\turl = " + tc.remote + "\n")
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(entries))
+			}
+			got := entries[0]
+			if got.ResolvedProject != tc.wantResolved {
+				t.Errorf("ResolvedProject = %q, want %q", got.ResolvedProject, tc.wantResolved)
+			}
+			if got.URL != tc.wantURL {
+				t.Errorf("URL = %q, want %q", got.URL, tc.wantURL)
+			}
+			for _, secret := range []string{"s3cretpw", "ciuser"} {
+				if strings.Contains(got.ResolvedProject, secret) {
+					t.Errorf("ResolvedProject %q leaked %q", got.ResolvedProject, secret)
+				}
+				if strings.Contains(got.URL, secret) {
+					t.Errorf("URL %q leaked %q", got.URL, secret)
+				}
+			}
+		})
+	}
+}
+
+// TestFormatListMarkdown_RemoteWithCredentials_RendersNoPassword verifies that
+// the rendered submodule table, which is the text a model reads, carries no
+// part of a credentialed remote.
+func TestFormatListMarkdown_RemoteWithCredentials_RendersNoPassword(t *testing.T) {
+	entries := parseGitmodules("[submodule \"lib\"]\n\tpath = lib\n\turl = https://ciuser:s3cretpw@gitlab.example.com/group/project.git\n")
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	result := FormatListMarkdown(ListOutput{Submodules: entries, Count: len(entries)})
+	if len(result.Content) == 0 {
+		t.Fatal("expected rendered content")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	md := text.Text
+
+	for _, secret := range []string{"s3cretpw", "ciuser"} {
+		t.Run("withholds "+secret, func(t *testing.T) {
+			if strings.Contains(md, secret) {
+				t.Errorf("submodule table leaked %q:\n%s", secret, md)
+			}
+		})
+	}
+	if !strings.Contains(md, "group/project") {
+		t.Errorf("submodule table missing the resolved project:\n%s", md)
+	}
+}
+
 // parentDir unit tests.
 
 // TestParentDir covers ParentDir with table-driven subtests.

--- a/internal/tools/runnercontrollertokens/markdown.go
+++ b/internal/tools/runnercontrollertokens/markdown.go
@@ -16,8 +16,8 @@ func FormatOutputMarkdown(out Output) string {
 	fmt.Fprintf(&b, "- **Controller ID**: %d\n", out.RunnerControllerID)
 	toolutil.WriteDescription(&b, out.Description)
 	if out.Token != "" {
-		//gitlab:allow-unescaped out.Token: the secret GitLab minted, which the reader has to copy back verbatim.
-		fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
+		//gitlab:allow-unescaped out.Token: the secret GitLab minted, inside a code span so the reader can copy it back verbatim.
+		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
 	}
 	if out.LastUsedAt != "" {
 		fmt.Fprintf(&b, "- **Last Used At**: %s\n", toolutil.FormatTime(out.LastUsedAt))
@@ -25,7 +25,12 @@ func FormatOutputMarkdown(out Output) string {
 	if out.CreatedAt != "" {
 		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
 	}
-	toolutil.WriteHints(&b, "Store the token value securely. It cannot be retrieved later")
+	// The storage advice belongs to the card that carries a token. A get
+	// answers with the same type and no token, and telling its reader to store
+	// a value the card does not hold sends them looking for one.
+	if out.Token != "" {
+		toolutil.WriteHints(&b, "Store the token value securely. It cannot be retrieved later")
+	}
 	return b.String()
 }
 

--- a/internal/tools/runnercontrollertokens/runner_controller_tokens_test.go
+++ b/internal/tools/runnercontrollertokens/runner_controller_tokens_test.go
@@ -511,6 +511,39 @@ func TestFormatOutputMarkdown(t *testing.T) {
 	}
 }
 
+// TestFormatOutputMarkdown_TokenShapes_CodeSpannedAndHintedOnlyWhenPresent
+// verifies that the token is written inside a code span, and that the advice
+// to store it securely is written only on a card that carries one.
+//
+// Both halves matter. A token written as bare Markdown is read as Markdown, so
+// an underscore pair in it is eaten as emphasis and what the reader copies
+// back is not what GitLab minted. And the same Go type answers a get, which
+// carries no token: telling that reader to store a value the card does not
+// hold sends them hunting for a credential that was never shown.
+func TestFormatOutputMarkdown_TokenShapes_CodeSpannedAndHintedOnlyWhenPresent(t *testing.T) {
+	const storeHint = "Store the token value securely"
+
+	t.Run("token is code spanned and hinted", func(t *testing.T) {
+		md := FormatOutputMarkdown(Output{ID: 10, RunnerControllerID: 1, Token: "glrt-a_b_c"})
+		if !strings.Contains(md, "- **Token**: `glrt-a_b_c`\n") {
+			t.Errorf("token not written inside a code span:\n%s", md)
+		}
+		if !strings.Contains(md, storeHint) {
+			t.Errorf("card carrying a token missing the storage hint:\n%s", md)
+		}
+	})
+
+	t.Run("no token means no storage hint", func(t *testing.T) {
+		md := FormatOutputMarkdown(Output{ID: 10, RunnerControllerID: 1, Description: "my-token"})
+		if strings.Contains(md, "**Token**") {
+			t.Errorf("empty token still announced:\n%s", md)
+		}
+		if strings.Contains(md, storeHint) {
+			t.Errorf("card carrying no token still tells the reader to store one:\n%s", md)
+		}
+	})
+}
+
 // TestFormatListMarkdown verifies list Markdown with data and empty.
 func TestFormatListMarkdown(t *testing.T) {
 	out := ListOutput{

--- a/internal/tools/runners/markdown.go
+++ b/internal/tools/runners/markdown.go
@@ -127,8 +127,10 @@ func FormatJobListMarkdown(out JobListOutput) string {
 func FormatAuthTokenMarkdown(out AuthTokenOutput) string {
 	var b strings.Builder
 	b.WriteString("## Runner Authentication Token\n\n")
-	//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, which the reader has to copy back verbatim.
-	fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
+	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, inside a code span so the reader can copy it back verbatim.
+		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
+	}
 	if out.ExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
 	}
@@ -140,8 +142,10 @@ func FormatAuthTokenMarkdown(out AuthTokenOutput) string {
 func FormatRegTokenMarkdown(out AuthTokenOutput) string {
 	var b strings.Builder
 	b.WriteString("## Runner Registration Token\n\n")
-	//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, which the reader has to copy back verbatim.
-	fmt.Fprintf(&b, "- **Token**: %s\n", out.Token)
+	if out.Token != "" {
+		//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, inside a code span so the reader can copy it back verbatim.
+		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
+	}
 	if out.ExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
 	}

--- a/internal/tools/runners/runners_test.go
+++ b/internal/tools/runners/runners_test.go
@@ -1975,7 +1975,7 @@ func TestFormatAuthTokenMarkdown_Full(t *testing.T) {
 
 	for _, want := range []string{
 		"## Runner Authentication Token",
-		"**Token**: glrt-abc123",
+		"**Token**: `glrt-abc123`",
 		"**Expires At**: 31 Dec 2026 23:59 UTC",
 	} {
 		t.Run(want, func(t *testing.T) {
@@ -1994,6 +1994,49 @@ func TestFormatAuthTokenMarkdown_NoExpiry(t *testing.T) {
 	}
 }
 
+// TestFormatAuthTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded verifies
+// that a runner authentication token is written inside a code span and that an
+// empty one writes no token line at all.
+//
+// It matters for two reasons. A token written as bare Markdown is read as
+// Markdown, so an underscore pair in it is eaten as emphasis and what the
+// reader copies back is not what GitLab minted. And a card that announces a
+// **Token** with nothing after it tells a reader a credential was issued when
+// none was, which is how the shared form at accesstokens/markdown.go already
+// reads.
+func TestFormatAuthTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded(t *testing.T) {
+	t.Run("token is inside a code span", func(t *testing.T) {
+		md := FormatAuthTokenMarkdown(AuthTokenOutput{Token: "glrt-a_b_c"})
+		if !strings.Contains(md, "- **Token**: `glrt-a_b_c`\n") {
+			t.Errorf("token not written inside a code span:\n%s", md)
+		}
+	})
+	t.Run("empty token writes no line", func(t *testing.T) {
+		md := FormatAuthTokenMarkdown(AuthTokenOutput{ExpiresAt: "2026-12-31T23:59:59Z"})
+		if strings.Contains(md, "**Token**") {
+			t.Errorf("empty token still announced:\n%s", md)
+		}
+	})
+}
+
+// TestFormatRegTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded verifies the
+// same two properties for the registration token card, which is a second copy
+// of the same renderer and carried the same two defects.
+func TestFormatRegTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded(t *testing.T) {
+	t.Run("token is inside a code span", func(t *testing.T) {
+		md := FormatRegTokenMarkdown(AuthTokenOutput{Token: "reg-a_b_c"})
+		if !strings.Contains(md, "- **Token**: `reg-a_b_c`\n") {
+			t.Errorf("token not written inside a code span:\n%s", md)
+		}
+	})
+	t.Run("empty token writes no line", func(t *testing.T) {
+		md := FormatRegTokenMarkdown(AuthTokenOutput{ExpiresAt: "2026-06-01T00:00:00Z"})
+		if strings.Contains(md, "**Token**") {
+			t.Errorf("empty token still announced:\n%s", md)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // FormatRegTokenMarkdown — with and without ExpiresAt
 // ---------------------------------------------------------------------------.
@@ -2007,7 +2050,7 @@ func TestFormatRegTokenMarkdown_Full(t *testing.T) {
 
 	for _, want := range []string{
 		"## Runner Registration Token",
-		"**Token**: reg-tok-123",
+		"**Token**: `reg-tok-123`",
 		"**Expires At**: 1 Jun 2026 00:00 UTC",
 	} {
 		t.Run(want, func(t *testing.T) {

--- a/internal/tools/users/user_misc.go
+++ b/internal/tools/users/user_misc.go
@@ -370,8 +370,10 @@ func FormatUserRunnerMarkdownString(o UserRunnerOutput) string {
 	var b strings.Builder
 	b.WriteString("## User Runner Created\n\n")
 	fmt.Fprintf(&b, toolutil.FmtMdID, o.ID)
-	//gitlab:allow-unescaped o.Token: the runner token GitLab minted, which the reader has to copy back verbatim.
-	fmt.Fprintf(&b, "- **Token**: %s\n", o.Token)
+	if o.Token != "" {
+		//gitlab:allow-unescaped o.Token: the runner token GitLab minted, inside a code span so the reader can copy it back verbatim.
+		fmt.Fprintf(&b, "- **Token**: `%s`\n", o.Token)
+	}
 	if o.TokenExpiresAt != "" {
 		fmt.Fprintf(&b, "- **Token Expires At**: %s\n", toolutil.FormatTime(o.TokenExpiresAt))
 	}

--- a/internal/tools/users/user_misc_test.go
+++ b/internal/tools/users/user_misc_test.go
@@ -667,6 +667,29 @@ func TestFormatUserRunnerMarkdownString_NoExpiry(t *testing.T) {
 	}
 }
 
+// TestFormatUserRunnerMarkdownString_TokenShapes_AreCodeSpannedAndGuarded
+// verifies that the created runner's token is written inside a code span and
+// that a card with no token announces none.
+//
+// A token written as bare Markdown is read as Markdown, so an underscore pair
+// in it is eaten as emphasis and the value copied back is not the one GitLab
+// minted. The one-time nature of the value is already stated by the hint below
+// it, so an empty **Token** line promises a credential the card never carried.
+func TestFormatUserRunnerMarkdownString_TokenShapes_AreCodeSpannedAndGuarded(t *testing.T) {
+	t.Run("token is inside a code span", func(t *testing.T) {
+		md := FormatUserRunnerMarkdownString(UserRunnerOutput{ID: 101, Token: "glrt-a_b_c"})
+		if !strings.Contains(md, "- **Token**: `glrt-a_b_c`\n") {
+			t.Errorf("token not written inside a code span:\n%s", md)
+		}
+	})
+	t.Run("empty token writes no line", func(t *testing.T) {
+		md := FormatUserRunnerMarkdownString(UserRunnerOutput{ID: 101, TokenExpiresAt: "2026-06-01T00:00:00Z"})
+		if strings.Contains(md, "**Token**:") {
+			t.Errorf("empty token still announced:\n%s", md)
+		}
+	})
+}
+
 // TestFormatDeleteUserIdentityMarkdownString verifies identity deletion markdown.
 func TestFormatDeleteUserIdentityMarkdownString(t *testing.T) {
 	md := FormatDeleteUserIdentityMarkdownString(DeleteUserIdentityOutput{

--- a/internal/toolutil/url_redact.go
+++ b/internal/toolutil/url_redact.go
@@ -1,0 +1,67 @@
+package toolutil
+
+import (
+	"net/url"
+	"strings"
+)
+
+// RedactedPlaceholder is what a formatter writes instead of a value it will
+// not echo, so that a reader sees something was withheld rather than that a
+// tool had nothing to report. It is the one spelling every such site uses, so
+// a reader who has met it once recognizes it everywhere.
+const RedactedPlaceholder = "[redacted]"
+
+// urlElidedPathMarker is appended to an origin whose path, query or fragment
+// was dropped, so a reader can tell a bare origin from one that carried more.
+const urlElidedPathMarker = "/..."
+
+// RedactURL renders u with the three parts a secret can hide in removed: the
+// userinfo, the query and the fragment. What survives is the scheme, the host
+// and the path, which is what identifies the destination.
+//
+// A URL reaches a model through this server whenever a tool reports where it
+// is talking to, and each of the three dropped parts is somewhere a credential
+// is routinely written: a proxy login in the userinfo, a signed token in the
+// query, a fragment carried over from a browser. None of them identifies the
+// destination, so none of them is worth the risk of echoing.
+//
+// The path survives because for an instance URL it names the installation (a
+// GitLab served under a subpath) rather than the caller, and because client-go
+// builds its own error text from the same three parts, which leaves the two
+// agreeing instead of this being the one place that says more. Use
+// [RedactURLToOrigin] for a destination whose path is itself the secret.
+func RedactURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host + u.EscapedPath()
+}
+
+// RedactURLToOrigin parses raw and renders its origin alone: the scheme and
+// the host. It drops what [RedactURL] drops and the path with it, replacing a
+// path, query or fragment that was there with "/..." so a reader can see that
+// something was withheld.
+//
+// The path goes because for a webhook, an integration endpoint or any other
+// callback URL the path is where the secret lives: a Slack or Teams hook is a
+// public host with an unguessable path, and truncating such a URL to a fixed
+// number of characters leaks the front of it, userinfo included. The host is
+// what an auditor reads these values for, and the host is all that is left.
+//
+// Text that does not parse as a URL, or that names no scheme and host, is
+// reported as [RedactedPlaceholder] rather than echoed: a value that is not a
+// URL is a value nothing here has judged.
+func RedactURLToOrigin(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return RedactedPlaceholder
+	}
+	origin := u.Scheme + "://" + u.Host
+	if path := u.EscapedPath(); path != "" && path != "/" {
+		return origin + urlElidedPathMarker
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return origin + urlElidedPathMarker
+	}
+	return origin
+}

--- a/internal/toolutil/url_redact_test.go
+++ b/internal/toolutil/url_redact_test.go
@@ -1,0 +1,163 @@
+package toolutil
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRedactURL_URLWithSecrets_DropsUserinfoQueryAndFragment verifies that the
+// shared instance-URL renderer keeps only the scheme, host and path, and drops
+// the userinfo, query and fragment.
+//
+// It matters because this value is handed to whichever MCP client called the
+// tool and copied into whatever that client logs: a proxy credential written
+// into GITLAB_URL would otherwise travel with every health report.
+func TestRedactURL_URLWithSecrets_DropsUserinfoQueryAndFragment(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "userinfo with password",
+			raw:  "https://proxyuser:s3cret@gitlab.example.com/gitlab",
+			want: "https://gitlab.example.com/gitlab",
+		},
+		{
+			name: "userinfo without password",
+			raw:  "https://proxyuser@gitlab.example.com/",
+			want: "https://gitlab.example.com/",
+		},
+		{
+			name: "query and fragment",
+			raw:  "https://gitlab.example.com/gitlab?private_token=glpat-abcdefghij#frag",
+			want: "https://gitlab.example.com/gitlab",
+		},
+		{
+			name: "plain url is unchanged",
+			raw:  "https://gitlab.example.com",
+			want: "https://gitlab.example.com",
+		},
+		{
+			name: "port survives",
+			raw:  "http://gitlab.internal:8443/sub/path",
+			want: "http://gitlab.internal:8443/sub/path",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := url.Parse(tc.raw)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) failed: %v", tc.raw, err)
+			}
+			got := RedactURL(parsed)
+			if got != tc.want {
+				t.Errorf("RedactURL(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+			for _, secret := range []string{"s3cret", "glpat-abcdefghij", "proxyuser", "frag"} {
+				if strings.Contains(got, secret) {
+					t.Errorf("RedactURL(%q) = %q, must not contain %q", tc.raw, got, secret)
+				}
+			}
+		})
+	}
+}
+
+// TestRedactURL_NilURL_ReturnsEmpty verifies that the renderer answers a nil
+// URL with an empty string rather than panicking, since a caller holding an
+// unparsed base URL has nothing to report.
+func TestRedactURL_NilURL_ReturnsEmpty(t *testing.T) {
+	if got := RedactURL(nil); got != "" {
+		t.Errorf("RedactURL(nil) = %q, want empty", got)
+	}
+}
+
+// TestRedactURLToOrigin_CallbackURL_KeepsOnlyTheOrigin verifies that a webhook
+// or integration URL is reduced to its scheme and host, with any path, query
+// or fragment replaced by the elision marker.
+//
+// It matters because a callback URL's path is the secret: a hook endpoint is a
+// public host plus an unguessable path, and the value is rendered into a
+// prompt a model reads.
+func TestRedactURLToOrigin_CallbackURL_KeepsOnlyTheOrigin(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "secret path",
+			raw:  "https://hooks.example.com/services/T00000/B00000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			want: "https://hooks.example.com/...",
+		},
+		{
+			name: "userinfo and short path",
+			raw:  "https://hookuser:hookpass@hooks.example.com/a",
+			want: "https://hooks.example.com/...",
+		},
+		{
+			name: "query only",
+			raw:  "https://hooks.example.com/?token=s3cret",
+			want: "https://hooks.example.com/...",
+		},
+		{
+			name: "fragment only",
+			raw:  "https://hooks.example.com#s3cret",
+			want: "https://hooks.example.com/...",
+		},
+		{
+			name: "bare origin",
+			raw:  "https://hooks.example.com",
+			want: "https://hooks.example.com",
+		},
+		{
+			name: "root path is not an elision",
+			raw:  "https://hooks.example.com/",
+			want: "https://hooks.example.com",
+		},
+		{
+			name: "not a url",
+			raw:  "not a url at all",
+			want: RedactedPlaceholder,
+		},
+		{
+			name: "scheme without host",
+			raw:  "mailto:ops@example.com",
+			want: RedactedPlaceholder,
+		},
+		{
+			name: "empty",
+			raw:  "",
+			want: RedactedPlaceholder,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactURLToOrigin(tc.raw)
+			if got != tc.want {
+				t.Errorf("RedactURLToOrigin(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+			for _, secret := range []string{"hookpass", "hookuser", "s3cret", "XXXXXXXXXXXXXXXXXXXXXXXX", "B00000"} {
+				if strings.Contains(got, secret) {
+					t.Errorf("RedactURLToOrigin(%q) = %q, must not contain %q", tc.raw, got, secret)
+				}
+			}
+		})
+	}
+}
+
+// TestRedactURLToOrigin_LongURL_DoesNotEchoItsPrefix verifies that the
+// renderer never returns a leading slice of the input, which is how the
+// webhook table used to hide a URL and is what leaked the userinfo of a long
+// one.
+func TestRedactURLToOrigin_LongURL_DoesNotEchoItsPrefix(t *testing.T) {
+	raw := "https://hookuser:hookpass@hooks.example.com/services/very/long/secret/path"
+	got := RedactURLToOrigin(raw)
+	if strings.HasPrefix(raw, got) {
+		t.Errorf("RedactURLToOrigin(%q) = %q, which is a prefix of the input", raw, got)
+	}
+	if got != "https://hooks.example.com/..." {
+		t.Errorf("RedactURLToOrigin(%q) = %q, want %q", raw, got, "https://hooks.example.com/...")
+	}
+}


### PR DESCRIPTION
A read of all 741 registered Markdown formatters (issue 697) found seven places where a credential reaches the model's transcript. Each was confirmed by two independent verifiers reading the formatter and the value it renders, so none of them is theoretical, and none of them waits for the card rule that audit settled on.

- `pipelinetriggers` printed the whole trigger token on every get and once per row on every list. GitLab returns it on those endpoints, so rendering it was our choice: the create card, which mints the token, still prints it in full inside a code span, and every other card and row prints the `glptt-` prefix and four characters, with a hint naming where the full value is. A token too short to mask reads `[redacted]`.
- `runners` wrote the authentication and registration tokens as bare Markdown, and an empty `**Token**:` line when there was none. `runnercontrollertokens` did the same and wrote "Store the token value securely" on a get carrying no token. `users` printed a runner token with no code span and no guard. All four now follow the form `accesstokens` already used: the value inside backticks, written only when it is there.
- `instancevariables` rendered the value of a variable the instance marks Hidden. The shared renderer already had both halves of the guard, so the card adopts it: `!Masked && !Hidden`, with the Hidden flag shown as its own row.
- `repositorysubmodules` resolved `https://user:password@host/group/project.git` by taking the SCP branch on the `@` and the `:`, which published the password in the rendered path and in the `url` field of the structured output. The SCP branch is now taken only for a remote with no scheme; anything else goes through `net/url` with the userinfo dropped, and the published field is redacted the same way.
- `prompts`' webhook audit masked a URL by printing its first thirty characters, which is the userinfo and the front of a secret path. It now renders the origin alone.

The redaction both ends needed is one file, `internal/toolutil/url_redact.go`: `RedactURL` drops userinfo, query and fragment and keeps the path, which is what a health check wants and what the unexported helper in `internal/tools/health` already did; `RedactURLToOrigin` drops the path as well, for a destination whose path is the secret. They are separate functions on purpose rather than one rule forced on both callers.

Each fix carries a test that fails on the old code by asserting the secret's absence and the redacted form's presence, not merely that the output changed.

Two things worth stating because they bound what this buys. The trigger token is still in the structured JSON on get and list, since removing it would break the 1:1 mapping with GitLab's own response; the Markdown is the editorial surface and the hints now say where the full value is. And an SCP remote keeps its `git@`, which is the ssh account rather than a secret: only a userinfo carrying a password is stripped.
