### PR TITLE
fix(toolutil): open a block for the summary and pagination lines

### DIFF
--- a/internal/tools/accesstokens/markdown.go
+++ b/internal/tools/accesstokens/markdown.go
@@ -63,7 +63,7 @@ func FormatListMarkdown(out ListOutput) string {
 			toolutil.EscapeMdTableCell(scopes), expires)
 	}
 	b.WriteString("\n")
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(
 		&b,
 		"Use action 'get' with token_id for full details",

--- a/internal/tools/awardemoji/markdown.go
+++ b/internal/tools/awardemoji/markdown.go
@@ -38,7 +38,7 @@ func FormatListMarkdownString(out ListOutput) string {
 		fmt.Fprintf(&b, "- :%s: by %s (ID: %d) - %s\n", toolutil.EscapeMdTableCell(e.Name),
 			toolutil.EscapeMdTableCell(awardEmojiUserMarkdown(e)), e.ID, toolutil.FormatTime(e.CreatedAt))
 	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, toolutil.HintPreserveLinks, "Use the selected tool surface's matching award emoji actions for this resource; delete actions require explicit confirm=true plus the same resource identifiers and award_id")
 	return b.String()
 }

--- a/internal/tools/events/markdown.go
+++ b/internal/tools/events/markdown.go
@@ -97,7 +97,7 @@ func formatEventListMarkdown(title, emptyText string, events []markdownEvent, pa
 		fmt.Fprintf(&b, "- **%s**%s%s by %s, %s%s\n", e.ActionName, target, formatWikiPage(e.WikiPage),
 			toolutil.EscapeMdTableCell(author), toolutil.FormatTime(e.CreatedAt), formatOrigin(e.Imported, e.ImportedFrom))
 	}
-	b.WriteString(toolutil.FormatPagination(pagination))
+	toolutil.WritePagination(&b, pagination)
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/tools/freezeperiods/markdown.go
+++ b/internal/tools/freezeperiods/markdown.go
@@ -27,7 +27,7 @@ func FormatListMarkdownString(out ListOutput) string {
 			toolutil.EscapeMdTableCell(fp.FreezeStart), toolutil.EscapeMdTableCell(fp.FreezeEnd),
 			toolutil.EscapeMdTableCell(fp.CronTimezone))
 	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, "Use `gitlab_get_freeze_period` to view details of a specific freeze period")
 	return b.String()
 }

--- a/internal/tools/groupcredentials/markdown.go
+++ b/internal/tools/groupcredentials/markdown.go
@@ -57,7 +57,7 @@ func FormatPATListMarkdown(out PATListOutput) string {
 			//gitlab:allow-unescaped t.ExpiresAt: a date gl.ISOTime rendered as YYYY-MM-DD.
 			t.ID, toolutil.EscapeMdTableCell(t.Name), t.UserID, t.Active, t.Revoked, scopes, t.ExpiresAt)
 	}
-	sb.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&sb, out.Pagination)
 	return sb.String()
 }
 
@@ -99,7 +99,7 @@ func FormatSSHKeyListMarkdown(out SSHKeyListOutput) string {
 			//gitlab:allow-unescaped k.ExpiresAt: a timestamp toSSHKeyOutput rendered with the constant toolutil.DateTimeFormat layout.
 			k.ID, toolutil.EscapeMdTableCell(k.Title), k.UserID, k.CreatedAt, k.ExpiresAt)
 	}
-	sb.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&sb, out.Pagination)
 	return sb.String()
 }
 

--- a/internal/tools/invites/markdown.go
+++ b/internal/tools/invites/markdown.go
@@ -32,7 +32,7 @@ func FormatListPendingMarkdownString(out ListPendingInvitationsOutput) string {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, "Manage pending invitations by approving, revoking, or resending them")
 	return b.String()
 }

--- a/internal/tools/namespaces/markdown.go
+++ b/internal/tools/namespaces/markdown.go
@@ -27,7 +27,7 @@ func FormatListMarkdownString(out ListOutput) string {
 		fmt.Fprintf(&b, "- **%s** (ID: %d), kind: %s, path: `%s`\n",
 			toolutil.EscapeMdTableCell(ns.Name), ns.ID, ns.Kind, toolutil.EscapeMdTableCell(ns.FullPath))
 	}
-	b.WriteString(toolutil.FormatPagination(out.Pagination))
+	toolutil.WritePagination(&b, out.Pagination)
 	toolutil.WriteHints(&b, "Use `gitlab_namespace_get` to view details of a specific namespace")
 	return b.String()
 }

--- a/internal/tools/todos/markdown.go
+++ b/internal/tools/todos/markdown.go
@@ -71,7 +71,7 @@ func FormatListMarkdownString(v ListOutput) string {
 			toolutil.EscapeMdTableCell(projectName(t)),
 		)
 	}
-	b.WriteString(toolutil.FormatPagination(v.Pagination))
+	toolutil.WritePagination(&b, v.Pagination)
 	toolutil.WriteHints(
 		&b,
 		toolutil.HintPreserveLinks,

--- a/internal/toolutil/markdown.go
+++ b/internal/toolutil/markdown.go
@@ -137,18 +137,46 @@ func WriteMdURLNewline(b *strings.Builder, url string) {
 	WriteMdURL(b, url)
 }
 
-// WritePagination appends a newline-wrapped pagination summary to the builder.
+// StartMdBlock separates what is written next from what the formatter wrote
+// before it, so the next line opens a Markdown block of its own.
+//
+// A line written straight after a table row does not open anything: GFM reads
+// it as another row, splits it on its pipes and drops whatever the header has
+// no column for. The pagination line went out that way from four packages —
+// "Page 2 of 7 | 84 items total | 20 per page" arriving as a two-cell row with
+// the third cell gone — and so did the "Showing N of M results" line, which
+// became a one-cell row in six more. Neither was visible in a test asserting
+// the substring is present, because it is.
+func StartMdBlock(b *strings.Builder) {
+	written := b.String()
+	if written == "" || strings.HasSuffix(written, "\n\n") {
+		return
+	}
+	if !strings.HasSuffix(written, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+}
+
+// WritePagination appends a pagination summary as a block of its own.
+//
+// Prefer it over writing [FormatPagination]'s result into a builder directly:
+// the separation above the line is the whole difference between a paginated
+// list and a table with a corrupted last row.
 func WritePagination(b *strings.Builder, p PaginationOutput) {
-	fmt.Fprintf(b, FmtMdSectionText, FormatPagination(p))
+	StartMdBlock(b)
+	b.WriteString(FormatPagination(p))
+	b.WriteByte('\n')
 }
 
 // WriteListSummary appends a brief "Showing N of M results (page X of Y)"
-// line between the heading and the table body. It is a no-op when there is
-// only a single page, because the heading count already conveys everything.
+// line as a block of its own. It is a no-op when there is only a single page,
+// because the heading count already conveys everything.
 func WriteListSummary(b *strings.Builder, shown int, p PaginationOutput) {
 	if p.TotalPages <= 1 {
 		return
 	}
+	StartMdBlock(b)
 	fmt.Fprintf(b, "Showing %d of %d results (page %d of %d)\n\n", shown, p.TotalItems, p.Page, p.TotalPages)
 }
 

--- a/internal/toolutil/markdown_test.go
+++ b/internal/toolutil/markdown_test.go
@@ -92,6 +92,54 @@ func TestWritePagination(t *testing.T) {
 	}
 }
 
+// TestStartMdBlock verifies that what is written next opens a block of its own.
+// A line that does not is read as one more row of the table above it.
+func TestStartMdBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		written string
+		want    string
+	}{
+		{name: "an empty builder needs no separation", written: "", want: ""},
+		{name: "a finished line is separated by one newline", written: "| 1 | a |\n", want: "| 1 | a |\n\n"},
+		{name: "an unterminated line is ended and then separated", written: "text", want: "text\n\n"},
+		{name: "a blank line already there is left alone", written: "text\n\n", want: "text\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			b.WriteString(tt.written)
+			StartMdBlock(&b)
+			if got := b.String(); got != tt.want {
+				t.Errorf("StartMdBlock() left %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWritePagination_AfterATableRow verifies the separation the pagination
+// line needs. Without it GFM reads the line as another row, splits it on its
+// own pipes and drops the cells the header has no column for.
+func TestWritePagination_AfterATableRow(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("| ID | Name |\n| --- | --- |\n| 1 | a |\n")
+	WritePagination(&b, PaginationOutput{Page: 2, TotalPages: 7, TotalItems: 84, PerPage: 20})
+	if got := b.String(); !strings.Contains(got, "| 1 | a |\n\nPage 2 of 7") {
+		t.Errorf("the pagination line must open a block of its own, got:\n%s", got)
+	}
+}
+
+// TestWriteListSummary_AfterATableRow verifies the same separation for the
+// summary line, which six list formatters write under their rows.
+func TestWriteListSummary_AfterATableRow(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("| ID |\n| --- |\n| 1 |\n")
+	WriteListSummary(&b, 20, PaginationOutput{Page: 1, TotalPages: 3, TotalItems: 50, PerPage: 20})
+	if got := b.String(); !strings.Contains(got, "| 1 |\n\nShowing 20 of 50") {
+		t.Errorf("the summary line must open a block of its own, got:\n%s", got)
+	}
+}
+
 // TestMarkdownTableHeader verifies dynamic table header generation.
 func TestMarkdownTableHeader(t *testing.T) {
 	header := MarkdownTableHeader("ID", "Name", "Status")


### PR DESCRIPTION
## Description

A line written straight after a table row does not start a paragraph. GFM reads it as another row, splits it on its pipes and drops whatever the header has no column for.

`WriteListSummary` wrote its line with no blank line above it, and nine formatters wrote `FormatPagination`'s result into their builder by hand rather than through `WritePagination`. So `Page 2 of 7 | 84 items total | 20 per page` reached the model as a two-cell row with the third cell gone in four packages, and six more lost the "Showing N of M results" line into the table the same way.

Both helpers now open a block of their own through a new `StartMdBlock`, and the nine call sites go through `WritePagination`, which is where the separation lives.

First of three parts of #697, and the only one that stands on its own. It is a separate defect with a separate cause, and it depends on nothing in the other two.

## Related Issue

Refs #697

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [ ] CI / build / tooling

## Changes Made

- `toolutil.StartMdBlock` separates what is written next from what the formatter wrote before it, and `WritePagination` and `WriteListSummary` both open a block through it.
- Nine formatters that wrote `FormatPagination`'s result directly move to `WritePagination`: `todos`, `namespaces`, `accesstokens`, `events`, `invites`, `groupcredentials` (twice), `awardemoji`, `freezeperiods`.
- Table-driven tests for `StartMdBlock`, plus one test each for `WritePagination` and `WriteListSummary` writing under a table row — the position the defect needed and no existing test used.

## How to Test

1. `go test ./internal/toolutil/ ./internal/tools/todos/ ./internal/tools/groupcredentials/ ./internal/tools/accesstokens/ -count=1`
2. To see the defect itself, render this through any GFM implementation — the third cell is dropped, because the header declares two columns:

   ```markdown
   | ID | Name |
   | --- | --- |
   | 1 | a |
   Page 7 of 7 | 7 items total | 7 per page
   ```

3. `go build ./...`

## Breaking Changes / Migration Notes

N/A. The rendered text of every affected response gains a blank line; no field is added, removed or renamed.

## Checklist

### Code Quality

- [x] Code compiles: `go build ./...`
- [x] Consolidated Go analysis passes on changed packages
- [x] Code is formatted (`goimports`, `gofumpt`, `gci`)
- [x] Follows idiomatic Go patterns and the conventions documented in `CLAUDE.md` / `.github/instructions/`

### Testing

- [x] All existing tests pass: `go test ./... -count=1`
- [x] New tests added for new functionality
- [x] Edge cases and error scenarios covered
- [ ] If applicable, E2E tests updated/added under `test/e2e/suite/` — not applicable, no tool surface changes

### Documentation

- [ ] Not applicable: no public API or configuration change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown list output so pagination and summaries appear correctly after tables.
  * Standardized pagination rendering across list views, preserving proper spacing and readability.

* **Tests**
  * Added coverage for Markdown block separation and pagination or summary content following table rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->