### PR TITLE
refactor(markdown): the card vocabulary for merge requests, CI/CD, repository content and packages

### DIFF
--- a/internal/tools/attestations/attestations_test.go
+++ b/internal/tools/attestations/attestations_test.go
@@ -133,16 +133,24 @@ func assertAttestationOutputWithoutTimestamps(t *testing.T, got Output) {
 
 // --- FormatOutputMarkdown ---.
 
+// attestationCardHints is the guidance section every attestation card closes
+// with.
+const attestationCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use `gitlab_download_attestation` to download this attestation's content\n" +
+	"- Use `gitlab_list_attestations` to view all attestations for the project\n"
+
 // TestFormatOutputMarkdown validates the single-attestation markdown renderer.
 // Covers zero-ID (empty), full output with all optional fields, and partial
 // output with some optional fields omitted.
+//
+// Each case pins the whole card. A card is one document — heading, rows,
+// guidance — and a substring assertion cannot tell a row that rendered from a
+// row that landed somewhere Markdown shows as literal text.
 func TestFormatOutputMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    Output
-		want     string
-		notWant  []string
-		contains []string
+		name  string
+		input Output
+		want  string
 	}{
 		{
 			name:  "zero ID returns empty string",
@@ -162,21 +170,19 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				SubjectDigest: "sha256:deadbeef",
 				DownloadURL:   "https://gitlab.example.com/download",
 				CreatedAt:     "2026-06-15T12:00:00Z",
-				ExpireAt:      "2026-06-15T12:00:00Z",
+				ExpireAt:      "2026-07-15T12:00:00Z",
 			},
-			contains: []string{
-				"## Attestation #42 (IID 7)",
-				"**Project ID**: 10",
-				"**Build ID**: 200",
-				"**Status**: success",
-				"**Predicate Kind**: slsa_provenance",
-				"**Predicate Type**: https://slsa.dev/provenance/v0.2",
-				"`sha256:deadbeef`",
-				"**Download URL**",
-				"**Created**: 2026-06-15T12:00:00Z",
-				"**Expires**: 2026-06-15T12:00:00Z",
-				"gitlab_download_attestation",
-			},
+			want: "## Attestation #42 (IID 7)\n\n" +
+				"- **Project ID**: 10\n" +
+				"- **Build ID**: 200\n" +
+				"- **Status**: success\n" +
+				"- **Predicate Kind**: slsa_provenance\n" +
+				"- **Predicate Type**: https://slsa.dev/provenance/v0.2\n" +
+				"- **Subject Digest**: `sha256:deadbeef`\n" +
+				"- **Download URL**: [https://gitlab.example.com/download](https://gitlab.example.com/download)\n" +
+				"- **Created**: 15 Jun 2026 12:00 UTC\n" +
+				"- **Expires**: 15 Jul 2026 12:00 UTC\n" +
+				attestationCardHints,
 		},
 		{
 			name: "partial output omits empty optional fields",
@@ -186,38 +192,18 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				BuildID: 100,
 				Status:  "pending",
 			},
-			contains: []string{
-				"## Attestation #1 (IID 1)",
-				"**Status**: pending",
-			},
-			notWant: []string{
-				"Predicate Kind",
-				"Predicate Type",
-				"Subject Digest",
-				"Download URL",
-				"Created",
-				"Expires",
-			},
+			want: "## Attestation #1 (IID 1)\n\n" +
+				"- **Project ID**: 0\n" +
+				"- **Build ID**: 100\n" +
+				"- **Status**: pending\n" +
+				attestationCardHints,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatOutputMarkdown(tt.input)
-			if tt.want != "" || (len(tt.contains) == 0 && len(tt.notWant) == 0) {
-				if got != tt.want {
-					t.Errorf("got %q, want %q", got, tt.want)
-				}
-			}
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q", s)
-				}
-			}
-			for _, s := range tt.notWant {
-				if strings.Contains(got, s) {
-					t.Errorf("output should not contain %q", s)
-				}
+			if got := FormatOutputMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatOutputMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
@@ -226,17 +212,19 @@ func TestFormatOutputMarkdown(t *testing.T) {
 // --- FormatListMarkdown ---.
 
 // TestFormatListMarkdown validates the attestation list markdown table renderer.
-// Covers empty list (no attestations message) and populated list with table headers.
+// Covers the empty list, which is one sentence and no heading counting zero,
+// and a populated list whose timestamps render in the display form and whose
+// guidance closes the response rather than opening it.
 func TestFormatListMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
-			name:     "empty list shows no-results message",
-			input:    ListOutput{},
-			contains: []string{"No attestations found."},
+			name:  "empty list shows no-results message",
+			input: ListOutput{},
+			want:  "No attestations found.\n",
 		},
 		{
 			name: "populated list renders markdown table",
@@ -259,22 +247,20 @@ func TestFormatListMarkdown(t *testing.T) {
 					},
 				},
 			},
-			contains: []string{
-				"## Attestations (2)",
-				"| ID | IID | Build | Status | Predicate Kind | Created |",
-				"| 1 | 1 | 100 | success | slsa_provenance | 2026-01-01T00:00:00Z |",
-				"| 2 | 2 | 101 | failed |",
-			},
+			want: "## Attestations (2)\n\n" +
+				"| ID | IID | Build | Status | Predicate Kind | Created |\n" +
+				"| --- | --- | --- | --- | --- | --- |\n" +
+				"| 1 | 1 | 100 | success | slsa_provenance | 1 Jan 2026 00:00 UTC |\n" +
+				"| 2 | 2 | 101 | failed |  | 1 Feb 2026 00:00 UTC |\n" +
+				"\n---\n💡 **Next steps:**\n" +
+				"- Use `gitlab_download_attestation` with an IID from the table to fetch one attestation's bundle\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
+			if got := FormatListMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
@@ -283,13 +269,13 @@ func TestFormatListMarkdown(t *testing.T) {
 // --- FormatDownloadMarkdown ---.
 
 // TestFormatDownloadMarkdown validates the download result markdown renderer.
-// Covers zero IID (empty) and populated output with size and content info.
+// Covers zero IID (empty) and populated output with size and content info,
+// both pinned as whole documents.
 func TestFormatDownloadMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    DownloadOutput
-		want     string
-		contains []string
+		name  string
+		input DownloadOutput
+		want  string
 	}{
 		{
 			name:  "zero IID returns empty string",
@@ -303,28 +289,18 @@ func TestFormatDownloadMarkdown(t *testing.T) {
 				Size:           1024,
 				ContentBase64:  "dGVzdA==",
 			},
-			contains: []string{
-				"## Attestation Download (IID 7)",
-				"**Size**: 1024 bytes",
-				"Base64-encoded",
-				"content_base64",
-				"gitlab_list_attestations",
-			},
+			want: "## Attestation Download (IID 7)\n\n" +
+				"- **Size**: 1024 bytes\n" +
+				"- **Content**: Base64-encoded in the `content_base64` field\n" +
+				"\n---\n💡 **Next steps:**\n" +
+				"- Use `gitlab_list_attestations` to view all attestations for the project\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatDownloadMarkdown(tt.input)
-			if tt.want != "" || len(tt.contains) == 0 {
-				if tt.want != "" && got != tt.want {
-					t.Errorf("got %q, want %q", got, tt.want)
-				}
-			}
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
+			if got := FormatDownloadMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatDownloadMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/attestations/markdown.go
+++ b/internal/tools/attestations/markdown.go
@@ -2,47 +2,33 @@ package attestations
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single attestation as Markdown.
+// FormatOutputMarkdown renders a single attestation as the card of one
+// object: the identity and status rows, the predicate it carries, the subject
+// it is about, and the two timestamps in the display form.
 func FormatOutputMarkdown(o Output) string {
 	if o.ID == 0 {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Attestation #%d (IID %d)\n\n", o.ID, o.IID)
-	fmt.Fprintf(&b, "- **Project ID**: %d\n", o.ProjectID)
-	fmt.Fprintf(&b, "- **Build ID**: %d\n", o.BuildID)
-	//gitlab:allow-unescaped o.Status: an attestation status GitLab picks from a fixed set (pending, success, failed).
-	fmt.Fprintf(&b, "- **Status**: %s\n", o.Status)
-	if o.PredicateKind != "" {
-		fmt.Fprintf(&b, "- **Predicate Kind**: %s\n", toolutil.EscapeMdTableCell(o.PredicateKind))
-	}
-	if o.PredicateType != "" {
-		// The predicate type is a URI the attestation's producer chose, such as
-		// https://slsa.dev/provenance/v1, not a set GitLab constrains.
-		fmt.Fprintf(&b, "- **Predicate Type**: %s\n", toolutil.EscapeMdTableCell(o.PredicateType))
-	}
-	if o.SubjectDigest != "" {
-		//gitlab:allow-unescaped o.SubjectDigest: a subject digest, hexadecimal digits after an algorithm name.
-		fmt.Fprintf(&b, "- **Subject Digest**: `%s`\n", o.SubjectDigest)
-	}
-	if o.DownloadURL != "" {
-		fmt.Fprintf(&b, "- **Download URL**: %s\n", toolutil.EscapeMdTableCell(o.DownloadURL))
-	}
-	if o.CreatedAt != "" {
-		//gitlab:allow-unescaped o.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, o.CreatedAt)
-	}
-	if o.ExpireAt != "" {
-		//gitlab:allow-unescaped o.ExpireAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
-		fmt.Fprintf(&b, "- **Expires**: %s\n", o.ExpireAt)
-	}
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, fmt.Sprintf("Attestation #%d (IID %d)", o.ID, o.IID))
+	c.Int("Project ID", o.ProjectID)
+	c.Int("Build ID", o.BuildID)
+	c.Field("Status", o.Status)
+	c.Field("Predicate Kind", o.PredicateKind)
+	// The predicate type is a URI the attestation's producer chose, such as
+	// https://slsa.dev/provenance/v1, not a set GitLab constrains.
+	c.Field("Predicate Type", o.PredicateType)
+	c.Code("Subject Digest", o.SubjectDigest)
+	c.Link("Download URL", o.DownloadURL, o.DownloadURL)
+	c.Time("Created", o.CreatedAt)
+	c.Time("Expires", o.ExpireAt)
+	c.End(
 		"Use `gitlab_download_attestation` to download this attestation's content",
 		"Use `gitlab_list_attestations` to view all attestations for the project",
 	)
@@ -50,42 +36,44 @@ func FormatOutputMarkdown(o Output) string {
 }
 
 // FormatListMarkdown renders a list of attestations as a Markdown table.
+//
+// The endpoint sends no pagination headers, so the heading counts what is
+// shown; the empty pagination is what says so rather than a zero total.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Attestations) == 0 {
-		return "No attestations found."
+		return toolutil.EmptyMessage("attestations")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Attestations (%d)\n\n", len(out.Attestations))
-	b.WriteString("| ID | IID | Build | Status | Predicate Kind | Created |\n")
-	b.WriteString("| --: | --: | ----: | ------ | -------------- | ------- |\n")
+	toolutil.WriteListHeading(&b, "Attestations", len(out.Attestations), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "IID", "Build", "Status", "Predicate Kind", "Created"))
 	for _, a := range out.Attestations {
-		fmt.Fprintf(
-			&b, "| %d | %d | %d | %s | %s | %s |\n",
-			a.ID,
-			a.IID,
-			a.BuildID,
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(a.ID, 10),
+			strconv.FormatInt(a.IID, 10),
+			strconv.FormatInt(a.BuildID, 10),
 			toolutil.EscapeMdTableCell(a.Status),
 			toolutil.EscapeMdTableCell(a.PredicateKind),
-			toolutil.EscapeMdTableCell(a.CreatedAt),
-		)
+			toolutil.FormatTime(a.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		"Use `gitlab_download_attestation` with an IID from the table to fetch one attestation's bundle")
 	return b.String()
 }
 
-// FormatDownloadMarkdown renders a download result as Markdown.
+// FormatDownloadMarkdown renders a download result as the card of one object:
+// how large the content is and where the bytes themselves are.
 func FormatDownloadMarkdown(o DownloadOutput) string {
 	if o.AttestationIID == 0 {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Attestation Download (IID %d)\n\n", o.AttestationIID)
-	fmt.Fprintf(&b, "- **Size**: %d bytes\n", o.Size)
-	b.WriteString("- **Content**: Base64-encoded in the `content_base64` field\n")
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_list_attestations` to view all attestations for the project",
-	)
+	c := toolutil.NewCard(&b, fmt.Sprintf("Attestation Download (IID %d)", o.AttestationIID))
+	c.Field("Size", fmt.Sprintf("%d bytes", o.Size))
+	c.Markdown("Content", "Base64-encoded in the `content_base64` field")
+	c.End("Use `gitlab_list_attestations` to view all attestations for the project")
 	return b.String()
 }
 

--- a/internal/tools/awardemoji/award_emoji_test.go
+++ b/internal/tools/awardemoji/award_emoji_test.go
@@ -390,9 +390,23 @@ func TestListSnippetAwardEmoji_Success(t *testing.T) {
 
 // Formatter tests.
 
-// TestFormatListMarkdownString_WithEmoji verifies the ListMarkdownString_WithEmoji Markdown formatter for a representative liststring_withemoji input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The guidance sections an award emoji result ends with, so each expectation
+// below can pin the whole rendered document. Delete award-emoji operations are
+// destructive, so the hint that names the confirmation is part of every one.
+const (
+	cardHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use the selected tool surface's matching award emoji delete action with award_id, the same resource identifiers, and explicit confirm=true\n"
+	linkedListHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use the selected tool surface's matching award emoji delete action with award_id, the same resource identifiers, and explicit confirm=true\n"
+	plainListHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use the selected tool surface's matching award emoji delete action with award_id, the same resource identifiers, and explicit confirm=true\n"
+)
+
+// TestFormatListMarkdownString_WithEmoji pins the whole list document: the
+// collection is a table, the awarding user is a link where GitLab gave a profile
+// URL and the bare handle where it did not, and the footer carries the
+// instruction to keep the links because the table has some.
 func TestFormatListMarkdownString_WithEmoji(t *testing.T) {
 	out := ListOutput{
 		AwardEmoji: []Output{
@@ -400,18 +414,41 @@ func TestFormatListMarkdownString_WithEmoji(t *testing.T) {
 			{ID: 11, Name: "heart", User: &UserOutput{ID: 2, Username: "dev"}, CreatedAt: "2026-02-01T00:00:00Z", AwardableID: 1, AwardableType: "Issue"},
 		},
 	}
-	md := FormatListMarkdownString(out)
-	if !contains(md, "Award Emoji (2)") {
-		t.Error("expected header with count 2")
+
+	got := FormatListMarkdownString(out)
+
+	want := "## Award Emoji (2)\n\n" +
+		"| ID | Emoji | User | Awarded |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 10 | :thumbsup: | [@admin](https://gitlab.example.com/admin) | 1 Jan 2026 00:00 UTC |\n" +
+		"| 11 | :heart: | @dev | 1 Feb 2026 00:00 UTC |\n" +
+		linkedListHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if !contains(md, ":thumbsup:") {
-		t.Error("expected :thumbsup:")
+}
+
+// TestFormatListMarkdownString_Paginated pins the heading and the footer of a
+// page of a larger list: the heading counts the total GitLab reported, and the
+// pagination line opens a block of its own after the last row rather than
+// continuing the table.
+func TestFormatListMarkdownString_Paginated(t *testing.T) {
+	out := ListOutput{
+		AwardEmoji: []Output{{ID: 10, Name: testEmojiThumbsup, User: &UserOutput{ID: 1, Username: "admin"}, CreatedAt: "2026-01-01T00:00:00Z"}},
+		Pagination: toolutil.PaginationOutput{Page: 2, PerPage: 1, TotalItems: 3, TotalPages: 3, NextPage: 3, HasMore: true},
 	}
-	if !contains(md, ":heart:") {
-		t.Error("expected :heart:")
-	}
-	if !contains(md, "[admin](https://gitlab.example.com/admin)") {
-		t.Error("expected linked username when user profile URL is available")
+
+	got := FormatListMarkdownString(out)
+
+	want := "## Award Emoji (3)\n\n" +
+		"Showing 1 of 3 results (page 2 of 3)\n\n" +
+		"| ID | Emoji | User | Awarded |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 10 | :thumbsup: | @admin | 1 Jan 2026 00:00 UTC |\n\n" +
+		"Page 2 of 3 | 3 items total | 1 per page\n" +
+		plainListHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -426,26 +463,33 @@ func TestFormatListMarkdownString_Empty(t *testing.T) {
 	}
 }
 
-// TestFormatMarkdownString verifies the MarkdownString Markdown formatter for a representative string input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMarkdownString pins the whole card of one award emoji, the
+// awardable included: an award that does not say what it sits on cannot be
+// found again, and the object is both in the heading and in a row of its own.
 func TestFormatMarkdownString(t *testing.T) {
 	out := Output{
-		ID:        10,
-		Name:      testEmojiThumbsup,
-		User:      &UserOutput{ID: 1, Username: "admin"},
-		CreatedAt: "2026-01-01T00:00:00Z",
+		ID:            10,
+		Name:          testEmojiThumbsup,
+		User:          &UserOutput{ID: 1, Username: "admin", Name: "Admin User", WebURL: "https://gitlab.example.com/admin"},
+		CreatedAt:     "2026-01-01T00:00:00Z",
+		AwardableID:   42,
+		AwardableType: "Issue",
 	}
-	md := FormatMarkdownString(out)
-	if !contains(md, ":thumbsup:") {
-		t.Error("expected :thumbsup: in markdown")
-	}
-	if !contains(md, "admin") {
-		t.Error("expected admin in markdown")
-	}
-	// Delete award-emoji operations are destructive and must require explicit confirmation guidance.
-	if !contains(md, "explicit confirm=true") {
-		t.Error("expected destructive confirmation hint in markdown")
+
+	got := FormatMarkdownString(out)
+
+	want := "## Award Emoji :thumbsup: on Issue 42\n\n" +
+		"- **ID**: 10\n" +
+		"- **Name**: :thumbsup:\n" +
+		"- **Awarded On**: Issue (ID 42)\n" +
+		"- **User**:\n" +
+		"  - **ID**: 1\n" +
+		"  - **Name**: Admin User\n" +
+		"  - **Username**: [@admin](https://gitlab.example.com/admin)\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		cardHintsBlock
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1426,24 +1470,32 @@ func TestFormatListMarkdown_Empty_Cov(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdownString_Empty_Cov verifies the ListMarkdownString_Empty_Cov Markdown formatter for a representative liststring_empty_cov input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdownString_Empty_Cov pins the whole response of a list with
+// nothing in it: one sentence, with no heading counting zero above it.
 func TestFormatListMarkdownString_Empty_Cov(t *testing.T) {
-	md := FormatListMarkdownString(ListOutput{})
-	if !strings.Contains(md, "No award emoji found") {
-		t.Error("expected empty message")
+	got := FormatListMarkdownString(ListOutput{})
+
+	if want := "No award emoji found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdownString_WithEmoji_Cov verifies the ListMarkdownString_WithEmoji_Cov Markdown formatter for a representative liststring_withemoji_cov input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdownString_WithEmoji_Cov pins the whole list document of an
+// award GitLab sent no time for: the date cell is empty rather than a zero
+// instant, and the footer carries no instruction to keep links the table has
+// none of.
 func TestFormatListMarkdownString_WithEmoji_Cov(t *testing.T) {
 	out := ListOutput{AwardEmoji: []Output{{ID: 1, Name: "thumbsup", User: &UserOutput{Username: "alice"}}}}
-	md := FormatListMarkdownString(out)
-	if !strings.Contains(md, "thumbsup") || !strings.Contains(md, "alice") {
-		t.Error("expected emoji details")
+
+	got := FormatListMarkdownString(out)
+
+	want := "## Award Emoji (1)\n\n" +
+		"| ID | Emoji | User | Awarded |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | :thumbsup: | @alice |  |\n" +
+		plainListHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1457,23 +1509,39 @@ func TestFormatMarkdown_Wrapper(t *testing.T) {
 	}
 }
 
-// TestFormatMarkdownString_NoCreatedAt verifies the MarkdownString_NoCreatedAt Markdown formatter for a representative string_nocreatedat input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMarkdownString_NoCreatedAt pins the whole card of an award GitLab
+// sent neither a time nor an awardable for: no row is written for either, where
+// a label with nothing after it used to read as a value GitLab sent.
 func TestFormatMarkdownString_NoCreatedAt(t *testing.T) {
-	md := FormatMarkdownString(Output{Name: "thumbsup", User: &UserOutput{Username: "alice"}})
-	if strings.Contains(md, "Created") {
-		t.Error("should not show Created for empty CreatedAt")
+	got := FormatMarkdownString(Output{Name: "thumbsup", User: &UserOutput{Username: "alice"}})
+
+	want := "## Award Emoji :thumbsup:\n\n" +
+		"- **ID**: 0\n" +
+		"- **Name**: :thumbsup:\n" +
+		"- **User**:\n" +
+		"  - **ID**: 0\n" +
+		"  - **Username**: @alice\n" +
+		cardHintsBlock
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMarkdownString_WithCreatedAt verifies the MarkdownString_WithCreatedAt Markdown formatter for a representative string_withcreatedat input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMarkdownString_WithCreatedAt pins the whole card of an award with a
+// time on it, in the display form rather than as GitLab sent it.
 func TestFormatMarkdownString_WithCreatedAt(t *testing.T) {
-	md := FormatMarkdownString(Output{Name: "thumbsup", User: &UserOutput{Username: "alice"}, CreatedAt: "2026-06-01T10:00:00Z"})
-	if !strings.Contains(md, "Created") || !strings.Contains(md, "1 Jun 2026") {
-		t.Error("expected Created date")
+	got := FormatMarkdownString(Output{Name: "thumbsup", User: &UserOutput{Username: "alice"}, CreatedAt: "2026-06-01T10:00:00Z"})
+
+	want := "## Award Emoji :thumbsup:\n\n" +
+		"- **ID**: 0\n" +
+		"- **Name**: :thumbsup:\n" +
+		"- **User**:\n" +
+		"  - **ID**: 0\n" +
+		"  - **Username**: @alice\n" +
+		"- **Created**: 1 Jun 2026 10:00 UTC\n" +
+		cardHintsBlock
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/awardemoji/markdown.go
+++ b/internal/tools/awardemoji/markdown.go
@@ -2,12 +2,17 @@ package awardemoji
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
+
+// awardEmojiHint is the one next step an award emoji result offers: the delete
+// action, which every surface spells with its own tool name.
+const awardEmojiHint = "Use the selected tool surface's matching award emoji delete action with award_id, the same resource identifiers, and explicit confirm=true"
 
 type awardEmojiNotFoundOutput struct {
 	Identifier string `json:"identifier"`
@@ -24,37 +29,51 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
 }
 
-// FormatListMarkdownString renders award emoji list as Markdown.
+// FormatListMarkdownString renders award emoji as a Markdown table, the shape a
+// collection of objects sharing columns takes. The heading counts what the
+// response vouches for rather than the length of the page, and the pagination
+// footer is written after the rows rather than against them.
 func FormatListMarkdownString(out ListOutput) string {
 	if len(out.AwardEmoji) == 0 {
-		return "No award emoji found.\n"
+		return toolutil.EmptyMessage("award emoji")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Award Emoji (%d)\n\n", len(out.AwardEmoji))
-	toolutil.WriteListSummary(&b, len(out.AwardEmoji), out.Pagination)
+	toolutil.WriteListHeading(&b, "Award Emoji", len(out.AwardEmoji), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Emoji", "User", "Awarded"))
+	linked := false
 	for _, e := range out.AwardEmoji {
-		// An emoji name is not held to GitLab's own list: an instance may carry
-		// custom emoji whose name a person chose.
-		fmt.Fprintf(&b, "- :%s: by %s (ID: %d) - %s\n", toolutil.EscapeMdTableCell(e.Name),
-			awardEmojiUserMarkdown(e), e.ID, toolutil.FormatTime(e.CreatedAt))
+		linked = linked || (e.User != nil && e.User.WebURL != "")
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			emojiCell(e.Name),
+			awardEmojiUserMarkdown(e),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks, "Use the selected tool surface's matching award emoji actions for this resource; delete actions require explicit confirm=true plus the same resource identifiers and award_id")
+	toolutil.WriteListFooter(&b, out.Pagination, linked, awardEmojiHint)
 	return b.String()
 }
 
+// emojiCell renders an emoji name in GitLab's own ":name:" spelling, or nothing
+// for an award whose name is missing, so a cell never reads "::". An emoji name
+// is not held to GitLab's own list: an instance may carry custom emoji whose
+// name a person chose.
+func emojiCell(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return ""
+	}
+	return ":" + toolutil.EscapeMdTableCell(name) + ":"
+}
+
 // awardEmojiUserMarkdown renders the awarding user as a cell: a link to their
-// profile when GitLab gave one, the escaped username otherwise. The result is
-// written as it is, because the cell escaper turns a finished link back into
-// text.
+// profile when GitLab gave one, the escaped handle otherwise, and nothing for an
+// award whose user GitLab did not send. The result is written as it is, because
+// the cell escaper turns a finished link back into text.
 func awardEmojiUserMarkdown(out Output) string {
 	if out.User == nil {
 		return ""
 	}
-	if out.User.WebURL == "" {
-		return toolutil.EscapeMdTableCell(out.User.Username)
-	}
-	return toolutil.MdTitleLink(out.User.Username, out.User.WebURL)
+	return toolutil.MdUserLink(out.User.Username, out.User.WebURL)
 }
 
 // FormatMarkdown formats a single award emoji as a Markdown CallToolResult.
@@ -62,20 +81,72 @@ func FormatMarkdown(out Output) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatMarkdownString(out))
 }
 
-// FormatMarkdownString renders a single award emoji as Markdown.
+// FormatMarkdownString renders a single award emoji as a card: the emoji, what
+// it was awarded on, who awarded it and when. The awardable is in the heading
+// and in a row of its own because an award emoji is meaningless without it: the
+// card used to name the emoji and the user and never say what had been reacted
+// to, which is the one identifier a reader needs to find it again.
 func FormatMarkdownString(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Award Emoji\n\n")
-	fmt.Fprintf(&b, "- **Name**: :%s:\n", toolutil.EscapeMdTableCell(out.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
+	c := toolutil.NewCard(&b, awardEmojiHeading(out))
+	c.Int("ID", out.ID)
+	c.Markdown("Name", emojiCell(out.Name))
+	c.Markdown("Awarded On", awardableCell(out))
 	if out.User != nil {
-		fmt.Fprintf(&b, "- **User**: %s (ID: %d)\n", toolutil.EscapeMdTableCell(out.User.Username), out.User.ID)
+		user := c.Sub("User")
+		user.Int("ID", out.User.ID)
+		user.Field("Name", out.User.Name)
+		user.Markdown("Username", toolutil.MdUserLink(out.User.Username, out.User.WebURL))
 	}
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
-	}
-	toolutil.WriteHints(&b, "Use the selected tool surface's matching award emoji delete action with award_id, the same resource identifiers, and explicit confirm=true")
+	c.Time("Created", out.CreatedAt)
+	c.End(awardEmojiHint)
 	return b.String()
+}
+
+// awardEmojiHeading composes the card's heading from the emoji and the object it
+// sits on, "Award Emoji :thumbsup: on Issue 42". The parts are written as GitLab
+// sent them: [toolutil.NewCard] escapes the whole composition.
+func awardEmojiHeading(out Output) string {
+	heading := "Award Emoji"
+	if name := strings.TrimSpace(out.Name); name != "" {
+		heading += " :" + name + ":"
+	}
+	if on := awardableText(out); on != "" {
+		heading += " on " + on
+	}
+	return heading
+}
+
+// awardableCell renders the awardable as a card value, "Issue (ID 42)": the
+// type GitLab names the object with, and the ID every award emoji action takes.
+func awardableCell(out Output) string {
+	kind := toolutil.EscapeMdTableCell(strings.TrimSpace(out.AwardableType))
+	switch {
+	case kind == "" && out.AwardableID == 0:
+		return ""
+	case kind == "":
+		return "ID " + strconv.FormatInt(out.AwardableID, 10)
+	case out.AwardableID == 0:
+		return kind
+	default:
+		return fmt.Sprintf("%s (ID %d)", kind, out.AwardableID)
+	}
+}
+
+// awardableText is the heading form of the awardable, escaped by the card's own
+// heading escaper rather than here.
+func awardableText(out Output) string {
+	kind := strings.TrimSpace(out.AwardableType)
+	switch {
+	case kind == "" && out.AwardableID == 0:
+		return ""
+	case kind == "":
+		return strconv.FormatInt(out.AwardableID, 10)
+	case out.AwardableID == 0:
+		return kind
+	default:
+		return kind + " " + strconv.FormatInt(out.AwardableID, 10)
+	}
 }
 
 func init() {

--- a/internal/tools/branches/branches_test.go
+++ b/internal/tools/branches/branches_test.go
@@ -1143,151 +1143,234 @@ func TestProtectedToOutput_EmptyAccessLevels(t *testing.T) {
 // Markdown formatters
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The guidance sections the four branch formatters close with, pinned once so
+// each whole-output expectation names them rather than restating them.
+const (
+	branchCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'merge_request.create' to open a merge request from this branch\n" +
+		"- Use action 'repository.commit_list' to see recent commits on this branch\n" +
+		"- Use action 'branch.delete' to remove the branch after merging\n"
+
+	branchListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'branch.get' to see one branch in full\n" +
+		"- Use action 'branch.create' to create a new branch\n" +
+		"- Use action 'branch.protect' to protect a branch\n"
+
+	protectedCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'branch.get_protected' to fetch this protection again before updating it\n" +
+		"- Use action 'branch.update_protected' to change protection settings\n" +
+		"- Use action 'branch.unprotect' to remove branch protection\n"
+
+	protectedListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'branch.get_protected' to see one rule in full before updating or unprotecting\n" +
+		"- Use action 'branch.protect' to add branch protection\n" +
+		"- Use action 'branch.list' to list the branches these rules match\n"
+)
+
+// TestFormatOutputMarkdown pins the whole card of a branch: its three state
+// flags, the three permission flags GitLab sends on every branch, the head
+// commit as a nested object, and the address.
 func TestFormatOutputMarkdown(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		Name:      "main",
 		Protected: true,
 		Default:   true,
 		Merged:    false,
-		Commit:    &CommitOutput{ID: "abc123"},
-		WebURL:    "https://gitlab.example.com/-/tree/main",
+		CanPush:   true,
+		Commit: &CommitOutput{
+			ID:            "abc123",
+			Title:         "Fix login",
+			AuthorName:    "Alice",
+			CommittedDate: "2026-03-20T15:45:00Z",
+		},
+		WebURL: "https://gitlab.example.com/-/tree/main",
 	})
-	if !strings.Contains(md, "## Branch: main") {
-		t.Error("expected heading with branch name")
-	}
-	if !strings.Contains(md, "abc123") {
-		t.Error("expected commit ID")
-	}
-	if !strings.Contains(md, "https://gitlab.example.com/-/tree/main") {
-		t.Error("expected web URL")
+
+	want := "## Branch: main\n\n" +
+		"- **Protected**: ✅\n" +
+		"- **Default**: ✅\n" +
+		"- **Merged**: ❌\n" +
+		"- **You Can Push**: ✅\n" +
+		"- **Developers Can Push**: ❌\n" +
+		"- **Developers Can Merge**: ❌\n" +
+		"- **Commit**:\n" +
+		"  - **SHA**: `abc123`\n" +
+		"  - **Title**: Fix login\n" +
+		"  - **Author**: Alice\n" +
+		"  - **Committed**: 20 Mar 2026 15:45 UTC\n" +
+		"- **URL**: [https://gitlab.example.com/-/tree/main](https://gitlab.example.com/-/tree/main)\n" +
+		branchCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_NoURL verifies the OutputMarkdown_NoURL Markdown formatter for a representative output_nourl input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatOutputMarkdown_NoURL pins the card of a branch GitLab answered
+// with no commit and no address: neither is written as a label with nothing
+// after it.
 func TestFormatOutputMarkdown_NoURL(t *testing.T) {
-	md := FormatOutputMarkdown(Output{Name: "dev"})
-	if !strings.Contains(md, "## Branch: dev") {
-		t.Error("expected heading with branch name")
-	}
-	if strings.Contains(md, "URL") {
-		t.Error("should not contain URL when empty")
+	got := FormatOutputMarkdown(Output{Name: "dev"})
+
+	want := "## Branch: dev\n\n" +
+		"- **Protected**: ❌\n" +
+		"- **Default**: ❌\n" +
+		"- **Merged**: ❌\n" +
+		"- **You Can Push**: ❌\n" +
+		"- **Developers Can Push**: ❌\n" +
+		"- **Developers Can Merge**: ❌\n" +
+		branchCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown verifies the ListMarkdown Markdown formatter for a representative list input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown pins the whole branch listing: the count GitLab
+// vouched for, a linked name where the response carried an address and a
+// plain one where it did not, and the flags as glyphs.
 func TestFormatListMarkdown(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Branches: []Output{
-			{Name: "main", Protected: true, Default: true},
-			{Name: "dev", Protected: false, Default: false},
+			{Name: "main", Protected: true, Default: true, WebURL: "https://gitlab.example.com/-/tree/main"},
+			{Name: "dev", Merged: true},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
-	if !strings.Contains(md, "## Branches (2)") {
-		t.Error("expected heading with count")
-	}
-	if !strings.Contains(md, "| main |") {
-		t.Error("expected main branch row")
-	}
-	if !strings.Contains(md, "| dev |") {
-		t.Error("expected dev branch row")
+
+	want := "## Branches (2)\n\n" +
+		"| Name | Protected | Default | Merged |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| [main](https://gitlab.example.com/-/tree/main) | ✅ | ✅ | ❌ |\n" +
+		"| dev | ❌ | ❌ | ✅ |\n" +
+		"\n2 items total\n" +
+		branchListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_ClickableBranchLinks verifies the ListMarkdown_ClickableBranchLinks Markdown formatter for a representative list_clickablebranchlinks input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown_ClickableBranchLinks(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
-		Branches: []Output{
-			{Name: "main", Protected: true, Default: true, WebURL: "https://gitlab.example.com/-/tree/main"},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
+// TestFormatListMarkdown_Keyset pins the heading of a keyset page, which
+// carries no total: the count is what is shown, and the reader is told more
+// follows rather than being shown a total of zero above two rows.
+func TestFormatListMarkdown_Keyset(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Branches:   []Output{{Name: "main"}},
+		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, NextPage: 2, HasMore: true},
 	})
-	if !strings.Contains(md, "[main](https://gitlab.example.com/-/tree/main)") {
-		t.Errorf("expected clickable branch link, got:\n%s", md)
+
+	want := "## Branches (1 shown, more available)\n\n" +
+		"| Name | Protected | Default | Merged |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| main | ❌ | ❌ | ❌ |\n" +
+		"\nPage 1 | 20 per page | more pages available\n" +
+		branchListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_NoLinkWithoutWebURL verifies the ListMarkdown_NoLinkWithoutWebURL Markdown formatter for a representative list_nolinkwithoutweburl input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown_NoLinkWithoutWebURL(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
-		Branches: []Output{
-			{Name: "dev", Protected: false, Default: false},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	})
-	if strings.Contains(md, "[dev](") {
-		t.Errorf("should not contain link when WebURL is empty, got:\n%s", md)
-	}
-	if !strings.Contains(md, "dev") {
-		t.Errorf("should contain branch name as plain text, got:\n%s", md)
-	}
-}
-
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown_Empty pins the whole response of a project with no
+// branches: one sentence, and no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No branches found") {
-		t.Error("expected 'No branches found' message")
+	got := FormatListMarkdown(ListOutput{})
+
+	want := "No branches found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatProtectedMarkdown verifies the ProtectedMarkdown Markdown formatter for a representative protected input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatProtectedMarkdown pins the whole card of a protection rule: the
+// access levels as the role names they stand for rather than as the numbers
+// GitLab sends, and both flags.
 func TestFormatProtectedMarkdown(t *testing.T) {
-	md := FormatProtectedMarkdown(ProtectedOutput{
+	got := FormatProtectedMarkdown(ProtectedOutput{
 		ID:                1,
 		Name:              "main",
 		PushAccessLevels:  []BranchAccessDescriptionOutput{{AccessLevel: 0}},
 		MergeAccessLevels: []BranchAccessDescriptionOutput{{AccessLevel: 40}},
 		AllowForcePush:    false,
 	})
-	if !strings.Contains(md, "## Protected Branch: main") {
-		t.Error("expected heading with protected branch name")
-	}
-	if !strings.Contains(md, "Push Access Levels") {
-		t.Error("expected push access levels")
+
+	want := "## Protected Branch: main\n\n" +
+		"- **ID**: 1\n" +
+		"- **Push Access Levels**: No access\n" +
+		"- **Merge Access Levels**: Maintainer\n" +
+		"- **Unprotect Access Levels**: -\n" +
+		"- **Allow Force Push**: ❌\n" +
+		"- **Code Owner Approval Required**: ❌\n" +
+		protectedCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatProtectedListMarkdown verifies the ProtectedListMarkdown Markdown formatter for a representative protectedlist input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatProtectedMarkdown_GranularLevels pins an entry that names one
+// user, group or deploy key rather than a role: the principal is named beside
+// the role the level stands for.
+func TestFormatProtectedMarkdown_GranularLevels(t *testing.T) {
+	got := FormatProtectedMarkdown(ProtectedOutput{
+		ID:                        7,
+		Name:                      "release/*",
+		PushAccessLevels:          []BranchAccessDescriptionOutput{{AccessLevel: 40, UserID: 3}},
+		MergeAccessLevels:         []BranchAccessDescriptionOutput{{AccessLevel: 30, GroupID: 9}},
+		UnprotectAccessLevels:     []BranchAccessDescriptionOutput{{AccessLevel: 60, DeployKeyID: 4}},
+		AllowForcePush:            true,
+		CodeOwnerApprovalRequired: true,
+		Inherited:                 true,
+	})
+
+	want := "## Protected Branch: release/*\n\n" +
+		"- **ID**: 7\n" +
+		"- **Push Access Levels**: Maintainer (User #3)\n" +
+		"- **Merge Access Levels**: Developer (Group #9)\n" +
+		"- **Unprotect Access Levels**: Admin (Deploy Key #4)\n" +
+		"- **Allow Force Push**: ✅\n" +
+		"- **Code Owner Approval Required**: ✅\n" +
+		"- **Inherited from the group, not set on the project**\n" +
+		protectedCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatProtectedListMarkdown pins the whole protected-branch listing.
 func TestFormatProtectedListMarkdown(t *testing.T) {
-	md := FormatProtectedListMarkdown(ProtectedListOutput{
+	got := FormatProtectedListMarkdown(ProtectedListOutput{
 		Branches: []ProtectedOutput{
 			{ID: 1, Name: "main", PushAccessLevels: []BranchAccessDescriptionOutput{{AccessLevel: 0}}, MergeAccessLevels: []BranchAccessDescriptionOutput{{AccessLevel: 40}}},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	if !strings.Contains(md, "## Protected Branches (1)") {
-		t.Error("expected heading with count")
-	}
-	if !strings.Contains(md, "| main |") {
-		t.Error("expected main row")
+
+	want := "## Protected Branches (1)\n\n" +
+		"| Name | Push Levels | Merge Levels | Force Push | Code Owner Approval |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| main | No access | Maintainer | ❌ | ❌ |\n" +
+		"\n1 items total\n" +
+		protectedListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatProtectedListMarkdown_Empty verifies the ProtectedListMarkdown_Empty Markdown formatter for a representative protectedlist_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatProtectedListMarkdown_Empty pins the whole response of a project
+// with no protection rules.
 func TestFormatProtectedListMarkdown_Empty(t *testing.T) {
-	md := FormatProtectedListMarkdown(ProtectedListOutput{})
-	if !strings.Contains(md, "No protected branches found") {
-		t.Error("expected 'No protected branches found' message")
+	got := FormatProtectedListMarkdown(ProtectedListOutput{})
+
+	want := "No protected branches found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -2099,14 +2182,26 @@ func TestShapeConverters_NilAndEmpty(t *testing.T) {
 	}
 }
 
-// TestAccessLevelsSummary verifies the compact access-level markdown summary.
+// TestAccessLevelsSummary verifies the access-level summary names the roles
+// the numbers stand for, and a level GitLab's own table does not name keeps
+// its number, which is the one thing a reader can act on.
 func TestAccessLevelsSummary(t *testing.T) {
-	if got := accessLevelsSummary(nil); got != "-" {
-		t.Errorf("empty summary = %q, want dash", got)
+	cases := []struct {
+		name   string
+		levels []BranchAccessDescriptionOutput
+		want   string
+	}{
+		{"empty", nil, "-"},
+		{"roles", []BranchAccessDescriptionOutput{{AccessLevel: 30}, {AccessLevel: 40}}, "Developer, Maintainer"},
+		{"unknown level", []BranchAccessDescriptionOutput{{AccessLevel: 35}}, "Level 35"},
+		{"user entry", []BranchAccessDescriptionOutput{{AccessLevel: 40, UserID: 3}}, "Maintainer (User #3)"},
 	}
-	got := accessLevelsSummary([]BranchAccessDescriptionOutput{{AccessLevel: 30}, {AccessLevel: 40}})
-	if got != "30, 40" {
-		t.Errorf("summary = %q, want \"30, 40\"", got)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := accessLevelsSummary(c.levels); got != c.want {
+				t.Errorf("summary = %q, want %q", got, c.want)
+			}
+		})
 	}
 }
 
@@ -2166,14 +2261,29 @@ func branchSpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[string]too
 // not model it, and it is the difference between a rule that can be edited here
 // and one that has to be edited on the group.
 func TestFormatProtectedMarkdown_Inherited(t *testing.T) {
-	inherited := FormatProtectedMarkdown(ProtectedOutput{ID: 1, Name: "main", Inherited: true})
-	if !strings.Contains(inherited, "**Inherited**: yes") {
-		t.Errorf("markdown missing the inherited line:\n%s", inherited)
-	}
-	own := FormatProtectedMarkdown(ProtectedOutput{ID: 1, Name: "main"})
-	if strings.Contains(own, "**Inherited**") {
-		t.Errorf("markdown claims a project's own rule is inherited:\n%s", own)
-	}
+	body := "## Protected Branch: main\n\n" +
+		"- **ID**: 1\n" +
+		"- **Push Access Levels**: -\n" +
+		"- **Merge Access Levels**: -\n" +
+		"- **Unprotect Access Levels**: -\n" +
+		"- **Allow Force Push**: ❌\n" +
+		"- **Code Owner Approval Required**: ❌\n"
+
+	t.Run("inherited from the group", func(t *testing.T) {
+		got := FormatProtectedMarkdown(ProtectedOutput{ID: 1, Name: "main", Inherited: true})
+		want := body + "- **Inherited from the group, not set on the project**\n" + protectedCardHints
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("the project's own rule", func(t *testing.T) {
+		got := FormatProtectedMarkdown(ProtectedOutput{ID: 1, Name: "main"})
+		want := body + protectedCardHints
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
 }
 
 // TestProtectedBranches_UnreadableCapturedInherited verifies that every

--- a/internal/tools/branches/markdown.go
+++ b/internal/tools/branches/markdown.go
@@ -2,12 +2,24 @@ package branches
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name that the action specs do not already
+// spell, the one form every surface resolves: the dynamic surface executes
+// them, and the meta and individual surfaces resolve them to their own tool
+// names.
+const (
+	actionBranchGet          = "branch.get"
+	actionBranchCreate       = "branch.create"
+	actionBranchDelete       = "branch.delete"
+	actionCommitList         = "repository.commit_list"
+	actionMergeRequestCreate = "merge_request.create"
 )
 
 type branchNotFoundOutput struct {
@@ -22,110 +34,135 @@ func formatBranchNotFound(out branchNotFoundOutput) *mcp.CallToolResult {
 	)
 }
 
-// FormatOutputMarkdown renders a single branch as a Markdown summary.
+// FormatOutputMarkdown renders one branch as a card: its flags, what the
+// caller may do with it, and the head commit as a nested object.
+//
+// The three permission flags GitLab sends on every branch — whether the caller
+// can push, and whether developers may push or merge — used to be dropped, so
+// a reader could not tell a branch they may write from one they may not.
 func FormatOutputMarkdown(br Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Branch: %s\n\n", toolutil.EscapeMdHeading(br.Name))
-	fmt.Fprintf(&b, "- **Protected**: %v\n", br.Protected)
-	fmt.Fprintf(&b, "- **Default**: %v\n", br.Default)
-	fmt.Fprintf(&b, "- **Merged**: %v\n", br.Merged)
+	c := toolutil.NewCard(&b, "Branch: "+br.Name)
+	c.Bool("Protected", br.Protected)
+	c.Bool("Default", br.Default)
+	c.Bool("Merged", br.Merged)
+	c.Bool("You Can Push", br.CanPush)
+	c.Bool("Developers Can Push", br.DevelopersCanPush)
+	c.Bool("Developers Can Merge", br.DevelopersCanMerge)
 	if br.Commit != nil {
-		//gitlab:allow-unescaped br.Commit.ID: a commit SHA, hexadecimal by construction.
-		fmt.Fprintf(&b, "- **Commit**: %s\n", br.Commit.ID)
+		commit := c.Sub("Commit")
+		commit.Code("SHA", br.Commit.ID)
+		commit.Field("Title", br.Commit.Title)
+		commit.Field("Author", br.Commit.AuthorName)
+		commit.Time("Committed", br.Commit.CommittedDate)
 	}
-	if br.WebURL != "" {
-		toolutil.WriteMdURL(&b, br.WebURL)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use the selected tool surface's merge-request create action to open an MR from this branch",
-		"Use the selected tool surface's repository commit-list action with the same project_id and ref_name to see recent commits on this branch",
-		"Use the selected tool surface's branch delete action with the same project_id, branch_name, and explicit confirm=true to remove the branch after merging",
+	c.URL(br.WebURL)
+	c.End(
+		toolutil.HintAction(actionMergeRequestCreate, "open a merge request from this branch"),
+		toolutil.HintAction(actionCommitList, "see recent commits on this branch"),
+		toolutil.HintAction(actionBranchDelete, "remove the branch after merging"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of branches as a Markdown table.
+// FormatListMarkdown renders a page of branches as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Branches (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Branches), out.Pagination)
 	if len(out.Branches) == 0 {
-		b.WriteString("No branches found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("branches")
 	}
-	b.WriteString("| Name | Protected | Default | Merged |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Branches", len(out.Branches), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Protected", "Default", "Merged"))
 	for _, br := range out.Branches {
-		name := toolutil.MdTitleLink(br.Name, br.WebURL)
-		fmt.Fprintf(&b, "| %s | %v | %v | %v |\n", name, br.Protected, br.Default, br.Merged)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(br.Name, br.WebURL),
+			toolutil.BoolEmoji(br.Protected),
+			toolutil.BoolEmoji(br.Default),
+			toolutil.BoolEmoji(br.Merged),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use the selected tool surface's branch get action with project_id and branch_name to see full details",
-		"Use the selected tool surface's branch create action with project_id, branch_name, and ref to create a new branch",
-		"Use the selected tool surface's branch protect action with project_id and branch_name to protect a branch",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionBranchGet, "see one branch in full"),
+		toolutil.HintAction(actionBranchCreate, "create a new branch"),
+		toolutil.HintAction(actionBranchProtect, "protect a branch"),
 	)
 	return b.String()
 }
 
-// accessLevelsSummary renders a compact comma-separated list of the numeric
-// access levels in a protected branch access-level array (e.g. "30, 40"), or
-// "-" when the array is empty.
+// accessLevelsSummary renders the access levels of a protected branch rule as
+// the role names GitLab gives them ("Maintainers, Developers"), or "-" when
+// the array is empty. The numbers alone, which this used to print, are a
+// lookup table a reader does not have.
 func accessLevelsSummary(levels []BranchAccessDescriptionOutput) string {
 	if len(levels) == 0 {
 		return "-"
 	}
 	parts := make([]string, 0, len(levels))
 	for _, l := range levels {
-		parts = append(parts, strconv.Itoa(l.AccessLevel))
+		parts = append(parts, accessLevelLabel(l))
 	}
 	return strings.Join(parts, ", ")
 }
 
-// FormatProtectedMarkdown renders a single protected branch as Markdown.
+// accessLevelLabel names one access-level entry: the role the level stands
+// for, and the principal the entry names when it grants one user, group or
+// deploy key rather than a role.
+func accessLevelLabel(l BranchAccessDescriptionOutput) string {
+	label := toolutil.AccessLevelDescription(gl.AccessLevelValue(l.AccessLevel))
+	switch {
+	case l.UserID != 0:
+		return fmt.Sprintf("%s (User #%d)", label, l.UserID)
+	case l.GroupID != 0:
+		return fmt.Sprintf("%s (Group #%d)", label, l.GroupID)
+	case l.DeployKeyID != 0:
+		return fmt.Sprintf("%s (Deploy Key #%d)", label, l.DeployKeyID)
+	default:
+		return label
+	}
+}
+
+// FormatProtectedMarkdown renders one protected branch rule as a card.
 func FormatProtectedMarkdown(pb ProtectedOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Branch: %s\n\n", toolutil.EscapeMdHeading(pb.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, pb.ID)
-	fmt.Fprintf(&b, "- **Push Access Levels**: %s\n", accessLevelsSummary(pb.PushAccessLevels))
-	fmt.Fprintf(&b, "- **Merge Access Levels**: %s\n", accessLevelsSummary(pb.MergeAccessLevels))
-	fmt.Fprintf(&b, "- **Unprotect Access Levels**: %s\n", accessLevelsSummary(pb.UnprotectAccessLevels))
-	fmt.Fprintf(&b, "- **Allow Force Push**: %v\n", pb.AllowForcePush)
-	if pb.Inherited {
-		b.WriteString("- **Inherited**: yes (this rule comes from the group, not the project)\n")
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use the selected tool surface's branch get_protected action with the same project_id and branch_name when a workflow asks to fetch this protection before updating it",
-		"Use the selected tool surface's branch update_protected action with the same project_id and branch_name to change protection settings",
-		"Use the selected tool surface's branch unprotect action with the same project_id, branch_name, and explicit confirm=true to remove branch protection",
+	c := toolutil.NewCard(&b, "Protected Branch: "+pb.Name)
+	c.Int("ID", pb.ID)
+	c.Field("Push Access Levels", accessLevelsSummary(pb.PushAccessLevels))
+	c.Field("Merge Access Levels", accessLevelsSummary(pb.MergeAccessLevels))
+	c.Field("Unprotect Access Levels", accessLevelsSummary(pb.UnprotectAccessLevels))
+	c.Bool("Allow Force Push", pb.AllowForcePush)
+	c.Bool("Code Owner Approval Required", pb.CodeOwnerApprovalRequired)
+	c.Flag("", "Inherited from the group, not set on the project", pb.Inherited)
+	c.End(
+		toolutil.HintAction(actionBranchGetProtected, "fetch this protection again before updating it"),
+		toolutil.HintAction(actionBranchUpdateProtected, "change protection settings"),
+		toolutil.HintAction(actionBranchUnprotect, "remove branch protection"),
 	)
 	return b.String()
 }
 
-// FormatProtectedListMarkdown renders a list of protected branches as a Markdown table.
+// FormatProtectedListMarkdown renders a page of protected branch rules as a
+// Markdown table.
 func FormatProtectedListMarkdown(out ProtectedListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Branches (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Branches), out.Pagination)
 	if len(out.Branches) == 0 {
-		b.WriteString("No protected branches found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("protected branches")
 	}
-	b.WriteString("| Name | Push Levels | Merge Levels | Force Push |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Protected Branches", len(out.Branches), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Push Levels", "Merge Levels", "Force Push", "Code Owner Approval"))
 	for _, pb := range out.Branches {
-		fmt.Fprintf(&b, "| %s | %s | %s | %v |\n", toolutil.EscapeMdTableCell(pb.Name), accessLevelsSummary(pb.PushAccessLevels), accessLevelsSummary(pb.MergeAccessLevels), pb.AllowForcePush)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(pb.Name),
+			toolutil.EscapeMdTableCell(accessLevelsSummary(pb.PushAccessLevels)),
+			toolutil.EscapeMdTableCell(accessLevelsSummary(pb.MergeAccessLevels)),
+			toolutil.BoolEmoji(pb.AllowForcePush),
+			toolutil.BoolEmoji(pb.CodeOwnerApprovalRequired),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use the selected tool surface's branch get_protected action with the same project_id and branch_name for full details before update/unprotect workflows",
-		"Use the selected tool surface's branch protect action with project_id and branch_name to add branch protection",
+	// The table carries no link, so the instruction to preserve one is dropped.
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionBranchGetProtected, "see one rule in full before updating or unprotecting"),
+		toolutil.HintAction(actionBranchProtect, "add branch protection"),
+		toolutil.HintAction(actionBranchList, "list the branches these rules match"),
 	)
 	return b.String()
 }

--- a/internal/tools/branchrules/branch_rules_test.go
+++ b/internal/tools/branchrules/branch_rules_test.go
@@ -493,13 +493,22 @@ func TestList_NullOptionalFields(t *testing.T) {
 
 // Markdown formatter tests.
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// branchRuleListHints is the guidance section every branch rule listing
+// closes with, pinned once so each whole-output expectation below names it
+// rather than restating it.
+const branchRuleListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'branch.get_protected' to see one rule's protection settings in full\n" +
+	"- Use action 'branch.protect' to change what a branch pattern requires\n"
+
+// TestFormatListMarkdown_Empty pins the whole response of a project with no
+// branch rules: one sentence, and no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No branch rules found") {
-		t.Error("empty output should contain 'No branch rules found'")
+	got := FormatListMarkdown(ListOutput{})
+
+	want := "No branch rules found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -534,36 +543,47 @@ func TestFormatListMarkdown_WithRules(t *testing.T) {
 		Pagination: toolutil.GraphQLForwardPaginationOutput{HasNextPage: false},
 	}
 
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "main") {
-		t.Error("should contain 'main'")
-	}
-	if !strings.Contains(md, "feature/*") {
-		t.Error("should contain 'feature/*'")
-	}
-	if !strings.Contains(md, "Security Review") {
-		t.Error("should contain approval rule name")
-	}
-	if !strings.Contains(md, "SonarQube") {
-		t.Error("should contain status check name")
-	}
-	if !strings.Contains(md, "Approval Rules for") {
-		t.Error("should contain approval rules detail section")
-	}
-	if !strings.Contains(md, "External Status Checks for") {
-		t.Error("should contain external status checks detail section")
+	got := FormatListMarkdown(out)
+
+	want := "## Branch Rules (2)\n\n" +
+		"| Name | Default | Protected | Branches | Force Push | CODEOWNERS | Approval Rules | Status Checks |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| main | ✅ | ✅ | 1 | ❌ | ✅ | 1 (Security Review) | 1 (SonarQube) |\n" +
+		"| feature/* | ❌ | ❌ | 5 | - | - | None | None |\n" +
+		"\n### Approval Rules for main\n\n" +
+		"| Name | Approvals Required | Type |\n" +
+		"| --- | --- | --- |\n" +
+		"| Security Review | 2 | REGULAR |\n" +
+		"\n### External Status Checks for main\n\n" +
+		"| Name | URL |\n" +
+		"| --- | --- |\n" +
+		"| SonarQube | [https://sonar.example.com](https://sonar.example.com) |\n" +
+		"\nShowing 2 items | no more pages\n" +
+		branchRuleListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestBoolIcon verifies the BoolIcon handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
-func TestBoolIcon(t *testing.T) {
-	if boolIcon(true) != "Yes" {
-		t.Errorf("boolIcon(true) = %q, want %q", boolIcon(true), "Yes")
-	}
-	if boolIcon(false) != "No" {
-		t.Errorf("boolIcon(false) = %q, want %q", boolIcon(false), "No")
+// TestFormatListMarkdown_NextPage pins that a connection with more to come
+// says so in the heading and names the cursor to pass back, which is the only
+// way a caller reaches the next page of a cursor-paginated list.
+func TestFormatListMarkdown_NextPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Rules:      []BranchRuleItem{{Name: "main", IsDefault: true, IsProtected: true, MatchingBranchesCount: 1}},
+		Pagination: toolutil.GraphQLForwardPaginationOutput{HasNextPage: true, EndCursor: "cursor7"},
+	})
+
+	want := "## Branch Rules (1 shown, more available)\n\n" +
+		"| Name | Default | Protected | Branches | Force Push | CODEOWNERS | Approval Rules | Status Checks |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| main | ✅ | ✅ | 1 | - | - | None | None |\n" +
+		"\nShowing 1 items | next page cursor: `cursor7`\n" +
+		branchRuleListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/branchrules/markdown.go
+++ b/internal/tools/branchrules/markdown.go
@@ -2,94 +2,103 @@ package branchrules
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown renders a paginated list of branch rules as Markdown.
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionBranchGetProtected = "branch.get_protected"
+	actionBranchProtect      = "branch.protect"
+)
+
+// FormatListMarkdown renders a page of branch rules as a Markdown table,
+// followed by one section per rule that carries approval rules or external
+// status checks.
 func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	sb.WriteString("## Branch Rules\n\n")
-
 	if len(out.Rules) == 0 {
-		sb.WriteString("No branch rules found.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("branch rules")
 	}
-
-	sb.WriteString("| Name | Default | Protected | Branches | Force Push | CODEOWNERS | Approval Rules | Status Checks |\n")
-	sb.WriteString("|------|---------|-----------|----------|------------|------------|----------------|---------------|\n")
-
+	var b strings.Builder
+	// A cursor-paginated connection sends no total, so the heading counts what
+	// is shown and says whether more follows, which is all the response knows.
+	toolutil.WriteListHeading(&b, "Branch Rules", len(out.Rules),
+		toolutil.PaginationOutput{HasMore: out.Pagination.HasNextPage})
+	b.WriteString(toolutil.MarkdownTableHeader(
+		"Name", "Default", "Protected", "Branches", "Force Push", "CODEOWNERS", "Approval Rules", "Status Checks",
+	))
 	for _, r := range out.Rules {
 		forcePush := "-"
 		codeOwners := "-"
 		if r.BranchProtection != nil {
-			forcePush = boolIcon(r.BranchProtection.AllowForcePush)
-			codeOwners = boolIcon(r.BranchProtection.CodeOwnerApprovalRequired)
+			forcePush = toolutil.BoolEmoji(r.BranchProtection.AllowForcePush)
+			codeOwners = toolutil.BoolEmoji(r.BranchProtection.CodeOwnerApprovalRequired)
 		}
-
-		approvals := formatApprovalRulesSummary(r.ApprovalRules)
-		checks := formatStatusChecksSummary(r.ExternalStatusChecks)
-
-		fmt.Fprintf(
-			&sb, "| %s | %s | %s | %d | %s | %s | %s | %s |\n",
+		b.WriteString(toolutil.MarkdownTableRow(
 			toolutil.EscapeMdTableCell(r.Name),
-			boolIcon(r.IsDefault),
-			boolIcon(r.IsProtected),
-			r.MatchingBranchesCount,
+			toolutil.BoolEmoji(r.IsDefault),
+			toolutil.BoolEmoji(r.IsProtected),
+			strconv.Itoa(r.MatchingBranchesCount),
 			forcePush,
 			codeOwners,
-			approvals,
-			checks,
-		)
+			formatApprovalRulesSummary(r.ApprovalRules),
+			formatStatusChecksSummary(r.ExternalStatusChecks),
+		))
 	}
-
-	sb.WriteString("\n")
-
-	// Render detailed sections for rules with approval rules or external status checks.
 	for _, r := range out.Rules {
-		if len(r.ApprovalRules) > 0 {
-			// A branch rule's name is the branch pattern a maintainer typed.
-			fmt.Fprintf(&sb, "### Approval Rules for `%s`\n\n", toolutil.EscapeMdHeading(r.Name))
-			sb.WriteString("| Name | Approvals Required | Type |\n")
-			sb.WriteString("|------|--------------------|------|\n")
-			for _, ar := range r.ApprovalRules {
-				fmt.Fprintf(
-					&sb, "| %s | %d | %s |\n",
-					toolutil.EscapeMdTableCell(ar.Name),
-					ar.ApprovalsRequired,
-					toolutil.EscapeMdTableCell(ar.Type),
-				)
-			}
-			sb.WriteString("\n")
-		}
-		if len(r.ExternalStatusChecks) > 0 {
-			fmt.Fprintf(&sb, "### External Status Checks for `%s`\n\n", toolutil.EscapeMdHeading(r.Name))
-			sb.WriteString("| Name | URL |\n")
-			sb.WriteString("|------|-----|\n")
-			for _, esc := range r.ExternalStatusChecks {
-				fmt.Fprintf(
-					&sb, "| %s | %s |\n",
-					toolutil.EscapeMdTableCell(esc.Name),
-					toolutil.EscapeMdTableCell(esc.ExternalURL),
-				)
-			}
-			sb.WriteString("\n")
-		}
+		writeApprovalRuleSection(&b, r)
+		writeStatusCheckSection(&b, r)
 	}
-
-	sb.WriteString(toolutil.FormatGraphQLForwardPagination(out.Pagination, len(out.Rules)))
-	sb.WriteString("\n")
-	return sb.String()
+	toolutil.WriteGraphQLPagination(&b, toolutil.GraphQLPaginationOutput{
+		HasNextPage: out.Pagination.HasNextPage,
+		EndCursor:   out.Pagination.EndCursor,
+	}, len(out.Rules))
+	// The table carries no link, so the hints carry no instruction to preserve
+	// one, and they are written once, after the tables, rather than opening the
+	// response above its own table header.
+	toolutil.WriteHints(&b,
+		toolutil.HintAction(actionBranchGetProtected, "see one rule's protection settings in full"),
+		toolutil.HintAction(actionBranchProtect, "change what a branch pattern requires"),
+	)
+	return b.String()
 }
 
-// boolIcon returns "Yes" or "No" for use in Markdown table cells.
-func boolIcon(v bool) string {
-	if v {
-		return "Yes"
+// writeApprovalRuleSection writes the approval rules of one branch rule as a
+// table under its own heading, and nothing when the rule has none. The rule's
+// name is the heading's subject rather than a hand-written code span, since a
+// backtick in the name would end the span and the rest would render as
+// Markdown.
+func writeApprovalRuleSection(b *strings.Builder, r BranchRuleItem) {
+	if len(r.ApprovalRules) == 0 {
+		return
 	}
-	return "No"
+	fmt.Fprintf(b, "\n### Approval Rules for %s\n\n", toolutil.EscapeMdHeading(r.Name))
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Approvals Required", "Type"))
+	for _, ar := range r.ApprovalRules {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(ar.Name),
+			strconv.Itoa(ar.ApprovalsRequired),
+			toolutil.EscapeMdTableCell(ar.Type),
+		))
+	}
+}
+
+// writeStatusCheckSection writes the external status checks of one branch rule
+// as a table under its own heading, and nothing when the rule has none.
+func writeStatusCheckSection(b *strings.Builder, r BranchRuleItem) {
+	if len(r.ExternalStatusChecks) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n### External Status Checks for %s\n\n", toolutil.EscapeMdHeading(r.Name))
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "URL"))
+	for _, esc := range r.ExternalStatusChecks {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(esc.Name),
+			toolutil.MdTitleLink(esc.ExternalURL, esc.ExternalURL),
+		))
+	}
 }
 
 // formatApprovalRulesSummary returns a Markdown-safe summary of approval rules,

--- a/internal/tools/cicatalog/ci_catalog_test.go
+++ b/internal/tools/cicatalog/ci_catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
@@ -683,9 +684,11 @@ func TestGet_NullOptionalFields(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No catalog resources found.") {
-		t.Error("expected empty message")
+	// The empty render used to open with a guidance section telling the reader
+	// to keep the links of a table that is not there.
+	const want = "No catalog resources found.\n"
+	if md := FormatListMarkdown(ListOutput{}); md != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -696,6 +699,7 @@ func TestFormatListMarkdown_WithItems(t *testing.T) {
 		Resources: []ResourceItem{
 			{
 				Name:                "go-pipeline",
+				FullPath:            "g/go-pipeline",
 				WebPath:             "/explore/catalog/g/go-pipeline",
 				StarCount:           42,
 				Last30DayUsageCount: 5,
@@ -704,14 +708,20 @@ func TestFormatListMarkdown_WithItems(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "go-pipeline") {
-		t.Error("expected resource name in output")
-	}
-	if !strings.Contains(md, "42") {
-		t.Error("expected star count in output")
-	}
-	if !strings.Contains(md, "2.1.0") {
-		t.Error("expected version in output")
+	// The name is not linked: GitLab answers with webPath, a path relative to
+	// the instance root, and a link built from it resolved against whatever
+	// base the reading client happened to have. The full path the get action
+	// takes is shown instead.
+	want := "## CI/CD Catalog Resources (1)\n\n" +
+		"| Name | Path | Description | Stars | Usage (30d) | Verification | Latest Version | Released |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| go-pipeline | `g/go-pipeline` |  | 42 | 5 |  | 2.1.0 | 15 Jun 2026 10:30 UTC |\n" +
+		"\nShowing 1 items | no more pages\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'ci_catalog.get' to see one resource with its components and inputs\n" +
+		"- Use action 'template.lint' to check a configuration that includes one\n"
+	if md != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -742,65 +752,60 @@ func TestFormatGetMarkdown_WithComponents(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "go-pipeline") {
-		t.Error("expected resource name")
-	}
-	if !strings.Contains(md, "`build`") {
-		t.Error("expected component name")
-	}
-	if !strings.Contains(md, "binary_name") {
-		t.Error("expected input name")
-	}
-	if !strings.Contains(md, "**yes**") {
-		t.Error("expected required marker")
-	}
-	if !strings.Contains(md, "2.1.0") {
-		t.Error("expected version in versions table")
+	want := "## Catalog Resource: go-pipeline\n\n" +
+		"- **ID**: `gid://gitlab/Ci::CatalogResource/1`\n" +
+		"- **Full Path**: `my-group/go-pipeline`\n" +
+		"- **Web Path**: `/explore/catalog/my-group/go-pipeline`\n" +
+		"\n### Components (Latest Version)\n\n" +
+		"#### build\n\n" +
+		"- **Description**: Build binary\n" +
+		"- **Include**: `gitlab.example.com/my-group/go-pipeline/build@2.1.0`\n" +
+		"\n| Input | Type | Required | Default | Description |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| `go_version` | string | ❌ | 1.22 |  |\n" +
+		"| `binary_name` | string | ✅ |  |  |\n" +
+		"\n### Released Versions\n\n" +
+		"| Version | Released | Components |\n" +
+		"| --- | --- | --- |\n" +
+		"| 2.1.0 | 15 Jun 2026 10:30 UTC | build |\n" +
+		catalogCardHints
+	if md != want {
+		t.Errorf("FormatGetMarkdown(components)\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestTruncate verifies the Truncate handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
-func TestTruncate(t *testing.T) {
+// catalogCardHints is the guidance section the catalog resource card closes
+// with.
+const catalogCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'template.lint' to check a configuration that includes this component\n" +
+	"- Use action 'ci_catalog.list' to browse the catalog for others\n"
+
+// TestTruncateRunes verifies the description cell's shortening. It counts
+// runes rather than bytes: cutting a UTF-8 sequence in half leaves a
+// replacement character in the middle of a description, and a description is
+// the one field of a catalog resource most likely to need more than one byte
+// per character.
+func TestTruncateRunes(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		maxLen int
-		want   string
+		name     string
+		input    string
+		maxRunes int
+		want     string
 	}{
 		{"short", "hello", 10, "hello"},
 		{"exact", "hello", 5, "hello"},
 		{"long", "hello world this is long", 10, "hello w..."},
+		{"multibyte cut on a rune boundary", "añadir un paso de compilación", 10, "añadir ..."},
+		{"maxRunes below the ellipsis", "hello", 2, "he"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncate(tt.input, tt.maxLen)
+			got := truncateRunes(tt.input, tt.maxRunes)
 			if got != tt.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.input, tt.maxRunes, got, tt.want)
 			}
-		})
-	}
-}
-
-// TestFormatDate verifies the Date Markdown formatter for a representative date input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatDate(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"empty", "", ""},
-		{"iso", "2026-06-15T10:30:00Z", "2026-06-15"},
-		{"short", "2026-06", "2026-06"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := formatDate(tt.input)
-			if got != tt.want {
-				t.Errorf("formatDate(%q) = %q, want %q", tt.input, got, tt.want)
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateRunes(%q, %d) = %q, which is not valid UTF-8", tt.input, tt.maxRunes, got)
 			}
 		})
 	}
@@ -843,29 +848,19 @@ func TestFormatGetMarkdown_MinimalResource(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "GITLAB_MAINTAINED") {
-		t.Error("expected Verification row")
-	}
-	if !strings.Contains(md, "go, ci") {
-		t.Error("expected Topics row")
-	}
-	if !strings.Contains(md, "| Archived | yes |") {
-		t.Error("expected Archived row")
-	}
-	if !strings.Contains(md, "### Description") {
-		t.Error("expected Description section for non-empty description")
-	}
-	if !strings.Contains(md, "Latest Release") {
-		t.Error("expected Latest Release row for non-empty LatestReleasedAt")
-	}
-	if !strings.Contains(md, "Latest Version") {
-		t.Error("expected Latest Version row for non-empty LatestVersionName")
-	}
-	if strings.Contains(md, "### Components") {
-		t.Error("expected no Components section for empty components")
-	}
-	if strings.Contains(md, "### Released Versions") {
-		t.Error("expected no Versions section for empty versions")
+	want := "## Catalog Resource: minimal 📦\n\n" +
+		"- **ID**: `gid://gitlab/Ci::CatalogResource/2`\n" +
+		"- **Full Path**: `group/minimal`\n" +
+		"- **Web Path**: `/explore/catalog/group/minimal`\n" +
+		"- **Verification**: GITLAB_MAINTAINED\n" +
+		"- **Topics**: go, ci\n" +
+		"- 📦 **Archived**\n" +
+		"- **Latest Release**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Latest Version**: 1.0.0\n" +
+		"- **Description**: A minimal catalog resource\n" +
+		catalogCardHints
+	if md != want {
+		t.Errorf("FormatGetMarkdown(minimal)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -891,17 +886,43 @@ func TestFormatGetMarkdown_ComponentWithoutInputs(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "`simple`") {
-		t.Error("expected component name header")
+	want := "## Catalog Resource: no-inputs\n\n" +
+		"- **ID**: `gid://gitlab/Ci::CatalogResource/3`\n" +
+		"- **Full Path**: `group/no-inputs`\n" +
+		"- **Web Path**: `/explore/catalog/group/no-inputs`\n" +
+		"\n### Components (Latest Version)\n\n" +
+		"#### simple\n\n" +
+		"- **Description**: A component without any inputs\n" +
+		"- **Include**: `gitlab.example.com/group/no-inputs/simple@1.0.0`\n" +
+		catalogCardHints
+	if md != want {
+		t.Errorf("FormatGetMarkdown(component without inputs)\n got %q\nwant %q", md, want)
 	}
-	if !strings.Contains(md, "A component without any inputs") {
-		t.Error("expected component description")
-	}
-	if !strings.Contains(md, "**Include:** `gitlab.example.com/group/no-inputs/simple@1.0.0`") {
-		t.Error("expected include path")
-	}
-	if strings.Contains(md, "| Input |") {
-		t.Error("expected no Inputs table for component with empty Inputs")
+}
+
+// TestFormatGetMarkdown_DescriptionIsQuoted verifies that a multi-line
+// description a maintainer typed is quoted under its label rather than written
+// into the response as Markdown of its own: it used to be interpolated raw,
+// so a heading in it became a heading of the response.
+func TestFormatGetMarkdown_DescriptionIsQuoted(t *testing.T) {
+	md := FormatGetMarkdown(GetOutput{
+		Resource: ResourceDetail{
+			ResourceItem: ResourceItem{
+				Name:        "prose",
+				FullPath:    "group/prose",
+				Description: "First line\n\n## Injected heading",
+			},
+		},
+	})
+	want := "## Catalog Resource: prose\n\n" +
+		"- **Full Path**: `group/prose`\n" +
+		"- **Description**:\n" +
+		"  > First line\n" +
+		"  >\n" +
+		"  > ## Injected heading\n" +
+		catalogCardHints
+	if md != want {
+		t.Errorf("FormatGetMarkdown(prose)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/cicatalog/markdown.go
+++ b/internal/tools/cicatalog/markdown.go
@@ -1,144 +1,155 @@
 package cicatalog
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown renders a paginated list of catalog resources as Markdown.
+// Canonical action IDs the hints name.
+const (
+	actionCatalogGetHint  = "ci_catalog.get"
+	actionCatalogListHint = "ci_catalog.list"
+	actionLintHint        = "template.lint"
+)
+
+// descriptionCellRunes is how much of a resource description one table cell
+// carries before it is cut.
+const descriptionCellRunes = 60
+
+// FormatListMarkdown renders a page of catalog resources as a Markdown table.
+//
+// The name is not linked. GitLab's catalog query answers with webPath, a path
+// relative to the instance root ("/explore/catalog/group/project"), and this
+// package never learns which instance answered, so a link built from it
+// resolved against whatever base the reading client happened to have. The path
+// is shown as the value it is, beside the full path the get action takes.
 func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	sb.WriteString("## CI/CD Catalog Resources\n\n")
-
 	if len(out.Resources) == 0 {
-		sb.WriteString("No catalog resources found.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("catalog resources")
 	}
-
-	sb.WriteString("| Name | Description | Stars | Usage (30d) | Verification | Latest Version | Released |\n")
-	sb.WriteString("|------|-------------|-------|-------------|--------------|----------------|----------|\n")
-
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "CI/CD Catalog Resources", len(out.Resources), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader(
+		"Name", "Path", "Description", "Stars", "Usage (30d)", "Verification", "Latest Version", "Released",
+	))
 	for _, r := range out.Resources {
-		desc := toolutil.EscapeMdTableCell(truncate(r.Description, 60))
-		name := toolutil.MdTitleLink(r.Name, r.WebPath)
-		fmt.Fprintf(
-			&sb, "| %s | %s | %d | %d | %s | %s | %s |\n",
-			name,
-			desc,
-			r.StarCount,
-			r.Last30DayUsageCount,
+		b.WriteString(toolutil.MarkdownTableRow(
+			resourceNameCell(r.Name, r.Archived),
+			toolutil.MdCodeSpanCell(r.FullPath),
+			toolutil.EscapeMdTableCell(truncateRunes(r.Description, descriptionCellRunes)),
+			strconv.Itoa(r.StarCount),
+			strconv.Itoa(r.Last30DayUsageCount),
 			toolutil.EscapeMdTableCell(r.VerificationLevel),
 			toolutil.EscapeMdTableCell(r.LatestVersionName),
-			formatDate(r.LatestReleasedAt),
-		)
+			toolutil.FormatTime(r.LatestReleasedAt),
+		))
 	}
-
-	sb.WriteString("\n")
-	sb.WriteString(toolutil.FormatGraphQLPagination(out.Pagination, len(out.Resources)))
-	sb.WriteString("\n")
-	return sb.String()
+	toolutil.WriteGraphQLPagination(&b, out.Pagination, len(out.Resources))
+	toolutil.WriteHints(&b,
+		toolutil.HintAction(actionCatalogGetHint, "see one resource with its components and inputs"),
+		toolutil.HintAction(actionLintHint, "check a configuration that includes one"),
+	)
+	return b.String()
 }
 
-// FormatGetMarkdown renders a single catalog resource detail as Markdown.
+// resourceNameCell carries the archived marker, without which a reader cannot
+// tell a resource nobody maintains any more from a live one.
+func resourceNameCell(name string, archived bool) string {
+	cell := toolutil.EscapeMdTableCell(name)
+	if archived {
+		cell += " " + toolutil.EmojiArchived
+	}
+	return cell
+}
+
+// FormatGetMarkdown renders one catalog resource as the card of a single
+// object: its own fields, then its components and released versions as the
+// nested collections they are.
 func FormatGetMarkdown(out GetOutput) string {
 	r := out.Resource
-	var sb strings.Builder
-
-	fmt.Fprintf(&sb, "## Catalog Resource: %s\n\n", toolutil.EscapeMdHeading(r.Name))
-	writeCatalogResourceSummary(&sb, r)
-	writeCatalogResourceComponents(&sb, r.Components)
-	writeCatalogResourceVersions(&sb, r.Versions)
-	return sb.String()
+	var b strings.Builder
+	c := toolutil.NewCard(&b, catalogHeading(r))
+	writeCatalogResourceSummary(c, r)
+	writeCatalogResourceComponents(c, r.Components)
+	writeCatalogResourceVersions(c, r.Versions)
+	c.End(
+		toolutil.HintAction(actionLintHint, "check a configuration that includes this component"),
+		toolutil.HintAction(actionCatalogListHint, "browse the catalog for others"),
+	)
+	return b.String()
 }
 
-func writeCatalogResourceSummary(sb *strings.Builder, r ResourceDetail) {
-	sb.WriteString("| Field | Value |\n|-------|-------|\n")
-	fmt.Fprintf(sb, "| ID | %s |\n", toolutil.EscapeMdTableCell(r.ID))
-	fmt.Fprintf(sb, "| Full Path | %s |\n", toolutil.EscapeMdTableCell(r.FullPath))
-	fmt.Fprintf(sb, "| Web Path | %s |\n", toolutil.MdTitleLink(r.WebPath, r.WebPath))
-	fmt.Fprintf(sb, "| Stars | %d |\n", r.StarCount)
-	fmt.Fprintf(sb, "| Usage (30d) | %d |\n", r.Last30DayUsageCount)
-	if r.VerificationLevel != "" {
-		fmt.Fprintf(sb, "| Verification | %s |\n", toolutil.EscapeMdTableCell(r.VerificationLevel))
-	}
-	if len(r.Topics) > 0 {
-		fmt.Fprintf(sb, "| Topics | %s |\n", toolutil.EscapeMdTableCell(strings.Join(r.Topics, ", ")))
-	}
+// catalogHeading names the resource and marks an archived one.
+func catalogHeading(r ResourceDetail) string {
+	heading := "Catalog Resource: " + r.Name
 	if r.Archived {
-		sb.WriteString("| Archived | yes |\n")
+		heading += " " + toolutil.EmojiArchived
 	}
-	if r.LatestReleasedAt != "" {
-		fmt.Fprintf(sb, "| Latest Release | %s |\n", formatDate(r.LatestReleasedAt))
-	}
-	if r.LatestVersionName != "" {
-		fmt.Fprintf(sb, "| Latest Version | %s |\n", toolutil.EscapeMdTableCell(r.LatestVersionName))
-	}
-	if r.Description != "" {
-		fmt.Fprintf(sb, "\n### Description\n\n%s\n", r.Description)
-	}
+	return heading
 }
 
-func writeCatalogResourceComponents(sb *strings.Builder, components []ComponentItem) {
+func writeCatalogResourceSummary(c *toolutil.Card, r ResourceDetail) {
+	c.Code("ID", r.ID)
+	c.Code("Full Path", r.FullPath)
+	// A relative path, shown as the path it is rather than linked: see
+	// FormatListMarkdown.
+	c.Code("Web Path", r.WebPath)
+	c.Count("Stars", int64(r.StarCount))
+	c.Count("Usage (30d)", int64(r.Last30DayUsageCount))
+	c.Field("Verification", r.VerificationLevel)
+	c.Field("Visibility", r.VisibilityLevel)
+	c.Field("Topics", strings.Join(r.Topics, ", "))
+	c.Flag(toolutil.EmojiArchived, "Archived", r.Archived)
+	c.Time("Latest Release", r.LatestReleasedAt)
+	c.Field("Latest Version", r.LatestVersionName)
+	// The description is whatever the resource's maintainer typed, so it is
+	// quoted rather than written into the response as Markdown of its own.
+	c.Text("Description", r.Description)
+}
+
+func writeCatalogResourceComponents(c *toolutil.Card, components []ComponentItem) {
 	if len(components) == 0 {
 		return
 	}
-	sb.WriteString("\n### Components (Latest Version)\n\n")
+	section := c.Section("Components (Latest Version)")
 	for _, component := range components {
-		writeCatalogResourceComponent(sb, component)
+		writeCatalogResourceComponent(section, component)
 	}
 }
 
-func writeCatalogResourceComponent(sb *strings.Builder, component ComponentItem) {
-	fmt.Fprintf(sb, "#### `%s`\n\n", toolutil.EscapeMdHeading(component.Name))
-	if component.Description != "" {
-		fmt.Fprintf(sb, "%s\n\n", component.Description)
-	}
-	fmt.Fprintf(sb, "**Include:** `%s`\n\n", component.IncludePath)
+func writeCatalogResourceComponent(section *toolutil.Card, component ComponentItem) {
+	card := section.Section(component.Name)
+	card.Text("Description", component.Description)
+	card.Code("Include", component.IncludePath)
 	if len(component.Inputs) == 0 {
 		return
 	}
-	sb.WriteString("| Input | Type | Required | Default | Description |\n")
-	sb.WriteString("|-------|------|----------|---------|-------------|\n")
+	table := card.Table("", "Input", "Type", "Required", "Default", "Description")
 	for _, input := range component.Inputs {
-		writeCatalogComponentInput(sb, input)
+		table.Row(
+			toolutil.MdCodeSpanCell(input.Name),
+			toolutil.EscapeMdTableCell(input.Type),
+			toolutil.BoolEmoji(input.Required),
+			toolutil.EscapeMdTableCell(input.Default),
+			toolutil.EscapeMdTableCell(input.Description),
+		)
 	}
-	sb.WriteString("\n")
 }
 
-func writeCatalogComponentInput(sb *strings.Builder, input InputItem) {
-	required := "no"
-	if input.Required {
-		required = "**yes**"
-	}
-	fmt.Fprintf(
-		sb, "| `%s` | %s | %s | %s | %s |\n",
-		toolutil.EscapeMdTableCell(input.Name),
-		toolutil.EscapeMdTableCell(input.Type),
-		required,
-		toolutil.EscapeMdTableCell(input.Default),
-		toolutil.EscapeMdTableCell(input.Description),
-	)
-}
-
-func writeCatalogResourceVersions(sb *strings.Builder, versions []VersionItem) {
+func writeCatalogResourceVersions(c *toolutil.Card, versions []VersionItem) {
 	if len(versions) == 0 {
 		return
 	}
-	sb.WriteString("\n### Released Versions\n\n")
-	sb.WriteString("| Version | Released | Components |\n")
-	sb.WriteString("|---------|----------|------------|\n")
+	table := c.Table("Released Versions", "Version", "Released", "Components")
 	for _, version := range versions {
-		fmt.Fprintf(
-			sb, "| %s | %s | %s |\n",
+		table.Row(
 			toolutil.EscapeMdTableCell(version.Name),
-			formatDate(version.ReleasedAt),
+			toolutil.FormatTime(version.ReleasedAt),
 			toolutil.EscapeMdTableCell(strings.Join(catalogVersionComponentNames(version), ", ")),
 		)
 	}
-	sb.WriteString("\n")
 }
 
 func catalogVersionComponentNames(version VersionItem) []string {
@@ -149,28 +160,20 @@ func catalogVersionComponentNames(version VersionItem) []string {
 	return names
 }
 
-// truncate shortens s to maxLen characters, appending "..." if truncated.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+// truncateRunes shortens s to maxRunes characters, appending "..." when it
+// cut anything. It counts runes rather than bytes: cutting a UTF-8 sequence in
+// half leaves a replacement character in the middle of a description, and a
+// description is the one field of a catalog resource most likely to be
+// written in a language that needs more than one byte per character.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
 		return s
 	}
-	return s[:maxLen-3] + "..."
-}
-
-// formatDate extracts the YYYY-MM-DD date portion from an ISO 8601 timestamp.
-// Returns an empty string if iso is empty.
-//
-// Slicing the first ten bytes shortens the value without saying anything about
-// what is in them, so the result is escaped: what arrives here is a GraphQL
-// field this package copies verbatim, and a cell is where it lands.
-func formatDate(iso string) string {
-	if iso == "" {
-		return ""
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
 	}
-	if len(iso) >= 10 {
-		return toolutil.EscapeMdTableCell(iso[:10])
-	}
-	return toolutil.EscapeMdTableCell(iso)
+	return string(runes[:maxRunes-3]) + "..."
 }
 
 func init() {

--- a/internal/tools/cilint/ci_lint_test.go
+++ b/internal/tools/cilint/ci_lint_test.go
@@ -6,7 +6,6 @@ package cilint
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
@@ -307,15 +306,6 @@ func TestCILint_CancelledContext(t *testing.T) {
 
 // ---------- Tests consolidated from coverage_test.go ----------.
 
-const (
-	// mdHeadingWarnings identifies the md heading warnings constant used by this package.
-	mdHeadingWarnings = "### Warnings"
-	// mdHeadingIncludes identifies the md heading includes constant used by this package.
-	mdHeadingIncludes = "### Includes"
-	// mdHeadingMergedYAML identifies the md heading merged YAML constant used by this package.
-	mdHeadingMergedYAML = "### Merged YAML"
-)
-
 // ---------------------------------------------------------------------------
 // LintProject — API error
 // ---------------------------------------------------------------------------.
@@ -493,28 +483,24 @@ func TestFormatOutputMarkdown_ValidAllSections(t *testing.T) {
 		},
 	})
 
-	for _, want := range []string{
-		"## CI Lint: ✅ Valid",
-		mdHeadingWarnings,
-		"- warn1",
-		"- warn2",
-		mdHeadingIncludes,
-		"| Type | Location | Context Project |",
-		"| local |",
-		"| remote |",
-		mdHeadingMergedYAML,
-		"```yaml",
-		"stages:",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-
-	if strings.Contains(md, "### Errors") {
-		t.Error("should not contain Errors section when errors is nil")
+	// The messages are table rows rather than bare list items: a lint message
+	// quotes the user's own CI file back, and one beginning with '#' or '-'
+	// opened a heading or a nested list where it was the content of an item.
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Warnings\n\n" +
+		"| Message |\n| --- |\n" +
+		"| warn1 |\n| warn2 |\n" +
+		"\n### Includes\n\n" +
+		"| Type | Location | Context Project |\n| --- | --- | --- |\n" +
+		"| local | .gitlab-ci.yml | my/project |\n" +
+		"| remote | https://example.com/ci.yml |  |\n" +
+		"\n### Merged YAML\n\n" +
+		"```yaml\nstages:\n  - build\n```\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Fix the reported errors and warnings before committing this CI configuration\n" +
+		"- Use action 'template.lint' to check the corrected configuration again\n"
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(all sections)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -531,29 +517,27 @@ func TestFormatOutputMarkdown_InvalidWithErrors(t *testing.T) {
 		Errors: []string{"syntax error on line 5", "unknown key: foo"},
 	})
 
-	for _, want := range []string{
-		"## CI Lint: ❌ Invalid",
-		"### Errors",
-		"- syntax error on line 5",
-		"- unknown key: foo",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-
-	if strings.Contains(md, mdHeadingWarnings) {
-		t.Error("should not contain Warnings section when no warnings")
-	}
-	if strings.Contains(md, mdHeadingIncludes) {
-		t.Error("should not contain Includes section when no includes")
-	}
-	if strings.Contains(md, mdHeadingMergedYAML) {
-		t.Error("should not contain Merged YAML section when empty")
+	want := "## CI Lint: ❌ Invalid\n\n" +
+		"### Errors\n\n" +
+		"| Message |\n| --- |\n" +
+		"| syntax error on line 5 |\n| unknown key: foo |\n" +
+		lintFixHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(errors)\n got %q\nwant %q", md, want)
 	}
 }
+
+// lintFixHints is the guidance section a result with errors or warnings closes
+// with.
+const lintFixHints = "\n---\n💡 **Next steps:**\n" +
+	"- Fix the reported errors and warnings before committing this CI configuration\n" +
+	"- Use action 'template.lint' to check the corrected configuration again\n"
+
+// lintCleanHints is the guidance section a result with nothing to fix closes
+// with: telling a reader to fix errors GitLab did not report is noise.
+const lintCleanHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'template.lint_project' to lint the configuration committed in a project\n" +
+	"- Use action 'pipeline.create' to run a pipeline with it\n"
 
 // ---------------------------------------------------------------------------
 // FormatOutputMarkdown — empty output (all defaults)
@@ -563,10 +547,11 @@ func TestFormatOutputMarkdown_InvalidWithErrors(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatOutputMarkdown_Empty(t *testing.T) {
-	md := FormatOutputMarkdown(Output{})
-	// Zero-value Output has Valid=false, which produces the Invalid header
-	if !strings.Contains(md, "❌ Invalid") {
-		t.Errorf("expected Invalid header for zero-value Output, got %q", md)
+	// A zero-value Output is Valid=false, which is the Invalid verdict with
+	// nothing under it to explain itself.
+	want := "## CI Lint: ❌ Invalid\n" + lintCleanHints
+	if md := FormatOutputMarkdown(Output{}); md != want {
+		t.Errorf("FormatOutputMarkdown(zero)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -578,12 +563,34 @@ func TestFormatOutputMarkdown_Empty(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatOutputMarkdown_ValidNoContentReturnsMinimalMessage(t *testing.T) {
-	md := FormatOutputMarkdown(Output{Valid: true})
-	if md == "" {
-		t.Error("expected non-empty string for valid output with no content")
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"The configuration is valid, with no errors, warnings, includes or jobs.\n"
+	if md := FormatOutputMarkdown(Output{Valid: true}); md != want {
+		t.Errorf("FormatOutputMarkdown(valid, nothing else)\n got %q\nwant %q", md, want)
 	}
-	if !strings.Contains(md, "Valid") {
-		t.Errorf("expected 'Valid' in output, got %q", md)
+}
+
+// TestFormatOutputMarkdown_ListsTheJobsGitLabExpanded checks the jobs table.
+// GitLab sends the expanded jobs when include_jobs is set, the Output has
+// carried them since the captured-response read, and no rendering showed them:
+// the expansion is the answer to "what will this pipeline run".
+func TestFormatOutputMarkdown_ListsTheJobsGitLabExpanded(t *testing.T) {
+	md := FormatOutputMarkdown(Output{
+		Valid: true,
+		Jobs: []toolutil.LintJobOutput{
+			{Name: "build", Stage: "build", When: "on_success", AllowFailure: false, TagList: []string{"docker", "linux"}},
+			{Name: "deploy", Stage: "deploy", When: "manual", AllowFailure: true},
+		},
+	})
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Jobs\n\n" +
+		"| Name | Stage | When | Allow Failure | Tags |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| build | build | on_success | ❌ | docker, linux |\n" +
+		"| deploy | deploy | manual | ✅ |  |\n" +
+		lintCleanHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(jobs)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -599,14 +606,12 @@ func TestFormatOutputMarkdown_OnlyMergedYaml(t *testing.T) {
 		Valid:      true,
 		MergedYaml: "image: alpine",
 	})
-	if !strings.Contains(md, mdHeadingMergedYAML) {
-		t.Errorf("expected Merged YAML section:\n%s", md)
-	}
-	if !strings.Contains(md, "```yaml") {
-		t.Errorf("expected yaml code block:\n%s", md)
-	}
-	if !strings.Contains(md, "image: alpine") {
-		t.Errorf("expected yaml content:\n%s", md)
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Merged YAML\n\n" +
+		"```yaml\nimage: alpine\n```\n" +
+		lintCleanHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(merged yaml)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -624,11 +629,13 @@ func TestFormatOutputMarkdown_OnlyIncludes(t *testing.T) {
 			{Type: "template", Location: "Auto-DevOps.gitlab-ci.yml", ContextProject: "gitlab-org/gitlab"},
 		},
 	})
-	if !strings.Contains(md, mdHeadingIncludes) {
-		t.Errorf("expected Includes section:\n%s", md)
-	}
-	if !strings.Contains(md, "| template |") {
-		t.Errorf("expected include row:\n%s", md)
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Includes\n\n" +
+		"| Type | Location | Context Project |\n| --- | --- | --- |\n" +
+		"| template | Auto-DevOps.gitlab-ci.yml | gitlab-org/gitlab |\n" +
+		lintCleanHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(includes)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -644,11 +651,13 @@ func TestFormatOutputMarkdown_OnlyWarnings(t *testing.T) {
 		Valid:    true,
 		Warnings: []string{"deprecated keyword"},
 	})
-	if !strings.Contains(md, mdHeadingWarnings) {
-		t.Errorf("expected Warnings section:\n%s", md)
-	}
-	if !strings.Contains(md, "- deprecated keyword") {
-		t.Errorf("expected warning entry:\n%s", md)
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Warnings\n\n" +
+		"| Message |\n| --- |\n" +
+		"| deprecated keyword |\n" +
+		lintFixHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(warnings)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -664,11 +673,13 @@ func TestFormatOutputMarkdown_OnlyErrors(t *testing.T) {
 		Valid:  false,
 		Errors: []string{"config error"},
 	})
-	if !strings.Contains(md, "## CI Lint: ❌ Invalid") {
-		t.Errorf("expected invalid header:\n%s", md)
-	}
-	if !strings.Contains(md, "- config error") {
-		t.Errorf("expected error entry:\n%s", md)
+	want := "## CI Lint: ❌ Invalid\n\n" +
+		"### Errors\n\n" +
+		"| Message |\n| --- |\n" +
+		"| config error |\n" +
+		lintFixHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(one error)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -686,12 +697,13 @@ func TestFormatOutputMarkdown_IncludesSpecialChars(t *testing.T) {
 			{Type: "local", Location: "path/with|pipe", ContextProject: "proj|etc"},
 		},
 	})
-	if !strings.Contains(md, mdHeadingIncludes) {
-		t.Errorf("expected Includes section:\n%s", md)
-	}
-	// Pipe characters should be escaped in table cells
-	if strings.Contains(md, "path/with|pipe") {
-		t.Errorf("pipe char in Location should be escaped:\n%s", md)
+	want := "## CI Lint: ✅ Valid\n\n" +
+		"### Includes\n\n" +
+		"| Type | Location | Context Project |\n| --- | --- | --- |\n" +
+		"| local | path/with&#124;pipe | proj&#124;etc |\n" +
+		lintCleanHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(special chars)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/cilint/markdown.go
+++ b/internal/tools/cilint/markdown.go
@@ -1,56 +1,115 @@
 package cilint
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a CI lint result as Markdown.
+// Canonical action IDs the hints name.
+const (
+	actionTemplateLint        = "template.lint"
+	actionTemplateLintProject = "template.lint_project"
+)
+
+// FormatOutputMarkdown renders a CI lint result as the card of one object: the
+// verdict, then the errors, warnings, includes and jobs as the nested
+// collections they are, then the merged YAML in a fence.
+//
+// The messages are a collection and are rendered as table rows rather than as
+// bare list items: a lint message quotes the user's own CI file back, and a
+// message beginning with '#' or '-' opened a heading or a nested list where it
+// was written as the content of a list item.
 func FormatOutputMarkdown(v Output) string {
-	if v.Valid && len(v.Errors) == 0 && len(v.Warnings) == 0 && len(v.Includes) == 0 && v.MergedYaml == "" {
-		return fmt.Sprintf("## CI Lint: %s Valid\n\nConfiguration is valid with no errors, warnings, or includes.\n", toolutil.BoolEmoji(true))
-	}
 	var b strings.Builder
-	if v.Valid {
-		fmt.Fprintf(&b, "## CI Lint: %s Valid\n\n", toolutil.BoolEmoji(true))
-	} else {
-		fmt.Fprintf(&b, "## CI Lint: %s Invalid\n\n", toolutil.BoolEmoji(false))
+	c := toolutil.NewCard(&b, lintHeading(v))
+	if isEmptyResult(v) {
+		c.Note("The configuration is valid, with no errors, warnings, includes or jobs.")
+		c.End()
+		return b.String()
 	}
-	if len(v.Errors) > 0 {
-		b.WriteString("### Errors\n\n")
-		for _, e := range v.Errors {
-			// A lint message quotes the user's own CI file back, job and stage
-			// names included.
-			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(e))
-		}
-		b.WriteString("\n")
-	}
-	if len(v.Warnings) > 0 {
-		b.WriteString("### Warnings\n\n")
-		for _, w := range v.Warnings {
-			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(w))
-		}
-		b.WriteString("\n")
-	}
-	if len(v.Includes) > 0 {
-		b.WriteString("### Includes\n\n")
-		b.WriteString("| Type | Location | Context Project |\n")
-		b.WriteString("| --- | --- | --- |\n")
-		for _, inc := range v.Includes {
-			fmt.Fprintf(&b, "| %s | %s | %s |\n",
-				//gitlab:allow-unescaped inc.Type: an include kind GitLab names, one of local, file, remote, template or component.
-				inc.Type, toolutil.EscapeMdTableCell(inc.Location), toolutil.EscapeMdTableCell(inc.ContextProject))
-		}
-		b.WriteString("\n")
-	}
-	if v.MergedYaml != "" {
-		b.WriteString("### Merged YAML\n\n")
-		b.WriteString(toolutil.MarkdownFencedBlock("yaml", v.MergedYaml))
-	}
-	toolutil.WriteHints(&b, "Fix reported errors and warnings before committing your CI configuration")
+	writeMessages(c, "Errors", v.Errors)
+	writeMessages(c, "Warnings", v.Warnings)
+	writeIncludes(c, v.Includes)
+	writeLintJobs(c, v.Jobs)
+	c.Fence("Merged YAML", "yaml", v.MergedYaml)
+	c.End(lintHints(v)...)
 	return b.String()
+}
+
+// lintHeading states the verdict the whole result turns on.
+func lintHeading(v Output) string {
+	if v.Valid {
+		return "CI Lint: " + toolutil.BoolEmoji(true) + " Valid"
+	}
+	return "CI Lint: " + toolutil.BoolEmoji(false) + " Invalid"
+}
+
+// isEmptyResult reports whether GitLab accepted the configuration and said
+// nothing else about it.
+func isEmptyResult(v Output) bool {
+	return v.Valid && len(v.Errors) == 0 && len(v.Warnings) == 0 &&
+		len(v.Includes) == 0 && len(v.Jobs) == 0 && v.MergedYaml == ""
+}
+
+// writeMessages renders one list of lint messages as a nested collection.
+func writeMessages(c *toolutil.Card, title string, messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	table := c.Table(title, "Message")
+	for _, message := range messages {
+		table.Row(toolutil.EscapeMdTableCell(message))
+	}
+}
+
+// writeIncludes renders the files the configuration pulls in.
+func writeIncludes(c *toolutil.Card, includes []Include) {
+	if len(includes) == 0 {
+		return
+	}
+	table := c.Table("Includes", "Type", "Location", "Context Project")
+	for _, inc := range includes {
+		table.Row(
+			toolutil.EscapeMdTableCell(inc.Type),
+			toolutil.EscapeMdTableCell(inc.Location),
+			toolutil.EscapeMdTableCell(inc.ContextProject),
+		)
+	}
+}
+
+// writeLintJobs renders the jobs the configuration expands into, which GitLab
+// sends when include_jobs is set and which this result carried without ever
+// showing: the expansion is the answer to "what will this pipeline run".
+func writeLintJobs(c *toolutil.Card, jobs []toolutil.LintJobOutput) {
+	if len(jobs) == 0 {
+		return
+	}
+	table := c.Table("Jobs", "Name", "Stage", "When", "Allow Failure", "Tags")
+	for _, job := range jobs {
+		table.Row(
+			toolutil.EscapeMdTableCell(job.Name),
+			toolutil.EscapeMdTableCell(job.Stage),
+			toolutil.EscapeMdTableCell(job.When),
+			toolutil.BoolEmoji(job.AllowFailure),
+			toolutil.EscapeMdTableCell(strings.Join(job.TagList, ", ")),
+		)
+	}
+}
+
+// lintHints tells a reader what to do next, and says nothing about fixing
+// errors when GitLab reported none.
+func lintHints(v Output) []string {
+	if len(v.Errors) > 0 || len(v.Warnings) > 0 {
+		return []string{
+			"Fix the reported errors and warnings before committing this CI configuration",
+			toolutil.HintAction(actionTemplateLint, "check the corrected configuration again"),
+		}
+	}
+	return []string{
+		toolutil.HintAction(actionTemplateLintProject, "lint the configuration committed in a project"),
+		toolutil.HintAction(actionPipelineCreate, "run a pipeline with it"),
+	}
 }
 
 func init() {

--- a/internal/tools/civariables/ci_variables_test.go
+++ b/internal/tools/civariables/ci_variables_test.go
@@ -878,22 +878,17 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## CI/CD Variables (2)",
-		"| Key |",
-		"| --- |",
-		"| DB_HOST |",
-		"| API_KEY |",
-		"env_var",
-		testEnvScope,
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## CI/CD Variables (2)\n\n" +
+		"| Key | Type | Protected | Masked | Scope |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| DB_HOST | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " | * |\n" +
+		"| API_KEY | env_var | " + toolutil.EmojiSuccess + " | " + toolutil.EmojiSuccess + " | " + testEnvScope + " |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'get' with a key to see variable details\n" +
+		"- Use action 'create' to add a new CI/CD variable\n"
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -901,12 +896,9 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No CI/CD variables found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| Key |") {
-		t.Error("should not contain table header when empty")
+	const want = "No CI/CD variables found.\n"
+	if md := FormatListMarkdown(ListOutput{}); md != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -920,10 +912,10 @@ func TestFormatListMarkdown_EscapesTableCells(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	// Pipe chars in key/scope should be escaped to not break the table
-	if strings.Contains(md, "| MY|VAR |") {
-		t.Errorf("pipe in key should be escaped:\n%s", md)
+	// A pipe in the key or the scope must not break the row it sits in.
+	const wantRow = "| MY&#124;VAR | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " | scope&#124;test |\n"
+	if md := FormatListMarkdown(out); !strings.Contains(md, wantRow) {
+		t.Errorf("FormatListMarkdown() missing %q:\n%s", wantRow, md)
 	}
 }
 

--- a/internal/tools/commitdiscussions/commit_discussions_test.go
+++ b/internal/tools/commitdiscussions/commit_discussions_test.go
@@ -429,95 +429,186 @@ func TestUpdateNote_APIError(t *testing.T) {
 // Formatter Tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdownString_WithData verifies the ListMarkdownString_WithData Markdown formatter for a representative liststring_withdata input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The three guidance sections the cards and the list of this package end with,
+// so each expectation below can pin the whole rendered document.
+const (
+	listHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_get_commit_discussion` with discussion_id to view full discussion details\n" +
+		"- Use `gitlab_create_commit_discussion` to start a new discussion on this commit\n"
+	threadHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_add_commit_discussion_note` to reply to this discussion\n" +
+		"- Use `gitlab_update_commit_discussion_note` to edit a note\n"
+	noteHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_update_commit_discussion_note` with note_id to edit this note\n" +
+		"- Use `gitlab_add_commit_discussion_note` with discussion_id to reply to this discussion\n"
+)
+
+// TestFormatListMarkdownString_WithData pins the whole list document of a page
+// of discussion threads: the heading counts the total GitLab reported rather
+// than the length of the page, the summary names the page, and the pagination
+// footer opens a block of its own after the last row.
 func TestFormatListMarkdownString_WithData(t *testing.T) {
 	out := ListOutput{
 		Discussions: []Output{
 			{ID: testDiscussionID, Notes: []*NoteOutput{{Author: &toolutil.NoteUserOutput{Username: testAuthorAlice}, CreatedAt: testDate20260101, Body: "comment"}}},
 			{ID: "d2", Notes: []*NoteOutput{{Author: &toolutil.NoteUserOutput{Username: "bob"}, CreatedAt: "2026-01-02", Body: "reply"}}},
 		},
+		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 45, TotalPages: 3, NextPage: 2, HasMore: true},
 	}
-	md := FormatListMarkdownString(out)
-	if !strings.Contains(md, "Commit Discussions (2)") {
-		t.Errorf("expected header, got:\n%s", md)
-	}
-	if !strings.Contains(md, testDiscussionID) || !strings.Contains(md, "d2") {
-		t.Error("expected discussion IDs")
-	}
-	if !strings.Contains(md, testAuthorAlice) {
-		t.Error("expected author")
+
+	got := FormatListMarkdownString(out)
+
+	want := "## Commit Discussions (45)\n\n" +
+		"Showing 2 of 45 results (page 1 of 3)\n\n" +
+		"| ID | Author | Notes |\n" +
+		"| --- | --- | --- |\n" +
+		"| d1 | alice | 1 |\n" +
+		"| d2 | bob | 1 |\n\n" +
+		"Page 1 of 3 | 45 items total | 20 per page\n" +
+		listHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdownString_Empty verifies the ListMarkdownString_Empty Markdown formatter for a representative liststring_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdownString_Empty pins the whole response of a commit with
+// no discussions: one sentence, with no heading counting zero above it.
 func TestFormatListMarkdownString_Empty(t *testing.T) {
-	out := ListOutput{Discussions: nil}
-	md := FormatListMarkdownString(out)
-	if !strings.Contains(md, "No commit discussions found") {
-		t.Error("expected empty message")
+	got := FormatListMarkdownString(ListOutput{Discussions: nil})
+
+	if want := "No commit discussions found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatMarkdownString_WithNotes verifies the MarkdownString_WithNotes Markdown formatter for a representative string_withnotes input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMarkdownString_WithNotes pins the whole card of a thread: its own
+// fields first, then one section per note with the body quoted under its label.
 func TestFormatMarkdownString_WithNotes(t *testing.T) {
 	out := Output{
 		ID:    testDiscussionID,
-		Notes: []*NoteOutput{{Author: &toolutil.NoteUserOutput{Username: "dev"}, CreatedAt: testDate20260101, Body: "LGTM"}},
+		Notes: []*NoteOutput{{ID: 7, Author: &toolutil.NoteUserOutput{Username: "dev"}, CreatedAt: testDate20260101, Body: "LGTM"}},
 	}
-	md := FormatMarkdownString(out)
-	if !strings.Contains(md, "Discussion "+testDiscussionID) {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "LGTM") {
-		t.Error("expected note body")
+
+	got := FormatMarkdownString(out)
+
+	want := "## Discussion d1\n\n" +
+		"- **Notes**: 1\n" +
+		"- **Individual Note**: ❌\n\n" +
+		"### Note #7\n\n" +
+		"- **Author**: @dev\n" +
+		"- **Created**: 1 Jan 2026\n" +
+		"- **Body**: LGTM\n" +
+		threadHintsBlock
+	if got != want {
+		t.Errorf("thread card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMarkdownString_Empty verifies the MarkdownString_Empty Markdown formatter for a representative string_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMarkdownString_Resolvable pins the thread card of a resolvable
+// thread: the resolution state is a row of its own, and a nil note in the slice
+// the SDK may hand back adds no empty section.
+func TestFormatMarkdownString_Resolvable(t *testing.T) {
+	out := Output{
+		ID:             testDiscussionID,
+		IndividualNote: true,
+		Resolvable:     true,
+		Resolved:       true,
+		Notes:          []*NoteOutput{nil},
+	}
+
+	got := FormatMarkdownString(out)
+
+	want := "## Discussion d1\n\n" +
+		"- **Notes**: 1\n" +
+		"- **Individual Note**: ✅\n" +
+		"- **Resolvable**: resolved\n" +
+		threadHintsBlock
+	if got != want {
+		t.Errorf("thread card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatMarkdownString_Empty pins the card of a thread GitLab answered with
+// no notes: the heading and the flag it does carry, and no count of zero.
 func TestFormatMarkdownString_Empty(t *testing.T) {
-	out := Output{ID: testDiscussionID, Notes: nil}
-	md := FormatMarkdownString(out)
-	if !strings.Contains(md, "Discussion "+testDiscussionID) {
-		t.Error("expected header even with no notes")
+	got := FormatMarkdownString(Output{ID: testDiscussionID, Notes: nil})
+
+	want := "## Discussion d1\n\n" +
+		"- **Individual Note**: ❌\n" +
+		threadHintsBlock
+	if got != want {
+		t.Errorf("thread card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatNoteMarkdownString verifies the NoteMarkdownString Markdown formatter for a representative notestring input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatNoteMarkdownString pins the whole card of a note on a line of a
+// diff: the author as a handle, the resolution state a resolvable note carries,
+// the file and line the note hangs on, and the body.
 func TestFormatNoteMarkdownString(t *testing.T) {
-	n := NoteOutput{ID: 10, Author: &toolutil.NoteUserOutput{Username: "dev"}, Body: "Nice!", CreatedAt: testDate20260101}
-	md := FormatNoteMarkdownString(n)
-	if !strings.Contains(md, "Note") {
-		t.Error("expected header")
+	n := NoteOutput{
+		ID:         10,
+		Author:     &toolutil.NoteUserOutput{Username: "dev"},
+		Body:       "Nice!",
+		CreatedAt:  testDate20260101,
+		Resolvable: true,
+		Resolved:   true,
+		ResolvedBy: &toolutil.NoteUserOutput{Username: testAuthorAlice},
+		Position:   &toolutil.NotePositionOutput{NewPath: "internal/app.go", NewLine: 42},
 	}
-	if !strings.Contains(md, "10") {
-		t.Error("expected note ID")
-	}
-	if !strings.Contains(md, "Nice!") {
-		t.Error("expected body")
-	}
-	if !strings.Contains(md, "1 Jan 2026") {
-		t.Error("expected created date")
+
+	got := FormatNoteMarkdownString(n)
+
+	want := "## Discussion Note #10\n\n" +
+		"- **Author**: @dev\n" +
+		"- **Created**: 1 Jan 2026\n" +
+		"- **Resolvable**: resolved\n" +
+		"- **Resolved By**: @alice\n" +
+		"- **Position**: `internal/app.go`:42\n" +
+		"- **Body**: Nice!\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatNoteMarkdownString_NoDate verifies the NoteMarkdownString_NoDate Markdown formatter for a representative notestring_nodate input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatNoteMarkdownString_SystemNoteOnRemovedLine pins the card of a
+// system note anchored to a removed line: the marker the flag writes, the old
+// path and line, and no resolution state on a note that cannot be resolved.
+func TestFormatNoteMarkdownString_SystemNoteOnRemovedLine(t *testing.T) {
+	n := NoteOutput{
+		ID:       12,
+		Author:   &toolutil.NoteUserOutput{Username: "bot"},
+		Body:     "changed the description",
+		System:   true,
+		Internal: true,
+		Position: &toolutil.NotePositionOutput{OldPath: "internal/old.go", OldLine: 7},
+	}
+
+	got := FormatNoteMarkdownString(n)
+
+	want := "## Discussion Note #12\n\n" +
+		"- **Author**: @bot\n" +
+		"- **System note**\n" +
+		"- **Internal note**\n" +
+		"- **Position**: `internal/old.go`:7\n" +
+		"- **Body**: changed the description\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatNoteMarkdownString_NoDate pins the card of a note GitLab answered
+// with neither a time nor an author: neither row is written, where a label with
+// nothing after it used to read as a value GitLab sent.
 func TestFormatNoteMarkdownString_NoDate(t *testing.T) {
-	n := NoteOutput{ID: 11, Author: &toolutil.NoteUserOutput{Username: "bot"}, Body: "OK"}
-	md := FormatNoteMarkdownString(n)
-	if strings.Contains(md, "Created") {
-		t.Error("should not show Created when empty")
+	got := FormatNoteMarkdownString(NoteOutput{ID: 11, Body: "OK"})
+
+	want := "## Discussion Note #11\n\n" +
+		"- **Body**: OK\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/commitdiscussions/markdown.go
+++ b/internal/tools/commitdiscussions/markdown.go
@@ -8,6 +8,18 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// The thread and note cards below are the ones every REST discussion domain
+// renders. [Output] and [NoteOutput] are aliases of the shared thread shapes
+// ([toolutil.DiscussionThreadOutput] and [toolutil.DiscussionThreadNoteOutput]),
+// the Markdown registry keys on the type and keeps the first registration, and
+// this package's init is the first to run, so a merge request, issue or snippet
+// discussion is rendered by these two functions too. They therefore show every
+// field the shared shape carries, the diff position included, and only their
+// hints name the commit tools. The duplicate registrations are pinned by
+// TestMarkdownRegistry_Registrations_HaveNoUndeclaredProblems and are retired by
+// giving each domain a shape of its own, which is a change to the four packages
+// that share these aliases rather than to a formatter.
+
 // firstNoteAuthor returns the author username of a discussion's first note, or
 // "" when the thread has no notes.
 func firstNoteAuthor(d Output) string {
@@ -17,60 +29,112 @@ func firstNoteAuthor(d Output) string {
 	return d.Notes[0].AuthorUsername()
 }
 
-// FormatNoteMarkdownString renders a single commit discussion note as Markdown.
+// noteResolution is the word a resolvable note or thread's state reads as, the
+// spelling the shared note card ([toolutil.FormatNoteMarkdown]) uses.
+func noteResolution(resolved bool) string {
+	if resolved {
+		return "resolved"
+	}
+	return "unresolved"
+}
+
+// notePosition renders the diff position of a note anchored to a line of a
+// file: the path as a code span and the line it hangs on. A note on a removed
+// line carries the old path and line and no new ones, so both are read in turn;
+// a note on the thread itself carries no position and renders nothing.
+func notePosition(p *toolutil.NotePositionOutput) string {
+	if p == nil {
+		return ""
+	}
+	path, line := p.NewPath, p.NewLine
+	if path == "" {
+		path, line = p.OldPath, p.OldLine
+	}
+	span := toolutil.MdCodeSpan(path)
+	if span == "" {
+		return ""
+	}
+	if line > 0 {
+		return span + ":" + strconv.FormatInt(line, 10)
+	}
+	return span
+}
+
+// FormatNoteMarkdownString renders a single discussion note as a card: the
+// author as a handle, the time, the flags that hold, the resolution state of a
+// note that can carry one, the diff position of a note on a line, and the body
+// as the card's long text. A note that is not resolvable shows no resolution
+// state, where the card used to print "Resolved: false" for every note in a
+// domain whose notes cannot be resolved at all.
 func FormatNoteMarkdownString(n NoteOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Discussion Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(n.AuthorUsername()))
-	if n.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
+	c := toolutil.NewCard(&b, fmt.Sprintf("Discussion Note #%d", n.ID))
+	c.Markdown("Author", toolutil.MdUserHandle(n.AuthorUsername()))
+	c.Time("Created", n.CreatedAt)
+	c.Flag("", "System note", n.System)
+	c.Flag("", "Internal note", n.Internal)
+	if n.Resolvable {
+		c.Field("Resolvable", noteResolution(n.Resolved))
+		c.Markdown("Resolved By", toolutil.MdUserHandle(n.ResolvedByUsername()))
 	}
-	fmt.Fprintf(&b, "- **Resolved**: %v\n", n.Resolved)
-	fmt.Fprintf(&b, "\n%s\n", toolutil.WrapGFMBody(n.Body))
-	toolutil.WriteHints(
-		&b,
+	c.Markdown("Position", notePosition(n.Position))
+	c.Text("Body", n.Body)
+	c.End(
 		"Use `gitlab_update_commit_discussion_note` with note_id to edit this note",
 		"Use `gitlab_add_commit_discussion_note` with discussion_id to reply to this discussion",
 	)
 	return b.String()
 }
 
-// FormatMarkdownString renders a commit discussion thread with all its notes as
-// Markdown.
+// FormatMarkdownString renders a discussion thread as a card: the thread's own
+// fields first, then one section per note, each with the author, the time, the
+// position of a diff note and the body quoted under its label.
 func FormatMarkdownString(d Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Discussion %s\n\n", toolutil.EscapeMdHeading(d.ID))
-	fmt.Fprintf(&b, "- **Notes**: %d\n", len(d.Notes))
-	fmt.Fprintf(&b, "- **Individual Note**: %v\n", d.IndividualNote)
-	for i, n := range d.Notes {
-		fmt.Fprintf(&b, "\n### Note %d (by %s)\n\n%s\n", i+1, toolutil.EscapeMdHeading(n.AuthorUsername()), toolutil.WrapGFMBody(n.Body))
+	c := toolutil.NewCard(&b, "Discussion "+d.ID)
+	c.Count("Notes", int64(len(d.Notes)))
+	c.Bool("Individual Note", d.IndividualNote)
+	if d.Resolvable {
+		c.Field("Resolvable", noteResolution(d.Resolved))
 	}
-	toolutil.WriteHints(
-		&b,
+	for _, n := range d.Notes {
+		if n == nil {
+			continue
+		}
+		s := c.Section(fmt.Sprintf("Note #%d", n.ID))
+		s.Markdown("Author", toolutil.MdUserHandle(n.AuthorUsername()))
+		s.Time("Created", n.CreatedAt)
+		s.Flag("", "System note", n.System)
+		s.Markdown("Position", notePosition(n.Position))
+		s.Text("Body", n.Body)
+	}
+	c.End(
 		"Use `gitlab_add_commit_discussion_note` to reply to this discussion",
 		"Use `gitlab_update_commit_discussion_note` to edit a note",
 	)
 	return b.String()
 }
 
-// FormatListMarkdownString renders a list of commit discussion threads as a
-// Markdown table.
+// FormatListMarkdownString renders commit discussion threads as a Markdown
+// table, the collection shape: one row per thread with the author of its first
+// note and how many notes it holds. The heading counts what the response
+// vouches for rather than the length of the page, and the pagination footer is
+// written after the rows by the shared footer.
 func FormatListMarkdownString(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Discussions (%d)\n\n", len(out.Discussions))
-	toolutil.WriteListSummary(&b, len(out.Discussions), out.Pagination)
 	if len(out.Discussions) == 0 {
-		b.WriteString("No commit discussions found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("commit discussions")
 	}
-	b.WriteString("| ID | Author | Notes |\n")
-	b.WriteString(toolutil.TblSep3Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commit Discussions", len(out.Discussions), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Author", "Notes"))
 	for _, d := range out.Discussions {
-		fmt.Fprintf(&b, toolutil.FmtRow3Str, toolutil.EscapeMdTableCell(d.ID), toolutil.EscapeMdTableCell(firstNoteAuthor(d)), strconv.Itoa(len(d.Notes)))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(d.ID),
+			toolutil.EscapeMdTableCell(firstNoteAuthor(d)),
+			strconv.Itoa(len(d.Notes)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
+	toolutil.WriteListFooter(&b, out.Pagination, false,
 		"Use `gitlab_get_commit_discussion` with discussion_id to view full discussion details",
 		"Use `gitlab_create_commit_discussion` to start a new discussion on this commit",
 	)

--- a/internal/tools/commits/commits.go
+++ b/internal/tools/commits/commits.go
@@ -104,9 +104,7 @@ func authorToOutput(a gl.Author) *BasicUserOutput {
 		State:    a.State,
 		Blocked:  a.Blocked,
 	}
-	if a.CreatedAt != nil {
-		out.CreatedAt = a.CreatedAt.String()
-	}
+	out.CreatedAt = toolutil.RFC3339Ptr(a.CreatedAt)
 	return out
 }
 
@@ -218,15 +216,14 @@ func commitToFields(c *gl.Commit) commitFields {
 		extendedTrailers: c.ExtendedTrailers,
 		lastPipeline:     pipelineInfoToOutput(c.LastPipeline),
 	}
-	if c.CommittedDate != nil {
-		f.committedDate = c.CommittedDate.String()
-	}
-	if c.AuthoredDate != nil {
-		f.authoredDate = c.AuthoredDate.String()
-	}
-	if c.CreatedAt != nil {
-		f.createdAt = c.CreatedAt.String()
-	}
+	// The three timestamps go out in the wire form every other date this server
+	// publishes takes. Go's default layout, which these used to carry, is not
+	// RFC 3339, so nothing could parse them back: the Markdown time helper fell
+	// through to its escape branch and printed "2026-03-20 15:45:00 +0000 UTC"
+	// where every other card shows a date a reader can read.
+	f.committedDate = toolutil.RFC3339Ptr(c.CommittedDate)
+	f.authoredDate = toolutil.RFC3339Ptr(c.AuthoredDate)
+	f.createdAt = toolutil.RFC3339Ptr(c.CreatedAt)
 	if c.Status != nil {
 		f.status = string(*c.Status)
 	}
@@ -781,15 +778,9 @@ func statusToOutput(s *gl.CommitStatus) StatusOutput {
 		PipelineID:   s.PipelineID,
 		AllowFailure: s.AllowFailure,
 	}
-	if s.CreatedAt != nil {
-		out.CreatedAt = s.CreatedAt.String()
-	}
-	if s.StartedAt != nil {
-		out.StartedAt = s.StartedAt.String()
-	}
-	if s.FinishedAt != nil {
-		out.FinishedAt = s.FinishedAt.String()
-	}
+	out.CreatedAt = toolutil.RFC3339Ptr(s.CreatedAt)
+	out.StartedAt = toolutil.RFC3339Ptr(s.StartedAt)
+	out.FinishedAt = toolutil.RFC3339Ptr(s.FinishedAt)
 	out.Author = authorToOutput(s.Author)
 	return out
 }

--- a/internal/tools/commits/commits_test.go
+++ b/internal/tools/commits/commits_test.go
@@ -1928,55 +1928,161 @@ func TestRevert_EmptyBranch(t *testing.T) {
 // Format*Markdown Tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The guidance sections the commit formatters close with, pinned once so each
+// whole-output expectation names them rather than restating them.
+const (
+	commitCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_get' to see this commit's full details and stats\n" +
+		"- Use action 'repository.commit_diff' to see the file changes for this commit\n" +
+		"- Use action 'repository.commit_refs' to see the branches and tags containing it\n"
+
+	noCommitHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_cherry_pick' to apply the commit for real\n" +
+		"- Use action 'repository.commit_list' to check the branch for the commit\n"
+
+	commitListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'repository.commit_get' to see one commit in full\n" +
+		"- Use action 'repository.commit_diff' to see the file changes of one commit\n"
+
+	commitDetailHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_diff' to view the file changes\n" +
+		"- Use action 'repository.commit_cherry_pick' to apply this commit to another branch\n"
+
+	commitDiffHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_get' to view one changed file\n" +
+		"- Use action 'repository.commit_comment_create' to comment on the changes\n"
+
+	commitRefsHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'branch.get' to view one branch\n" +
+		"- Use action 'tag.get' to view one tag\n"
+
+	commitCommentsHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_comment_create' to add a comment\n" +
+		"- Use action 'repository.commit_get' to view the commit\n"
+
+	commitCommentHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_comments' to list every comment on the commit\n" +
+		"- Use action 'repository.file_get' to view the referenced file\n"
+
+	commitStatusesHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_status_set' to update a status\n" +
+		"- Use action 'repository.commit_get' to view the commit\n"
+
+	commitStatusHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_status_set' to update this status\n" +
+		"- Use action 'repository.commit_statuses' to see all statuses on the commit\n"
+
+	commitMRsHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'merge_request.get' to view one merge request\n" +
+		"- Use action 'merge_request.changes_get' to see its diff\n"
+
+	commitSignatureHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_get' to view the full commit details\n"
+)
+
+// TestFormatOutputMarkdown pins the whole commit card. The author's address is
+// written in parentheses rather than in angle brackets, which GFM turns into a
+// mailto autolink to an address nobody chose to publish.
 func TestFormatOutputMarkdown(t *testing.T) {
-	c := Output{ShortID: "abc12", Title: "feat: init", AuthorName: "Alice", AuthorEmail: "a@t.com", CommittedDate: "2026-01-01", WebURL: "https://example.com"}
-	md := FormatOutputMarkdown(c)
-	if !strings.Contains(md, "abc12") {
-		t.Error(errExpShortID)
-	}
-	if !strings.Contains(md, "feat: init") {
-		t.Error("expected title")
-	}
-	if !strings.Contains(md, "Alice") {
-		t.Error("expected author")
+	got := FormatOutputMarkdown(Output{
+		ShortID:       "abc12",
+		Title:         "feat: init",
+		AuthorName:    "Alice",
+		AuthorEmail:   "a@t.com",
+		CommittedDate: "2026-01-01",
+		WebURL:        "https://example.com",
+	})
+
+	want := "## Commit abc12\n\n" +
+		"- **Title**: feat: init\n" +
+		"- **Author**: Alice (a@t.com)\n" +
+		"- **Date**: 1 Jan 2026\n" +
+		"- **URL**: [https://example.com](https://example.com)\n" +
+		commitCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown verifies the ListMarkdown Markdown formatter for a representative list input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatOutputMarkdown_Pipeline pins the pipeline row: a commit whose
+// pipeline the card omits is one a reader cannot tell has failed.
+func TestFormatOutputMarkdown_Pipeline(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ShortID: "abc12",
+		Title:   "feat: init",
+		Status:  "running",
+		LastPipeline: &LastPipelineOutput{
+			ID: 77, Status: "failed", WebURL: "https://gitlab.example.com/-/pipelines/77",
+		},
+	})
+
+	want := "## Commit abc12\n\n" +
+		"- **Title**: feat: init\n" +
+		"- **Pipeline**: ❌ failed [#77](https://gitlab.example.com/-/pipelines/77)\n" +
+		commitCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_DryRun pins the answer to a cherry-pick or revert
+// run with dry_run, which commits nothing and which GitLab answers with no
+// commit at all: this used to render as a commit card whose heading and every
+// field were empty, indistinguishable from a commit that had been made.
+func TestFormatOutputMarkdown_DryRun(t *testing.T) {
+	got := FormatOutputMarkdown(Output{})
+
+	want := "## No Commit Created\n\n" +
+		"GitLab returned no commit. A dry run reports whether the change would apply cleanly and commits nothing; run the same action without dry_run to commit it.\n" +
+		noCommitHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown pins the whole commit listing, the pipeline of each
+// commit included.
 func TestFormatListMarkdown(t *testing.T) {
-	out := ListOutput{
-		Commits:    []Output{{ShortID: "a1", Title: "feat: x", AuthorName: "A", CommittedDate: "2026-01-01"}},
+	got := FormatListMarkdown(ListOutput{
+		Commits: []Output{
+			{ShortID: "a1", Title: "feat: x", AuthorName: "A", CommittedDate: "2026-01-01", Status: "success"},
+		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "Commits (1)") {
-		t.Errorf("expected header, got:\n%s", md)
-	}
-	if !strings.Contains(md, "a1") {
-		t.Error(errExpShortID)
+	})
+
+	want := "## Commits (1)\n\n" +
+		"| Short ID | Title | Author | Date | Pipeline |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| a1 | feat: x | A | 1 Jan 2026 | ✅ success |\n" +
+		"\n1 items total\n" +
+		commitListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown_Empty pins the whole response of a ref with no
+// commits.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	out := ListOutput{Commits: nil, Pagination: toolutil.PaginationOutput{}}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "No commits found") {
-		t.Error("expected 'No commits found'")
+	got := FormatListMarkdown(ListOutput{})
+
+	want := "No commits found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_ClickableCommitLinks verifies that commit short IDs
-// in the list are rendered as clickable Markdown links [shortID](weburl).
+// TestFormatListMarkdown_ClickableCommitLinks pins that a commit the response
+// carried an address for is linked by its short id.
 func TestFormatListMarkdown_ClickableCommitLinks(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Commits: []Output{
 			{
 				ShortID: "abc123", Title: "feat: x", AuthorName: "A",
@@ -1985,18 +2091,25 @@ func TestFormatListMarkdown_ClickableCommitLinks(t *testing.T) {
 			},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "[abc123](https://gitlab.example.com/commit/abc123)") {
-		t.Errorf("expected clickable commit link, got:\n%s", md)
+	})
+
+	want := "## Commits (1)\n\n" +
+		"| Short ID | Title | Author | Date | Pipeline |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [abc123](https://gitlab.example.com/commit/abc123) | feat: x | A | 1 Jan 2026 |  |\n" +
+		"\n1 items total\n" +
+		commitListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatDetailMarkdown verifies the DetailMarkdown Markdown formatter for a representative detail input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatDetailMarkdown pins the whole commit detail card: the parents as a
+// code span, the stats, and the message quoted under its label where it says
+// more than the title.
 func TestFormatDetailMarkdown(t *testing.T) {
-	c := DetailOutput{
+	got := FormatDetailMarkdown(DetailOutput{
 		ShortID:     "abc",
 		Title:       "feat: test",
 		Message:     "feat: test\n\nLong description",
@@ -2005,316 +2118,352 @@ func TestFormatDetailMarkdown(t *testing.T) {
 		ParentIDs:   []string{"p1", "p2"},
 		Stats:       &CommitStatsOutput{Additions: 10, Deletions: 3, Total: 13},
 		WebURL:      "https://example.com",
-	}
-	md := FormatDetailMarkdown(c)
-	if !strings.Contains(md, "abc") {
-		t.Error(errExpShortID)
-	}
-	if !strings.Contains(md, "p1, p2") {
-		t.Error("expected parent IDs")
-	}
-	if !strings.Contains(md, "+10") {
-		t.Error("expected additions stat")
-	}
-	if !strings.Contains(md, "Long description") {
-		t.Error("expected message body")
+	})
+
+	want := "## Commit abc\n\n" +
+		"- **Title**: feat: test\n" +
+		"- **Author**: Bob (b@t.com)\n" +
+		"- **Parents**: `p1, p2`\n" +
+		"- **Stats**: +10 -3 (13 total)\n" +
+		"- **URL**: [https://example.com](https://example.com)\n" +
+		"- **Message**:\n" +
+		"  > feat: test\n" +
+		"  >\n" +
+		"  > Long description\n" +
+		commitDetailHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatDetailMarkdown_Minimal verifies the DetailMarkdown_Minimal Markdown formatter for a representative detail_minimal input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatDetailMarkdown_Minimal pins that a commit with no parents, no
+// stats and a message that repeats its title writes none of the three.
 func TestFormatDetailMarkdown_Minimal(t *testing.T) {
-	c := DetailOutput{ShortID: "x", Title: "t", Message: "t", WebURL: "u"}
-	md := FormatDetailMarkdown(c)
-	if strings.Contains(md, "Parents") {
-		t.Error("should not show Parents when empty")
-	}
-	if strings.Contains(md, "Stats") {
-		t.Error("should not show Stats when nil")
-	}
-	if strings.Contains(md, "### Message") {
-		t.Error("should not show Message section when title == message")
+	got := FormatDetailMarkdown(DetailOutput{ShortID: "x", Title: "t", Message: "t", WebURL: "u"})
+
+	want := "## Commit x\n\n" +
+		"- **Title**: t\n" +
+		"- **URL**: [u](u)\n" +
+		commitDetailHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatDiffMarkdown verifies the DiffMarkdown Markdown formatter for a representative diff input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatDiffMarkdown pins the whole diff listing, the four statuses
+// included.
 func TestFormatDiffMarkdown(t *testing.T) {
-	out := DiffOutput{
+	got := FormatDiffMarkdown(DiffOutput{
 		Diffs: []toolutil.DiffOutput{
 			{OldPath: "a.go", NewPath: "a.go", NewFile: true},
 			{OldPath: "b.go", NewPath: "b.go", DeletedFile: true},
 			{OldPath: "c.go", NewPath: "d.go", RenamedFile: true},
 			{OldPath: "e.go", NewPath: "e.go"},
 		},
-	}
-	md := FormatDiffMarkdown(out)
-	if !strings.Contains(md, "4 files") {
-		t.Error("expected '4 files' header")
-	}
-	if !strings.Contains(md, "added") {
-		t.Error("expected 'added' status")
-	}
-	if !strings.Contains(md, "deleted") {
-		t.Error("expected 'deleted' status")
-	}
-	if !strings.Contains(md, "renamed") {
-		t.Error("expected 'renamed' status")
-	}
-	if !strings.Contains(md, "modified") {
-		t.Error("expected 'modified' status")
+	})
+
+	want := "## Commit Diffs (4)\n\n" +
+		"| Status | Old Path | New Path |\n" +
+		"| --- | --- | --- |\n" +
+		"| added | `a.go` | `a.go` |\n" +
+		"| deleted | `b.go` | `b.go` |\n" +
+		"| renamed | `c.go` | `d.go` |\n" +
+		"| modified | `e.go` | `e.go` |\n" +
+		commitDiffHints
+
+	if got != want {
+		t.Errorf("diff mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatDiffMarkdown_Empty verifies the DiffMarkdown_Empty Markdown formatter for a representative diff_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatDiffMarkdown_Empty pins the whole response of a commit that
+// changed nothing.
 func TestFormatDiffMarkdown_Empty(t *testing.T) {
-	out := DiffOutput{Diffs: nil}
-	md := FormatDiffMarkdown(out)
-	if !strings.Contains(md, "No diffs found") {
-		t.Error("expected 'No diffs found'")
+	got := FormatDiffMarkdown(DiffOutput{})
+
+	want := "No changed files found.\n"
+
+	if got != want {
+		t.Errorf("empty diff mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatRefsMarkdown verifies the RefsMarkdown Markdown formatter for a representative refs input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRefsMarkdown pins the whole ref listing.
 func TestFormatRefsMarkdown(t *testing.T) {
-	out := RefsOutput{
+	got := FormatRefsMarkdown(RefsOutput{
 		Refs: []RefOutput{
 			{Type: "branch", Name: "main"},
 			{Type: "tag", Name: "v1.0"},
 		},
-	}
-	md := FormatRefsMarkdown(out)
-	if !strings.Contains(md, "Commit Refs (2)") {
-		t.Error("expected header with count")
-	}
-	if !strings.Contains(md, "main") {
-		t.Error("expected 'main' branch")
-	}
-	if !strings.Contains(md, "v1.0") {
-		t.Error("expected 'v1.0' tag")
+	})
+
+	want := "## Commit Refs (2)\n\n" +
+		"| Type | Name |\n" +
+		"| --- | --- |\n" +
+		"| branch | main |\n" +
+		"| tag | v1.0 |\n" +
+		commitRefsHints
+
+	if got != want {
+		t.Errorf("refs mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatRefsMarkdown_Empty verifies the RefsMarkdown_Empty Markdown formatter for a representative refs_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRefsMarkdown_Empty pins the whole response of a commit on no
+// branch or tag.
 func TestFormatRefsMarkdown_Empty(t *testing.T) {
-	out := RefsOutput{Refs: nil}
-	md := FormatRefsMarkdown(out)
-	if !strings.Contains(md, "No branch or tag refs found") {
-		t.Error("expected 'No branch or tag refs found'")
+	got := FormatRefsMarkdown(RefsOutput{})
+
+	want := "No branch or tag refs found.\n"
+
+	if got != want {
+		t.Errorf("empty refs mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCommentsMarkdown verifies the CommentsMarkdown Markdown formatter for a representative comments input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatCommentsMarkdown pins the whole comment listing, and the heading
+// counting what GitLab reported in all rather than the length of the page.
 func TestFormatCommentsMarkdown(t *testing.T) {
-	out := CommentsOutput{
+	got := FormatCommentsMarkdown(CommentsOutput{
 		Comments: []CommentOutput{
 			{Author: &BasicUserOutput{Username: "dev"}, Note: "LGTM", Path: testFileMainGo, Line: 10},
 			{Author: &BasicUserOutput{Username: "bot"}, Note: "OK"},
 		},
-	}
-	md := FormatCommentsMarkdown(out)
-	if !strings.Contains(md, "Commit Comments (2)") {
-		t.Error("expected header with count")
-	}
-	if !strings.Contains(md, "LGTM") {
-		t.Error("expected note text")
-	}
-	if !strings.Contains(md, "10") {
-		t.Error("expected line number")
-	}
-	if !strings.Contains(md, "| - |") {
-		t.Error("expected dash for empty path")
+		Pagination: toolutil.PaginationOutput{TotalItems: 45, TotalPages: 3, Page: 1, PerPage: 20},
+	})
+
+	want := "## Commit Comments (45)\n\n" +
+		"Showing 2 of 45 results (page 1 of 3)\n\n" +
+		"| Author | Note | Path | Line |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| dev | LGTM | main.go | 10 |\n" +
+		"| bot | OK | - | - |\n" +
+		"\nPage 1 of 3 | 45 items total | 20 per page\n" +
+		commitCommentsHints
+
+	if got != want {
+		t.Errorf("comments mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCommentsMarkdown_Empty verifies the CommentsMarkdown_Empty Markdown formatter for a representative comments_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatCommentsMarkdown_Empty pins the whole response of a commit with no
+// comments.
 func TestFormatCommentsMarkdown_Empty(t *testing.T) {
-	out := CommentsOutput{Comments: nil}
-	md := FormatCommentsMarkdown(out)
-	if !strings.Contains(md, "No commit comments found") {
-		t.Error("expected 'No commit comments found'")
+	got := FormatCommentsMarkdown(CommentsOutput{})
+
+	want := "No commit comments found.\n"
+
+	if got != want {
+		t.Errorf("empty comments mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCommentMarkdown verifies the CommentMarkdown Markdown formatter for a representative comment input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatCommentMarkdown pins the whole card of one commit comment.
 func TestFormatCommentMarkdown(t *testing.T) {
-	c := CommentOutput{Author: &BasicUserOutput{Username: "dev"}, Note: "Nice!", Path: testFileMainGo, Line: 5}
-	md := FormatCommentMarkdown(c)
-	if !strings.Contains(md, "Commit Comment") {
-		t.Error(errExpHeader)
-	}
-	if !strings.Contains(md, "Nice!") {
-		t.Error("expected note")
-	}
-	if !strings.Contains(md, testFileMainGo) {
-		t.Error("expected path")
+	got := FormatCommentMarkdown(CommentOutput{
+		Author:    &BasicUserOutput{Username: "dev"},
+		Note:      "Nice!",
+		Path:      testFileMainGo,
+		Line:      5,
+		LineType:  "new",
+		CreatedAt: "2026-03-20T15:45:00Z",
+	})
+
+	want := "## Commit Comment\n\n" +
+		"- **Author**: @dev\n" +
+		"- **Created**: 20 Mar 2026 15:45 UTC\n" +
+		"- **Path**: `main.go`\n" +
+		"- **Line**: 5\n" +
+		"- **Line Type**: new\n" +
+		"- **Note**: Nice!\n" +
+		commitCommentHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCommentMarkdown_NoPath verifies the CommentMarkdown_NoPath Markdown formatter for a representative comment_nopath input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatCommentMarkdown_NoPath pins a comment on the commit itself rather
+// than on a line: neither the path nor the line is written, where "line 0"
+// used to read as a line number.
 func TestFormatCommentMarkdown_NoPath(t *testing.T) {
-	c := CommentOutput{Author: &BasicUserOutput{Username: "dev"}, Note: "OK"}
-	md := FormatCommentMarkdown(c)
-	if strings.Contains(md, "Path") {
-		t.Error("should not show Path when empty")
+	got := FormatCommentMarkdown(CommentOutput{Author: &BasicUserOutput{Username: "dev"}, Note: "OK"})
+
+	want := "## Commit Comment\n\n" +
+		"- **Author**: @dev\n" +
+		"- **Note**: OK\n" +
+		commitCommentHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatStatusesMarkdown verifies the StatusesMarkdown Markdown formatter for a representative statuses input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatStatusesMarkdown pins the whole status listing, each build state
+// carrying the glyph every pipeline status in this tree shows.
 func TestFormatStatusesMarkdown(t *testing.T) {
-	out := StatusesOutput{
+	got := FormatStatusesMarkdown(StatusesOutput{
 		Statuses: []StatusOutput{
 			{ID: 1, Status: "success", Name: "build", Ref: "main", Description: "OK"},
 		},
-	}
-	md := FormatStatusesMarkdown(out)
-	if !strings.Contains(md, "Commit Statuses (1)") {
-		t.Error(errExpHeader)
-	}
-	if !strings.Contains(md, "success") {
-		t.Error("expected status")
+	})
+
+	want := "## Commit Statuses (1)\n\n" +
+		"| ID | Status | Name | Ref | Description |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | ✅ success | build | main | OK |\n" +
+		commitStatusesHints
+
+	if got != want {
+		t.Errorf("statuses mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatStatusesMarkdown_Empty verifies the StatusesMarkdown_Empty Markdown formatter for a representative statuses_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatStatusesMarkdown_Empty pins the whole response of a commit with no
+// statuses.
 func TestFormatStatusesMarkdown_Empty(t *testing.T) {
-	out := StatusesOutput{Statuses: nil}
-	md := FormatStatusesMarkdown(out)
-	if !strings.Contains(md, "No commit statuses found") {
-		t.Error("expected 'No commit statuses found'")
+	got := FormatStatusesMarkdown(StatusesOutput{})
+
+	want := "No commit statuses found.\n"
+
+	if got != want {
+		t.Errorf("empty statuses mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatStatusMarkdown verifies the StatusMarkdown Markdown formatter for a representative status input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatStatusMarkdown pins the whole card of one commit status.
 func TestFormatStatusMarkdown(t *testing.T) {
-	s := StatusOutput{ID: 1, Status: "success", Name: "build", Ref: "main", Description: "Passed", TargetURL: testCIURL}
-	md := FormatStatusMarkdown(s)
-	if !strings.Contains(md, "Commit Status #1") {
-		t.Error(errExpHeader)
-	}
-	if !strings.Contains(md, "Passed") {
-		t.Error("expected description")
-	}
-	if !strings.Contains(md, testCIURL) {
-		t.Error("expected target URL")
+	got := FormatStatusMarkdown(StatusOutput{
+		ID: 1, Status: "success", Name: "build", Ref: "main",
+		SHA: "abc123", Description: "Passed", TargetURL: testCIURL,
+		PipelineID: 9, CreatedAt: "2026-03-20T15:45:00Z",
+		Author: &BasicUserOutput{Username: "ci"},
+	})
+
+	want := "## Commit Status #1\n\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Name**: build\n" +
+		"- **Ref**: main\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **Author**: @ci\n" +
+		"- **Allow Failure**: ❌\n" +
+		"- **Pipeline ID**: 9\n" +
+		"- **Created**: 20 Mar 2026 15:45 UTC\n" +
+		"- **Target**: [" + testCIURL + "](" + testCIURL + ")\n" +
+		"- **Description**: Passed\n" +
+		commitStatusHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatStatusMarkdown_Minimal verifies the StatusMarkdown_Minimal Markdown formatter for a representative status_minimal input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatStatusMarkdown_Minimal pins a status GitLab sent no description,
+// target or author for: none of the three is written as a label with nothing
+// after it.
 func TestFormatStatusMarkdown_Minimal(t *testing.T) {
-	s := StatusOutput{ID: 2, Status: "pending", Name: "test", Ref: "dev"}
-	md := FormatStatusMarkdown(s)
-	if strings.Contains(md, "Description") {
-		t.Error("should not show Description when empty")
-	}
-	if strings.Contains(md, "http") {
-		t.Error("should not show URL when empty")
+	got := FormatStatusMarkdown(StatusOutput{ID: 2, Status: "pending", Name: "test", Ref: "dev"})
+
+	want := "## Commit Status #2\n\n" +
+		"- **Status**: \U0001F7E1 pending\n" +
+		"- **Name**: test\n" +
+		"- **Ref**: dev\n" +
+		"- **Allow Failure**: ❌\n" +
+		commitStatusHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMRsByCommitMarkdown verifies the MRsByCommitMarkdown Markdown formatter for a representative mrsbycommit input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMRsByCommitMarkdown pins the whole listing of the merge requests a
+// commit belongs to, each state carrying its glyph.
 func TestFormatMRsByCommitMarkdown(t *testing.T) {
-	out := MRsByCommitOutput{
+	got := FormatMRsByCommitMarkdown(MRsByCommitOutput{
 		MergeRequests: []BasicMROutput{
-			{IID: 1, Title: "Feature", State: "merged", SourceBranch: "feat", TargetBranch: "main", Author: "dev"},
+			{
+				IID: 1, Title: "Feature", State: "merged",
+				SourceBranch: "feat", TargetBranch: "main", Author: "dev",
+				WebURL: "https://gitlab.example.com/-/merge_requests/1",
+			},
 		},
-	}
-	md := FormatMRsByCommitMarkdown(out)
-	if !strings.Contains(md, "Merge Requests for Commit (1)") {
-		t.Error(errExpHeader)
-	}
-	if !strings.Contains(md, "Feature") {
-		t.Error("expected MR title")
-	}
-	if !strings.Contains(md, "merged") {
-		t.Error("expected state")
+	})
+
+	want := "## Merge Requests for Commit (1)\n\n" +
+		"| IID | Title | State | Source -> Target | Author |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [!1](https://gitlab.example.com/-/merge_requests/1) | Feature | \U0001F7E3 merged | feat -> main | dev |\n" +
+		commitMRsHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMRsByCommitMarkdown_Empty verifies the MRsByCommitMarkdown_Empty Markdown formatter for a representative mrsbycommit_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMRsByCommitMarkdown_Empty pins the whole response of a commit that
+// belongs to no merge request.
 func TestFormatMRsByCommitMarkdown_Empty(t *testing.T) {
-	out := MRsByCommitOutput{MergeRequests: nil}
-	md := FormatMRsByCommitMarkdown(out)
-	if !strings.Contains(md, "No merge requests found") {
-		t.Error("expected 'No merge requests found'")
+	got := FormatMRsByCommitMarkdown(MRsByCommitOutput{})
+
+	want := "No merge requests found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatGPGSignatureMarkdown verifies the GPGSignatureMarkdown Markdown formatter for a representative gpgsignature input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatGPGSignatureMarkdown pins the whole card of a PGP-signed commit,
+// the key's user written without the angle brackets GFM autolinks.
 func TestFormatGPGSignatureMarkdown(t *testing.T) {
-	sig := GPGSignatureOutput{
+	got := FormatGPGSignatureMarkdown(GPGSignatureOutput{
 		KeyID:              1,
 		KeyPrimaryKeyID:    "ABC123",
 		KeyUserName:        "Test",
 		KeyUserEmail:       "t@t.com",
 		VerificationStatus: "verified",
-	}
-	md := FormatGPGSignatureMarkdown(sig)
-	if !strings.Contains(md, "Commit Signature") {
-		t.Error(errExpHeader)
-	}
-	if !strings.Contains(md, "verified") {
-		t.Error("expected verification status")
-	}
-	if !strings.Contains(md, "ABC123") {
-		t.Error("expected key ID")
+	})
+
+	want := "## Commit Signature\n\n" +
+		"- **Verification**: verified\n" +
+		"- **Key User**: Test (t@t.com)\n" +
+		"- **Key ID**: 1\n" +
+		"- **Primary Key ID**: `ABC123`\n" +
+		commitSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatGPGSignatureMarkdown_SSH verifies the signature Markdown formatter
-// renders SSH-signature details (type, key title, usage) for an SSH-signed
-// commit and omits the PGP key-user block.
+// TestFormatGPGSignatureMarkdown_SSH pins the whole card of an SSH-signed
+// commit: the key's title and usage, and none of the PGP key-user rows.
 func TestFormatGPGSignatureMarkdown_SSH(t *testing.T) {
-	sig := GPGSignatureOutput{
+	got := FormatGPGSignatureMarkdown(GPGSignatureOutput{
 		SignatureType:      "SSH",
 		VerificationStatus: "verified",
 		CommitSource:       "gitaly",
 		Key:                &SSHSignatureKey{ID: 11, Title: "MyKey", UsageType: "auth_and_signing"},
-	}
-	md := FormatGPGSignatureMarkdown(sig)
-	for _, want := range []string{"SSH", "verified", "MyKey", "auth_and_signing", "gitaly"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("expected Markdown to contain %q\n%s", want, md)
-			}
-		})
+	})
+
+	want := "## Commit Signature\n\n" +
+		"- **Type**: SSH\n" +
+		"- **Verification**: verified\n" +
+		"- **SSH Key**: MyKey\n" +
+		"- **Usage**: auth_and_signing\n" +
+		"- **Commit Source**: gitaly\n" +
+		commitSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatGPGSignatureMarkdown_X509 verifies the signature Markdown formatter
-// renders X.509-certificate details (subject, email) for an X.509-signed commit.
+// TestFormatGPGSignatureMarkdown_X509 pins the whole card of an X.509-signed
+// commit.
 func TestFormatGPGSignatureMarkdown_X509(t *testing.T) {
-	sig := GPGSignatureOutput{
+	got := FormatGPGSignatureMarkdown(GPGSignatureOutput{
 		SignatureType:      "X509",
 		VerificationStatus: "unverified",
 		X509Certificate: &X509CertificateOutput{
@@ -2322,14 +2471,38 @@ func TestFormatGPGSignatureMarkdown_X509(t *testing.T) {
 			Subject: "CN=gitlab@example.org,OU=Example,O=World",
 			Email:   "gitlab@example.org",
 		},
+	})
+
+	want := "## Commit Signature\n\n" +
+		"- **Type**: X509\n" +
+		"- **Verification**: unverified\n" +
+		"- **X.509 Subject**: CN=gitlab@example.org,OU=Example,O=World\n" +
+		"- **X.509 Email**: gitlab@example.org\n" +
+		commitSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	md := FormatGPGSignatureMarkdown(sig)
-	for _, want := range []string{"X509", "unverified", "CN=gitlab@example.org", "gitlab@example.org"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("expected Markdown to contain %q\n%s", want, md)
-			}
-		})
+}
+
+// TestFormatGPGSignatureMarkdown_AbsentX509Subject pins that a certificate
+// GitLab sent no subject for writes no subject row: a label with nothing after
+// it reads as a value that failed to render.
+func TestFormatGPGSignatureMarkdown_AbsentX509Subject(t *testing.T) {
+	got := FormatGPGSignatureMarkdown(GPGSignatureOutput{
+		SignatureType:      "X509",
+		VerificationStatus: "unverified",
+		X509Certificate:    &X509CertificateOutput{ID: 1, Email: "gitlab@example.org"},
+	})
+
+	want := "## Commit Signature\n\n" +
+		"- **Type**: X509\n" +
+		"- **Verification**: unverified\n" +
+		"- **X.509 Email**: gitlab@example.org\n" +
+		commitSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -2670,6 +2843,50 @@ func TestActionSpecs_CommitGetRoute(t *testing.T) {
 	}
 	if out.ID != "abc123" {
 		t.Fatalf("ID = %q, want abc123", out.ID)
+	}
+}
+
+// TestGet_TimestampsAreTheWireForm pins that the three timestamps a commit
+// carries go out in RFC 3339, the form every other date this server publishes
+// takes and the one the display helper can read back.
+//
+// They used to be written with Go's default layout, which is not RFC 3339, so
+// nothing could parse them: the Markdown time helper fell through to its
+// escape branch and printed "2026-01-01 00:00:00 +0000 UTC" where every other
+// card shows a date a reader can read.
+func TestGet_TimestampsAreTheWireForm(t *testing.T) {
+	const respJSON = `{"id":"abc123","short_id":"abc123","title":"T","message":"M",` +
+		`"authored_date":"2026-01-01T00:00:00Z","committed_date":"2026-03-20T15:45:00Z",` +
+		`"created_at":"2026-01-02T03:04:05Z","web_url":"u"}`
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v4/projects/42/repository/commits/abc123" {
+			testutil.RespondJSON(w, http.StatusOK, respJSON)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	out, err := Get(context.Background(), client, GetInput{ProjectID: "42", SHA: "abc123"})
+	if err != nil {
+		t.Fatalf("Get() unexpected error: %v", err)
+	}
+
+	fields := []struct {
+		name, got, want string
+	}{
+		{"committed_date", out.CommittedDate, "2026-03-20T15:45:00Z"},
+		{"authored_date", out.AuthoredDate, "2026-01-01T00:00:00Z"},
+		{"created_at", out.CreatedAt, "2026-01-02T03:04:05Z"},
+	}
+	for _, f := range fields {
+		t.Run(f.name, func(t *testing.T) {
+			if f.got != f.want {
+				t.Errorf("%s = %q, want %q", f.name, f.got, f.want)
+			}
+		})
+	}
+	if got := toolutil.FormatTime(out.CommittedDate); got != "20 Mar 2026 15:45 UTC" {
+		t.Errorf("the display helper reads the committed date as %q, want %q", got, "20 Mar 2026 15:45 UTC")
 	}
 }
 

--- a/internal/tools/commits/markdown.go
+++ b/internal/tools/commits/markdown.go
@@ -1,11 +1,32 @@
 package commits
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name, the one form every surface resolves:
+// the dynamic surface executes them, and the meta and individual surfaces
+// resolve them to their own tool names. Every commit action is a route on the
+// gitlab_repository catalog group, so each ID carries that domain rather than
+// a "commit." prefix of its own.
+const (
+	hintCommitGet           = "repository.commit_get"
+	hintCommitList          = "repository.commit_list"
+	hintCommitDiff          = "repository.commit_diff"
+	hintCommitRefs          = "repository.commit_refs"
+	hintCommitComments      = "repository.commit_comments"
+	hintCommitCommentCreate = "repository.commit_comment_create"
+	hintCommitStatuses      = "repository.commit_statuses"
+	hintCommitStatusSet     = "repository.commit_status_set"
+	hintCommitCherryPick    = "repository.commit_cherry_pick"
+	hintFileGet             = "repository.file_get"
+	hintBranchGet           = "branch.get"
+	hintTagGet              = "tag.get"
+	hintMRGet               = "merge_request.get"
+	hintMRChangesGet        = "merge_request.changes_get"
 )
 
 // userDisplay returns a human-readable name for a commit comment/status author,
@@ -24,91 +45,159 @@ func userDisplay(u *BasicUserOutput) string {
 	return "-"
 }
 
-// FormatOutputMarkdown renders a single commit as a Markdown summary.
+// userHandle renders a commit comment or status author as the "@handle"
+// GitLab shows, and nothing at all when GitLab sent no author, so a card
+// carries no row rather than a dash.
+func userHandle(u *BasicUserOutput) string {
+	if u == nil {
+		return ""
+	}
+	if handle := toolutil.MdUserHandle(u.Username); handle != "" {
+		return handle
+	}
+	return toolutil.EscapeMdTableCell(u.Name)
+}
+
+// pipelineSummary renders the pipeline of a commit as its status glyph, the
+// status word and a link to the pipeline itself, and nothing when GitLab
+// reported neither. A commit whose pipeline the card omits is one a reader
+// cannot tell has failed.
+func pipelineSummary(status string, p *LastPipelineOutput) string {
+	state := status
+	if p != nil && p.Status != "" {
+		state = p.Status
+	}
+	summary := ""
+	if state != "" {
+		summary = toolutil.PipelineStatusEmoji(state) + " " + toolutil.EscapeMdTableCell(state)
+	}
+	if p == nil || p.ID == 0 {
+		return summary
+	}
+	link := toolutil.MdTitleLink("#"+strconv.FormatInt(p.ID, 10), p.WebURL)
+	if summary == "" {
+		return link
+	}
+	return summary + " " + link
+}
+
+// commitIdent renders the person a commit names: their name, and the address
+// beside it in parentheses rather than in angle brackets, which GFM turns
+// into a mailto autolink to an address nobody chose to publish.
+func commitIdent(name, email string) string {
+	switch {
+	case name == "" && email == "":
+		return ""
+	case email == "":
+		return toolutil.EscapeMdTableCell(name)
+	case name == "":
+		return toolutil.EscapeMdTableCell(email)
+	default:
+		return toolutil.EscapeMdTableCell(name) + " (" + toolutil.EscapeMdTableCell(email) + ")"
+	}
+}
+
+// FormatOutputMarkdown renders one commit as a card.
+//
+// A cherry-pick or revert run with dry_run commits nothing and GitLab answers
+// with no commit at all, which this used to render as a commit card whose
+// heading and every field were empty: a reader could not tell it from a commit
+// that had been made.
 func FormatOutputMarkdown(c Output) string {
+	if c.ID == "" && c.ShortID == "" {
+		return formatNoCommitMarkdown()
+	}
 	var b strings.Builder
-	//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which is hexadecimal.
-	fmt.Fprintf(&b, "## Commit %s\n\n", c.ShortID)
+	card := toolutil.NewCard(&b, "Commit "+c.ShortID)
 	// A commit's title and ident are what whoever made the commit typed, and
 	// this server's own commit.create passes an author name and email through.
-	fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(c.Title))
-	fmt.Fprintf(&b, "- **Author**: %s <%s>\n",
-		toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.AuthorEmail))
-	fmt.Fprintf(&b, "- **Date**: %s\n", toolutil.FormatTime(c.CommittedDate))
-	toolutil.WriteMdURL(&b, c.WebURL)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'commit_get' with this SHA to see full commit details and stats",
-		"Use action 'commit_diff' to see file changes for this commit",
-		"Use action 'commit_refs' to see branches/tags containing this commit",
+	card.Field("Title", c.Title)
+	card.Markdown("Author", commitIdent(c.AuthorName, c.AuthorEmail))
+	card.Time("Date", c.CommittedDate)
+	card.Markdown("Pipeline", pipelineSummary(c.Status, c.LastPipeline))
+	card.URL(c.WebURL)
+	card.End(
+		toolutil.HintAction(hintCommitGet, "see this commit's full details and stats"),
+		toolutil.HintAction(hintCommitDiff, "see the file changes for this commit"),
+		toolutil.HintAction(hintCommitRefs, "see the branches and tags containing it"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of commits as a Markdown table.
-func FormatListMarkdown(out ListOutput) string {
+// formatNoCommitMarkdown is the answer to a call GitLab returned no commit
+// for: a dry run reports whether the change applies and commits nothing.
+func formatNoCommitMarkdown() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Commits (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Commits), out.Pagination)
-	if len(out.Commits) == 0 {
-		b.WriteString("No commits found.\n")
-		return b.String()
-	}
-	b.WriteString("| Short ID | Title | Author | Date |\n")
-	b.WriteString(toolutil.TblSep4Col)
-	for _, c := range out.Commits {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(c.ShortID, c.WebURL), toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'commit_get' with a SHA to see commit summary",
-		"Use action 'commit_diff' to see file changes for a specific commit",
+	card := toolutil.NewCard(&b, "No Commit Created")
+	card.Note("GitLab returned no commit. A dry run reports whether the change would apply cleanly and commits nothing; run the same action without dry_run to commit it.")
+	card.End(
+		toolutil.HintAction(hintCommitCherryPick, "apply the commit for real"),
+		toolutil.HintAction(hintCommitList, "check the branch for the commit"),
 	)
 	return b.String()
 }
 
-// FormatDetailMarkdown renders a single commit detail as a Markdown summary.
+// FormatListMarkdown renders a page of commits as a Markdown table.
+func FormatListMarkdown(out ListOutput) string {
+	if len(out.Commits) == 0 {
+		return toolutil.EmptyMessage("commits")
+	}
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commits", len(out.Commits), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Short ID", "Title", "Author", "Date", "Pipeline"))
+	for _, c := range out.Commits {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(c.ShortID, c.WebURL),
+			toolutil.EscapeMdTableCell(c.Title),
+			toolutil.EscapeMdTableCell(c.AuthorName),
+			toolutil.FormatTime(c.CommittedDate),
+			pipelineSummary(c.Status, c.LastPipeline),
+		))
+	}
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintCommitGet, "see one commit in full"),
+		toolutil.HintAction(hintCommitDiff, "see the file changes of one commit"),
+	)
+	return b.String()
+}
+
+// FormatDetailMarkdown renders one commit in full as a card: its fields, then
+// its message as quoted prose when the message says more than the title.
 func FormatDetailMarkdown(c DetailOutput) string {
 	var b strings.Builder
-	//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which is hexadecimal.
-	fmt.Fprintf(&b, "## Commit %s\n\n", c.ShortID)
+	card := toolutil.NewCard(&b, "Commit "+c.ShortID)
 	// A commit's title and ident are what whoever made the commit typed, and
 	// this server's own commit.create passes an author name and email through.
-	fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(c.Title))
-	fmt.Fprintf(&b, "- **Author**: %s <%s>\n",
-		toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.AuthorEmail))
-	fmt.Fprintf(&b, "- **Date**: %s\n", toolutil.FormatTime(c.CommittedDate))
-	if len(c.ParentIDs) > 0 {
-		//gitlab:allow-unescaped strings.Join(c.ParentIDs, ", "): full git object ids, which are hexadecimal.
-		fmt.Fprintf(&b, "- **Parents**: %s\n", strings.Join(c.ParentIDs, ", "))
-	}
+	card.Field("Title", c.Title)
+	card.Markdown("Author", commitIdent(c.AuthorName, c.AuthorEmail))
+	card.Markdown("Committer", commitIdent(c.CommitterName, c.CommitterEmail))
+	card.Time("Date", c.CommittedDate)
+	card.Code("Parents", strings.Join(c.ParentIDs, ", "))
 	if c.Stats != nil {
-		fmt.Fprintf(&b, "- **Stats**: +%d -%d (%d total)\n", c.Stats.Additions, c.Stats.Deletions, c.Stats.Total)
+		card.Field("Stats", "+"+strconv.FormatInt(c.Stats.Additions, 10)+
+			" -"+strconv.FormatInt(c.Stats.Deletions, 10)+
+			" ("+strconv.FormatInt(c.Stats.Total, 10)+" total)")
 	}
+	card.Markdown("Pipeline", pipelineSummary(c.Status, c.LastPipeline))
+	card.URL(c.WebURL)
 	if c.Message != "" && c.Message != c.Title {
-		fmt.Fprintf(&b, "\n### Message\n\n%s\n", toolutil.WrapGFMBody(c.Message))
+		card.Text("Message", c.Message)
 	}
-	toolutil.WriteMdURLNewline(&b, c.WebURL)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_diff` to view file changes",
-		"Use `gitlab_commit_cherry_pick` to apply this commit to another branch",
+	card.End(
+		toolutil.HintAction(hintCommitDiff, "view the file changes"),
+		toolutil.HintAction(hintCommitCherryPick, "apply this commit to another branch"),
 	)
 	return b.String()
 }
 
-// FormatDiffMarkdown renders a paginated list of commit diffs as a Markdown table.
+// FormatDiffMarkdown renders the files one commit changed as a Markdown table.
 func FormatDiffMarkdown(out DiffOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Diffs (%d files)\n\n", len(out.Diffs))
 	if len(out.Diffs) == 0 {
-		b.WriteString("No diffs found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("changed files")
 	}
-	b.WriteString("| Status | Old Path | New Path |\n")
-	b.WriteString(toolutil.TblSep3Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commit Diffs", len(out.Diffs), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Status", "Old Path", "New Path"))
 	for _, d := range out.Diffs {
 		status := "modified"
 		switch {
@@ -119,50 +208,50 @@ func FormatDiffMarkdown(out DiffOutput) string {
 		case d.RenamedFile:
 			status = "renamed"
 		}
-		fmt.Fprintf(&b, toolutil.FmtRow3Str, status, toolutil.EscapeMdTableCell(d.OldPath), toolutil.EscapeMdTableCell(d.NewPath))
+		b.WriteString(toolutil.MarkdownTableRow(
+			status,
+			toolutil.MdCodeSpanCell(d.OldPath),
+			toolutil.MdCodeSpanCell(d.NewPath),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_get` to view a specific changed file",
-		"Use `gitlab_commit_comment_create` to comment on the changes",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintFileGet, "view one changed file"),
+		toolutil.HintAction(hintCommitCommentCreate, "comment on the changes"),
 	)
 	return b.String()
 }
 
-// FormatRefsMarkdown renders a paginated list of commit refs as Markdown.
+// FormatRefsMarkdown renders the branches and tags a commit is on as a
+// Markdown table.
 func FormatRefsMarkdown(out RefsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Refs (%d)\n\n", len(out.Refs))
 	if len(out.Refs) == 0 {
-		b.WriteString("No branch or tag refs found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("branch or tag refs")
 	}
-	b.WriteString("| Type | Name |\n")
-	b.WriteString(toolutil.TblSep2Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commit Refs", len(out.Refs), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Type", "Name"))
 	for _, r := range out.Refs {
-		//gitlab:allow-unescaped r.Type: the ref kind GitLab answers with, either branch or tag.
-		fmt.Fprintf(&b, "| %s | %s |\n", r.Type, toolutil.EscapeMdTableCell(r.Name))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(r.Type),
+			toolutil.EscapeMdTableCell(r.Name),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_branch_get` to view branch details",
-		"Use `gitlab_tag_get` to view tag details",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintBranchGet, "view one branch"),
+		toolutil.HintAction(hintTagGet, "view one tag"),
 	)
 	return b.String()
 }
 
-// FormatCommentsMarkdown renders a paginated list of commit comments.
+// FormatCommentsMarkdown renders a page of commit comments as a Markdown
+// table.
 func FormatCommentsMarkdown(out CommentsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Comments (%d)\n\n", len(out.Comments))
 	if len(out.Comments) == 0 {
-		b.WriteString("No commit comments found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("commit comments")
 	}
-	b.WriteString("| Author | Note | Path | Line |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commit Comments", len(out.Comments), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Author", "Note", "Path", "Line"))
 	for _, c := range out.Comments {
 		path := c.Path
 		if path == "" {
@@ -172,147 +261,157 @@ func FormatCommentsMarkdown(out CommentsOutput) string {
 		if c.Line > 0 {
 			line = strconv.FormatInt(c.Line, 10)
 		}
-		fmt.Fprintf(&b, toolutil.FmtRow4Str, toolutil.EscapeMdTableCell(userDisplay(c.Author)), toolutil.EscapeMdTableCell(c.Note), toolutil.EscapeMdTableCell(path), line)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(userDisplay(c.Author)),
+			toolutil.EscapeMdTableCell(c.Note),
+			toolutil.EscapeMdTableCell(path),
+			line,
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_comment_create` to add a comment",
-		"Use `gitlab_commit_get` to view the commit details",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintCommitCommentCreate, "add a comment"),
+		toolutil.HintAction(hintCommitGet, "view the commit"),
 	)
 	return b.String()
 }
 
-// FormatCommentMarkdown renders a single commit comment.
+// FormatCommentMarkdown renders one commit comment as a card.
 func FormatCommentMarkdown(c CommentOutput) string {
 	var b strings.Builder
-	b.WriteString("## Commit Comment\n\n")
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(userDisplay(c.Author)))
-	fmt.Fprintf(&b, "- **Note**: %s\n", toolutil.EscapeMdTableCell(c.Note))
-	if c.Path != "" {
-		fmt.Fprintf(&b, "- **Path**: %s (line %d)\n", toolutil.EscapeMdTableCell(c.Path), c.Line)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_comments` to list all comments",
-		"Use `gitlab_file_get` to view the referenced file",
+	card := toolutil.NewCard(&b, "Commit Comment")
+	card.Markdown("Author", userHandle(c.Author))
+	card.Time("Created", c.CreatedAt)
+	card.Code("Path", c.Path)
+	// A line of zero means the comment is on the commit rather than on a line,
+	// which "line 0" read as a line number.
+	card.Count("Line", c.Line)
+	card.Field("Line Type", c.LineType)
+	card.Text("Note", c.Note)
+	card.End(
+		toolutil.HintAction(hintCommitComments, "list every comment on the commit"),
+		toolutil.HintAction(hintFileGet, "view the referenced file"),
 	)
 	return b.String()
 }
 
-// FormatStatusesMarkdown renders a paginated list of commit statuses.
+// FormatStatusesMarkdown renders a page of commit statuses as a Markdown
+// table.
 func FormatStatusesMarkdown(out StatusesOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Statuses (%d)\n\n", len(out.Statuses))
 	if len(out.Statuses) == 0 {
-		b.WriteString("No commit statuses found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("commit statuses")
 	}
-	b.WriteString("| ID | Status | Name | Ref | Description |\n")
-	b.WriteString(toolutil.TblSep5Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Commit Statuses", len(out.Statuses), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Status", "Name", "Ref", "Description"))
 	for _, s := range out.Statuses {
-		//gitlab:allow-unescaped s.Status: a build state GitLab rejects with a 400 unless it is one of the six its own schema enumerates.
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n", s.ID, s.Status, toolutil.EscapeMdTableCell(s.Name), toolutil.EscapeMdTableCell(s.Ref), toolutil.EscapeMdTableCell(s.Description))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(s.ID, 10),
+			statusCell(s.Status),
+			toolutil.EscapeMdTableCell(s.Name),
+			toolutil.EscapeMdTableCell(s.Ref),
+			toolutil.EscapeMdTableCell(s.Description),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_status_set` to update a status",
-		"Use `gitlab_commit_get` to view commit details",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintCommitStatusSet, "update a status"),
+		toolutil.HintAction(hintCommitGet, "view the commit"),
 	)
 	return b.String()
 }
 
-// FormatStatusMarkdown renders a single commit status.
+// statusCell renders a build state with the glyph every pipeline status in
+// this tree carries, and nothing when GitLab sent no state.
+func statusCell(status string) string {
+	if status == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// FormatStatusMarkdown renders one commit status as a card.
 func FormatStatusMarkdown(s StatusOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Commit Status #%d\n\n", s.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdStatus, s.Status)
+	card := toolutil.NewCard(&b, "Commit Status #"+strconv.FormatInt(s.ID, 10))
+	card.Markdown("Status", statusCell(s.Status))
 	// The name and the ref of a commit status are both supplied by whatever CI
 	// system posted it, and this server's own commit_status_set writes them.
-	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(s.Name))
-	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(s.Ref))
-	if s.Description != "" {
-		toolutil.WriteDescription(&b, s.Description)
-	}
-	if s.TargetURL != "" {
-		toolutil.WriteMdURL(&b, s.TargetURL)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_status_set` to update this status",
-		"Use `gitlab_commit_statuses` to see all statuses",
+	card.Field("Name", s.Name)
+	card.Field("Ref", s.Ref)
+	card.Code("SHA", s.SHA)
+	card.Markdown("Author", userHandle(s.Author))
+	card.Bool("Allow Failure", s.AllowFailure)
+	card.Count("Pipeline ID", s.PipelineID)
+	card.Time("Created", s.CreatedAt)
+	card.Time("Started", s.StartedAt)
+	card.Time("Finished", s.FinishedAt)
+	card.Link("Target", s.TargetURL, s.TargetURL)
+	card.Text("Description", s.Description)
+	card.End(
+		toolutil.HintAction(hintCommitStatusSet, "update this status"),
+		toolutil.HintAction(hintCommitStatuses, "see all statuses on the commit"),
 	)
 	return b.String()
 }
 
-// FormatMRsByCommitMarkdown renders a list of merge requests for a commit.
+// FormatMRsByCommitMarkdown renders the merge requests a commit belongs to as
+// a Markdown table.
 func FormatMRsByCommitMarkdown(out MRsByCommitOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Merge Requests for Commit (%d)\n\n", len(out.MergeRequests))
 	if len(out.MergeRequests) == 0 {
-		b.WriteString("No merge requests found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("merge requests")
 	}
-	b.WriteString("| IID | Title | State | Source -> Target | Author |\n")
-	b.WriteString(toolutil.TblSep5Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Merge Requests for Commit", len(out.MergeRequests), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("IID", "Title", "State", "Source -> Target", "Author"))
 	for _, mr := range out.MergeRequests {
-		fmt.Fprintf(&b, "| !%d | %s | %s | %s -> %s | %s |\n",
-			//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
-			mr.IID, toolutil.EscapeMdTableCell(mr.Title), mr.State,
-			toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch),
-			toolutil.EscapeMdTableCell(mr.Author))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink("!"+strconv.FormatInt(mr.IID, 10), mr.WebURL),
+			toolutil.EscapeMdTableCell(mr.Title),
+			mrStateCell(mr.State),
+			toolutil.EscapeMdTableCell(mr.SourceBranch)+" -> "+toolutil.EscapeMdTableCell(mr.TargetBranch),
+			toolutil.EscapeMdTableCell(mr.Author),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_get` to view MR details",
-		"Use `gitlab_mr_changes_get` to see MR diff",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, true,
+		toolutil.HintAction(hintMRGet, "view one merge request"),
+		toolutil.HintAction(hintMRChangesGet, "see its diff"),
 	)
 	return b.String()
 }
 
-// FormatGPGSignatureMarkdown renders a GPG signature as Markdown.
+// mrStateCell renders a merge request state with its emoji, the way every
+// merge request row in the tree shows it.
+func mrStateCell(state string) string {
+	if state == "" {
+		return ""
+	}
+	return toolutil.MRStateEmoji(state) + " " + toolutil.EscapeMdTableCell(state)
+}
+
+// FormatGPGSignatureMarkdown renders a commit's signature as a card: the
+// verdict, then whichever signer object the signing scheme carries.
 func FormatGPGSignatureMarkdown(sig GPGSignatureOutput) string {
 	var b strings.Builder
-	b.WriteString("## Commit Signature\n\n")
-	if sig.SignatureType != "" {
-		//gitlab:allow-unescaped sig.SignatureType: the signing scheme GitLab names, one of PGP, SSH or X509.
-		fmt.Fprintf(&b, "- **Type**: %s\n", sig.SignatureType)
-	}
-	//gitlab:allow-unescaped sig.VerificationStatus: a verification verdict GitLab computes, not text it stored.
-	fmt.Fprintf(&b, "- **Verification**: %s\n", sig.VerificationStatus)
+	c := toolutil.NewCard(&b, "Commit Signature")
+	c.Field("Type", sig.SignatureType)
+	c.Field("Verification", sig.VerificationStatus)
 	switch {
 	case sig.X509Certificate != nil:
-		fmt.Fprintf(&b, "- **X.509 Subject**: %s\n", toolutil.EscapeMdTableCell(sig.X509Certificate.Subject))
-		if sig.X509Certificate.Email != "" {
-			// Read out of the signer's own certificate, like the subject above.
-			fmt.Fprintf(&b, "- **X.509 Email**: %s\n", toolutil.EscapeMdTableCell(sig.X509Certificate.Email))
-		}
+		// Both are read out of the signer's own certificate, which GitLab
+		// stores as parsed rather than validating.
+		c.Field("X.509 Subject", sig.X509Certificate.Subject)
+		c.Field("X.509 Email", sig.X509Certificate.Email)
 	case sig.Key != nil:
-		if sig.Key.Title != "" {
-			fmt.Fprintf(&b, "- **SSH Key**: %s\n", toolutil.EscapeMdTableCell(sig.Key.Title))
-		}
-		if sig.Key.UsageType != "" {
-			//gitlab:allow-unescaped sig.Key.UsageType: the key usage GitLab records, one of auth, signing or auth_and_signing.
-			fmt.Fprintf(&b, "- **Usage**: %s\n", sig.Key.UsageType)
-		}
+		c.Field("SSH Key", sig.Key.Title)
+		c.Field("Usage", sig.Key.UsageType)
 	default:
 		// Both come out of the GPG key's user ID packet, which is whatever the
 		// key's owner typed when they generated it.
-		fmt.Fprintf(&b, "- **Key User**: %s <%s>\n",
-			toolutil.EscapeMdTableCell(sig.KeyUserName), toolutil.EscapeMdTableCell(sig.KeyUserEmail))
-		fmt.Fprintf(&b, "- **Key ID**: %d\n", sig.KeyID)
-		//gitlab:allow-unescaped sig.KeyPrimaryKeyID: a GPG key id, which is hexadecimal.
-		fmt.Fprintf(&b, "- **Primary Key ID**: %s\n", sig.KeyPrimaryKeyID)
+		c.Markdown("Key User", commitIdent(sig.KeyUserName, sig.KeyUserEmail))
+		c.Int("Key ID", sig.KeyID)
+		c.Code("Primary Key ID", sig.KeyPrimaryKeyID)
 	}
-	if sig.CommitSource != "" {
-		//gitlab:allow-unescaped sig.CommitSource: where GitLab read the commit from, either gitaly or rugged.
-		fmt.Fprintf(&b, "- **Commit Source**: %s\n", sig.CommitSource)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_get` to view the full commit details",
-	)
+	c.Field("Commit Source", sig.CommitSource)
+	c.End(toolutil.HintAction(hintCommitGet, "view the full commit details"))
 	return b.String()
 }
 

--- a/internal/tools/containerregistry/container_registry_test.go
+++ b/internal/tools/containerregistry/container_registry_test.go
@@ -438,10 +438,6 @@ const (
 	fmtExpectedProjectIDErr = "expected project_id required error, got %v"
 	// fmtExpectedRepoIDErr identifies the fmt expected repo ID err constant used by this package.
 	fmtExpectedRepoIDErr = "expected repository_id required error, got %v"
-	// fmtExpectedInMarkdown identifies the fmt expected in markdown constant used by this package.
-	fmtExpectedInMarkdown = "expected %q in markdown, got:\n%s"
-	// fmtExpectedEmptyMsg identifies the fmt expected empty msg constant used by this package.
-	fmtExpectedEmptyMsg = "expected empty message, got:\n%s"
 	// testMethodNotAllowed identifies the test method not allowed constant used by this package.
 	testMethodNotAllowed = "method not allowed"
 	// testProdPattern identifies the test prod pattern constant used by this package.
@@ -573,45 +569,50 @@ func TestConvertTag_NilCreatedAt(t *testing.T) {
 // FormatRepositoryMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatRepositoryMarkdown_Full verifies the RepositoryMarkdown_Full Markdown formatter for a representative repository_full input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// repositoryCardHints is the guidance a registry repository card closes with.
+const repositoryCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'registry_tag_list' to list tags in this repository\n" +
+	"- Use action 'registry_delete' to delete this repository\n"
+
+// TestFormatRepositoryMarkdown_Full verifies the whole card of a fully
+// populated registry repository. The ID row is what the audit found missing:
+// every follow-up action on a repository takes repository_id, and the card
+// that named the repository did not carry it.
 func TestFormatRepositoryMarkdown_Full(t *testing.T) {
 	out := RepositoryOutput{
 		ID: 100, Name: "img", Path: testCovRepoPath, ProjectID: 42,
 		Location: "loc", TagsCount: 3,
 		Status: "delete_scheduled", CreatedAt: "2026-01-15T10:00:00Z",
 	}
-	md := FormatRepositoryMarkdown(out)
-	for _, want := range []string{"Registry Repository: " + testCovRepoPath, "img", testCovRepoPath, "loc", "3", "delete_scheduled", "15 Jan 2026"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf(fmtExpectedInMarkdown, want, md)
-			}
-		})
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain numeric ID column")
-	}
-	if strings.Contains(md, "| Project ID |") {
-		t.Error("should not contain numeric Project ID column")
+	got := FormatRepositoryMarkdown(out)
+	want := "## Registry Repository: " + testCovRepoPath + "\n\n" +
+		"- **ID**: 100\n" +
+		"- **Name**: img\n" +
+		"- **Path**: " + testCovRepoPath + "\n" +
+		"- **Location**: loc\n" +
+		"- **Tags Count**: 3\n" +
+		"- **Status**: delete_scheduled\n" +
+		"- **Created At**: 15 Jan 2026 10:00 UTC\n" +
+		repositoryCardHints
+	if got != want {
+		t.Errorf("FormatRepositoryMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatRepositoryMarkdown_EmptyOptionalFields verifies the RepositoryMarkdown_EmptyOptionalFields Markdown formatter for a representative repository_emptyoptionalfields input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRepositoryMarkdown_EmptyOptionalFields verifies the card omits
+// every row GitLab did not fill, the tag count included: the count is sent
+// only when the caller asked for it, so a zero is silence rather than a
+// repository with no tags.
 func TestFormatRepositoryMarkdown_EmptyOptionalFields(t *testing.T) {
 	out := RepositoryOutput{ID: 1, Name: "n", Path: "p", ProjectID: 1}
-	md := FormatRepositoryMarkdown(out)
-	if strings.Contains(md, "Status") {
-		t.Error("should not contain Status row when empty")
-	}
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At row when empty")
-	}
-	if !strings.Contains(md, "Registry Repository: p") {
-		t.Errorf("expected heading with path, got:\n%s", md)
+	got := FormatRepositoryMarkdown(out)
+	want := "## Registry Repository: p\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: n\n" +
+		"- **Path**: p\n" +
+		repositoryCardHints
+	if got != want {
+		t.Errorf("FormatRepositoryMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -619,9 +620,9 @@ func TestFormatRepositoryMarkdown_EmptyOptionalFields(t *testing.T) {
 // FormatRepositoryListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatRepositoryListMarkdown_WithItems verifies the RepositoryListMarkdown_WithItems Markdown formatter for a representative repositorylist_withitems input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRepositoryListMarkdown_WithItems verifies the whole table. The ID
+// column is the one every follow-up action needs, and a repository whose tag
+// count GitLab did not report shows a dash rather than a zero it never sent.
 func TestFormatRepositoryListMarkdown_WithItems(t *testing.T) {
 	out := RepositoryListOutput{
 		Repositories: []RepositoryOutput{
@@ -629,30 +630,26 @@ func TestFormatRepositoryListMarkdown_WithItems(t *testing.T) {
 			{ID: 2, Name: "b", Path: "x/b", TagsCount: 0},
 		},
 	}
-	md := FormatRepositoryListMarkdown(out)
-	if !strings.Contains(md, "Repositories (2)") {
-		t.Errorf("expected header with count 2, got:\n%s", md)
-	}
-	if strings.Contains(md, "| ID ") {
-		t.Error("should not contain numeric ID column in list")
-	}
-	for _, want := range []string{"| a |", "| x/a |", "| b |", "| x/b |"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf(fmtExpectedInMarkdown, want, md)
-			}
-		})
+	got := FormatRepositoryListMarkdown(out)
+	want := "## Registry Repositories (2)\n\n" +
+		"| ID | Name | Path | Tags Count |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | a | x/a | 2 |\n" +
+		"| 2 | b | x/b | - |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_get' with repository_id for full details\n"
+	if got != want {
+		t.Errorf("FormatRepositoryListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatRepositoryListMarkdown_Empty verifies the RepositoryListMarkdown_Empty Markdown formatter for a representative repositorylist_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRepositoryListMarkdown_Empty verifies an empty list is the one
+// sentence and nothing else: no heading counting zero above it.
 func TestFormatRepositoryListMarkdown_Empty(t *testing.T) {
-	out := RepositoryListOutput{}
-	md := FormatRepositoryListMarkdown(out)
-	if !strings.Contains(md, "No registry repositories found") {
-		t.Errorf(fmtExpectedEmptyMsg, md)
+	got := FormatRepositoryListMarkdown(RepositoryListOutput{})
+	want := "No registry repositories found.\n"
+	if got != want {
+		t.Errorf("FormatRepositoryListMarkdown() = %q, want %q", got, want)
 	}
 }
 
@@ -660,39 +657,47 @@ func TestFormatRepositoryListMarkdown_Empty(t *testing.T) {
 // FormatTagMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatTagMarkdown_Full verifies the TagMarkdown_Full Markdown formatter for a representative tag_full input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// tagCardHints is the guidance a registry tag card closes with.
+const tagCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'registry_tag_delete' to remove this tag\n"
+
+// TestFormatTagMarkdown_Full verifies the whole card of a fully populated
+// tag, with the digest and revision as code spans and the size carrying its
+// unit.
 func TestFormatTagMarkdown_Full(t *testing.T) {
 	out := TagOutput{
 		Name: "v1.0", Path: "p", Location: "loc",
-		Digest: "sha256:abc", Revision: "rev1",
+		Digest: "sha256:abc", Revision: "rev1", ShortRevision: "rev",
 		TotalSize: 1024, CreatedAt: "2026-02-01T08:00:00Z",
 	}
-	md := FormatTagMarkdown(out)
-	for _, want := range []string{"v1.0", "sha256:abc", "rev1", "1024", "1 Feb 2026"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf(fmtExpectedInMarkdown, want, md)
-			}
-		})
+	got := FormatTagMarkdown(out)
+	want := "## Registry Tag: v1.0\n\n" +
+		"- **Name**: v1.0\n" +
+		"- **Path**: p\n" +
+		"- **Location**: loc\n" +
+		"- **Digest**: `sha256:abc`\n" +
+		"- **Revision**: `rev1`\n" +
+		"- **Short Revision**: `rev`\n" +
+		"- **Total Size**: 1024 bytes\n" +
+		"- **Created At**: 1 Feb 2026 08:00 UTC\n" +
+		tagCardHints
+	if got != want {
+		t.Errorf("FormatTagMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatTagMarkdown_EmptyOptionalFields verifies the TagMarkdown_EmptyOptionalFields Markdown formatter for a representative tag_emptyoptionalfields input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatTagMarkdown_EmptyOptionalFields verifies the card omits every row
+// GitLab did not fill.
 func TestFormatTagMarkdown_EmptyOptionalFields(t *testing.T) {
-	out := TagOutput{Name: "latest", Path: "p", Location: "loc"}
-	md := FormatTagMarkdown(out)
-	if strings.Contains(md, "Digest") {
-		t.Error("should not contain Digest row when empty")
-	}
-	if strings.Contains(md, "Revision") {
-		t.Error("should not contain Revision row when empty")
-	}
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At row when empty")
+	got := FormatTagMarkdown(TagOutput{Name: "latest", Path: "p", Location: "loc"})
+	want := "## Registry Tag: latest\n\n" +
+		"- **Name**: latest\n" +
+		"- **Path**: p\n" +
+		"- **Location**: loc\n" +
+		"- **Total Size**: 0 bytes\n" +
+		tagCardHints
+	if got != want {
+		t.Errorf("FormatTagMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -700,9 +705,8 @@ func TestFormatTagMarkdown_EmptyOptionalFields(t *testing.T) {
 // FormatTagListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatTagListMarkdown_WithItems verifies the TagListMarkdown_WithItems Markdown formatter for a representative taglist_withitems input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatTagListMarkdown_WithItems verifies the whole table, whose size
+// column names its unit in the header rather than showing a bare number.
 func TestFormatTagListMarkdown_WithItems(t *testing.T) {
 	out := TagListOutput{
 		Tags: []TagOutput{
@@ -710,20 +714,27 @@ func TestFormatTagListMarkdown_WithItems(t *testing.T) {
 			{Name: "v2", Path: "p", TotalSize: 200},
 		},
 	}
-	md := FormatTagListMarkdown(out)
-	if !strings.Contains(md, "Tags (2)") {
-		t.Errorf("expected header with count 2, got:\n%s", md)
+	got := FormatTagListMarkdown(out)
+	want := "## Registry Tags (2)\n\n" +
+		"| Name | Path | Total Size (bytes) |\n" +
+		"| --- | --- | --- |\n" +
+		"| v1 | p | 100 |\n" +
+		"| v2 | p | 200 |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_tag_get' with tag name for full details\n" +
+		"- Use action 'registry_tag_delete_bulk' to clean up old tags\n"
+	if got != want {
+		t.Errorf("FormatTagListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatTagListMarkdown_Empty verifies the TagListMarkdown_Empty Markdown formatter for a representative taglist_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatTagListMarkdown_Empty verifies an empty list is the one sentence
+// and nothing else.
 func TestFormatTagListMarkdown_Empty(t *testing.T) {
-	out := TagListOutput{}
-	md := FormatTagListMarkdown(out)
-	if !strings.Contains(md, "No registry tags found") {
-		t.Errorf(fmtExpectedEmptyMsg, md)
+	got := FormatTagListMarkdown(TagListOutput{})
+	want := "No registry tags found.\n"
+	if got != want {
+		t.Errorf("FormatTagListMarkdown() = %q, want %q", got, want)
 	}
 }
 
@@ -731,14 +742,13 @@ func TestFormatTagListMarkdown_Empty(t *testing.T) {
 // FormatProtectionRuleListMarkdown — empty case
 // ---------------------------------------------------------------------------.
 
-// TestFormatProtectionRuleListMarkdown_Empty verifies the ProtectionRuleListMarkdown_Empty Markdown formatter for a representative protectionrulelist_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatProtectionRuleListMarkdown_Empty verifies an empty list is the
+// one sentence and nothing else.
 func TestFormatProtectionRuleListMarkdown_Empty(t *testing.T) {
-	out := ProtectionRuleListOutput{}
-	md := FormatProtectionRuleListMarkdown(out)
-	if !strings.Contains(md, "No protection rules found") {
-		t.Errorf(fmtExpectedEmptyMsg, md)
+	got := FormatProtectionRuleListMarkdown(ProtectionRuleListOutput{})
+	want := "No protection rules found.\n"
+	if got != want {
+		t.Errorf("FormatProtectionRuleListMarkdown() = %q, want %q", got, want)
 	}
 }
 
@@ -1347,66 +1357,62 @@ func registrySpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[string]t
 // Additional formatter tests for TASK-053 improvements
 // ---------------------------------------------------------------------------.
 
-// TestFormatRepositoryMarkdown_FallbackToName verifies the RepositoryMarkdown_FallbackToName Markdown formatter for a representative repository_fallbacktoname input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRepositoryMarkdown_FallbackToName verifies the heading falls back
+// to the repository's name when GitLab sent no path.
 func TestFormatRepositoryMarkdown_FallbackToName(t *testing.T) {
-	out := RepositoryOutput{ID: 1, Name: "my-img", Path: ""}
-	md := FormatRepositoryMarkdown(out)
-	if !strings.Contains(md, "Registry Repository: my-img") {
-		t.Errorf("expected heading with name fallback, got:\n%s", md)
+	got := FormatRepositoryMarkdown(RepositoryOutput{ID: 1, Name: "my-img", Path: ""})
+	want := "## Registry Repository: my-img\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: my-img\n" +
+		repositoryCardHints
+	if got != want {
+		t.Errorf("FormatRepositoryMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatProtectionRuleMarkdown_NoNumericIDs verifies the ProtectionRuleMarkdown_NoNumericIDs Markdown formatter for a representative protectionrule_nonumericids input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatProtectionRuleMarkdown_NoNumericIDs(t *testing.T) {
+// TestFormatProtectionRuleMarkdown_CarriesTheRuleID verifies the whole card of
+// a repository-path protection rule: the pattern in the heading and again as a
+// code span, and the rule id every follow-up action takes.
+func TestFormatProtectionRuleMarkdown_CarriesTheRuleID(t *testing.T) {
 	out := ProtectionRuleOutput{
 		ID: 77, ProjectID: 42,
 		RepositoryPathPattern:       testStagingPattern,
 		MinimumAccessLevelForPush:   "owner",
 		MinimumAccessLevelForDelete: "admin",
 	}
-	md := FormatProtectionRuleMarkdown(out)
-	if !strings.Contains(md, "Protection Rule: staging/*") {
-		t.Errorf("expected heading with pattern, got:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain numeric ID column")
-	}
-	if strings.Contains(md, "| Project ID |") {
-		t.Error("should not contain numeric Project ID column")
-	}
-	for _, want := range []string{testStagingPattern, "owner", "admin"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf(fmtExpectedInMarkdown, want, md)
-			}
-		})
+	got := FormatProtectionRuleMarkdown(out)
+	want := "## Protection Rule: " + testStagingPattern + "\n\n" +
+		"- **ID**: 77\n" +
+		"- **Repository Path Pattern**: `" + testStagingPattern + "`\n" +
+		"- **Min Access Level (Push)**: owner\n" +
+		"- **Min Access Level (Delete)**: admin\n" +
+		protectionRuleCardHints
+	if got != want {
+		t.Errorf("FormatProtectionRuleMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatProtectionRuleListMarkdown_NoNumericIDs verifies the ProtectionRuleListMarkdown_NoNumericIDs Markdown formatter for a representative protectionrulelist_nonumericids input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatProtectionRuleListMarkdown_NoNumericIDs(t *testing.T) {
+// TestFormatProtectionRuleListMarkdown_WithItems verifies the whole table. The
+// ID column is the one registry_rule_update and registry_rule_delete both
+// take, and a list that showed only patterns left a reader with no way to name
+// the rule it had just found.
+func TestFormatProtectionRuleListMarkdown_WithItems(t *testing.T) {
 	out := ProtectionRuleListOutput{
 		Rules: []ProtectionRuleOutput{
 			{ID: 1, RepositoryPathPattern: testProdPattern, MinimumAccessLevelForPush: "maintainer", MinimumAccessLevelForDelete: "admin"},
 			{ID: 2, RepositoryPathPattern: testStagingPattern, MinimumAccessLevelForPush: "owner", MinimumAccessLevelForDelete: "owner"},
 		},
 	}
-	md := FormatProtectionRuleListMarkdown(out)
-	if strings.Contains(md, "| ID ") {
-		t.Error("should not contain numeric ID column in list")
-	}
-	for _, want := range []string{testProdPattern, testStagingPattern, "maintainer", "owner"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf(fmtExpectedInMarkdown, want, md)
-			}
-		})
+	got := FormatProtectionRuleListMarkdown(out)
+	want := "## Protection Rules (2)\n\n" +
+		"| ID | Pattern | Min Push | Min Delete |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | `" + testProdPattern + "` | maintainer | admin |\n" +
+		"| 2 | `" + testStagingPattern + "` | owner | owner |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_rule_create' to add a new rule\n"
+	if got != want {
+		t.Errorf("FormatProtectionRuleListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 

--- a/internal/tools/containerregistry/markdown.go
+++ b/internal/tools/containerregistry/markdown.go
@@ -2,6 +2,7 @@ package containerregistry
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v3"
@@ -9,171 +10,191 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatRepositoryMarkdown formats a single registry repository as markdown.
+// FormatRepositoryMarkdown renders one registry repository as the card of one
+// object.
 func FormatRepositoryMarkdown(out RepositoryOutput) string {
-	heading := out.Path
-	if heading == "" {
-		heading = out.Name
+	name := out.Path
+	if name == "" {
+		name = out.Name
 	}
 	var b strings.Builder
 	// The name, the path and the location a path is built into are the image
 	// name whoever pushed it chose. What holds them to a safe character set is
 	// the OCI reference grammar, which a separate service enforces and this one
 	// neither sees nor models.
-	fmt.Fprintf(&b, "## Registry Repository: %s\n\n", toolutil.EscapeMdHeading(heading))
-	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
-	fmt.Fprintf(&b, "| Path | %s |\n", toolutil.EscapeMdTableCell(out.Path))
-	fmt.Fprintf(&b, "| Location | %s |\n", toolutil.EscapeMdTableCell(out.Location))
-	fmt.Fprintf(&b, "| Tags Count | %d |\n", out.TagsCount)
-	if out.Status != "" {
-		//gitlab:allow-unescaped out.Status: a container repository status, a gl.ContainerRegistryStatus GitLab picks from a fixed set (delete_scheduled, delete_failed, delete_ongoing).
-		fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
-	}
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "| Created At | %s |\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, repositoryHeading(name))
+	c.Int("ID", out.ID)
+	c.Field("Name", out.Name)
+	c.Field("Path", out.Path)
+	c.Field("Location", out.Location)
+	// The tag count is sent only when the caller asked for it, so a zero is
+	// GitLab saying nothing rather than a repository with no tags; Count is
+	// the row that writes nothing for it.
+	c.Count("Tags Count", out.TagsCount)
+	c.Field("Status", string(out.Status))
+	c.Time("Created At", out.CreatedAt)
+	c.End(
 		"Use action 'registry_tag_list' to list tags in this repository",
 		"Use action 'registry_delete' to delete this repository",
 	)
 	return b.String()
 }
 
+// repositoryHeading names the card after the image when GitLab sent a name,
+// and after the resource alone when it did not, so the heading never ends in
+// a colon with nothing behind it.
+func repositoryHeading(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "Registry Repository"
+	}
+	return "Registry Repository: " + name
+}
+
 // FormatRepositoryListMarkdown formats a list of registry repositories.
 func FormatRepositoryListMarkdown(out RepositoryListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Registry Repositories (%d)\n\n", len(out.Repositories))
-	toolutil.WriteListSummary(&b, len(out.Repositories), out.Pagination)
 	if len(out.Repositories) == 0 {
-		b.WriteString("No registry repositories found.\n")
-		toolutil.WritePagination(&b, out.Pagination)
-		return b.String()
+		return toolutil.EmptyMessage("registry repositories")
 	}
-	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Tags Count"))
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Registry Repositories", len(out.Repositories), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Path", "Tags Count"))
 	for _, r := range out.Repositories {
-		fmt.Fprintf(&b, "| %s | %s | %d |\n",
-			toolutil.EscapeMdTableCell(r.Name), toolutil.EscapeMdTableCell(r.Path), r.TagsCount)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.EscapeMdTableCell(r.Name),
+			toolutil.EscapeMdTableCell(r.Path),
+			countCell(r.TagsCount),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'registry_get' with repository_id for full details",
-	)
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		"Use action 'registry_get' with repository_id for full details")
 	return b.String()
 }
 
-// FormatTagMarkdown formats a single registry tag as markdown.
+// countCell renders a count GitLab sends only when it was asked for: a dash
+// says nothing was reported, where a bare 0 would claim the repository has no
+// tags. Distinguishing an absent count from a real zero needs the field to be
+// optional in the output type, which is a surface change this does not make.
+func countCell(count int64) string {
+	if count == 0 {
+		return "-"
+	}
+	return strconv.FormatInt(count, 10)
+}
+
+// FormatTagMarkdown renders one registry tag as the card of one object.
 func FormatTagMarkdown(out TagOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Registry Tag: %s\n\n", toolutil.EscapeMdHeading(out.Name))
-	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
-	fmt.Fprintf(&b, "| Path | %s |\n", toolutil.EscapeMdTableCell(out.Path))
-	fmt.Fprintf(&b, "| Location | %s |\n", toolutil.EscapeMdTableCell(out.Location))
-	if out.Digest != "" {
-		//gitlab:allow-unescaped out.Digest: an image manifest digest, an algorithm name and hexadecimal digits.
-		fmt.Fprintf(&b, "| Digest | %s |\n", out.Digest)
-	}
-	if out.Revision != "" {
-		//gitlab:allow-unescaped out.Revision: an image revision, hexadecimal digits only.
-		fmt.Fprintf(&b, "| Revision | %s |\n", out.Revision)
-	}
-	fmt.Fprintf(&b, "| Total Size | %d |\n", out.TotalSize)
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "| Created At | %s |\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'registry_tag_delete' to remove this tag",
-	)
+	c := toolutil.NewCard(&b, tagHeading(out.Name))
+	c.Field("Name", out.Name)
+	c.Field("Path", out.Path)
+	c.Field("Location", out.Location)
+	// The digest and the revision are values a reader copies character by
+	// character, so each is a code span sized to its content.
+	c.Code("Digest", out.Digest)
+	c.Code("Revision", out.Revision)
+	c.Code("Short Revision", out.ShortRevision)
+	c.Field("Total Size", fmt.Sprintf("%d bytes", out.TotalSize))
+	c.Time("Created At", out.CreatedAt)
+	c.End("Use action 'registry_tag_delete' to remove this tag")
 	return b.String()
+}
+
+// tagHeading names the card after the tag when GitLab sent a name, and after
+// the resource alone when it did not.
+func tagHeading(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "Registry Tag"
+	}
+	return "Registry Tag: " + name
 }
 
 // FormatTagListMarkdown formats a list of registry tags.
 func FormatTagListMarkdown(out TagListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Registry Tags (%d)\n\n", len(out.Tags))
-	toolutil.WriteListSummary(&b, len(out.Tags), out.Pagination)
 	if len(out.Tags) == 0 {
-		b.WriteString("No registry tags found.\n")
-		toolutil.WritePagination(&b, out.Pagination)
-		return b.String()
+		return toolutil.EmptyMessage("registry tags")
 	}
-	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Total Size"))
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Registry Tags", len(out.Tags), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Total Size (bytes)"))
 	for _, t := range out.Tags {
-		fmt.Fprintf(&b, "| %s | %s | %d |\n",
-			toolutil.EscapeMdTableCell(t.Name), toolutil.EscapeMdTableCell(t.Path), t.TotalSize)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(t.Name),
+			toolutil.EscapeMdTableCell(t.Path),
+			strconv.FormatInt(t.TotalSize, 10),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
+	toolutil.WriteListFooter(&b, out.Pagination, false,
 		"Use action 'registry_tag_get' with tag name for full details",
-		"Use action 'registry_tag_delete_bulk' to clean up old tags",
-	)
+		"Use action 'registry_tag_delete_bulk' to clean up old tags")
 	return b.String()
 }
 
-// FormatProtectionRuleMarkdown formats a single protection rule as markdown.
+// FormatProtectionRuleMarkdown renders one repository-path protection rule as
+// the card of one object.
 func FormatProtectionRuleMarkdown(out ProtectionRuleOutput) string {
 	var b strings.Builder
 	// The pattern is free text this server's own registry_rule_create and
 	// registry_rule_update pass through with no validation of their own.
-	fmt.Fprintf(&b, "## Protection Rule: %s\n\n", toolutil.EscapeMdHeading(out.RepositoryPathPattern))
-	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Repository Path Pattern | %s |\n", toolutil.EscapeMdTableCell(out.RepositoryPathPattern))
-	//gitlab:allow-unescaped out.MinimumAccessLevelForPush: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
-	fmt.Fprintf(&b, "| Min Access Level (Push) | %s |\n", out.MinimumAccessLevelForPush)
-	//gitlab:allow-unescaped out.MinimumAccessLevelForDelete: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
-	fmt.Fprintf(&b, "| Min Access Level (Delete) | %s |\n", out.MinimumAccessLevelForDelete)
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, protectionRuleHeading("Protection Rule", out.RepositoryPathPattern))
+	c.Int("ID", out.ID)
+	c.Code("Repository Path Pattern", out.RepositoryPathPattern)
+	c.Field("Min Access Level (Push)", string(out.MinimumAccessLevelForPush))
+	c.Field("Min Access Level (Delete)", string(out.MinimumAccessLevelForDelete))
+	c.End(
 		"Use action 'registry_rule_update' to modify access levels",
 		"Use action 'registry_rule_delete' to remove this rule",
 	)
 	return b.String()
 }
 
+// protectionRuleHeading names a rule card after the pattern it matches, and
+// after the resource alone when GitLab sent none.
+func protectionRuleHeading(resource, pattern string) string {
+	if strings.TrimSpace(pattern) == "" {
+		return resource
+	}
+	return resource + ": " + pattern
+}
+
 // FormatProtectionRuleListMarkdown formats a list of protection rules.
+//
+// GitLab sends no pagination headers for this endpoint, so the heading counts
+// what is shown rather than a total nobody reported.
 func FormatProtectionRuleListMarkdown(out ProtectionRuleListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Protection Rules (%d)\n\n", len(out.Rules))
-	toolutil.WriteListSummary(&b, len(out.Rules), out.Pagination)
 	if len(out.Rules) == 0 {
-		b.WriteString("No protection rules found.\n")
-		toolutil.WritePagination(&b, out.Pagination)
-		return b.String()
+		return toolutil.EmptyMessage("protection rules")
 	}
-	b.WriteString(toolutil.MarkdownTableHeader("Pattern", "Min Push", "Min Delete"))
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Protection Rules", len(out.Rules), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Pattern", "Min Push", "Min Delete"))
 	for _, r := range out.Rules {
-		fmt.Fprintf(&b, "| %s | %s | %s |\n",
-			//gitlab:allow-unescaped r.MinimumAccessLevelForPush: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
-			//gitlab:allow-unescaped r.MinimumAccessLevelForDelete: a protection rule access level, a gl.ProtectionRuleAccessLevel GitLab picks from a fixed set (maintainer, owner, admin).
-			toolutil.EscapeMdTableCell(r.RepositoryPathPattern), r.MinimumAccessLevelForPush, r.MinimumAccessLevelForDelete)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.MdCodeSpanCell(r.RepositoryPathPattern),
+			toolutil.EscapeMdTableCell(string(r.MinimumAccessLevelForPush)),
+			toolutil.EscapeMdTableCell(string(r.MinimumAccessLevelForDelete)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'registry_rule_create' to add a new rule",
-	)
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		"Use action 'registry_rule_create' to add a new rule")
 	return b.String()
 }
 
-// FormatTagProtectionRuleMarkdown formats a single tag protection rule as markdown.
+// FormatTagProtectionRuleMarkdown renders one tag protection rule as the card
+// of one object.
 func FormatTagProtectionRuleMarkdown(out TagProtectionRuleOutput) string {
 	var b strings.Builder
 	// An RE2 pattern a person types, where '|' is ordinary alternation, so
 	// "v.+|latest" would end the heading's own line without it.
-	fmt.Fprintf(&b, "## Tag Protection Rule: %s\n\n", toolutil.EscapeMdHeading(out.TagNamePattern))
-	fmt.Fprint(&b, toolutil.TblFieldValue)
-	fmt.Fprintf(&b, "| Tag Name Pattern | %s |\n", toolutil.EscapeMdTableCell(out.TagNamePattern))
-	//gitlab:allow-unescaped protectionAccessLabel(out.MinimumAccessLevelForPush): the same access level through a helper whose only other result is the constant "immutable".
-	fmt.Fprintf(&b, "| Min Access Level (Push) | %s |\n", protectionAccessLabel(out.MinimumAccessLevelForPush))
-	//gitlab:allow-unescaped protectionAccessLabel(out.MinimumAccessLevelForDelete): the same access level through a helper whose only other result is the constant "immutable".
-	fmt.Fprintf(&b, "| Min Access Level (Delete) | %s |\n", protectionAccessLabel(out.MinimumAccessLevelForDelete))
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, protectionRuleHeading("Tag Protection Rule", out.TagNamePattern))
+	c.Int("ID", out.ID)
+	c.Code("Tag Name Pattern", out.TagNamePattern)
+	c.Field("Min Access Level (Push)", protectionAccessLabel(out.MinimumAccessLevelForPush))
+	c.Field("Min Access Level (Delete)", protectionAccessLabel(out.MinimumAccessLevelForDelete))
+	c.End(
 		"Use action 'registry_tag_rule_update' to modify access levels",
 		"Use action 'registry_tag_rule_delete' to remove this rule",
 	)
@@ -182,27 +203,23 @@ func FormatTagProtectionRuleMarkdown(out TagProtectionRuleOutput) string {
 
 // FormatTagProtectionRuleListMarkdown formats a list of tag protection rules.
 func FormatTagProtectionRuleListMarkdown(out TagProtectionRuleListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Tag Protection Rules (%d)\n\n", len(out.Rules))
-	toolutil.WriteListSummary(&b, len(out.Rules), out.Pagination)
 	if len(out.Rules) == 0 {
-		b.WriteString("No tag protection rules found.\n")
-		toolutil.WritePagination(&b, out.Pagination)
-		return b.String()
+		return toolutil.EmptyMessage("tag protection rules")
 	}
-	b.WriteString(toolutil.MarkdownTableHeader("Tag Pattern", "Min Push", "Min Delete"))
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Tag Protection Rules", len(out.Rules), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Tag Pattern", "Min Push", "Min Delete"))
 	for _, r := range out.Rules {
-		fmt.Fprintf(&b, "| %s | %s | %s |\n",
-			//gitlab:allow-unescaped protectionAccessLabel(r.MinimumAccessLevelForPush): the same access level through a helper whose only other result is the constant "immutable".
-			//gitlab:allow-unescaped protectionAccessLabel(r.MinimumAccessLevelForDelete): the same access level through a helper whose only other result is the constant "immutable".
-			toolutil.EscapeMdTableCell(r.TagNamePattern), protectionAccessLabel(r.MinimumAccessLevelForPush), protectionAccessLabel(r.MinimumAccessLevelForDelete))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.MdCodeSpanCell(r.TagNamePattern),
+			toolutil.EscapeMdTableCell(protectionAccessLabel(r.MinimumAccessLevelForPush)),
+			toolutil.EscapeMdTableCell(protectionAccessLabel(r.MinimumAccessLevelForDelete)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
+	toolutil.WriteListFooter(&b, out.Pagination, false,
 		"Use action 'registry_tag_rule_create' to add a new rule",
-		"These rules protect image *tags*; use action 'registry_rule_list' for repository-path protection rules",
-	)
+		"These rules protect image *tags*; use action 'registry_rule_list' for repository-path protection rules")
 	return b.String()
 }
 

--- a/internal/tools/containerregistry/protection_rules_test.go
+++ b/internal/tools/containerregistry/protection_rules_test.go
@@ -220,9 +220,14 @@ func TestDeleteProtectionRule_MissingRuleID(t *testing.T) {
 // Markdown formatters
 // ---------------------------------------------------------------------------.
 
-// TestFormatProtectionRuleMarkdown verifies the ProtectionRuleMarkdown Markdown formatter for a representative protectionrule input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// protectionRuleCardHints is the guidance a repository-path protection rule
+// card closes with.
+const protectionRuleCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'registry_rule_update' to modify access levels\n" +
+	"- Use action 'registry_rule_delete' to remove this rule\n"
+
+// TestFormatProtectionRuleMarkdown verifies the whole card of a
+// repository-path protection rule.
 func TestFormatProtectionRuleMarkdown(t *testing.T) {
 	out := ProtectionRuleOutput{
 		ID: 1, ProjectID: 10,
@@ -230,23 +235,34 @@ func TestFormatProtectionRuleMarkdown(t *testing.T) {
 		MinimumAccessLevelForPush:   "maintainer",
 		MinimumAccessLevelForDelete: "admin",
 	}
-	md := FormatProtectionRuleMarkdown(out)
-	if !strings.Contains(md, testProdPattern) {
-		t.Errorf("expected pattern in markdown, got: %s", md)
+	got := FormatProtectionRuleMarkdown(out)
+	want := "## Protection Rule: " + testProdPattern + "\n\n" +
+		"- **ID**: 1\n" +
+		"- **Repository Path Pattern**: `" + testProdPattern + "`\n" +
+		"- **Min Access Level (Push)**: maintainer\n" +
+		"- **Min Access Level (Delete)**: admin\n" +
+		protectionRuleCardHints
+	if got != want {
+		t.Errorf("FormatProtectionRuleMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatProtectionRuleListMarkdown verifies the ProtectionRuleListMarkdown Markdown formatter for a representative protectionrulelist input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatProtectionRuleListMarkdown verifies the whole table for a
+// single-rule list.
 func TestFormatProtectionRuleListMarkdown(t *testing.T) {
 	out := ProtectionRuleListOutput{
 		Rules: []ProtectionRuleOutput{
 			{ID: 1, RepositoryPathPattern: testProdPattern, MinimumAccessLevelForPush: "maintainer", MinimumAccessLevelForDelete: "admin"},
 		},
 	}
-	md := FormatProtectionRuleListMarkdown(out)
-	if !strings.Contains(md, testProdPattern) {
-		t.Errorf("expected pattern in markdown, got: %s", md)
+	got := FormatProtectionRuleListMarkdown(out)
+	want := "## Protection Rules (1)\n\n" +
+		"| ID | Pattern | Min Push | Min Delete |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | `" + testProdPattern + "` | maintainer | admin |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_rule_create' to add a new rule\n"
+	if got != want {
+		t.Errorf("FormatProtectionRuleListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }

--- a/internal/tools/containerregistry/tag_protection_rules_test.go
+++ b/internal/tools/containerregistry/tag_protection_rules_test.go
@@ -245,9 +245,20 @@ func TestDeleteTagProtectionRule_MissingRuleID(t *testing.T) {
 // Markdown formatters
 // ---------------------------------------------------------------------------.
 
-// TestFormatTagProtectionRuleMarkdown verifies the TagProtectionRuleMarkdown formatter for a representative input.
-// The test exercises rendering of a single tag protection rule.
-// It asserts the rendered Markdown contains the tag pattern.
+// tagRuleCardHints is the guidance a tag protection rule card closes with,
+// and tagRuleListHints the guidance the list closes with.
+const (
+	tagRuleCardHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_tag_rule_update' to modify access levels\n" +
+		"- Use action 'registry_tag_rule_delete' to remove this rule\n"
+	tagRuleListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'registry_tag_rule_create' to add a new rule\n" +
+		"- These rules protect image *tags*; use action 'registry_rule_list' for repository-path protection rules\n"
+)
+
+// TestFormatTagProtectionRuleMarkdown verifies the whole card of a tag
+// protection rule. The pattern is an RE2 expression a person types, so it is
+// a code span rather than an escaped cell: '|' is ordinary alternation there.
 func TestFormatTagProtectionRuleMarkdown(t *testing.T) {
 	out := TagProtectionRuleOutput{
 		ID: 1, ProjectID: 10,
@@ -255,45 +266,60 @@ func TestFormatTagProtectionRuleMarkdown(t *testing.T) {
 		MinimumAccessLevelForPush:   "maintainer",
 		MinimumAccessLevelForDelete: "admin",
 	}
-	md := FormatTagProtectionRuleMarkdown(out)
-	if !strings.Contains(md, "v.+") {
-		t.Errorf("expected pattern in markdown, got: %s", md)
+	got := FormatTagProtectionRuleMarkdown(out)
+	want := "## Tag Protection Rule: v.+\n\n" +
+		"- **ID**: 1\n" +
+		"- **Tag Name Pattern**: `v.+`\n" +
+		"- **Min Access Level (Push)**: maintainer\n" +
+		"- **Min Access Level (Delete)**: admin\n" +
+		tagRuleCardHints
+	if got != want {
+		t.Errorf("FormatTagProtectionRuleMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatTagProtectionRuleMarkdown_Immutable verifies that an empty access level renders as "immutable".
-// The test exercises the protectionAccessLabel helper through the formatter.
-// It asserts the rendered Markdown surfaces the immutable label.
+// TestFormatTagProtectionRuleMarkdown_Immutable verifies that an empty access
+// level renders as "immutable", which is how the API expresses a rule that
+// forbids push and delete for everyone.
 func TestFormatTagProtectionRuleMarkdown_Immutable(t *testing.T) {
-	out := TagProtectionRuleOutput{ID: 1, ProjectID: 10, TagNamePattern: "prod-.+"}
-	md := FormatTagProtectionRuleMarkdown(out)
-	if !strings.Contains(md, "immutable") {
-		t.Errorf("expected immutable label in markdown, got: %s", md)
+	got := FormatTagProtectionRuleMarkdown(TagProtectionRuleOutput{ID: 1, ProjectID: 10, TagNamePattern: "prod-.+"})
+	want := "## Tag Protection Rule: prod-.+\n\n" +
+		"- **ID**: 1\n" +
+		"- **Tag Name Pattern**: `prod-.+`\n" +
+		"- **Min Access Level (Push)**: immutable\n" +
+		"- **Min Access Level (Delete)**: immutable\n" +
+		tagRuleCardHints
+	if got != want {
+		t.Errorf("FormatTagProtectionRuleMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatTagProtectionRuleListMarkdown verifies the TagProtectionRuleListMarkdown formatter for a representative input.
-// The test exercises rendering of a populated rule list.
-// It asserts the rendered Markdown contains the tag pattern.
+// TestFormatTagProtectionRuleListMarkdown verifies the whole table for a
+// populated rule list.
 func TestFormatTagProtectionRuleListMarkdown(t *testing.T) {
 	out := TagProtectionRuleListOutput{
 		Rules: []TagProtectionRuleOutput{
 			{ID: 1, TagNamePattern: "v.+", MinimumAccessLevelForPush: "maintainer", MinimumAccessLevelForDelete: "admin"},
 		},
 	}
-	md := FormatTagProtectionRuleListMarkdown(out)
-	if !strings.Contains(md, "v.+") {
-		t.Errorf("expected pattern in markdown, got: %s", md)
+	got := FormatTagProtectionRuleListMarkdown(out)
+	want := "## Tag Protection Rules (1)\n\n" +
+		"| ID | Tag Pattern | Min Push | Min Delete |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | `v.+` | maintainer | admin |\n" +
+		tagRuleListHints
+	if got != want {
+		t.Errorf("FormatTagProtectionRuleListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatTagProtectionRuleListMarkdown_Empty verifies that the list formatter handles the empty state.
-// The test exercises rendering of an empty rule list.
-// It asserts the rendered Markdown shows the empty-state message.
+// TestFormatTagProtectionRuleListMarkdown_Empty verifies an empty list is the
+// one sentence and nothing else.
 func TestFormatTagProtectionRuleListMarkdown_Empty(t *testing.T) {
-	md := FormatTagProtectionRuleListMarkdown(TagProtectionRuleListOutput{})
-	if !strings.Contains(md, "No tag protection rules found") {
-		t.Errorf("expected empty-state message, got: %s", md)
+	got := FormatTagProtectionRuleListMarkdown(TagProtectionRuleListOutput{})
+	want := "No tag protection rules found.\n"
+	if got != want {
+		t.Errorf("FormatTagProtectionRuleListMarkdown() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/tools/dependencies/dependencies_test.go
+++ b/internal/tools/dependencies/dependencies_test.go
@@ -548,23 +548,32 @@ func paginationInput(page, perPage int) toolutil.PaginationInput {
 
 // --- Markdown Formatter Tests ---
 
+// depListHeader is the dependency table's header and delimiter rows, and
+// depListHints the guidance the list closes with.
+const (
+	depListHeader = "| Name | Version | Package Manager | Vulns | Licenses | Malware |\n" +
+		"| --- | --- | --- | --- | --- | --- |\n"
+	depListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use `gitlab_create_dependency_list_export` to export the whole list as a CycloneDX SBOM\n"
+)
+
 // TestFormatListMarkdown validates Markdown rendering for dependency lists,
-// covering empty lists, single items, and multiple items with vulnerabilities/licenses.
+// covering empty lists, single items, multiple items with
+// vulnerabilities/licenses, and the three answers the malware column carries.
+//
+// Every case pins the whole response: the heading, the table, the pagination
+// footer and the guidance are one document, and a substring assertion cannot
+// see a row that landed outside the table it belongs to.
 func TestFormatListMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
-		excludes []string
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
 			name:  "renders empty list",
 			input: ListOutput{},
-			contains: []string{
-				"## Project Dependencies",
-				"No dependencies found.",
-			},
-			excludes: []string{"| Name |"},
+			want:  "No dependencies found.\n",
 		},
 		{
 			name: "renders single dependency without vulns or licenses",
@@ -573,10 +582,8 @@ func TestFormatListMarkdown(t *testing.T) {
 					{Name: "lodash", Version: "4.17.21", PackageManager: "npm", DependencyFilePath: "package-lock.json"},
 				},
 			},
-			contains: []string{
-				"| Name | Version | Package Manager | Vulns | Licenses |",
-				"| lodash | 4.17.21 | npm | 0 | 0 |",
-			},
+			want: "## Project Dependencies (1)\n\n" + depListHeader +
+				"| lodash | 4.17.21 | npm | 0 | 0 | - |\n" + depListHints,
 		},
 		{
 			name: "renders dependency with vulnerabilities and licenses",
@@ -587,40 +594,44 @@ func TestFormatListMarkdown(t *testing.T) {
 						DependencyFilePath: "Gemfile.lock",
 						Vulnerabilities:    []VulnerabilityOutput{{Name: "CVE-1", Severity: "high", ID: 1}},
 						Licenses:           []LicenseOutput{{Name: "MIT", URL: "https://mit.example.com"}},
+						Malware:            new(false),
 					},
 				},
 			},
-			contains: []string{
-				"| rails | 7.0.4 | bundler | 1 | 1 |",
-			},
+			want: "## Project Dependencies (1)\n\n" + depListHeader +
+				"| rails | 7.0.4 | bundler | 1 | 1 | " + toolutil.EmojiSuccess + " clear |\n" + depListHints,
 		},
 		{
-			name: "renders multiple dependencies",
+			name: "renders a malware detection with the warning sign, never a tick",
+			input: ListOutput{
+				Dependencies: []Output{
+					{Name: "evil", Version: "1.0.0", PackageManager: "npm", Malware: new(true)},
+				},
+			},
+			want: "## Project Dependencies (1)\n\n" + depListHeader +
+				"| evil | 1.0.0 | npm | 0 | 0 | " + toolutil.EmojiWarning + " detected |\n" + depListHints,
+		},
+		{
+			name: "renders multiple dependencies with the total GitLab sent",
 			input: ListOutput{
 				Dependencies: []Output{
 					{Name: "react", Version: "18.2.0", PackageManager: "npm"},
 					{Name: "vue", Version: "3.3.0", PackageManager: "npm"},
 				},
+				Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 2, TotalItems: 45, TotalPages: 23, HasMore: true, NextPage: 2},
 			},
-			contains: []string{
-				"| react |",
-				"| vue |",
-			},
+			want: "## Project Dependencies (45)\n\n" +
+				"Showing 2 of 45 results (page 1 of 23)\n\n" + depListHeader +
+				"| react | 18.2.0 | npm | 0 | 0 | - |\n" +
+				"| vue | 3.3.0 | npm | 0 | 0 | - |\n" +
+				"\nPage 1 of 23 | 45 items total | 2 per page\n" + depListHints,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
-			}
-			for _, s := range tt.excludes {
-				if strings.Contains(got, s) {
-					t.Errorf("output should not contain %q\ngot:\n%s", s, got)
-				}
+			if got := FormatListMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
@@ -630,52 +641,46 @@ func TestFormatListMarkdown(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatExportMarkdown(t *testing.T) {
+	const (
+		heading = "## Dependency List Export\n\n"
+		hints   = "\n---\n💡 **Next steps:**\n" +
+			"- Use `gitlab_download_dependency_list_export` once the export has finished\n"
+	)
 	tests := []struct {
-		name     string
-		input    ExportOutput
-		contains []string
-		excludes []string
+		name  string
+		input ExportOutput
+		want  string
 	}{
 		{
 			name:  "renders finished export with download URL",
 			input: ExportOutput{ID: 1, HasFinished: true, Self: "https://example.com/self", Download: "https://example.com/download"},
-			contains: []string{
-				"## Dependency List Export",
-				"| ID | 1 |",
-				"| Self | https://example.com/self |",
-				"| Download | https://example.com/download |",
-			},
+			want: heading +
+				"- **ID**: 1\n" +
+				"- **Finished**: " + toolutil.BoolEmoji(true) + "\n" +
+				"- **Self**: https://example.com/self\n" +
+				"- **Download**: https://example.com/download\n" + hints,
 		},
 		{
 			name:  "renders unfinished export without download URL",
 			input: ExportOutput{ID: 2, HasFinished: false, Self: "https://example.com/self"},
-			contains: []string{
-				"| ID | 2 |",
-			},
-			excludes: []string{"| Download |"},
+			want: heading +
+				"- **ID**: 2\n" +
+				"- **Finished**: " + toolutil.BoolEmoji(false) + "\n" +
+				"- **Self**: https://example.com/self\n" + hints,
 		},
 		{
 			name:  "renders export without self or download URLs",
 			input: ExportOutput{ID: 3, HasFinished: false},
-			excludes: []string{
-				"| Self |",
-				"| Download |",
-			},
+			want: heading +
+				"- **ID**: 3\n" +
+				"- **Finished**: " + toolutil.BoolEmoji(false) + "\n" + hints,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatExportMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
-			}
-			for _, s := range tt.excludes {
-				if strings.Contains(got, s) {
-					t.Errorf("output should not contain %q\ngot:\n%s", s, got)
-				}
+			if got := FormatExportMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatExportMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
@@ -686,37 +691,28 @@ func TestFormatExportMarkdown(t *testing.T) {
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatDownloadMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    DownloadOutput
-		contains []string
+		name  string
+		input DownloadOutput
+		want  string
 	}{
 		{
 			name:  "renders SBOM content in JSON code block",
 			input: DownloadOutput{Content: `{"bomFormat":"CycloneDX"}`},
-			contains: []string{
-				"## Dependency List Export (CycloneDX SBOM)",
-				"```json",
-				`{"bomFormat":"CycloneDX"}`,
-				"```",
-			},
+			want: "## Dependency List Export (CycloneDX SBOM)\n\n" +
+				"```json\n" + `{"bomFormat":"CycloneDX"}` + "\n```\n",
 		},
 		{
-			name:  "renders empty content",
+			name:  "an export with no content says so rather than opening an empty fence",
 			input: DownloadOutput{Content: ""},
-			contains: []string{
-				"```json",
-				"```",
-			},
+			want: "## Dependency List Export (CycloneDX SBOM)\n\n" +
+				"GitLab returned no SBOM content for this export.\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatDownloadMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
+			if got := FormatDownloadMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatDownloadMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/dependencies/markdown.go
+++ b/internal/tools/dependencies/markdown.go
@@ -1,64 +1,82 @@
 package dependencies
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown renders a paginated list of dependencies as Markdown.
+// FormatListMarkdown renders a paginated list of dependencies as a Markdown
+// table.
 func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	sb.WriteString("## Project Dependencies\n\n")
 	if len(out.Dependencies) == 0 {
-		sb.WriteString("No dependencies found.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("dependencies")
 	}
-	sb.WriteString("| Name | Version | Package Manager | Vulns | Licenses |\n")
-	sb.WriteString("|------|---------|-----------------|-------|----------|\n")
+	var sb strings.Builder
+	toolutil.WriteListHeading(&sb, "Project Dependencies", len(out.Dependencies), out.Pagination)
+	sb.WriteString(toolutil.MarkdownTableHeader("Name", "Version", "Package Manager", "Vulns", "Licenses", "Malware"))
 	for _, d := range out.Dependencies {
-		fmt.Fprintf(
-			&sb, "| %s | %s | %s | %d | %d |\n",
+		sb.WriteString(toolutil.MarkdownTableRow(
 			toolutil.EscapeMdTableCell(d.Name),
 			toolutil.EscapeMdTableCell(d.Version),
-			//gitlab:allow-unescaped d.PackageManager: a package manager GitLab names from the scanner it ran (bundler, npm, maven and the rest).
-			d.PackageManager,
-			len(d.Vulnerabilities),
-			len(d.Licenses),
-		)
+			toolutil.EscapeMdTableCell(d.PackageManager),
+			strconv.Itoa(len(d.Vulnerabilities)),
+			strconv.Itoa(len(d.Licenses)),
+			malwareCell(d.Malware),
+		))
 	}
-	toolutil.WriteListSummary(&sb, len(out.Dependencies), out.Pagination)
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&sb, out.Pagination, false,
+		"Use `gitlab_create_dependency_list_export` to export the whole list as a CycloneDX SBOM")
 	return sb.String()
 }
 
-// FormatExportMarkdown renders a dependency list export status as Markdown.
+// malwareCell renders the three answers GitLab gives about malware, and never
+// as a bare tick: [toolutil.BoolEmoji] maps true to a tick, which under the
+// heading "Malware" reads as "this package is fine". A detection therefore
+// carries the warning sign, a cleared package the tick, and a package no scan
+// covered a dash, since an absent flag means the scan did not run rather than
+// that the package is clean.
+func malwareCell(malware *bool) string {
+	switch {
+	case malware == nil:
+		return "-"
+	case *malware:
+		return toolutil.EmojiWarning + " detected"
+	default:
+		return toolutil.EmojiSuccess + " clear"
+	}
+}
+
+// FormatExportMarkdown renders a dependency list export status as the card of
+// one object.
 func FormatExportMarkdown(e ExportOutput) string {
 	var sb strings.Builder
-	sb.WriteString("## Dependency List Export\n\n")
-	sb.WriteString("| Field | Value |\n|-------|-------|\n")
-	fmt.Fprintf(&sb, "| ID | %d |\n", e.ID)
-	fmt.Fprintf(&sb, "| Finished | %s |\n", toolutil.BoolEmoji(e.HasFinished))
-	if e.Self != "" {
-		fmt.Fprintf(&sb, "| Self | %s |\n", toolutil.EscapeMdTableCell(e.Self))
-	}
-	if e.Download != "" {
-		fmt.Fprintf(&sb, "| Download | %s |\n", toolutil.EscapeMdTableCell(e.Download))
-	}
+	c := toolutil.NewCard(&sb, "Dependency List Export")
+	c.Int("ID", e.ID)
+	c.Bool("Finished", e.HasFinished)
+	c.Field("Self", e.Self)
+	c.Field("Download", e.Download)
+	c.End("Use `gitlab_download_dependency_list_export` once the export has finished")
 	return sb.String()
 }
 
 // FormatDownloadMarkdown renders the downloaded SBOM content as Markdown.
 func FormatDownloadMarkdown(d DownloadOutput) string {
 	var sb strings.Builder
-	sb.WriteString("## Dependency List Export (CycloneDX SBOM)\n\n")
+	c := toolutil.NewCard(&sb, "Dependency List Export (CycloneDX SBOM)")
 	// The SBOM names every component of the project, and those names come out
 	// of the project's own dependency files. JSON escaping leaves a backtick
 	// alone, so a dependency named with a run of three would close a
 	// three-backtick fence and put the rest of the document at the top level of
-	// the response.
-	sb.WriteString(toolutil.MarkdownFencedBlock("json", d.Content))
+	// the response; the card sizes the fence to the body.
+	if strings.TrimSpace(d.Content) == "" {
+		c.Note("GitLab returned no SBOM content for this export.")
+		return sb.String()
+	}
+	c.Fence("", "json", d.Content)
 	return sb.String()
 }
 

--- a/internal/tools/dependencyfirewall/markdown.go
+++ b/internal/tools/dependencyfirewall/markdown.go
@@ -1,7 +1,6 @@
 package dependencyfirewall
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -41,33 +40,40 @@ func init() {
 // assurance nobody made.
 func FormatEvaluatePackageMarkdown(out EvaluatePackageOutput) string {
 	var b strings.Builder
-	b.WriteString("## Dependency Firewall Evaluation\n\n")
+	c := toolutil.NewCard(&b, "Dependency Firewall Evaluation")
 
+	// The three documented outcomes are rendered as composed rows: the glyph
+	// and the parenthetical are the server's own words beside a word GitLab
+	// chose, and the word is one of the three constants above. An outcome the
+	// documentation does not list is written through the escaping row, since
+	// it is a value GitLab sent and nothing here constrains it.
 	switch strings.ToLower(out.Outcome) {
 	case outcomeAllowed:
-		fmt.Fprintf(&b, "- Outcome: %s **allowed** (no policy rule matched the package)\n", toolutil.EmojiSuccess)
+		c.Markdown("Outcome", toolutil.EmojiSuccess+" **allowed** (no policy rule matched the package)")
 	case outcomeWarned:
-		fmt.Fprintf(&b, "- Outcome: %s **warned** (a policy rule matched and the policy is in warn mode)\n", toolutil.EmojiWarning)
+		c.Markdown("Outcome", toolutil.EmojiWarning+" **warned** (a policy rule matched and the policy is in warn mode)")
 	case outcomeBlocked:
-		fmt.Fprintf(&b, "- Outcome: %s **blocked** (a policy rule matched and the policy is in enforce mode)\n", toolutil.EmojiCross)
+		c.Markdown("Outcome", toolutil.EmojiCross+" **blocked** (a policy rule matched and the policy is in enforce mode)")
 	case "":
-		b.WriteString("- Outcome: not reported\n")
+		c.Field("Outcome", "not reported")
 	default:
-		fmt.Fprintf(&b, "- Outcome: %s\n", toolutil.EscapeMdTableCell(out.Outcome))
+		c.Field("Outcome", out.Outcome)
 	}
 
-	if out.Reason != nil && strings.TrimSpace(*out.Reason) != "" {
-		fmt.Fprintf(&b, "- Reason: %s\n", toolutil.EscapeMdTableCell(*out.Reason))
+	if out.Reason != nil {
+		c.Field("Reason", *out.Reason)
 	}
 
 	switch strings.ToLower(out.Outcome) {
 	case outcomeWarned, outcomeBlocked:
-		toolutil.WriteHints(&b,
+		c.End(
 			"The reason names the policy that matched. Read it with the project's security policy configuration before overriding anything",
-			"An allowed alternative version can be found by evaluating other versions of the same package")
+			"An allowed alternative version can be found by evaluating other versions of the same package",
+		)
 	default:
-		toolutil.WriteHints(&b,
-			"An allowed outcome means no policy rule matched, not that GitLab holds vulnerability or license data for the package")
+		c.End(
+			"An allowed outcome means no policy rule matched, not that GitLab holds vulnerability or license data for the package",
+		)
 	}
 	return b.String()
 }

--- a/internal/tools/dependencyfirewall/markdown_test.go
+++ b/internal/tools/dependencyfirewall/markdown_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// hintsAllowed is the guidance an allowed, empty or unrecognized outcome
+// closes with, and hintsMatched the guidance a warned or blocked one does.
+const (
+	hintsAllowed = "\n---\n💡 **Next steps:**\n" +
+		"- An allowed outcome means no policy rule matched, not that GitLab holds vulnerability or license data for the package\n"
+	hintsMatched = "\n---\n💡 **Next steps:**\n" +
+		"- The reason names the policy that matched. Read it with the project's security policy configuration before overriding anything\n" +
+		"- An allowed alternative version can be found by evaluating other versions of the same package\n"
+)
+
 // resultText concatenates the text content of a tool result.
 func resultText(t *testing.T, content []mcp.Content) string {
 	t.Helper()
@@ -26,78 +36,83 @@ func resultText(t *testing.T, content []mcp.Content) string {
 // TestFormatEvaluatePackageMarkdown verifies each documented outcome renders
 // its own wording, and that an allowed verdict is never described as a
 // safety assurance the API did not give.
+//
+// Every case pins the whole card: the heading, the rows, the blank line and
+// the guidance section are one document, and a substring assertion cannot see
+// a row that landed somewhere it does not render.
 func TestFormatEvaluatePackageMarkdown(t *testing.T) {
+	const heading = "## Dependency Firewall Evaluation\n\n"
 	tests := []struct {
-		name        string
-		out         EvaluatePackageOutput
-		wantAll     []string
-		wantMissing []string
+		name string
+		out  EvaluatePackageOutput
+		want string
 	}{
 		{
-			name:    "allowed",
-			out:     EvaluatePackageOutput{Outcome: outcomeAllowed},
-			wantAll: []string{"allowed", "no policy rule matched", "not that GitLab holds vulnerability or license data"},
+			name: "allowed",
+			out:  EvaluatePackageOutput{Outcome: outcomeAllowed},
+			want: heading +
+				"- **Outcome**: " + toolutil.EmojiSuccess + " **allowed** (no policy rule matched the package)\n" +
+				hintsAllowed,
 		},
 		{
-			name:    "warned",
-			out:     EvaluatePackageOutput{Outcome: outcomeWarned, Reason: new("license policy 'deny-gpl'")},
-			wantAll: []string{"warned", "warn mode", "license policy 'deny-gpl'", "names the policy that matched"},
+			name: "warned",
+			out:  EvaluatePackageOutput{Outcome: outcomeWarned, Reason: new("license policy 'deny-gpl'")},
+			want: heading +
+				"- **Outcome**: " + toolutil.EmojiWarning + " **warned** (a policy rule matched and the policy is in warn mode)\n" +
+				"- **Reason**: license policy 'deny-gpl'\n" +
+				hintsMatched,
 		},
 		{
-			name:    "blocked",
-			out:     EvaluatePackageOutput{Outcome: outcomeBlocked, Reason: new("Package 'lodash' violates 'deny-mit' policy")},
-			wantAll: []string{"blocked", "enforce mode", "deny-mit"},
+			name: "blocked",
+			out:  EvaluatePackageOutput{Outcome: outcomeBlocked, Reason: new("Package 'lodash' violates 'deny-mit' policy")},
+			want: heading +
+				"- **Outcome**: " + toolutil.EmojiCross + " **blocked** (a policy rule matched and the policy is in enforce mode)\n" +
+				"- **Reason**: Package 'lodash' violates 'deny-mit' policy\n" +
+				hintsMatched,
 		},
 		{
-			name:        "empty outcome",
-			out:         EvaluatePackageOutput{},
-			wantAll:     []string{"not reported"},
-			wantMissing: []string{"Reason:"},
+			name: "empty outcome",
+			out:  EvaluatePackageOutput{},
+			want: heading + "- **Outcome**: not reported\n" + hintsAllowed,
 		},
 		{
-			name:    "unknown outcome is passed through",
-			out:     EvaluatePackageOutput{Outcome: "quarantined"},
-			wantAll: []string{"quarantined"},
+			name: "unknown outcome is passed through",
+			out:  EvaluatePackageOutput{Outcome: "quarantined"},
+			want: heading + "- **Outcome**: quarantined\n" + hintsAllowed,
 		},
 		{
-			name:        "blank reason is omitted",
-			out:         EvaluatePackageOutput{Outcome: outcomeAllowed, Reason: new("   ")},
-			wantMissing: []string{"Reason:"},
+			name: "blank reason is omitted",
+			out:  EvaluatePackageOutput{Outcome: outcomeAllowed, Reason: new("   ")},
+			want: heading +
+				"- **Outcome**: " + toolutil.EmojiSuccess + " **allowed** (no policy rule matched the package)\n" +
+				hintsAllowed,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatEvaluatePackageMarkdown(tt.out)
-			if !strings.HasPrefix(md, "## Dependency Firewall Evaluation") {
-				t.Errorf("markdown does not start with the heading:\n%s", md)
-			}
-			for _, want := range tt.wantAll {
-				if !strings.Contains(md, want) {
-					t.Errorf("markdown is missing %q:\n%s", want, md)
-				}
-			}
-			for _, unwanted := range tt.wantMissing {
-				if strings.Contains(md, unwanted) {
-					t.Errorf("markdown unexpectedly contains %q:\n%s", unwanted, md)
-				}
+			if got := FormatEvaluatePackageMarkdown(tt.out); got != tt.want {
+				t.Errorf("FormatEvaluatePackageMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
 }
 
 // TestFormatEvaluatePackageMarkdown_EscapesReason verifies a reason carrying
-// table syntax or newlines cannot break the rendered document.
+// table syntax or newlines cannot break the rendered document: the pipe
+// becomes its entity and the line break collapses to a space, so the reason
+// stays one list item.
 func TestFormatEvaluatePackageMarkdown_EscapesReason(t *testing.T) {
-	md := FormatEvaluatePackageMarkdown(EvaluatePackageOutput{
+	got := FormatEvaluatePackageMarkdown(EvaluatePackageOutput{
 		Outcome: outcomeBlocked,
 		Reason:  new("policy | with pipes\nand a newline"),
 	})
-	if strings.Contains(md, "policy | with pipes") {
-		t.Errorf("pipe was not escaped:\n%s", md)
-	}
-	if strings.Contains(md, "pipes\nand") {
-		t.Errorf("newline was not flattened:\n%s", md)
+	want := "## Dependency Firewall Evaluation\n\n" +
+		"- **Outcome**: " + toolutil.EmojiCross + " **blocked** (a policy rule matched and the policy is in enforce mode)\n" +
+		"- **Reason**: policy &#124; with pipes and a newline\n" +
+		hintsMatched
+	if got != want {
+		t.Errorf("FormatEvaluatePackageMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -109,8 +124,8 @@ func TestFormatEvaluatePackageMarkdown_RegisteredForOutput(t *testing.T) {
 	if result == nil {
 		t.Fatal("MarkdownForResult() = nil, want the registered formatter")
 	}
-	if text := resultText(t, result.Content); !strings.Contains(text, "Dependency Firewall Evaluation") {
-		t.Errorf("registered formatter produced %q", text)
+	if got, want := resultText(t, result.Content), FormatEvaluatePackageMarkdown(EvaluatePackageOutput{Outcome: outcomeAllowed}); got != want {
+		t.Errorf("registered formatter produced %q, want %q", got, want)
 	}
 }
 

--- a/internal/tools/deploymentmergerequests/deployment_merge_requests_test.go
+++ b/internal/tools/deploymentmergerequests/deployment_merge_requests_test.go
@@ -174,28 +174,42 @@ func TestList_Error(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// listHints is the guidance section every deployment merge request listing
+// closes with, written once so the whole-output expectations below name it
+// rather than repeating four lines each.
+const listHints = "\n---\n💡 **Next steps:**\n" +
+	"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+	"- Use action 'merge_request.get' to read one of these merge requests in full\n" +
+	"- Use action 'mr_review.changes_get' to see what one of them changed\n"
+
+// tableHead is the header and delimiter of the deployment merge request table.
+const tableHead = "| IID | Title | State | Author | Source -> Target |\n| --- | --- | --- | --- | --- |\n"
+
+// TestFormatListMarkdown_Empty verifies that a deployment with no merge
+// requests renders the one-sentence empty message and nothing else: no
+// heading counting zero and no table header above an empty body.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	result := FormatListMarkdown(ListOutput{})
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	got := FormatListMarkdownString(ListOutput{})
+	want := "No merge requests for this deployment found.\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_WithData verifies the ListMarkdown_WithData Markdown formatter for a representative list_withdata input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown_WithData verifies the whole rendering of a one-row
+// listing: the heading, the shared merge request row shape (the IID carries
+// the link, the state carries its glyph, the author is a handle) and the
+// guidance section.
 func TestFormatListMarkdown_WithData(t *testing.T) {
 	out := ListOutput{
 		MergeRequests: []Output{
 			{IID: 1, Title: "MR One", State: "merged", Author: &toolutil.BasicUserOutput{Username: "dev"}, SourceBranch: "feat", TargetBranch: "main"},
 		},
 	}
-	result := FormatListMarkdown(out)
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	want := "## Deployment Merge Requests (1)\n\n" + tableHead +
+		"| !1 | MR One | 🟣 merged | @dev | feat -> main |\n" + listHints
+	if got := FormatListMarkdownString(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -630,35 +644,13 @@ func TestFormatListMarkdown_MultipleItems(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 3, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	result := FormatListMarkdown(out)
-	if result == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-
-	text := result.Content[0].(*mcp.TextContent).Text
-
-	for _, want := range []string{
-		"## Deployment Merge Requests (3)",
-		"| IID |",
-		"|-----|",
-		"!10",
-		"!11",
-		"!12",
-		"Feature A",
-		"Fix B",
-		"Hotfix C",
-		"dev1",
-		"dev2",
-		"dev3",
-		"feat-a -> main",
-		"fix-b -> develop",
-		"hotfix-c -> main",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(text, want) {
-				t.Errorf("markdown missing %q:\n%s", want, text)
-			}
-		})
+	want := "## Deployment Merge Requests (3)\n\n" + tableHead +
+		"| !10 | Feature A | 🟣 merged | @dev1 | feat-a -> main |\n" +
+		"| !11 | Fix B | 🟢 opened | @dev2 | fix-b -> develop |\n" +
+		"| !12 | Hotfix C | 🔴 closed | @dev3 | hotfix-c -> main |\n" +
+		"\nPage 1 of 1 | 3 items total | 20 per page\n" + listHints
+	if got := FormatListMarkdownString(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -671,13 +663,10 @@ func TestFormatListMarkdown_SpecialCharacters(t *testing.T) {
 			{IID: 1, Title: "Title with | pipe", State: "merged", Author: &toolutil.BasicUserOutput{Username: "user"}, SourceBranch: "src", TargetBranch: "tgt"},
 		},
 	}
-	result := FormatListMarkdown(out)
-	if result == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := result.Content[0].(*mcp.TextContent).Text
-	if strings.Contains(text, "| pipe |") {
-		t.Error("pipe character in title should be escaped")
+	want := "## Deployment Merge Requests (1)\n\n" + tableHead +
+		"| !1 | Title with &#124; pipe | 🟣 merged | @user | src -> tgt |\n" + listHints
+	if got := FormatListMarkdownString(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -689,12 +678,10 @@ func TestFormatListMarkdown_EmptyOutput(t *testing.T) {
 	if result == nil {
 		t.Fatal(errExpNonNilResult)
 	}
-	text := result.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "No merge requests found") {
-		t.Errorf("expected empty message, got:\n%s", text)
-	}
-	if strings.Contains(text, "| IID |") {
-		t.Error("should not contain table header when empty")
+	got := result.Content[0].(*mcp.TextContent).Text
+	want := "No merge requests for this deployment found.\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -702,13 +689,10 @@ func TestFormatListMarkdown_EmptyOutput(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatListMarkdown_NilSlice(t *testing.T) {
-	result := FormatListMarkdown(ListOutput{})
-	if result == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := result.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "No merge requests found") {
-		t.Errorf("expected empty message for nil slice, got:\n%s", text)
+	got := FormatListMarkdownString(ListOutput{})
+	want := "No merge requests for this deployment found.\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -1079,15 +1063,13 @@ func TestToOutput_DiffRefs_EachShaAloneProducesTheObject(t *testing.T) {
 // than dereferencing nothing. GitLab omits the object on a merge request whose
 // author was deleted.
 func TestFormatListMarkdown_NoAuthor_LeavesTheColumnEmpty(t *testing.T) {
-	rendered := FormatListMarkdown(ListOutput{MergeRequests: []Output{{
+	got := FormatListMarkdownString(ListOutput{MergeRequests: []Output{{
 		IID: 10, Title: "Add feature X", State: "merged",
 		SourceBranch: "feature-x", TargetBranch: "main",
 	}}})
-	text := rendered.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "| !10 |") {
-		t.Fatalf("rendered markdown does not carry the row: %s", text)
-	}
-	if !strings.Contains(text, "|  | feature-x -> main |") {
-		t.Errorf("author column = not empty, want an empty cell; rendered: %s", text)
+	want := "## Deployment Merge Requests (1)\n\n" + tableHead +
+		"| !10 | Add feature X | 🟣 merged |  | feature-x -> main |\n" + listHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }

--- a/internal/tools/deploymentmergerequests/markdown.go
+++ b/internal/tools/deploymentmergerequests/markdown.go
@@ -9,32 +9,58 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown formats the list of deployment merge requests as markdown.
-func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
-	if len(out.MergeRequests) == 0 {
-		return toolutil.ToolResultWithMarkdown("No merge requests found for this deployment.\n")
-	}
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionMergeRequestGet     = "merge_request.get"
+	actionMergeRequestChanges = "mr_review.changes_get"
+)
 
+// FormatListMarkdown renders the merge requests a deployment shipped.
+func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
+	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
+}
+
+// FormatListMarkdownString renders the deployment's merge requests as a
+// Markdown table, in the row shape every merge request table in the tree uses:
+// the IID carries the link, the title is a cell of its own, and the state
+// carries its glyph. Linking the title instead put a GitLab-authored value in
+// a link label, and left a reader with no reference to call the MR by.
+func FormatListMarkdownString(out ListOutput) string {
+	if len(out.MergeRequests) == 0 {
+		return toolutil.EmptyMessage("merge requests for this deployment")
+	}
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Deployment Merge Requests (%d)\n\n", len(out.MergeRequests))
-	sb.WriteString("| IID | Title | State | Author | Source -> Target |\n")
-	sb.WriteString("|-----|-------|-------|--------|----------------|\n")
+	toolutil.WriteListHeading(&sb, "Deployment Merge Requests", len(out.MergeRequests), out.Pagination)
+	sb.WriteString(toolutil.MarkdownTableHeader("IID", "Title", "State", "Author", "Source -> Target"))
 	for _, mr := range out.MergeRequests {
 		author := ""
 		if mr.Author != nil {
 			author = mr.Author.Username
 		}
-		fmt.Fprintf(&sb, "| !%d | %s | %s | %s | %s -> %s |\n",
-			mr.IID,
-			toolutil.MdTitleLink(mr.Title, mr.WebURL),
-			//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
-			mr.State,
-			toolutil.EscapeMdTableCell(author),
-			toolutil.EscapeMdTableCell(mr.SourceBranch),
-			toolutil.EscapeMdTableCell(mr.TargetBranch))
+		sb.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL),
+			toolutil.EscapeMdTableCell(mr.Title),
+			mrStateCell(mr.State),
+			toolutil.MdUserHandle(author),
+			// A branch name is not an identifier: git check-ref-format permits
+			// '|', '<' and '>'.
+			toolutil.EscapeMdTableCell(mr.SourceBranch)+" -> "+toolutil.EscapeMdTableCell(mr.TargetBranch),
+		))
 	}
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_mr_get` to view full MR details")
-	return toolutil.ToolResultWithMarkdown(sb.String())
+	toolutil.WriteListFooter(&sb, out.Pagination, true,
+		toolutil.HintAction(actionMergeRequestGet, "read one of these merge requests in full"),
+		toolutil.HintAction(actionMergeRequestChanges, "see what one of them changed"),
+	)
+	return sb.String()
+}
+
+// mrStateCell renders a merge request state with its emoji, the way every merge
+// request row in the tree shows it, and nothing when GitLab sent no state.
+func mrStateCell(state string) string {
+	if strings.TrimSpace(state) == "" {
+		return ""
+	}
+	return toolutil.MRStateEmoji(state) + " " + toolutil.EscapeMdTableCell(state)
 }
 
 func init() {

--- a/internal/tools/deployments/deployments_test.go
+++ b/internal/tools/deployments/deployments_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
@@ -1068,38 +1069,111 @@ func TestDeploymentApproveOrReject_CancelledContext(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown_AllFields verifies the OutputMarkdown_AllFields Markdown formatter for a representative output_allfields input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// cardHints is the guidance section a deployment card that needs no approval
+// closes with, and blockedHints the one a deployment waiting on approvals
+// carries instead.
+const (
+	cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'environment.deployment_merge_requests' to list the merge requests this deployment shipped\n" +
+		"- Use action 'environment.get' to see the environment it deployed to\n"
+	blockedHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'environment.deployment_approve_or_reject' to approve or reject this blocked deployment\n" +
+		"- Use action 'environment.deployment_merge_requests' to list the merge requests this deployment shipped\n" +
+		"- Use action 'environment.get' to see the environment it deployed to\n"
+)
+
+// listHints is the guidance section the listing closes with, the preserve-links
+// instruction first because the ID column links to the pipeline that ran each
+// deployment.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- " + toolutil.HintPreserveLinks + "\n" +
+	"- Use action 'environment.deployment_get' to see one deployment, its approvals and its pipeline\n" +
+	"- Use action 'environment.deployment_list' to page through the rest of the project's deployments\n" +
+	"- Use action 'environment.deployment_merge_requests' to list the merge requests a deployment shipped\n"
+
+// TestFormatOutputMarkdown_AllFields pins the whole card of a deployment with
+// everything GitLab sends on an ordinary one: the status with its glyph, the
+// deployer as a profile link, and no approval rows for a deployment that needs
+// none.
 func TestFormatOutputMarkdown_AllFields(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:          1,
 		IID:         10,
 		Ref:         "main",
 		SHA:         "abc123",
 		Status:      "success",
-		User:        &UserOutput{Username: "admin"},
+		User:        &UserOutput{Username: "admin", WebURL: "https://gitlab.example.com/admin"},
 		Environment: &EnvironmentOutput{Name: "production"},
 		CreatedAt:   "2026-06-01T00:00:00Z",
 		UpdatedAt:   "2026-06-01T01:00:00Z",
 	})
 
-	for _, want := range []string{
-		"## Deployment #1",
-		"| IID | 10 |",
-		"| Ref | main |",
-		"| SHA | abc123 |",
-		"| Status | success |",
-		"| User | admin |",
-		"| Environment | production |",
-		"| Created | 1 Jun 2026 00:00 UTC |",
-		"| Updated | 1 Jun 2026 01:00 UTC |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Deployment #1\n\n" +
+		"- **IID**: 10\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Ref**: main\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **Environment**: production\n" +
+		"- **Deployed By**: [@admin](https://gitlab.example.com/admin)\n" +
+		"- **Created**: 1 Jun 2026 00:00 UTC\n" +
+		"- **Updated**: 1 Jun 2026 01:00 UTC\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_Blocked pins what the card was missing entirely: a
+// deployment GitLab is holding for approval says how many are outstanding, who
+// has answered so far and which rules it is counted against, and offers the
+// action that unblocks it.
+func TestFormatOutputMarkdown_Blocked(t *testing.T) {
+	approved := time.Date(2026, 6, 2, 9, 30, 0, 0, time.UTC)
+	got := FormatOutputMarkdown(Output{
+		ID:                   4,
+		IID:                  2,
+		Ref:                  "main",
+		SHA:                  "0123456789abcdef",
+		Status:               "blocked",
+		Environment:          &EnvironmentOutput{Name: "production"},
+		PendingApprovalCount: 1,
+		Approvals: []toolutil.DeploymentApprovalOutput{{
+			User:      &toolutil.UserBasicOutput{Username: "dana", WebURL: "https://gitlab.example.com/dana"},
+			Status:    "approved",
+			CreatedAt: &approved,
+			Comment:   "looks good",
+		}},
+		ApprovalSummary: &toolutil.DeploymentApprovalSummaryOutput{Rules: []toolutil.DeploymentApprovalRuleOutput{
+			{
+				ID: 1, AccessLevel: 40, AccessLevelDescription: "Maintainers", RequiredApprovals: 2,
+				DeploymentApprovals: []toolutil.DeploymentApprovalOutput{{Status: "approved"}},
+			},
+			{ID: 2, AccessLevelDescription: "Sam Bauch", UserID: 7, RequiredApprovals: 1},
+		}},
+	})
+
+	want := "## Deployment #4\n\n" +
+		"- **IID**: 2\n" +
+		// PipelineStatusEmoji has no entry for a deployment's own "blocked"
+		// state, the one status a pipeline never has, so it renders the glyph
+		// it gives any value its table does not know.
+		"- **Status**: ❓ blocked\n" +
+		"- **Ref**: main\n" +
+		"- **SHA**: `01234567`\n" +
+		"- **Environment**: production\n" +
+		"- **Pending Approvals**: 1\n" +
+		"\n### Approvals\n\n" +
+		"| User | Status | When | Comment |\n| --- | --- | --- | --- |\n" +
+		"| [@dana](https://gitlab.example.com/dana) | approved | 2 Jun 2026 09:30 UTC | looks good |\n" +
+		"\n### Approval Rules\n\n" +
+		"| ID | Level | Grantee | Description | Required | Approved |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 1 | Maintainer |  | Maintainers | 2 | 1 |\n" +
+		"| 2 | - | user #7 | Sam Bauch | 1 | 0 |\n" +
+		blockedHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1113,11 +1187,11 @@ func TestFormatOutputMarkdown_ZeroID(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown_MinimalFields verifies the OutputMarkdown_MinimalFields Markdown formatter for a representative output_minimalfields input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatOutputMarkdown_MinimalFields pins the whole card of a deployment
+// GitLab answered with nothing optional: no label with an empty value under
+// it, and no approval rows for a deployment that needs none.
 func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:     2,
 		IID:    2,
 		Ref:    "develop",
@@ -1125,28 +1199,22 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		Status: "running",
 	})
 
-	if !strings.Contains(md, "## Deployment #2") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	for _, absent := range []string{
-		"| User |",
-		"| Environment |",
-		"| Created |",
-		"| Updated |",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+	want := "## Deployment #2\n\n" +
+		"- **IID**: 2\n" +
+		"- **Status**: \U0001F535 running\n" +
+		"- **Ref**: develop\n" +
+		"- **SHA**: `def456`\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_WithPipelineWebURL verifies the OutputMarkdown_WithPipelineWebURL Markdown formatter for a representative output_withpipelineweburl input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatOutputMarkdown_WithPipelineWebURL pins the two rows the backing job
+// adds: the pipeline as a link, and its own status beside the deployment's.
 func TestFormatOutputMarkdown_WithPipelineWebURL(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:     5,
 		IID:    5,
 		Ref:    "main",
@@ -1156,16 +1224,23 @@ func TestFormatOutputMarkdown_WithPipelineWebURL(t *testing.T) {
 			ID: 99,
 			Pipeline: &DeployablePipelineOutput{
 				ID:     123,
+				Status: "success",
 				WebURL: "https://gitlab.example.com/my-org/project/-/pipelines/123",
 			},
 		},
 	})
 
-	if !strings.Contains(md, "| Pipeline |") {
-		t.Errorf("markdown missing Pipeline row:\n%s", md)
-	}
-	if !strings.Contains(md, "https://gitlab.example.com/my-org/project/-/pipelines/123") {
-		t.Errorf("markdown missing pipeline URL:\n%s", md)
+	want := "## Deployment #5\n\n" +
+		"- **IID**: 5\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Ref**: main\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **Pipeline**: [#123](https://gitlab.example.com/my-org/project/-/pipelines/123)\n" +
+		"- **Pipeline Status**: ✅ success\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1173,52 +1248,67 @@ func TestFormatOutputMarkdown_WithPipelineWebURL(t *testing.T) {
 // FormatListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithDeployments verifies the ListMarkdown_WithDeployments Markdown formatter for a representative list_withdeployments input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown_WithDeployments pins the whole listing: the heading
+// counting what GitLab reported, each row's ID linked to the pipeline that ran
+// it where there is one, and one guidance section at the end.
 func TestFormatListMarkdown_WithDeployments(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Deployments: []Output{
-			{ID: 1, IID: 1, Ref: "main", SHA: "abc", Status: "success", Environment: &EnvironmentOutput{Name: "production"}, User: &UserOutput{Username: "admin"}},
-			{ID: 2, IID: 2, Ref: "develop", SHA: "def", Status: "running", Environment: &EnvironmentOutput{Name: "staging"}, User: &UserOutput{Username: "dev"}},
+			{
+				ID: 1, IID: 1, Ref: "main", SHA: "abc", Status: "success",
+				Environment: &EnvironmentOutput{Name: "production"},
+				User:        &UserOutput{Username: "admin", WebURL: "https://gitlab.example.com/admin"},
+				Deployable: &DeployableOutput{Pipeline: &DeployablePipelineOutput{
+					ID: 123, WebURL: "https://gitlab.example.com/acme/web/-/pipelines/123",
+				}},
+			},
+			{
+				ID: 2, IID: 2, Ref: "develop", SHA: "def", Status: "running",
+				Environment: &EnvironmentOutput{Name: "staging"},
+				User:        &UserOutput{Username: "dev"},
+			},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
+	})
 
-	for _, want := range []string{
-		"## Deployments (2)",
-		"| ID |",
-		"| --- |",
-		"| 1 |",
-		"| 2 |",
-		"main",
-		"develop",
-		"success",
-		"running",
-		"production",
-		"staging",
-		"admin",
-		"dev",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Deployments (2)\n\n" +
+		"| ID | IID | Ref | Status | Environment | Deployed By |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| [1](https://gitlab.example.com/acme/web/-/pipelines/123) | 1 | main | ✅ success | production | [@admin](https://gitlab.example.com/admin) |\n" +
+		"| 2 | 2 | develop | \U0001F535 running | staging | @dev |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No deployments found") {
-		t.Errorf("expected empty message:\n%s", md)
+// TestFormatListMarkdown_KeysetPage pins the heading of a page GitLab sent no
+// total for: it counts the rows shown rather than claiming a total of zero
+// above them.
+func TestFormatListMarkdown_KeysetPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Deployments: []Output{{ID: 9, IID: 3, Ref: "main", Status: "success"}},
+		Pagination:  toolutil.PaginationOutput{HasMore: true},
+	})
+
+	want := "## Deployments (1 shown, more available)\n\n" +
+		"| ID | IID | Ref | Status | Environment | Deployed By |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 9 | 3 | main | ✅ success |  |  |\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+}
+
+// TestFormatListMarkdown_Empty pins that a project with no deployments renders
+// the one sentence and nothing else.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No deployments found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1239,40 +1329,43 @@ func TestFormatDeploymentNotFound(t *testing.T) {
 // FormatApproveOrRejectMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatApproveOrRejectMarkdown_Approved verifies the ApproveOrRejectMarkdown_Approved Markdown formatter for a representative approveorreject_approved input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// confirmHints is the guidance section the approve/reject confirmation closes
+// with.
+const confirmHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'environment.deployment_get' to read the deployment back with its approvals\n" +
+	"- Use action 'environment.deployment_list' to see the other deployments to this environment\n"
+
+// TestFormatApproveOrRejectMarkdown_Approved pins the whole confirmation: one
+// line of the server's own sentence, then the guidance section.
 func TestFormatApproveOrRejectMarkdown_Approved(t *testing.T) {
-	md := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{
+	got := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{
 		Message: "Deployment #10 approved successfully",
 	})
-	if !strings.Contains(md, "Deployment #10 approved successfully") {
-		t.Errorf("markdown missing approval message:\n%s", md)
-	}
-	if !strings.Contains(md, "✅") {
-		t.Errorf("markdown missing checkmark:\n%s", md)
+
+	if want := "✅ Deployment #10 approved successfully\n" + confirmHints; got != want {
+		t.Errorf("confirmation mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatApproveOrRejectMarkdown_Rejected verifies the ApproveOrRejectMarkdown_Rejected Markdown formatter for a representative approveorreject_rejected input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatApproveOrRejectMarkdown_Rejected pins the same shape for the other
+// half of the action.
 func TestFormatApproveOrRejectMarkdown_Rejected(t *testing.T) {
-	md := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{
+	got := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{
 		Message: "Deployment #10 rejected successfully",
 	})
-	if !strings.Contains(md, "Deployment #10 rejected successfully") {
-		t.Errorf("markdown missing rejection message:\n%s", md)
+
+	if want := "✅ Deployment #10 rejected successfully\n" + confirmHints; got != want {
+		t.Errorf("confirmation mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatApproveOrRejectMarkdown_EmptyMessage verifies the ApproveOrRejectMarkdown_EmptyMessage Markdown formatter for a representative approveorreject_emptymessage input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatApproveOrRejectMarkdown_EmptyMessage pins that a result carrying no
+// sentence still renders the glyph and the guidance rather than nothing.
 func TestFormatApproveOrRejectMarkdown_EmptyMessage(t *testing.T) {
-	md := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{})
-	if md == "" {
-		t.Error("expected non-empty markdown even for empty message")
+	got := FormatApproveOrRejectMarkdown(ApproveOrRejectOutput{})
+
+	if want := "✅ \n" + confirmHints; got != want {
+		t.Errorf("confirmation mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1284,7 +1377,7 @@ func TestFormatApproveOrRejectMarkdown_EmptyMessage(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the returned output matches the expected fields.
 func TestToOutput_AllOptionalFields(t *testing.T) {
-	out := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:          100,
 		IID:         50,
 		Ref:         "v2.0.0",
@@ -1296,22 +1389,19 @@ func TestToOutput_AllOptionalFields(t *testing.T) {
 		UpdatedAt:   "2026-12-01T12:00:00Z",
 	})
 
-	for _, want := range []string{
-		"## Deployment #100",
-		"| IID | 50 |",
-		"| Ref | v2.0.0 |",
-		"| SHA | deadbeef |",
-		"| Status | failed |",
-		"| User | deployer |",
-		"| Environment | canary |",
-		"| Created | 1 Dec 2026 00:00 UTC |",
-		"| Updated | 1 Dec 2026 12:00 UTC |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(out, want) {
-				t.Errorf("markdown missing %q:\n%s", want, out)
-			}
-		})
+	want := "## Deployment #100\n\n" +
+		"- **IID**: 50\n" +
+		"- **Status**: ❌ failed\n" +
+		"- **Ref**: v2.0.0\n" +
+		"- **SHA**: `deadbeef`\n" +
+		"- **Environment**: canary\n" +
+		"- **Deployed By**: @deployer\n" +
+		"- **Created**: 1 Dec 2026 00:00 UTC\n" +
+		"- **Updated**: 1 Dec 2026 12:00 UTC\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/deployments/markdown.go
+++ b/internal/tools/deployments/markdown.go
@@ -2,11 +2,26 @@ package deployments
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// The canonical catalog IDs the hints name. A deployment action is projected
+// under the environment domain, so the ID every surface resolves is
+// "environment.deployment_get" and not the "deployment.get" the cross-link
+// constants in action_specs.go spell.
+const (
+	hintActionDeploymentGet     = "environment.deployment_get"
+	hintActionDeploymentList    = "environment.deployment_list"
+	hintActionDeploymentMRs     = "environment.deployment_merge_requests"
+	hintActionDeploymentApprove = "environment.deployment_approve_or_reject"
+	hintActionEnvironmentGet    = "environment.get"
 )
 
 type deploymentNotFoundOutput struct {
@@ -21,80 +36,213 @@ func formatDeploymentNotFound(out deploymentNotFoundOutput) *mcp.CallToolResult 
 	)
 }
 
-// FormatOutputMarkdown renders a single deployment as Markdown.
+// FormatOutputMarkdown renders one deployment as the card of a single object:
+// what was deployed where, then the approvals it is waiting on as a nested
+// collection.
 func FormatOutputMarkdown(d Output) string {
 	if d.ID == 0 {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Deployment #%d\n\n", d.ID)
-	b.WriteString("| Field | Value |\n")
-	b.WriteString(toolutil.TblSep2Col)
-	fmt.Fprintf(&b, "| IID | %d |\n", d.IID)
-	fmt.Fprintf(&b, "| Ref | %s |\n", toolutil.EscapeMdTableCell(d.Ref))
-	//gitlab:allow-unescaped d.SHA: a commit SHA, hexadecimal by construction.
-	fmt.Fprintf(&b, "| SHA | %s |\n", d.SHA)
-	//gitlab:allow-unescaped d.Status: a deployment status GitLab picks from a fixed set (created, running, success, failed, canceled, blocked).
-	fmt.Fprintf(&b, "| Status | %s |\n", d.Status)
-	if d.User != nil && d.User.Username != "" {
-		fmt.Fprintf(&b, "| User | %s |\n", toolutil.EscapeMdTableCell(d.User.Username))
+	c := toolutil.NewCard(&b, fmt.Sprintf("Deployment #%d", d.ID))
+	c.Int("IID", int64(d.IID))
+	c.Markdown("Status", statusCell(d.Status))
+	c.Field("Ref", d.Ref)
+	// A commit SHA, hexadecimal by construction, shown the way GitLab shows it.
+	c.Code("SHA", shortSHA(d.SHA))
+	if d.Environment != nil {
+		c.Field("Environment", d.Environment.Name)
 	}
-	if d.Environment != nil && d.Environment.Name != "" {
-		fmt.Fprintf(&b, "| Environment | %s |\n", toolutil.EscapeMdTableCell(d.Environment.Name))
+	if d.User != nil {
+		c.Markdown("Deployed By", toolutil.MdUserLink(d.User.Username, d.User.WebURL))
 	}
-	if d.CreatedAt != "" {
-		fmt.Fprintf(&b, "| Created | %s |\n", toolutil.FormatTime(d.CreatedAt))
+	c.Time("Created", d.CreatedAt)
+	c.Time("Updated", d.UpdatedAt)
+	if d.Deployable != nil && d.Deployable.Pipeline != nil {
+		p := d.Deployable.Pipeline
+		c.Link("Pipeline", fmt.Sprintf("#%d", p.ID), p.WebURL)
+		c.Markdown("Pipeline Status", statusCell(p.Status))
 	}
-	if d.UpdatedAt != "" {
-		fmt.Fprintf(&b, "| Updated | %s |\n", toolutil.FormatTime(d.UpdatedAt))
-	}
-	if d.Deployable != nil && d.Deployable.Pipeline != nil && d.Deployable.Pipeline.WebURL != "" {
-		fmt.Fprintf(&b, "| Pipeline | %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", d.Deployable.Pipeline.ID), d.Deployable.Pipeline.WebURL))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_environment action 'list' to see all environments",
-		"Use gitlab_merge_request to see related merge request details",
-	)
+	// A deployment blocked on approvals says nothing about it anywhere else:
+	// the card used to render as an ordinary deployment while GitLab was
+	// waiting for someone to approve it.
+	c.Count("Pending Approvals", d.PendingApprovalCount)
+	writeApprovals(c, d.Approvals)
+	writeApprovalRules(c, d.ApprovalSummary)
+	c.End(deploymentHints(d)...)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of deployments as a Markdown table.
+// statusCell renders a deployment or pipeline status with the glyph every
+// pipeline-shaped status in the tree carries, and nothing when GitLab sent
+// none.
+func statusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	// A deployment status GitLab picks from a fixed set (created, running,
+	// success, failed, canceled, blocked).
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// shortSHA renders the first eight characters of a commit SHA, the form GitLab
+// itself shows, and leaves a shorter value alone.
+func shortSHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+// writeApprovals writes what has been recorded against the deployment so far.
+func writeApprovals(c *toolutil.Card, approvals []toolutil.DeploymentApprovalOutput) {
+	if len(approvals) == 0 {
+		return
+	}
+	t := c.Table("Approvals", "User", "Status", "When", "Comment")
+	for _, a := range approvals {
+		user := ""
+		if a.User != nil {
+			user = toolutil.MdUserLink(a.User.Username, a.User.WebURL)
+		}
+		t.Row(
+			user,
+			toolutil.EscapeMdTableCell(a.Status),
+			approvalTime(a.CreatedAt),
+			toolutil.EscapeMdTableCell(a.Comment),
+		)
+	}
+}
+
+// approvalTime renders when an approval was recorded in the display form every
+// other timestamp in a card carries, and nothing when GitLab sent none.
+func approvalTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return toolutil.FormatTimeValue(*t)
+}
+
+// writeApprovalRules writes the rules the deployment is counted against, so a
+// reader can tell who is being waited on rather than only how many are left.
+func writeApprovalRules(c *toolutil.Card, summary *toolutil.DeploymentApprovalSummaryOutput) {
+	if summary == nil || len(summary.Rules) == 0 {
+		return
+	}
+	t := c.Table("Approval Rules", "ID", "Level", "Grantee", "Description", "Required", "Approved")
+	for _, r := range summary.Rules {
+		t.Row(
+			strconv.FormatInt(r.ID, 10),
+			levelCell(r),
+			granteeCell(r),
+			toolutil.EscapeMdTableCell(r.AccessLevelDescription),
+			strconv.FormatInt(r.RequiredApprovals, 10),
+			strconv.Itoa(approvedCount(r.DeploymentApprovals)),
+		)
+	}
+}
+
+// levelCell renders the role a rule grants, and "-" for a rule that names a
+// user or a group instead, whose access_level is not what decides.
+func levelCell(r toolutil.DeploymentApprovalRuleOutput) string {
+	if granteeCell(r) != "" {
+		return "-"
+	}
+	return toolutil.AccessLevelDescription(gl.AccessLevelValue(r.AccessLevel))
+}
+
+// granteeCell names who a granular rule is about, and nothing for a rule that
+// grants a role to everyone who holds it.
+func granteeCell(r toolutil.DeploymentApprovalRuleOutput) string {
+	switch {
+	case r.UserID != 0:
+		return fmt.Sprintf("user #%d", r.UserID)
+	case r.GroupID != 0:
+		return fmt.Sprintf("group #%d", r.GroupID)
+	default:
+		return ""
+	}
+}
+
+// approvedCount counts the approvals recorded against a rule, rejections
+// aside: a rejection is recorded in the same list and is not an approval.
+func approvedCount(approvals []toolutil.DeploymentApprovalOutput) int {
+	n := 0
+	for _, a := range approvals {
+		if a.Status == "approved" {
+			n++
+		}
+	}
+	return n
+}
+
+// deploymentHints names the next steps this deployment allows: a blocked one
+// is approved or rejected, and every one of them leads to its environment and
+// to the merge requests it shipped.
+func deploymentHints(d Output) []string {
+	hints := make([]string, 0, 3)
+	if d.PendingApprovalCount > 0 {
+		hints = append(hints, toolutil.HintAction(hintActionDeploymentApprove, "approve or reject this blocked deployment"))
+	}
+	hints = append(hints, toolutil.HintAction(hintActionDeploymentMRs, "list the merge requests this deployment shipped"))
+	return append(hints, toolutil.HintAction(hintActionEnvironmentGet, "see the environment it deployed to"))
+}
+
+// FormatListMarkdown renders a page of a project's deployments as a Markdown
+// table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Deployments) == 0 {
-		return "No deployments found.\n"
+		return toolutil.EmptyMessage("deployments")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Deployments (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Deployments), out.Pagination)
-	b.WriteString("| ID | IID | Ref | Status | Environment | User |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Deployments", len(out.Deployments), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "IID", "Ref", "Status", "Environment", "Deployed By"))
 	for _, d := range out.Deployments {
-		var envName, userName string
+		var envName, user string
 		if d.Environment != nil {
 			envName = d.Environment.Name
 		}
 		if d.User != nil {
-			userName = d.User.Username
+			user = toolutil.MdUserLink(d.User.Username, d.User.WebURL)
 		}
-		fmt.Fprintf(&b, "| %d | %d | %s | %s | %s | %s |\n",
-			d.ID, d.IID, toolutil.EscapeMdTableCell(d.Ref), d.Status, toolutil.EscapeMdTableCell(envName), toolutil.EscapeMdTableCell(userName))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(strconv.Itoa(d.ID), pipelineURL(d)),
+			strconv.Itoa(d.IID),
+			toolutil.EscapeMdTableCell(d.Ref),
+			statusCell(d.Status),
+			toolutil.EscapeMdTableCell(envName),
+			user,
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' with a deployment_id to see details",
-		"Use gitlab_environment action 'list' to see all environments",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionDeploymentGet, "see one deployment, its approvals and its pipeline"),
+		toolutil.HintAction(hintActionDeploymentList, "page through the rest of the project's deployments"),
+		toolutil.HintAction(hintActionDeploymentMRs, "list the merge requests a deployment shipped"),
 	)
 	return b.String()
 }
 
-// FormatApproveOrRejectMarkdown renders the approve/reject result as Markdown.
+// pipelineURL is the page a deployment row links to: a deployment has no page
+// of its own, and the pipeline that ran it is where a reader goes next. Both
+// hops are optional, so a deployment with no backing job links nothing.
+func pipelineURL(d Output) string {
+	if d.Deployable == nil || d.Deployable.Pipeline == nil {
+		return ""
+	}
+	return d.Deployable.Pipeline.WebURL
+}
+
+// FormatApproveOrRejectMarkdown renders the approve/reject confirmation, which
+// is a one-line result rather than a card: GitLab answers the call with no
+// object, and the sentence is the server's own, composed from the deployment
+// id and the status the schema validated.
 func FormatApproveOrRejectMarkdown(o ApproveOrRejectOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s %s\n", toolutil.EmojiSuccess, o.Message)
-	toolutil.WriteHints(&b, "Use action 'list' to see all deployments for this environment")
+	b.WriteString(toolutil.EmojiSuccess + " " + toolutil.StripControlBytes(o.Message) + "\n")
+	toolutil.WriteHints(&b,
+		toolutil.HintAction(hintActionDeploymentGet, "read the deployment back with its approvals"),
+		toolutil.HintAction(hintActionDeploymentList, "see the other deployments to this environment"),
+	)
 	return b.String()
 }
 

--- a/internal/tools/environments/environments_test.go
+++ b/internal/tools/environments/environments_test.go
@@ -773,11 +773,11 @@ func TestEnvironmentStop_ForceFalse(t *testing.T) {
 // toOutput — all optional timestamp fields
 // ---------------------------------------------------------------------------.
 
-// TestToOutput_AllTimestampFields verifies the ToOutput_AllTimestampFields handler.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the returned output matches the expected fields.
+// TestToOutput_AllTimestampFields pins the whole card of an environment whose
+// three timestamps GitLab all sent: each is rendered in the display form and
+// none of them as the wire string.
 func TestToOutput_AllTimestampFields(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:          1,
 		Name:        "production",
 		Slug:        "production",
@@ -790,23 +790,20 @@ func TestToOutput_AllTimestampFields(t *testing.T) {
 		AutoStopAt:  "2026-12-31T23:59:59Z",
 	})
 
-	for _, want := range []string{
-		"## Environment: production",
-		"| ID | 1 |",
-		"| Slug | production |",
-		"| State | available |",
-		"| Tier | production |",
-		"| Description | Main prod environment |",
-		"| URL | https://prod.example.com |",
-		"| Created | 1 Jan 2026 00:00 UTC |",
-		"| Updated | 15 Jun 2026 12:00 UTC |",
-		"| Auto-Stop At | 31 Dec 2026 23:59 UTC |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Environment: production\n\n" +
+		"- **ID**: 1\n" +
+		"- **Slug**: production\n" +
+		"- **State**: available\n" +
+		"- **Tier**: production\n" +
+		"- **Description**: Main prod environment\n" +
+		"- **External URL**: [https://prod.example.com](https://prod.example.com)\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Updated**: 15 Jun 2026 12:00 UTC\n" +
+		"- **Auto-Stop At**: 31 Dec 2026 23:59 UTC\n" +
+		availableHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -837,36 +834,136 @@ func TestFormatEnvironmentNotFound(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown_MinimalFields verifies the OutputMarkdown_MinimalFields Markdown formatter for a representative output_minimalfields input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// stoppedHints and availableHints are the two guidance sections an environment
+// card closes with, chosen by the state the environment is in.
+const (
+	stoppedHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'environment.delete' to delete this stopped environment\n" +
+		"- Use action 'environment.deployment_list' to see the deployments to this environment\n"
+	availableHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'environment.stop' to stop this environment\n" +
+		"- Use action 'environment.deployment_list' to see the deployments to this environment\n"
+)
+
+// listHints is the guidance section the listing closes with, the preserve-links
+// instruction first because the External URL column carries links.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- " + toolutil.HintPreserveLinks + "\n" +
+	"- Use action 'environment.get' to see one environment and what is deployed to it\n" +
+	"- Use action 'environment.create' to add a new environment\n" +
+	"- Use action 'environment.list' to page through the rest of the project's environments\n"
+
+// TestFormatOutputMarkdown_MinimalFields pins the whole card of an environment
+// GitLab answered with nothing optional: four rows, no label with an empty
+// value under it, and the hint the state allows.
 func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:    7,
 		Name:  "dev",
 		Slug:  "dev",
 		State: "stopped",
 	})
 
-	if !strings.Contains(md, "## Environment: dev") {
-		t.Errorf("missing header:\n%s", md)
+	want := "## Environment: dev\n\n" +
+		"- **ID**: 7\n" +
+		"- **Slug**: dev\n" +
+		"- **State**: stopped\n" +
+		stoppedHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if !strings.Contains(md, "| State | stopped |") {
-		t.Errorf("missing state:\n%s", md)
+}
+
+// TestFormatOutputMarkdown_FullCard pins the whole card of an environment with
+// everything GitLab sends: the external URL as a link, the project and the
+// cluster agent as nested objects, and the deployment running on it as a
+// section, which is the question an environment is looked up to answer.
+func TestFormatOutputMarkdown_FullCard(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ID:                  12,
+		Name:                "production",
+		Slug:                "production",
+		State:               "available",
+		Tier:                "production",
+		Description:         "Customer-facing",
+		ExternalURL:         "https://prod.example.com",
+		AutoStopSetting:     "with_action",
+		KubernetesNamespace: "prod",
+		FluxResourcePath:    "kustomization/prod",
+		CreatedAt:           "2026-01-02T03:04:00Z",
+		UpdatedAt:           "2026-02-03T04:05:00Z",
+		AutoStopAt:          "2026-03-04T05:06:00Z",
+		Project: &ProjectOutput{
+			ID:                3,
+			PathWithNamespace: "acme/web",
+			WebURL:            "https://gitlab.example.com/acme/web",
+		},
+		ClusterAgent: &ClusterAgentOutput{ID: 4, Name: "prod-agent"},
+		LastDeployment: &DeploymentOutput{
+			ID:        90,
+			IID:       12,
+			Ref:       "main",
+			SHA:       "0123456789abcdef",
+			Status:    "success",
+			CreatedAt: "2026-03-01T10:00:00Z",
+			User:      &DeploymentUserOutput{Username: "dana", WebURL: "https://gitlab.example.com/dana"},
+			Deployable: &DeployableOutput{
+				Pipeline: &DeployablePipelineOutput{ID: 77, WebURL: "https://gitlab.example.com/acme/web/-/pipelines/77"},
+			},
+		},
+	})
+
+	want := "## Environment: production\n\n" +
+		"- **ID**: 12\n" +
+		"- **Slug**: production\n" +
+		"- **State**: available\n" +
+		"- **Tier**: production\n" +
+		"- **Description**: Customer-facing\n" +
+		"- **External URL**: [https://prod.example.com](https://prod.example.com)\n" +
+		"- **Auto-Stop Setting**: with_action\n" +
+		"- **Kubernetes Namespace**: `prod`\n" +
+		"- **Flux Resource Path**: `kustomization/prod`\n" +
+		"- **Created**: 2 Jan 2026 03:04 UTC\n" +
+		"- **Updated**: 3 Feb 2026 04:05 UTC\n" +
+		"- **Auto-Stop At**: 4 Mar 2026 05:06 UTC\n" +
+		"- **Project**:\n" +
+		"  - **ID**: 3\n" +
+		"  - **Path**: acme/web\n" +
+		"  - **URL**: [https://gitlab.example.com/acme/web](https://gitlab.example.com/acme/web)\n" +
+		"- **Cluster Agent**:\n" +
+		"  - **ID**: 4\n" +
+		"  - **Name**: prod-agent\n" +
+		"\n### Last Deployment\n\n" +
+		"- **ID**: 90\n" +
+		"- **IID**: 12\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Ref**: main\n" +
+		"- **SHA**: `01234567`\n" +
+		"- **Created**: 1 Mar 2026 10:00 UTC\n" +
+		"- **Deployed By**: [@dana](https://gitlab.example.com/dana)\n" +
+		"- **Pipeline**: [#77](https://gitlab.example.com/acme/web/-/pipelines/77)\n" +
+		availableHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	for _, absent := range []string{
-		"| Tier |",
-		"| Description |",
-		"| URL |",
-		"| Created |",
-		"| Updated |",
-		"| Auto-Stop At |",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+}
+
+// TestFormatOutputMarkdown_StoppingOffersNeitherStopNorDelete pins the third
+// state: an environment GitLab is still stopping can be neither stopped again
+// nor deleted, so the card offers only the deployments.
+func TestFormatOutputMarkdown_StoppingOffersNeitherStopNorDelete(t *testing.T) {
+	got := FormatOutputMarkdown(Output{ID: 5, Name: "dev", State: "stopping"})
+
+	want := "## Environment: dev\n\n" +
+		"- **ID**: 5\n" +
+		"- **State**: stopping\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'environment.deployment_list' to see the deployments to this environment\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -874,51 +971,58 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 // FormatListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithEnvironments verifies the ListMarkdown_WithEnvironments Markdown formatter for a representative list_withenvironments input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown_WithEnvironments pins the whole listing: the heading
+// counting what GitLab reported, the external URL as a link, the pagination
+// line and one guidance section.
 func TestFormatListMarkdown_WithEnvironments(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Environments: []Output{
 			{ID: 1, Name: "production", State: "available", Tier: "production", ExternalURL: "https://prod.example.com"},
 			{ID: 2, Name: "staging", State: "available", Tier: "staging", ExternalURL: "https://staging.example.com"},
 			{ID: 3, Name: "dev", State: "stopped", Tier: "development", ExternalURL: ""},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 3, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
+	})
 
-	for _, want := range []string{
-		"## Environments (3)",
-		"| ID |",
-		"| --- |",
-		"| 1 |",
-		"| 2 |",
-		"| 3 |",
-		"production",
-		"staging",
-		"dev",
-		"available",
-		"stopped",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Environments (3)\n\n" +
+		"| ID | Name | State | Tier | External URL |\n| --- | --- | --- | --- | --- |\n" +
+		"| 1 | production | available | production | [https://prod.example.com](https://prod.example.com) |\n" +
+		"| 2 | staging | available | staging | [https://staging.example.com](https://staging.example.com) |\n" +
+		"| 3 | dev | stopped | development |  |\n" +
+		"\nPage 1 of 1 | 3 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty Markdown formatter for a representative list_empty input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No environments found") {
-		t.Errorf("expected empty message:\n%s", md)
+// TestFormatListMarkdown_KeysetPage pins the heading of a page GitLab sent no
+// total for: it counts the rows shown rather than claiming a total of zero
+// above them.
+func TestFormatListMarkdown_KeysetPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Environments: []Output{{ID: 1, Name: "production", State: "available"}},
+		Pagination:   toolutil.PaginationOutput{HasMore: true},
+	})
+
+	want := "## Environments (1 shown, more available)\n\n" +
+		"| ID | Name | State | Tier | External URL |\n| --- | --- | --- | --- | --- |\n" +
+		"| 1 | production | available |  |  |\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+}
+
+// TestFormatListMarkdown_Empty pins that a project with no environments
+// renders the one sentence and nothing else.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No environments found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/environments/markdown.go
+++ b/internal/tools/environments/markdown.go
@@ -2,11 +2,22 @@ package environments
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// The canonical catalog IDs the hints name that the specs do not already
+// spell. A deployment action is projected under the environment domain, so the
+// ID every surface resolves is "environment.deployment_list" and not the
+// "deployment.list" the cross-link constant in action_specs.go spells.
+const (
+	actionEnvironmentCreate  = "environment.create"
+	actionEnvironmentDelete  = "environment.delete"
+	hintActionDeploymentList = "environment.deployment_list"
 )
 
 type environmentNotFoundOutput struct {
@@ -21,64 +32,123 @@ func formatEnvironmentNotFound(out environmentNotFoundOutput) *mcp.CallToolResul
 	)
 }
 
-// FormatOutputMarkdown renders a single environment as Markdown.
+// FormatOutputMarkdown renders one environment as the card of a single object:
+// its own fields, the project and cluster agent as nested objects, and the
+// deployment that put the code there as a section of its own.
 func FormatOutputMarkdown(e Output) string {
 	if e.Name == "" {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Environment: %s\n\n", toolutil.EscapeMdHeading(e.Name))
-	b.WriteString("| Field | Value |\n")
-	b.WriteString(toolutil.TblSep2Col)
-	fmt.Fprintf(&b, "| ID | %d |\n", e.ID)
-	fmt.Fprintf(&b, "| Slug | %s |\n", toolutil.EscapeMdTableCell(e.Slug))
-	//gitlab:allow-unescaped e.State: an environment state GitLab picks from a fixed set (available, stopping, stopped).
-	fmt.Fprintf(&b, "| State | %s |\n", e.State)
-	if e.Tier != "" {
-		fmt.Fprintf(&b, "| Tier | %s |\n", toolutil.EscapeMdTableCell(e.Tier))
+	c := toolutil.NewCard(&b, "Environment: "+e.Name)
+	c.Int("ID", e.ID)
+	c.Field("Slug", e.Slug)
+	// An environment state GitLab picks from a fixed set (available, stopping,
+	// stopped).
+	c.Field("State", e.State)
+	c.Field("Tier", e.Tier)
+	c.Field("Description", e.Description)
+	// The external URL is the address the deployed application answers on, so
+	// it is written as the link it is rather than as text a reader has to copy.
+	c.Link("External URL", e.ExternalURL, e.ExternalURL)
+	c.Field("Auto-Stop Setting", e.AutoStopSetting)
+	c.Code("Kubernetes Namespace", e.KubernetesNamespace)
+	c.Code("Flux Resource Path", e.FluxResourcePath)
+	c.Time("Created", e.CreatedAt)
+	c.Time("Updated", e.UpdatedAt)
+	c.Time("Auto-Stop At", e.AutoStopAt)
+	if e.Project != nil {
+		p := c.Sub("Project")
+		p.Int("ID", e.Project.ID)
+		p.Field("Path", e.Project.PathWithNamespace)
+		p.Link("URL", e.Project.WebURL, e.Project.WebURL)
 	}
-	if e.Description != "" {
-		fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(e.Description))
+	if e.ClusterAgent != nil {
+		a := c.Sub("Cluster Agent")
+		a.Int("ID", e.ClusterAgent.ID)
+		a.Field("Name", e.ClusterAgent.Name)
 	}
-	if e.ExternalURL != "" {
-		fmt.Fprintf(&b, "| URL | %s |\n", toolutil.EscapeMdTableCell(e.ExternalURL))
-	}
-	if e.CreatedAt != "" {
-		fmt.Fprintf(&b, "| Created | %s |\n", toolutil.FormatTime(e.CreatedAt))
-	}
-	if e.UpdatedAt != "" {
-		fmt.Fprintf(&b, "| Updated | %s |\n", toolutil.FormatTime(e.UpdatedAt))
-	}
-	if e.AutoStopAt != "" {
-		fmt.Fprintf(&b, "| Auto-Stop At | %s |\n", toolutil.FormatTime(e.AutoStopAt))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'stop' to stop this environment",
-		"Use gitlab_environment action 'deployment_list' with environment to see deployments",
-	)
+	writeLastDeployment(c, e.LastDeployment)
+	c.End(stateHints(e.State)...)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of environments as a Markdown table.
+// writeLastDeployment writes what is deployed to the environment right now.
+// Without it the card answered "what is this environment?" and never "what is
+// running on it?", which is the question an environment is looked up for.
+func writeLastDeployment(c *toolutil.Card, d *DeploymentOutput) {
+	if d == nil {
+		return
+	}
+	s := c.Section("Last Deployment")
+	// A deployment's ids start at one, so a zero is GitLab not having sent the
+	// field rather than a deployment numbered nought.
+	s.Count("ID", d.ID)
+	s.Count("IID", d.IID)
+	if d.Status != "" {
+		// A deployment status GitLab picks from a fixed set (created, running,
+		// success, failed, canceled, blocked), rendered with the glyph every
+		// pipeline-shaped status in the tree carries.
+		s.Markdown("Status", toolutil.PipelineStatusEmoji(d.Status)+" "+toolutil.EscapeMdTableCell(d.Status))
+	}
+	s.Field("Ref", d.Ref)
+	s.Code("SHA", shortSHA(d.SHA))
+	s.Time("Created", d.CreatedAt)
+	if d.User != nil {
+		s.Markdown("Deployed By", toolutil.MdUserLink(d.User.Username, d.User.WebURL))
+	}
+	if d.Deployable != nil && d.Deployable.Pipeline != nil {
+		s.Link("Pipeline", fmt.Sprintf("#%d", d.Deployable.Pipeline.ID), d.Deployable.Pipeline.WebURL)
+	}
+}
+
+// shortSHA renders the first eight characters of a commit SHA, the form GitLab
+// itself shows, and leaves a shorter value alone.
+func shortSHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+// stateHints picks the next step the environment's own state allows: an
+// available environment can be stopped, a stopped one can be deleted, and
+// offering "stop" for an environment that is already stopped was advice GitLab
+// answers with an error.
+func stateHints(state string) []string {
+	hints := make([]string, 0, 2)
+	switch state {
+	case "stopped":
+		hints = append(hints, toolutil.HintAction(actionEnvironmentDelete, "delete this stopped environment"))
+	case "stopping":
+	default:
+		hints = append(hints, toolutil.HintAction(actionEnvironmentStop, "stop this environment"))
+	}
+	return append(hints, toolutil.HintAction(hintActionDeploymentList, "see the deployments to this environment"))
+}
+
+// FormatListMarkdown renders a page of a project's environments as a Markdown
+// table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Environments) == 0 {
-		return "No environments found.\n"
+		return toolutil.EmptyMessage("environments")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Environments (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Environments), out.Pagination)
-	b.WriteString("| ID | Name | State | Tier | External URL |\n")
-	b.WriteString("| --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Environments", len(out.Environments), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "State", "Tier", "External URL"))
 	for _, e := range out.Environments {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
-			e.ID, toolutil.EscapeMdTableCell(e.Name), e.State, toolutil.EscapeMdTableCell(e.Tier), toolutil.EscapeMdTableCell(e.ExternalURL))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			toolutil.EscapeMdTableCell(e.Name),
+			toolutil.EscapeMdTableCell(e.State),
+			toolutil.EscapeMdTableCell(e.Tier),
+			toolutil.MdTitleLink(e.ExternalURL, e.ExternalURL),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' with an environment_id to see details",
-		"Use action 'create' to add a new environment",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionEnvironmentGet, "see one environment and what is deployed to it"),
+		toolutil.HintAction(actionEnvironmentCreate, "add a new environment"),
+		toolutil.HintAction(actionEnvironmentList, "page through the rest of the project's environments"),
 	)
 	return b.String()
 }

--- a/internal/tools/epicdiscussions/epic_discussions_test.go
+++ b/internal/tools/epicdiscussions/epic_discussions_test.go
@@ -1052,15 +1052,29 @@ func TestDeleteNote(t *testing.T) {
 // Formatters
 // --------------------------------------------------------------------------
 
-// TestFormatListMarkdownString uses table-driven subtests to verify that FormatListMarkdownString renders a table for populated inputs and an empty-state message otherwise.
+// The guidance sections the three shared renderers end with, so each
+// expectation below can pin the whole rendered document.
+const (
+	listHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_get_epic_discussion` to view full discussion details\n"
+	threadHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_add_epic_discussion_note` to reply to this discussion\n"
+	noteHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_update_epic_discussion_note` to edit this note\n"
+)
+
+// TestFormatListMarkdownString uses table-driven subtests to pin the whole
+// document the shared discussion list renderer writes: a thread per section with
+// its notes quoted under their authors and the cursor line below them, and one
+// sentence for an epic with no discussions.
 func TestFormatListMarkdownString(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   ListOutput
-		wantSub string
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
-			name: "renders table with discussions",
+			name: "renders the threads with the cursor line",
 			input: ListOutput{
 				Discussions: []Output{
 					{
@@ -1072,61 +1086,89 @@ func TestFormatListMarkdownString(t *testing.T) {
 				},
 				Pagination: toolutil.GraphQLForwardPaginationOutput{},
 			},
-			wantSub: "d1hex",
+			want: "## Epic Discussions (1)\n\n" +
+				"### Discussion d1hex\n" +
+				"- **@alice** (1 Jan 2026 00:00 UTC, note 100):\n" +
+				"  > Hello\n\n" +
+				"Showing 1 items | no more pages\n" +
+				listHintsBlock,
 		},
 		{
-			name:    "renders empty state when no discussions",
-			input:   ListOutput{},
-			wantSub: "No epic discussions",
+			name:  "renders empty state when no discussions",
+			input: ListOutput{},
+			want:  "No epic discussions found.\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatListMarkdownString(tt.input)
-			if !strings.Contains(md, tt.wantSub) {
-				t.Errorf("output %q does not contain %q", md, tt.wantSub)
+			if got := FormatListMarkdownString(tt.input); got != tt.want {
+				t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})
 	}
 }
 
-// TestFormatMarkdownString uses table-driven subtests to verify that FormatMarkdownString renders a discussion with notes and handles an empty discussion.
+// TestFormatMarkdownString uses table-driven subtests to pin the whole card of a
+// thread with notes and of one GitLab answered with none.
 func TestFormatMarkdownString(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   Output
-		wantSub string
+		name  string
+		input Output
+		want  string
 	}{
 		{
-			name:    "renders discussion with notes",
-			input:   Output{ID: "d1hex", Notes: []NoteOutput{{ID: 1, Body: "note body", Author: "bob", CreatedAt: "2026-01-01T00:00:00Z"}}},
-			wantSub: "bob",
+			name:  "renders discussion with notes",
+			input: Output{ID: "d1hex", Notes: []NoteOutput{{ID: 1, Body: "note body", Author: "bob", CreatedAt: "2026-01-01T00:00:00Z"}}},
+			want: "## Discussion d1hex\n\n" +
+				"- **@bob** (1 Jan 2026 00:00 UTC, note 1):\n" +
+				"  > note body\n" +
+				threadHintsBlock,
 		},
 		{
-			name:    "renders empty discussion",
-			input:   Output{ID: "d1hex"},
-			wantSub: "d1hex",
+			name:  "renders empty discussion",
+			input: Output{ID: "d1hex"},
+			want:  "## Discussion d1hex\n" + threadHintsBlock,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatMarkdownString(tt.input)
-			if !strings.Contains(md, tt.wantSub) {
-				t.Errorf("output %q does not contain %q", md, tt.wantSub)
+			if got := FormatMarkdownString(tt.input); got != tt.want {
+				t.Errorf("thread card mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})
 	}
 }
 
-// TestFormatNoteMarkdownString verifies the NoteMarkdownString Markdown formatter for a representative notestring input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatNoteMarkdownString pins the whole card of a note somebody wrote.
 func TestFormatNoteMarkdownString(t *testing.T) {
-	md := FormatNoteMarkdownString(NoteOutput{ID: 1, Body: "test note", Author: "carol", CreatedAt: "2026-01-01T00:00:00Z"})
-	if !strings.Contains(md, "carol") {
-		t.Errorf("expected author 'carol' in output, got %q", md)
+	got := FormatNoteMarkdownString(NoteOutput{ID: 1, Body: "test note", Author: "carol", CreatedAt: "2026-01-01T00:00:00Z"})
+
+	want := "## Discussion Note #1\n\n" +
+		"- **Author**: @carol\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Body**: test note\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatNoteMarkdownString_SystemNote pins the card of a system note: the
+// marker is written, where the view model used to drop the flag and a record
+// GitLab wrote itself read as a comment somebody typed.
+func TestFormatNoteMarkdownString_SystemNote(t *testing.T) {
+	got := FormatNoteMarkdownString(NoteOutput{ID: 2, Body: "changed title", Author: "carol", CreatedAt: "2026-01-01T00:00:00Z", System: true})
+
+	want := "## Discussion Note #2\n\n" +
+		"- **Author**: @carol\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **System note**\n" +
+		"- **Body**: changed title\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/epicdiscussions/markdown.go
+++ b/internal/tools/epicdiscussions/markdown.go
@@ -25,8 +25,13 @@ func toMarkdownDiscussion(out Output) toolutil.DiscussionMarkdown {
 	return toolutil.NewDiscussionMarkdown(out.ID, toolutil.NoteMarkdowns(out.Notes, toMarkdownNote))
 }
 
+// toMarkdownNote maps an epic discussion note onto the shared note view model,
+// the system flag included: a system note is GitLab's own record of a state
+// change rather than something a person wrote, and a card that does not mark it
+// reads as if somebody had.
 func toMarkdownNote(out NoteOutput) toolutil.DiscussionNoteMarkdown {
-	return toolutil.NewDiscussionNoteMarkdown(out.ID, out.Body, out.Author, out.CreatedAt)
+	return toolutil.NewNoteMarkdown(out.ID, out.Body, out.Author, out.CreatedAt,
+		toolutil.NoteMarkdownFlags{System: out.System}, "")
 }
 
 func init() {

--- a/internal/tools/epicnotes/epic_notes_test.go
+++ b/internal/tools/epicnotes/epic_notes_test.go
@@ -863,14 +863,26 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The two guidance sections an epic note result ends with, so each expectation
+// below can pin the whole rendered document.
+const (
+	noteHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'epic_note_update' with note_id to edit this note\n" +
+		"- Use action 'epic_note_delete' with note_id to remove this note\n"
+	listHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'epic_note_get' with note_id to read a specific note\n" +
+		"- Use action 'epic_note_create' to add a new note to this epic\n"
+)
+
+// TestFormatOutputMarkdown uses table-driven subtests to pin the whole note
+// card: the author as a handle, the system marker where it holds, and no author
+// row at all for a note GitLab answered with none, where the card used to write
+// a label with nothing after it.
 func TestFormatOutputMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    Output
-		contains []string
+		name  string
+		input Output
+		want  string
 	}{
 		{
 			name: "renders regular note with author and body",
@@ -881,13 +893,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				CreatedAt: "2026-01-15T10:00:00Z",
 				System:    false,
 			},
-			contains: []string{
-				"## Epic Note #100",
-				"alice",
-				"This looks good",
-				"epic_note_update",
-				"epic_note_delete",
-			},
+			want: "## Epic Note #100\n\n" +
+				"- **Author**: @alice\n" +
+				"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+				"- **Body**: This looks good\n" +
+				noteHintsBlock,
 		},
 		{
 			name: "renders system note with system flag",
@@ -898,11 +908,12 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				CreatedAt: "2026-01-15T12:00:00Z",
 				System:    true,
 			},
-			contains: []string{
-				"## Epic Note #101",
-				"**System note**",
-				"changed the description",
-			},
+			want: "## Epic Note #101\n\n" +
+				"- **Author**: @admin\n" +
+				"- **Created**: 15 Jan 2026 12:00 UTC\n" +
+				"- **System note**\n" +
+				"- **Body**: changed the description\n" +
+				noteHintsBlock,
 		},
 		{
 			name: "renders note with nil author object",
@@ -913,33 +924,32 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				CreatedAt: "2026-01-15T13:00:00Z",
 				System:    true,
 			},
-			contains: []string{
-				"## Epic Note #102",
-				"anonymous system entry",
-			},
+			want: "## Epic Note #102\n\n" +
+				"- **Created**: 15 Jan 2026 13:00 UTC\n" +
+				"- **System note**\n" +
+				"- **Body**: anonymous system entry\n" +
+				noteHintsBlock,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatOutputMarkdown(tt.input)
-			for _, want := range tt.contains {
-				if !strings.Contains(md, want) {
-					t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-				}
+			if got := FormatOutputMarkdown(tt.input); got != tt.want {
+				t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})
 	}
 }
 
-// TestFormatListMarkdown verifies the ListMarkdown Markdown formatter for a representative list input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatListMarkdown uses table-driven subtests to pin the whole list
+// document: the table with the system flag as a glyph rather than the word
+// "false", the cursor line the keyset connection ends with, and one sentence for
+// an epic with no notes.
 func TestFormatListMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
 			name: "renders table with notes",
@@ -950,16 +960,26 @@ func TestFormatListMarkdown(t *testing.T) {
 				},
 				Pagination: toolutil.GraphQLForwardPaginationOutput{HasNextPage: false},
 			},
-			contains: []string{
-				"## Epic Notes (2)",
-				"| ID | Author | Created | System |",
-				"| 100 |",
-				"| 101 |",
-				"alice",
-				"admin",
-				"epic_note_get",
-				"epic_note_create",
+			want: "## Epic Notes (2)\n\n" +
+				"| ID | Author | Created | System |\n" +
+				"| --- | --- | --- | --- |\n" +
+				"| 100 | alice | 15 Jan 2026 10:00 UTC | ❌ |\n" +
+				"| 101 | admin | 15 Jan 2026 12:00 UTC | ✅ |\n\n" +
+				"Showing 2 items | no more pages\n" +
+				listHintsBlock,
+		},
+		{
+			name: "renders the next-page cursor when one follows",
+			input: ListOutput{
+				Notes:      []Output{{ID: 100, Author: authorObj("alice"), CreatedAt: "2026-01-15T10:00:00Z"}},
+				Pagination: toolutil.GraphQLForwardPaginationOutput{HasNextPage: true, EndCursor: "eyJpZCI6IjEwMCJ9"},
 			},
+			want: "## Epic Notes (1)\n\n" +
+				"| ID | Author | Created | System |\n" +
+				"| --- | --- | --- | --- |\n" +
+				"| 100 | alice | 15 Jan 2026 10:00 UTC | ❌ |\n\n" +
+				"Showing 1 items | next page cursor: `eyJpZCI6IjEwMCJ9`\n" +
+				listHintsBlock,
 		},
 		{
 			name: "renders empty state when no notes",
@@ -967,20 +987,14 @@ func TestFormatListMarkdown(t *testing.T) {
 				Notes:      []Output{},
 				Pagination: toolutil.GraphQLForwardPaginationOutput{},
 			},
-			contains: []string{
-				"## Epic Notes (0)",
-				"No epic notes found.",
-			},
+			want: "No epic notes found.\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatListMarkdown(tt.input)
-			for _, want := range tt.contains {
-				if !strings.Contains(md, want) {
-					t.Errorf("markdown missing %q\ngot:\n%s", want, md)
-				}
+			if got := FormatListMarkdown(tt.input); got != tt.want {
+				t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/epicnotes/markdown.go
+++ b/internal/tools/epicnotes/markdown.go
@@ -1,14 +1,17 @@
 package epicnotes
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
 // noteAuthorUsername returns the note author's username, read from the
-// canonical author object (nil-guarded).
+// canonical author object (nil-guarded). Epic notes are served through the Work
+// Items GraphQL API and their author is this package's own object rather than
+// the shared note shape, so the accessor stays here; a note GitLab answered with
+// no author renders no author row at all.
 func noteAuthorUsername(n Output) string {
 	if n.Author != nil {
 		return n.Author.Username
@@ -16,43 +19,52 @@ func noteAuthorUsername(n Output) string {
 	return ""
 }
 
-// FormatOutputMarkdown renders a single epic note as a Markdown summary.
-func FormatOutputMarkdown(n Output) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Epic Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(noteAuthorUsername(n)))
-	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
-	if n.System {
-		b.WriteString("- **System note**\n")
-	}
-	fmt.Fprintf(&b, "\n%s\n", toolutil.WrapGFMBody(n.Body))
-	toolutil.WriteHints(
-		&b,
-		"Use action 'epic_note_update' with note_id to edit this note",
-		"Use action 'epic_note_delete' with note_id to remove this note",
-	)
-	return b.String()
+// toNoteMarkdown maps an epic note onto the shared note view model, so the card
+// is the one every note domain renders.
+func toNoteMarkdown(n Output) toolutil.NoteMarkdown {
+	return toolutil.NewNoteMarkdown(n.ID, n.Body, noteAuthorUsername(n), n.CreatedAt,
+		toolutil.NoteMarkdownFlags{System: n.System}, "")
 }
 
-// FormatListMarkdown renders a list of epic notes as a Markdown table.
+// FormatOutputMarkdown renders a single epic note as the shared note card: the
+// author as a handle, the time, the system marker when it holds, and the body
+// as the card's long text.
+func FormatOutputMarkdown(n Output) string {
+	return toolutil.FormatNoteMarkdown(toNoteMarkdown(n), toolutil.NoteMarkdownOptions{
+		Title: "Epic Note",
+		Hints: []string{
+			"Use action 'epic_note_update' with note_id to edit this note",
+			"Use action 'epic_note_delete' with note_id to remove this note",
+		},
+	})
+}
+
+// FormatListMarkdown renders a list of epic notes as a Markdown table. The
+// notes widget is a keyset connection, which counts nothing it has not walked,
+// so the heading carries the count shown and the cursor line below the rows says
+// whether more follow. The table carries no link, so its footer carries no
+// instruction to keep them.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Epic Notes (%d)\n\n", len(out.Notes))
 	if len(out.Notes) == 0 {
-		b.WriteString("No epic notes found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("epic notes")
 	}
-	b.WriteString("| ID | Author | Created | System |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Epic Notes", len(out.Notes), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Author", "Created", "System"))
 	for _, n := range out.Notes {
-		fmt.Fprintf(&b, "| %d | %s | %s | %v |\n", n.ID, toolutil.EscapeMdTableCell(noteAuthorUsername(n)), toolutil.FormatTime(n.CreatedAt), n.System)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(n.ID, 10),
+			toolutil.EscapeMdTableCell(noteAuthorUsername(n)),
+			toolutil.FormatTime(n.CreatedAt),
+			toolutil.BoolEmoji(n.System),
+		))
 	}
-	b.WriteString("\n")
-	b.WriteString(toolutil.FormatGraphQLForwardPagination(out.Pagination, len(out.Notes)))
-	b.WriteString("\n")
+	toolutil.WriteGraphQLPagination(&b, toolutil.GraphQLPaginationOutput{
+		HasNextPage: out.Pagination.HasNextPage,
+		EndCursor:   out.Pagination.EndCursor,
+	}, len(out.Notes))
 	toolutil.WriteHints(
 		&b,
-		toolutil.HintPreserveLinks,
 		"Use action 'epic_note_get' with note_id to read a specific note",
 		"Use action 'epic_note_create' to add a new note to this epic",
 	)

--- a/internal/tools/files/files_test.go
+++ b/internal/tools/files/files_test.go
@@ -1446,9 +1446,35 @@ func TestGetRawFileMetaData_WithLFS(t *testing.T) {
 // Markdown formatters
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// The guidance sections the file formatters close with, pinned once so each
+// whole-output expectation names them rather than restating them.
+const (
+	fileCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_update' to modify this file\n" +
+		"- Use action 'repository.file_blame' to see who changed each line\n" +
+		"- Use action 'repository.file_delete' to remove this file\n"
+
+	fileInfoHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_get' to verify the file content\n" +
+		"- Use action 'repository.commit_list' to see the commit history\n"
+
+	fileBlameHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_get' to view one blame range's commit in full\n" +
+		"- Use action 'repository.file_get' to read the current file content\n"
+
+	fileMetadataHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_get' to read the file content\n" +
+		"- Use action 'repository.file_blame' to see blame information\n"
+
+	fileRawHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_update' to modify this file\n" +
+		"- Use action 'repository.file_blame' to see who last changed each line\n"
+)
+
+// TestFormatOutputMarkdown pins the whole card of a repository file. The body
+// is fenced here rather than dropped: this card used to fall through its
+// content-category switch with nothing at all for a text file, which is every
+// ordinary source file the action is asked for.
 func TestFormatOutputMarkdown(t *testing.T) {
 	t.Run("empty file path returns empty string", func(t *testing.T) {
 		got := FormatOutputMarkdown(Output{})
@@ -1457,52 +1483,68 @@ func TestFormatOutputMarkdown(t *testing.T) {
 		}
 	})
 
-	t.Run("non-empty file renders markdown", func(t *testing.T) {
+	t.Run("a text file carries its content", func(t *testing.T) {
 		got := FormatOutputMarkdown(Output{
+			FileName: "main.go",
 			FilePath: "src/main.go",
 			Size:     1024,
 			Ref:      "main",
 			Encoding: "base64",
 			BlobID:   "blob123",
+			Content:  "package main",
 		})
-		for _, want := range []string{
-			"## File: src/main.go",
-			"**Size**: 1024 bytes",
-			"**Ref**: main",
-			"**Encoding**: base64",
-			"**Blob ID**: blob123",
-		} {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(got, want) {
-					t.Errorf("FormatOutputMarkdown missing %q in:\n%s", want, got)
-				}
-			})
+
+		want := "## File: src/main.go\n\n" +
+			"- **Name**: main.go\n" +
+			"- **Size (bytes)**: 1024\n" +
+			"- **Ref**: main\n" +
+			"- **Encoding**: base64\n" +
+			"- **Blob ID**: `blob123`\n" +
+			"- **Executable**: ❌\n" +
+			"\n### Content\n\n" +
+			"```go\npackage main\n```\n" +
+			fileCardHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("a binary file names its category and prints no body", func(t *testing.T) {
+		got := FormatOutputMarkdown(Output{
+			FilePath:        "logo.bin",
+			Size:            9,
+			ContentCategory: "binary",
+		})
+
+		want := "## File: logo.bin\n\n" +
+			"- **Size (bytes)**: 9\n" +
+			"- **Executable**: ❌\n" +
+			"- **Content Type**: binary (content omitted, not viewable as text)\n" +
+			fileCardHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
 
-// TestFormatFileInfoMarkdown verifies the FileInfoMarkdown Markdown formatter for a representative fileinfo input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatFileInfoMarkdown pins the whole card of a create, update or delete
+// result, with and without the commit ids GitLab answers with.
 func TestFormatFileInfoMarkdown(t *testing.T) {
 	t.Run("without commit IDs", func(t *testing.T) {
 		got := FormatFileInfoMarkdown(FileInfoOutput{
 			FilePath: "new_file.txt",
 			Branch:   "feature",
 		})
-		for _, want := range []string{
-			"## File Operation Result",
-			"**File**: new_file.txt",
-			"**Branch**: feature",
-		} {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(got, want) {
-					t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
-				}
-			})
-		}
-		if strings.Contains(got, "Commit ID") {
-			t.Errorf("FormatFileInfoMarkdown should omit empty commit IDs:\n%s", got)
+
+		want := "## File Operation Result\n\n" +
+			"- **File**: new_file.txt\n" +
+			"- **Branch**: feature\n" +
+			fileInfoHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 
@@ -1513,27 +1555,34 @@ func TestFormatFileInfoMarkdown(t *testing.T) {
 			CommitID:     "commit123",
 			LastCommitID: "last456",
 		})
-		for _, want := range []string{"**Commit ID**: commit123", "**Last commit ID**: last456"} {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(got, want) {
-					t.Errorf("FormatFileInfoMarkdown missing %q in:\n%s", want, got)
-				}
-			})
+
+		want := "## File Operation Result\n\n" +
+			"- **File**: new_file.txt\n" +
+			"- **Branch**: feature\n" +
+			"- **Commit ID**: `commit123`\n" +
+			"- **Last Commit ID**: `last456`\n" +
+			fileInfoHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
 
-// TestFormatBlameMarkdown verifies the BlameMarkdown Markdown formatter for a representative blame input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatBlameMarkdown pins the whole blame render: one section per range,
+// the commit that last touched it as rows of that section, and the lines
+// themselves fenced.
 func TestFormatBlameMarkdown(t *testing.T) {
 	t.Run("empty ranges", func(t *testing.T) {
-		got := FormatBlameMarkdown(BlameOutput{
-			FilePath: "empty.go",
-			Ranges:   nil,
-		})
-		if !strings.Contains(got, "No blame data found") {
-			t.Errorf("expected 'No blame data found' in:\n%s", got)
+		got := FormatBlameMarkdown(BlameOutput{FilePath: "empty.go"})
+
+		want := "## File Blame: empty.go\n\n" +
+			"GitLab returned no blame ranges for this file.\n" +
+			"\n---\n\U0001F4A1 **Next steps:**\n" +
+			"- Use action 'repository.file_get' to read the current file content\n"
+
+		if got != want {
+			t.Errorf("blame mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 
@@ -1543,28 +1592,27 @@ func TestFormatBlameMarkdown(t *testing.T) {
 			Ranges: []BlameRangeOutput{
 				{
 					Commit: BlameRangeCommitOutput{
-						ID:         "abc12345deadbeef",
-						Message:    "initial commit",
-						AuthorName: "Alice",
+						ID:            "abc12345deadbeef",
+						Message:       "initial commit",
+						AuthorName:    "Alice",
+						CommittedDate: "2026-03-20T15:45:00Z",
 					},
 					Lines: []string{"package main", "", "func main() {}"},
 				},
 			},
 		})
-		for _, want := range []string{
-			"## File Blame: main.go",
-			"Range 1",
-			"Alice",
-			"abc12345",
-			"initial commit",
-			"package main",
-			"func main() {}",
-		} {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(got, want) {
-					t.Errorf("FormatBlameMarkdown missing %q in:\n%s", want, got)
-				}
-			})
+
+		want := "## File Blame: main.go\n\n" +
+			"### Range 1: abc12345\n\n" +
+			"- **Commit**: `abc12345`\n" +
+			"- **Author**: Alice\n" +
+			"- **Committed**: 20 Mar 2026 15:45 UTC\n" +
+			"- **Message**: initial commit\n" +
+			"\n```go\npackage main\n\nfunc main() {}\n```\n" +
+			fileBlameHints
+
+		if got != want {
+			t.Errorf("blame mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 
@@ -1573,24 +1621,29 @@ func TestFormatBlameMarkdown(t *testing.T) {
 			FilePath: "short.go",
 			Ranges: []BlameRangeOutput{
 				{
-					Commit: BlameRangeCommitOutput{
-						ID:         "abc",
-						Message:    "short",
-						AuthorName: "Bob",
-					},
-					Lines: []string{"line1"},
+					Commit: BlameRangeCommitOutput{ID: "abc", Message: "short", AuthorName: "Bob"},
+					Lines:  []string{"line1"},
 				},
 			},
 		})
-		if !strings.Contains(got, "abc") {
-			t.Errorf("expected short ID 'abc' in:\n%s", got)
+
+		want := "## File Blame: short.go\n\n" +
+			"### Range 1: abc\n\n" +
+			"- **Commit**: `abc`\n" +
+			"- **Author**: Bob\n" +
+			"- **Message**: short\n" +
+			"\n```go\nline1\n```\n" +
+			fileBlameHints
+
+		if got != want {
+			t.Errorf("blame mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
 
-// TestFormatMetaDataMarkdown verifies the MetaDataMarkdown Markdown formatter for a representative metadata input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatMetaDataMarkdown pins the whole metadata card, which carries no
+// body at all: the executable bit is a flag rather than the word "yes", so a
+// file that is not executable says so instead of saying nothing.
 func TestFormatMetaDataMarkdown(t *testing.T) {
 	t.Run("without execute filemode", func(t *testing.T) {
 		got := FormatMetaDataMarkdown(MetaDataOutput{
@@ -1604,20 +1657,21 @@ func TestFormatMetaDataMarkdown(t *testing.T) {
 			LastCommitID: "c1",
 			SHA256:       "sha256val",
 		})
-		for _, want := range []string{
-			"## File Metadata: data.json",
-			"**Name**: data.json",
-			"**Size**: 512 bytes",
-			"**SHA-256**: sha256val",
-		} {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(got, want) {
-					t.Errorf("FormatMetaDataMarkdown missing %q in:\n%s", want, got)
-				}
-			})
-		}
-		if strings.Contains(got, "Executable") {
-			t.Error("should not contain 'Executable' when ExecuteFilemode is false")
+
+		want := "## File Metadata: data.json\n\n" +
+			"- **Name**: data.json\n" +
+			"- **Size (bytes)**: 512\n" +
+			"- **Ref**: main\n" +
+			"- **Encoding**: base64\n" +
+			"- **Blob ID**: `b1`\n" +
+			"- **Commit ID**: `c1`\n" +
+			"- **Last Commit ID**: `c1`\n" +
+			"- **SHA-256**: `sha256val`\n" +
+			"- **Executable**: ❌\n" +
+			fileMetadataHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 
@@ -1627,32 +1681,35 @@ func TestFormatMetaDataMarkdown(t *testing.T) {
 			FileName:        "script.sh",
 			ExecuteFilemode: true,
 		})
-		if !strings.Contains(got, "**Executable**: yes") {
-			t.Errorf("expected '**Executable**: yes' in:\n%s", got)
+
+		want := "## File Metadata: script.sh\n\n" +
+			"- **Name**: script.sh\n" +
+			"- **Size (bytes)**: 0\n" +
+			"- **Executable**: ✅\n" +
+			fileMetadataHints
+
+		if got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
 
-// TestFormatRawMarkdown verifies the RawMarkdown Markdown formatter for a representative raw input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
+// TestFormatRawMarkdown pins the whole card of a raw file read, the body
+// fenced with the language the path names.
 func TestFormatRawMarkdown(t *testing.T) {
 	got := FormatRawMarkdown(RawOutput{
 		FilePath: "readme.md",
 		Size:     42,
 		Content:  "# Hello World",
 	})
-	for _, want := range []string{
-		"## Raw File: readme.md",
-		"**Size**: 42 bytes",
-		"# Hello World",
-		"```",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(got, want) {
-				t.Errorf("FormatRawMarkdown missing %q in:\n%s", want, got)
-			}
-		})
+
+	want := "## Raw File: readme.md\n\n" +
+		"- **Size (bytes)**: 42\n" +
+		"\n```markdown\n# Hello World\n```\n" +
+		fileRawHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/files/markdown.go
+++ b/internal/tools/files/markdown.go
@@ -1,7 +1,7 @@
 package files
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,7 +9,20 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-const fmtSizeBytes = "- **Size**: %d bytes\n"
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionFileGet      = "repository.file_get"
+	actionFileUpdate   = "repository.file_update"
+	actionFileDelete   = "repository.file_delete"
+	actionFileBlame    = "repository.file_blame"
+	actionFileMetadata = "repository.file_metadata"
+	actionCommitGet    = "repository.commit_get"
+	actionCommitList   = "repository.commit_list"
+)
+
+// imageNote is the sentence a card writes where the bytes themselves are
+// attached to the result rather than printed.
+const imageNote = "\U0001F5BC️ Image content is attached below as ImageContent for multimodal viewing."
 
 type fileNotFoundOutput struct {
 	Identifier string `json:"identifier"`
@@ -21,8 +34,13 @@ func formatFileNotFound(out fileNotFoundOutput) *mcp.CallToolResult {
 		"Use gitlab_repository_tree to list repository paths")
 }
 
-// FormatOutputMarkdown renders file metadata as a Markdown summary.
-// For image and binary files, it includes content type information instead of content.
+// FormatOutputMarkdown renders one repository file as a card: its metadata,
+// then its body.
+//
+// A text file's body is fenced here rather than dropped: the card used to fall
+// through its content-category switch with nothing for a file that is neither
+// an image nor binary, which is every ordinary source file this action is
+// asked for.
 func FormatOutputMarkdown(f Output) string {
 	if f.FilePath == "" {
 		return ""
@@ -30,166 +48,160 @@ func FormatOutputMarkdown(f Output) string {
 	var b strings.Builder
 	// A repository path is whatever whoever added the file named it, and git
 	// forbids only NUL and the separator inside a path component.
-	fmt.Fprintf(&b, "## File: %s\n\n", toolutil.EscapeMdHeading(f.FilePath))
-	fmt.Fprintf(&b, fmtSizeBytes, f.Size)
-	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(f.Ref))
-	//gitlab:allow-unescaped f.Encoding: a content encoding GitLab emits as the literal "base64", never text anybody typed.
-	fmt.Fprintf(&b, "- **Encoding**: %s\n", f.Encoding)
-	//gitlab:allow-unescaped f.BlobID: a git blob object id, hexadecimal digits only.
-	fmt.Fprintf(&b, "- **Blob ID**: %s\n", f.BlobID)
+	c := toolutil.NewCard(&b, "File: "+f.FilePath)
+	c.Field("Name", f.FileName)
+	c.Int("Size (bytes)", f.Size)
+	c.Field("Ref", f.Ref)
+	c.Field("Encoding", f.Encoding)
+	c.Code("Blob ID", f.BlobID)
+	c.Code("Commit ID", f.CommitID)
+	c.Code("Last Commit ID", f.LastCommitID)
+	c.Code("SHA-256", f.SHA256)
+	c.Bool("Executable", f.ExecuteFilemode)
 	switch f.ContentCategory {
 	case "image":
-		//gitlab:allow-unescaped f.ImageMIMEType: a MIME type this package derived from the file extension through toolutil.ImageMIMEType, which returns a compiled-in constant.
-		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", f.ImageMIMEType)
-		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
+		c.Field("Content Type", "image ("+f.ImageMIMEType+")")
+		c.Note(imageNote)
 	case "binary":
-		b.WriteString("- **Content type**: binary (content omitted, not viewable as text)\n")
+		c.Field("Content Type", "binary (content omitted, not viewable as text)")
+	default:
+		c.Fence("Content", langFromPath(f.FilePath), f.Content)
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'file_update' to modify this file",
-		"Use action 'file_blame' to see who changed each line",
-		"Use action 'file_delete' to remove this file",
+	c.End(
+		toolutil.HintAction(actionFileUpdate, "modify this file"),
+		toolutil.HintAction(actionFileBlame, "see who changed each line"),
+		toolutil.HintAction(actionFileDelete, "remove this file"),
 	)
 	return b.String()
 }
 
 func fileGetResult(out Output) *mcp.CallToolResult {
 	md := FormatOutputMarkdown(out)
-	switch out.ContentCategory {
-	case "image":
+	if out.ContentCategory == "image" {
 		return toolutil.ToolResultWithImage(md, toolutil.ContentDetail, out.ImageData, out.ImageMIMEType)
-	case "binary":
-		return toolutil.ToolResultAnnotated(md, toolutil.ContentDetail)
-	default:
-		return toolutil.ToolResultAnnotated(md, toolutil.ContentDetail)
 	}
+	return toolutil.ToolResultAnnotated(md, toolutil.ContentDetail)
 }
 
-// FormatFileInfoMarkdown renders file info (create/update result).
+// FormatFileInfoMarkdown renders the commit a file create, update or delete
+// produced as the card of that result.
 func FormatFileInfoMarkdown(out FileInfoOutput) string {
 	var b strings.Builder
-	b.WriteString("## File Operation Result\n\n")
-	fmt.Fprintf(&b, "- **File**: %s\n", toolutil.EscapeMdTableCell(out.FilePath))
-	fmt.Fprintf(&b, "- **Branch**: %s\n", toolutil.EscapeMdTableCell(out.Branch))
-	if out.CommitID != "" {
-		//gitlab:allow-unescaped out.CommitID: a git commit SHA, hexadecimal digits only.
-		fmt.Fprintf(&b, "- **Commit ID**: %s\n", out.CommitID)
-	}
-	if out.LastCommitID != "" {
-		//gitlab:allow-unescaped out.LastCommitID: a git commit SHA, hexadecimal digits only.
-		fmt.Fprintf(&b, "- **Last commit ID**: %s\n", out.LastCommitID)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_get` to verify the file content",
-		"Use `gitlab_commit_list` to see the commit history",
+	c := toolutil.NewCard(&b, "File Operation Result")
+	c.Field("File", out.FilePath)
+	c.Field("Branch", out.Branch)
+	c.Code("Commit ID", out.CommitID)
+	c.Code("Last Commit ID", out.LastCommitID)
+	c.End(
+		toolutil.HintAction(actionFileGet, "verify the file content"),
+		toolutil.HintAction(actionCommitList, "see the commit history"),
 	)
 	return b.String()
 }
 
-// FormatBlameMarkdown renders blame information as Markdown.
+// FormatBlameMarkdown renders the blame of a file: one section per range, each
+// naming the commit that last touched it and fencing the lines themselves.
 func FormatBlameMarkdown(out BlameOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File Blame: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
+	c := toolutil.NewCard(&b, "File Blame: "+out.FilePath)
 	if len(out.Ranges) == 0 {
-		b.WriteString("No blame data found.\n")
+		c.Note("GitLab returned no blame ranges for this file.")
+		c.End(toolutil.HintAction(actionFileGet, "read the current file content"))
 		return b.String()
 	}
 	for i, r := range out.Ranges {
-		// Named rather than sliced inline so the exemption below can refer to
-		// it: a directive's expression is cut at its first colon.
-		shortID := r.Commit.ID[:minLen(len(r.Commit.ID), 8)]
-		//gitlab:allow-unescaped shortID: the first eight characters of a git commit SHA, hexadecimal digits only.
-		fmt.Fprintf(&b, "### Range %d: %s (%s)\n\n", i+1,
-			toolutil.EscapeMdTableCell(r.Commit.AuthorName), shortID)
-		fmt.Fprintf(&b, "**%s**\n\n", toolutil.EscapeMdTableCell(r.Commit.Message))
-		b.WriteString(toolutil.MarkdownFencedBlock(langFromPath(out.FilePath), strings.Join(r.Lines, "\n")))
-		b.WriteString("\n")
+		section := c.Section(blameRangeHeading(i, r))
+		section.Code("Commit", shortSHA(r.Commit.ID))
+		section.Field("Author", r.Commit.AuthorName)
+		section.Time("Committed", r.Commit.CommittedDate)
+		section.Text("Message", r.Commit.Message)
+		section.Fence("", langFromPath(out.FilePath), strings.Join(r.Lines, "\n"))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_get` to view commit details for a blame range",
-		"Use `gitlab_file_get` to view the current file content",
+	c.End(
+		toolutil.HintAction(actionCommitGet, "view one blame range's commit in full"),
+		toolutil.HintAction(actionFileGet, "read the current file content"),
 	)
 	return b.String()
 }
 
-// FormatMetaDataMarkdown renders file metadata as Markdown.
+// blameRangeHeading names one blame range by its position and the commit it
+// belongs to. The author's name is a row of the section rather than part of
+// the heading: a heading carries no link and no code span, so a name that
+// reads as Markdown belongs on a row the card escapes.
+func blameRangeHeading(index int, r BlameRangeOutput) string {
+	return "Range " + strconv.Itoa(index+1) + ": " + shortSHA(r.Commit.ID)
+}
+
+// shortSHA is a git object id abbreviated to the eight characters a reader
+// compares by, or the whole id when it is shorter.
+func shortSHA(sha string) string {
+	return sha[:minLen(len(sha), 8)]
+}
+
+// FormatMetaDataMarkdown renders a file's metadata as a card, with no body.
 func FormatMetaDataMarkdown(out MetaDataOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File Metadata: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
-	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.FileName))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(out.Ref))
-	//gitlab:allow-unescaped out.Encoding: a content encoding GitLab emits as the literal "base64", never text anybody typed.
-	fmt.Fprintf(&b, "- **Encoding**: %s\n", out.Encoding)
-	//gitlab:allow-unescaped out.BlobID: a git blob object id, hexadecimal digits only.
-	fmt.Fprintf(&b, "- **Blob ID**: %s\n", out.BlobID)
-	fmt.Fprintf(&b, "- **Commit ID**: %s\n", out.CommitID)
-	fmt.Fprintf(&b, "- **Last Commit ID**: %s\n", out.LastCommitID)
-	//gitlab:allow-unescaped out.SHA256: a SHA-256 digest of the file content, hexadecimal digits only.
-	fmt.Fprintf(&b, "- **SHA-256**: %s\n", out.SHA256)
-	if out.ExecuteFilemode {
-		b.WriteString("- **Executable**: yes\n")
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_get` to read the file content",
-		"Use `gitlab_file_blame` to see blame information",
+	c := toolutil.NewCard(&b, "File Metadata: "+out.FilePath)
+	c.Field("Name", out.FileName)
+	c.Int("Size (bytes)", out.Size)
+	c.Field("Ref", out.Ref)
+	c.Field("Encoding", out.Encoding)
+	c.Code("Blob ID", out.BlobID)
+	c.Code("Commit ID", out.CommitID)
+	c.Code("Last Commit ID", out.LastCommitID)
+	c.Code("SHA-256", out.SHA256)
+	c.Bool("Executable", out.ExecuteFilemode)
+	c.End(
+		toolutil.HintAction(actionFileGet, "read the file content"),
+		toolutil.HintAction(actionFileBlame, "see blame information"),
 	)
 	return b.String()
 }
 
-// FormatRawMarkdown renders raw file content as Markdown.
+// FormatRawMarkdown renders raw file content as a card whose body is fenced.
 func FormatRawMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Raw File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
-	fmt.Fprintf(&b, fmtSizeBytes+"\n", out.Size)
-	b.WriteString(toolutil.MarkdownFencedBlock(langFromPath(out.FilePath), out.Content))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_update` to modify this file",
-		"Use `gitlab_file_blame` to see who last changed each line",
+	c := toolutil.NewCard(&b, "Raw File: "+out.FilePath)
+	c.Int("Size (bytes)", int64(out.Size))
+	c.Fence("", langFromPath(out.FilePath), out.Content)
+	c.End(
+		toolutil.HintAction(actionFileUpdate, "modify this file"),
+		toolutil.HintAction(actionFileBlame, "see who last changed each line"),
 	)
 	return b.String()
 }
 
-// FormatRawImageMarkdown renders metadata for a raw image file.
+// FormatRawImageMarkdown renders the metadata of a raw image file; the bytes
+// themselves are attached to the result.
 func FormatRawImageMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Image File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	//gitlab:allow-unescaped out.ImageMIMEType: a MIME type this package derived from the file extension through toolutil.ImageMIMEType, which returns a compiled-in constant.
-	fmt.Fprintf(&b, "- **Content type**: %s\n", out.ImageMIMEType)
-	b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
+	c := toolutil.NewCard(&b, "Image File: "+out.FilePath)
+	c.Int("Size (bytes)", int64(out.Size))
+	c.Field("Content Type", out.ImageMIMEType)
+	c.Note(imageNote)
+	c.End(toolutil.HintAction(actionFileMetadata, "get additional file properties"))
 	return b.String()
 }
 
-// FormatRawBinaryMarkdown renders metadata for a raw binary file.
+// FormatRawBinaryMarkdown renders the metadata of a raw binary file, whose
+// content is not viewable as text.
 func FormatRawBinaryMarkdown(out RawOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Binary File: %s\n\n", toolutil.EscapeMdHeading(out.FilePath))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	b.WriteString("- **Content type**: binary (content omitted, not viewable as text)\n")
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_metadata` to get additional file properties",
-	)
+	c := toolutil.NewCard(&b, "Binary File: "+out.FilePath)
+	c.Int("Size (bytes)", int64(out.Size))
+	c.Field("Content Type", "binary (content omitted, not viewable as text)")
+	c.End(toolutil.HintAction(actionFileMetadata, "get additional file properties"))
 	return b.String()
 }
 
 func fileRawResult(out RawOutput) *mcp.CallToolResult {
 	switch out.ContentCategory {
 	case "image":
-		md := FormatRawImageMarkdown(out)
-		return toolutil.ToolResultWithImage(md, toolutil.ContentAssistant, out.ImageData, out.ImageMIMEType)
+		return toolutil.ToolResultWithImage(FormatRawImageMarkdown(out), toolutil.ContentAssistant, out.ImageData, out.ImageMIMEType)
 	case "binary":
-		md := FormatRawBinaryMarkdown(out)
-		return toolutil.ToolResultAnnotated(md, toolutil.ContentAssistant)
+		return toolutil.ToolResultAnnotated(FormatRawBinaryMarkdown(out), toolutil.ContentAssistant)
 	default:
-		md := FormatRawMarkdown(out)
-		return toolutil.ToolResultAnnotated(md, toolutil.ContentAssistant)
+		return toolutil.ToolResultAnnotated(FormatRawMarkdown(out), toolutil.ContentAssistant)
 	}
 }
 

--- a/internal/tools/freezeperiods/freeze_periods_test.go
+++ b/internal/tools/freezeperiods/freeze_periods_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
 const (
@@ -219,11 +220,23 @@ func TestFormatMarkdownString(t *testing.T) {
 		CronTimezone: "UTC",
 		CreatedAt:    "2026-01-01T00:00:00Z",
 	}
-	md := FormatMarkdownString(out)
-	if md == "" {
-		t.Fatal("expected non-empty markdown")
+	want := "## Freeze Period #1\n\n" +
+		"- **ID**: 1\n" +
+		"- **Start**: `" + testCronFreezeStart + "`\n" +
+		"- **End**: `0 7 * * 1`\n" +
+		"- **Timezone**: UTC\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		freezeCardHints
+	if md := FormatMarkdownString(out); md != want {
+		t.Errorf("FormatMarkdownString()\n got %q\nwant %q", md, want)
 	}
 }
+
+// freezeCardHints is the guidance section a freeze period card closes with.
+const freezeCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'environment.freeze_update' to change this freeze window\n" +
+	"- Use action 'environment.freeze_delete' to remove it\n" +
+	"- Use action 'environment.freeze_list' to see every freeze window of this project\n"
 
 // TestFormatListMarkdownString_Empty verifies the ListMarkdownString_Empty Markdown formatter for a representative liststring_empty input.
 // The test exercises the GET path of the underlying GitLab API call.
@@ -505,21 +518,36 @@ func TestFormatListMarkdownString_WithItems(t *testing.T) {
 			{ID: 2, FreezeStart: "0 0 * * 6", FreezeEnd: "0 0 * * 1", CronTimezone: "Europe/London"},
 		},
 	}
+	// Freeze periods are a collection of objects sharing columns, so they are a
+	// table: the list items they used to be put four values on one line and
+	// left the pagination footer to land after them.
+	want := "## Freeze Periods (2)\n\n" +
+		"| ID | Start | End | Timezone |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | `0 23 * * 5` | `0 7 * * 1` | UTC |\n" +
+		"| 2 | `0 0 * * 6` | `0 0 * * 1` | Europe/London |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'environment.freeze_get' to see one freeze period in full\n" +
+		"- Use action 'environment.freeze_create' to add a freeze window\n"
+	if md := FormatListMarkdownString(out); md != want {
+		t.Errorf("FormatListMarkdownString()\n got %q\nwant %q", md, want)
+	}
+}
+
+// TestFormatListMarkdownString_CountsTheTotalGitLabReported checks the heading
+// of a page of a longer list: it counts what the response reports in all,
+// where it used to count the rows on the page and read as the whole list.
+func TestFormatListMarkdownString_CountsTheTotalGitLabReported(t *testing.T) {
+	out := ListOutput{
+		FreezePeriods: []Output{{ID: 1, FreezeStart: "0 23 * * 5", FreezeEnd: "0 7 * * 1", CronTimezone: "UTC"}},
+		Pagination:    toolutil.PaginationOutput{Page: 1, PerPage: 1, TotalItems: 45, TotalPages: 45},
+	}
 	md := FormatListMarkdownString(out)
-	if md == "" {
-		t.Fatal("expected non-empty Markdown")
+	if !containsStr(md, "## Freeze Periods (45)\n") {
+		t.Errorf("heading does not count the reported total:\n%s", md)
 	}
-	if !containsStr(md, "Freeze Periods (2)") {
-		t.Error("expected header with count")
-	}
-	if !containsStr(md, "ID 1") {
-		t.Error("expected ID 1 in output")
-	}
-	if !containsStr(md, "ID 2") {
-		t.Error("expected ID 2 in output")
-	}
-	if !containsStr(md, "Europe/London") {
-		t.Error("expected timezone in output")
+	if !containsStr(md, "\nPage 1 of 45 | 45 items total | 1 per page\n") {
+		t.Errorf("pagination footer missing or misplaced:\n%s", md)
 	}
 }
 
@@ -561,12 +589,15 @@ func TestFormatMarkdownString_AllFields(t *testing.T) {
 		CronTimezone: "America/New_York",
 		CreatedAt:    "2026-01-01T00:00:00Z",
 	}
-	md := FormatMarkdownString(out)
-	if !containsStr(md, "America/New_York") {
-		t.Error("expected timezone in output")
-	}
-	if !containsStr(md, "1 Jan 2026 00:00 UTC") {
-		t.Error("expected created_at in output")
+	want := "## Freeze Period #5\n\n" +
+		"- **ID**: 5\n" +
+		"- **Start**: `0 23 * * 5`\n" +
+		"- **End**: `0 7 * * 1`\n" +
+		"- **Timezone**: America/New_York\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		freezeCardHints
+	if md := FormatMarkdownString(out); md != want {
+		t.Errorf("FormatMarkdownString(all fields)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/freezeperiods/markdown.go
+++ b/internal/tools/freezeperiods/markdown.go
@@ -2,6 +2,7 @@ package freezeperiods
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,26 +10,47 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// Canonical action IDs the hints name.
+const (
+	actionFreezeGet    = "environment.freeze_get"
+	actionFreezeList   = "environment.freeze_list"
+	actionFreezeCreate = "environment.freeze_create"
+	actionFreezeUpdate = "environment.freeze_update"
+	actionFreezeDelete = "environment.freeze_delete"
+)
+
 // FormatListMarkdown formats a list of freeze periods as Markdown.
 func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
 }
 
-// FormatListMarkdownString renders freeze periods list as Markdown.
+// FormatListMarkdownString renders a page of freeze periods as a Markdown
+// table: a collection of objects that share columns.
+//
+// The heading counts the total GitLab reports rather than the page length, and
+// the pagination footer is written before the guidance section rather than
+// after the rows of the next block.
 func FormatListMarkdownString(out ListOutput) string {
 	if len(out.FreezePeriods) == 0 {
-		return "No freeze periods found.\n"
+		return toolutil.EmptyMessage("freeze periods")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Freeze Periods (%d)\n\n", len(out.FreezePeriods))
-	toolutil.WriteListSummary(&b, len(out.FreezePeriods), out.Pagination)
+	toolutil.WriteListHeading(&b, "Freeze Periods", len(out.FreezePeriods), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Start", "End", "Timezone"))
 	for _, fp := range out.FreezePeriods {
-		fmt.Fprintf(&b, "- **ID %d**: start=`%s` end=`%s` tz=%s\n", fp.ID,
-			toolutil.EscapeMdTableCell(fp.FreezeStart), toolutil.EscapeMdTableCell(fp.FreezeEnd),
-			toolutil.EscapeMdTableCell(fp.CronTimezone))
+		// A freeze window is two cron expressions and a timezone a maintainer
+		// types, and GitLab validates only that the cron parses.
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(fp.ID, 10),
+			toolutil.MdCodeSpanCell(fp.FreezeStart),
+			toolutil.MdCodeSpanCell(fp.FreezeEnd),
+			toolutil.EscapeMdTableCell(fp.CronTimezone),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, "Use `gitlab_get_freeze_period` to view details of a specific freeze period")
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionFreezeGet, "see one freeze period in full"),
+		toolutil.HintAction(actionFreezeCreate, "add a freeze window"),
+	)
 	return b.String()
 }
 
@@ -37,22 +59,23 @@ func FormatMarkdown(out Output) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatMarkdownString(out))
 }
 
-// FormatMarkdownString renders a single freeze period as Markdown.
+// FormatMarkdownString renders one freeze period as the card of a single
+// object.
 func FormatMarkdownString(out Output) string {
 	var b strings.Builder
-	b.WriteString("## Freeze Period\n\n")
-	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	// A freeze window is two cron expressions and a timezone a maintainer
-	// types, and GitLab validates only that the cron parses.
-	fmt.Fprintf(&b, "- **Start**: `%s`\n", toolutil.EscapeMdTableCell(out.FreezeStart))
-	fmt.Fprintf(&b, "- **End**: `%s`\n", toolutil.EscapeMdTableCell(out.FreezeEnd))
-	if out.CronTimezone != "" {
-		fmt.Fprintf(&b, "- **Timezone**: %s\n", toolutil.EscapeMdTableCell(out.CronTimezone))
-	}
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
-	}
-	toolutil.WriteHints(&b, "Use `gitlab_update_freeze_period` to modify this freeze period")
+	c := toolutil.NewCard(&b, fmt.Sprintf("Freeze Period #%d", out.ID))
+	c.Int("ID", out.ID)
+	// The two cron expressions and the timezone are a maintainer's own text.
+	c.Code("Start", out.FreezeStart)
+	c.Code("End", out.FreezeEnd)
+	c.Field("Timezone", out.CronTimezone)
+	c.Time("Created", out.CreatedAt)
+	c.Time("Updated", out.UpdatedAt)
+	c.End(
+		toolutil.HintAction(actionFreezeUpdate, "change this freeze window"),
+		toolutil.HintAction(actionFreezeDelete, "remove it"),
+		toolutil.HintAction(actionFreezeList, "see every freeze window of this project"),
+	)
 	return b.String()
 }
 

--- a/internal/tools/groupprotectedbranches/group_protected_branches_test.go
+++ b/internal/tools/groupprotectedbranches/group_protected_branches_test.go
@@ -4,7 +4,6 @@ package groupprotectedbranches
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v3"
@@ -710,113 +709,143 @@ func assertInt64Pointer(t *testing.T, name string, got *int64, want int64) {
 	}
 }
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatOutputMarkdown(t *testing.T) {
-	t.Run("renders branch with access levels", func(t *testing.T) {
-		out := Output{
-			ID:   1,
-			Name: "main",
-			PushAccessLevels: []AccessLevelOutput{
-				{ID: 10, AccessLevel: 40, AccessLevelDescription: "Maintainers"},
-			},
-			MergeAccessLevels: []AccessLevelOutput{
-				{ID: 11, AccessLevel: 30, AccessLevelDescription: "Developers + Maintainers"},
-			},
-			UnprotectAccessLevels:     []AccessLevelOutput{},
-			AllowForcePush:            false,
-			CodeOwnerApprovalRequired: true,
-		}
-		md := FormatOutputMarkdown(out)
+// cardHints is the guidance section every protected-branch card closes with.
+const cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'group.protected_branch_update' to add or remove an allowed user, group or role\n" +
+	"- Use action 'group.protected_branch_unprotect' to remove this protection from every subgroup project\n"
 
-		checks := []string{
-			"## Protected Branch: main",
-			"**Allow Force Push**: false",
-			"**Code Owner Approval Required**: true",
-			"### Push Access Levels",
-			"| 10 | 40 | Maintainers |",
-			"### Merge Access Levels",
-			"| 11 | 30 | Developers + Maintainers |",
-			"gitlab_group_protected_branch_update",
-			"gitlab_group_protected_branch_unprotect",
-		}
-		for _, want := range checks {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(md, want) {
-					t.Errorf("FormatOutputMarkdown missing %q", want)
-				}
-			})
-		}
-		if strings.Contains(md, "### Unprotect Access Levels") {
-			t.Error("FormatOutputMarkdown should not render empty Unprotect Access Levels section")
-		}
+// listHints is the guidance section the listing closes with. The table carries
+// no link, so the preserve-links instruction is not written.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'group.protected_branch_get' to see one branch's access levels in full\n" +
+	"- Use action 'group.protected_branch_protect' to protect another branch or wildcard\n" +
+	"- Use action 'group.protected_branch_list' to page through the rest of the group's protected branches\n"
+
+const accessHeader = "| ID | Level | Grantee | Description |\n| --- | --- | --- | --- |\n"
+
+// TestFormatOutputMarkdown_WithAccessLevels pins the whole card of a protected
+// branch: the flags as glyphs, each set of access levels as its own table, and
+// no heading for a set GitLab sent empty.
+func TestFormatOutputMarkdown_WithAccessLevels(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ID:   1,
+		Name: "main",
+		PushAccessLevels: []AccessLevelOutput{
+			{ID: 10, AccessLevel: 40, AccessLevelDescription: "Maintainers"},
+		},
+		MergeAccessLevels: []AccessLevelOutput{
+			{ID: 11, AccessLevel: 30, AccessLevelDescription: "Developers + Maintainers"},
+		},
+		UnprotectAccessLevels:     []AccessLevelOutput{},
+		AllowForcePush:            false,
+		CodeOwnerApprovalRequired: true,
 	})
 
-	t.Run("renders branch without access levels", func(t *testing.T) {
-		out := Output{
-			ID:                        2,
-			Name:                      "release/*",
-			PushAccessLevels:          []AccessLevelOutput{},
-			MergeAccessLevels:         []AccessLevelOutput{},
-			UnprotectAccessLevels:     []AccessLevelOutput{},
-			AllowForcePush:            true,
-			CodeOwnerApprovalRequired: false,
-		}
-		md := FormatOutputMarkdown(out)
+	want := "## Protected Branch: main\n\n" +
+		"- **ID**: 1\n" +
+		"- **Allow Force Push**: ❌\n" +
+		"- **Code Owner Approval Required**: ✅\n" +
+		"\n### Push Access Levels\n\n" +
+		accessHeader +
+		"| 10 | Maintainer |  | Maintainers |\n" +
+		"\n### Merge Access Levels\n\n" +
+		accessHeader +
+		"| 11 | Developer |  | Developers + Maintainers |\n" +
+		cardHints
 
-		if !strings.Contains(md, "## Protected Branch: release/*") {
-			t.Error("missing heading")
-		}
-		if !strings.Contains(md, "**Allow Force Push**: true") {
-			t.Error("missing force push")
-		}
-		for _, heading := range []string{"### Push Access Levels", "### Merge Access Levels", "### Unprotect Access Levels"} {
-			t.Run(heading, func(t *testing.T) {
-				if strings.Contains(md, heading) {
-					t.Errorf("should not render empty section %q", heading)
-				}
-			})
-		}
-	})
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
 }
 
-// TestFormatListMarkdown verifies the ListMarkdown Markdown formatter for a representative list input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown(t *testing.T) {
-	t.Run("renders table with branches", func(t *testing.T) {
-		out := ListOutput{
-			Branches: []Output{
-				{ID: 1, Name: "main", AllowForcePush: false, CodeOwnerApprovalRequired: true},
-				{ID: 2, Name: "release/*", AllowForcePush: true, CodeOwnerApprovalRequired: false},
-			},
-			Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 2, TotalPages: 1},
-		}
-		md := FormatListMarkdown(out)
-
-		checks := []string{
-			"| ID | Name | Force Push | Code Owner |",
-			"| 1 | main | false | true |",
-			"| 2 | release/* | true | false |",
-			"gitlab_group_protected_branch_get",
-			"gitlab_group_protected_branch_protect",
-		}
-		for _, want := range checks {
-			t.Run(want, func(t *testing.T) {
-				if !strings.Contains(md, want) {
-					t.Errorf("FormatListMarkdown missing %q", want)
-				}
-			})
-		}
+// TestFormatOutputMarkdown_GranularRules pins what the grantee column was added
+// for: a rule naming a user, a group or a deploy key says so, and its Level
+// reads "-" rather than the role number GitLab echoes beside it, which is not
+// what the rule grants.
+func TestFormatOutputMarkdown_GranularRules(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ID:   7,
+		Name: "release/*",
+		PushAccessLevels: []AccessLevelOutput{
+			{ID: 20, AccessLevel: 40, AccessLevelDescription: "Sam Bauch", UserID: 123},
+			{ID: 21, AccessLevel: 40, AccessLevelDescription: "Release managers", GroupID: 55},
+			{ID: 22, AccessLevel: 40, AccessLevelDescription: "deploy-bot", DeployKeyID: 9},
+			{ID: 23, AccessLevel: 0, AccessLevelDescription: "No one"},
+		},
+		AllowForcePush: true,
 	})
 
-	t.Run("renders empty message when no branches", func(t *testing.T) {
-		out := ListOutput{Branches: []Output{}}
-		md := FormatListMarkdown(out)
-		want := "No group protected branches found."
-		if !strings.Contains(md, want) {
-			t.Errorf("FormatListMarkdown = %q, want to contain %q", md, want)
-		}
+	want := "## Protected Branch: release/*\n\n" +
+		"- **ID**: 7\n" +
+		"- **Allow Force Push**: ✅\n" +
+		"- **Code Owner Approval Required**: ❌\n" +
+		"\n### Push Access Levels\n\n" +
+		accessHeader +
+		"| 20 | - | user #123 | Sam Bauch |\n" +
+		"| 21 | - | group #55 | Release managers |\n" +
+		"| 22 | - | deploy key #9 | deploy-bot |\n" +
+		"| 23 | No access |  | No one |\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_NoAccessLevels pins the card of a branch with no
+// rules at all: three fields and no empty section under them.
+func TestFormatOutputMarkdown_NoAccessLevels(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ID:                        2,
+		Name:                      "release/*",
+		PushAccessLevels:          []AccessLevelOutput{},
+		MergeAccessLevels:         []AccessLevelOutput{},
+		UnprotectAccessLevels:     []AccessLevelOutput{},
+		AllowForcePush:            true,
+		CodeOwnerApprovalRequired: false,
 	})
+
+	want := "## Protected Branch: release/*\n\n" +
+		"- **ID**: 2\n" +
+		"- **Allow Force Push**: ✅\n" +
+		"- **Code Owner Approval Required**: ❌\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_WithBranches pins the whole listing: the heading
+// counting what GitLab reported, the table opening a block of its own rather
+// than continuing a hint bullet, and one guidance section at the end.
+func TestFormatListMarkdown_WithBranches(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Branches: []Output{
+			{ID: 1, Name: "main", AllowForcePush: false, CodeOwnerApprovalRequired: true},
+			{ID: 2, Name: "release/*", AllowForcePush: true, CodeOwnerApprovalRequired: false},
+		},
+		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 2, TotalPages: 1},
+	})
+
+	want := "## Group Protected Branches (2)\n\n" +
+		"| ID | Name | Force Push | Code Owner |\n| --- | --- | --- | --- |\n" +
+		"| 1 | main | ❌ | ✅ |\n" +
+		"| 2 | release/* | ✅ | ❌ |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Empty pins that a group with no protected branches
+// renders the one sentence and nothing else.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{Branches: []Output{}})
+
+	if want := "No group protected branches found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
 }

--- a/internal/tools/groupprotectedbranches/markdown.go
+++ b/internal/tools/groupprotectedbranches/markdown.go
@@ -2,64 +2,104 @@ package groupprotectedbranches
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single group protected branch as Markdown.
+// FormatOutputMarkdown renders one group protected branch as the card of a
+// single object: its own fields, then each set of access levels as a nested
+// collection under a heading of its own.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Branch: %s\n\n", toolutil.EscapeMdHeading(out.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, out.ID)
-	fmt.Fprintf(&b, "- **Allow Force Push**: %t\n", out.AllowForcePush)
-	fmt.Fprintf(&b, "- **Code Owner Approval Required**: %t\n", out.CodeOwnerApprovalRequired)
-	writeAccessLevels(&b, "Push Access Levels", out.PushAccessLevels)
-	writeAccessLevels(&b, "Merge Access Levels", out.MergeAccessLevels)
-	writeAccessLevels(&b, "Unprotect Access Levels", out.UnprotectAccessLevels)
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_protected_branch_update to modify settings",
-		"Use gitlab_group_protected_branch_unprotect to remove protection",
+	c := toolutil.NewCard(&b, "Protected Branch: "+out.Name)
+	c.Int("ID", out.ID)
+	c.Bool("Allow Force Push", out.AllowForcePush)
+	c.Bool("Code Owner Approval Required", out.CodeOwnerApprovalRequired)
+	writeAccessLevels(c, "Push Access Levels", out.PushAccessLevels)
+	writeAccessLevels(c, "Merge Access Levels", out.MergeAccessLevels)
+	writeAccessLevels(c, "Unprotect Access Levels", out.UnprotectAccessLevels)
+	c.End(
+		toolutil.HintAction(actionUpdate, "add or remove an allowed user, group or role"),
+		toolutil.HintAction(actionUnprotect, "remove this protection from every subgroup project"),
 	)
 	return b.String()
 }
 
-func writeAccessLevels(b *strings.Builder, heading string, levels []AccessLevelOutput) {
+// writeAccessLevels writes one set of access levels as a table under the card.
+//
+// The grantee is a column of its own because the access level alone does not
+// say who the rule is about: GitLab answers a per-user or per-group rule with
+// the same access_level it answers a role rule with, and the description that
+// used to be the only other column is the role name for one and a person's or
+// a group's display name for the other, so two rows that grant entirely
+// different things rendered alike.
+func writeAccessLevels(c *toolutil.Card, heading string, levels []AccessLevelOutput) {
 	if len(levels) == 0 {
 		return
 	}
-	fmt.Fprintf(b, "\n### %s\n\n", heading)
-	b.WriteString("| ID | Level | Description |\n| --- | --- | --- |\n")
+	t := c.Table(heading, "ID", "Level", "Grantee", "Description")
 	for _, l := range levels {
-		// GitLab's access-level description is a role name for a plain rule but
-		// a user's display name or a group's name for a granular one.
-		fmt.Fprintf(b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, toolutil.EscapeMdTableCell(l.AccessLevelDescription))
+		t.Row(
+			strconv.FormatInt(l.ID, 10),
+			levelCell(l),
+			granteeCell(l),
+			// GitLab's access-level description is a role name for a plain rule
+			// but a user's display name or a group's name for a granular one.
+			toolutil.EscapeMdTableCell(l.AccessLevelDescription),
+		)
 	}
 }
 
-// FormatListMarkdown renders a paginated list of group protected branches as Markdown.
+// levelCell renders the role a rule grants, and "-" for a rule that names a
+// user, a group or a deploy key instead, whose access_level is not what
+// decides.
+func levelCell(l AccessLevelOutput) string {
+	if granteeCell(l) != "" {
+		return "-"
+	}
+	return toolutil.AccessLevelDescription(gl.AccessLevelValue(l.AccessLevel))
+}
+
+// granteeCell names who a granular rule is about, and nothing for a rule that
+// grants a role to everyone who holds it.
+func granteeCell(l AccessLevelOutput) string {
+	switch {
+	case l.UserID != 0:
+		return fmt.Sprintf("user #%d", l.UserID)
+	case l.GroupID != 0:
+		return fmt.Sprintf("group #%d", l.GroupID)
+	case l.DeployKeyID != 0:
+		return fmt.Sprintf("deploy key #%d", l.DeployKeyID)
+	default:
+		return ""
+	}
+}
+
+// FormatListMarkdown renders a page of a group's protected branches as a
+// Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Branches) == 0 {
-		return "No group protected branches found.\n"
+		return toolutil.EmptyMessage("group protected branches")
 	}
 	var b strings.Builder
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
-	toolutil.WriteListSummary(&b, len(out.Branches), out.Pagination)
-	b.WriteString("| ID | Name | Force Push | Code Owner |\n| --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Group Protected Branches", len(out.Branches), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Force Push", "Code Owner"))
 	for _, br := range out.Branches {
-		fmt.Fprintf(
-			&b, "| %d | %s | %t | %t |\n",
-			br.ID,
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(br.ID, 10),
 			toolutil.EscapeMdTableCell(br.Name),
-			br.AllowForcePush,
-			br.CodeOwnerApprovalRequired,
-		)
+			toolutil.BoolEmoji(br.AllowForcePush),
+			toolutil.BoolEmoji(br.CodeOwnerApprovalRequired),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_protected_branch_get with a branch name for details",
-		"Use gitlab_group_protected_branch_protect to add new rules",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionGet, "see one branch's access levels in full"),
+		toolutil.HintAction(actionProtect, "protect another branch or wildcard"),
+		toolutil.HintAction(actionList, "page through the rest of the group's protected branches"),
 	)
 	return b.String()
 }

--- a/internal/tools/groupprotectedenvs/group_protected_envs_test.go
+++ b/internal/tools/groupprotectedenvs/group_protected_envs_test.go
@@ -586,121 +586,124 @@ func TestUnprotect_ServerErrorUsesGenericMessage(t *testing.T) {
 
 // --- Markdown formatter tests ---
 
-// TestFormatOutputMarkdown verifies the OutputMarkdown Markdown formatter for a representative output input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatOutputMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Output
-		contains []string
-	}{
-		{
-			name: "renders full environment with access levels and rules",
-			input: Output{
+// cardHints is the guidance section every protected-environment card closes
+// with.
+const cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'group.protected_env_update' to change the deploy access levels or approval rules\n" +
+	"- Use action 'group.protected_env_unprotect' to remove this protection from the group\n"
+
+// listHints is the guidance section the listing closes with. The table carries
+// no link, so the preserve-links instruction is not written.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'group.protected_env_get' to see one environment's rules in full\n" +
+	"- Use action 'group.protected_env_protect' to protect another environment tier\n" +
+	"- Use action 'group.protected_env_list' to page through the rest of the group's protected environments\n"
+
+// TestFormatOutputMarkdown_WithRules pins the whole card of a protected
+// environment that carries both tables: the headline defers to the per-rule
+// counts below it, and each rule says which role it grants and to whom.
+func TestFormatOutputMarkdown_WithRules(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		Name:                  "production",
+		RequiredApprovalCount: 2,
+		DeployAccessLevels: []AccessLevelOutput{
+			{ID: 1, AccessLevel: 40, AccessLevelDescription: "Maintainers"},
+			{ID: 2, AccessLevel: 40, AccessLevelDescription: "Release managers", GroupID: 55, GroupInheritanceType: 1},
+		},
+		ApprovalRules: []ApprovalRuleOutput{
+			{ID: 5, AccessLevel: 30, AccessLevelDescription: "Developers", RequiredApprovalCount: 1},
+			{ID: 6, AccessLevelDescription: "Sam Bauch", UserID: 123, RequiredApprovalCount: 1},
+		},
+	})
+
+	want := "## Protected Environment: production\n\n" +
+		"- **Required Approvals**: per approval rule (see below)\n" +
+		"\n### Deploy Access Levels\n\n" +
+		"| ID | Level | Grantee | Description | Inheritance |\n| --- | --- | --- | --- | --- |\n" +
+		"| 1 | Maintainer |  | Maintainers |  |\n" +
+		"| 2 | - | group #55 | Release managers | inherited |\n" +
+		"\n### Approval Rules\n\n" +
+		"| ID | Level | Grantee | Description | Required | Inheritance |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 5 | Developer |  | Developers | 1 |  |\n" +
+		"| 6 | - | user #123 | Sam Bauch | 1 |  |\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_NoRules pins the card of an environment GitLab sent
+// with no rules at all: the headline count it did send, and no empty table
+// under it.
+func TestFormatOutputMarkdown_NoRules(t *testing.T) {
+	got := FormatOutputMarkdown(Output{Name: "staging", RequiredApprovalCount: 0})
+
+	want := "## Protected Environment: staging\n\n" +
+		"- **Required Approvals**: 0\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_DeployLevelsOnly pins the card of an environment
+// whose only rules are deploy access levels: the headline is the count GitLab
+// sent, since no approval rule overrides it.
+func TestFormatOutputMarkdown_DeployLevelsOnly(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		Name:                  "dev",
+		RequiredApprovalCount: 1,
+		DeployAccessLevels:    []AccessLevelOutput{{ID: 3, AccessLevel: 30, AccessLevelDescription: "Developers", GroupID: 7}},
+	})
+
+	want := "## Protected Environment: dev\n\n" +
+		"- **Required Approvals**: 1\n" +
+		"\n### Deploy Access Levels\n\n" +
+		"| ID | Level | Grantee | Description | Inheritance |\n| --- | --- | --- | --- | --- |\n" +
+		"| 3 | - | group #7 | Developers | direct |\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Empty pins that a group with no protected
+// environments renders the one sentence and nothing else.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No group protected environments found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_WithEnvironments pins the whole listing: the heading
+// falls back to the rows shown when GitLab sent no total, the table opens a
+// block of its own, and one guidance section closes the document.
+func TestFormatListMarkdown_WithEnvironments(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Environments: []Output{
+			{
 				Name:                  "production",
 				RequiredApprovalCount: 2,
-				DeployAccessLevels: []AccessLevelOutput{
-					{ID: 1, AccessLevel: 40, AccessLevelDescription: "Maintainers"},
-				},
-				ApprovalRules: []ApprovalRuleOutput{
-					{ID: 5, AccessLevel: 30, AccessLevelDescription: "Developers", RequiredApprovalCount: 1},
-				},
+				DeployAccessLevels:    []AccessLevelOutput{{ID: 1}},
+				ApprovalRules:         []ApprovalRuleOutput{{ID: 5}},
 			},
-			contains: []string{
-				"## Protected Environment: production",
-				"**Required Approval Count**: 2",
-				"### Deploy Access Levels",
-				"| 1 | 40 | Maintainers |",
-				"### Approval Rules",
-				"| 5 | 30 | Developers | 1 |",
-			},
+			{Name: "staging", RequiredApprovalCount: 0},
 		},
-		{
-			name: "renders environment without access levels or rules",
-			input: Output{
-				Name:                  "staging",
-				RequiredApprovalCount: 0,
-			},
-			contains: []string{
-				"## Protected Environment: staging",
-				"**Required Approval Count**: 0",
-			},
-		},
-	}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatOutputMarkdown(tt.input)
-			for _, want := range tt.contains {
-				if !strings.Contains(got, want) {
-					t.Errorf("output missing %q\ngot:\n%s", want, got)
-				}
-			}
-		})
-	}
-}
+	want := "## Group Protected Environments (2)\n\n" +
+		"| Name | Required Approvals | Deploy Access Levels | Approval Rules |\n| --- | --- | --- | --- |\n" +
+		"| production | 2 | 1 | 1 |\n" +
+		"| staging | 0 | 0 | 0 |\n" +
+		listHints
 
-// TestFormatOutputMarkdown_NoTables verifies the OutputMarkdown_NoTables Markdown formatter for a representative output_notables input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatOutputMarkdown_NoTables(t *testing.T) {
-	got := FormatOutputMarkdown(Output{Name: "dev", RequiredApprovalCount: 0})
-	if strings.Contains(got, "### Deploy Access Levels") {
-		t.Error("should not contain Deploy Access Levels section for empty list")
-	}
-	if strings.Contains(got, "### Approval Rules") {
-		t.Error("should not contain Approval Rules section for empty list")
-	}
-}
-
-// TestFormatListMarkdown verifies the ListMarkdown Markdown formatter for a representative list input.
-// The test exercises the GET path of the underlying GitLab API call.
-// It asserts the rendered Markdown contains the expected section headings and content.
-func TestFormatListMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
-	}{
-		{
-			name:     "returns message for empty list",
-			input:    ListOutput{},
-			contains: []string{"No group protected environments found."},
-		},
-		{
-			name: "renders table with environments",
-			input: ListOutput{
-				Environments: []Output{
-					{
-						Name:                  "production",
-						RequiredApprovalCount: 2,
-						DeployAccessLevels:    []AccessLevelOutput{{ID: 1}},
-						ApprovalRules:         []ApprovalRuleOutput{{ID: 5}},
-					},
-					{
-						Name:                  "staging",
-						RequiredApprovalCount: 0,
-					},
-				},
-			},
-			contains: []string{
-				"| Name | Approval Count | Deploy Levels | Rules |",
-				"| production | 2 | 1 | 1 |",
-				"| staging | 0 | 0 | 0 |",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			for _, want := range tt.contains {
-				if !strings.Contains(got, want) {
-					t.Errorf("output missing %q\ngot:\n%s", want, got)
-				}
-			}
-		})
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/groupprotectedenvs/markdown.go
+++ b/internal/tools/groupprotectedenvs/markdown.go
@@ -2,62 +2,130 @@ package groupprotectedenvs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single group protected environment as Markdown.
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionGet       = "group.protected_env_get"
+	actionList      = "group.protected_env_list"
+	actionProtect   = "group.protected_env_protect"
+	actionUnprotect = "group.protected_env_unprotect"
+	actionUpdate    = "group.protected_env_update"
+)
+
+// FormatOutputMarkdown renders one group-level protected environment as the
+// card of a single object: the approvals it needs, then the deploy access
+// levels and the approval rules as nested collections.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Environment: %s\n\n", toolutil.EscapeMdHeading(out.Name))
-	fmt.Fprintf(&b, "- **Required Approval Count**: %d\n", out.RequiredApprovalCount)
+	c := toolutil.NewCard(&b, "Protected Environment: "+out.Name)
+	// A tier with approval rules of its own counts its approvals per rule, so
+	// the headline number GitLab sends beside them is not what gates a
+	// deployment.
+	if len(out.ApprovalRules) > 0 {
+		c.Field("Required Approvals", "per approval rule (see below)")
+	} else {
+		c.Int("Required Approvals", out.RequiredApprovalCount)
+	}
 	if len(out.DeployAccessLevels) > 0 {
-		b.WriteString("\n### Deploy Access Levels\n\n")
-		b.WriteString("| ID | Level | Description |\n| --- | --- | --- |\n")
+		t := c.Table("Deploy Access Levels", "ID", "Level", "Grantee", "Description", "Inheritance")
 		for _, l := range out.DeployAccessLevels {
-			// GitLab's access-level description is a role name for a plain rule
-			// but a user's display name or a group's name for a granular one.
-			fmt.Fprintf(&b, "| %d | %d | %s |\n", l.ID, l.AccessLevel, toolutil.EscapeMdTableCell(l.AccessLevelDescription))
+			t.Row(
+				strconv.FormatInt(l.ID, 10),
+				levelCell(l.AccessLevel, l.UserID, l.GroupID),
+				granteeCell(l.UserID, l.GroupID),
+				// GitLab's access-level description is a role name for a plain
+				// rule but a user's display name or a group's name for a
+				// granular one.
+				toolutil.EscapeMdTableCell(l.AccessLevelDescription),
+				inheritanceCell(l.GroupID, l.GroupInheritanceType),
+			)
 		}
 	}
 	if len(out.ApprovalRules) > 0 {
-		b.WriteString("\n### Approval Rules\n\n")
-		b.WriteString("| ID | Level | Description | Required |\n| --- | --- | --- | --- |\n")
+		t := c.Table("Approval Rules", "ID", "Level", "Grantee", "Description", "Required", "Inheritance")
 		for _, r := range out.ApprovalRules {
-			fmt.Fprintf(&b, "| %d | %d | %s | %d |\n", r.ID, r.AccessLevel, toolutil.EscapeMdTableCell(r.AccessLevelDescription), r.RequiredApprovalCount)
+			t.Row(
+				strconv.FormatInt(r.ID, 10),
+				levelCell(r.AccessLevel, r.UserID, r.GroupID),
+				granteeCell(r.UserID, r.GroupID),
+				toolutil.EscapeMdTableCell(r.AccessLevelDescription),
+				strconv.FormatInt(r.RequiredApprovalCount, 10),
+				inheritanceCell(r.GroupID, r.GroupInheritanceType),
+			)
 		}
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_protected_environment_update to modify settings",
-		"Use gitlab_group_protected_environment_unprotect to remove protection",
+	c.End(
+		toolutil.HintAction(actionUpdate, "change the deploy access levels or approval rules"),
+		toolutil.HintAction(actionUnprotect, "remove this protection from the group"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of group protected environments as Markdown.
+// levelCell renders the role a rule grants, and "-" for a rule that names a
+// user or a group instead, whose access_level is not what decides.
+func levelCell(accessLevel int, userID, groupID int64) string {
+	if granteeCell(userID, groupID) != "" {
+		return "-"
+	}
+	return toolutil.AccessLevelDescription(gl.AccessLevelValue(accessLevel))
+}
+
+// granteeCell names who a granular rule is about, and nothing for a rule that
+// grants a role to everyone who holds it. GitLab sends zero for the id it is
+// not about, which used to be rendered as a numeric 0 in a column of its own.
+func granteeCell(userID, groupID int64) string {
+	switch {
+	case userID != 0:
+		return fmt.Sprintf("user #%d", userID)
+	case groupID != 0:
+		return fmt.Sprintf("group #%d", groupID)
+	default:
+		return ""
+	}
+}
+
+// inheritanceCell says whether a group rule reaches the group's inherited
+// members or only its direct ones, and nothing at all for a rule that is not
+// about a group, where GitLab's zero means "not applicable" rather than
+// "direct".
+func inheritanceCell(groupID, inheritanceType int64) string {
+	if groupID == 0 {
+		return ""
+	}
+	if inheritanceType == 0 {
+		return "direct"
+	}
+	return "inherited"
+}
+
+// FormatListMarkdown renders a page of a group's protected environments as a
+// Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Environments) == 0 {
-		return "No group protected environments found.\n"
+		return toolutil.EmptyMessage("group protected environments")
 	}
 	var b strings.Builder
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
-	toolutil.WriteListSummary(&b, len(out.Environments), out.Pagination)
-	b.WriteString("| Name | Approval Count | Deploy Levels | Rules |\n| --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Group Protected Environments", len(out.Environments), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Required Approvals", "Deploy Access Levels", "Approval Rules"))
 	for _, e := range out.Environments {
-		fmt.Fprintf(
-			&b, "| %s | %d | %d | %d |\n",
+		b.WriteString(toolutil.MarkdownTableRow(
 			toolutil.EscapeMdTableCell(e.Name),
-			e.RequiredApprovalCount,
-			len(e.DeployAccessLevels),
-			len(e.ApprovalRules),
-		)
+			strconv.FormatInt(e.RequiredApprovalCount, 10),
+			strconv.Itoa(len(e.DeployAccessLevels)),
+			strconv.Itoa(len(e.ApprovalRules)),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_protected_environment_get with an environment name for details",
-		"Use gitlab_group_protected_environment_protect to add new protection",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionGet, "see one environment's rules in full"),
+		toolutil.HintAction(actionProtect, "protect another environment tier"),
+		toolutil.HintAction(actionList, "page through the rest of the group's protected environments"),
 	)
 	return b.String()
 }

--- a/internal/tools/groupreleases/markdown.go
+++ b/internal/tools/groupreleases/markdown.go
@@ -1,10 +1,16 @@
 package groupreleases
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionGroupReleaseList = "group.release_list"
+	actionReleaseGet       = "release.get"
+	actionReleaseLinkList  = "release.link_list"
 )
 
 // releaseWebURL derives the release page URL from the _links object, preferring
@@ -23,38 +29,57 @@ func releaseWebURL(r Output) string {
 	return ""
 }
 
-// releaseAuthor returns the author username for compact rendering, or "" when
-// no author is associated with the release.
+// releaseAuthor renders the author as the handle linked to their profile, the
+// way the project-scoped release list renders one, and nothing when no author
+// is associated with the release.
 func releaseAuthor(r Output) string {
 	if r.Author == nil {
 		return ""
 	}
-	return r.Author.Username
+	return toolutil.MdUserLink(r.Author.Username, r.Author.WebURL)
 }
 
-// FormatListMarkdown renders a paginated list of group releases as Markdown.
+// releasedCell renders the date a release went out, falling back to when it was
+// created, and marks a release dated in the future with the calendar glyph
+// GitLab's own upcoming_release flag stands for.
+func releasedCell(r Output) string {
+	released := r.ReleasedAt
+	if released == "" {
+		released = r.CreatedAt
+	}
+	cell := toolutil.FormatTime(released)
+	if r.UpcomingRelease && cell != "" {
+		return toolutil.EmojiCalendar + " " + cell
+	}
+	return cell
+}
+
+// FormatListMarkdown renders a page of a group's releases as a Markdown table:
+// a collection of objects that share columns, under the heading the response
+// can vouch for and above the pagination footer.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Releases) == 0 {
-		return "No group releases found.\n"
+		return toolutil.EmptyMessage("group releases")
 	}
 	var b strings.Builder
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
-	toolutil.WriteListSummary(&b, len(out.Releases), out.Pagination)
-	b.WriteString("| Tag | Name | Released | Author |\n| --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Group Releases", len(out.Releases), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Tag", "Name", "Released", "Author"))
 	for _, r := range out.Releases {
 		// A tag name may hold ']' and both angle brackets, which the cell
 		// escaper leaves alone, so the label of a hand-built link could be
 		// closed from inside it.
-		tag := toolutil.MdTitleLink(r.TagName, releaseWebURL(r))
-		fmt.Fprintf(
-			&b, "| %s | %s | %s | %s |\n",
-			tag,
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(r.TagName, releaseWebURL(r)),
 			toolutil.EscapeMdTableCell(r.Name),
-			//gitlab:allow-unescaped r.ReleasedAt: a timestamp this package formatted itself from the time client-go parsed.
-			r.ReleasedAt,
-			toolutil.EscapeMdTableCell(releaseAuthor(r)),
-		)
+			releasedCell(r),
+			releaseAuthor(r),
+		))
 	}
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionReleaseGet, "read one release in full, with its notes and assets"),
+		toolutil.HintAction(actionReleaseLinkList, "list the asset links of a release"),
+		toolutil.HintAction(actionGroupReleaseList, "page through the rest of the group's releases"),
+	)
 	return b.String()
 }
 

--- a/internal/tools/groupreleases/markdown_test.go
+++ b/internal/tools/groupreleases/markdown_test.go
@@ -2,150 +2,130 @@
 package groupreleases
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// TestFormatListMarkdown validates the Markdown formatter for group releases.
-// It covers empty results, a single release, multiple releases, and special
-// characters that require escaping in Markdown table cells.
-func TestFormatListMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    ListOutput
-		wantSub  []string
-		wantNot  []string
-		wantFull string
-	}{
-		{
-			name:     "empty releases returns no-results message",
-			input:    ListOutput{},
-			wantFull: "No group releases found.\n",
-		},
-		{
-			name: "single release renders table with one row",
-			input: ListOutput{
-				Releases: []Output{
-					{
-						TagName:    "v1.0.0",
-						Name:       "First Release",
-						ReleasedAt: "2026-06-01",
-						Author:     &toolutil.AuthorOutput{Username: "admin"},
-					},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{
-				"| Tag | Name | Released | Author |",
-				"| v1.0.0 | First Release | 2026-06-01 | admin |",
-			},
-		},
-		{
-			name: "multiple releases renders all rows",
-			input: ListOutput{
-				Releases: []Output{
-					{TagName: "v2.0.0", Name: "Second", ReleasedAt: "2026-07-01", Author: &toolutil.AuthorOutput{Username: "dev1"}},
-					{TagName: "v1.0.0", Name: "First", ReleasedAt: "2026-06-01", Author: &toolutil.AuthorOutput{Username: "dev2"}},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 2, TotalPages: 1},
-			},
-			wantSub: []string{
-				"| v2.0.0 | Second | 2026-07-01 | dev1 |",
-				"| v1.0.0 | First | 2026-06-01 | dev2 |",
-			},
-		},
-		{
-			name: "special characters in tag and name are escaped",
-			input: ListOutput{
-				Releases: []Output{
-					{TagName: "v1|beta", Name: "Rel|ease", ReleasedAt: "2026-01-01", Author: &toolutil.AuthorOutput{Username: "user"}},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{"v1"},
-			wantNot: []string{"| v1|beta |"},
-		},
-		{
-			name: "empty optional fields render blank cells",
-			input: ListOutput{
-				Releases: []Output{
-					{TagName: "v0.1.0", Name: "Early"},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{
-				"| v0.1.0 | Early |  |  |",
-			},
-		},
-		{
-			name: "non-nil links without self or edit url renders plain tag",
-			input: ListOutput{
-				Releases: []Output{
-					{
-						TagName: "v3.9.0",
-						Name:    "NoURL",
-						Links:   &toolutil.LinksOutput{ClosedIssuesURL: "https://ci"},
-					},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{"| v3.9.0 | NoURL |"},
-			wantNot: []string{"[v3.9.0]("},
-		},
-		{
-			name: "self link renders tag as clickable link",
-			input: ListOutput{
-				Releases: []Output{
-					{
-						TagName: "v4.0.0",
-						Name:    "Linked",
-						Author:  &toolutil.AuthorOutput{Username: "rel"},
-						Links:   &toolutil.LinksOutput{Self: "https://git.example.com/g/p/-/releases/v4.0.0"},
-					},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{
-				"[v4.0.0](https://git.example.com/g/p/-/releases/v4.0.0)",
-			},
-		},
-		{
-			name: "edit_url fallback derives release web url",
-			input: ListOutput{
-				Releases: []Output{
-					{
-						TagName: "v5.0.0",
-						Name:    "EditFallback",
-						Links:   &toolutil.LinksOutput{EditURL: "https://git.example.com/g/p/-/releases/v5.0.0/edit"},
-					},
-				},
-				Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
-			},
-			wantSub: []string{
-				"[v5.0.0](https://git.example.com/g/p/-/releases/v5.0.0)",
-			},
-			wantNot: []string{"/edit)"},
-		},
-	}
+// listHints is the guidance section every group release listing closes with,
+// the preserve-links instruction first because the Tag column carries links.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- " + toolutil.HintPreserveLinks + "\n" +
+	"- Use action 'release.get' to read one release in full, with its notes and assets\n" +
+	"- Use action 'release.link_list' to list the asset links of a release\n" +
+	"- Use action 'group.release_list' to page through the rest of the group's releases\n"
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			if tt.wantFull != "" && got != tt.wantFull {
-				t.Fatalf("got %q, want %q", got, tt.wantFull)
-			}
-			for _, sub := range tt.wantSub {
-				if !strings.Contains(got, sub) {
-					t.Errorf("output missing %q\ngot:\n%s", sub, got)
-				}
-			}
-			for _, not := range tt.wantNot {
-				if strings.Contains(got, not) {
-					t.Errorf("output should NOT contain %q\ngot:\n%s", not, got)
-				}
-			}
-		})
+const listHeader = "| Tag | Name | Released | Author |\n| --- | --- | --- | --- |\n"
+
+// TestFormatListMarkdown_Empty pins that a group with no releases renders the
+// one sentence and nothing else: no heading counting zero above it.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No group releases found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_SinglePage pins the whole document of a one-page
+// listing: the heading counting what GitLab said, the table, the pagination
+// line separated from the last row, and the hints last.
+func TestFormatListMarkdown_SinglePage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Releases: []Output{{
+			TagName:    "v1.0.0",
+			Name:       "First Release",
+			ReleasedAt: "2026-06-01T00:00:00Z",
+			Author:     &toolutil.AuthorOutput{Username: "admin"},
+			Links:      &toolutil.LinksOutput{Self: "https://git.example.com/g/p/-/releases/v1.0.0"},
+		}},
+		Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
+	})
+
+	want := "## Group Releases (1)\n\n" +
+		listHeader +
+		"| [v1.0.0](https://git.example.com/g/p/-/releases/v1.0.0) | First Release | 1 Jun 2026 00:00 UTC | @admin |\n" +
+		"\n1 items total\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_MultiPage pins the heading, the summary line and the
+// pagination footer of a page that is one of several: the heading counts the
+// total GitLab reported rather than the rows shown.
+func TestFormatListMarkdown_MultiPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Releases: []Output{
+			{TagName: "v2.0.0", Name: "Second", ReleasedAt: "2026-07-01T10:00:00Z", Author: &toolutil.AuthorOutput{Username: "dev1"}},
+			{TagName: "v1.0.0", Name: "First", ReleasedAt: "2026-06-01T09:00:00Z", Author: &toolutil.AuthorOutput{Username: "dev2"}},
+		},
+		Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 3, TotalItems: 45, PerPage: 20},
+	})
+
+	want := "## Group Releases (45)\n\n" +
+		"Showing 2 of 45 results (page 1 of 3)\n\n" +
+		listHeader +
+		"| v2.0.0 | Second | 1 Jul 2026 10:00 UTC | @dev1 |\n" +
+		"| v1.0.0 | First | 1 Jun 2026 09:00 UTC | @dev2 |\n" +
+		"\nPage 1 of 3 | 45 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_UpcomingAndCreatedFallback pins the two things the
+// Released column answers besides a release date: a release GitLab marked
+// upcoming carries the calendar glyph, and one with no released_at falls back
+// to when it was created rather than rendering an empty cell.
+func TestFormatListMarkdown_UpcomingAndCreatedFallback(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Releases: []Output{
+			{TagName: "v9.0.0", Name: "Planned", ReleasedAt: "2027-01-01T00:00:00Z", UpcomingRelease: true},
+			{TagName: "v0.1.0", Name: "Early", CreatedAt: "2026-01-02T03:04:00Z"},
+		},
+		Pagination: toolutil.PaginationOutput{TotalItems: 2, TotalPages: 1},
+	})
+
+	want := "## Group Releases (2)\n\n" +
+		listHeader +
+		"| v9.0.0 | Planned | \U0001F4C5 1 Jan 2027 00:00 UTC |  |\n" +
+		"| v0.1.0 | Early | 2 Jan 2026 03:04 UTC |  |\n" +
+		"\n2 items total\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_HostileTagAndEditURLFallback pins both halves of the
+// Tag column: a tag name carrying a pipe and a bracket cannot split the row or
+// close a link label, and a release whose only link is the edit URL is linked
+// to the page that URL is the edit form of.
+func TestFormatListMarkdown_HostileTagAndEditURLFallback(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Releases: []Output{
+			{TagName: "v1|beta](http://attacker.invalid/)", Name: "Rel|ease"},
+			{TagName: "v5.0.0", Name: "EditFallback", Links: &toolutil.LinksOutput{EditURL: "https://git.example.com/g/p/-/releases/v5.0.0/edit"}},
+			{TagName: "v3.9.0", Name: "NoURL", Links: &toolutil.LinksOutput{ClosedIssuesURL: "https://ci.example.com"}},
+		},
+		Pagination: toolutil.PaginationOutput{TotalItems: 3, TotalPages: 1},
+	})
+
+	want := "## Group Releases (3)\n\n" +
+		listHeader +
+		"| v1&#124;beta](http://attacker.invalid/) | Rel&#124;ease |  |  |\n" +
+		"| [v5.0.0](https://git.example.com/g/p/-/releases/v5.0.0) | EditFallback |  |  |\n" +
+		"| v3.9.0 | NoURL |  |  |\n" +
+		"\n3 items total\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/internal/tools/groupvariables/group_variables_test.go
+++ b/internal/tools/groupvariables/group_variables_test.go
@@ -272,20 +272,45 @@ func TestDelete_MissingKey(t *testing.T) {
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatOutputMarkdown(t *testing.T) {
 	out := Output{Key: "MY_VAR", Value: "secret", VariableType: "env_var", Protected: true, EnvironmentScope: "*"}
-	md := FormatOutputMarkdown(out)
-	if md == "" {
-		t.Fatal("FormatOutputMarkdown returned empty string")
+	want := "## Group Variable: MY_VAR\n\n" +
+		"- **Type**: env_var\n" +
+		"- **Protected**: " + toolutil.EmojiSuccess + "\n" +
+		"- **Masked**: " + toolutil.EmojiCross + "\n" +
+		"- **Raw**: " + toolutil.EmojiCross + "\n" +
+		"- **Environment Scope**: *\n" +
+		"- **Value**: secret\n" +
+		groupVariableCardHints
+	if md := FormatOutputMarkdown(out); md != want {
+		t.Errorf("FormatOutputMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
+
+// groupVariableCardHints is the guidance section a group variable card closes
+// with. The two hints name the bare action words the shared renderer writes;
+// on the group surface those resolve to the group_update and group_delete
+// actions, which the hints do not spell.
+const groupVariableCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'update' to change this variable\n" +
+	"- Use action 'delete' to remove this variable\n"
 
 // TestFormatOutputMarkdown_Masked verifies the OutputMarkdown_Masked Markdown formatter for a representative output_masked input.
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatOutputMarkdown_Masked(t *testing.T) {
 	out := Output{Key: "MY_VAR", Value: "secret", Masked: true, VariableType: "env_var"}
+	want := "## Group Variable: MY_VAR\n\n" +
+		"- **Type**: env_var\n" +
+		"- **Protected**: " + toolutil.EmojiCross + "\n" +
+		"- **Masked**: " + toolutil.EmojiSuccess + "\n" +
+		"- **Raw**: " + toolutil.EmojiCross + "\n" +
+		"- **Value**: [masked]\n" +
+		groupVariableCardHints
 	md := FormatOutputMarkdown(out)
-	if md == "" {
-		t.Fatal("FormatOutputMarkdown returned empty string")
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(masked)\n got %q\nwant %q", md, want)
+	}
+	if strings.Contains(md, "secret") {
+		t.Errorf("a masked variable's value reached the Markdown:\n%s", md)
 	}
 }
 
@@ -297,9 +322,9 @@ func TestFormatListMarkdown_Empty_NilVariables(t *testing.T) {
 		Variables:  nil,
 		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 0, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	if md == "" {
-		t.Fatal("FormatListMarkdown returned empty string")
+	const want = "No group CI/CD variables found.\n"
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown(nil variables)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -311,11 +336,22 @@ func TestFormatListMarkdown(t *testing.T) {
 		Variables:  []Output{{Key: "MY_VAR", VariableType: "env_var", Protected: true, EnvironmentScope: "*"}},
 		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 1, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	if md == "" {
-		t.Fatal("FormatListMarkdown returned empty string")
+	want := "## Group CI/CD Variables (1)\n\n" +
+		"| Key | Type | Protected | Masked | Scope |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| MY_VAR | env_var | " + toolutil.EmojiSuccess + " | " + toolutil.EmojiCross + " | * |\n" +
+		"\nPage 1 of 1 | 1 items total | 20 per page\n" +
+		groupVariableListHints
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
+
+// groupVariableListHints is the guidance section the group variable list
+// closes with.
+const groupVariableListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'get' with key for full details\n" +
+	"- Use action 'create' to add a new group variable\n"
 
 // ---------- Tests consolidated from coverage_test.go ----------.
 
@@ -897,22 +933,15 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Group CI/CD Variables (2)",
-		"| Key |",
-		"| --- |",
-		"| DB_HOST |",
-		"| API_KEY |",
-		"env_var",
-		"production",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Group CI/CD Variables (2)\n\n" +
+		"| Key | Type | Protected | Masked | Scope |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| DB_HOST | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " | * |\n" +
+		"| API_KEY | env_var | " + toolutil.EmojiSuccess + " | " + toolutil.EmojiSuccess + " | production |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		groupVariableListHints
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown(with variables)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -920,12 +949,9 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No group CI/CD variables found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| Key |") {
-		t.Error("should not contain table header when empty")
+	const want = "No group CI/CD variables found.\n"
+	if md := FormatListMarkdown(ListOutput{}); md != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -939,9 +965,9 @@ func TestFormatListMarkdown_EscapesTableCells(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	if strings.Contains(md, "| MY|VAR |") {
-		t.Errorf("pipe in key should be escaped:\n%s", md)
+	const wantRow = "| MY&#124;VAR | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " | scope&#124;test |\n"
+	if md := FormatListMarkdown(out); !strings.Contains(md, wantRow) {
+		t.Errorf("FormatListMarkdown() missing %q:\n%s", wantRow, md)
 	}
 }
 

--- a/internal/tools/groupwikis/markdown.go
+++ b/internal/tools/groupwikis/markdown.go
@@ -1,55 +1,91 @@
 package groupwikis
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single group wiki page as Markdown.
+// Canonical action IDs the hints name that the action specs do not already
+// spell. Group wiki actions are routes on the gitlab_group catalog group, so
+// their IDs carry the group domain.
+//
+// The two are declared one per line with a directive each because gosec reads
+// a constant whose name ends in a verb over a dotted value as a credential;
+// the sibling IDs in action_specs.go are excused by path in .golangci.yml for
+// the same reason.
+const (
+	//nolint:gosec // G101 false positive: a canonical catalog action ID, never a credential.
+	actionGroupWikiCreate = "group.wiki_create"
+	//nolint:gosec // G101 false positive: a canonical catalog action ID, never a credential.
+	actionGroupWikiDelete = "group.wiki_delete"
+)
+
+// FormatOutputMarkdown renders one group wiki page as a card: the page's own
+// fields, then its body under a label of its own.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Wiki: %s\n\n", toolutil.EscapeMdHeading(out.Title))
-	fmt.Fprintf(&b, "- **Slug**: %s\n", toolutil.EscapeMdTableCell(out.Slug))
-	//gitlab:allow-unescaped out.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
-	fmt.Fprintf(&b, "- **Format**: %s\n", out.Format)
-	if out.Encoding != "" {
-		fmt.Fprintf(&b, "- **Encoding**: %s\n", toolutil.EscapeMdTableCell(out.Encoding))
-	}
-	if out.Content != "" {
-		fmt.Fprintf(&b, "\n### Content\n\n%s\n", out.Content)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_wiki_edit to update this page",
-		"Use gitlab_group_wiki_delete to remove this page",
+	c := toolutil.NewCard(&b, wikiHeading(out.Title))
+	c.Field("Slug", out.Slug)
+	c.Field("Format", out.Format)
+	c.Field("Encoding", out.Encoding)
+	c.Count("Page Metadata ID", out.WikiPageMetaID)
+	writeWikiContent(c, out.Format, out.Content)
+	c.End(
+		toolutil.HintAction(actionGroupWikiEdit, "update this page"),
+		toolutil.HintAction(actionGroupWikiDelete, "remove this page"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of group wiki pages as a Markdown table.
+// wikiHeading names the card: the page's title, and the bare word when GitLab
+// sent none, so the heading never ends in a colon with nothing after it.
+func wikiHeading(title string) string {
+	if strings.TrimSpace(title) == "" {
+		return "Wiki"
+	}
+	return "Wiki: " + title
+}
+
+// writeWikiContent writes the page body under its own label. A Markdown page
+// is quoted, so nothing a page author wrote can add a heading, a row or a
+// guidance section to the card; a page in any other format is fenced with that
+// format as the info string, since quoting rdoc or asciidoc would render it as
+// the Markdown it is not. The body used to be written raw, which let a page
+// forge the whole response.
+func writeWikiContent(c *toolutil.Card, format, content string) {
+	if content == "" {
+		return
+	}
+	if format == "" || strings.EqualFold(format, "markdown") {
+		c.Text("Content", content)
+		return
+	}
+	c.Fence("Content", format, content)
+}
+
+// FormatListMarkdown renders a page of group wiki pages as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.WikiPages) == 0 {
-		return "No group wiki pages found.\n"
+		return toolutil.EmptyMessage("group wiki pages")
 	}
 	var b strings.Builder
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
-	b.WriteString("| Title | Slug | Format |\n")
-	b.WriteString("| --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Group Wiki Pages", len(out.WikiPages), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("Title", "Slug", "Format"))
 	for _, w := range out.WikiPages {
-		fmt.Fprintf(
-			&b, "| %s | %s | %s |\n",
+		b.WriteString(toolutil.MarkdownTableRow(
 			toolutil.EscapeMdTableCell(w.Title),
 			toolutil.EscapeMdTableCell(w.Slug),
-			//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
-			w.Format,
-		)
+			toolutil.EscapeMdTableCell(w.Format),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_group_wiki_get with a slug to read page content",
-		"Use gitlab_group_wiki_create to add a new page",
+	// The table carries no link, so the hints carry no instruction to preserve
+	// one: the leading HintPreserveLinks this list used to open with put a
+	// guidance section above its own table header, which stopped the table
+	// rendering at all.
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(actionGroupWikiGet, "read one page's content"),
+		toolutil.HintAction(actionGroupWikiCreate, "add a new page"),
 	)
 	return b.String()
 }

--- a/internal/tools/groupwikis/markdown_test.go
+++ b/internal/tools/groupwikis/markdown_test.go
@@ -1,185 +1,158 @@
 // markdown_test.go validates Markdown formatting functions for group wiki
-// MCP tool output. Covers single-page rendering (with/without content and
-// encoding), list rendering (empty, single, multiple pages), and special
-// characters in fields.
+// MCP tool output. Every expectation is the whole render: a substring
+// assertion is what let a table that had stopped rendering keep passing.
 package groupwikis
 
 import (
-	"strings"
 	"testing"
 )
 
-// TestFormatOutputMarkdown validates the single wiki page Markdown formatter.
-// It covers pages with full fields, optional encoding, optional content, and
-// minimal fields.
+// The guidance sections the two group wiki formatters close with.
+const (
+	groupWikiCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'group.wiki_edit' to update this page\n" +
+		"- Use action 'group.wiki_delete' to remove this page\n"
+
+	groupWikiListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'group.wiki_get' to read one page's content\n" +
+		"- Use action 'group.wiki_create' to add a new page\n"
+)
+
+// TestFormatOutputMarkdown pins the whole card of a group wiki page, in each
+// of the four shapes GitLab answers with: a Markdown page, a page in another
+// format, a page read without its content, and a page whose every field is
+// empty.
 func TestFormatOutputMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Output
-		contains []string
-		excludes []string
+	cases := []struct {
+		name  string
+		input Output
+		want  string
 	}{
 		{
-			name: "full fields with content and encoding",
+			// A Markdown body is quoted, so a heading in the page cannot become
+			// a heading of the response: this content used to be written raw.
+			name: "markdown page is quoted",
 			input: Output{
 				Title:    "Home",
 				Slug:     "home",
 				Format:   "markdown",
-				Content:  "# Welcome",
+				Content:  "# Welcome\n\nRead the setup guide.",
 				Encoding: "utf-8",
 			},
-			contains: []string{
-				"## Wiki: Home",
-				"**Slug**: home",
-				"**Format**: markdown",
-				"**Encoding**: utf-8",
-				"### Content",
-				"# Welcome",
-				"gitlab_group_wiki_edit",
-				"gitlab_group_wiki_delete",
-			},
+			want: "## Wiki: Home\n\n" +
+				"- **Slug**: home\n" +
+				"- **Format**: markdown\n" +
+				"- **Encoding**: utf-8\n" +
+				"- **Content**:\n" +
+				"  > # Welcome\n" +
+				"  >\n" +
+				"  > Read the setup guide.\n" +
+				groupWikiCardHints,
 		},
 		{
-			name: "without encoding omits encoding line",
+			// A page in another format is fenced with that format, since
+			// quoting it would render it as the Markdown it is not.
+			name: "asciidoc page is fenced",
 			input: Output{
 				Title:   "Setup",
 				Slug:    "setup",
 				Format:  "asciidoc",
-				Content: "Setup instructions",
+				Content: "= Setup instructions",
 			},
-			contains: []string{
-				"## Wiki: Setup",
-				"**Slug**: setup",
-				"**Format**: asciidoc",
-				"### Content",
-				"Setup instructions",
-			},
-			excludes: []string{
-				"**Encoding**",
-			},
+			want: "## Wiki: Setup\n\n" +
+				"- **Slug**: setup\n" +
+				"- **Format**: asciidoc\n" +
+				"\n### Content\n\n" +
+				"```asciidoc\n= Setup instructions\n```\n" +
+				groupWikiCardHints,
 		},
 		{
-			name: "without content omits content section",
-			input: Output{
-				Title:  "Empty",
-				Slug:   "empty",
-				Format: "markdown",
-			},
-			contains: []string{
-				"## Wiki: Empty",
-				"**Slug**: empty",
-			},
-			excludes: []string{
-				"### Content",
-			},
+			name:  "page read without its content",
+			input: Output{Title: "Empty", Slug: "empty", Format: "markdown"},
+			want: "## Wiki: Empty\n\n" +
+				"- **Slug**: empty\n" +
+				"- **Format**: markdown\n" +
+				groupWikiCardHints,
 		},
 		{
-			name: "minimal fields",
-			input: Output{
-				Title:  "",
-				Slug:   "",
-				Format: "",
-			},
-			contains: []string{
-				"## Wiki:",
-				"**Slug**:",
-				"**Format**:",
-			},
+			// Every field absent writes no row at all, rather than a label with
+			// nothing after it.
+			name:  "every field empty",
+			input: Output{},
+			want:  "## Wiki\n" + groupWikiCardHints,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatOutputMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
-			}
-			for _, s := range tt.excludes {
-				if strings.Contains(got, s) {
-					t.Errorf("output should not contain %q\ngot:\n%s", s, got)
-				}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FormatOutputMarkdown(c.input); got != c.want {
+				t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, c.want)
 			}
 		})
 	}
 }
 
-// TestFormatListMarkdown validates the wiki list Markdown table formatter.
-// It covers empty list, single page, and multiple pages with special characters.
+// TestFormatListMarkdown pins the whole group wiki listing. The table used to
+// be written under a guidance section the formatter opened with, which made
+// its header a lazy continuation of that section's last list item: no table
+// rendered at all, and the substring assertions that replaced this one passed
+// throughout.
 func TestFormatListMarkdown(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
-		excludes []string
+	cases := []struct {
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
-			name:  "empty list returns no-results message",
+			name:  "no pages",
 			input: ListOutput{WikiPages: nil},
-			contains: []string{
-				"No group wiki pages found.",
-			},
-			excludes: []string{
-				"| Title",
-			},
+			want:  "No group wiki pages found.\n",
 		},
 		{
-			name: "single page renders table",
-			input: ListOutput{
-				WikiPages: []Output{
-					{Title: "Home", Slug: "home", Format: "markdown"},
-				},
-			},
-			contains: []string{
-				"| Title | Slug | Format |",
-				"| --- | --- | --- |",
-				"| Home | home | markdown |",
-				"gitlab_group_wiki_get",
-				"gitlab_group_wiki_create",
-			},
+			name: "one page",
+			input: ListOutput{WikiPages: []Output{
+				{Title: "Home", Slug: "home", Format: "markdown"},
+			}},
+			want: "## Group Wiki Pages (1)\n\n" +
+				"| Title | Slug | Format |\n" +
+				"| --- | --- | --- |\n" +
+				"| Home | home | markdown |\n" +
+				groupWikiListHints,
 		},
 		{
-			name: "multiple pages render rows",
-			input: ListOutput{
-				WikiPages: []Output{
-					{Title: "Home", Slug: "home", Format: "markdown"},
-					{Title: "Setup Guide", Slug: "setup-guide", Format: "asciidoc"},
-					{Title: "FAQ", Slug: "faq", Format: "rdoc"},
-				},
-			},
-			contains: []string{
-				"| Home | home | markdown |",
-				"| Setup Guide | setup-guide | asciidoc |",
-				"| FAQ | faq | rdoc |",
-			},
+			name: "several pages",
+			input: ListOutput{WikiPages: []Output{
+				{Title: "Home", Slug: "home", Format: "markdown"},
+				{Title: "Setup Guide", Slug: "setup-guide", Format: "asciidoc"},
+				{Title: "FAQ", Slug: "faq", Format: "rdoc"},
+			}},
+			want: "## Group Wiki Pages (3)\n\n" +
+				"| Title | Slug | Format |\n" +
+				"| --- | --- | --- |\n" +
+				"| Home | home | markdown |\n" +
+				"| Setup Guide | setup-guide | asciidoc |\n" +
+				"| FAQ | faq | rdoc |\n" +
+				groupWikiListHints,
 		},
 		{
-			name: "special characters in title are escaped",
-			input: ListOutput{
-				WikiPages: []Output{
-					{Title: "Pipe | Test", Slug: "pipe-test", Format: "markdown"},
-				},
-			},
-			contains: []string{
-				"pipe-test",
-				"markdown",
-			},
+			// A pipe a page author typed into a title is an entity, so it stays
+			// inside its cell instead of opening a column of its own.
+			name: "a pipe in a title stays in its cell",
+			input: ListOutput{WikiPages: []Output{
+				{Title: "Pipe | Test", Slug: "pipe-test", Format: "markdown"},
+			}},
+			want: "## Group Wiki Pages (1)\n\n" +
+				"| Title | Slug | Format |\n" +
+				"| --- | --- | --- |\n" +
+				"| Pipe &#124; Test | pipe-test | markdown |\n" +
+				groupWikiListHints,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("output missing %q\ngot:\n%s", s, got)
-				}
-			}
-			for _, s := range tt.excludes {
-				if strings.Contains(got, s) {
-					t.Errorf("output should not contain %q\ngot:\n%s", s, got)
-				}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FormatListMarkdown(c.input); got != c.want {
+				t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, c.want)
 			}
 		})
 	}

--- a/internal/tools/instancevariables/instance_variables_test.go
+++ b/internal/tools/instancevariables/instance_variables_test.go
@@ -316,15 +316,47 @@ func TestFormatListMarkdown(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, TotalPages: 1, Page: 1, PerPage: 20},
 	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "VAR1") {
-		t.Error("expected VAR1 in list output")
+	// The list keeps four columns: an instance variable's scope is the same on
+	// every row, so a column repeating it says nothing. The card names it.
+	want := "## Instance CI/CD Variables (2)\n\n" +
+		"| Key | Type | Protected | Masked |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| VAR1 | env_var | " + toolutil.EmojiSuccess + " | " + toolutil.EmojiCross + " |\n" +
+		"| VAR2 | file | " + toolutil.EmojiCross + " | " + toolutil.EmojiSuccess + " |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		variableListHints
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", md, want)
 	}
-	if !strings.Contains(md, "VAR2") {
-		t.Error("expected VAR2 in list output")
-	}
-	if !strings.Contains(md, "Instance CI/CD Variables (2)") {
-		t.Error("expected header with count")
+}
+
+// variableListHints is the guidance section the instance variable list closes
+// with.
+const variableListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'get' with key for full details\n" +
+	"- Use action 'create' to add a new instance variable\n"
+
+// TestFormatOutputMarkdown_NamesTheEnvironmentScope verifies that the scope
+// GitLab sends reaches the card. The view model used to receive an empty
+// string in its place, so an instance variable scoped to one environment read
+// as one that applies everywhere.
+func TestFormatOutputMarkdown_NamesTheEnvironmentScope(t *testing.T) {
+	md := FormatOutputMarkdown(Output{
+		Key:              "DB_HOST",
+		Value:            "localhost",
+		VariableType:     "env_var",
+		EnvironmentScope: "production",
+	})
+	want := "## Instance Variable: DB_HOST\n\n" +
+		"- **Type**: env_var\n" +
+		"- **Protected**: " + toolutil.EmojiCross + "\n" +
+		"- **Masked**: " + toolutil.EmojiCross + "\n" +
+		"- **Raw**: " + toolutil.EmojiCross + "\n" +
+		"- **Environment Scope**: production\n" +
+		"- **Value**: localhost\n" +
+		variableCardHints
+	if md != want {
+		t.Errorf("variable card with a scope:\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -332,9 +364,9 @@ func TestFormatListMarkdown(t *testing.T) {
 // The test exercises the GET path of the underlying GitLab API call.
 // It asserts the rendered Markdown contains the expected section headings and content.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No instance CI/CD variables found") {
-		t.Errorf("FormatListMarkdown(empty) = %q, want no-results message", md)
+	const want = "No instance CI/CD variables found.\n"
+	if md := FormatListMarkdown(ListOutput{}); md != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -810,21 +842,15 @@ func TestFormatListMarkdown_WithVariables(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Instance CI/CD Variables (2)",
-		"| Key |",
-		"| --- |",
-		"| DB_HOST |",
-		"| API_KEY |",
-		"env_var",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Instance CI/CD Variables (2)\n\n" +
+		"| Key | Type | Protected | Masked |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| DB_HOST | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " |\n" +
+		"| API_KEY | env_var | " + toolutil.EmojiSuccess + " | " + toolutil.EmojiSuccess + " |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		variableListHints
+	if md := FormatListMarkdown(out); md != want {
+		t.Errorf("FormatListMarkdown(with variables)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -876,8 +902,8 @@ func TestFormatListMarkdown_EscapesTableCells(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	if strings.Contains(md, "| MY|VAR |") {
-		t.Errorf("pipe in key should be escaped:\n%s", md)
+	const wantRow = "| MY&#124;VAR | env_var | " + toolutil.EmojiCross + " | " + toolutil.EmojiCross + " |\n"
+	if md := FormatListMarkdown(out); !strings.Contains(md, wantRow) {
+		t.Errorf("FormatListMarkdown() missing %q:\n%s", wantRow, md)
 	}
 }

--- a/internal/tools/instancevariables/markdown.go
+++ b/internal/tools/instancevariables/markdown.go
@@ -12,8 +12,12 @@ import (
 // that asked only whether the variable was masked printed it. The shared
 // renderer this delegates to has held both halves since hidden variables
 // existed, and it reports the flag as well, which the card did not.
+// The card names the environment scope, which the view model used to drop:
+// an instance variable carries one like every other CI/CD variable, and the
+// project and group cards have always shown it. The list table leaves it out,
+// where a column repeating the same scope on every row says nothing.
 func FormatOutputMarkdown(v Output) string {
-	return toolutil.FormatCICDVariableDetailMarkdown(toMarkdownVariable(v), "Instance Variable", false)
+	return toolutil.FormatCICDVariableDetailMarkdown(toMarkdownVariable(v), "Instance Variable", true)
 }
 
 // FormatListMarkdown renders a paginated list of instance CI/CD variables as a Markdown table.
@@ -28,10 +32,12 @@ func FormatListMarkdown(out ListOutput) string {
 // toMarkdownVariable maps an instance variable onto the shared view model.
 // Hidden travels with Masked because the shared renderer withholds the value
 // for either: a variable created with masked_and_hidden is never shown again
-// in GitLab's own UI, whether or not it is also masked.
+// in GitLab's own UI, whether or not it is also masked. The environment scope
+// travels with them because the Output carries what GitLab sent and the view
+// model used to receive an empty string in its place.
 func toMarkdownVariable(v Output) toolutil.CICDVariableMarkdown {
 	flags := toolutil.CICDVariableFlags{Protected: v.Protected, Masked: v.Masked, Hidden: v.Hidden, Raw: v.Raw}
-	return toolutil.NewCICDVariableMarkdown(v.Key, v.Value, v.VariableType, flags, "", v.Description)
+	return toolutil.NewCICDVariableMarkdown(v.Key, v.Value, v.VariableType, flags, v.EnvironmentScope, v.Description)
 }
 
 func init() {

--- a/internal/tools/jobs/action_specs_test.go
+++ b/internal/tools/jobs/action_specs_test.go
@@ -284,22 +284,23 @@ func TestFormatOutputMarkdown_OptionalBranches(t *testing.T) {
 		CreatedAt:      "2024-01-01T00:00:00Z",
 		WebURL:         "https://gitlab.com/job/1",
 	}
-	md := FormatOutputMarkdown(out)
-
-	checks := []string{
-		"abc123def456", // truncated commit SHA
-		"45.5s",
-		"2.5s",
-		"script_failure",
-		"85.5%",
-		"admin",
-	}
-	for _, want := range checks {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q", want)
-			}
-		})
+	want := "## ❌ Job #1: build\n\n" +
+		"- **Stage**: build\n" +
+		"- **Status**: ❌ failed\n" +
+		"- **Allow Failure**: ❌\n" +
+		"- **Ref**: main\n" +
+		"- **Tag**: ❌\n" +
+		"- **Commit**: `abc123def456`\n" +
+		"- **Duration**: 45.5s\n" +
+		"- **Queued**: 2.5s\n" +
+		"- **Failure Reason**: script_failure\n" +
+		"- **Coverage**: 85.5%\n" +
+		"- **User**: @admin\n" +
+		"- **Created**: 1 Jan 2024 00:00 UTC\n" +
+		"- **URL**: [https://gitlab.com/job/1](https://gitlab.com/job/1)\n" +
+		jobCardHints
+	if md := FormatOutputMarkdown(out); md != want {
+		t.Errorf("FormatOutputMarkdown(optional branches)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/jobs/jobs_test.go
+++ b/internal/tools/jobs/jobs_test.go
@@ -1877,28 +1877,65 @@ func TestFormatOutputMarkdown_AllFields(t *testing.T) {
 		WebURL:         "https://gitlab.example.com/-/jobs/100",
 	})
 
-	for _, want := range []string{
-		"Job #100",
-		"build",
-		"**Pipeline**: #10",
-		"**Stage**: build",
-		"**Status**: success",
-		"**Allow Failure**: yes",
-		"**Ref**: main",
-		"`abcdef123456`",
-		"**Duration**: 45.5s",
-		"**Queued**: 2.1s",
-		"**Failure Reason**: script_failure",
-		"**Coverage**: 85.5%",
-		"**User**: testuser",
-		"**Created**:",
-		"https://gitlab.example.com/-/jobs/100",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## ✅ Job #100: build\n\n" +
+		"- **Pipeline**: #10\n" +
+		"- **Stage**: build\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Allow Failure**: ✅\n" +
+		"- **Ref**: main\n" +
+		"- **Tag**: ❌\n" +
+		"- **Commit**: `abcdef123456`\n" +
+		"- **Duration**: 45.5s\n" +
+		"- **Queued**: 2.1s\n" +
+		"- **Failure Reason**: script_failure\n" +
+		"- **Coverage**: 85.5%\n" +
+		"- **User**: @testuser\n" +
+		"- **Created**: 1 Mar 2026 10:00 UTC\n" +
+		"- **URL**: [https://gitlab.example.com/-/jobs/100](https://gitlab.example.com/-/jobs/100)\n" +
+		jobCardHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(all fields)\n got %q\nwant %q", md, want)
+	}
+}
+
+// jobCardHints is the guidance section a job card closes with when the job is
+// neither erased nor archived.
+const jobCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.trace' to read this job's log\n" +
+	"- Use action 'job.retry' to re-run this job\n" +
+	"- Use action 'job.cancel' to cancel it while it is still running\n"
+
+// TestFormatOutputMarkdown_ErasedAndArchivedRowsAndHints checks the three
+// rows a job's own state decides, and that the hints follow them: GitLab keeps
+// no log for an erased job and refuses both a retry and a cancel on an
+// archived one, so offering those was advice that could only fail. The hints
+// are replaced rather than dropped, so the card still closes with three.
+func TestFormatOutputMarkdown_ErasedAndArchivedRowsAndHints(t *testing.T) {
+	md := FormatOutputMarkdown(Output{
+		ID:                7,
+		Name:              "build",
+		Stage:             "build",
+		Status:            "success",
+		Ref:               "main",
+		ErasedAt:          "2026-03-02T08:00:00Z",
+		ArtifactsExpireAt: "2026-04-01T00:00:00Z",
+		Archived:          true,
+	})
+	want := "## ✅ Job #7: build 📦\n\n" +
+		"- **Stage**: build\n" +
+		"- **Status**: ✅ success\n" +
+		"- **Allow Failure**: ❌\n" +
+		"- **Ref**: main\n" +
+		"- **Tag**: ❌\n" +
+		"- **Erased**: 2 Mar 2026 08:00 UTC\n" +
+		"- **Artifacts Expire**: 1 Apr 2026 00:00 UTC\n" +
+		"- 📦 **Archived**\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.list_project' to look at the project's other jobs, since this one's log was erased\n" +
+		"- Use action 'pipeline.get' to open the pipeline this job ran in\n" +
+		"- Use action 'job.list' to see the other jobs of that pipeline\n"
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(erased and archived)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -1919,7 +1956,8 @@ func TestFormatWaitResult_TimedOutMarksError(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown_MinimalFields verifies FormatOutputMarkdown when minimal fields.
+// TestFormatOutputMarkdown_MinimalFields checks that a job GitLab said little
+// about renders only the rows it answered: no label stands without a value.
 func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 	md := FormatOutputMarkdown(Output{
 		ID:     50,
@@ -1928,22 +1966,15 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		Status: "running",
 		Ref:    "develop",
 	})
-
-	if !strings.Contains(md, "Job #50") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	for _, absent := range []string{
-		"**Duration**",
-		"**Queued**",
-		"**Failure Reason**",
-		"**Coverage**",
-		"**User**",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+	want := "## 🔵 Job #50: test\n\n" +
+		"- **Stage**: test\n" +
+		"- **Status**: 🔵 running\n" +
+		"- **Allow Failure**: ❌\n" +
+		"- **Ref**: develop\n" +
+		"- **Tag**: ❌\n" +
+		jobCardHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(minimal)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -1960,57 +1991,57 @@ func TestFormatListMarkdown_WithJobs(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Jobs (2)",
-		"| ID |",
-		"| --- |",
-		// These jobs carry no web URL, and MdTitleLink renders a bare label
-		// rather than the empty link the hand-written "[%d](%s)" produced.
-		"#100",
-		"#101",
-		"build",
-		"test",
-		"success",
-		"failed",
-		"45.5s",
-		"12.3s",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	// These jobs carry no web URL, and MdTitleLink renders a bare label rather
+	// than the empty link the hand-written "[%d](%s)" produced.
+	want := "## Jobs (2)\n\n" +
+		"| ID | Name | Stage | Status | Duration |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| #100 | build | build | ✅ success | 45.5s |\n" +
+		"| #101 | test | test | ❌ failed | 12.3s |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		jobListHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// jobListHints is the guidance section a job list closes with.
+const jobListHints = "\n---\n💡 **Next steps:**\n" +
+	"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+	"- Use action 'job.get' to see one job in full\n" +
+	"- Use action 'job.trace' to read a job's log\n"
+
+// TestFormatListMarkdown_Empty checks that an empty page is the one sentence
+// and nothing else.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No jobs found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No jobs found.\n"
+	if got := FormatListMarkdown(ListOutput{}); got != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_ClickableJobLinks verifies that job IDs
-// in the list are rendered as clickable Markdown links [#ID](weburl).
-func TestFormatListMarkdown_ClickableJobLinks(t *testing.T) {
+// TestFormatListMarkdown_KeysetPageLinksAndMarksArchived checks the two things
+// a keyset page decides: the heading counts the rows shown, since GitLab sends
+// no total, and an archived job is marked in the row, without which a reader
+// cannot tell one GitLab will not retry from a live one.
+func TestFormatListMarkdown_KeysetPageLinksAndMarksArchived(t *testing.T) {
 	out := ListOutput{
 		Jobs: []Output{
 			{
 				ID: 200, Name: "deploy", Stage: "deploy", Status: "success", Duration: 10.0,
-				WebURL: "https://gitlab.example.com/-/jobs/200",
+				Archived: true,
+				WebURL:   "https://gitlab.example.com/-/jobs/200",
 			},
 		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
+		Pagination: toolutil.PaginationOutput{NextPage: 2},
 	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "[#200](https://gitlab.example.com/-/jobs/200)") {
-		t.Errorf("expected clickable job link, got:\n%s", md)
+	want := "## Jobs (1 shown, more available)\n\n" +
+		"| ID | Name | Stage | Status | Duration |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [#200](https://gitlab.example.com/-/jobs/200) | deploy 📦 | deploy | ✅ success | 10.0s |\n" +
+		jobListHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown(keyset)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -2018,51 +2049,53 @@ func TestFormatListMarkdown_ClickableJobLinks(t *testing.T) {
 // FormatTraceMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatTraceMarkdown_WithData verifies FormatTraceMarkdown when with data.
+// traceHints is the guidance section a job trace closes with.
+const traceHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.get' to see this job's details\n" +
+	"- Use action 'job.retry' to re-run it\n"
+
+// TestFormatTraceMarkdown_WithData checks the whole trace rendering: the
+// heading, the log in a fence sized to its own content, and no truncation
+// note when nothing was cut.
 func TestFormatTraceMarkdown_WithData(t *testing.T) {
 	md := FormatTraceMarkdown(TraceOutput{
 		JobID: 100,
 		Trace: "Running with gitlab-runner 15.0.0\nJob succeeded",
 	})
-
-	for _, want := range []string{
-		"## Job #100 Trace",
-		"```",
-		"Running with gitlab-runner 15.0.0",
-		"Job succeeded",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	if strings.Contains(md, "Truncated") {
-		t.Error("should not contain truncation warning")
+	want := "## Job #100 Trace\n\n" +
+		"```\nRunning with gitlab-runner 15.0.0\nJob succeeded\n```\n" +
+		traceHints
+	if md != want {
+		t.Errorf("FormatTraceMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatTraceMarkdown_Truncated verifies FormatTraceMarkdown when truncated.
+// TestFormatTraceMarkdown_Truncated checks that the note names the end that is
+// missing. The log is cut at the first 100 KB and a failure is almost always
+// at the end of it, so a reader told only "truncated" would look for the error
+// in what is shown.
 func TestFormatTraceMarkdown_Truncated(t *testing.T) {
 	md := FormatTraceMarkdown(TraceOutput{
 		JobID:     100,
 		Trace:     "partial log...",
 		Truncated: true,
 	})
-
-	if !strings.Contains(md, "Trace truncated at 100KB") {
-		t.Errorf("missing truncation warning:\n%s", md)
+	want := "## Job #100 Trace\n\n" +
+		"⚠️ Showing the first 100 KB of the log. The end, where a failure usually appears, is not included.\n" +
+		"\n```\npartial log...\n```\n" +
+		traceHints
+	if md != want {
+		t.Errorf("FormatTraceMarkdown(truncated)\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatTraceMarkdown_Empty verifies FormatTraceMarkdown when empty.
+// TestFormatTraceMarkdown_Empty checks that a job with no log yet renders no
+// fence at all: an empty fence is a glyph that reads as content.
 func TestFormatTraceMarkdown_Empty(t *testing.T) {
 	md := FormatTraceMarkdown(TraceOutput{JobID: 99})
-	if !strings.Contains(md, "## Job #99 Trace") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "```") {
-		t.Errorf("missing code fence:\n%s", md)
+	want := "## Job #99 Trace\n" + traceHints
+	if md != want {
+		t.Errorf("FormatTraceMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -2079,36 +2112,48 @@ func TestFormatBridgeListMarkdown_WithData(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatBridgeListMarkdown(out)
-
-	for _, want := range []string{
-		"## Bridge Jobs (2)",
-		"| ID |",
-		"| --- |",
-		"| 200 |",
-		"| 201 |",
-		"trigger-downstream",
-		"trigger-other",
-		"success",
-		"failed",
-		"#50",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Bridge Jobs (2)\n\n" +
+		"| ID | Name | Stage | Status | Duration | Downstream |\n" +
+		"| --- | --- | --- | --- | --- | --- |\n" +
+		"| #200 | trigger-downstream | deploy | ✅ success | 10.0s | #50 |\n" +
+		"| #201 | trigger-other | deploy | ❌ failed | 5.0s |  |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'pipeline.get' to open the downstream pipeline\n"
+	if got := FormatBridgeListMarkdown(out); got != want {
+		t.Errorf("FormatBridgeListMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatBridgeListMarkdown_Empty verifies FormatBridgeListMarkdown when empty.
-func TestFormatBridgeListMarkdown_Empty(t *testing.T) {
-	md := FormatBridgeListMarkdown(BridgeListOutput{})
-	if !strings.Contains(md, "No bridge jobs found") {
-		t.Errorf("expected empty message:\n%s", md)
+// TestFormatBridgeListMarkdown_LinksTheDownstreamPipeline checks that the
+// downstream cell is a link when GitLab sent the pipeline's address: the
+// bridge exists to point at that pipeline, and the cell named it without
+// reaching it.
+func TestFormatBridgeListMarkdown_LinksTheDownstreamPipeline(t *testing.T) {
+	out := BridgeListOutput{
+		Bridges: []BridgeOutput{{
+			ID: 300, Name: "trigger", Stage: "deploy", Status: "success", Duration: 1.0,
+			WebURL: "https://gitlab.example.com/-/jobs/300",
+			DownstreamPipeline: &PipelineInfoObject{
+				ID: 77, WebURL: "https://gitlab.example.com/downstream/-/pipelines/77",
+			},
+		}},
 	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	md := FormatBridgeListMarkdown(out)
+	const wantRow = "| [#300](https://gitlab.example.com/-/jobs/300) | trigger | deploy | ✅ success | 1.0s | " +
+		"[#77](https://gitlab.example.com/downstream/-/pipelines/77) |\n"
+	if !strings.Contains(md, wantRow) {
+		t.Errorf("FormatBridgeListMarkdown() missing %q:\n%s", wantRow, md)
+	}
+}
+
+// TestFormatBridgeListMarkdown_Empty checks that an empty page is the one
+// sentence and nothing else.
+func TestFormatBridgeListMarkdown_Empty(t *testing.T) {
+	const want = "No bridge jobs found.\n"
+	if got := FormatBridgeListMarkdown(BridgeListOutput{}); got != want {
+		t.Errorf("FormatBridgeListMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -2122,43 +2167,49 @@ func TestFormatArtifactsMarkdown_WithJobID(t *testing.T) {
 		JobID: 100,
 		Size:  2048,
 	})
-
-	for _, want := range []string{
-		"## Job #100 Artifacts",
-		"**Size**: 2048 bytes",
-		"base64-encoded",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	if strings.Contains(md, "Truncated") {
-		t.Error("should not contain truncation warning")
+	want := "## Job #100 Artifacts\n\n" +
+		"- **Size (bytes)**: 2048\n" +
+		"\nThe archive is base64-encoded; decode it to extract the files.\n" +
+		artifactsHints
+	if md != want {
+		t.Errorf("FormatArtifactsMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatArtifactsMarkdown_WithoutJobID verifies FormatArtifactsMarkdown when without job ID.
+// artifactsHints is the guidance section an artifacts download closes with.
+const artifactsHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.download_single_artifact' to fetch one file out of the archive instead\n"
+
+// TestFormatArtifactsMarkdown_WithoutJobID checks the heading of the by-ref
+// download, which answers for a ref rather than for a job ID and must not
+// print "Job #0".
 func TestFormatArtifactsMarkdown_WithoutJobID(t *testing.T) {
 	md := FormatArtifactsMarkdown(ArtifactsOutput{Size: 512})
-	if !strings.Contains(md, "## Artifacts") {
-		t.Errorf("missing generic header:\n%s", md)
-	}
-	if strings.Contains(md, "Job #0") {
-		t.Error("should not have job-specific header when JobID=0")
+	want := "## Artifacts\n\n" +
+		"- **Size (bytes)**: 512\n" +
+		"\nThe archive is base64-encoded; decode it to extract the files.\n" +
+		artifactsHints
+	if md != want {
+		t.Errorf("FormatArtifactsMarkdown(no job)\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatArtifactsMarkdown_Truncated verifies FormatArtifactsMarkdown when truncated.
+// TestFormatArtifactsMarkdown_Truncated checks that a cut archive is marked
+// with the warning sign rather than a tick, which on "Truncated" reads as
+// success.
 func TestFormatArtifactsMarkdown_Truncated(t *testing.T) {
 	md := FormatArtifactsMarkdown(ArtifactsOutput{
 		JobID:     100,
 		Size:      1048576,
 		Truncated: true,
 	})
-	if !strings.Contains(md, "Truncated") {
-		t.Errorf("missing truncation warning:\n%s", md)
+	want := "## Job #100 Artifacts\n\n" +
+		"- **Size (bytes)**: 1048576\n" +
+		"- ⚠️ **Truncated at 1 MB**\n" +
+		"\nThe archive is base64-encoded; decode it to extract the files.\n" +
+		artifactsHints
+	if md != want {
+		t.Errorf("FormatArtifactsMarkdown(truncated)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -2174,38 +2225,38 @@ func TestFormatSingleArtifactMarkdown_WithJobID(t *testing.T) {
 		Size:         256,
 		Content:      "test report content",
 	})
-
-	for _, want := range []string{
-		"## Job #100",
-		"report.txt",
-		"**Size**: 256 bytes",
-		"test report content",
-		"```",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Job #100: report.txt\n\n" +
+		"- **Size (bytes)**: 256\n" +
+		"\n```\ntest report content\n```\n" +
+		singleArtifactHints
+	if md != want {
+		t.Errorf("FormatSingleArtifactMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatSingleArtifactMarkdown_WithoutJobID verifies FormatSingleArtifactMarkdown when without job ID.
+// singleArtifactHints is the guidance section one artifact file closes with.
+const singleArtifactHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.artifacts' to download the whole artifacts archive\n"
+
+// TestFormatSingleArtifactMarkdown_WithoutJobID checks that the by-ref
+// download heads with the path alone rather than "Job #0".
 func TestFormatSingleArtifactMarkdown_WithoutJobID(t *testing.T) {
 	md := FormatSingleArtifactMarkdown(SingleArtifactOutput{
 		ArtifactPath: "output.log",
 		Size:         64,
 		Content:      "log data",
 	})
-	if !strings.Contains(md, "## output.log") {
-		t.Errorf("missing path-only header:\n%s", md)
-	}
-	if strings.Contains(md, "Job #0") {
-		t.Error("should not have job-specific header when JobID=0")
+	want := "## output.log\n\n" +
+		"- **Size (bytes)**: 64\n" +
+		"\n```\nlog data\n```\n" +
+		singleArtifactHints
+	if md != want {
+		t.Errorf("FormatSingleArtifactMarkdown(no job)\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatSingleArtifactMarkdown_Truncated verifies FormatSingleArtifactMarkdown when truncated.
+// TestFormatSingleArtifactMarkdown_Truncated checks that a cut file is marked
+// with the warning sign.
 func TestFormatSingleArtifactMarkdown_Truncated(t *testing.T) {
 	md := FormatSingleArtifactMarkdown(SingleArtifactOutput{
 		JobID:        100,
@@ -2214,8 +2265,13 @@ func TestFormatSingleArtifactMarkdown_Truncated(t *testing.T) {
 		Content:      "...",
 		Truncated:    true,
 	})
-	if !strings.Contains(md, "Truncated") {
-		t.Errorf("missing truncation warning:\n%s", md)
+	want := "## Job #100: big.bin\n\n" +
+		"- **Size (bytes)**: 1048576\n" +
+		"- ⚠️ **Truncated at 1 MB**\n" +
+		"\n```\n...\n```\n" +
+		singleArtifactHints
+	if md != want {
+		t.Errorf("FormatSingleArtifactMarkdown(truncated)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/jobs/markdown.go
+++ b/internal/tools/jobs/markdown.go
@@ -9,213 +9,291 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single job as a Markdown summary.
+// FormatOutputMarkdown renders one job as the card of a single object.
 func FormatOutputMarkdown(j Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## %s Job #%d: %s\n\n", toolutil.PipelineStatusEmoji(j.Status), j.ID, toolutil.EscapeMdHeading(j.Name))
+	c := toolutil.NewCard(&b, jobHeading(j))
+	writeJobDetail(c, j)
+	c.End(jobHints(j)...)
+	return b.String()
+}
+
+// jobHeading composes the card's heading: the status as a glyph, the job's ID
+// and name, and the archived marker an archived job carries.
+func jobHeading(j Output) string {
+	heading := fmt.Sprintf("%s Job #%d: %s", toolutil.PipelineStatusEmoji(j.Status), j.ID, j.Name)
+	if j.Archived {
+		heading += " " + toolutil.EmojiArchived
+	}
+	return heading
+}
+
+// writeJobDetail writes the job's own rows onto the card it is given, so the
+// wait result shows the same fields under its own H3 rather than embedding a
+// second H2 and a second guidance section.
+func writeJobDetail(c *toolutil.Card, j Output) {
 	if j.Pipeline != nil && j.Pipeline.ID > 0 {
-		fmt.Fprintf(&b, "- **Pipeline**: #%d\n", j.Pipeline.ID)
+		c.Field("Pipeline", fmt.Sprintf("#%d", j.Pipeline.ID))
 	}
 	// A stage name is written in .gitlab-ci.yml, and GitLab constrains its
-	// length rather than its characters; the jobs tables already escape it.
-	fmt.Fprintf(&b, "- **Stage**: %s\n", toolutil.EscapeMdTableCell(j.Stage))
-	//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
-	fmt.Fprintf(&b, toolutil.FmtMdStatus, j.Status)
-	if j.AllowFailure {
-		b.WriteString("- **Allow Failure**: yes\n")
-	}
-	fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(j.Ref))
+	// length rather than its characters.
+	c.Field("Stage", j.Stage)
+	c.Markdown("Status", jobStatusCell(j.Status))
+	c.Bool("Allow Failure", j.AllowFailure)
+	c.Field("Ref", j.Ref)
+	c.Bool("Tag", j.Tag)
 	if j.Commit != nil && j.Commit.ID != "" {
-		// Named rather than sliced inline so the exemption can refer to it: a
-		// directive's expression is cut at its first colon.
-		shortID := j.Commit.ID[:min(len(j.Commit.ID), 12)]
-		//gitlab:allow-unescaped shortID: the first twelve characters of a git object id, which is hexadecimal.
-		fmt.Fprintf(&b, "- **Commit**: `%s`\n", shortID)
+		c.Code("Commit", j.Commit.ID[:min(len(j.Commit.ID), 12)])
 	}
 	if j.Duration > 0 {
-		fmt.Fprintf(&b, "- **Duration**: %.1fs\n", j.Duration)
+		c.Field("Duration", fmt.Sprintf("%.1fs", j.Duration))
 	}
 	if j.QueuedDuration > 0 {
-		fmt.Fprintf(&b, "- **Queued**: %.1fs\n", j.QueuedDuration)
+		c.Field("Queued", fmt.Sprintf("%.1fs", j.QueuedDuration))
 	}
-	if j.FailureReason != "" {
-		//gitlab:allow-unescaped j.FailureReason: GitLab stores the failure reason as an integer column behind a fixed enum map and serializes the key, such as script_failure.
-		fmt.Fprintf(&b, "- **Failure Reason**: %s\n", j.FailureReason)
-	}
+	// GitLab stores the failure reason as an integer column behind a fixed
+	// enum map and serializes the key, such as script_failure.
+	c.Field("Failure Reason", j.FailureReason)
 	if j.Coverage > 0 {
-		fmt.Fprintf(&b, "- **Coverage**: %.1f%%\n", j.Coverage)
+		c.Field("Coverage", fmt.Sprintf("%.1f%%", j.Coverage))
 	}
-	if j.User != nil && j.User.Username != "" {
-		fmt.Fprintf(&b, "- **User**: %s\n", toolutil.EscapeMdTableCell(j.User.Username))
+	if j.User != nil {
+		c.Markdown("User", toolutil.MdUserLink(j.User.Username, j.User.WebURL))
 	}
-	if j.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(j.CreatedAt))
-	}
-	toolutil.WriteMdURL(&b, j.WebURL)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'trace' to view the full job log output",
-		"Use action 'retry' to re-run this job",
-		"Use action 'cancel' to cancel a running job",
-	)
-	return b.String()
+	c.Time("Created", j.CreatedAt)
+	// The three rows below decide what a reader may still do with the job:
+	// an erased job has no log left, an archived one can be neither retried
+	// nor cancelled, and an expiry says how long the artifacts remain.
+	c.Time("Erased", j.ErasedAt)
+	c.Time("Artifacts Expire", j.ArtifactsExpireAt)
+	c.Flag(toolutil.EmojiArchived, "Archived", j.Archived)
+	c.URL(j.WebURL)
 }
 
-// FormatListMarkdown renders a paginated list of jobs as a Markdown table.
+// jobStatusCell renders a job status with its glyph, and nothing when GitLab
+// sent no status.
+func jobStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// jobHints names only what the job's own state still allows: GitLab keeps no
+// log for an erased job, and refuses both a retry and a cancel on an archived
+// one, so offering those was advice that could only fail.
+//
+// Each condition replaces a hint rather than dropping one, so the card always
+// closes with the same three next steps and a reader is never left with a
+// state and nothing to do about it.
+func jobHints(j Output) []string {
+	log := toolutil.HintAction(actionJobTrace, "read this job's log")
+	if j.ErasedAt != "" {
+		log = toolutil.HintAction(actionJobListProject, "look at the project's other jobs, since this one's log was erased")
+	}
+	if j.Archived {
+		return []string{
+			log,
+			toolutil.HintAction(actionPipelineGet, "open the pipeline this job ran in"),
+			toolutil.HintAction(actionJobList, "see the other jobs of that pipeline"),
+		}
+	}
+	return []string{
+		log,
+		toolutil.HintAction(actionJobRetry, "re-run this job"),
+		toolutil.HintAction(actionJobCancel, "cancel it while it is still running"),
+	}
+}
+
+// FormatListMarkdown renders a page of jobs as a Markdown table.
+//
+// The heading counts what the response can vouch for rather than
+// Pagination.TotalItems alone, which keyset pagination never sends.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Jobs (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Jobs), out.Pagination)
 	if len(out.Jobs) == 0 {
-		b.WriteString("No jobs found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("jobs")
 	}
-	b.WriteString("| ID | Name | Stage | Status | Duration |\n")
-	b.WriteString(toolutil.TblSep5Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Jobs", len(out.Jobs), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Stage", "Status", "Duration"))
 	for _, j := range out.Jobs {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s %s | %.1fs |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", j.ID), j.WebURL), toolutil.EscapeMdTableCell(j.Name), toolutil.EscapeMdTableCell(j.Stage), toolutil.PipelineStatusEmoji(j.Status), j.Status, j.Duration)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", j.ID), j.WebURL),
+			jobNameCell(j),
+			toolutil.EscapeMdTableCell(j.Stage),
+			jobStatusCell(j.Status),
+			fmt.Sprintf("%.1fs", j.Duration),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'get' with a job_id to see job details",
-		"Use action 'trace' to view job log output",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionJobGet, "see one job in full"),
+		toolutil.HintAction(actionJobTrace, "read a job's log"),
 	)
 	return b.String()
 }
 
-// FormatTraceMarkdown renders a job trace log in a code fence.
+// jobNameCell carries the archived marker, without which a reader cannot tell
+// an archived job — one GitLab will neither retry nor cancel — from a live one.
+func jobNameCell(j Output) string {
+	cell := toolutil.EscapeMdTableCell(j.Name)
+	if j.Archived {
+		cell += " " + toolutil.EmojiArchived
+	}
+	return cell
+}
+
+// FormatTraceMarkdown renders a job's log as the card of that job: the note
+// says what was cut, then the log in a fence sized to its own content.
 func FormatTraceMarkdown(t TraceOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Job #%d Trace\n\n", t.JobID)
+	c := toolutil.NewCard(&b, fmt.Sprintf("Job #%d Trace", t.JobID))
 	if t.Truncated {
-		b.WriteString(toolutil.EmojiWarning + " *Trace truncated at 100KB.*\n\n")
+		// Naming the end that is missing matters: the log is cut at the front
+		// 100 KB, and a failure is almost always at the end of it, so a reader
+		// told only "truncated" would look for the error in what is shown.
+		c.Note(toolutil.EmojiWarning + " Showing the first 100 KB of the log. The end, where a failure usually appears, is not included.")
 	}
-	b.WriteString(toolutil.MarkdownFencedBlock("", t.Trace))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_job_get` to see job details",
-		"Use `gitlab_job_retry` to retry this job",
+	c.Fence("", "", t.Trace)
+	c.End(
+		toolutil.HintAction(actionJobGet, "see this job's details"),
+		toolutil.HintAction(actionJobRetry, "re-run it"),
 	)
 	return b.String()
 }
 
-// FormatBridgeListMarkdown renders a paginated list of bridge jobs as a Markdown table.
+// FormatBridgeListMarkdown renders a page of bridge (trigger) jobs as a
+// Markdown table, with the downstream pipeline linked.
 func FormatBridgeListMarkdown(out BridgeListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Bridge Jobs (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Bridges), out.Pagination)
 	if len(out.Bridges) == 0 {
-		b.WriteString("No bridge jobs found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("bridge jobs")
 	}
-	b.WriteString("| ID | Name | Stage | Status | Duration | Downstream |\n")
-	b.WriteString(toolutil.TblSep6Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Bridge Jobs", len(out.Bridges), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Stage", "Status", "Duration", "Downstream"))
 	for _, br := range out.Bridges {
-		ds := ""
-		if br.DownstreamPipeline != nil && br.DownstreamPipeline.ID > 0 {
-			ds = fmt.Sprintf("#%d", br.DownstreamPipeline.ID)
-		}
-		fmt.Fprintf(&b, "| %d | %s | %s | %s %s | %.1fs | %s |\n",
-			br.ID, toolutil.EscapeMdTableCell(br.Name), toolutil.EscapeMdTableCell(br.Stage),
-			//gitlab:allow-unescaped br.Status: a bridge carries the same job status enum a job does.
-			toolutil.PipelineStatusEmoji(br.Status), br.Status, br.Duration, ds)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", br.ID), br.WebURL),
+			toolutil.EscapeMdTableCell(br.Name),
+			toolutil.EscapeMdTableCell(br.Stage),
+			jobStatusCell(br.Status),
+			fmt.Sprintf("%.1fs", br.Duration),
+			downstreamCell(br),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_pipeline_get` to view the downstream pipeline",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionPipelineGet, "open the downstream pipeline"),
 	)
 	return b.String()
 }
 
-// FormatArtifactsMarkdown renders artifact download info.
+// downstreamCell links the downstream pipeline a bridge triggered, and is
+// empty when the bridge triggered none.
+func downstreamCell(br BridgeOutput) string {
+	if br.DownstreamPipeline == nil || br.DownstreamPipeline.ID == 0 {
+		return ""
+	}
+	return toolutil.MdTitleLink(fmt.Sprintf("#%d", br.DownstreamPipeline.ID), br.DownstreamPipeline.WebURL)
+}
+
+// FormatArtifactsMarkdown renders an artifacts download as the card of one
+// archive.
 func FormatArtifactsMarkdown(out ArtifactsOutput) string {
 	var b strings.Builder
-	if out.JobID > 0 {
-		fmt.Fprintf(&b, "## Job #%d Artifacts\n\n", out.JobID)
-	} else {
-		b.WriteString("## Artifacts\n\n")
-	}
-	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
-	if out.Truncated {
-		b.WriteString("- " + toolutil.EmojiWarning + " **Truncated**: content exceeds 1MB limit\n")
-	}
-	b.WriteString("- **Content**: base64-encoded archive (use a decoder to extract)\n")
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_job_download_single_artifact` to get a specific file",
-	)
+	c := toolutil.NewCard(&b, artifactsHeading(out))
+	c.Int("Size (bytes)", int64(out.Size))
+	c.Warn("Truncated at 1 MB", out.Truncated)
+	c.Note("The archive is base64-encoded; decode it to extract the files.")
+	c.End(toolutil.HintAction(actionJobDownloadSingle, "fetch one file out of the archive instead"))
 	return b.String()
 }
 
-// FormatSingleArtifactMarkdown renders a single artifact file content.
+// artifactsHeading names the job when the caller asked for one, since the
+// by-ref download answers for a ref rather than for a job ID.
+func artifactsHeading(out ArtifactsOutput) string {
+	if out.JobID > 0 {
+		return fmt.Sprintf("Job #%d Artifacts", out.JobID)
+	}
+	return "Artifacts"
+}
+
+// FormatSingleArtifactMarkdown renders one artifact file as the card of that
+// file, its content in a fence sized to the content.
 func FormatSingleArtifactMarkdown(out SingleArtifactOutput) string {
 	var b strings.Builder
-	if out.JobID > 0 {
-		// The artifact path is echoed from the caller's own argument: an entry
-		// name in a zip, authored by whoever wrote the CI job.
-		fmt.Fprintf(&b, "## Job #%d: %s\n\n", out.JobID, toolutil.EscapeMdHeading(out.ArtifactPath))
-	} else {
-		fmt.Fprintf(&b, "## %s\n\n", toolutil.EscapeMdHeading(out.ArtifactPath))
-	}
-	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
-	if out.Truncated {
-		b.WriteString("- " + toolutil.EmojiWarning + " **Truncated**: content exceeds 1MB limit\n")
-	}
-	// The fence is sized to the content: an artifact that contains a fence
-	// marker of its own must not close the block early.
-	b.WriteString("\n" + toolutil.MarkdownFencedBlock("", out.Content))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_job_artifacts` to download the full artifacts archive",
-	)
+	// The artifact path is echoed from the caller's own argument: an entry
+	// name in a zip, authored by whoever wrote the CI job.
+	c := toolutil.NewCard(&b, singleArtifactHeading(out))
+	c.Int("Size (bytes)", int64(out.Size))
+	c.Warn("Truncated at 1 MB", out.Truncated)
+	// The fence is sized to the content: an artifact carrying a fence marker
+	// of its own must not close the block early.
+	c.Fence("", "", out.Content)
+	c.End(toolutil.HintAction(actionJobArtifacts, "download the whole artifacts archive"))
 	return b.String()
 }
 
-// FormatWaitMarkdown renders the job wait result as a Markdown summary.
+func singleArtifactHeading(out SingleArtifactOutput) string {
+	if out.JobID > 0 {
+		return fmt.Sprintf("Job #%d: %s", out.JobID, out.ArtifactPath)
+	}
+	return out.ArtifactPath
+}
+
+// FormatWaitMarkdown renders the job wait result as the card of the job that
+// was waited for: the wait's own rows, then the job's fields under one H3,
+// and one guidance section at the end.
 func FormatWaitMarkdown(out WaitOutput) string {
 	var b strings.Builder
-	if out.TimedOut {
-		//gitlab:allow-unescaped out.Job.Status: the polled job's status is the same GitLab enum a job's own status is.
-		//gitlab:allow-unescaped out.FinalStatus: the status the poller last read off the job, so the same GitLab enum.
-		//gitlab:allow-unescaped out.WaitedFor: the poller writes this duration itself, with time.Duration.String over time.Since.
-		fmt.Fprintf(&b, "## \u23F0 Job #%d: Timed Out (current: %s)\n\n", out.Job.ID, out.Job.Status)
-	} else {
-		var emoji string
-		switch out.FinalStatus {
-		case "failed":
-			emoji = toolutil.EmojiCross
-		case "canceled":
-			emoji = toolutil.EmojiProhibited
-		default:
-			emoji = toolutil.EmojiSuccess
-		}
-		fmt.Fprintf(&b, "## %s Job #%d: %s\n\n", emoji, out.Job.ID, out.FinalStatus)
-	}
-	fmt.Fprintf(&b, "- **Waited**: %s (%d polls)\n", out.WaitedFor, out.PollCount)
-	fmt.Fprintf(&b, "- **Final Status**: %s\n", out.FinalStatus)
-	if out.TimedOut {
-		b.WriteString("- **Timed Out**: yes\n")
-	}
-	b.WriteString("\n### Job Details\n\n")
-	b.WriteString(FormatOutputMarkdown(out.Job))
-	if out.TimedOut {
-		toolutil.WriteHints(
-			&b,
-			"Job is still running. Call gitlab_job_wait again to continue waiting",
-			"Use gitlab_job_cancel to abort the job",
-		)
-	} else if out.FinalStatus == "failed" {
-		toolutil.WriteHints(
-			&b,
-			"Use gitlab_job action 'trace' to see the job log for failure details",
-			"Use gitlab_job action 'retry' to retry the failed job",
-		)
-	}
+	c := toolutil.NewCard(&b, jobWaitHeading(out))
+	// The poller writes this duration itself, with time.Duration.String over
+	// time.Since, so it is the server's own text rather than GitLab's.
+	c.Field("Waited", out.WaitedFor)
+	c.Int("Polls", int64(out.PollCount))
+	c.Field("Final Status", out.FinalStatus)
+	c.Warn("Timed Out", out.TimedOut)
+	writeJobDetail(c.Section("Job Details"), out.Job)
+	c.End(jobWaitHints(out)...)
 	return b.String()
+}
+
+// jobWaitHeading names the outcome: the timer glyph and the status still
+// running when the wait gave up, and the final status otherwise.
+func jobWaitHeading(out WaitOutput) string {
+	if out.TimedOut {
+		return fmt.Sprintf("⏰ Job #%d: Timed Out (current: %s)", out.Job.ID, out.Job.Status)
+	}
+	return fmt.Sprintf("%s Job #%d: %s", jobOutcomeEmoji(out.FinalStatus), out.Job.ID, out.FinalStatus)
+}
+
+// jobOutcomeEmoji is the glyph a terminal job state is shown by.
+func jobOutcomeEmoji(finalStatus string) string {
+	switch finalStatus {
+	case "failed":
+		return toolutil.EmojiCross
+	case "canceled":
+		return toolutil.EmojiProhibited
+	default:
+		return toolutil.EmojiSuccess
+	}
+}
+
+// jobWaitHints names what a caller can do with the outcome the wait reached,
+// and nothing when the job simply succeeded.
+func jobWaitHints(out WaitOutput) []string {
+	switch {
+	case out.TimedOut:
+		return []string{
+			toolutil.HintAction(actionJobWait, "keep waiting for this job"),
+			toolutil.HintAction(actionJobCancel, "abort it instead"),
+		}
+	case out.FinalStatus == "failed":
+		return []string{
+			toolutil.HintAction(actionJobTrace, "read the log for the failure"),
+			toolutil.HintAction(actionJobRetry, "retry the job"),
+		}
+	default:
+		return nil
+	}
 }
 
 // formatWaitResult wraps the Markdown output of [FormatWaitMarkdown] in

--- a/internal/tools/jobs/wait_test.go
+++ b/internal/tools/jobs/wait_test.go
@@ -424,85 +424,100 @@ func TestJobWait_ContextCanceledDuringPoll(t *testing.T) {
 	}
 }
 
-// TestFormatWaitMarkdown_Success verifies markdown rendering for a successfully completed job.
+// waitJobRows is the job the wait fixtures poll, rendered under the wait's own
+// H3. The job is embedded without its heading so the response carries one H2,
+// one guidance section and no card nested inside another.
+func waitJobRows(status string) string {
+	return "\n### Job Details\n\n" +
+		"- **Status**: " + status + "\n" +
+		"- **Allow Failure**: ❌\n" +
+		"- **Tag**: ❌\n" +
+		"- **URL**: [https://gitlab.example.com/-/jobs/100](https://gitlab.example.com/-/jobs/100)\n"
+}
+
+// TestFormatWaitMarkdown_Success checks the whole rendering of a wait that
+// ended well: the wait's own rows, the job under one H3, and no guidance
+// section, since a job that succeeded needs no next step.
 func TestFormatWaitMarkdown_Success(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ✅ Job #100: success\n\n" +
+		"- **Waited**: 30s\n" +
+		"- **Polls**: 3\n" +
+		"- **Final Status**: success\n" +
+		waitJobRows("✅ success")
+	got := FormatWaitMarkdown(WaitOutput{
 		Job:         Output{ID: 100, Name: "build", Status: "success", WebURL: "https://gitlab.example.com/-/jobs/100"},
 		WaitedFor:   "30s",
 		PollCount:   3,
 		FinalStatus: "success",
 	})
-	if !strings.Contains(md, "Job #100") {
-		t.Error("expected 'Job #100' in markdown")
-	}
-	if !strings.Contains(md, "success") {
-		t.Error("expected 'success' in markdown")
-	}
-	if !strings.Contains(md, "30s") {
-		t.Error("expected waited duration in markdown")
-	}
-	if !strings.Contains(md, "3 polls") {
-		t.Error("expected poll count in markdown")
-	}
-	if strings.Contains(md, "Timed Out") {
-		t.Error("should not contain 'Timed Out' for success")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(success)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_Failed verifies markdown rendering for a failed job with hints.
+// TestFormatWaitMarkdown_Failed checks that a failed wait names the two
+// actions that follow it, by the canonical IDs every surface resolves.
 func TestFormatWaitMarkdown_Failed(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ❌ Job #100: failed\n\n" +
+		"- **Waited**: 45s\n" +
+		"- **Polls**: 5\n" +
+		"- **Final Status**: failed\n" +
+		waitJobRows("❌ failed") +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.trace' to read the log for the failure\n" +
+		"- Use action 'job.retry' to retry the job\n"
+	got := FormatWaitMarkdown(WaitOutput{
 		Job:         Output{ID: 100, Name: "build", Status: "failed", WebURL: "https://gitlab.example.com/-/jobs/100"},
 		WaitedFor:   "45s",
 		PollCount:   5,
 		FinalStatus: "failed",
 	})
-	if !strings.Contains(md, "Job #100") {
-		t.Error("expected 'Job #100' in markdown")
-	}
-	if !strings.Contains(md, "failed") {
-		t.Error("expected 'failed' in markdown")
-	}
-	if !strings.Contains(md, "gitlab_job") {
-		t.Error("expected hint about job trace in markdown for failed job")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(failed)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_TimedOut verifies markdown rendering for a timed-out job wait.
+// TestFormatWaitMarkdown_TimedOut checks that a timeout is marked with the
+// warning sign rather than a tick — a tick on "Timed Out" reads as success —
+// and that the heading names the status the job is still in.
 func TestFormatWaitMarkdown_TimedOut(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ⏰ Job #100: Timed Out (current: running)\n\n" +
+		"- **Waited**: 300s\n" +
+		"- **Polls**: 30\n" +
+		"- **Final Status**: running\n" +
+		"- ⚠️ **Timed Out**\n" +
+		waitJobRows("🔵 running") +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.wait' to keep waiting for this job\n" +
+		"- Use action 'job.cancel' to abort it instead\n"
+	got := FormatWaitMarkdown(WaitOutput{
 		Job:         Output{ID: 100, Name: "build", Status: "running", WebURL: "https://gitlab.example.com/-/jobs/100"},
 		WaitedFor:   "300s",
 		PollCount:   30,
 		FinalStatus: "running",
 		TimedOut:    true,
 	})
-	if !strings.Contains(md, "Timed Out") {
-		t.Error("expected 'Timed Out' in markdown")
-	}
-	if !strings.Contains(md, "Job #100") {
-		t.Error("expected 'Job #100' in markdown")
-	}
-	if !strings.Contains(md, "gitlab_job_wait") {
-		t.Error("expected hint about calling wait again")
-	}
-	if !strings.Contains(md, "gitlab_job_cancel") {
-		t.Error("expected hint about cancel")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(timed out)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_Canceled verifies markdown rendering for a canceled job.
+// TestFormatWaitMarkdown_Canceled checks a wait that ended on a cancellation:
+// the outcome is neither a success nor a failure, so it carries the stop glyph
+// and no hints.
 func TestFormatWaitMarkdown_Canceled(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## 🚫 Job #100: canceled\n\n" +
+		"- **Waited**: 15s\n" +
+		"- **Polls**: 2\n" +
+		"- **Final Status**: canceled\n" +
+		waitJobRows("⛔ canceled")
+	got := FormatWaitMarkdown(WaitOutput{
 		Job:         Output{ID: 100, Name: "build", Status: "canceled", WebURL: "https://gitlab.example.com/-/jobs/100"},
 		WaitedFor:   "15s",
 		PollCount:   2,
 		FinalStatus: "canceled",
 	})
-	if !strings.Contains(md, "Job #100") {
-		t.Error("expected 'Job #100' in markdown")
-	}
-	if !strings.Contains(md, "canceled") {
-		t.Error("expected 'canceled' in markdown")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(canceled)\n got %q\nwant %q", got, want)
 	}
 }

--- a/internal/tools/jobtokenscope/job_token_scope_test.go
+++ b/internal/tools/jobtokenscope/job_token_scope_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
-	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
 // TestGetAccessSettings_Success verifies GetAccessSettings when success.
@@ -215,27 +214,50 @@ func TestRemoveGroupAllowlist_ZeroTargetGroupID(t *testing.T) {
 	}
 }
 
-// TestFormatAccessSettingsMarkdown verifies FormatAccessSettingsMarkdown.
+// markdownText reads the one text block a formatter's result carries.
+func markdownText(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	if r == nil {
+		t.Fatal(errExpNonNilResult)
+	}
+	content, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result content is %T, want *mcp.TextContent", r.Content[0])
+	}
+	return content.Text
+}
+
+// TestFormatAccessSettingsMarkdown checks the whole card of an enforced job
+// token scope.
 func TestFormatAccessSettingsMarkdown(t *testing.T) {
-	r := FormatAccessSettingsMarkdown(AccessSettingsOutput{InboundEnabled: true})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
+	want := "## Job Token Access Settings\n\n" +
+		"- **Inbound job token access**: limited to the allowlist\n" +
+		accessSettingsHints
+	if got := markdownText(t, FormatAccessSettingsMarkdown(AccessSettingsOutput{InboundEnabled: true})); got != want {
+		t.Errorf("FormatAccessSettingsMarkdown(enabled)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListInboundAllowlistMarkdown_Empty verifies FormatListInboundAllowlistMarkdown when empty.
+// accessSettingsHints is the guidance section the settings card closes with.
+const accessSettingsHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.token_scope_list_inbound' to see the projects the allowlist holds\n" +
+	"- Use action 'job.token_scope_patch' to turn the restriction on or off\n"
+
+// TestFormatListInboundAllowlistMarkdown_Empty checks that an empty allowlist
+// is the one sentence and nothing else.
 func TestFormatListInboundAllowlistMarkdown_Empty(t *testing.T) {
-	r := FormatListInboundAllowlistMarkdown(ListInboundAllowlistOutput{})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
+	const want = "No projects on the job token inbound allowlist found.\n"
+	if got := markdownText(t, FormatListInboundAllowlistMarkdown(ListInboundAllowlistOutput{})); got != want {
+		t.Errorf("FormatListInboundAllowlistMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListGroupAllowlistMarkdown_Empty verifies FormatListGroupAllowlistMarkdown when empty.
+// TestFormatListGroupAllowlistMarkdown_Empty checks that an empty group
+// allowlist is the one sentence and nothing else.
 func TestFormatListGroupAllowlistMarkdown_Empty(t *testing.T) {
-	r := FormatListGroupAllowlistMarkdown(ListGroupAllowlistOutput{})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
+	const want = "No groups on the job token allowlist found.\n"
+	if got := markdownText(t, FormatListGroupAllowlistMarkdown(ListGroupAllowlistOutput{})); got != want {
+		t.Errorf("FormatListGroupAllowlistMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -577,46 +599,16 @@ func TestRemoveGroupAllowlist_CancelledContext(t *testing.T) {
 // FormatAccessSettingsMarkdown — disabled state
 // ---------------------------------------------------------------------------.
 
-// TestFormatAccessSettingsMarkdown_Disabled verifies FormatAccessSettingsMarkdown when disabled.
+// TestFormatAccessSettingsMarkdown_Disabled checks the card of a project with
+// the job token scope off. The row names the restriction rather than the
+// switch: "Inbound access: disabled" read as though access itself were denied,
+// and it is the opposite — every project's job token may reach this one.
 func TestFormatAccessSettingsMarkdown_Disabled(t *testing.T) {
-	r := FormatAccessSettingsMarkdown(AccessSettingsOutput{InboundEnabled: false})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "disabled") {
-		t.Errorf("expected 'disabled' in markdown, got: %s", text)
-	}
-}
-
-// TestFormatAccessSettingsMarkdown_Enabled verifies FormatAccessSettingsMarkdown when enabled.
-func TestFormatAccessSettingsMarkdown_Enabled(t *testing.T) {
-	r := FormatAccessSettingsMarkdown(AccessSettingsOutput{InboundEnabled: true})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "enabled") {
-		t.Errorf("expected 'enabled' in markdown, got: %s", text)
-	}
-	if strings.Contains(text, "disabled") {
-		t.Errorf("should not contain 'disabled' when enabled, got: %s", text)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// FormatPatchResultMarkdown
-// ---------------------------------------------------------------------------.
-
-// TestFormatPatchResultMarkdown verifies FormatPatchResultMarkdown.
-func TestFormatPatchResultMarkdown(t *testing.T) {
-	r := FormatPatchResultMarkdown(toolutil.DeleteOutput{Status: "updated"})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "updated") {
-		t.Errorf("expected 'updated' in markdown, got: %s", text)
+	want := "## Job Token Access Settings\n\n" +
+		"- **Inbound job token access**: not limited (any project's job token may access this project)\n" +
+		accessSettingsHints
+	if got := markdownText(t, FormatAccessSettingsMarkdown(AccessSettingsOutput{InboundEnabled: false})); got != want {
+		t.Errorf("FormatAccessSettingsMarkdown(disabled)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -632,24 +624,18 @@ func TestFormatListInboundAllowlistMarkdown_WithData(t *testing.T) {
 			{ID: 11, Name: "proj-b", PathWithNamespace: "grp/proj-b", WebURL: "https://gitlab.example.com/grp/proj-b"},
 		},
 	})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	for _, want := range []string{
-		"Job Token Inbound Allowlist (2 projects)",
-		"| ID |",
-		"| 10 |",
-		"| 11 |",
-		"proj-a",
-		"proj-b",
-		"grp/proj-a",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(text, want) {
-				t.Errorf("markdown missing %q:\n%s", want, text)
-			}
-		})
+	// The name carries the link, so a reader is never asked to click a column
+	// that says "View" and nothing about where it goes.
+	want := "## Job Token Inbound Allowlist (2)\n\n" +
+		"| ID | Name | Path |\n| --- | --- | --- |\n" +
+		"| 10 | [proj-a](https://gitlab.example.com/grp/proj-a) | grp/proj-a |\n" +
+		"| 11 | [proj-b](https://gitlab.example.com/grp/proj-b) | grp/proj-b |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'job.token_scope_add_project' to allow another project\n" +
+		"- Use action 'job.token_scope_remove_project' to remove one from the allowlist\n"
+	if got := markdownText(t, r); got != want {
+		t.Errorf("FormatListInboundAllowlistMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -657,18 +643,19 @@ func TestFormatListInboundAllowlistMarkdown_WithData(t *testing.T) {
 // FormatAddProjectAllowlistMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatAddProjectAllowlistMarkdown verifies FormatAddProjectAllowlistMarkdown.
+// TestFormatAddProjectAllowlistMarkdown checks the whole card of the entry
+// that was created: a create result returns the object, so it is a card.
 func TestFormatAddProjectAllowlistMarkdown(t *testing.T) {
 	r := FormatAddProjectAllowlistMarkdown(InboundAllowItemOutput{SourceProjectID: 42, TargetProjectID: 99})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "99") {
-		t.Errorf("expected target project ID in markdown, got: %s", text)
-	}
-	if !strings.Contains(text, "42") {
-		t.Errorf("expected source project ID in markdown, got: %s", text)
+	want := "## Job Token Inbound Allowlist Entry\n\n" +
+		"- **Project**: 42\n" +
+		"- **Allowed project**: 99\n" +
+		"\nThe allowed project's job token may now reach this project.\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.token_scope_list_inbound' to see the whole allowlist\n" +
+		"- Use action 'job.token_scope_get' to check whether the restriction is enforced at all\n"
+	if got := markdownText(t, r); got != want {
+		t.Errorf("FormatAddProjectAllowlistMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -684,24 +671,16 @@ func TestFormatListGroupAllowlistMarkdown_WithData(t *testing.T) {
 			{ID: 6, Name: "group-b", FullPath: "org/group-b", WebURL: "https://gitlab.example.com/groups/org/group-b"},
 		},
 	})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	for _, want := range []string{
-		"Job Token Group Allowlist (2 groups)",
-		"| ID |",
-		"| 5 |",
-		"| 6 |",
-		"group-a",
-		"group-b",
-		"org/group-b",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(text, want) {
-				t.Errorf("markdown missing %q:\n%s", want, text)
-			}
-		})
+	want := "## Job Token Group Allowlist (2)\n\n" +
+		"| ID | Name | Path |\n| --- | --- | --- |\n" +
+		"| 5 | [group-a](https://gitlab.example.com/groups/group-a) | group-a |\n" +
+		"| 6 | [group-b](https://gitlab.example.com/groups/org/group-b) | org/group-b |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'job.token_scope_add_group' to allow another group\n" +
+		"- Use action 'job.token_scope_remove_group' to remove one from the allowlist\n"
+	if got := markdownText(t, r); got != want {
+		t.Errorf("FormatListGroupAllowlistMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -709,18 +688,19 @@ func TestFormatListGroupAllowlistMarkdown_WithData(t *testing.T) {
 // FormatAddGroupAllowlistMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatAddGroupAllowlistMarkdown verifies FormatAddGroupAllowlistMarkdown.
+// TestFormatAddGroupAllowlistMarkdown checks the whole card of the group entry
+// that was created.
 func TestFormatAddGroupAllowlistMarkdown(t *testing.T) {
 	r := FormatAddGroupAllowlistMarkdown(GroupAllowlistItemOutput{SourceProjectID: 42, TargetGroupID: 5})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if !strings.Contains(text, "5") {
-		t.Errorf("expected target group ID in markdown, got: %s", text)
-	}
-	if !strings.Contains(text, "42") {
-		t.Errorf("expected source project ID in markdown, got: %s", text)
+	want := "## Job Token Group Allowlist Entry\n\n" +
+		"- **Project**: 42\n" +
+		"- **Allowed group**: 5\n" +
+		"\nEvery project in the allowed group may now reach this project with its job token.\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.token_scope_list_groups' to see the whole group allowlist\n" +
+		"- Use action 'job.token_scope_get' to check whether the restriction is enforced at all\n"
+	if got := markdownText(t, r); got != want {
+		t.Errorf("FormatAddGroupAllowlistMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -735,12 +715,9 @@ func TestFormatListInboundAllowlistMarkdown_EscapesPipes(t *testing.T) {
 			{ID: 10, Name: "proj|special", PathWithNamespace: "grp/proj-special", WebURL: "https://gitlab.example.com/grp/proj-special"},
 		},
 	})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if strings.Contains(text, "| proj|special |") {
-		t.Errorf("pipe character in name should be escaped:\n%s", text)
+	const wantRow = "| 10 | [proj&#124;special](https://gitlab.example.com/grp/proj-special) | grp/proj-special |\n"
+	if got := markdownText(t, r); !strings.Contains(got, wantRow) {
+		t.Errorf("FormatListInboundAllowlistMarkdown() missing %q:\n%s", wantRow, got)
 	}
 }
 
@@ -755,11 +732,8 @@ func TestFormatListGroupAllowlistMarkdown_EscapesPipes(t *testing.T) {
 			{ID: 5, Name: "group|special", FullPath: "group-special", WebURL: "https://gitlab.example.com/groups/group-special"},
 		},
 	})
-	if r == nil {
-		t.Fatal(errExpNonNilResult)
-	}
-	text := r.Content[0].(*mcp.TextContent).Text
-	if strings.Contains(text, "| group|special |") {
-		t.Errorf("pipe character in name should be escaped:\n%s", text)
+	const wantRow = "| 5 | [group&#124;special](https://gitlab.example.com/groups/group-special) | group-special |\n"
+	if got := markdownText(t, r); !strings.Contains(got, wantRow) {
+		t.Errorf("FormatListGroupAllowlistMarkdown() missing %q:\n%s", wantRow, got)
 	}
 }

--- a/internal/tools/jobtokenscope/markdown.go
+++ b/internal/tools/jobtokenscope/markdown.go
@@ -1,7 +1,7 @@
 package jobtokenscope
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,62 +9,124 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatAccessSettingsMarkdown formats access settings as markdown.
+// Canonical action IDs the hints name. None of them is a credential; they are
+// named for the scope rather than for the job token so that the secret scanner
+// does not read "Token" in an identifier bound to a string literal.
+const (
+	hintScopeGet           = "job.token_scope_get"
+	hintScopePatch         = "job.token_scope_patch"
+	hintScopeListInbound   = "job.token_scope_list_inbound"
+	hintScopeAddProject    = "job.token_scope_add_project"
+	hintScopeListGroups    = "job.token_scope_list_groups"
+	hintScopeAddGroup      = "job.token_scope_add_group"
+	hintScopeRemoveGroup   = "job.token_scope_remove_group"
+	hintScopeRemoveProject = "job.token_scope_remove_project"
+)
+
+// FormatAccessSettingsMarkdown renders a project's job token access settings
+// as the card of one object.
+//
+// The row names the restriction rather than the switch: inbound_enabled true
+// means the scope is enforced, so only the projects on the allowlist may reach
+// this one with a job token. "Inbound access: enabled" read as the opposite —
+// as though enabling it granted access — and a tick would have read the same
+// way, which is why the state is spelled out in words.
 func FormatAccessSettingsMarkdown(out AccessSettingsOutput) *mcp.CallToolResult {
-	status := "disabled"
-	if out.InboundEnabled {
-		status = "enabled"
+	var b strings.Builder
+	c := toolutil.NewCard(&b, "Job Token Access Settings")
+	c.Field("Inbound job token access", inboundAccessDescription(out.InboundEnabled))
+	c.End(
+		toolutil.HintAction(hintScopeListInbound, "see the projects the allowlist holds"),
+		toolutil.HintAction(hintScopePatch, "turn the restriction on or off"),
+	)
+	return toolutil.ToolResultWithMarkdown(b.String())
+}
+
+// inboundAccessDescription says what the flag means for a caller: which job
+// tokens may reach this project.
+func inboundAccessDescription(enabled bool) string {
+	if enabled {
+		return "limited to the allowlist"
 	}
-	return toolutil.ToolResultWithMarkdown(fmt.Sprintf("## Job Token Access Settings\n\nInbound access: **%s**", status))
+	return "not limited (any project's job token may access this project)"
 }
 
-// FormatPatchResultMarkdown formats the patch result as markdown.
-func FormatPatchResultMarkdown(out toolutil.DeleteOutput) *mcp.CallToolResult {
-	return toolutil.ToolResultWithMarkdown(fmt.Sprintf("Job token access settings %s successfully.", out.Status))
-}
-
-// FormatListInboundAllowlistMarkdown formats the inbound allowlist as markdown.
+// FormatListInboundAllowlistMarkdown renders the projects on the inbound
+// allowlist as a Markdown table.
 func FormatListInboundAllowlistMarkdown(out ListInboundAllowlistOutput) *mcp.CallToolResult {
 	if len(out.Projects) == 0 {
-		return toolutil.ToolResultWithMarkdown("No projects in the job token inbound allowlist.\n")
+		return toolutil.ToolResultWithMarkdown(toolutil.EmptyMessage("projects on the job token inbound allowlist"))
 	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Job Token Inbound Allowlist (%d projects)\n\n", len(out.Projects))
-	sb.WriteString("| ID | Name | Path | URL |\n")
-	sb.WriteString("|----|------|------|-----|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Job Token Inbound Allowlist", len(out.Projects), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Path"))
 	for _, p := range out.Projects {
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", p.ID, toolutil.EscapeMdTableCell(p.Name),
-			toolutil.EscapeMdTableCell(p.PathWithNamespace), toolutil.MdTitleLink("View", p.WebURL))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(p.ID, 10),
+			// The name carries the link, so a reader is never asked to click
+			// a column that says "View" and nothing about where it goes.
+			toolutil.MdTitleLink(p.Name, p.WebURL),
+			toolutil.EscapeMdTableCell(p.PathWithNamespace),
+		))
 	}
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_add_project_job_token_allowlist` to add a project")
-	return toolutil.ToolResultWithMarkdown(sb.String())
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintScopeAddProject, "allow another project"),
+		toolutil.HintAction(hintScopeRemoveProject, "remove one from the allowlist"),
+	)
+	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
-// FormatAddProjectAllowlistMarkdown formats the add project result as markdown.
+// FormatAddProjectAllowlistMarkdown renders the allowlist entry that was
+// created as the card of that entry.
 func FormatAddProjectAllowlistMarkdown(out InboundAllowItemOutput) *mcp.CallToolResult {
-	return toolutil.ToolResultWithMarkdown(fmt.Sprintf("Project %d added to inbound allowlist of project %d.", out.TargetProjectID, out.SourceProjectID))
+	var b strings.Builder
+	c := toolutil.NewCard(&b, "Job Token Inbound Allowlist Entry")
+	c.Int("Project", out.SourceProjectID)
+	c.Int("Allowed project", out.TargetProjectID)
+	c.Note("The allowed project's job token may now reach this project.")
+	c.End(
+		toolutil.HintAction(hintScopeListInbound, "see the whole allowlist"),
+		toolutil.HintAction(hintScopeGet, "check whether the restriction is enforced at all"),
+	)
+	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
-// FormatListGroupAllowlistMarkdown formats the group allowlist as markdown.
+// FormatListGroupAllowlistMarkdown renders the groups on the job token
+// allowlist as a Markdown table.
 func FormatListGroupAllowlistMarkdown(out ListGroupAllowlistOutput) *mcp.CallToolResult {
 	if len(out.Groups) == 0 {
-		return toolutil.ToolResultWithMarkdown("No groups in the job token allowlist.\n")
+		return toolutil.ToolResultWithMarkdown(toolutil.EmptyMessage("groups on the job token allowlist"))
 	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Job Token Group Allowlist (%d groups)\n\n", len(out.Groups))
-	sb.WriteString("| ID | Name | Path | URL |\n")
-	sb.WriteString("|----|------|------|-----|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Job Token Group Allowlist", len(out.Groups), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Path"))
 	for _, g := range out.Groups {
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", g.ID, toolutil.EscapeMdTableCell(g.Name),
-			toolutil.EscapeMdTableCell(g.FullPath), toolutil.MdTitleLink("View", g.WebURL))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(g.ID, 10),
+			toolutil.MdTitleLink(g.Name, g.WebURL),
+			toolutil.EscapeMdTableCell(g.FullPath),
+		))
 	}
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks, "Use `gitlab_add_group_job_token_allowlist` to add a group")
-	return toolutil.ToolResultWithMarkdown(sb.String())
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintScopeAddGroup, "allow another group"),
+		toolutil.HintAction(hintScopeRemoveGroup, "remove one from the allowlist"),
+	)
+	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
-// FormatAddGroupAllowlistMarkdown formats the add group result as markdown.
+// FormatAddGroupAllowlistMarkdown renders the group allowlist entry that was
+// created as the card of that entry.
 func FormatAddGroupAllowlistMarkdown(out GroupAllowlistItemOutput) *mcp.CallToolResult {
-	return toolutil.ToolResultWithMarkdown(fmt.Sprintf("Group %d added to allowlist of project %d.", out.TargetGroupID, out.SourceProjectID))
+	var b strings.Builder
+	c := toolutil.NewCard(&b, "Job Token Group Allowlist Entry")
+	c.Int("Project", out.SourceProjectID)
+	c.Int("Allowed group", out.TargetGroupID)
+	c.Note("Every project in the allowed group may now reach this project with its job token.")
+	c.End(
+		toolutil.HintAction(hintScopeListGroups, "see the whole group allowlist"),
+		toolutil.HintAction(hintScopeGet, "check whether the restriction is enforced at all"),
+	)
+	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
 func init() {

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -297,7 +297,9 @@ func TestFormatMR_Markdown(t *testing.T) {
 	checks := []string{
 		"MR !15: Add feature", "opened",
 		"**Source**: feature", "**Target**: main",
-		mdDescriptionHdr, "Adds a feature",
+		// The description is a labeled row now rather than an H3 section:
+		// the card writes prose under its label, quoted when it spans lines.
+		"- **Description**: Adds a feature",
 		"@dev1", "enhancement", "@dev2", "@dev3",
 	}
 	for _, c := range checks {
@@ -318,10 +320,12 @@ func TestFormatMRMarkdownDraft_Conflicts(t *testing.T) {
 		WebURL: "https://gitlab.example.com/mr/99",
 	}
 	md := mergerequests.FormatMarkdown(mr)
-	if !strings.Contains(md, "Draft") {
+	if !strings.Contains(md, "**Draft merge request**") {
 		t.Error("missing draft indicator")
 	}
-	if !strings.Contains(md, "Conflicts") {
+	// A negative-polarity condition is marked with the warning sign rather
+	// than with the tick a true would otherwise take.
+	if !strings.Contains(md, "⚠️ **Has conflicts**") {
 		t.Error("missing conflict indicator")
 	}
 }
@@ -348,7 +352,7 @@ func TestFormatMR_ApproveMarkdown(t *testing.T) {
 	a := mergerequests.ApproveOutput{ApprovalsRequired: 2, ApprovedBy: 1, Approved: false}
 	md := mergerequests.FormatApproveMarkdown(a)
 
-	if !strings.Contains(md, "**Approved**: false") {
+	if !strings.Contains(md, "**Approved**: ❌") {
 		t.Error("missing approved field")
 	}
 	if !strings.Contains(md, "**Approvals Required**: 2") {
@@ -383,21 +387,35 @@ func TestFormatMR_NotesListMarkdown(t *testing.T) {
 	})
 }
 
-// TestFormatDiscussion_NoteMarkdown verifies discussion note fields in Markdown.
+// TestFormatDiscussion_NoteMarkdown verifies discussion note fields in
+// Markdown. A note nothing can resolve carries no resolution row at all: the
+// "**Resolved**: false" this replaced was printed on every note, resolvable or
+// not, which told a reader a thread was open that was never a thread.
 func TestFormatDiscussion_NoteMarkdown(t *testing.T) {
-	n := mrdiscussions.NoteOutput{ID: 5, Body: "Needs fix", Author: &toolutil.NoteUserOutput{Username: "reviewer"}, CreatedAt: testDate20260101, Resolved: false}
+	n := mrdiscussions.NoteOutput{ID: 5, Body: "Needs fix", Author: &toolutil.NoteUserOutput{Username: "reviewer"}, CreatedAt: testDate20260101}
 	md := mrdiscussions.FormatNoteMarkdown(n)
 
 	if !strings.Contains(md, "## Discussion Note #5") {
 		t.Error(errMissingHeader)
 	}
-	if !strings.Contains(md, "**Resolved**: false") {
-		t.Error("missing resolved field")
+	if strings.Contains(md, "Resolvable") {
+		t.Errorf("a note that is not resolvable carries a resolution row:\n%s", md)
 	}
+
+	t.Run("resolvable", func(t *testing.T) {
+		n.Resolvable = true
+		resolvable := mrdiscussions.FormatNoteMarkdown(n)
+		if !strings.Contains(resolvable, "**Resolvable**: unresolved") {
+			t.Errorf("missing resolution state:\n%s", resolvable)
+		}
+	})
 }
 
 // TestFormatMR_DiscussionMarkdown verifies that a discussion thread with
-// multiple notes renders each note as a sub-heading.
+// multiple notes renders each note as a list item naming its author and its ID,
+// with the body quoted underneath — the shape every discussion family shares.
+// The "### Note N (by author)" heading this replaced put a name in a heading
+// and the body at column zero, where it could add structure of its own.
 func TestFormatMR_DiscussionMarkdown(t *testing.T) {
 	d := mrdiscussions.Output{
 		ID:             "abc123",
@@ -412,11 +430,11 @@ func TestFormatMR_DiscussionMarkdown(t *testing.T) {
 	if !strings.Contains(md, "## Discussion abc123") {
 		t.Error(errMissingHeader)
 	}
-	if !strings.Contains(md, "### Note 1 (by dev1)") {
-		t.Error("missing first note")
+	if !strings.Contains(md, "- **@dev1** (, note 1):\n  > First note") {
+		t.Errorf("missing first note:\n%s", md)
 	}
-	if !strings.Contains(md, "### Note 2 (by dev2)") {
-		t.Error("missing second note")
+	if !strings.Contains(md, "- **@dev2** (, note 2):\n  > Reply") {
+		t.Errorf("missing second note:\n%s", md)
 	}
 }
 
@@ -445,8 +463,8 @@ func TestFormatMR_ChangesMarkdown(t *testing.T) {
 	}
 	md := mrchanges.FormatOutputMarkdown(out)
 
-	if !strings.Contains(md, "## MR !15 Changes (4 files)") {
-		t.Error(errMissingHeader)
+	if !strings.Contains(md, "## MR !15 Changes\n\n- **Files**: 4\n") {
+		t.Errorf("%s:\n%s", errMissingHeader, md)
 	}
 	if !strings.Contains(md, "| a.go | modified |") {
 		t.Error("missing modified file")
@@ -2468,24 +2486,39 @@ func mdGateLog(t *testing.T, title string, findings []mdGateFinding) {
 // TestMarkdownRegistry_EveryFormatter_KeepsTableBoundaries drives every
 // registered formatter and the renderers outside the registry through the
 // line model and reports what the client would render differently from what
-// the formatter wrote. It reports rather than fails, and asserts the one
-// thing that proves the gate works: the two files the audit proved broken,
-// mergetrains and iterationdata, are among what it reports.
+// the formatter wrote. It reports rather than fails, apart from the two
+// assertions that keep it honest.
+//
+// The first is that it still sees the class it exists for: iterationdata opens
+// a table and writes a list row into it, which ends the table with no body and
+// leaves every later row on the page as literal pipes, and it has not been
+// migrated yet.
+//
+// The second is the other half of the same proof, and is what the fixed
+// formatter is worth: mergetrains was the sibling the audit proved broken, the
+// card migration moved it onto [toolutil.Card], and nothing about it may be
+// reported again. An assertion that it is still broken would have to be
+// deleted by whoever fixed it, which is how a gate stops proving anything.
 func TestMarkdownRegistry_EveryFormatter_KeepsTableBoundaries(t *testing.T) {
 	report := mdGateScan(t)
 
 	mdGateLog(t, "structural scan", report.findings)
 	t.Logf("structural scan: %d case(s), %d render(s), %d silent render(s)", len(report.cases), report.rendered, report.silent)
-	for _, name := range []string{"mergetrains", "iterationdata"} {
-		t.Run(name+" is reported", func(t *testing.T) {
-			for _, f := range report.findings {
-				if f.kase.pkg == name {
-					return
-				}
+	t.Run("iterationdata is reported", func(t *testing.T) {
+		for _, f := range report.findings {
+			if f.kase.pkg == "iterationdata" {
+				return
 			}
-			t.Errorf("the gate reports nothing for %s, whose tables the audit proved broken, so the gate does not see the defect it exists for", name)
-		})
-	}
+		}
+		t.Error("the gate reports nothing for iterationdata, whose tables the audit proved broken, so the gate does not see the defect it exists for")
+	})
+	t.Run("mergetrains keeps its table boundaries", func(t *testing.T) {
+		for _, f := range report.findings {
+			if f.kase.pkg == "mergetrains" {
+				t.Errorf("mergetrains was migrated onto the card and is reported again: %s", f)
+			}
+		}
+	})
 	for _, f := range report.findings {
 		if f.rule == "P0" {
 			t.Errorf("%s", f)

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -280,17 +280,31 @@ func TestFormatTag_ListMarkdown(t *testing.T) {
 	}
 }
 
-// TestFormatRelease_Markdown verifies that release fields and description
-// section appear in Markdown output.
+// TestFormatRelease_Markdown verifies the whole card a release renders as.
+// The release notes are a labeled quote under the fields rather than the
+// "### Description" section this used to assert: a one-line body stays on the
+// field's line, and a longer one is quoted under it, which is what the card
+// contract settled on for prose a person typed into GitLab.
 func TestFormatRelease_Markdown(t *testing.T) {
-	r := releases.Output{TagName: "v1.0", Name: "Version 1.0", Description: "Features", CreatedAt: testDate20260101, ReleasedAt: "2026-01-02"}
-	md := releases.FormatMarkdown(r)
+	got := releases.FormatMarkdown(releases.Output{
+		TagName: "v1.0", Name: "Version 1.0", Description: "Features",
+		CreatedAt: testDate20260101, ReleasedAt: "2026-01-02",
+	})
 
-	if !strings.Contains(md, "## Release: Version 1.0") {
-		t.Error(errMissingHeader)
-	}
-	if !strings.Contains(md, mdDescriptionHdr) {
-		t.Error("missing description section")
+	want := "## Release: Version 1.0\n\n" +
+		"- **Tag**: v1.0\n" +
+		"- **Created**: 1 Jan 2026\n" +
+		"- **Released**: 2 Jan 2026\n" +
+		"- **Description**: Features\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'release.link_list' to see the assets linked to this release\n" +
+		"- Use action 'release.link_create' to add a single asset link\n" +
+		"- Use action 'release.link_create_batch' to add several asset links in one call\n" +
+		"- Use action 'package.publish_and_link' to upload a binary and link it to this release\n" +
+		"- Use action 'release.update' to edit the release notes\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -2632,16 +2646,17 @@ func TestMarkdownRegistry_Exceptions_NameACaseEach(t *testing.T) {
 // by the migration. The audit knew of two; the record showed twelve, because
 // the shared note and discussion shapes are registered by every domain that
 // renders them and the first init to run wins for all of them, which is the
-// same defect as the runner token with more surfaces behind it. Eleven are
-// left: the one interface-typed registration, groupimportexport's dispatcher
-// over `any`, went with that package's card migration.
+// same defect as the runner token with more surfaces behind it. Ten are left:
+// the one interface-typed registration, groupimportexport's dispatcher over
+// `any`, went with that package's card migration, and the runner token went
+// with the runners migration, which gave the registration token an output
+// type of its own so the two secrets stopped sharing a formatter.
 func TestMarkdownRegistry_Registrations_HaveNoUndeclaredProblems(t *testing.T) {
 	got := toolutil.MarkdownRegistrationProblems()
 
 	want := []string{
 		"duplicate Markdown formatter for iterationdata.Output: the first registration is kept",
 		"duplicate Markdown formatter for labeldata.Output: the first registration is kept",
-		"duplicate Markdown formatter for runners.AuthTokenOutput: the first registration is kept",
 		"duplicate Markdown formatter for toolutil.DiscussionThreadNoteOutput: the first registration is kept",
 		"duplicate Markdown formatter for toolutil.DiscussionThreadNoteOutput: the first registration is kept",
 		"duplicate Markdown formatter for toolutil.DiscussionThreadNoteOutput: the first registration is kept",

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -156,44 +156,80 @@ func TestFormatProject_ListMarkdown(t *testing.T) {
 	})
 }
 
-// TestFormatBranch_Markdown verifies that branch fields appear in Markdown output.
+// TestFormatBranch_Markdown pins the branch card as the reader sees it: the
+// flags as glyphs and the head commit as a nested object.
 func TestFormatBranch_Markdown(t *testing.T) {
-	br := branches.Output{Name: "feature-x", Protected: true, Default: false, Merged: false, Commit: &branches.CommitOutput{ID: "abc123"}}
-	md := branches.FormatOutputMarkdown(br)
+	got := branches.FormatOutputMarkdown(branches.Output{
+		Name: "feature-x", Protected: true, Commit: &branches.CommitOutput{ID: "abc123"},
+	})
 
-	if !strings.Contains(md, "## Branch: feature-x") {
-		t.Error(errMissingHeader)
-	}
-	if !strings.Contains(md, "**Protected**: true") {
-		t.Error("missing protected field")
-	}
-	if !strings.Contains(md, "**Commit**: abc123") {
-		t.Error("missing commit")
+	want := "## Branch: feature-x\n\n" +
+		"- **Protected**: ✅\n" +
+		"- **Default**: ❌\n" +
+		"- **Merged**: ❌\n" +
+		"- **You Can Push**: ❌\n" +
+		"- **Developers Can Push**: ❌\n" +
+		"- **Developers Can Merge**: ❌\n" +
+		"- **Commit**:\n" +
+		"  - **SHA**: `abc123`\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'merge_request.create' to open a merge request from this branch\n" +
+		"- Use action 'repository.commit_list' to see recent commits on this branch\n" +
+		"- Use action 'branch.delete' to remove the branch after merging\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatBranch_ListMarkdown verifies table rendering for branch lists.
+// TestFormatBranch_ListMarkdown pins the branch table row.
 func TestFormatBranch_ListMarkdown(t *testing.T) {
-	out := branches.ListOutput{
+	got := branches.FormatListMarkdown(branches.ListOutput{
 		Branches:   []branches.Output{{Name: "main", Protected: true, Default: true}},
 		Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
-	}
-	md := branches.FormatListMarkdown(out)
-	if !strings.Contains(md, "| main | true | true |") {
-		t.Error("missing branch row")
+	})
+
+	want := "## Branches (1)\n\n" +
+		"| Name | Protected | Default | Merged |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| main | ✅ | ✅ | ❌ |\n" +
+		"\nPage 1 of 1 | 1 items total | 20 per page\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'branch.get' to see one branch in full\n" +
+		"- Use action 'branch.create' to create a new branch\n" +
+		"- Use action 'branch.protect' to protect a branch\n"
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatProtected_BranchMarkdown verifies protected branch fields in Markdown.
+// TestFormatProtected_BranchMarkdown pins the protection card: the access
+// levels as the role names they stand for rather than the numbers GitLab
+// sends.
 func TestFormatProtected_BranchMarkdown(t *testing.T) {
-	pb := branches.ProtectedOutput{ID: 1, Name: "main", PushAccessLevels: []branches.BranchAccessDescriptionOutput{{AccessLevel: 40}}, MergeAccessLevels: []branches.BranchAccessDescriptionOutput{{AccessLevel: 30}}, AllowForcePush: false}
-	md := branches.FormatProtectedMarkdown(pb)
+	got := branches.FormatProtectedMarkdown(branches.ProtectedOutput{
+		ID:                1,
+		Name:              "main",
+		PushAccessLevels:  []branches.BranchAccessDescriptionOutput{{AccessLevel: 40}},
+		MergeAccessLevels: []branches.BranchAccessDescriptionOutput{{AccessLevel: 30}},
+	})
 
-	if !strings.Contains(md, "## Protected Branch: main") {
-		t.Error(errMissingHeader)
-	}
-	if !strings.Contains(md, "**Push Access Levels**: 40") {
-		t.Error("missing push level")
+	want := "## Protected Branch: main\n\n" +
+		"- **ID**: 1\n" +
+		"- **Push Access Levels**: Maintainer\n" +
+		"- **Merge Access Levels**: Developer\n" +
+		"- **Unprotect Access Levels**: -\n" +
+		"- **Allow Force Push**: ❌\n" +
+		"- **Code Owner Approval Required**: ❌\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'branch.get_protected' to fetch this protection again before updating it\n" +
+		"- Use action 'branch.update_protected' to change protection settings\n" +
+		"- Use action 'branch.unprotect' to remove branch protection\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -221,15 +257,26 @@ func TestFormatTag_Markdown(t *testing.T) {
 	}
 }
 
-// TestFormatTag_ListMarkdown verifies table rendering for tag lists.
+// TestFormatTag_ListMarkdown pins the tag table row. The commit column is the
+// commit the tag resolves to, and falls back to the tag object's own id where
+// GitLab sent no commit.
 func TestFormatTag_ListMarkdown(t *testing.T) {
-	out := tags.ListOutput{
+	got := tags.FormatListMarkdownString(tags.ListOutput{
 		Tags:       []tags.Output{{Name: "v1.0", Target: "abc", Protected: true}},
 		Pagination: toolutil.PaginationOutput{Page: 1, TotalPages: 1, TotalItems: 1, PerPage: 20},
-	}
-	md := tags.FormatListMarkdownString(out)
-	if !strings.Contains(md, "| v1.0 | abc | true |") {
-		t.Error("missing tag row")
+	})
+
+	want := "## Tags (1)\n\n" +
+		"| Name | Commit | Protected |\n" +
+		"| --- | --- | --- |\n" +
+		"| v1.0 | `abc` | ✅ |\n" +
+		"\nPage 1 of 1 | 1 items total | 20 per page\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.get' to see one tag in full\n" +
+		"- Use action 'tag.create' to create a new tag\n"
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -480,33 +527,50 @@ func TestFormatMR_ChangesMarkdown(t *testing.T) {
 	}
 }
 
-// TestFormatCommit_Markdown verifies that commit fields appear in Markdown.
+// TestFormatCommit_Markdown pins the commit card. The author's address is
+// written in parentheses rather than in angle brackets, which GFM turns into a
+// mailto autolink.
 func TestFormatCommit_Markdown(t *testing.T) {
-	c := commits.Output{
+	got := commits.FormatOutputMarkdown(commits.Output{
 		ID: "abc123full", ShortID: "abc123", Title: testTitleFixBug,
 		AuthorName: "Dev", AuthorEmail: "dev@example.com",
 		CommittedDate: testDate20260101, WebURL: "https://gitlab.example.com/commit/abc123",
-	}
-	md := commits.FormatOutputMarkdown(c)
+	})
 
-	if !strings.Contains(md, "## Commit abc123") {
-		t.Error(errMissingHeader)
-	}
-	if !strings.Contains(md, "**Author**: Dev <dev@example.com>") {
-		t.Error("missing author")
+	want := "## Commit abc123\n\n" +
+		"- **Title**: " + testTitleFixBug + "\n" +
+		"- **Author**: Dev (dev@example.com)\n" +
+		"- **Date**: 1 Jan 2026\n" +
+		"- **URL**: [https://gitlab.example.com/commit/abc123](https://gitlab.example.com/commit/abc123)\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_get' to see this commit's full details and stats\n" +
+		"- Use action 'repository.commit_diff' to see the file changes for this commit\n" +
+		"- Use action 'repository.commit_refs' to see the branches and tags containing it\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatFile_Markdown verifies that file metadata fields appear in Markdown.
+// TestFormatFile_Markdown pins the file card of a metadata-only read.
 func TestFormatFile_Markdown(t *testing.T) {
-	f := files.Output{FilePath: testFileSrcMainGo, Size: 1024, Ref: "main", Encoding: "base64", BlobID: "blob123"}
-	md := files.FormatOutputMarkdown(f)
+	got := files.FormatOutputMarkdown(files.Output{
+		FilePath: testFileSrcMainGo, Size: 1024, Ref: "main", Encoding: "base64", BlobID: "blob123",
+	})
 
-	if !strings.Contains(md, "## File: src/main.go") {
-		t.Error(errMissingHeader)
-	}
-	if !strings.Contains(md, "**Size**: 1024 bytes") {
-		t.Error("missing size")
+	want := "## File: src/main.go\n\n" +
+		"- **Size (bytes)**: 1024\n" +
+		"- **Ref**: main\n" +
+		"- **Encoding**: base64\n" +
+		"- **Blob ID**: `blob123`\n" +
+		"- **Executable**: ❌\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_update' to modify this file\n" +
+		"- Use action 'repository.file_blame' to see who changed each line\n" +
+		"- Use action 'repository.file_delete' to remove this file\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -905,22 +969,33 @@ func TestFormatCommit_ListMarkdown(t *testing.T) {
 	})
 }
 
-// TestFormatCommit_DetailMarkdown verifies commit detail fields including stats.
+// TestFormatCommit_DetailMarkdown pins the commit detail card, the message
+// quoted under its own label where it says more than the title.
 func TestFormatCommit_DetailMarkdown(t *testing.T) {
-	c := commits.DetailOutput{
+	got := commits.FormatDetailMarkdown(commits.DetailOutput{
 		ShortID: "abc1234", Title: "feat: add feature", Message: "feat: add feature\n\nDetailed description",
 		AuthorName: "dev", AuthorEmail: "dev@example.com", CommittedDate: testDate20260101,
 		ParentIDs: []string{"parent1", "parent2"}, WebURL: "https://gl.example.com/commit/abc",
 		Stats: &commits.CommitStatsOutput{Additions: 10, Deletions: 3, Total: 13},
-	}
-	md := commits.FormatDetailMarkdown(c)
-	checks := []string{"## Commit abc1234", "+10 -3", "parent1, parent2", "### Message"}
-	for _, ch := range checks {
-		t.Run(ch, func(t *testing.T) {
-			if !strings.Contains(md, ch) {
-				t.Errorf(fmtMissing, ch)
-			}
-		})
+	})
+
+	want := "## Commit abc1234\n\n" +
+		"- **Title**: feat: add feature\n" +
+		"- **Author**: dev (dev@example.com)\n" +
+		"- **Date**: 1 Jan 2026\n" +
+		"- **Parents**: `parent1, parent2`\n" +
+		"- **Stats**: +10 -3 (13 total)\n" +
+		"- **URL**: [https://gl.example.com/commit/abc](https://gl.example.com/commit/abc)\n" +
+		"- **Message**:\n" +
+		"  > feat: add feature\n" +
+		"  >\n" +
+		"  > Detailed description\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_diff' to view the file changes\n" +
+		"- Use action 'repository.commit_cherry_pick' to apply this commit to another branch\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -864,7 +864,7 @@ func TestFormatPipeline_DetailMarkdown(t *testing.T) {
 		YamlErrors: "", User: &toolutil.BasicUserOutput{Username: "admin"}, WebURL: "https://gl.example.com/p/100",
 	}
 	md := pipelines.FormatDetailMarkdown(p)
-	checks := []string{"Pipeline #100", "success", "**Duration**: 120s", "**Coverage**: 85.5%", "**User**: admin"}
+	checks := []string{"Pipeline #100", "success", "**Duration**: 120s", "**Coverage**: 85.5%", "**User**: @admin"}
 	for _, c := range checks {
 		t.Run(c, func(t *testing.T) {
 			if !strings.Contains(md, c) {
@@ -1305,7 +1305,9 @@ func TestFormatJob_TraceMarkdown(t *testing.T) {
 	t.Run("truncated trace", func(t *testing.T) {
 		tr := jobs.TraceOutput{JobID: 99, Trace: "big output", Truncated: true}
 		md := jobs.FormatTraceMarkdown(tr)
-		if !strings.Contains(md, "truncated") {
+		// The note names the end that is missing: the log is cut at the first
+		// 100 KB and a failure is almost always at the end of it.
+		if !strings.Contains(md, "Showing the first 100 KB of the log.") {
 			t.Error("missing truncation warning")
 		}
 	})

--- a/internal/tools/mergerequests/markdown.go
+++ b/internal/tools/mergerequests/markdown.go
@@ -2,6 +2,7 @@ package mergerequests
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,6 +10,28 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/issues"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/tools/pipelines"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name. A hint names the ID every surface
+// resolves — the dynamic surface executes it, and the meta and individual
+// surfaces resolve it to their own tool names — so a hint written this way is
+// never a name the serving surface does not register, which is what the mix of
+// tool names and bare action words in these hints used to be.
+const (
+	hintActionMRCreate        = "merge_request.create"
+	hintActionMRCommits       = "merge_request.commits"
+	hintActionMRPipelines     = "merge_request.pipelines"
+	hintActionMRRelatedIssues = "merge_request.related_issues"
+	hintActionMRDependencies  = "merge_request.dependencies_list"
+	hintActionMRParticipants  = "merge_request.participants"
+	hintActionChangesGet      = "mr_review.changes_get"
+	hintActionDiscussionList  = "mr_review.discussion_list"
+	hintActionNoteCreate      = "mr_review.note_create"
+	hintActionIssueGet        = "issue.get"
+	hintActionCommitGet       = "commit.get"
+	hintActionPipelineGet     = "pipeline.get"
+	hintActionJobList         = "job.list"
+	hintActionTodoMarkDone    = "user.todo_mark_done"
 )
 
 type mergeRequestNotFoundOutput struct {
@@ -24,56 +47,113 @@ func formatMergeRequestNotFound(out mergeRequestNotFoundOutput) *mcp.CallToolRes
 	)
 }
 
-// FormatMarkdown renders a single merge request as a Markdown summary.
+// FormatMarkdown renders a single merge request as the card of one object: its
+// own fields, the conditions that hold, then the description as quoted prose.
 func FormatMarkdown(mr Output) string {
 	var b strings.Builder
-	titlePrefix := toolutil.MRStateEmoji(mr.State)
-	if mr.Draft {
-		titlePrefix += " " + toolutil.EmojiDraft
-	}
-	fmt.Fprintf(&b, "## %s MR !%d: %s\n\n", titlePrefix, mr.IID, toolutil.EscapeMdHeading(mr.Title))
-	if path := mrProjectPath(mr); path != "" {
-		fmt.Fprintf(&b, "- **Project**: %s\n", toolutil.EscapeMdTableCell(path))
-	}
-	//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
-	fmt.Fprintf(&b, "- **State**: %s %s\n", toolutil.MRStateEmoji(mr.State), mr.State)
-	if mr.Draft {
-		fmt.Fprintf(&b, "- %s **Draft** merge request\n", toolutil.EmojiDraft)
-	}
+	c := toolutil.NewCard(&b, mergeRequestHeading(mr))
+	c.Field("Project", mrProjectPath(mr))
+	c.Markdown("State", mrStateCell(mr.State))
+	c.Flag(toolutil.EmojiDraft, "Draft merge request", mr.Draft)
 	// A branch name is not an identifier: git check-ref-format forbids a space
 	// and the control bytes and permits '|', '<' and '>', so a pushable branch
-	// can end this row or open a tag in it.
-	fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n",
-		toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
-	if mr.DetailedMergeStatus != "" {
-		//gitlab:allow-unescaped mr.DetailedMergeStatus: a merge status GitLab computes from a fixed set (mergeable, ci_must_pass, conflict and the rest).
-		fmt.Fprintf(&b, "- **Merge Status**: %s\n", mr.DetailedMergeStatus)
+	// can end a row or open a tag in it.
+	c.Field("Source", mr.SourceBranch)
+	c.Field("Target", mr.TargetBranch)
+	c.Field("Merge Status", mr.DetailedMergeStatus)
+	c.Warn("Has conflicts", mr.HasConflicts)
+	c.Markdown("Author", toolutil.MdUserHandle(userName(mr.Author)))
+	c.Markdown("Assignees", handleList(userNames(mr.Assignees)))
+	c.Markdown("Reviewers", handleList(userNames(mr.Reviewers)))
+	if mr.Milestone != nil {
+		c.Field("Milestone", mr.Milestone.Title)
 	}
-	writeMergeRequestPeopleAndLabels(&b, mr)
-	writeMergeRequestPipeline(&b, mr)
-	if mr.ChangesCount != "" {
-		//gitlab:allow-unescaped mr.ChangesCount: a changed-file count GitLab renders as a string, "3" or "1000+".
-		fmt.Fprintf(&b, "- **Changes**: %s files\n", mr.ChangesCount)
-	}
-	if mr.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(mr.CreatedAt))
-	}
-	writeMergeRequestTerminalActor(&b, mr)
-	if mr.UserNotesCount > 0 {
-		fmt.Fprintf(&b, "- **Comments**: %d\n", mr.UserNotesCount)
-	}
-	if mr.Description != "" {
-		fmt.Fprintf(&b, "\n### Description\n\n%s%s\n", toolutil.WrapGFMBody(mr.Description), toolutil.RichContentHint(toolutil.DetectRichContent(mr.Description), mr.WebURL))
-	}
-	toolutil.WriteMdURLNewline(&b, mr.WebURL)
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_mr_review action 'changes_get' to see the diff of this MR",
-		"Use gitlab_mr_review action 'discussion_list' to see review threads",
-		"Use gitlab_merge_request action 'pipelines' to check CI/CD status",
-		"Use gitlab_merge_request action 'approve' or 'merge' to progress the MR",
+	// A label title is free text: GitLab's only rule on one is that it carries
+	// no comma.
+	c.Field("Labels", strings.Join(mr.Labels, ", "))
+	c.Markdown("Pipeline", mrPipelineCell(mr))
+	c.Field("Changes", changesText(mr.ChangesCount))
+	c.Time("Created", mr.CreatedAt)
+	writeTerminalActor(c, mr)
+	c.Count("Comments", mr.UserNotesCount)
+	// The four conditions that decide whether a merge request can be worked on
+	// at all, and none of which the card used to show: a locked discussion
+	// refuses every comment, an auto-merge is already scheduled, a rebase is
+	// running, and a merge error is why the last attempt failed.
+	c.Warn("Discussion locked", mr.DiscussionLocked)
+	c.Flag(toolutil.EmojiRefresh, "Auto-merge set (merges when the pipeline succeeds)", mr.MergeWhenPipelineSucceeds)
+	c.Flag(toolutil.EmojiRefresh, "Rebase in progress", mr.RebaseInProgress)
+	c.Field("Merge Error", mr.MergeError)
+	c.URL(mr.WebURL)
+	c.Text("Description", mr.Description)
+	c.Note(toolutil.RichContentHint(toolutil.DetectRichContent(mr.Description), mr.WebURL))
+	c.End(
+		toolutil.HintAction(hintActionChangesGet, "see the diff of this merge request"),
+		toolutil.HintAction(hintActionDiscussionList, "see its review threads"),
+		toolutil.HintAction(hintActionMRPipelines, "check its CI status"),
+		toolutil.HintAction(actionMRApprove, "approve it"),
+		toolutil.HintAction(actionMRMerge, "merge it"),
 	)
 	return b.String()
+}
+
+// mergeRequestHeading composes the card's heading: the state as a glyph, the
+// draft marker a draft carries, the reference and the title. The whole
+// composition is escaped by the card.
+func mergeRequestHeading(mr Output) string {
+	prefix := toolutil.MRStateEmoji(mr.State)
+	if mr.Draft {
+		prefix += " " + toolutil.EmojiDraft
+	}
+	heading := fmt.Sprintf("%s MR !%d", prefix, mr.IID)
+	if strings.TrimSpace(mr.Title) == "" {
+		return heading
+	}
+	return heading + ": " + mr.Title
+}
+
+// mrStateCell renders a merge request state with its emoji, and nothing when
+// GitLab sent no state.
+func mrStateCell(state string) string {
+	if strings.TrimSpace(state) == "" {
+		return ""
+	}
+	return toolutil.MRStateEmoji(state) + " " + toolutil.EscapeMdTableCell(state)
+}
+
+// changesText renders GitLab's own count of changed files, which it sends as a
+// string because it caps it ("1000+").
+func changesText(count string) string {
+	if strings.TrimSpace(count) == "" {
+		return ""
+	}
+	return count + " files"
+}
+
+// mrPipelineCell renders the merge request's pipeline as its number linked to
+// the pipeline, with the status glyph and word when GitLab sent one.
+func mrPipelineCell(mr Output) string {
+	if mr.Pipeline == nil || mr.Pipeline.ID <= 0 {
+		return ""
+	}
+	cell := toolutil.MdTitleLink(fmt.Sprintf("#%d", mr.Pipeline.ID), mr.Pipeline.WebURL)
+	if mr.Pipeline.Status != "" {
+		cell += " " + toolutil.PipelineStatusEmoji(mr.Pipeline.Status) + " " + toolutil.EscapeMdTableCell(mr.Pipeline.Status)
+	}
+	return cell
+}
+
+// writeTerminalActor writes who ended the merge request and when, for the two
+// states that have an ending.
+func writeTerminalActor(c *toolutil.Card, mr Output) {
+	switch mr.State {
+	case "merged":
+		c.Markdown("Merged By", toolutil.MdUserHandle(userName(mr.MergeUser)))
+		c.Time("Merged", mr.MergedAt)
+	case "closed":
+		c.Markdown("Closed By", toolutil.MdUserHandle(userName(mr.ClosedBy)))
+		c.Time("Closed", mr.ClosedAt)
+	}
 }
 
 // AuthorName returns the username of the merge request author, or "" when the
@@ -124,403 +204,352 @@ func userNames(users []*toolutil.BasicUserOutput) []string {
 	return out
 }
 
-func writeMergeRequestPeopleAndLabels(b *strings.Builder, mr Output) {
-	if mr.HasConflicts {
-		fmt.Fprintf(b, "- %s **Has Conflicts**\n", toolutil.EmojiWarning)
-	}
-	if author := userName(mr.Author); author != "" {
-		fmt.Fprintf(b, toolutil.FmtMdAuthorAt, toolutil.EscapeMdTableCell(author))
-	}
-	if names := userNames(mr.Assignees); len(names) > 0 {
-		fmt.Fprintf(b, "- **Assignees**: %s\n", toolutil.EscapeMdTableCell(strings.Join(prefixAt(names), ", ")))
-	}
-	if names := userNames(mr.Reviewers); len(names) > 0 {
-		fmt.Fprintf(b, "- **Reviewers**: %s\n", toolutil.EscapeMdTableCell(strings.Join(prefixAt(names), ", ")))
-	}
-	if mr.Milestone != nil && mr.Milestone.Title != "" {
-		fmt.Fprintf(b, "- **Milestone**: %s\n", toolutil.EscapeMdTableCell(mr.Milestone.Title))
-	}
-	if len(mr.Labels) > 0 {
-		// A label title is free text: GitLab's only rule on one is that it
-		// carries no comma.
-		fmt.Fprintf(b, "- **Labels**: %s\n", toolutil.EscapeMdTableCell(strings.Join(mr.Labels, ", ")))
-	}
-}
-
-func writeMergeRequestPipeline(b *strings.Builder, mr Output) {
-	if mr.Pipeline == nil || mr.Pipeline.ID <= 0 {
-		return
-	}
-	if mr.Pipeline.WebURL != "" {
-		fmt.Fprintf(b, "- **Pipeline**: %s\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", mr.Pipeline.ID), mr.Pipeline.WebURL))
-		return
-	}
-	fmt.Fprintf(b, "- **Pipeline**: #%d\n", mr.Pipeline.ID)
-}
-
-func writeMergeRequestTerminalActor(b *strings.Builder, mr Output) {
-	if mr.State == "merged" {
-		if name := userName(mr.MergeUser); name != "" {
-			writeMergeRequestActorLine(b, "Merged By", name, mr.MergedAt)
+// handleList renders usernames as the "@handle" list a card row shows, each
+// escaped, and nothing at all when there are none, so a card never shows a
+// bare "@".
+func handleList(names []string) string {
+	handles := make([]string, 0, len(names))
+	for _, name := range names {
+		if handle := toolutil.MdUserHandle(name); handle != "" {
+			handles = append(handles, handle)
 		}
 	}
-	if mr.State == "closed" {
-		if name := userName(mr.ClosedBy); name != "" {
-			writeMergeRequestActorLine(b, "Closed By", name, mr.ClosedAt)
-		}
-	}
+	return strings.Join(handles, ", ")
 }
 
-func writeMergeRequestActorLine(b *strings.Builder, label, user, at string) {
-	fmt.Fprintf(b, "- **%s**: @%s", label, toolutil.EscapeMdTableCell(user))
-	if at != "" {
-		fmt.Fprintf(b, " on %s", toolutil.FormatTime(at))
-	}
-	b.WriteByte('\n')
-}
-
-// prefixAt adds '@' before each username for Markdown @mention formatting.
-func prefixAt(usernames []string) []string {
-	result := make([]string, len(usernames))
-	for i, u := range usernames {
-		result[i] = "@" + u
-	}
-	return result
-}
-
-// FormatListMarkdown renders a list of merge requests as a Markdown table.
+// FormatListMarkdown renders a page of merge requests as a Markdown table: a
+// collection of objects that share columns.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Merge Requests (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.MergeRequests), out.Pagination)
 	if len(out.MergeRequests) == 0 {
-		b.WriteString("No merge requests found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("merge requests")
 	}
-	b.WriteString("| IID | Title | State | Author | Project | Source -> Target |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Merge Requests", len(out.MergeRequests), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("IID", "Title", "State", "Author", "Project", "Source -> Target"))
 	for _, mr := range out.MergeRequests {
-		draftTag := ""
+		title := toolutil.EscapeMdTableCell(mr.Title)
 		if mr.Draft {
-			draftTag = " " + toolutil.EmojiDraft
+			title += " " + toolutil.EmojiDraft
 		}
-		//gitlab:allow-unescaped mr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
-		fmt.Fprintf(&b, "| %s | %s%s | %s %s | %s | %s | %s -> %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL), toolutil.EscapeMdTableCell(mr.Title), draftTag, toolutil.MRStateEmoji(mr.State), mr.State, toolutil.EscapeMdTableCell(userName(mr.Author)), toolutil.EscapeMdTableCell(mrProjectPath(mr)), toolutil.EscapeMdTableCell(mr.SourceBranch), toolutil.EscapeMdTableCell(mr.TargetBranch))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL),
+			title,
+			mrStateCell(mr.State),
+			toolutil.MdUserHandle(userName(mr.Author)),
+			toolutil.EscapeMdTableCell(mrProjectPath(mr)),
+			toolutil.EscapeMdTableCell(mr.SourceBranch)+" -> "+toolutil.EscapeMdTableCell(mr.TargetBranch),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'get' with a merge_request_iid to see full details",
-		"Use action 'create' to open a new merge request",
-		"Use gitlab_mr_review action 'changes_get' to review MR diffs",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionMRGet, "see one merge request in full"),
+		toolutil.HintAction(hintActionMRCreate, "open a new merge request"),
+		toolutil.HintAction(hintActionChangesGet, "review a merge request's diff"),
 	)
 	return b.String()
 }
 
-// FormatApproveMarkdown renders the MR approval status as Markdown.
+// FormatApproveMarkdown renders the approval state after an approve or
+// unapprove as the card of one object.
 func FormatApproveMarkdown(a ApproveOutput) string {
 	var b strings.Builder
-	b.WriteString("## MR Approval Status\n\n")
-	fmt.Fprintf(&b, "- **Approved**: %v\n", a.Approved)
-	fmt.Fprintf(&b, "- **Approvals Required**: %d\n", a.ApprovalsRequired)
-	fmt.Fprintf(&b, "- **Approved By**: %d\n", a.ApprovedBy)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_merge` to merge this MR",
-		"Use `gitlab_mr_get` to see full MR details",
+	c := toolutil.NewCard(&b, "MR Approval Status")
+	c.Bool("Approved", a.Approved)
+	c.Int("Approvals Required", int64(a.ApprovalsRequired))
+	c.Int("Approvals Given", int64(a.ApprovedBy))
+	c.End(
+		toolutil.HintAction(actionMRMerge, "merge this merge request"),
+		toolutil.HintAction(actionMRGet, "see its full details"),
 	)
 	return b.String()
 }
 
-// FormatCommitsMarkdown renders a paginated list of MR commits as a Markdown table.
+// FormatCommitsMarkdown renders the commits of a merge request as a Markdown
+// table.
 func FormatCommitsMarkdown(out CommitsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Commits (%d)\n\n", out.Pagination.TotalItems)
 	if len(out.Commits) == 0 {
-		b.WriteString("No commits found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("commits")
 	}
-	b.WriteString("| Short ID | Title | Author | Date |\n")
-	b.WriteString(toolutil.TblSep4Col)
-	for _, c := range out.Commits {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", toolutil.MdTitleLink(c.ShortID, c.WebURL), toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName), toolutil.FormatTime(c.CommittedDate))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_commit_get` to view a specific commit",
-		"Use `gitlab_mr_changes_get` to review the combined diff",
-	)
-	return b.String()
-}
-
-// FormatPipelinesMarkdown renders a list of MR pipelines as a Markdown table.
-func FormatPipelinesMarkdown(out PipelinesOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Pipelines (%d)\n\n", len(out.Pipelines))
-	if len(out.Pipelines) == 0 {
-		b.WriteString("No pipelines found.\n")
-		return b.String()
+	toolutil.WriteListHeading(&b, "MR Commits", len(out.Commits), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Short ID", "Title", "Author", "Date"))
+	for _, commit := range out.Commits {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(commit.ShortID, commit.WebURL),
+			toolutil.EscapeMdTableCell(commit.Title),
+			toolutil.EscapeMdTableCell(commit.AuthorName),
+			toolutil.FormatTime(commit.CommittedDate),
+		))
 	}
-	b.WriteString("| ID | Status | Source | Ref |\n")
-	b.WriteString(toolutil.TblSep4Col)
-	for _, p := range out.Pipelines {
-		//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
-		fmt.Fprintf(&b, "| %s | %s %s | %s | %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref))
-	}
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_pipeline_get` to view pipeline details",
-		"Use `gitlab_job_list` to see job statuses",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionCommitGet, "view one of these commits"),
+		toolutil.HintAction(hintActionChangesGet, "review the combined diff"),
 	)
 	return b.String()
 }
 
-// FormatRebaseMarkdown renders a rebase result as a short Markdown message.
+// FormatPipelinesMarkdown renders the pipelines of a merge request as a
+// Markdown table.
+func FormatPipelinesMarkdown(out PipelinesOutput) string {
+	if len(out.Pipelines) == 0 {
+		return toolutil.EmptyMessage("pipelines")
+	}
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "MR Pipelines", len(out.Pipelines), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Status", "Source", "Ref"))
+	for _, p := range out.Pipelines {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL),
+			pipelineStatusCell(p.Status),
+			toolutil.EscapeMdTableCell(p.Source),
+			toolutil.EscapeMdTableCell(p.Ref),
+		))
+	}
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, true,
+		toolutil.HintAction(hintActionPipelineGet, "view one pipeline's details"),
+		toolutil.HintAction(hintActionJobList, "see its job statuses"),
+	)
+	return b.String()
+}
+
+// pipelineStatusCell renders a pipeline status with its glyph, and nothing when
+// GitLab sent no status.
+func pipelineStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// FormatRebaseMarkdown renders the outcome of a rebase.
 func FormatRebaseMarkdown(r RebaseOutput) string {
 	var b strings.Builder
+	heading := toolutil.EmojiSuccess + " Rebase completed"
+	note := "The rebase has finished successfully."
 	if r.RebaseInProgress {
-		b.WriteString("## " + toolutil.EmojiRefresh + " Rebase in progress\n\nThe rebase has been initiated and is currently running.\n")
-	} else {
-		b.WriteString("## " + toolutil.EmojiSuccess + " Rebase completed\n\nThe rebase has finished successfully.\n")
+		heading = toolutil.EmojiRefresh + " Rebase in progress"
+		note = "The rebase has been initiated and is currently running."
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_mr_get to check rebase status",
-		"Use action 'merge' once the rebase is complete",
+	c := toolutil.NewCard(&b, heading)
+	c.Bool("Rebase in progress", r.RebaseInProgress)
+	c.Note(note)
+	c.End(
+		toolutil.HintAction(actionMRGet, "check whether the rebase has finished"),
+		toolutil.HintAction(actionMRMerge, "merge once it has"),
 	)
 	return b.String()
 }
 
-// FormatParticipantsMarkdown renders MR participants as a Markdown table.
+// FormatParticipantsMarkdown renders the participants of a merge request as a
+// Markdown table.
 func FormatParticipantsMarkdown(out ParticipantsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Participants (%d)\n\n", len(out.Participants))
 	if len(out.Participants) == 0 {
-		b.WriteString("No participants found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("participants")
 	}
-	b.WriteString("| ID | Username | Name | State |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "MR Participants", len(out.Participants), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Username", "Name", "State"))
 	for _, p := range out.Participants {
-		//gitlab:allow-unescaped p.State: a user account state, one of GitLab's fixed set (active, blocked, deactivated, banned).
-		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n",
-			p.ID, toolutil.MdTitleLink("@"+p.Username, p.WebURL), toolutil.EscapeMdTableCell(p.Name), p.State)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(p.ID, 10),
+			toolutil.MdUserLink(p.Username, p.WebURL),
+			toolutil.EscapeMdTableCell(p.Name),
+			toolutil.EscapeMdTableCell(p.State),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_mr_get` to view MR details",
-		"Use `gitlab_mr_note_create` to notify participants",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, true,
+		toolutil.HintAction(actionMRGet, "view the merge request"),
+		toolutil.HintAction(hintActionNoteCreate, "notify these participants"),
 	)
 	return b.String()
 }
 
-// FormatReviewersMarkdown renders MR reviewers as a Markdown table.
+// FormatReviewersMarkdown renders the reviewers of a merge request as a
+// Markdown table.
 func FormatReviewersMarkdown(out ReviewersOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Reviewers (%d)\n\n", len(out.Reviewers))
 	if len(out.Reviewers) == 0 {
-		b.WriteString("No reviewers found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("reviewers")
 	}
-	b.WriteString("| ID | Username | Name | Review State | Assigned At |\n")
-	b.WriteString(toolutil.TblSep5Col)
-	for _, r := range out.Reviewers {
-		//gitlab:allow-unescaped r.Review: a review state, one of GitLab's fixed set (unreviewed, reviewed, requested_changes, approved).
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
-			r.ID, toolutil.MdTitleLink("@"+r.Username, r.WebURL), toolutil.EscapeMdTableCell(r.Name), r.Review, toolutil.FormatTime(r.CreatedAt))
-	}
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_mr_update` to add or change reviewers",
-		"Use `gitlab_mr_approve` to approve the MR",
-	)
-	return b.String()
-}
-
-// FormatIssuesClosedMarkdown renders the issues-closed-on-merge list as a Markdown table.
-func FormatIssuesClosedMarkdown(out IssuesClosedOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Issues Closed on Merge (%d)\n\n", out.Pagination.TotalItems)
-	if len(out.Issues) == 0 {
-		b.WriteString("No issues will be closed on merge.\n")
-		return b.String()
+	toolutil.WriteListHeading(&b, "MR Reviewers", len(out.Reviewers), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Username", "Name", "Review State", "Assigned At"))
+	for _, r := range out.Reviewers {
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.MdUserLink(r.Username, r.WebURL),
+			toolutil.EscapeMdTableCell(r.Name),
+			toolutil.EscapeMdTableCell(r.Review),
+			toolutil.FormatTime(r.CreatedAt),
+		))
 	}
-	b.WriteString("| IID | Title | State | Author | Labels |\n")
-	b.WriteString(toolutil.TblSep5Col)
-	for _, issue := range out.Issues {
-		//gitlab:allow-unescaped issue.State: an issue state, one of GitLab's fixed set (opened, closed).
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", issue.IID), issue.WebURL), toolutil.EscapeMdTableCell(issue.Title), issue.State, toolutil.EscapeMdTableCell(issues.AuthorName(issue)), toolutil.EscapeMdTableCell(strings.Join(issue.Labels, ", ")))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_issue_get` to view details of an issue",
-		"Use `gitlab_mr_merge` to merge and close these issues",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, true,
+		toolutil.HintAction(actionMRUpdate, "add or change reviewers"),
+		toolutil.HintAction(actionMRApprove, "approve the merge request"),
 	)
 	return b.String()
 }
 
-// FormatCreatePipelineMarkdown renders a single pipeline (from create-pipeline) as Markdown.
+// FormatIssuesClosedMarkdown renders the issues a merge would close as a
+// Markdown table.
+func FormatIssuesClosedMarkdown(out IssuesClosedOutput) string {
+	if len(out.Issues) == 0 {
+		return toolutil.EmptyMessage("issues that would be closed on merge")
+	}
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Issues Closed on Merge", len(out.Issues), out.Pagination)
+	writeIssueRows(&b, out.Issues)
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionIssueGet, "view one of these issues"),
+		toolutil.HintAction(actionMRMerge, "merge and close them"),
+	)
+	return b.String()
+}
+
+// FormatRelatedIssuesMarkdown renders the issues a merge request references as
+// a Markdown table.
+func FormatRelatedIssuesMarkdown(out RelatedIssuesOutput) string {
+	if len(out.Issues) == 0 {
+		return toolutil.EmptyMessage("related issues")
+	}
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Related Issues", len(out.Issues), out.Pagination)
+	writeIssueRows(&b, out.Issues)
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionIssueGet, "view one issue's details"),
+		toolutil.HintAction(hintActionMRRelatedIssues, "list them again after the merge request changes"),
+	)
+	return b.String()
+}
+
+// writeIssueRows writes the issue table the two issue listings share: the same
+// columns, the same escaping and the same state glyph, so the two cannot drift.
+func writeIssueRows(b *strings.Builder, list []issues.BasicOutput) {
+	b.WriteString(toolutil.MarkdownTableHeader("IID", "Title", "State", "Author", "Labels"))
+	for _, issue := range list {
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", issue.IID), issue.WebURL),
+			toolutil.EscapeMdTableCell(issue.Title),
+			issueStateCell(issue.State),
+			toolutil.MdUserHandle(issues.AuthorName(issue)),
+			toolutil.EscapeMdTableCell(strings.Join(issue.Labels, ", ")),
+		))
+	}
+}
+
+// issueStateCell renders an issue state with its emoji, and nothing when GitLab
+// sent no state.
+func issueStateCell(state string) string {
+	if strings.TrimSpace(state) == "" {
+		return ""
+	}
+	return toolutil.IssueStateEmoji(state) + " " + toolutil.EscapeMdTableCell(state)
+}
+
+// FormatCreatePipelineMarkdown renders the pipeline a merge request just
+// created as the card of one object.
 func FormatCreatePipelineMarkdown(p pipelines.Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## %s Pipeline #%d Created\n\n", toolutil.PipelineStatusEmoji(p.Status), p.ID)
-	//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
-	fmt.Fprintf(&b, "- **Status**: %s %s\n", toolutil.PipelineStatusEmoji(p.Status), p.Status)
-	if p.Source != "" {
-		//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
-		fmt.Fprintf(&b, "- **Source**: %s\n", p.Source)
-	}
-	if p.Ref != "" {
-		fmt.Fprintf(&b, "- **Ref**: %s\n", toolutil.EscapeMdTableCell(p.Ref))
-	}
-	if p.SHA != "" {
-		//gitlab:allow-unescaped p.SHA: a commit SHA, hexadecimal digits only.
-		fmt.Fprintf(&b, "- **SHA**: %s\n", p.SHA)
-	}
-	if p.WebURL != "" {
-		toolutil.WriteMdURL(&b, p.WebURL)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_pipeline_get` to check pipeline progress",
-		"Use `gitlab_job_list` to monitor job statuses",
+	c := toolutil.NewCard(&b, fmt.Sprintf("%s Pipeline #%d Created", toolutil.PipelineStatusEmoji(p.Status), p.ID))
+	c.Int("ID", p.ID)
+	c.Markdown("Status", pipelineStatusCell(p.Status))
+	c.Field("Source", p.Source)
+	c.Field("Ref", p.Ref)
+	c.Code("SHA", p.SHA)
+	c.URL(p.WebURL)
+	c.End(
+		toolutil.HintAction(hintActionPipelineGet, "check the pipeline's progress"),
+		toolutil.HintAction(hintActionJobList, "monitor its job statuses"),
 	)
 	return b.String()
 }
 
-// FormatTimeStatsMarkdown renders time tracking statistics as markdown.
+// FormatTimeStatsMarkdown renders a merge request's time tracking as the card
+// of one object: the two durations GitLab renders for a reader and the two
+// counts of seconds they are computed from.
 func FormatTimeStatsMarkdown(ts TimeStatsOutput) string {
 	var b strings.Builder
-	b.WriteString("## Time Tracking Stats\n\n")
-	if ts.HumanTimeEstimate != "" {
-		//gitlab:allow-unescaped ts.HumanTimeEstimate: a duration GitLab renders from a count of seconds, "3d 4h 30m".
-		fmt.Fprintf(&b, "- **Estimate**: %s (%d seconds)\n", ts.HumanTimeEstimate, ts.TimeEstimate)
-	} else {
-		b.WriteString("- **Estimate**: not set\n")
-	}
-	if ts.HumanTotalTimeSpent != "" {
-		//gitlab:allow-unescaped ts.HumanTotalTimeSpent: a duration GitLab renders from a count of seconds, "3d 4h 30m".
-		fmt.Fprintf(&b, "- **Spent**: %s (%d seconds)\n", ts.HumanTotalTimeSpent, ts.TotalTimeSpent)
-	} else {
-		b.WriteString("- **Spent**: none\n")
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_update` to add time tracking notes",
+	c := toolutil.NewCard(&b, "Time Tracking Stats")
+	c.FieldOr("Estimate", ts.HumanTimeEstimate, "not set")
+	c.FieldOr("Spent", ts.HumanTotalTimeSpent, "none")
+	c.Int("Estimate (seconds)", ts.TimeEstimate)
+	c.Int("Spent (seconds)", ts.TotalTimeSpent)
+	c.End(
+		toolutil.HintAction(actionMRTimeEstimateSet, "set the estimate"),
+		toolutil.HintAction(actionMRSpentTimeAdd, "log time spent"),
 	)
 	return b.String()
 }
 
-// FormatRelatedIssuesMarkdown renders related issues as markdown.
-func FormatRelatedIssuesMarkdown(out RelatedIssuesOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Related Issues (%d)\n\n", len(out.Issues))
-	if len(out.Issues) == 0 {
-		b.WriteString("No related issues found.\n")
-		return b.String()
-	}
-	b.WriteString("| IID | Title | State | Author | Labels |\n")
-	b.WriteString(toolutil.TblSep5Col)
-	for _, iss := range out.Issues {
-		//gitlab:allow-unescaped iss.State: an issue state, one of GitLab's fixed set (opened, closed).
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", iss.IID), iss.WebURL),
-			toolutil.EscapeMdTableCell(iss.Title),
-			iss.State,
-			toolutil.EscapeMdTableCell(issues.AuthorName(iss)),
-			toolutil.EscapeMdTableCell(strings.Join(iss.Labels, ", ")))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_issue_get` to view issue details",
-		"Use `gitlab_issue_note_create` to comment on an issue",
-	)
-	return b.String()
-}
-
-// FormatCreateTodoMarkdown renders a created to-do item as markdown.
+// FormatCreateTodoMarkdown renders the to-do item a merge request just created
+// as the card of one object.
 func FormatCreateTodoMarkdown(t CreateTodoOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Todo Created (#%d)\n\n", t.ID)
-	//gitlab:allow-unescaped t.ActionName: a to-do action, a gl.TodoAction GitLab picks from a fixed set.
-	fmt.Fprintf(&b, "- **Action**: %s\n", t.ActionName)
-	//gitlab:allow-unescaped t.TargetType: a to-do target type, a gl.TodoTargetType GitLab picks from a fixed set.
-	fmt.Fprintf(&b, "- **Type**: %s\n", t.TargetType)
-	if t.TargetTitle != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdTarget, toolutil.EscapeMdTableCell(t.TargetTitle))
-	}
-	if t.TargetURL != "" {
-		toolutil.WriteMdURL(&b, t.TargetURL)
-	}
-	//gitlab:allow-unescaped t.State: a to-do state GitLab picks from a fixed set (pending, done).
-	fmt.Fprintf(&b, toolutil.FmtMdState, t.State)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_get` to view the MR",
-		"Use `gitlab_todo_mark_done` to mark completed",
+	c := toolutil.NewCard(&b, fmt.Sprintf("Todo #%d", t.ID))
+	c.Int("ID", t.ID)
+	c.Field("Action", t.ActionName)
+	c.Field("Target Type", t.TargetType)
+	c.Field("Target", t.TargetTitle)
+	c.Field("Project", t.ProjectName)
+	c.Field("State", t.State)
+	c.Time("Created", t.CreatedAt)
+	c.URL(t.TargetURL)
+	c.End(
+		toolutil.HintAction(actionMRGet, "view the merge request this is about"),
+		toolutil.HintAction(hintActionTodoMarkDone, "mark this todo as completed"),
 	)
 	return b.String()
 }
 
-// FormatDependencyMarkdown renders a single merge request dependency as markdown.
+// FormatDependencyMarkdown renders one merge request dependency as the card of
+// one object, with the merge requests at both ends as nested objects.
 func FormatDependencyMarkdown(d DependencyOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Dependency (#%d)\n\n", d.ID)
-	if bmr := d.BlockingMergeRequest; bmr != nil {
-		fmt.Fprintf(&b, "- **Blocking MR**: !%d (ID: %d)\n", bmr.IID, bmr.ID)
-		fmt.Fprintf(&b, toolutil.FmtMdTitle, toolutil.EscapeMdTableCell(bmr.Title))
-		//gitlab:allow-unescaped bmr.State: a merge request state, one of GitLab's fixed set (opened, closed, locked, merged).
-		fmt.Fprintf(&b, toolutil.FmtMdState, bmr.State)
-		fmt.Fprintf(&b, "- **Source**: %s -> **Target**: %s\n",
-			toolutil.EscapeMdTableCell(bmr.SourceBranch), toolutil.EscapeMdTableCell(bmr.TargetBranch))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_get` to view the blocking MR",
+	c := toolutil.NewCard(&b, fmt.Sprintf("MR Dependency #%d", d.ID))
+	c.Int("ID", d.ID)
+	c.Count("Project ID", d.ProjectID)
+	writeBlockingMR(c, "Blocking MR", d.BlockingMergeRequest)
+	writeBlockingMR(c, "Blocked MR", d.BlockedMergeRequest)
+	c.End(
+		toolutil.HintAction(actionMRGet, "view either merge request in full"),
+		toolutil.HintAction(hintActionMRDependencies, "list every dependency of this merge request"),
 	)
 	return b.String()
 }
 
-// FormatDependenciesMarkdown renders a list of merge request dependencies as markdown.
+// writeBlockingMR writes one end of a dependency as a nested object under its
+// label, or nothing when GitLab did not send it.
+func writeBlockingMR(c *toolutil.Card, label string, mr *BlockingMergeRequestOutput) {
+	if mr == nil {
+		return
+	}
+	sub := c.Sub(label)
+	sub.Markdown("Reference", toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL))
+	sub.Int("ID", mr.ID)
+	sub.Field("Title", mr.Title)
+	sub.Markdown("State", mrStateCell(mr.State))
+	sub.Field("Source", mr.SourceBranch)
+	sub.Field("Target", mr.TargetBranch)
+}
+
+// FormatDependenciesMarkdown renders the dependencies of a merge request as a
+// Markdown table.
 func FormatDependenciesMarkdown(out DependenciesOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Dependencies (%d)\n\n", len(out.Dependencies))
 	if len(out.Dependencies) == 0 {
-		b.WriteString("No dependencies found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("dependencies")
 	}
-	b.WriteString("| ID | Blocking MR | Title | State |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "MR Dependencies", len(out.Dependencies), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Blocking MR", "Title", "State"))
 	for _, d := range out.Dependencies {
-		var iid int64
-		var title, state string
+		reference, title, state := "", "", ""
 		if bmr := d.BlockingMergeRequest; bmr != nil {
-			iid, title, state = bmr.IID, bmr.Title, bmr.State
+			reference = toolutil.MdTitleLink(fmt.Sprintf("!%d", bmr.IID), bmr.WebURL)
+			title, state = toolutil.EscapeMdTableCell(bmr.Title), mrStateCell(bmr.State)
 		}
-		//gitlab:allow-unescaped state: the blocking merge request's state, read out of bmr.State a few lines above.
-		fmt.Fprintf(&b, "| %d | !%d | %s | %s |\n",
-			d.ID,
-			iid,
-			toolutil.EscapeMdTableCell(title),
-			state)
+		b.WriteString(toolutil.MarkdownTableRow(strconv.FormatInt(d.ID, 10), reference, title, state))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_mr_get` to view a blocking MR",
-		"Use `gitlab_mr_merge` to resolve blocking dependencies",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, true,
+		toolutil.HintAction(actionMRGet, "view a blocking merge request"),
+		toolutil.HintAction(actionMRMerge, "merge a blocker to clear the dependency"),
 	)
 	return b.String()
 }

--- a/internal/tools/mergerequests/merge_requests_test.go
+++ b/internal/tools/mergerequests/merge_requests_test.go
@@ -760,17 +760,24 @@ func TestMRGet_SuccessPipelineFields(t *testing.T) {
 	}
 }
 
-// TestPrefixAt verifies username @mention formatting.
-func TestPrefixAt(t *testing.T) {
-	got := prefixAt([]string{"alice", "bob"})
-	want := []string{"@alice", "@bob"}
-	if len(got) != len(want) {
-		t.Fatalf("prefixAt length = %d, want %d", len(got), len(want))
+// TestHandleList verifies username @mention formatting: every name becomes an
+// escaped handle, a blank one is dropped rather than rendered as a bare "@",
+// and an empty list renders as nothing at all.
+func TestHandleList(t *testing.T) {
+	cases := []struct {
+		name  string
+		names []string
+		want  string
+	}{
+		{name: "two names", names: []string{"alice", "bob"}, want: "@alice, @bob"},
+		{name: "blank dropped", names: []string{"alice", "", "bob"}, want: "@alice, @bob"},
+		{name: "none", names: nil, want: ""},
+		{name: "escaped", names: []string{"a|b"}, want: "@a&#124;b"},
 	}
-	for i, w := range want {
-		t.Run(w, func(t *testing.T) {
-			if got[i] != w {
-				t.Errorf("prefixAt[%d] = %q, want %q", i, got[i], w)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := handleList(tc.names); got != tc.want {
+				t.Errorf("handleList(%v) = %q, want %q", tc.names, got, tc.want)
 			}
 		})
 	}
@@ -1876,9 +1883,28 @@ var testLabels = []string{testLabelBug, "critical"}
 // Format*Markdown tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatMarkdown_Populated verifies FormatMarkdown when populated.
+// The guidance sections the merge request formatters close with, written once
+// so the whole-output expectations below name them rather than repeating them.
+const (
+	cardHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.changes_get' to see the diff of this merge request\n" +
+		"- Use action 'mr_review.discussion_list' to see its review threads\n" +
+		"- Use action 'merge_request.pipelines' to check its CI status\n" +
+		"- Use action 'merge_request.approve' to approve it\n" +
+		"- Use action 'merge_request.merge' to merge it\n"
+	listHints = "\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'merge_request.get' to see one merge request in full\n" +
+		"- Use action 'merge_request.create' to open a new merge request\n" +
+		"- Use action 'mr_review.changes_get' to review a merge request's diff\n"
+	preserveLinksHint = "- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n"
+)
+
+// TestFormatMarkdown_Populated verifies the whole rendering of a merge request
+// card, including the four conditions it never used to show: a locked
+// discussion refuses every comment, an auto-merge is already scheduled, a
+// rebase is running, and a merge error is why the last attempt failed.
 func TestFormatMarkdown_Populated(t *testing.T) {
-	md := FormatMarkdown(Output{
+	got := FormatMarkdown(Output{
 		IID: 1, Title: "feat: new login", State: testStateOpened,
 		SourceBranch: testFeatureBranch, TargetBranch: testBranchMain,
 		DetailedMergeStatus: "can_be_merged", Draft: true, HasConflicts: true,
@@ -1887,312 +1913,435 @@ func TestFormatMarkdown_Populated(t *testing.T) {
 		Reviewers: []*toolutil.BasicUserOutput{{Username: "dave"}}, Labels: []string{testLabelBug, "enhancement"},
 		CreatedAt: testCreatedAt, UserNotesCount: 5,
 		Description: "Full description here", WebURL: testMRWebURL,
+		References:                &toolutil.ReferencesOutput{Full: "group/proj!1"},
+		Milestone:                 &toolutil.MRMilestoneOutput{Title: testMilestoneV1},
+		Pipeline:                  &toolutil.PipelineInfoOutput{ID: 9, Status: "running", WebURL: "https://gitlab.example.com/p/9"},
+		ChangesCount:              "3",
+		DiscussionLocked:          true,
+		MergeWhenPipelineSucceeds: true,
+		RebaseInProgress:          true,
+		MergeError:                "Merge conflict",
 	})
-	for _, want := range []string{
-		"feat: new login", testStateOpened, testFeatureBranch, testBranchMain,
-		"Draft", "Has Conflicts", "@alice", "@bob", "@carol", "@dave",
-		testLabelBug, "enhancement", "1 Jan 2026", "Comments", "5",
-		"Full description here", testMRWebURL,
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatMarkdown missing %q", want)
-			}
-		})
+	want := "## 🟢 📝 MR !1: feat: new login\n\n" +
+		"- **Project**: group/proj\n" +
+		"- **State**: 🟢 opened\n" +
+		"- 📝 **Draft merge request**\n" +
+		"- **Source**: feature/login\n" +
+		"- **Target**: main\n" +
+		"- **Merge Status**: can_be_merged\n" +
+		"- ⚠️ **Has conflicts**\n" +
+		"- **Author**: @alice\n" +
+		"- **Assignees**: @bob, @carol\n" +
+		"- **Reviewers**: @dave\n" +
+		"- **Milestone**: v1.0\n" +
+		"- **Labels**: bug, enhancement\n" +
+		"- **Pipeline**: [#9](https://gitlab.example.com/p/9) 🔵 running\n" +
+		"- **Changes**: 3 files\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Comments**: 5\n" +
+		"- ⚠️ **Discussion locked**\n" +
+		"- 🔄 **Auto-merge set (merges when the pipeline succeeds)**\n" +
+		"- 🔄 **Rebase in progress**\n" +
+		"- **Merge Error**: Merge conflict\n" +
+		"- **URL**: [" + testMRWebURL + "](" + testMRWebURL + ")\n" +
+		"- **Description**: Full description here\n" + cardHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatMarkdown_Empty verifies FormatMarkdown when empty.
+// TestFormatMarkdown_Empty verifies that a zero merge request shows no label
+// with nothing after it: the heading, and the guidance, and nothing else.
 func TestFormatMarkdown_Empty(t *testing.T) {
-	md := FormatMarkdown(Output{})
-	if md == "" {
-		t.Error("FormatMarkdown returned empty string for zero Output")
+	want := "## ❓ MR !0\n" + cardHints
+	if got := FormatMarkdown(Output{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Populated verifies FormatListMarkdown when populated.
+// TestFormatMarkdown_Merged verifies that a merged merge request names who
+// merged it and when, and a closed one who closed it, which is the one pair of
+// rows the state decides.
+func TestFormatMarkdown_Merged(t *testing.T) {
+	got := FormatMarkdown(Output{
+		IID: 2, Title: "done", State: testStateMerged,
+		MergeUser: &toolutil.BasicUserOutput{Username: testAuthorBob}, MergedAt: "2026-02-03T04:05:06Z",
+	})
+	want := "## 🟣 MR !2: done\n\n" +
+		"- **State**: 🟣 merged\n" +
+		"- **Merged By**: @bob\n" +
+		"- **Merged**: 3 Feb 2026 04:05 UTC\n" + cardHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Populated verifies the whole rendering of a merge
+// request listing: the IID carries the link, the draft marker rides on the
+// title, and the state carries its glyph.
 func TestFormatListMarkdown_Populated(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		MergeRequests: []Output{
 			{IID: 1, Title: "MR1", State: testStateOpened, Draft: true, Author: &toolutil.BasicUserOutput{Username: testAuthorAlice}, SourceBranch: "a", TargetBranch: "b"},
 			{IID: 2, Title: "MR2", State: testStateMerged, Author: &toolutil.BasicUserOutput{Username: testAuthorBob}, SourceBranch: "c", TargetBranch: "d"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
-	for _, want := range []string{"MR1", "MR2", testAuthorAlice, testAuthorBob, "📝"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatListMarkdown missing %q", want)
-			}
-		})
+	want := "## Merge Requests (2)\n\n" +
+		"| IID | Title | State | Author | Project | Source -> Target |\n" +
+		"| --- | --- | --- | --- | --- | --- |\n" +
+		"| !1 | MR1 📝 | 🟢 opened | @alice |  | a -> b |\n" +
+		"| !2 | MR2 | 🟣 merged | @bob |  | c -> d |\n" +
+		"\n2 items total\n" + listHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty verifies that a project with no merge request
+// renders the one-sentence empty message and no heading counting zero.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No merge requests found") {
-		t.Error("FormatListMarkdown should say no MRs found for empty list")
+	want := "No merge requests found.\n"
+	if got := FormatListMarkdown(ListOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatApproveMarkdown_Populated verifies FormatApproveMarkdown when populated.
+// TestFormatApproveMarkdown_Populated verifies the whole rendering of the
+// approval status: the flag is a glyph rather than the bare "true" the %v this
+// replaced printed.
 func TestFormatApproveMarkdown_Populated(t *testing.T) {
-	md := FormatApproveMarkdown(ApproveOutput{Approved: true, ApprovalsRequired: 2, ApprovedBy: 1})
-	for _, want := range []string{"Approved", "true", "2", "1"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatApproveMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Approval Status\n\n" +
+		"- **Approved**: ✅\n" +
+		"- **Approvals Required**: 2\n" +
+		"- **Approvals Given**: 1\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.merge' to merge this merge request\n" +
+		"- Use action 'merge_request.get' to see its full details\n"
+	if got := FormatApproveMarkdown(ApproveOutput{Approved: true, ApprovalsRequired: 2, ApprovedBy: 1}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatApproveMarkdown_Empty verifies FormatApproveMarkdown when empty.
+// TestFormatApproveMarkdown_Empty verifies that an unapproved merge request
+// renders every count, since zero is an answer here rather than an absence.
 func TestFormatApproveMarkdown_Empty(t *testing.T) {
-	md := FormatApproveMarkdown(ApproveOutput{})
-	if md == "" {
-		t.Error("FormatApproveMarkdown returned empty string for zero value")
+	want := "## MR Approval Status\n\n" +
+		"- **Approved**: ❌\n" +
+		"- **Approvals Required**: 0\n" +
+		"- **Approvals Given**: 0\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.merge' to merge this merge request\n" +
+		"- Use action 'merge_request.get' to see its full details\n"
+	if got := FormatApproveMarkdown(ApproveOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCommitsMarkdown_Populated verifies FormatCommitsMarkdown when populated.
+// TestFormatCommitsMarkdown_Populated verifies the whole rendering of the
+// commits of a merge request.
 func TestFormatCommitsMarkdown_Populated(t *testing.T) {
-	md := FormatCommitsMarkdown(CommitsOutput{
+	got := FormatCommitsMarkdown(CommitsOutput{
 		Commits: []commits.Output{
-			{ShortID: "abc1234", Title: "feat: add login", AuthorName: "Alice", CommittedDate: testDate20260101},
+			{ShortID: "abc1234", Title: "feat: add login", AuthorName: "Alice", CommittedDate: testDate20260101, WebURL: "https://gitlab.example.com/c/abc1234"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	for _, want := range []string{"abc1234", "feat: add login", "Alice", "1 Jan 2026"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatCommitsMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Commits (1)\n\n" +
+		"| Short ID | Title | Author | Date |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| [abc1234](https://gitlab.example.com/c/abc1234) | feat: add login | Alice | 1 Jan 2026 |\n" +
+		"\n1 items total\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'commit.get' to view one of these commits\n" +
+		"- Use action 'mr_review.changes_get' to review the combined diff\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCommitsMarkdown_Empty verifies FormatCommitsMarkdown when empty.
+// TestFormatCommitsMarkdown_Empty verifies the empty-commits message.
 func TestFormatCommitsMarkdown_Empty(t *testing.T) {
-	md := FormatCommitsMarkdown(CommitsOutput{})
-	if !strings.Contains(md, "No commits found") {
-		t.Error("FormatCommitsMarkdown should say no commits for empty output")
+	want := "No commits found.\n"
+	if got := FormatCommitsMarkdown(CommitsOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatPipelinesMarkdown_Populated verifies FormatPipelinesMarkdown when populated.
+// TestFormatPipelinesMarkdown_Populated verifies the whole rendering of a merge
+// request's pipelines, each status carrying its glyph.
 func TestFormatPipelinesMarkdown_Populated(t *testing.T) {
-	md := FormatPipelinesMarkdown(PipelinesOutput{
-		Pipelines: []pipelines.Output{
-			{ID: 10, Status: "success", Source: "push", Ref: testBranchMain},
-		},
+	got := FormatPipelinesMarkdown(PipelinesOutput{
+		Pipelines: []pipelines.Output{{ID: 10, Status: "success", Source: "push", Ref: testBranchMain}},
 	})
-	for _, want := range []string{"10", "success", "push", testBranchMain} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatPipelinesMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Pipelines (1)\n\n" +
+		"| ID | Status | Source | Ref |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| #10 | ✅ success | push | main |\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'pipeline.get' to view one pipeline's details\n" +
+		"- Use action 'job.list' to see its job statuses\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatPipelinesMarkdown_Empty verifies FormatPipelinesMarkdown when empty.
+// TestFormatPipelinesMarkdown_Empty verifies the empty-pipelines message.
 func TestFormatPipelinesMarkdown_Empty(t *testing.T) {
-	md := FormatPipelinesMarkdown(PipelinesOutput{})
-	if !strings.Contains(md, "No pipelines found") {
-		t.Error("FormatPipelinesMarkdown should say no pipelines for empty output")
+	want := "No pipelines found.\n"
+	if got := FormatPipelinesMarkdown(PipelinesOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRebaseMarkdown_InProgress verifies FormatRebaseMarkdown when in progress.
+// rebaseHints is the guidance section a rebase result closes with.
+const rebaseHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.get' to check whether the rebase has finished\n" +
+	"- Use action 'merge_request.merge' to merge once it has\n"
+
+// TestFormatRebaseMarkdown_InProgress verifies the whole rendering of a rebase
+// that is still running.
 func TestFormatRebaseMarkdown_InProgress(t *testing.T) {
-	md := FormatRebaseMarkdown(RebaseOutput{RebaseInProgress: true})
-	if !strings.Contains(md, "in progress") {
-		t.Error("FormatRebaseMarkdown should indicate rebase in progress")
+	want := "## 🔄 Rebase in progress\n\n" +
+		"- **Rebase in progress**: ✅\n\n" +
+		"The rebase has been initiated and is currently running.\n" + rebaseHints
+	if got := FormatRebaseMarkdown(RebaseOutput{RebaseInProgress: true}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRebaseMarkdown_Completed verifies FormatRebaseMarkdown when completed.
+// TestFormatRebaseMarkdown_Completed verifies the whole rendering of a rebase
+// that has finished.
 func TestFormatRebaseMarkdown_Completed(t *testing.T) {
-	md := FormatRebaseMarkdown(RebaseOutput{RebaseInProgress: false})
-	if !strings.Contains(md, "completed") {
-		t.Error("FormatRebaseMarkdown should indicate rebase completed")
+	want := "## ✅ Rebase completed\n\n" +
+		"- **Rebase in progress**: ❌\n\n" +
+		"The rebase has finished successfully.\n" + rebaseHints
+	if got := FormatRebaseMarkdown(RebaseOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatParticipantsMarkdown_Populated verifies FormatParticipantsMarkdown when populated.
+// TestFormatParticipantsMarkdown_Populated verifies the whole rendering of the
+// participants of a merge request, each username an "@handle".
 func TestFormatParticipantsMarkdown_Populated(t *testing.T) {
-	md := FormatParticipantsMarkdown(ParticipantsOutput{
+	got := FormatParticipantsMarkdown(ParticipantsOutput{
 		Participants: []ParticipantOutput{
 			{ID: 1, Username: testAuthorAlice, Name: "Alice A", State: testStateActive},
 			{ID: 2, Username: testAuthorBob, Name: "Bob B", State: testStateActive},
 		},
 	})
-	for _, want := range []string{testAuthorAlice, testAuthorBob, "Alice A", "Bob B", testStateActive, "Participants (2)"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatParticipantsMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Participants (2)\n\n" +
+		"| ID | Username | Name | State |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | @alice | Alice A | active |\n" +
+		"| 2 | @bob | Bob B | active |\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'merge_request.get' to view the merge request\n" +
+		"- Use action 'mr_review.note_create' to notify these participants\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatParticipantsMarkdown_Empty verifies FormatParticipantsMarkdown when empty.
+// TestFormatParticipantsMarkdown_Empty verifies the empty-participants message.
 func TestFormatParticipantsMarkdown_Empty(t *testing.T) {
-	md := FormatParticipantsMarkdown(ParticipantsOutput{})
-	if !strings.Contains(md, "No participants found") {
-		t.Error("FormatParticipantsMarkdown should say no participants for empty output")
+	want := "No participants found.\n"
+	if got := FormatParticipantsMarkdown(ParticipantsOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatReviewersMarkdown_Populated verifies FormatReviewersMarkdown when populated.
+// TestFormatReviewersMarkdown_Populated verifies the whole rendering of the
+// reviewers of a merge request.
 func TestFormatReviewersMarkdown_Populated(t *testing.T) {
-	md := FormatReviewersMarkdown(ReviewersOutput{
+	got := FormatReviewersMarkdown(ReviewersOutput{
 		Reviewers: []ReviewerOutput{
 			{ID: 10, Username: testAuthorCarol, Name: "Carol C", State: testStateActive, Review: "reviewed", CreatedAt: "2026-03-01T10:00:00Z"},
 		},
 	})
-	for _, want := range []string{testAuthorCarol, "Carol C", "reviewed", "1 Mar 2026", "Reviewers (1)"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatReviewersMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Reviewers (1)\n\n" +
+		"| ID | Username | Name | Review State | Assigned At |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 10 | @carol | Carol C | reviewed | 1 Mar 2026 10:00 UTC |\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'merge_request.update' to add or change reviewers\n" +
+		"- Use action 'merge_request.approve' to approve the merge request\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatReviewersMarkdown_Empty verifies FormatReviewersMarkdown when empty.
+// TestFormatReviewersMarkdown_Empty verifies the empty-reviewers message.
 func TestFormatReviewersMarkdown_Empty(t *testing.T) {
-	md := FormatReviewersMarkdown(ReviewersOutput{})
-	if !strings.Contains(md, "No reviewers found") {
-		t.Error("FormatReviewersMarkdown should say no reviewers for empty output")
+	want := "No reviewers found.\n"
+	if got := FormatReviewersMarkdown(ReviewersOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatIssuesClosedMarkdown_Populated verifies FormatIssuesClosedMarkdown when populated.
+// TestFormatIssuesClosedMarkdown_Populated verifies the whole rendering of the
+// issues a merge would close, through the issue table both issue listings share.
 func TestFormatIssuesClosedMarkdown_Populated(t *testing.T) {
-	md := FormatIssuesClosedMarkdown(IssuesClosedOutput{
+	got := FormatIssuesClosedMarkdown(IssuesClosedOutput{
 		Issues: []issues.BasicOutput{
 			{IID: 5, Title: "Bug fix", State: testStateOpened, Author: &toolutil.IssueUserOutput{Username: testAuthorAlice}, Labels: []string{testLabelBug}},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	for _, want := range []string{"Bug fix", testStateOpened, testAuthorAlice, testLabelBug, "#5"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatIssuesClosedMarkdown missing %q", want)
-			}
-		})
+	want := "## Issues Closed on Merge (1)\n\n" +
+		"| IID | Title | State | Author | Labels |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| #5 | Bug fix | 🟢 opened | @alice | bug |\n" +
+		"\n1 items total\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'issue.get' to view one of these issues\n" +
+		"- Use action 'merge_request.merge' to merge and close them\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatIssuesClosedMarkdown_Empty verifies FormatIssuesClosedMarkdown when empty.
+// TestFormatIssuesClosedMarkdown_Empty verifies the empty message.
 func TestFormatIssuesClosedMarkdown_Empty(t *testing.T) {
-	md := FormatIssuesClosedMarkdown(IssuesClosedOutput{})
-	if !strings.Contains(md, "No issues will be closed") {
-		t.Error("FormatIssuesClosedMarkdown should say no issues for empty output")
+	want := "No issues that would be closed on merge found.\n"
+	if got := FormatIssuesClosedMarkdown(IssuesClosedOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCreatePipelineMarkdown verifies FormatCreatePipelineMarkdown.
+// createPipelineHints is the guidance section a created pipeline closes with.
+const createPipelineHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'pipeline.get' to check the pipeline's progress\n" +
+	"- Use action 'job.list' to monitor its job statuses\n"
+
+// TestFormatCreatePipelineMarkdown verifies the whole rendering of the pipeline
+// a merge request just created.
 func TestFormatCreatePipelineMarkdown(t *testing.T) {
-	md := FormatCreatePipelineMarkdown(pipelines.Output{
+	got := FormatCreatePipelineMarkdown(pipelines.Output{
 		ID: 500, Status: testStatePending, Source: "merge_request_event", Ref: testFeatureBranch,
 		SHA: testSHAAbc, WebURL: "https://gitlab.example.com/pipelines/500",
 	})
-	for _, want := range []string{"500", testStatePending, "merge_request_event", testFeatureBranch, testSHAAbc, "https://gitlab.example.com/pipelines/500"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatCreatePipelineMarkdown missing %q", want)
-			}
-		})
+	want := "## 🟡 Pipeline #500 Created\n\n" +
+		"- **ID**: 500\n" +
+		"- **Status**: 🟡 pending\n" +
+		"- **Source**: merge_request_event\n" +
+		"- **Ref**: feature/login\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **URL**: [https://gitlab.example.com/pipelines/500](https://gitlab.example.com/pipelines/500)\n" +
+		createPipelineHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCreatePipelineMarkdown_Minimal verifies FormatCreatePipelineMarkdown when minimal.
+// TestFormatCreatePipelineMarkdown_Minimal verifies that a pipeline GitLab sent
+// nothing optional for shows no label with nothing after it.
 func TestFormatCreatePipelineMarkdown_Minimal(t *testing.T) {
-	md := FormatCreatePipelineMarkdown(pipelines.Output{ID: 1, Status: "created"})
-	if md == "" {
-		t.Error("FormatCreatePipelineMarkdown returned empty string")
-	}
-	if !strings.Contains(md, "created") {
-		t.Error("FormatCreatePipelineMarkdown should contain status")
+	want := "## 🆕 Pipeline #1 Created\n\n" +
+		"- **ID**: 1\n" +
+		"- **Status**: 🆕 created\n" + createPipelineHints
+	if got := FormatCreatePipelineMarkdown(pipelines.Output{ID: 1, Status: "created"}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatTimeStatsMarkdown_Populated verifies FormatTimeStatsMarkdown when populated.
+// timeStatsHints is the guidance section the time tracking card closes with.
+const timeStatsHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.time_estimate_set' to set the estimate\n" +
+	"- Use action 'merge_request.spent_time_add' to log time spent\n"
+
+// TestFormatTimeStatsMarkdown_Populated verifies the whole rendering of the
+// time tracking card: the two durations GitLab renders for a reader and the two
+// counts of seconds they are computed from.
 func TestFormatTimeStatsMarkdown_Populated(t *testing.T) {
-	md := FormatTimeStatsMarkdown(TimeStatsOutput{
+	got := FormatTimeStatsMarkdown(TimeStatsOutput{
 		HumanTimeEstimate: "3h", HumanTotalTimeSpent: "1h30m",
 		TimeEstimate: 10800, TotalTimeSpent: 5400,
 	})
-	for _, want := range []string{"3h", "10800", "1h30m", "5400"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatTimeStatsMarkdown missing %q", want)
-			}
-		})
+	want := "## Time Tracking Stats\n\n" +
+		"- **Estimate**: 3h\n" +
+		"- **Spent**: 1h30m\n" +
+		"- **Estimate (seconds)**: 10800\n" +
+		"- **Spent (seconds)**: 5400\n" + timeStatsHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatTimeStatsMarkdown_Empty verifies FormatTimeStatsMarkdown when empty.
+// TestFormatTimeStatsMarkdown_Empty verifies that a merge request nobody has
+// tracked time on says so in words rather than leaving the rows blank.
 func TestFormatTimeStatsMarkdown_Empty(t *testing.T) {
-	md := FormatTimeStatsMarkdown(TimeStatsOutput{})
-	if !strings.Contains(md, "not set") {
-		t.Error("FormatTimeStatsMarkdown should say 'not set' for empty estimate")
-	}
-	if !strings.Contains(md, "none") {
-		t.Error("FormatTimeStatsMarkdown should say 'none' for empty spent")
+	want := "## Time Tracking Stats\n\n" +
+		"- **Estimate**: not set\n" +
+		"- **Spent**: none\n" +
+		"- **Estimate (seconds)**: 0\n" +
+		"- **Spent (seconds)**: 0\n" + timeStatsHints
+	if got := FormatTimeStatsMarkdown(TimeStatsOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRelatedIssuesMarkdown_Populated verifies FormatRelatedIssuesMarkdown when populated.
+// TestFormatRelatedIssuesMarkdown_Populated verifies the whole rendering of the
+// issues a merge request references.
 func TestFormatRelatedIssuesMarkdown_Populated(t *testing.T) {
-	md := FormatRelatedIssuesMarkdown(RelatedIssuesOutput{
+	got := FormatRelatedIssuesMarkdown(RelatedIssuesOutput{
 		Issues: []issues.BasicOutput{
 			{IID: 10, Title: "Related bug", State: testStateOpened, Author: &toolutil.IssueUserOutput{Username: testAuthorAlice}, Labels: []string{testLabelBug, "critical"}},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	})
-	for _, want := range []string{"Related bug", testStateOpened, testAuthorAlice, testLabelBug, "critical", "#10"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatRelatedIssuesMarkdown missing %q", want)
-			}
-		})
+	want := "## Related Issues (1)\n\n" +
+		"| IID | Title | State | Author | Labels |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| #10 | Related bug | 🟢 opened | @alice | bug, critical |\n" +
+		"\n1 items total\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'issue.get' to view one issue's details\n" +
+		"- Use action 'merge_request.related_issues' to list them again after the merge request changes\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRelatedIssuesMarkdown_Empty verifies FormatRelatedIssuesMarkdown when empty.
+// TestFormatRelatedIssuesMarkdown_Empty verifies the empty message.
 func TestFormatRelatedIssuesMarkdown_Empty(t *testing.T) {
-	md := FormatRelatedIssuesMarkdown(RelatedIssuesOutput{})
-	if !strings.Contains(md, "No related issues found") {
-		t.Error("FormatRelatedIssuesMarkdown should say no related issues for empty output")
+	want := "No related issues found.\n"
+	if got := FormatRelatedIssuesMarkdown(RelatedIssuesOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCreateTodoMarkdown_Populated verifies FormatCreateTodoMarkdown when populated.
+// todoHints is the guidance section a created to-do closes with.
+const todoHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.get' to view the merge request this is about\n" +
+	"- Use action 'user.todo_mark_done' to mark this todo as completed\n"
+
+// TestFormatCreateTodoMarkdown_Populated verifies the whole rendering of the
+// to-do a merge request just created.
 func TestFormatCreateTodoMarkdown_Populated(t *testing.T) {
-	md := FormatCreateTodoMarkdown(CreateTodoOutput{
+	got := FormatCreateTodoMarkdown(CreateTodoOutput{
 		ID: 42, ActionName: testActionMarked, TargetType: testTargetTypeMR,
 		TargetTitle: testMRTitle, TargetURL: testMRWebURL,
 		State: testStatePending,
 	})
-	for _, want := range []string{"42", testActionMarked, testTargetTypeMR, testMRTitle, testMRWebURL, testStatePending} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatCreateTodoMarkdown missing %q", want)
-			}
-		})
+	want := "## Todo #42\n\n" +
+		"- **ID**: 42\n" +
+		"- **Action**: marked\n" +
+		"- **Target Type**: MergeRequest\n" +
+		"- **Target**: " + testMRTitle + "\n" +
+		"- **State**: pending\n" +
+		"- **URL**: [" + testMRWebURL + "](" + testMRWebURL + ")\n" + todoHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatCreateTodoMarkdown_Empty verifies FormatCreateTodoMarkdown when empty.
+// TestFormatCreateTodoMarkdown_Empty verifies that a zero to-do shows only the
+// one field whose zero is an answer.
 func TestFormatCreateTodoMarkdown_Empty(t *testing.T) {
-	md := FormatCreateTodoMarkdown(CreateTodoOutput{})
-	if md == "" {
-		t.Error("FormatCreateTodoMarkdown returned empty string for zero value")
+	want := "## Todo #0\n\n- **ID**: 0\n" + todoHints
+	if got := FormatCreateTodoMarkdown(CreateTodoOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -2250,54 +2399,94 @@ func TestFormatCreateTodoMarkdown_ClickableURL(t *testing.T) {
 	}
 }
 
-// TestFormatDependencyMarkdown_Populated verifies FormatDependencyMarkdown when populated.
+// dependencyHints is the guidance section a dependency card closes with.
+const dependencyHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.get' to view either merge request in full\n" +
+	"- Use action 'merge_request.dependencies_list' to list every dependency of this merge request\n"
+
+// TestFormatDependencyMarkdown_Populated verifies the whole rendering of one
+// dependency, with the blocking merge request as a nested object under its
+// label rather than as rows of its own.
 func TestFormatDependencyMarkdown_Populated(t *testing.T) {
-	md := FormatDependencyMarkdown(DependencyOutput{
+	got := FormatDependencyMarkdown(DependencyOutput{
 		ID: 1,
 		BlockingMergeRequest: &BlockingMergeRequestOutput{
 			ID: 100, IID: 10, Title: testBlockerTitle, State: testStateOpened,
 			SourceBranch: testBranchFeatA, TargetBranch: testBranchMain,
+			WebURL: "https://gitlab.example.com/mr/10",
 		},
 	})
-	for _, want := range []string{testBlockerTitle, "!10", testStateOpened, testBranchFeatA, testBranchMain} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatDependencyMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Dependency #1\n\n" +
+		"- **ID**: 1\n" +
+		"- **Blocking MR**:\n" +
+		"  - **Reference**: [!10](https://gitlab.example.com/mr/10)\n" +
+		"  - **ID**: 100\n" +
+		"  - **Title**: " + testBlockerTitle + "\n" +
+		"  - **State**: 🟢 opened\n" +
+		"  - **Source**: " + testBranchFeatA + "\n" +
+		"  - **Target**: main\n" + dependencyHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatDependencyMarkdown_Empty verifies FormatDependencyMarkdown when empty.
+// TestFormatDependencyMarkdown_Empty verifies that a dependency GitLab sent no
+// merge request for opens no empty nested object.
 func TestFormatDependencyMarkdown_Empty(t *testing.T) {
-	md := FormatDependencyMarkdown(DependencyOutput{})
-	if md == "" {
-		t.Error("FormatDependencyMarkdown returned empty string for zero value")
+	want := "## MR Dependency #0\n\n- **ID**: 0\n" + dependencyHints
+	if got := FormatDependencyMarkdown(DependencyOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatDependenciesMarkdown_Populated verifies FormatDependenciesMarkdown when populated.
+// TestFormatDependencyMarkdown_BlockedEnd verifies that the other end of a
+// dependency — the merge request this one blocks, which client-go does not
+// model and the capture reads (ADR-0021) — is rendered when GitLab sends it.
+func TestFormatDependencyMarkdown_BlockedEnd(t *testing.T) {
+	got := FormatDependencyMarkdown(DependencyOutput{
+		ID: 2, ProjectID: 42,
+		BlockedMergeRequest: &BlockingMergeRequestOutput{ID: 7, IID: 3, Title: "Waits on it", State: testStateOpened},
+	})
+	want := "## MR Dependency #2\n\n" +
+		"- **ID**: 2\n" +
+		"- **Project ID**: 42\n" +
+		"- **Blocked MR**:\n" +
+		"  - **Reference**: !3\n" +
+		"  - **ID**: 7\n" +
+		"  - **Title**: Waits on it\n" +
+		"  - **State**: 🟢 opened\n" + dependencyHints
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestFormatDependenciesMarkdown_Populated verifies the whole rendering of the
+// dependency listing, each blocker linked by its reference.
 func TestFormatDependenciesMarkdown_Populated(t *testing.T) {
-	md := FormatDependenciesMarkdown(DependenciesOutput{
+	got := FormatDependenciesMarkdown(DependenciesOutput{
 		Dependencies: []DependencyOutput{
 			{ID: 1, BlockingMergeRequest: &BlockingMergeRequestOutput{IID: 10, Title: testDepTitleA, State: testStateOpened}},
 			{ID: 2, BlockingMergeRequest: &BlockingMergeRequestOutput{IID: 20, Title: "Dep B", State: testStateMerged}},
 		},
 	})
-	for _, want := range []string{testDepTitleA, "Dep B", "!10", "!20", testStateOpened, testStateMerged, "Dependencies (2)"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatDependenciesMarkdown missing %q", want)
-			}
-		})
+	want := "## MR Dependencies (2)\n\n" +
+		"| ID | Blocking MR | Title | State |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | !10 | Dep A | 🟢 opened |\n" +
+		"| 2 | !20 | Dep B | 🟣 merged |\n" +
+		"\n---\n💡 **Next steps:**\n" + preserveLinksHint +
+		"- Use action 'merge_request.get' to view a blocking merge request\n" +
+		"- Use action 'merge_request.merge' to merge a blocker to clear the dependency\n"
+	if got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatDependenciesMarkdown_Empty verifies FormatDependenciesMarkdown when empty.
+// TestFormatDependenciesMarkdown_Empty verifies the empty message.
 func TestFormatDependenciesMarkdown_Empty(t *testing.T) {
-	md := FormatDependenciesMarkdown(DependenciesOutput{})
-	if !strings.Contains(md, "No dependencies found") {
-		t.Error("FormatDependenciesMarkdown should say no dependencies for empty output")
+	want := "No dependencies found.\n"
+	if got := FormatDependenciesMarkdown(DependenciesOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mergetrains/markdown.go
+++ b/internal/tools/mergetrains/markdown.go
@@ -2,9 +2,18 @@ package mergetrains
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionListProject = "merge_train.list_project"
+	actionListBranch  = "merge_train.list_branch"
+	actionGet         = "merge_train.get"
+	actionAdd         = "merge_train.add"
 )
 
 // userName returns the display username for a merge-train user sub-object, or
@@ -16,61 +25,96 @@ func userName(u *toolutil.BasicUserOutput) string {
 	return u.Username
 }
 
-// FormatListMarkdown formats a list of merge train entries.
+// mergeRequestCell renders the car's merge request as its reference linked to
+// the merge request, followed by the title. A car GitLab sent no merge request
+// for renders as nothing rather than as a link to "!0".
+func mergeRequestCell(mr MergeRequestOutput) string {
+	if mr.IID <= 0 && mr.Title == "" {
+		return ""
+	}
+	link := toolutil.MdTitleLink(fmt.Sprintf("!%d", mr.IID), mr.WebURL)
+	if mr.Title == "" {
+		return link
+	}
+	return link + " - " + toolutil.EscapeMdTableCell(mr.Title)
+}
+
+// pipelineCell renders the car's pipeline as its number linked to the pipeline,
+// with the status glyph and the status word GitLab sent. The status is what a
+// reader of a merge train wants first — a car sits in the train until its
+// pipeline finishes — and the card used to print the bare ID.
+func pipelineCell(p *toolutil.PipelineOutput) string {
+	if p == nil || p.ID <= 0 {
+		return ""
+	}
+	cell := toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL)
+	if p.Status != "" {
+		cell += " " + toolutil.PipelineStatusEmoji(p.Status) + " " + toolutil.EscapeMdTableCell(p.Status)
+	}
+	return cell
+}
+
+// durationCell renders a car's queue time in seconds, the unit GitLab counts
+// it in.
+func durationCell(seconds int64) string {
+	return strconv.FormatInt(seconds, 10) + "s"
+}
+
+// FormatListMarkdown renders a page of merge train cars as a Markdown table: a
+// collection of objects that share columns.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Trains) == 0 {
-		return "No merge trains found.\n"
+		return toolutil.EmptyMessage("merge trains")
 	}
 	var sb strings.Builder
-	sb.WriteString("## Merge Trains\n\n")
-	toolutil.WriteHints(&sb, toolutil.HintPreserveLinks)
-	sb.WriteString("| ID | MR | Title | Branch | Status | User | Duration |\n")
-	sb.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&sb, "Merge Trains", len(out.Trains), out.Pagination)
+	sb.WriteString(toolutil.MarkdownTableHeader("ID", "MR", "Title", "Target Branch", "Status", "Pipeline", "User", "Duration"))
 	for _, t := range out.Trains {
-		mr := toolutil.MdTitleLink(fmt.Sprintf("!%d", t.MergeRequest.IID), t.MergeRequest.WebURL)
-		// A branch name is not an identifier: git check-ref-format permits
-		// '|', '<' and '>'.
-		//gitlab:allow-unescaped t.Status: a merge-train car state GitLab's own state machine writes (created, idle, stale, fresh, merging, merged).
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s | %s | %s | %ds |\n",
-			t.ID, mr, toolutil.EscapeMdTableCell(t.MergeRequest.Title),
-			toolutil.EscapeMdTableCell(t.TargetBranch), t.Status,
-			toolutil.EscapeMdTableCell(userName(t.User)), t.Duration)
+		sb.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(t.ID, 10),
+			toolutil.MdTitleLink(fmt.Sprintf("!%d", t.MergeRequest.IID), t.MergeRequest.WebURL),
+			toolutil.EscapeMdTableCell(t.MergeRequest.Title),
+			// A branch name is not an identifier: git check-ref-format permits
+			// '|', '<' and '>'.
+			toolutil.EscapeMdTableCell(t.TargetBranch),
+			toolutil.EscapeMdTableCell(t.Status),
+			pipelineCell(t.Pipeline),
+			toolutil.MdUserHandle(userName(t.User)),
+			durationCell(t.Duration),
+		))
 	}
-	toolutil.WriteListSummary(&sb, len(out.Trains), out.Pagination)
-	toolutil.WritePagination(&sb, out.Pagination)
+	toolutil.WriteListFooter(&sb, out.Pagination, true,
+		toolutil.HintAction(actionGet, "read one merge request's position on the train"),
+		toolutil.HintAction(actionAdd, "add another merge request to the train"),
+	)
 	return sb.String()
 }
 
-// FormatOutputMarkdown formats a single merge train entry.
+// FormatOutputMarkdown renders one merge train car as the card of one object.
+//
+// It used to open a "| Property | Value |" table and then write a list row into
+// it, which ended the table with no body and left every later "| Status | … |"
+// on the page as literal pipes. A card row is a complete block wherever it
+// lands, which is why this is a card and not a table.
 func FormatOutputMarkdown(out Output) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Merge Train #%d\n\n", out.ID)
-	sb.WriteString("| Property | Value |\n|---|---|\n")
-	fmt.Fprintf(&sb, toolutil.FmtMdID, out.ID)
-	//gitlab:allow-unescaped out.Status: a merge-train car state GitLab's own state machine writes (created, idle, stale, fresh, merging, merged).
-	fmt.Fprintf(&sb, "| Status | %s |\n", out.Status)
-	fmt.Fprintf(&sb, "| Target Branch | %s |\n", toolutil.EscapeMdTableCell(out.TargetBranch))
-	mr := fmt.Sprintf("%s - %s",
-		toolutil.MdTitleLink(fmt.Sprintf("!%d", out.MergeRequest.IID), out.MergeRequest.WebURL),
-		toolutil.EscapeMdTableCell(out.MergeRequest.Title))
-	fmt.Fprintf(&sb, "| Merge Request | %s |\n", mr)
-	if name := userName(out.User); name != "" {
-		fmt.Fprintf(&sb, "| User | %s |\n", toolutil.EscapeMdTableCell(name))
-	}
-	if out.Pipeline != nil && out.Pipeline.ID > 0 {
-		fmt.Fprintf(&sb, "| Pipeline | #%d |\n", out.Pipeline.ID)
-	}
-	fmt.Fprintf(&sb, "| Duration | %ds |\n", out.Duration)
-	fmt.Fprintf(&sb, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
-	if out.MergedAt != "" {
-		fmt.Fprintf(&sb, "| Merged At | %s |\n", toolutil.FormatTime(out.MergedAt))
-	}
-	toolutil.WriteHints(
-		&sb,
-		"Use `gitlab_list_project_merge_trains` to view all merge trains",
-		"Use `gitlab_add_merge_request_to_merge_train` to add another MR to the train",
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("Merge Train #%d", out.ID))
+	c.Int("ID", out.ID)
+	c.Field("Status", out.Status)
+	c.Field("Target Branch", out.TargetBranch)
+	c.Markdown("Merge Request", mergeRequestCell(out.MergeRequest))
+	c.Markdown("User", toolutil.MdUserHandle(userName(out.User)))
+	c.Markdown("Pipeline", pipelineCell(out.Pipeline))
+	c.Field("Duration", durationCell(out.Duration))
+	c.Time("Created", out.CreatedAt)
+	c.Time("Updated", out.UpdatedAt)
+	c.Time("Merged", out.MergedAt)
+	c.End(
+		toolutil.HintAction(actionListProject, "see every merge train in the project"),
+		toolutil.HintAction(actionListBranch, "see the rest of this branch's train"),
+		toolutil.HintAction(actionAdd, "add another merge request to the train"),
 	)
-	return sb.String()
+	return b.String()
 }
 
 func init() {

--- a/internal/tools/mergetrains/merge_trains_test.go
+++ b/internal/tools/mergetrains/merge_trains_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -642,19 +641,34 @@ func TestToOutput_MinimalFields(t *testing.T) {
 	}
 }
 
+// listTableHead is the header and delimiter of the merge train table, and
+// listHints the guidance section every listing closes with, written once so the
+// whole-output expectations below name them rather than repeating them.
+const (
+	listTableHead = "| ID | MR | Title | Target Branch | Status | Pipeline | User | Duration |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+	listHints = "\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'merge_train.get' to read one merge request's position on the train\n" +
+		"- Use action 'merge_train.add' to add another merge request to the train\n"
+)
+
 // TestFormatListMarkdown validates Markdown formatting for merge train lists.
 // Covers empty trains, trains with WebURL links, and trains without WebURL.
+//
+// Every case asserts the whole rendering rather than a substring of it. The
+// substring form is what let the card next door open a table and write list
+// rows into it while "| Status | merged |" still matched.
 func TestFormatListMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    ListOutput
-		contains []string
-		equals   string
+		name  string
+		input ListOutput
+		want  string
 	}{
 		{
-			name:   "empty list returns no-results message",
-			input:  ListOutput{Trains: []Output{}},
-			equals: "No merge trains found.\n",
+			name:  "empty list returns no-results message",
+			input: ListOutput{Trains: []Output{}},
+			want:  "No merge trains found.\n",
 		},
 		{
 			name: "renders table with WebURL link",
@@ -665,20 +679,15 @@ func TestFormatListMarkdown(t *testing.T) {
 						TargetBranch: "main",
 						Status:       "merged",
 						User:         &toolutil.BasicUserOutput{ID: 1, Username: "admin"},
+						Pipeline:     &toolutil.PipelineOutput{ID: 200, Status: "success", WebURL: "https://gitlab.example.com/-/pipelines/200"},
 						Duration:     120,
 						MergeRequest: MergeRequestOutput{IID: 5, Title: "Fix bug", WebURL: "https://gitlab.example.com/-/merge_requests/5"},
 					},
 				},
 			},
-			contains: []string{
-				"## Merge Trains",
-				"[!5](https://gitlab.example.com/-/merge_requests/5)",
-				"| 1 |",
-				"| main |",
-				"| merged |",
-				"| admin |",
-				"| 120s |",
-			},
+			want: "## Merge Trains (1)\n\n" + listTableHead +
+				"| 1 | [!5](https://gitlab.example.com/-/merge_requests/5) | Fix bug | main | merged | " +
+				"[#200](https://gitlab.example.com/-/pipelines/200) ✅ success | @admin | 120s |\n" + listHints,
 		},
 		{
 			name: "renders MR without WebURL as plain text",
@@ -694,37 +703,38 @@ func TestFormatListMarkdown(t *testing.T) {
 					},
 				},
 			},
-			contains: []string{
-				"!10",
-				"Add feature",
-				"| develop |",
-				"| idle |",
-			},
+			want: "## Merge Trains (1)\n\n" + listTableHead +
+				"| 2 | !10 | Add feature | develop | idle |  | @dev | 0s |\n" + listHints,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatListMarkdown(tt.input)
-			if tt.equals != "" && got != tt.equals {
-				t.Errorf("got %q, want %q", got, tt.equals)
-			}
-			for _, want := range tt.contains {
-				if !strings.Contains(got, want) {
-					t.Errorf("output missing %q\ngot:\n%s", want, got)
-				}
+			if got := FormatListMarkdown(tt.input); got != tt.want {
+				t.Errorf("rendered =\n%q\nwant\n%q", got, tt.want)
 			}
 		})
 	}
 }
 
-// TestFormatOutputMarkdown validates Markdown formatting for a single merge train entry.
-// Covers minimal output, full output with all fields, and output without WebURL.
+// cardHints is the guidance section a merge train card closes with.
+const cardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_train.list_project' to see every merge train in the project\n" +
+	"- Use action 'merge_train.list_branch' to see the rest of this branch's train\n" +
+	"- Use action 'merge_train.add' to add another merge request to the train\n"
+
+// TestFormatOutputMarkdown validates Markdown formatting for a single merge
+// train entry: the card of one object, asserted whole.
+//
+// This is the formatter the audit proved broken. It used to open a
+// "| Property | Value |" table and then write "- **ID**: 1" into it, which
+// ended the table with no body and left every later "| Status | merged |" on
+// the page as literal pipes — while a test asserting exactly that substring
+// passed. Nothing here is a substring any more.
 func TestFormatOutputMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    Output
-		contains []string
-		absent   []string
+		name  string
+		input Output
+		want  string
 	}{
 		{
 			name: "renders full output with all optional fields",
@@ -733,22 +743,24 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				TargetBranch: "main",
 				Status:       "merged",
 				User:         &toolutil.BasicUserOutput{ID: 1, Username: "admin"},
-				Pipeline:     &toolutil.PipelineOutput{ID: 200},
+				Pipeline:     &toolutil.PipelineOutput{ID: 200, Status: "success", WebURL: "https://gitlab.example.com/-/pipelines/200"},
 				Duration:     120,
 				CreatedAt:    "2026-01-15T10:00:00Z",
+				UpdatedAt:    "2026-01-16T10:00:00Z",
 				MergedAt:     "2026-01-17T10:00:00Z",
 				MergeRequest: MergeRequestOutput{IID: 5, Title: "Fix bug", WebURL: "https://gitlab.example.com/-/merge_requests/5"},
 			},
-			contains: []string{
-				"## Merge Train #1",
-				"| Status | merged |",
-				"| Target Branch | main |",
-				"[!5](https://gitlab.example.com/-/merge_requests/5)",
-				"| User | admin |",
-				"| Pipeline | #200 |",
-				"| Duration | 120s |",
-				"| Merged At |",
-			},
+			want: "## Merge Train #1\n\n" +
+				"- **ID**: 1\n" +
+				"- **Status**: merged\n" +
+				"- **Target Branch**: main\n" +
+				"- **Merge Request**: [!5](https://gitlab.example.com/-/merge_requests/5) - Fix bug\n" +
+				"- **User**: @admin\n" +
+				"- **Pipeline**: [#200](https://gitlab.example.com/-/pipelines/200) ✅ success\n" +
+				"- **Duration**: 120s\n" +
+				"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+				"- **Updated**: 16 Jan 2026 10:00 UTC\n" +
+				"- **Merged**: 17 Jan 2026 10:00 UTC\n" + cardHints,
 		},
 		{
 			name: "renders minimal output without optional fields",
@@ -759,16 +771,12 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				Duration:     0,
 				MergeRequest: MergeRequestOutput{IID: 10, Title: "Add feature"},
 			},
-			contains: []string{
-				"## Merge Train #2",
-				"| Status | idle |",
-				"!10",
-			},
-			absent: []string{
-				"| User |",
-				"| Pipeline |",
-				"| Merged At |",
-			},
+			want: "## Merge Train #2\n\n" +
+				"- **ID**: 2\n" +
+				"- **Status**: idle\n" +
+				"- **Target Branch**: develop\n" +
+				"- **Merge Request**: !10 - Add feature\n" +
+				"- **Duration**: 0s\n" + cardHints,
 		},
 		{
 			name: "renders MR without WebURL as plain text",
@@ -778,26 +786,18 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				Status:       "active",
 				MergeRequest: MergeRequestOutput{IID: 7, Title: "Update docs"},
 			},
-			contains: []string{
-				"!7 - Update docs",
-			},
-			absent: []string{
-				"[!7](",
-			},
+			want: "## Merge Train #3\n\n" +
+				"- **ID**: 3\n" +
+				"- **Status**: active\n" +
+				"- **Target Branch**: main\n" +
+				"- **Merge Request**: !7 - Update docs\n" +
+				"- **Duration**: 0s\n" + cardHints,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatOutputMarkdown(tt.input)
-			for _, want := range tt.contains {
-				if !strings.Contains(got, want) {
-					t.Errorf("output missing %q\ngot:\n%s", want, got)
-				}
-			}
-			for _, notWant := range tt.absent {
-				if strings.Contains(got, notWant) {
-					t.Errorf("output should not contain %q\ngot:\n%s", notWant, got)
-				}
+			if got := FormatOutputMarkdown(tt.input); got != tt.want {
+				t.Errorf("rendered =\n%q\nwant\n%q", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/modelregistry/markdown.go
+++ b/internal/tools/modelregistry/markdown.go
@@ -7,24 +7,33 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatDownloadMarkdown formats a downloaded ML model package file as Markdown.
+// FormatDownloadMarkdown renders a downloaded ML model package file as the
+// card of one object: where it came from, what it is called and how large it
+// is, with the note that the bytes themselves travel in the structured
+// output.
 func FormatDownloadMarkdown(o DownloadOutput) string {
 	var sb strings.Builder
 	// Every one of these is echoed from the caller's own arguments: the
 	// project, the model version, the package path and the file name inside it.
-	fmt.Fprintf(&sb, "## ML Model Package: %s\n\n", toolutil.EscapeMdHeading(o.Filename))
-	sb.WriteString("| Field | Value |\n|---|---|\n")
-	fmt.Fprintf(&sb, "| Project | %s |\n", toolutil.EscapeMdTableCell(o.ProjectID))
-	fmt.Fprintf(&sb, "| Model Version | %s |\n", toolutil.EscapeMdTableCell(o.ModelVersionID))
-	fmt.Fprintf(&sb, "| Path | %s |\n", toolutil.EscapeMdTableCell(o.Path))
-	fmt.Fprintf(&sb, "| Filename | %s |\n", toolutil.EscapeMdTableCell(o.Filename))
-	fmt.Fprintf(&sb, "| Size | %d bytes |\n", o.SizeBytes)
-	sb.WriteString("\n_Content is base64-encoded in the structured JSON output._\n")
-	toolutil.WriteHints(
-		&sb,
-		"Use `gitlab_package_list` to browse available model packages",
-	)
+	c := toolutil.NewCard(&sb, downloadHeading(o.Filename))
+	c.Field("Project", o.ProjectID)
+	c.Field("Model Version", o.ModelVersionID)
+	c.Field("Path", o.Path)
+	c.Field("Filename", o.Filename)
+	c.Field("Size", fmt.Sprintf("%d bytes", o.SizeBytes))
+	c.Note("_Content is base64-encoded in the structured JSON output._")
+	c.End("Use `gitlab_package_list` to browse available model packages")
 	return sb.String()
+}
+
+// downloadHeading names the card after the file when GitLab sent a name, and
+// after the resource alone when it did not, so the heading never ends in a
+// colon with nothing behind it.
+func downloadHeading(filename string) string {
+	if strings.TrimSpace(filename) == "" {
+		return "ML Model Package"
+	}
+	return "ML Model Package: " + filename
 }
 
 func init() {

--- a/internal/tools/modelregistry/markdown_test.go
+++ b/internal/tools/modelregistry/markdown_test.go
@@ -3,18 +3,22 @@
 package modelregistry
 
 import (
-	"strings"
 	"testing"
 )
 
 // TestFormatDownloadMarkdown validates Markdown rendering of a downloaded
-// ML model package file. Covers all output fields (project, model version,
-// path, filename, size) and verifies the hints section is appended.
+// ML model package file.
+//
+// Each case pins the whole response rather than a substring: the card's rows,
+// the note and the guidance section are one document, and a substring
+// assertion is what let a row survive in a table another row had already
+// closed. The cases cover a populated download, a response with nothing in it
+// but a size, and a large file.
 func TestFormatDownloadMarkdown(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    DownloadOutput
-		contains []string
+		name  string
+		input DownloadOutput
+		want  string
 	}{
 		{
 			name: "all fields populated",
@@ -26,19 +30,18 @@ func TestFormatDownloadMarkdown(t *testing.T) {
 				ContentBase64:  "bW9kZWwtZGF0YQ==",
 				SizeBytes:      1024,
 			},
-			contains: []string{
-				"## ML Model Package: classifier.bin",
-				"| Project | 42 |",
-				"| Model Version | 7 |",
-				"| Path | models/v1 |",
-				"| Filename | classifier.bin |",
-				"| Size | 1024 bytes |",
-				"base64-encoded",
-				"gitlab_package_list",
-			},
+			want: "## ML Model Package: classifier.bin\n\n" +
+				"- **Project**: 42\n" +
+				"- **Model Version**: 7\n" +
+				"- **Path**: models/v1\n" +
+				"- **Filename**: classifier.bin\n" +
+				"- **Size**: 1024 bytes\n\n" +
+				"_Content is base64-encoded in the structured JSON output._\n\n" +
+				"---\n💡 **Next steps:**\n" +
+				"- Use `gitlab_package_list` to browse available model packages\n",
 		},
 		{
-			name: "empty fields render without panic",
+			name: "empty fields render the resource heading and the size alone",
 			input: DownloadOutput{
 				ProjectID:      "",
 				ModelVersionID: "",
@@ -46,11 +49,11 @@ func TestFormatDownloadMarkdown(t *testing.T) {
 				Filename:       "",
 				SizeBytes:      0,
 			},
-			contains: []string{
-				"## ML Model Package:",
-				"| Size | 0 bytes |",
-				"base64-encoded",
-			},
+			want: "## ML Model Package\n\n" +
+				"- **Size**: 0 bytes\n\n" +
+				"_Content is base64-encoded in the structured JSON output._\n\n" +
+				"---\n💡 **Next steps:**\n" +
+				"- Use `gitlab_package_list` to browse available model packages\n",
 		},
 		{
 			name: "large file size renders correctly",
@@ -61,23 +64,22 @@ func TestFormatDownloadMarkdown(t *testing.T) {
 				Filename:       "weights.h5",
 				SizeBytes:      104857600,
 			},
-			contains: []string{
-				"## ML Model Package: weights.h5",
-				"| Project | group/project |",
-				"| Model Version | candidate:5 |",
-				"| Path | deep/nested/path |",
-				"| Size | 104857600 bytes |",
-			},
+			want: "## ML Model Package: weights.h5\n\n" +
+				"- **Project**: group/project\n" +
+				"- **Model Version**: candidate:5\n" +
+				"- **Path**: deep/nested/path\n" +
+				"- **Filename**: weights.h5\n" +
+				"- **Size**: 104857600 bytes\n\n" +
+				"_Content is base64-encoded in the structured JSON output._\n\n" +
+				"---\n💡 **Next steps:**\n" +
+				"- Use `gitlab_package_list` to browse available model packages\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatDownloadMarkdown(tt.input)
-			for _, s := range tt.contains {
-				if !strings.Contains(got, s) {
-					t.Errorf("expected output to contain %q, got:\n%s", s, got)
-				}
+			if got := FormatDownloadMarkdown(tt.input); got != tt.want {
+				t.Errorf("FormatDownloadMarkdown() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/mrapprovals/markdown.go
+++ b/internal/tools/mrapprovals/markdown.go
@@ -1,109 +1,161 @@
 package mrapprovals
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// userNames returns the display names of a slice of basic-user outputs,
-// skipping nil entries. Used by the Markdown formatters to render the
-// approver/eligible/user object lists as comma-separated names.
-func userNames(users []*BasicUserOutput) []string {
-	names := make([]string, 0, len(users))
-	for _, u := range users {
-		if u != nil {
-			names = append(names, u.Name)
-		}
+// actionMRMerge is the one canonical action ID these hints name that the
+// action specs beside them do not already declare.
+const actionMRMerge = "merge_request.merge"
+
+// userCell renders one approver: the "@handle" linked to the profile, and the
+// display name when GitLab sent no username. Both halves are escaped, which the
+// comma-joined list of raw names this replaced was not.
+func userCell(u *BasicUserOutput) string {
+	if u == nil {
+		return ""
 	}
-	return names
+	if handle := toolutil.MdUserLink(u.Username, u.WebURL); handle != "" {
+		return handle
+	}
+	return toolutil.MdTitleLink(u.Name, u.WebURL)
 }
 
-// groupNames returns the display names of a slice of group outputs, skipping
-// nil entries.
-func groupNames(groups []*GroupOutput) []string {
-	names := make([]string, 0, len(groups))
+// userList renders a set of approvers as the comma-joined list a row shows, and
+// nothing at all when there are none.
+func userList(users []*BasicUserOutput) string {
+	cells := make([]string, 0, len(users))
+	for _, u := range users {
+		if cell := userCell(u); cell != "" {
+			cells = append(cells, cell)
+		}
+	}
+	return strings.Join(cells, ", ")
+}
+
+// groupPaths renders approval groups by their full path, each escaped.
+func groupPaths(groups []*GroupOutput) string {
+	paths := make([]string, 0, len(groups))
 	for _, g := range groups {
-		if g != nil {
-			names = append(names, g.Name)
-		}
-	}
-	return names
-}
-
-// approverNames returns the display names of merge-request approver users,
-// appending the approval timestamp in parentheses when present. Skips entries
-// with a nil user object.
-func approverNames(users []*MergeRequestApproverUserOutput) []string {
-	names := make([]string, 0, len(users))
-	for _, u := range users {
-		if u == nil || u.User == nil {
+		if g == nil {
 			continue
 		}
-		if u.ApprovedAt != "" {
-			names = append(names, fmt.Sprintf("%s (%s)", u.User.Name, u.ApprovedAt))
-		} else {
-			names = append(names, u.User.Name)
+		path := g.FullPath
+		if path == "" {
+			path = g.Name
+		}
+		if path != "" {
+			paths = append(paths, toolutil.EscapeMdTableCell(path))
 		}
 	}
-	return names
+	return strings.Join(paths, ", ")
 }
 
-// FormatStateMarkdown renders the MR approval state as Markdown.
+// approverList renders the users who approved, each with the moment they
+// approved in the display form every other timestamp takes. The names used to
+// be joined raw, and the timestamp printed as GitLab sent it.
+func approverList(users []*MergeRequestApproverUserOutput) string {
+	cells := make([]string, 0, len(users))
+	for _, u := range users {
+		if u == nil {
+			continue
+		}
+		cell := userCell(u.User)
+		if cell == "" {
+			continue
+		}
+		if at := toolutil.FormatTime(u.ApprovedAt); at != "" {
+			cell += " (" + at + ")"
+		}
+		cells = append(cells, cell)
+	}
+	return strings.Join(cells, ", ")
+}
+
+// FormatStateMarkdown renders the approval state of a merge request: the card
+// of one object, with the rules it is judged by as a nested collection.
 func FormatStateMarkdown(s StateOutput) string {
 	var b strings.Builder
-	overwritten := "No"
-	if s.ApprovalRulesOverwritten {
-		overwritten = "Yes"
-	}
-	fmt.Fprintf(&b, "## MR Approval State\n\n**Rules overwritten**: %s\n\n", overwritten)
+	c := toolutil.NewCard(&b, "MR Approval State")
+	c.Bool("Rules overwritten", s.ApprovalRulesOverwritten)
+	c.Int("Rules", int64(len(s.Rules)))
 	if len(s.Rules) == 0 {
-		b.WriteString("No approval rules configured.\n")
+		c.Note("No approval rules are configured for this merge request.")
+		c.End(
+			toolutil.HintAction(actionApprovalRules, "list the rules configured on this merge request"),
+			toolutil.HintAction(actionApprovalRuleCreate, "add an approval rule"),
+		)
 		return b.String()
 	}
-	b.WriteString("| ID | Name | Type | Required | Approved | Approved By |\n")
-	b.WriteString("| -- | ---- | ---- | -------- | -------- | ----------- |\n")
+	t := c.Table("Rules", "ID", "Name", "Type", "Required", "Approved", "Approved By")
 	for _, r := range s.Rules {
-		approved := toolutil.BoolEmoji(r.Approved)
-		approvedBy := strings.Join(userNames(r.ApprovedBy), ", ")
-		//gitlab:allow-unescaped r.RuleType: an approval rule type GitLab picks from a fixed set (regular, any_approver, code_owner, report_approver).
-		fmt.Fprintf(&b, "| %d | %s | %s | %d | %s | %s |\n", r.ID, toolutil.EscapeMdTableCell(r.Name), r.RuleType, r.ApprovalsRequired, approved, toolutil.EscapeMdTableCell(approvedBy))
+		t.Row(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.EscapeMdTableCell(r.Name),
+			toolutil.EscapeMdTableCell(r.RuleType),
+			strconv.Itoa(r.ApprovalsRequired),
+			toolutil.BoolEmoji(r.Approved),
+			userList(r.ApprovedBy),
+		)
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'approve' to approve this MR",
-		"Use action 'unapprove' to withdraw approval",
+	c.End(
+		toolutil.HintAction(actionMRApprove, "approve this merge request"),
+		toolutil.HintAction(actionMRUnapprove, "withdraw an approval"),
 	)
 	return b.String()
 }
 
-// FormatRulesMarkdown renders a list of MR approval rules as Markdown.
+// anyProfileLink reports whether any eligible approver carries a profile URL,
+// which decides whether the table has a link to preserve. The instruction to
+// keep the links of a table that has none is noise a model has to read past,
+// so it is asked rather than assumed: an instance that hides profile URLs
+// renders these rules as plain names.
+func anyProfileLink(rules []RuleOutput) bool {
+	for _, r := range rules {
+		for _, u := range r.EligibleApprovers {
+			if u != nil && u.WebURL != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FormatRulesMarkdown renders the approval rules of a merge request as a
+// Markdown table: a collection of objects that share columns.
+//
+// There is no Approved column here: the three approval_rules routes present
+// MergeRequestApprovalRule, which does not expose it. Only the approval_state
+// route does, and [FormatStateMarkdown] renders that one.
 func FormatRulesMarkdown(out RulesOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Approval Rules (%d)\n\n", len(out.Rules))
 	if len(out.Rules) == 0 {
-		b.WriteString("No approval rules configured.\n")
-		return b.String()
+		return toolutil.EmptyMessage("approval rules")
 	}
-	// No Approved column: the three approval_rules routes present
-	// MergeRequestApprovalRule, which does not expose it. Only the
-	// approval_state route does, and FormatStateMarkdown renders that one.
-	b.WriteString("| ID | Name | Type | Required | Eligible |\n")
-	b.WriteString("| -- | ---- | ---- | -------- | -------- |\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "MR Approval Rules", len(out.Rules), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Type", "Required", "Eligible"))
 	for _, r := range out.Rules {
-		eligible := strings.Join(userNames(r.EligibleApprovers), ", ")
-		fmt.Fprintf(&b, "| %d | %s | %s | %d | %s |\n", r.ID, toolutil.EscapeMdTableCell(r.Name), r.RuleType, r.ApprovalsRequired, toolutil.EscapeMdTableCell(eligible))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.EscapeMdTableCell(r.Name),
+			toolutil.EscapeMdTableCell(r.RuleType),
+			strconv.Itoa(r.ApprovalsRequired),
+			userList(r.EligibleApprovers),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'approval_rule_create' to add new rules",
-		"Use action 'approval_rule_update' or 'approval_rule_delete' to manage existing rules",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, anyProfileLink(out.Rules),
+		toolutil.HintAction(actionApprovalRuleCreate, "add a rule"),
+		toolutil.HintAction(actionApprovalRuleUpdate, "change an existing rule"),
+		toolutil.HintAction(actionApprovalRuleDelete, "remove a rule"),
 	)
 	return b.String()
 }
 
-// FormatConfigMarkdown renders a merge request's approvals as Markdown.
+// FormatConfigMarkdown renders a merge request's approvals as the card of one
+// object.
 //
 // The rows it used to print for approvals required, approvals left and whether
 // rules exist are gone with the fields behind them: GitLab answers none of them
@@ -111,45 +163,39 @@ func FormatRulesMarkdown(out RulesOutput) string {
 // those questions is action 'approval_state', which the hints point at.
 func FormatConfigMarkdown(c ConfigOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Approvals\n\n")
-	fmt.Fprintf(&b, "| Field | Value |\n| ----- | ----- |\n")
-	fmt.Fprintf(&b, "| Approved | %v |\n", c.Approved)
-	fmt.Fprintf(&b, "| User Has Approved | %v |\n", c.UserHasApproved)
-	fmt.Fprintf(&b, "| User Can Approve | %v |\n", c.UserCanApprove)
-	if names := approverNames(c.ApprovedBy); len(names) > 0 {
-		fmt.Fprintf(&b, "\n**Approved by**: %s\n", strings.Join(names, ", "))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'approve' or 'unapprove' to change approval status",
-		"Use action 'approval_state' for how many approvals are required and left",
-		"Use action 'approval_rules' to see all configured rules",
+	card := toolutil.NewCard(&b, "MR Approvals")
+	card.Bool("Approved", c.Approved)
+	card.Bool("You have approved", c.UserHasApproved)
+	card.Bool("You can approve", c.UserCanApprove)
+	card.Markdown("Approved By", approverList(c.ApprovedBy))
+	card.End(
+		toolutil.HintAction(actionMRApprove, "approve this merge request"),
+		toolutil.HintAction(actionMRUnapprove, "withdraw your approval"),
+		toolutil.HintAction(actionApprovalState, "see how many approvals are required and left"),
+		toolutil.HintAction(actionApprovalRules, "see every configured rule"),
 	)
 	return b.String()
 }
 
-// FormatRuleMarkdown renders a single MR approval rule as Markdown.
+// FormatRuleMarkdown renders one approval rule as the card of one object.
 func FormatRuleMarkdown(r RuleOutput) string {
 	var b strings.Builder
 	// An approval rule's name is free text a maintainer types.
-	fmt.Fprintf(&b, "## Approval Rule: %s\n\n", toolutil.EscapeMdHeading(r.Name))
-	fmt.Fprintf(&b, "| Field | Value |\n| ----- | ----- |\n")
-	fmt.Fprintf(&b, "| ID | %d |\n", r.ID)
-	fmt.Fprintf(&b, "| Type | %s |\n", r.RuleType)
-	fmt.Fprintf(&b, "| Approvals Required | %d |\n", r.ApprovalsRequired)
-	if eligible := userNames(r.EligibleApprovers); len(eligible) > 0 {
-		fmt.Fprintf(&b, "| Eligible | %s |\n", toolutil.EscapeMdTableCell(strings.Join(eligible, ", ")))
-	}
-	if users := userNames(r.Users); len(users) > 0 {
-		fmt.Fprintf(&b, "| Users | %s |\n", toolutil.EscapeMdTableCell(strings.Join(users, ", ")))
-	}
-	if groups := groupNames(r.Groups); len(groups) > 0 {
-		fmt.Fprintf(&b, "| Groups | %s |\n", toolutil.EscapeMdTableCell(strings.Join(groups, ", ")))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'approval_rule_update' to modify this rule",
-		"Use action 'approval_rule_delete' to remove this rule",
+	c := toolutil.NewCard(&b, "Approval Rule: "+r.Name)
+	c.Int("ID", r.ID)
+	c.Field("Type", r.RuleType)
+	c.Field("Report Type", r.ReportType)
+	c.Field("Section", r.Section)
+	c.Int("Approvals Required", int64(r.ApprovalsRequired))
+	c.Bool("Overridden", r.Overridden)
+	c.Warn("Contains groups you cannot see", r.ContainsHiddenGroups)
+	c.Markdown("Eligible", userList(r.EligibleApprovers))
+	c.Markdown("Users", userList(r.Users))
+	c.Markdown("Groups", groupPaths(r.Groups))
+	c.End(
+		toolutil.HintAction(actionApprovalRuleUpdate, "modify this rule"),
+		toolutil.HintAction(actionApprovalRuleDelete, "remove this rule"),
+		toolutil.HintAction(actionMRMerge, "merge once the rule is satisfied"),
 	)
 	return b.String()
 }

--- a/internal/tools/mrapprovals/mr_approvals_test.go
+++ b/internal/tools/mrapprovals/mr_approvals_test.go
@@ -1163,113 +1163,187 @@ func TestConfig_ToOutputNilEntries(t *testing.T) {
 // FormatStateMarkdown tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatStateMarkdown_WithRules verifies FormatStateMarkdown when with rules.
+// stateHints is the guidance section an approval state card with rules closes
+// with, and stateEmptyHints the one it closes with when there are none.
+const (
+	stateHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.approve' to approve this merge request\n" +
+		"- Use action 'merge_request.unapprove' to withdraw an approval\n"
+	stateEmptyHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.approval_rules' to list the rules configured on this merge request\n" +
+		"- Use action 'merge_request.approval_rule_create' to add an approval rule\n"
+)
+
+// TestFormatStateMarkdown_WithRules verifies the whole rendering of an approval
+// state: the card's own rows, then the rules as a nested collection under an H3
+// of their own. The rows precede the table, which is what keeps every row a row
+// rather than a line of literal pipes below the table's last one.
 func TestFormatStateMarkdown_WithRules(t *testing.T) {
 	s := StateOutput{
 		ApprovalRulesOverwritten: true,
 		Rules: []StateRuleOutput{
-			{ID: 1, Name: "Security", RuleType: "regular", ApprovalsRequired: 2, Approved: true, ApprovedBy: []*BasicUserOutput{{Name: "Alice"}}},
-			{ID: 2, Name: "QA", RuleType: "code_owner", ApprovalsRequired: 1, Approved: false, ApprovedBy: nil},
+			{ID: 1, Name: "Security", RuleType: "regular", ApprovalsRequired: 2, Approved: true, ApprovedBy: []*BasicUserOutput{{Name: "Alice", Username: "alice"}}},
+			{ID: 2, Name: "QA", RuleType: "code_owner", ApprovalsRequired: 1},
 		},
 	}
-	md := FormatStateMarkdown(s)
-	assertContains(t, md, "## MR Approval State")
-	assertContains(t, md, "**Rules overwritten**: Yes")
-	assertContains(t, md, "| 1 |")
-	assertContains(t, md, "| 2 |")
-	assertContains(t, md, "✅")
-	assertContains(t, md, "❌")
-	assertContains(t, md, "Alice")
+	want := "## MR Approval State\n\n" +
+		"- **Rules overwritten**: ✅\n" +
+		"- **Rules**: 2\n\n" +
+		"### Rules\n\n" +
+		"| ID | Name | Type | Required | Approved | Approved By |\n" +
+		"| --- | --- | --- | --- | --- | --- |\n" +
+		"| 1 | Security | regular | 2 | ✅ | @alice |\n" +
+		"| 2 | QA | code_owner | 1 | ❌ |  |\n" + stateHints
+	if got := FormatStateMarkdown(s); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
-// TestFormatStateMarkdown_Empty verifies FormatStateMarkdown when empty.
+// TestFormatStateMarkdown_Empty verifies the whole rendering when no rule is
+// configured: the card says so in one sentence and opens no empty table.
 func TestFormatStateMarkdown_Empty(t *testing.T) {
-	md := FormatStateMarkdown(StateOutput{})
-	assertContains(t, md, "**Rules overwritten**: No")
-	assertContains(t, md, "No approval rules configured.")
+	want := "## MR Approval State\n\n" +
+		"- **Rules overwritten**: ❌\n" +
+		"- **Rules**: 0\n\n" +
+		"No approval rules are configured for this merge request.\n" + stateEmptyHints
+	if got := FormatStateMarkdown(StateOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------
 // FormatRulesMarkdown tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatRulesMarkdown_WithRules verifies FormatRulesMarkdown when with rules.
+// rulesHints is the guidance section an approval rules listing closes with,
+// and rulesLinkedHints the same section for a listing whose approvers carry a
+// profile URL, which is the only link the table can hold.
+const (
+	rulesHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.approval_rule_create' to add a rule\n" +
+		"- Use action 'merge_request.approval_rule_update' to change an existing rule\n" +
+		"- Use action 'merge_request.approval_rule_delete' to remove a rule\n"
+	rulesLinkedHints = "\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'merge_request.approval_rule_create' to add a rule\n" +
+		"- Use action 'merge_request.approval_rule_update' to change an existing rule\n" +
+		"- Use action 'merge_request.approval_rule_delete' to remove a rule\n"
+	rulesTableHead = "| ID | Name | Type | Required | Eligible |\n| --- | --- | --- | --- | --- |\n"
+)
+
+// TestFormatRulesMarkdown_WithRules verifies the whole rendering of an approval
+// rules listing. There is no Approved column: the three approval_rules routes
+// present an entity that does not expose it, and a column claiming one would
+// print false on every row. The instruction to keep the table's links is
+// absent because this table has none: nobody here carries a profile URL.
 func TestFormatRulesMarkdown_WithRules(t *testing.T) {
 	out := RulesOutput{
 		Rules: []RuleOutput{
-			{ID: 10, Name: "Team", RuleType: "regular", ApprovalsRequired: 1, EligibleApprovers: []*BasicUserOutput{{Name: "Eve"}, {Name: "Frank"}}},
+			{ID: 10, Name: "Team", RuleType: "regular", ApprovalsRequired: 1, EligibleApprovers: []*BasicUserOutput{{Name: "Eve", Username: "eve"}, {Name: "Frank"}}},
 		},
 	}
-	md := FormatRulesMarkdown(out)
-	assertContains(t, md, "## MR Approval Rules (1)")
-	assertContains(t, md, "| 10 |")
-	assertContains(t, md, "Eve, Frank")
-	// The approval_rules routes do not send approved, so the table does not
-	// claim one either.
-	assertNotContains(t, md, "Approved")
+	want := "## MR Approval Rules (1)\n\n" + rulesTableHead +
+		"| 10 | Team | regular | 1 | @eve, Frank |\n" + rulesHints
+	if got := FormatRulesMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
-// TestFormatRulesMarkdown_Empty verifies FormatRulesMarkdown when empty.
+// TestFormatRulesMarkdown_LinkedApprovers verifies that a listing whose
+// approvers carry a profile URL links them and asks the model to keep the
+// links, which the one above must not do.
+func TestFormatRulesMarkdown_LinkedApprovers(t *testing.T) {
+	out := RulesOutput{
+		Rules: []RuleOutput{
+			{ID: 11, Name: "Leads", RuleType: "regular", ApprovalsRequired: 2, EligibleApprovers: []*BasicUserOutput{
+				{Name: "Eve", Username: "eve", WebURL: "https://gitlab.example.com/eve"},
+			}},
+		},
+	}
+	want := "## MR Approval Rules (1)\n\n" + rulesTableHead +
+		"| 11 | Leads | regular | 2 | [@eve](https://gitlab.example.com/eve) |\n" + rulesLinkedHints
+	if got := FormatRulesMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestFormatRulesMarkdown_Empty verifies that a merge request with no approval
+// rule renders the one-sentence empty message and no heading counting zero.
 func TestFormatRulesMarkdown_Empty(t *testing.T) {
-	md := FormatRulesMarkdown(RulesOutput{})
-	assertContains(t, md, "## MR Approval Rules (0)")
-	assertContains(t, md, "No approval rules configured.")
+	want := "No approval rules found.\n"
+	if got := FormatRulesMarkdown(RulesOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------
 // FormatConfigMarkdown tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatConfigMarkdown_Full verifies FormatConfigMarkdown when full.
+// configHints is the guidance section the approvals card closes with.
+const configHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.approve' to approve this merge request\n" +
+	"- Use action 'merge_request.unapprove' to withdraw your approval\n" +
+	"- Use action 'merge_request.approval_state' to see how many approvals are required and left\n" +
+	"- Use action 'merge_request.approval_rules' to see every configured rule\n"
+
+// TestFormatConfigMarkdown_Full verifies the whole rendering of the approvals
+// card: four rows and the guidance. The rows that used to print here read
+// fields GitLab does not answer with at this endpoint, so each printed a zero;
+// the count and the rules live on approval_state, which the hints point at.
 func TestFormatConfigMarkdown_Full(t *testing.T) {
 	c := ConfigOutput{
 		Approved:        true,
 		UserHasApproved: true,
 		UserCanApprove:  false,
-		ApprovedBy:      []*MergeRequestApproverUserOutput{{User: &BasicUserOutput{Name: "Alice"}}},
+		ApprovedBy:      []*MergeRequestApproverUserOutput{{User: &BasicUserOutput{Name: "Alice", Username: "alice"}}},
 	}
-	md := FormatConfigMarkdown(c)
-	assertContains(t, md, "## MR Approvals")
-	assertContains(t, md, "| Approved | true |")
-	assertContains(t, md, "| User Has Approved | true |")
-	assertContains(t, md, "| User Can Approve | false |")
-	assertContains(t, md, "**Approved by**: Alice")
-	// The rows that used to print here read fields GitLab does not answer with,
-	// so each printed a zero: the count and the rules live on approval_state.
-	assertNotContains(t, md, "Approvals Required")
-	assertNotContains(t, md, "Approvals Left")
-	assertNotContains(t, md, "Has Approval Rules")
-	assertNotContains(t, md, "Suggested approvers")
-	assertContains(t, md, "Use action 'approval_state'")
+	want := "## MR Approvals\n\n" +
+		"- **Approved**: ✅\n" +
+		"- **You have approved**: ✅\n" +
+		"- **You can approve**: ❌\n" +
+		"- **Approved By**: @alice\n" + configHints
+	if got := FormatConfigMarkdown(c); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
-// TestFormatConfigMarkdown_Minimal verifies FormatConfigMarkdown when minimal.
+// TestFormatConfigMarkdown_Minimal verifies that a merge request nobody has
+// approved renders the three flags and no approver row at all.
 func TestFormatConfigMarkdown_Minimal(t *testing.T) {
-	md := FormatConfigMarkdown(ConfigOutput{})
-	assertContains(t, md, "| Approved | false |")
-	assertNotContains(t, md, "**Approved by**")
+	want := "## MR Approvals\n\n" +
+		"- **Approved**: ❌\n" +
+		"- **You have approved**: ❌\n" +
+		"- **You can approve**: ❌\n" + configHints
+	if got := FormatConfigMarkdown(ConfigOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
-// TestFormatConfigMarkdown_ApprovedByWithDate verifies that FormatConfigMarkdown
-// includes the approval date in parentheses when ApprovedAt is non-empty.
+// TestFormatConfigMarkdown_ApprovedByWithDate verifies that the approver row
+// carries the moment each approval happened, in the display form every other
+// timestamp takes, and nothing at all for an approval GitLab dated nowhere.
 func TestFormatConfigMarkdown_ApprovedByWithDate(t *testing.T) {
 	c := ConfigOutput{
 		ApprovedBy: []*MergeRequestApproverUserOutput{
-			{User: &BasicUserOutput{Name: "Alice"}, ApprovedAt: "2026-03-15T14:00:00Z"},
-			{User: &BasicUserOutput{Name: "Bob"}, ApprovedAt: ""},
+			{User: &BasicUserOutput{Name: "Alice", Username: "alice"}, ApprovedAt: "2026-03-15T14:00:00Z"},
+			{User: &BasicUserOutput{Name: "Bob", Username: "bob"}, ApprovedAt: ""},
 		},
 	}
-	md := FormatConfigMarkdown(c)
-	assertContains(t, md, "Alice (2026-03-15T14:00:00Z)")
-	assertContains(t, md, "Bob")
-	if strings.Contains(md, "Bob (") {
-		t.Error("Bob should not have date parentheses")
+	want := "## MR Approvals\n\n" +
+		"- **Approved**: ❌\n" +
+		"- **You have approved**: ❌\n" +
+		"- **You can approve**: ❌\n" +
+		"- **Approved By**: @alice (15 Mar 2026 14:00 UTC), @bob\n" + configHints
+	if got := FormatConfigMarkdown(c); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
 // TestFormatConfigMarkdown_SkipsNilApprovers verifies the config Markdown
 // formatter skips approver entries with a nil user object while rendering the
-// remaining named approvers.
+// remaining named approvers, and falls back to the display name for a user
+// GitLab sent without a username.
 func TestFormatConfigMarkdown_SkipsNilApprovers(t *testing.T) {
 	c := ConfigOutput{
 		ApprovedBy: []*MergeRequestApproverUserOutput{
@@ -1278,37 +1352,62 @@ func TestFormatConfigMarkdown_SkipsNilApprovers(t *testing.T) {
 			{User: &BasicUserOutput{Name: "Carol"}},
 		},
 	}
-	md := FormatConfigMarkdown(c)
-	assertContains(t, md, "**Approved by**: Carol")
+	want := "## MR Approvals\n\n" +
+		"- **Approved**: ❌\n" +
+		"- **You have approved**: ❌\n" +
+		"- **You can approve**: ❌\n" +
+		"- **Approved By**: Carol\n" + configHints
+	if got := FormatConfigMarkdown(c); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------
 // FormatRuleMarkdown tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatRuleMarkdown_Full verifies FormatRuleMarkdown when full.
+// ruleHints is the guidance section an approval rule card closes with.
+const ruleHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'merge_request.approval_rule_update' to modify this rule\n" +
+	"- Use action 'merge_request.approval_rule_delete' to remove this rule\n" +
+	"- Use action 'merge_request.merge' to merge once the rule is satisfied\n"
+
+// TestFormatRuleMarkdown_Full verifies the whole rendering of one approval
+// rule, including the two conditions the card never used to show: whether the
+// rule overrides the project's, and whether it names groups the caller cannot
+// see, which is why the eligible list can look shorter than it is.
 func TestFormatRuleMarkdown_Full(t *testing.T) {
 	r := RuleOutput{
-		ID:                1,
-		Name:              "Team Leads",
-		RuleType:          "regular",
-		ApprovalsRequired: 2,
-		EligibleApprovers: []*BasicUserOutput{{Name: "Alice"}, {Name: "Bob"}},
-		Users:             []*BasicUserOutput{{Name: "Alice"}},
-		Groups:            []*GroupOutput{{Name: "Leads"}},
+		ID:                   1,
+		Name:                 "Team Leads",
+		RuleType:             "regular",
+		ReportType:           "code_coverage",
+		Section:              "backend",
+		ApprovalsRequired:    2,
+		Overridden:           true,
+		ContainsHiddenGroups: true,
+		EligibleApprovers:    []*BasicUserOutput{{Name: "Alice", Username: "alice"}, {Name: "Bob", Username: "bob"}},
+		Users:                []*BasicUserOutput{{Name: "Alice", Username: "alice"}},
+		Groups:               []*GroupOutput{{Name: "Leads", FullPath: "acme/leads"}},
 	}
-	md := FormatRuleMarkdown(r)
-	assertContains(t, md, "## Approval Rule: Team Leads")
-	assertContains(t, md, "| ID | 1 |")
-	assertContains(t, md, "| Type | regular |")
-	assertContains(t, md, "| Approvals Required | 2 |")
-	assertNotContains(t, md, "| Approved |")
-	assertContains(t, md, "| Eligible | Alice, Bob |")
-	assertContains(t, md, "| Users | Alice |")
-	assertContains(t, md, "| Groups | Leads |")
+	want := "## Approval Rule: Team Leads\n\n" +
+		"- **ID**: 1\n" +
+		"- **Type**: regular\n" +
+		"- **Report Type**: code_coverage\n" +
+		"- **Section**: backend\n" +
+		"- **Approvals Required**: 2\n" +
+		"- **Overridden**: ✅\n" +
+		"- ⚠️ **Contains groups you cannot see**\n" +
+		"- **Eligible**: @alice, @bob\n" +
+		"- **Users**: @alice\n" +
+		"- **Groups**: acme/leads\n" + ruleHints
+	if got := FormatRuleMarkdown(r); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
 }
 
-// TestFormatRuleMarkdown_Minimal verifies FormatRuleMarkdown when minimal.
+// TestFormatRuleMarkdown_Minimal verifies that a rule GitLab sent nothing
+// optional for shows no label with nothing after it.
 func TestFormatRuleMarkdown_Minimal(t *testing.T) {
 	r := RuleOutput{
 		ID:                3,
@@ -1316,27 +1415,13 @@ func TestFormatRuleMarkdown_Minimal(t *testing.T) {
 		RuleType:          "any_approver",
 		ApprovalsRequired: 0,
 	}
-	md := FormatRuleMarkdown(r)
-	assertContains(t, md, "## Approval Rule: Basic")
-	assertNotContains(t, md, "| Approved |")
-	assertNotContains(t, md, "| Eligible |")
-	assertNotContains(t, md, "| Users |")
-	assertNotContains(t, md, "| Groups |")
-}
-
-// assertContains checks contains invariants for tests.
-func assertContains(t *testing.T, s, substr string) {
-	t.Helper()
-	if !strings.Contains(s, substr) {
-		t.Errorf("expected string to contain %q, got:\n%s", substr, s)
-	}
-}
-
-// assertNotContains checks not contains invariants for tests.
-func assertNotContains(t *testing.T, s, substr string) {
-	t.Helper()
-	if strings.Contains(s, substr) {
-		t.Errorf("expected string NOT to contain %q, got:\n%s", substr, s)
+	want := "## Approval Rule: Basic\n\n" +
+		"- **ID**: 3\n" +
+		"- **Type**: any_approver\n" +
+		"- **Approvals Required**: 0\n" +
+		"- **Overridden**: ❌\n" + ruleHints
+	if got := FormatRuleMarkdown(r); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mrapprovalsettings/markdown.go
+++ b/internal/tools/mrapprovalsettings/markdown.go
@@ -1,46 +1,72 @@
 package mrapprovalsettings
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// formatSetting renders one setting as the three cells of its row.
+// Canonical action IDs the hints name. Both update actions are named when the
+// formatter does not know which scope it is rendering, because the registry
+// dispatches on the Go type and the group and project handlers answer with the
+// same one.
+const (
+	actionGroupUpdate   = "merge_request.approval_settings_group_update"
+	actionProjectUpdate = "merge_request.approval_settings_project_update"
+)
+
+// settingCells renders one setting as the three cells that follow its name: the
+// value, whether a parent locked it, and the group it was inherited from.
 //
-// The pipes in the result are the column separators this row is made of, so
-// the escaping goes on the one value that is not this package's own: the name
+// The escaping goes on the one value that is not this package's own: the name
 // of the group a setting was inherited from.
-func formatSetting(s SettingOutput) string {
-	val := toolutil.BoolEmoji(s.Value)
-	locked := toolutil.BoolEmoji(s.Locked)
+func settingCells(s SettingOutput) []string {
 	inherited := "-"
 	if s.InheritedFrom != "" {
 		inherited = toolutil.EscapeMdTableCell(s.InheritedFrom)
 	}
-	return fmt.Sprintf("%s | %s | %s", val, locked, inherited)
+	return []string{toolutil.BoolEmoji(s.Value), toolutil.BoolEmoji(s.Locked), inherited}
 }
 
-// FormatOutputMarkdown renders MR approval settings as a Markdown table.
-// scope should be "Group" or "Project".
+// FormatOutputMarkdown renders merge request approval settings: the settings
+// are a collection of objects sharing columns, so they are a table under the
+// card's heading.
+//
+// scope is "Group" or "Project" when the caller knows which of the two routes
+// answered, and empty when it does not. The registry dispatches on the Go type
+// and both routes answer with [Output], so the registered formatter passes
+// none: an empty scope used to be interpolated into the heading and into a tool
+// name, giving "##  MR Approval Settings" and a hint naming
+// gitlab_update__mr_approval_settings, which no surface registers.
 func FormatOutputMarkdown(out Output, scope string) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## %s MR Approval Settings\n\n", scope)
-	sb.WriteString("| Setting | Value | Locked | Inherited From |\n")
-	sb.WriteString("| ------- | ----- | ------ | -------------- |\n")
-	fmt.Fprintf(&sb, "| Allow author approval | %s |\n", formatSetting(out.AllowAuthorApproval))
-	fmt.Fprintf(&sb, "| Allow committer approval | %s |\n", formatSetting(out.AllowCommitterApproval))
-	fmt.Fprintf(&sb, "| Allow approver list overrides | %s |\n", formatSetting(out.AllowOverridesToApproverListPerMergeRequest))
-	fmt.Fprintf(&sb, "| Retain approvals on push | %s |\n", formatSetting(out.RetainApprovalsOnPush))
-	fmt.Fprintf(&sb, "| Selective code owner removals | %s |\n", formatSetting(out.SelectiveCodeOwnerRemovals))
-	fmt.Fprintf(&sb, "| Require password to approve | %s |\n", formatSetting(out.RequirePasswordToApprove))
-	fmt.Fprintf(&sb, "| Require reauthentication | %s |\n", formatSetting(out.RequireReauthenticationToApprove))
-	toolutil.WriteHints(
-		&sb,
-		"Use gitlab_update_"+strings.ToLower(scope)+"_mr_approval_settings to change settings",
-	)
+	c := toolutil.NewCard(&sb, strings.TrimSpace(scope+" MR Approval Settings"))
+	t := c.Table("", "Setting", "Value", "Locked", "Inherited From")
+	t.Row(append([]string{"Allow author approval"}, settingCells(out.AllowAuthorApproval)...)...)
+	t.Row(append([]string{"Allow committer approval"}, settingCells(out.AllowCommitterApproval)...)...)
+	t.Row(append([]string{"Allow approver list overrides"}, settingCells(out.AllowOverridesToApproverListPerMergeRequest)...)...)
+	t.Row(append([]string{"Retain approvals on push"}, settingCells(out.RetainApprovalsOnPush)...)...)
+	t.Row(append([]string{"Selective code owner removals"}, settingCells(out.SelectiveCodeOwnerRemovals)...)...)
+	t.Row(append([]string{"Require password to approve"}, settingCells(out.RequirePasswordToApprove)...)...)
+	t.Row(append([]string{"Require reauthentication"}, settingCells(out.RequireReauthenticationToApprove)...)...)
+	c.End(updateHints(scope)...)
 	return sb.String()
+}
+
+// updateHints names the update action for the scope that answered, or both when
+// the scope is unknown.
+func updateHints(scope string) []string {
+	switch strings.ToLower(strings.TrimSpace(scope)) {
+	case "group":
+		return []string{toolutil.HintAction(actionGroupUpdate, "change these group settings")}
+	case "project":
+		return []string{toolutil.HintAction(actionProjectUpdate, "change these project settings")}
+	default:
+		return []string{
+			toolutil.HintAction(actionGroupUpdate, "change a group's approval settings"),
+			toolutil.HintAction(actionProjectUpdate, "change a project's approval settings"),
+		}
+	}
 }
 
 func init() {

--- a/internal/tools/mrapprovalsettings/mr_approval_settings_test.go
+++ b/internal/tools/mrapprovalsettings/mr_approval_settings_test.go
@@ -387,14 +387,43 @@ func TestUpdateProjectSettings(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------
 
-// TestFormatOutputMarkdown validates the markdown table rendering for
-// different scopes and setting combinations.
+// settingsTableHead is the header and delimiter of the approval settings table.
+const settingsTableHead = "| Setting | Value | Locked | Inherited From |\n| --- | --- | --- | --- |\n"
+
+// settingsRows renders the seven rows of a settings table with the value,
+// locked and inherited-from cells each case expects, so the whole-output
+// expectations below name only what differs.
+func settingsRows(rows ...string) string {
+	return strings.Join(rows, "")
+}
+
+// TestFormatOutputMarkdown validates the whole rendering of the approval
+// settings for each scope: the heading the scope names, the seven settings as
+// one table, and the update action the hint points at.
+//
+// The empty scope is its own case because it is the one the registry reaches:
+// both the group and the project route answer with [Output], so the registered
+// formatter cannot know which one it is rendering. It used to interpolate the
+// empty string into both the heading and a tool name, giving
+// "##  MR Approval Settings" and gitlab_update__mr_approval_settings.
 func TestFormatOutputMarkdown(t *testing.T) {
+	groupHint := "\n---\n💡 **Next steps:**\n- Use action 'merge_request.approval_settings_group_update' to change these group settings\n"
+	projectHint := "\n---\n💡 **Next steps:**\n- Use action 'merge_request.approval_settings_project_update' to change these project settings\n"
+	bothHints := "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'merge_request.approval_settings_group_update' to change a group's approval settings\n" +
+		"- Use action 'merge_request.approval_settings_project_update' to change a project's approval settings\n"
+	allOff := settingsRows(
+		"| Allow approver list overrides | ❌ | ❌ | - |\n",
+		"| Retain approvals on push | ❌ | ❌ | - |\n",
+		"| Selective code owner removals | ❌ | ❌ | - |\n",
+		"| Require password to approve | ❌ | ❌ | - |\n",
+		"| Require reauthentication | ❌ | ❌ | - |\n",
+	)
 	tests := []struct {
-		name        string
-		output      Output
-		scope       string
-		wantContain []string
+		name   string
+		output Output
+		scope  string
+		want   string
 	}{
 		{
 			name:  "renders project scope with all fields",
@@ -403,46 +432,39 @@ func TestFormatOutputMarkdown(t *testing.T) {
 				AllowAuthorApproval:    SettingOutput{Value: true, Locked: false},
 				AllowCommitterApproval: SettingOutput{Value: false, Locked: true, InheritedFrom: "group"},
 			},
-			wantContain: []string{
-				"## Project MR Approval Settings",
-				"Allow author approval",
-				"Allow committer approval",
-				"group",
-				"gitlab_update_project_mr_approval_settings",
-			},
+			want: "## Project MR Approval Settings\n\n" + settingsTableHead +
+				"| Allow author approval | ✅ | ❌ | - |\n" +
+				"| Allow committer approval | ❌ | ✅ | group |\n" + allOff + projectHint,
 		},
 		{
-			name:  "renders group scope with hint",
-			scope: "Group",
+			name:   "renders group scope with hint",
+			scope:  "Group",
+			output: Output{RetainApprovalsOnPush: SettingOutput{Value: true, Locked: false}},
+			want: "## Group MR Approval Settings\n\n" + settingsTableHead +
+				"| Allow author approval | ❌ | ❌ | - |\n" +
+				"| Allow committer approval | ❌ | ❌ | - |\n" +
+				"| Allow approver list overrides | ❌ | ❌ | - |\n" +
+				"| Retain approvals on push | ✅ | ❌ | - |\n" +
+				"| Selective code owner removals | ❌ | ❌ | - |\n" +
+				"| Require password to approve | ❌ | ❌ | - |\n" +
+				"| Require reauthentication | ❌ | ❌ | - |\n" + groupHint,
+		},
+		{
+			name:  "renders no scope with a neutral heading and both update actions",
+			scope: "",
 			output: Output{
-				RetainApprovalsOnPush: SettingOutput{Value: true, Locked: false},
+				AllowAuthorApproval: SettingOutput{Value: true},
 			},
-			wantContain: []string{
-				"## Group MR Approval Settings",
-				"Retain approvals on push",
-				"gitlab_update_group_mr_approval_settings",
-			},
-		},
-		{
-			name:   "renders inherited_from dash when empty",
-			scope:  "Project",
-			output: Output{AllowAuthorApproval: SettingOutput{Value: false, Locked: false, InheritedFrom: ""}},
-			wantContain: []string{
-				"| - |",
-			},
+			want: "## MR Approval Settings\n\n" + settingsTableHead +
+				"| Allow author approval | ✅ | ❌ | - |\n" +
+				"| Allow committer approval | ❌ | ❌ | - |\n" + allOff + bothHints,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := FormatOutputMarkdown(tt.output, tt.scope)
-			if md == "" {
-				t.Fatal("expected non-empty markdown")
-			}
-			for _, want := range tt.wantContain {
-				if !strings.Contains(md, want) {
-					t.Errorf("markdown missing %q", want)
-				}
+			if got := FormatOutputMarkdown(tt.output, tt.scope); got != tt.want {
+				t.Errorf("rendered =\n%q\nwant\n%q", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/mrchanges/markdown.go
+++ b/internal/tools/mrchanges/markdown.go
@@ -2,153 +2,172 @@ package mrchanges
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders the list of file changes in a merge request.
+// diffBudgetBytes bounds how much patch text one changes result carries.
+//
+// The diffs used to be dropped entirely: the result named the files and never
+// showed a line of what changed, so a reviewer had to make a second call for
+// every file. They are shown now, in the order GitLab sent them, and a patch
+// that no longer fits is named in the note rather than silently omitted, so the
+// reader knows the rest is reachable through the raw diff rather than absent.
+const diffBudgetBytes = 60_000
+
+// changeStatus is the word a file's row shows: what happened to it, and for a
+// rename the path it came from.
+func changeStatus(d FileDiffOutput) string {
+	switch {
+	case d.NewFile:
+		return "added"
+	case d.DeletedFile:
+		return "deleted"
+	case d.RenamedFile:
+		// The old path is a repository path a committer chose, and git allows
+		// every byte but NUL and the separator inside a component.
+		return "renamed from " + toolutil.EscapeMdTableCell(d.OldPath)
+	default:
+		return "modified"
+	}
+}
+
+// writeChangeTable writes the file table of a set of diffs under the card's
+// own heading, or none when there are no files.
+func writeChangeTable(c *toolutil.Card, title string, diffs []FileDiffOutput) {
+	if len(diffs) == 0 {
+		return
+	}
+	t := c.Table(title, "File", "Status")
+	for _, d := range diffs {
+		t.Row(toolutil.EscapeMdTableCell(d.NewPath), changeStatus(d))
+	}
+}
+
+// writeDiffBodies writes each file's patch as a fenced block until the budget
+// is spent, and returns the files whose patch was left out. A patch is fenced
+// by [toolutil.Card.Fence], which sizes the fence past the longest backtick run
+// the patch holds, so a diff of a Markdown file cannot close it early.
+func writeDiffBodies(c *toolutil.Card, diffs []FileDiffOutput) []string {
+	budget := diffBudgetBytes
+	var elided []string
+	for _, d := range diffs {
+		if d.Diff == "" {
+			continue
+		}
+		if len(d.Diff) > budget {
+			elided = append(elided, d.NewPath)
+			continue
+		}
+		budget -= len(d.Diff)
+		c.Fence(d.NewPath, "diff", d.Diff)
+	}
+	return elided
+}
+
+// FormatOutputMarkdown renders the file changes of a merge request: the files
+// as a collection sharing columns, then each patch as a fenced block.
 func FormatOutputMarkdown(out Output) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR !%d Changes (%d files)\n\n", out.MRIID, len(out.Changes))
 	if len(out.Changes) == 0 {
-		b.WriteString("No file changes found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("file changes")
 	}
-	truncated := []string{}
-	b.WriteString("| File | Status |\n")
-	b.WriteString("| --- | --- |\n")
-	for _, c := range out.Changes {
-		status := "modified"
-		switch {
-		case c.NewFile:
-			status = "added"
-		case c.DeletedFile:
-			status = "deleted"
-		case c.RenamedFile:
-			// The old path is a repository path a committer chose, and git
-			// allows every byte but NUL and the separator inside a component.
-			status = "renamed from " + toolutil.EscapeMdTableCell(c.OldPath)
-		}
-		if c.Diff == "" && !c.DeletedFile {
-			// The hint lists the paths, and a path is a committer's choice
-			// like any other, so it is escaped where it joins the sentence.
-			truncated = append(truncated, toolutil.EscapeMdTableCell(c.NewPath))
-		}
-		fmt.Fprintf(&b, "| %s | %s |\n",
-			toolutil.EscapeMdTableCell(c.NewPath), status)
-	}
-	hints := []string{
-		"Use 'diff_versions_list' to list all diff versions of this MR",
-	}
-	if len(truncated) > 0 {
-		hints = append(hints,
-			fmt.Sprintf("Some file diffs are empty due to GitLab truncation (%s). Use 'diff_versions_list' to get version IDs, then 'diff_version_get' with a version_id to retrieve full diffs",
-				strings.Join(truncated, ", ")))
-	}
-	toolutil.WriteHints(&b, hints...)
-	return b.String()
-}
-
-// FormatDiffVersionsListMarkdown renders the list of diff versions as markdown.
-func FormatDiffVersionsListMarkdown(out DiffVersionsListOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Diff Versions (%d)\n\n", len(out.DiffVersions))
-	toolutil.WriteListSummary(&b, len(out.DiffVersions), out.Pagination)
-	if len(out.DiffVersions) == 0 {
-		b.WriteString("No diff versions found.\n")
-		return b.String()
+	c := toolutil.NewCard(&b, fmt.Sprintf("MR !%d Changes", out.MRIID))
+	c.Int("Files", int64(len(out.Changes)))
+	c.Count("Truncated by GitLab", int64(len(out.TruncatedFiles)))
+	writeChangeTable(c, "Files", out.Changes)
+	elided := writeDiffBodies(c, out.Changes)
+	if len(elided) > 0 {
+		c.Note(fmt.Sprintf("%d of %d patches are not shown here: the response would be too large. Read them with action '%s'.", len(elided), len(out.Changes), actionRawDiffs))
 	}
-	b.WriteString("| ID | State | Head SHA | Base SHA | Created |\n")
-	b.WriteString("| --- | --- | --- | --- | --- |\n")
-	for _, v := range out.DiffVersions {
-		short := v.HeadCommitSHA
-		if len(short) > 8 {
-			short = short[:8]
-		}
-		baseSHA := v.BaseCommitSHA
-		if len(baseSHA) > 8 {
-			baseSHA = baseSHA[:8]
-		}
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s |\n",
-			//gitlab:allow-unescaped v.State: a merge request diff state GitLab records, one of its own fixed set.
-			//gitlab:allow-unescaped short: the head commit SHA, hexadecimal digits git computed, truncated here.
-			//gitlab:allow-unescaped baseSHA: the base commit SHA, hexadecimal digits git computed, truncated here.
-			//gitlab:allow-unescaped v.CreatedAt: a timestamp this package formatted with time.Time.Format as RFC 3339.
-			v.ID, v.State, short, baseSHA, v.CreatedAt)
+	hints := []string{toolutil.HintAction(actionDiffVersionsList, "list every diff version of this merge request")}
+	if len(out.TruncatedFiles) > 0 {
+		// The paths themselves are in truncated_files: naming them here would
+		// put a committer's paths into the guidance section, and the structured
+		// field is where a caller reads them anyway.
+		hints = append(hints, fmt.Sprintf("GitLab truncated %d file diff(s); truncated_files names them. Use action '%s' with a version_id for the full patch", len(out.TruncatedFiles), actionDiffVersionGet))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, "Use action 'diff_version_get' with version ID for detailed diffs")
+	c.End(hints...)
 	return b.String()
 }
 
-// FormatDiffVersionGetMarkdown renders a single diff version detail as markdown.
+// FormatDiffVersionsListMarkdown renders the diff versions of a merge request
+// as a Markdown table.
+func FormatDiffVersionsListMarkdown(out DiffVersionsListOutput) string {
+	if len(out.DiffVersions) == 0 {
+		return toolutil.EmptyMessage("diff versions")
+	}
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "MR Diff Versions", len(out.DiffVersions), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "State", "Head SHA", "Base SHA", "Created"))
+	for _, v := range out.DiffVersions {
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(v.ID, 10),
+			toolutil.EscapeMdTableCell(v.State),
+			toolutil.MdCodeSpanCell(shortSHA(v.HeadCommitSHA)),
+			toolutil.MdCodeSpanCell(shortSHA(v.BaseCommitSHA)),
+			toolutil.FormatTime(v.CreatedAt),
+		))
+	}
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionDiffVersionGet, "read one version's commits and file diffs"),
+	)
+	return b.String()
+}
+
+// shortSHA abbreviates a commit SHA to the eight characters GitLab shows, and
+// leaves a shorter one alone.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// FormatDiffVersionGetMarkdown renders one diff version as the card of one
+// object, with its commits and its file changes as nested collections.
 func FormatDiffVersionGetMarkdown(out DiffVersionOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Diff Version %d\n\n", out.ID)
-	//gitlab:allow-unescaped out.State: a merge request diff state GitLab records, one of its own fixed set.
-	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
-	//gitlab:allow-unescaped out.HeadCommitSHA: a commit SHA, hexadecimal digits git computed.
-	fmt.Fprintf(&b, "- **Head SHA**: %s\n", out.HeadCommitSHA)
-	//gitlab:allow-unescaped out.BaseCommitSHA: a commit SHA, hexadecimal digits git computed.
-	fmt.Fprintf(&b, "- **Base SHA**: %s\n", out.BaseCommitSHA)
-	//gitlab:allow-unescaped out.StartCommitSHA: a commit SHA, hexadecimal digits git computed.
-	fmt.Fprintf(&b, "- **Start SHA**: %s\n", out.StartCommitSHA)
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(out.CreatedAt))
-	}
-	if out.RealSize != "" {
-		//gitlab:allow-unescaped out.RealSize: GitLab's own count of the files in the diff, decimal digits with a trailing plus when the diff overflowed.
-		fmt.Fprintf(&b, "- **Real Size**: %s\n", out.RealSize)
-	}
-
+	c := toolutil.NewCard(&b, fmt.Sprintf("Diff Version %d", out.ID))
+	c.Int("ID", out.ID)
+	c.Field("State", out.State)
+	c.Code("Head SHA", out.HeadCommitSHA)
+	c.Code("Base SHA", out.BaseCommitSHA)
+	c.Code("Start SHA", out.StartCommitSHA)
+	c.Code("Patch ID SHA", out.PatchIDSHA)
+	c.Time("Created", out.CreatedAt)
+	c.Field("Real Size", out.RealSize)
 	if len(out.Commits) > 0 {
-		fmt.Fprintf(&b, "\n### Commits (%d)\n\n", len(out.Commits))
-		b.WriteString("| SHA | Author | Title |\n")
-		b.WriteString("| --- | --- | --- |\n")
-		for _, c := range out.Commits {
-			short := c.ShortID
-			if short == "" && len(c.ID) > 8 {
-				short = c.ID[:8]
+		t := c.Table(fmt.Sprintf("Commits (%d)", len(out.Commits)), "SHA", "Author", "Title")
+		for _, commit := range out.Commits {
+			short := commit.ShortID
+			if short == "" {
+				short = shortSHA(commit.ID)
 			}
-			//gitlab:allow-unescaped short: a commit SHA, hexadecimal digits git computed, truncated here.
-			fmt.Fprintf(&b, "| %s | %s | %s |\n",
-				short, toolutil.EscapeMdTableCell(c.AuthorName), toolutil.EscapeMdTableCell(c.Title))
+			t.Row(
+				toolutil.MdCodeSpanCell(short),
+				toolutil.EscapeMdTableCell(commit.AuthorName),
+				toolutil.EscapeMdTableCell(commit.Title),
+			)
 		}
 	}
-
-	if len(out.Diffs) > 0 {
-		fmt.Fprintf(&b, "\n### File Changes (%d)\n\n", len(out.Diffs))
-		b.WriteString("| File | Status |\n")
-		b.WriteString("| --- | --- |\n")
-		for _, d := range out.Diffs {
-			status := "modified"
-			switch {
-			case d.NewFile:
-				status = "added"
-			case d.DeletedFile:
-				status = "deleted"
-			case d.RenamedFile:
-				status = "renamed from " + toolutil.EscapeMdTableCell(d.OldPath)
-			}
-			fmt.Fprintf(&b, "| %s | %s |\n",
-				toolutil.EscapeMdTableCell(d.NewPath), status)
-		}
-	}
-	toolutil.WriteHints(&b, "Use 'diff_versions_list' to list all diff versions of this MR")
+	writeChangeTable(c, fmt.Sprintf("File Changes (%d)", len(out.Diffs)), out.Diffs)
+	c.End(toolutil.HintAction(actionDiffVersionsList, "list every diff version of this merge request"))
 	return b.String()
 }
 
-// FormatRawDiffsMarkdown renders the raw diff output as a fenced code block.
+// FormatRawDiffsMarkdown renders the raw patch of a merge request as one fenced
+// block.
 func FormatRawDiffsMarkdown(out RawDiffsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR !%d Raw Diffs\n\n", out.MRIID)
 	if out.RawDiff == "" {
-		b.WriteString("No diffs found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("diffs")
 	}
-	b.WriteString(toolutil.MarkdownFencedBlock("diff", out.RawDiff))
-	toolutil.WriteHints(&b, "Use action 'changes_get' for file-level change summary")
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("MR !%d Raw Diffs", out.MRIID))
+	c.Fence("", "diff", out.RawDiff)
+	c.End(toolutil.HintAction(actionChangesGet, "see the file-by-file change summary"))
 	return b.String()
 }
 

--- a/internal/tools/mrchanges/mr_changes_test.go
+++ b/internal/tools/mrchanges/mr_changes_test.go
@@ -323,7 +323,14 @@ func TestVersionIDRequired_Validation(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown_WithChanges verifies FormatOutputMarkdown when with changes.
+// fileTableHead is the header and delimiter of the file table the changes
+// result and the diff version card share.
+const fileTableHead = "| File | Status |\n| --- | --- |\n"
+
+// TestFormatOutputMarkdown_WithChanges verifies the whole rendering of a merge
+// request's changes: the counts, the file table, then each patch as a fenced
+// block under the file it belongs to. The patches used to be dropped entirely,
+// so the result named the files and never showed a line of what changed.
 func TestFormatOutputMarkdown_WithChanges(t *testing.T) {
 	out := Output{
 		MRIID: 42,
@@ -334,33 +341,27 @@ func TestFormatOutputMarkdown_WithChanges(t *testing.T) {
 			{NewPath: "new_name.go", OldPath: "old_name.go", Diff: "rename diff", RenamedFile: true},
 		},
 	}
-	md := FormatOutputMarkdown(out)
-
-	for _, want := range []string{
-		"## MR !42 Changes (4 files)",
-		"| File | Status |",
-		"| main.go | modified |",
-		"| new_file.go | added |",
-		"| removed.go | deleted |",
-		"| new_name.go | renamed from old_name.go |",
-		"diff_versions_list",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	for _, absent := range []string{"raw_diffs", "truncation"} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("markdown should not contain %q when no files are truncated:\n%s", absent, md)
-			}
-		})
+	want := "## MR !42 Changes\n\n" +
+		"- **Files**: 4\n\n" +
+		"### Files\n\n" + fileTableHead +
+		"| main.go | modified |\n" +
+		"| new_file.go | added |\n" +
+		"| removed.go | deleted |\n" +
+		"| new_name.go | renamed from old_name.go |\n\n" +
+		"### main.go\n\n```diff\nsome diff\n```\n\n" +
+		"### new_file.go\n\n```diff\n+new\n```\n\n" +
+		"### new_name.go\n\n```diff\nrename diff\n```\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.diff_versions_list' to list every diff version of this merge request\n"
+	if got := FormatOutputMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_TruncatedFiles verifies hints when GitLab truncates large diffs.
+// TestFormatOutputMarkdown_TruncatedFiles verifies that GitLab's own truncation
+// is counted and pointed at truncated_files, and that a deleted file — which
+// carries no patch because there is nothing left of it — is not counted as
+// truncated.
 func TestFormatOutputMarkdown_TruncatedFiles(t *testing.T) {
 	out := Output{
 		MRIID: 99,
@@ -370,41 +371,31 @@ func TestFormatOutputMarkdown_TruncatedFiles(t *testing.T) {
 			{NewPath: "huge_test.c", OldPath: "huge_test.c", Diff: ""},
 			{NewPath: "removed.go", OldPath: "removed.go", Diff: "", DeletedFile: true},
 		},
+		TruncatedFiles: []string{"big_test.c", "huge_test.c"},
 	}
-	md := FormatOutputMarkdown(out)
-
-	for _, want := range []string{
-		"## MR !99 Changes (4 files)",
-		"diff_versions_list",
-		"diff_version_get",
-		"big_test.c",
-		"huge_test.c",
-		"truncation",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	if strings.Contains(md, "removed.go") && strings.Contains(md, "truncation") {
-		// Deleted files with empty diff should NOT be in truncation warning
-		if strings.Contains(md, "removed.go, ") || strings.Contains(md, ", removed.go") {
-			t.Errorf("deleted file should not appear in truncation warning:\n%s", md)
-		}
+	want := "## MR !99 Changes\n\n" +
+		"- **Files**: 4\n" +
+		"- **Truncated by GitLab**: 2\n\n" +
+		"### Files\n\n" + fileTableHead +
+		"| small.go | modified |\n" +
+		"| big_test.c | modified |\n" +
+		"| huge_test.c | modified |\n" +
+		"| removed.go | deleted |\n\n" +
+		"### small.go\n\n```diff\nsome diff\n```\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.diff_versions_list' to list every diff version of this merge request\n" +
+		"- GitLab truncated 2 file diff(s); truncated_files names them. Use action 'mr_review.diff_version_get' with a version_id for the full patch\n"
+	if got := FormatOutputMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_Empty verifies FormatOutputMarkdown when empty.
+// TestFormatOutputMarkdown_Empty verifies that a merge request with no file
+// change renders the one-sentence empty message and no table header.
 func TestFormatOutputMarkdown_Empty(t *testing.T) {
-	out := Output{MRIID: 7, Changes: nil}
-	md := FormatOutputMarkdown(out)
-
-	if !strings.Contains(md, "No file changes found.") {
-		t.Errorf("expected 'No file changes found.' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "| File |") {
-		t.Error("should not contain table header when no changes")
+	want := "No file changes found.\n"
+	if got := FormatOutputMarkdown(Output{MRIID: 7}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -421,35 +412,25 @@ func TestFormatDiffVersionsListMarkdown_WithVersions(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatDiffVersionsListMarkdown(out)
-
-	for _, want := range []string{
-		"## MR Diff Versions (2)",
-		"| ID | State | Head SHA | Base SHA | Created |",
-		"| 1 | collected |",
-		"| 2 | overflow |",
-		"abcdef12", // truncated to 8
-		"12345678", // truncated to 8
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	// Full SHA should not appear (truncated to 8)
-	if strings.Contains(md, "abcdef1234567890") {
-		t.Errorf("head SHA should be truncated to 8 chars:\n%s", md)
+	want := "## MR Diff Versions (2)\n\n" +
+		"| ID | State | Head SHA | Base SHA | Created |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | collected | `abcdef12` | `12345678` | 15 Jan 2026 10:00 UTC |\n" +
+		"| 2 | overflow | `short` | `short2` | 16 Jan 2026 10:00 UTC |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.diff_version_get' to read one version's commits and file diffs\n"
+	if got := FormatDiffVersionsListMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatDiffVersionsListMarkdown_Empty verifies FormatDiffVersionsListMarkdown when empty.
+// TestFormatDiffVersionsListMarkdown_Empty verifies that a merge request with
+// no diff version renders the one-sentence empty message.
 func TestFormatDiffVersionsListMarkdown_Empty(t *testing.T) {
-	out := DiffVersionsListOutput{DiffVersions: nil}
-	md := FormatDiffVersionsListMarkdown(out)
-
-	if !strings.Contains(md, "No diff versions found.") {
-		t.Errorf("expected 'No diff versions found.' in markdown:\n%s", md)
+	want := "No diff versions found.\n"
+	if got := FormatDiffVersionsListMarkdown(DiffVersionsListOutput{}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -478,38 +459,33 @@ func TestFormatDiffVersionGetMarkdown_Full(t *testing.T) {
 			{NewPath: "renamed.go", OldPath: "original.go", RenamedFile: true},
 		},
 	}
-	md := FormatDiffVersionGetMarkdown(out)
-
-	for _, want := range []string{
-		"## Diff Version 5",
-		"**State**: collected",
-		"**Head SHA**: abc123",
-		"**Base SHA**: def456",
-		"**Start SHA**: ghi789",
-		"**Created**: 16 Jan 2026 10:00 UTC",
-		"**Real Size**: 3",
-		"### Commits (2)",
-		"| shrt123 |",
-		"| anotherh |", // fallback: ID[:8] when ShortID empty
-		"### File Changes (4)",
-		"| main.go | modified |",
-		"| added.go | added |",
-		"| deleted.go | deleted |",
-		"| renamed.go | renamed from original.go |",
-		"diff_versions_list",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	if strings.Contains(md, "raw_diffs") {
-		t.Errorf("should not reference non-existent raw_diffs action:\n%s", md)
+	want := "## Diff Version 5\n\n" +
+		"- **ID**: 5\n" +
+		"- **State**: collected\n" +
+		"- **Head SHA**: `abc123`\n" +
+		"- **Base SHA**: `def456`\n" +
+		"- **Start SHA**: `ghi789`\n" +
+		"- **Created**: 16 Jan 2026 10:00 UTC\n" +
+		"- **Real Size**: 3\n\n" +
+		"### Commits (2)\n\n" +
+		"| SHA | Author | Title |\n| --- | --- | --- |\n" +
+		"| `shrt123` | Dev | Fix bug |\n" +
+		"| `anotherh` | Dev2 | Second commit |\n\n" +
+		"### File Changes (4)\n\n" + fileTableHead +
+		"| main.go | modified |\n" +
+		"| added.go | added |\n" +
+		"| deleted.go | deleted |\n" +
+		"| renamed.go | renamed from original.go |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.diff_versions_list' to list every diff version of this merge request\n"
+	if got := FormatDiffVersionGetMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatDiffVersionGetMarkdown_Minimal verifies FormatDiffVersionGetMarkdown when minimal.
+// TestFormatDiffVersionGetMarkdown_Minimal verifies that a diff version GitLab
+// sent nothing optional for shows no label with nothing after it and opens no
+// empty section.
 func TestFormatDiffVersionGetMarkdown_Minimal(t *testing.T) {
 	out := DiffVersionOutput{
 		ID:            1,
@@ -517,23 +493,15 @@ func TestFormatDiffVersionGetMarkdown_Minimal(t *testing.T) {
 		HeadCommitSHA: "abc",
 		BaseCommitSHA: "def",
 	}
-	md := FormatDiffVersionGetMarkdown(out)
-
-	if !strings.Contains(md, "## Diff Version 1") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	// No CreatedAt, RealSize, Commits, Diffs → those sections absent
-	if strings.Contains(md, "**Created**") {
-		t.Errorf("should not contain Created when empty:\n%s", md)
-	}
-	if strings.Contains(md, "**Real Size**") {
-		t.Errorf("should not contain Real Size when empty:\n%s", md)
-	}
-	if strings.Contains(md, "### Commits") {
-		t.Errorf("should not contain Commits section when empty:\n%s", md)
-	}
-	if strings.Contains(md, "### File Changes") {
-		t.Errorf("should not contain File Changes section when empty:\n%s", md)
+	want := "## Diff Version 1\n\n" +
+		"- **ID**: 1\n" +
+		"- **State**: empty\n" +
+		"- **Head SHA**: `abc`\n" +
+		"- **Base SHA**: `def`\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.diff_versions_list' to list every diff version of this merge request\n"
+	if got := FormatDiffVersionGetMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -605,46 +573,36 @@ func TestRawDiffs_CancelledContext(t *testing.T) {
 // FormatRawDiffsMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatRawDiffsMarkdown_WithDiff verifies FormatRawDiffsMarkdown when with diff.
+// rawDiffsHints is the guidance section the raw diff card closes with.
+const rawDiffsHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'mr_review.changes_get' to see the file-by-file change summary\n"
+
+// TestFormatRawDiffsMarkdown_WithDiff verifies the whole rendering of a raw
+// patch: the heading, then the patch inside one fenced block.
 func TestFormatRawDiffsMarkdown_WithDiff(t *testing.T) {
-	out := RawDiffsOutput{MRIID: 3, RawDiff: "diff --git a/f.go b/f.go\n--- a/f.go\n+++ b/f.go\n@@ -1 +1 @@\n-old\n+new\n"}
-	md := FormatRawDiffsMarkdown(out)
-
-	for _, want := range []string{
-		"## MR !3 Raw Diffs",
-		"```diff",
-		"diff --git",
-		"```",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	const diff = "diff --git a/f.go b/f.go\n--- a/f.go\n+++ b/f.go\n@@ -1 +1 @@\n-old\n+new\n"
+	want := "## MR !3 Raw Diffs\n\n```diff\n" + diff + "```\n" + rawDiffsHints
+	if got := FormatRawDiffsMarkdown(RawDiffsOutput{MRIID: 3, RawDiff: diff}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRawDiffsMarkdown_Empty verifies FormatRawDiffsMarkdown when empty.
+// TestFormatRawDiffsMarkdown_Empty verifies that a merge request with no patch
+// renders the one-sentence empty message and opens no fence.
 func TestFormatRawDiffsMarkdown_Empty(t *testing.T) {
-	out := RawDiffsOutput{MRIID: 4, RawDiff: ""}
-	md := FormatRawDiffsMarkdown(out)
-
-	if !strings.Contains(md, "No diffs found.") {
-		t.Errorf("expected 'No diffs found.' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "```diff") {
-		t.Error("should not contain code fence when no diffs")
+	want := "No diffs found.\n"
+	if got := FormatRawDiffsMarkdown(RawDiffsOutput{MRIID: 4}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatRawDiffsMarkdown_NoTrailingNewline verifies FormatRawDiffsMarkdown when no trailing newline.
+// TestFormatRawDiffsMarkdown_NoTrailingNewline verifies that a patch GitLab
+// sent without a trailing newline still gets one before the closing fence,
+// which is what keeps the fence on a line of its own.
 func TestFormatRawDiffsMarkdown_NoTrailingNewline(t *testing.T) {
-	out := RawDiffsOutput{MRIID: 5, RawDiff: "some diff without trailing newline"}
-	md := FormatRawDiffsMarkdown(out)
-
-	// The formatter should add a newline before the closing fence
-	if !strings.Contains(md, "some diff without trailing newline\n```") {
-		t.Errorf("expected newline insertion before closing fence:\n%s", md)
+	want := "## MR !5 Raw Diffs\n\n```diff\nsome diff without trailing newline\n```\n" + rawDiffsHints
+	if got := FormatRawDiffsMarkdown(RawDiffsOutput{MRIID: 5, RawDiff: "some diff without trailing newline"}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mrcontextcommits/markdown.go
+++ b/internal/tools/mrcontextcommits/markdown.go
@@ -1,7 +1,6 @@
 package mrcontextcommits
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,21 +8,38 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown formats the list of context commits as markdown.
+// FormatListMarkdown renders the context commits attached to a merge request as
+// a Markdown table: a collection of objects that share columns.
 func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
+	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
+}
+
+// FormatListMarkdownString renders the context commit list as Markdown.
+func FormatListMarkdownString(out ListOutput) string {
 	if len(out.Commits) == 0 {
-		return toolutil.ToolResultWithMarkdown("No context commits found for this merge request.\n")
+		return toolutil.EmptyMessage("context commits")
 	}
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "## MR Context Commits (%d)\n\n", len(out.Commits))
-	sb.WriteString("| SHA | Title | Author |\n")
-	sb.WriteString("|-----|-------|--------|\n")
+	toolutil.WriteListHeading(&sb, "MR Context Commits", len(out.Commits), toolutil.PaginationOutput{})
+	sb.WriteString(toolutil.MarkdownTableHeader("SHA", "Title", "Author", "Created"))
 	for _, c := range out.Commits {
-		//gitlab:allow-unescaped c.ShortID: an abbreviated commit SHA, hexadecimal by construction.
-		fmt.Fprintf(&sb, "| %s | %s | %s |\n", c.ShortID, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName))
+		short := c.ShortID
+		if short == "" {
+			short = c.ID
+		}
+		sb.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdCodeSpanCell(short),
+			toolutil.EscapeMdTableCell(c.Title),
+			toolutil.EscapeMdTableCell(c.AuthorName),
+			toolutil.FormatTime(c.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use `gitlab_commit_get` to view full details of a specific commit")
-	return toolutil.ToolResultWithMarkdown(sb.String())
+	toolutil.WriteListFooter(&sb, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(actionCommitGet, "read one of these commits in full"),
+		toolutil.HintAction(actionContextCommitsCreate, "pin another commit to this review"),
+		toolutil.HintAction(actionContextCommitsDelete, "unpin one of these commits"),
+	)
+	return sb.String()
 }
 
 func init() {

--- a/internal/tools/mrcontextcommits/mr_context_commits_test.go
+++ b/internal/tools/mrcontextcommits/mr_context_commits_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
@@ -356,42 +354,44 @@ func TestDelete_CancelledContext(t *testing.T) {
 // FormatListMarkdown — content validation
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_ContentValidation verifies FormatListMarkdown when content validation.
+// contextCommitHints is the guidance section a context commit listing closes
+// with.
+const contextCommitHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'commit.get' to read one of these commits in full\n" +
+	"- Use action 'merge_request.context_commits_create' to pin another commit to this review\n" +
+	"- Use action 'merge_request.context_commits_delete' to unpin one of these commits\n"
+
+// TestFormatListMarkdown_ContentValidation verifies the whole rendering of a
+// context commit listing: the SHA as a code span, the pipe in a commit title
+// escaped so it cannot split the row, and the guidance naming canonical action
+// IDs rather than a tool name.
 func TestFormatListMarkdown_ContentValidation(t *testing.T) {
 	out := ListOutput{
 		Commits: []CommitItem{
-			{ID: "abc123", ShortID: "abc1", Title: "First | commit", AuthorName: "Dev"},
+			{ID: "abc123", ShortID: "abc1", Title: "First | commit", AuthorName: "Dev", CreatedAt: "2026-01-15T10:00:00Z"},
 			{ID: "def456", ShortID: "def4", Title: "Second commit", AuthorName: "Dev2"},
 		},
 	}
-	result := FormatListMarkdown(out)
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	want := "## MR Context Commits (2)\n\n" +
+		"| SHA | Title | Author | Created |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| `abc1` | First &#124; commit | Dev | 15 Jan 2026 10:00 UTC |\n" +
+		"| `def4` | Second commit | Dev2 |  |\n" + contextCommitHints
+	if got := FormatListMarkdownString(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
+}
 
-	tc, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected *mcp.TextContent, got %T", result.Content[0])
-	}
-	md := tc.Text
-
-	for _, want := range []string{
-		"## MR Context Commits (2)",
-		"| SHA | Title | Author |",
-		"| abc1 |",
-		"| def4 |",
-		"Dev2",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-
-	// Pipe in title should be escaped
-	if strings.Contains(md, "First | commit") {
-		t.Errorf("pipe in title should be escaped:\n%s", md)
+// TestFormatListMarkdown_FallsBackToTheFullSHA verifies that a commit GitLab
+// sent no abbreviated id for is still identified, by its full one.
+func TestFormatListMarkdown_FallsBackToTheFullSHA(t *testing.T) {
+	out := ListOutput{Commits: []CommitItem{{ID: "abc123def456", Title: "Only a long id", AuthorName: "Dev"}}}
+	want := "## MR Context Commits (1)\n\n" +
+		"| SHA | Title | Author | Created |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| `abc123def456` | Only a long id | Dev |  |\n" + contextCommitHints
+	if got := FormatListMarkdownString(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mrdiscussions/markdown.go
+++ b/internal/tools/mrdiscussions/markdown.go
@@ -1,67 +1,76 @@
 package mrdiscussions
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatNoteMarkdown renders a single discussion note as Markdown.
+// toMarkdownNote builds the shared note view model for a thread note.
+//
+// A confidential note is internal as far as a reader is concerned — GitLab
+// spells the same restriction both ways depending on the entity — so the two
+// flags are folded into the one the card shows.
+func toMarkdownNote(n NoteOutput) toolutil.NoteMarkdown {
+	flags := toolutil.NoteMarkdownFlags{
+		System:     n.System,
+		Internal:   n.Internal || n.Confidential,
+		Resolvable: n.Resolvable,
+		Resolved:   n.Resolved,
+	}
+	return toolutil.NewNoteMarkdown(n.ID, n.Body, n.AuthorUsername(), n.CreatedAt, flags, n.ResolvedByUsername())
+}
+
+// toMarkdownDiscussion builds the shared thread view model, every note through
+// [toMarkdownNote].
+func toMarkdownDiscussion(d Output) toolutil.DiscussionMarkdown {
+	notes := make([]toolutil.NoteMarkdown, 0, len(d.Notes))
+	for _, n := range d.Notes {
+		if n != nil {
+			notes = append(notes, toMarkdownNote(*n))
+		}
+	}
+	return toolutil.NewDiscussionMarkdown(d.ID, notes)
+}
+
+// FormatNoteMarkdown renders one discussion note as the note card every note
+// tool in the tree renders: the author as a handle, the time, the flags that
+// hold, the resolution state, and the body as quoted prose.
+//
+// It used to print "- **Resolved**: %v" on every note, resolvable or not, and
+// showed neither the internal flag nor who resolved the thread.
 func FormatNoteMarkdown(n NoteOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Discussion Note #%d\n\n", n.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdAuthor, toolutil.EscapeMdTableCell(n.AuthorUsername()))
-	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(n.CreatedAt))
-	fmt.Fprintf(&b, "- **Resolved**: %v\n", n.Resolved)
-	fmt.Fprintf(&b, "\n%s\n", toolutil.WrapGFMBody(n.Body))
-	toolutil.WriteHints(
-		&b,
-		"Use action 'discussion_note_update' with note_id to edit this note",
-		"Use action 'discussion_resolve' with discussion_id to resolve this discussion",
-	)
-	return b.String()
+	return toolutil.FormatNoteMarkdown(toMarkdownNote(n), toolutil.NoteMarkdownOptions{
+		Title:             "Discussion Note",
+		IncludeInternal:   true,
+		IncludeResolvable: true,
+		Hints: []string{
+			toolutil.HintAction(actionDiscussionNoteUpdate, "edit this note"),
+			toolutil.HintAction(actionDiscussionNoteDelete, "remove this note"),
+			toolutil.HintAction(actionDiscussionResolve, "resolve or unresolve the thread it belongs to"),
+		},
+	})
 }
 
-// FormatOutputMarkdown renders a discussion thread with all its notes as Markdown.
+// FormatOutputMarkdown renders one discussion thread through the renderer every
+// discussion family shares: the thread's heading, then each note as a list item
+// naming its author, time and ID, with the body quoted underneath.
 func FormatOutputMarkdown(d Output) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Discussion %s\n\n", toolutil.EscapeMdHeading(d.ID))
-	fmt.Fprintf(&b, "- **Notes**: %d\n", len(d.Notes))
-	fmt.Fprintf(&b, "- **Individual Note**: %v\n", d.IndividualNote)
-	for i, n := range d.Notes {
-		fmt.Fprintf(&b, "\n### Note %d (by %s)\n\n%s\n", i+1, toolutil.EscapeMdHeading(n.AuthorUsername()), toolutil.WrapGFMBody(n.Body))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'discussion_reply' to reply to this discussion",
-		"Use action 'discussion_resolve' with discussion_id to resolve/unresolve",
+	return toolutil.FormatDiscussionMarkdown(toMarkdownDiscussion(d),
+		toolutil.HintAction(actionDiscussionReply, "reply to this discussion"),
+		toolutil.HintAction(actionDiscussionResolve, "resolve or unresolve it"),
+		toolutil.HintAction(actionDiscussionNoteUpdate, "edit one of its notes"),
 	)
-	return b.String()
 }
 
-// FormatListMarkdown renders a list of discussion threads as a Markdown table.
+// FormatListMarkdown renders a page of merge request discussion threads through
+// the same shared renderer, so a thread reads the same whether it was listed or
+// fetched.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## MR Discussions (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Discussions), out.Pagination)
-	if len(out.Discussions) == 0 {
-		b.WriteString("No merge request discussions found.\n")
-		return b.String()
-	}
-	b.WriteString("| ID | Notes | Individual |\n")
-	b.WriteString(toolutil.TblSep3Col)
-	for _, d := range out.Discussions {
-		fmt.Fprintf(&b, toolutil.FmtRow3Str, toolutil.EscapeMdTableCell(d.ID), strconv.Itoa(len(d.Notes)), strconv.FormatBool(d.IndividualNote))
-	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'discussion_get' with discussion_id to see full discussion notes",
-		"Use action 'discussion_create' to start a new discussion on this MR",
+	return toolutil.FormatRESTDiscussionListMarkdown(
+		out.Discussions, out.Pagination, toMarkdownDiscussion,
+		"MR Discussions", toolutil.EmptyMessage("merge request discussions"),
+		toolutil.HintAction(actionDiscussionGet, "read one thread in full"),
+		toolutil.HintAction(actionDiscussionCreate, "start a new discussion on this merge request"),
 	)
-	return b.String()
 }
 
 func init() {

--- a/internal/tools/mrdiscussions/mr_discussions_test.go
+++ b/internal/tools/mrdiscussions/mr_discussions_test.go
@@ -763,41 +763,70 @@ func TestDeleteNote_APIError(t *testing.T) {
 // FormatNoteMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatNoteMarkdown_Full verifies FormatNoteMarkdown when full.
+// noteHints is the guidance section a discussion note card closes with, and
+// threadHints the one a thread closes with.
+const (
+	noteHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.discussion_note_update' to edit this note\n" +
+		"- Use action 'mr_review.discussion_note_delete' to remove this note\n" +
+		"- Use action 'mr_review.discussion_resolve' to resolve or unresolve the thread it belongs to\n"
+	threadHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.discussion_reply' to reply to this discussion\n" +
+		"- Use action 'mr_review.discussion_resolve' to resolve or unresolve it\n" +
+		"- Use action 'mr_review.discussion_note_update' to edit one of its notes\n"
+)
+
+// TestFormatNoteMarkdown_Full verifies the whole rendering of one discussion
+// note, through the note card every note tool in the tree shares: the
+// resolution state is a word rather than a bare true, it is shown only for a
+// note that can be resolved, and the resolver is named.
 func TestFormatNoteMarkdown_Full(t *testing.T) {
 	n := NoteOutput{
-		ID:        500,
-		Body:      "Looks good!",
-		Author:    &toolutil.NoteUserOutput{Username: "reviewer"},
-		CreatedAt: "2026-03-02T12:00:00Z",
-		Resolved:  true,
+		ID:         500,
+		Body:       "Looks good!",
+		Author:     &toolutil.NoteUserOutput{Username: "reviewer"},
+		CreatedAt:  "2026-03-02T12:00:00Z",
+		Resolvable: true,
+		Resolved:   true,
+		ResolvedBy: &toolutil.NoteUserOutput{Username: "maintainer"},
 	}
-	md := FormatNoteMarkdown(n)
-
-	for _, want := range []string{
-		"## Discussion Note #500",
-		"reviewer",
-		"2 Mar 2026 12:00 UTC",
-		"**Resolved**: true",
-		"Looks good!",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Discussion Note #500\n\n" +
+		"- **Author**: @reviewer\n" +
+		"- **Created**: 2 Mar 2026 12:00 UTC\n" +
+		"- **Resolvable**: resolved\n" +
+		"- **Resolved By**: @maintainer\n" +
+		"- **Body**: Looks good!\n" + noteHints
+	if got := FormatNoteMarkdown(n); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatNoteMarkdown_Minimal verifies FormatNoteMarkdown when minimal.
+// TestFormatNoteMarkdown_Minimal verifies that a note nothing can resolve shows
+// no resolution row at all: the "**Resolved**: false" this replaced was printed
+// on every note, resolvable or not.
 func TestFormatNoteMarkdown_Minimal(t *testing.T) {
 	n := NoteOutput{ID: 1, Body: "hi", Author: &toolutil.NoteUserOutput{Username: "u"}, CreatedAt: "2026-01-01T00:00:00Z"}
-	md := FormatNoteMarkdown(n)
-	if !strings.Contains(md, "## Discussion Note #1") {
-		t.Errorf("missing header:\n%s", md)
+	want := "## Discussion Note #1\n\n" +
+		"- **Author**: @u\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Body**: hi\n" + noteHints
+	if got := FormatNoteMarkdown(n); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
-	if !strings.Contains(md, "**Resolved**: false") {
-		t.Errorf("should show resolved false:\n%s", md)
+}
+
+// TestFormatNoteMarkdown_ConfidentialIsInternal verifies that a note GitLab
+// marked confidential is shown as internal, which is the same restriction under
+// the other entity's spelling.
+func TestFormatNoteMarkdown_ConfidentialIsInternal(t *testing.T) {
+	n := NoteOutput{ID: 2, Body: "secret", Author: &toolutil.NoteUserOutput{Username: "u"}, CreatedAt: "2026-01-01T00:00:00Z", Confidential: true}
+	want := "## Discussion Note #2\n\n" +
+		"- **Author**: @u\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Internal note**\n" +
+		"- **Body**: secret\n" + noteHints
+	if got := FormatNoteMarkdown(n); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -805,7 +834,13 @@ func TestFormatNoteMarkdown_Minimal(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown_Full verifies FormatOutputMarkdown when full.
+// TestFormatOutputMarkdown_Full verifies the whole rendering of a discussion
+// thread through the renderer every discussion family shares: each note is a
+// list item naming its author, time and ID, with the body quoted underneath.
+//
+// A note body is written by anybody who can comment, so it is quoted rather
+// than interpolated: the "### Note N (by author)" heading this replaced put the
+// author in a heading and the body at column zero.
 func TestFormatOutputMarkdown_Full(t *testing.T) {
 	d := Output{
 		ID:             "disc-abc",
@@ -815,37 +850,20 @@ func TestFormatOutputMarkdown_Full(t *testing.T) {
 			{ID: 2, Body: "Reply", Author: &toolutil.NoteUserOutput{Username: "bob"}, CreatedAt: "2026-01-02T00:00:00Z"},
 		},
 	}
-	md := FormatOutputMarkdown(d)
-
-	for _, want := range []string{
-		"## Discussion disc-abc",
-		"**Notes**: 2",
-		"**Individual Note**: false",
-		"### Note 1 (by alice)",
-		"First",
-		"### Note 2 (by bob)",
-		"Reply",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Discussion disc-abc\n\n" +
+		"- **@alice** (1 Jan 2026 00:00 UTC, note 1):\n  > First\n" +
+		"- **@bob** (2 Jan 2026 00:00 UTC, note 2):\n  > Reply\n" + threadHints
+	if got := FormatOutputMarkdown(d); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_Empty verifies FormatOutputMarkdown when empty.
+// TestFormatOutputMarkdown_Empty verifies that a thread GitLab sent no note for
+// renders its heading and the guidance, and nothing in between.
 func TestFormatOutputMarkdown_Empty(t *testing.T) {
-	d := Output{ID: "empty-disc", IndividualNote: true, Notes: nil}
-	md := FormatOutputMarkdown(d)
-	if !strings.Contains(md, "## Discussion empty-disc") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "**Notes**: 0") {
-		t.Errorf("should show 0 notes:\n%s", md)
-	}
-	if !strings.Contains(md, "**Individual Note**: true") {
-		t.Errorf("should show individual note:\n%s", md)
+	want := "## Discussion empty-disc\n" + threadHints
+	if got := FormatOutputMarkdown(Output{ID: "empty-disc", IndividualNote: true}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -853,46 +871,45 @@ func TestFormatOutputMarkdown_Empty(t *testing.T) {
 // FormatListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithDiscussions verifies FormatListMarkdown when with discussions.
+// TestFormatListMarkdown_WithDiscussions verifies the whole rendering of a
+// page of threads, through the same shared renderer a single thread goes
+// through, so a thread reads the same whether it was listed or fetched. The
+// ID/Notes/Individual table this replaced showed the thread ids and none of
+// what anybody said in them.
 func TestFormatListMarkdown_WithDiscussions(t *testing.T) {
 	out := ListOutput{
 		Discussions: []Output{
-			{ID: "d1", IndividualNote: false, Notes: []*NoteOutput{{ID: 1}, {ID: 2}}},
-			{ID: "d2", IndividualNote: true, Notes: []*NoteOutput{{ID: 3}}},
+			{ID: "d1", IndividualNote: false, Notes: []*NoteOutput{
+				{ID: 1, Body: "First", Author: &toolutil.NoteUserOutput{Username: "alice"}, CreatedAt: "2026-01-01T00:00:00Z"},
+				{ID: 2, Body: "Reply", Author: &toolutil.NoteUserOutput{Username: "bob"}, CreatedAt: "2026-01-02T00:00:00Z"},
+			}},
+			{ID: "d2", IndividualNote: true, Notes: []*NoteOutput{
+				{ID: 3, Body: "Standalone", Author: &toolutil.NoteUserOutput{Username: "carol"}, CreatedAt: "2026-01-03T00:00:00Z"},
+			}},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 5, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-	for _, want := range []string{
-		"## MR Discussions (5)",
-		"| ID |",
-		"| d1 |",
-		"| d2 |",
-		"2",
-		"1",
-		"false",
-		"true",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## MR Discussions (5)\n\n" +
+		"### Discussion d1\n" +
+		"- **@alice** (1 Jan 2026 00:00 UTC, note 1):\n  > First\n" +
+		"- **@bob** (2 Jan 2026 00:00 UTC, note 2):\n  > Reply\n\n" +
+		"### Discussion d2\n" +
+		"- **@carol** (3 Jan 2026 00:00 UTC, note 3):\n  > Standalone\n\n" +
+		"Page 1 of 1 | 5 items total | 20 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.discussion_get' to read one thread in full\n" +
+		"- Use action 'mr_review.discussion_create' to start a new discussion on this merge request\n"
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty verifies that a merge request with no discussion
+// renders the one-sentence empty message and no heading counting zero.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	out := ListOutput{
-		Discussions: []Output{},
-		Pagination:  toolutil.PaginationOutput{},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "No merge request discussions found.") {
-		t.Errorf("expected 'No merge request discussions found.' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	want := "No merge request discussions found.\n"
+	if got := FormatListMarkdown(ListOutput{Discussions: []Output{}}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mrdraftnotes/markdown.go
+++ b/internal/tools/mrdraftnotes/markdown.go
@@ -2,80 +2,120 @@ package mrdraftnotes
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single draft note as Markdown.
+// Canonical action IDs the hints name, the one form every surface resolves: the
+// draft note actions belong to the gitlab_mr_review catalog group, so their IDs
+// carry the mr_review domain. The action_specs.go constants of the same shape
+// spell that domain "mrdraftnotes" and are used for related-action metadata
+// only; a hint naming one would name an action no surface can execute.
+const (
+	hintActionDraftNoteGet        = "mr_review.draft_note_get"
+	hintActionDraftNoteUpdate     = "mr_review.draft_note_update"
+	hintActionDraftNoteDelete     = "mr_review.draft_note_delete"
+	hintActionDraftNotePublish    = "mr_review.draft_note_publish"
+	hintActionDraftNotePublishAll = "mr_review.draft_note_publish_all"
+)
+
+// noteCellRunes is how much of a draft note's body a list row shows.
+const noteCellRunes = 60
+
+// positionText renders where in the diff a draft note is anchored: the file,
+// the line when GitLab gave one, and the kind of position for anything that is
+// not a plain text line.
+//
+// The line is only named when there is one: a note on a file, or on an image,
+// carries no line number and "line 0" read as the top of the file.
+func positionText(p *PositionOutput) string {
+	if p == nil {
+		return ""
+	}
+	path := p.NewPath
+	if path == "" {
+		path = p.OldPath
+	}
+	line := p.NewLine
+	if line == 0 {
+		line = p.OldLine
+	}
+	// A repository path is a committer's choice, and git allows every byte but
+	// NUL and the separator inside a component.
+	text := toolutil.MdCodeSpan(path)
+	if line != 0 {
+		text += " line " + strconv.FormatInt(line, 10)
+	}
+	if p.PositionType != "" && p.PositionType != "text" {
+		text += " (" + toolutil.EscapeMdTableCell(p.PositionType) + ")"
+	}
+	return strings.TrimSpace(text)
+}
+
+// noteCell shortens a draft note's body for a list row, on rune boundaries: the
+// byte slice this replaced cut a multi-byte character in half and put the
+// fragment on the page.
+func noteCell(note string) string {
+	note = strings.ReplaceAll(toolutil.NormalizeText(note), "\n", " ")
+	runes := []rune(note)
+	if len(runes) > noteCellRunes {
+		return string(runes[:noteCellRunes]) + "…"
+	}
+	return note
+}
+
+// FormatOutputMarkdown renders one draft note as the card of one object.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Draft Note #%d\n\n", out.ID)
-	fmt.Fprintf(&b, "- **Author ID**: %d\n", out.AuthorID)
-	fmt.Fprintf(&b, "- **MR ID**: %d\n", out.MergeRequestID)
-	if out.CommitID != "" {
-		//gitlab:allow-unescaped out.CommitID: a commit SHA, hexadecimal by construction.
-		fmt.Fprintf(&b, "- **Commit**: `%s`\n", out.CommitID)
-	}
-	if out.LineCode != "" {
-		// GitLab builds a line code out of a file-path digest and two line
-		// numbers, but the digest is not verified here, so it is escaped.
-		fmt.Fprintf(&b, "- **Line Code**: `%s`\n", toolutil.EscapeMdTableCell(out.LineCode))
-	}
-	if out.DiscussionID != "" {
-		//gitlab:allow-unescaped out.DiscussionID: a discussion thread id, hexadecimal digits from GitLab's own digest.
-		fmt.Fprintf(&b, "- **Discussion**: %s\n", out.DiscussionID)
-	}
-	fmt.Fprintf(&b, "- **Resolve Discussion**: %v\n", out.ResolveDiscussion)
-	if p := out.Position; p != nil {
-		path := p.NewPath
-		if path == "" {
-			path = p.OldPath
-		}
-		line := p.NewLine
-		if line == 0 {
-			line = p.OldLine
-		}
-		fmt.Fprintf(&b, "- **Position**: `%s` line %d\n", toolutil.EscapeMdTableCell(path), line)
-	}
-	fmt.Fprintf(&b, "\n### Body\n\n%s\n", toolutil.WrapGFMBody(out.Note))
-	toolutil.WriteHints(
-		&b,
-		"Use action 'draft_note_publish' with draft_note_id to publish this note",
-		"Use action 'draft_note_update' to modify before publishing",
-		"Use action 'draft_note_delete' to discard this draft",
+	c := toolutil.NewCard(&b, fmt.Sprintf("Draft Note #%d", out.ID))
+	c.Int("ID", out.ID)
+	c.Int("Author ID", out.AuthorID)
+	// GitLab answers with the merge request's global database ID here, not the
+	// project-scoped IID every draft-note action takes, and the row used to be
+	// labeled "MR ID" as though it were the IID.
+	c.Int("MR global ID (not the IID)", out.MergeRequestID)
+	c.Code("Commit", out.CommitID)
+	// GitLab builds a line code out of a file-path digest and two line numbers,
+	// but the digest is not verified here, so the span is what shows it.
+	c.Code("Line Code", out.LineCode)
+	c.Code("Discussion", out.DiscussionID)
+	c.Bool("Resolves the discussion", out.ResolveDiscussion)
+	c.Markdown("Position", positionText(out.Position))
+	c.Text("Note", out.Note)
+	c.End(
+		toolutil.HintAction(hintActionDraftNotePublish, "publish this draft note"),
+		toolutil.HintAction(hintActionDraftNoteUpdate, "change it before publishing"),
+		toolutil.HintAction(hintActionDraftNoteDelete, "discard it"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of draft notes as a Markdown table.
+// FormatListMarkdown renders a page of draft notes as a Markdown table: a
+// collection of objects that share columns.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Draft Notes (%d)\n\n", len(out.DraftNotes))
-	toolutil.WriteListSummary(&b, len(out.DraftNotes), out.Pagination)
 	if len(out.DraftNotes) == 0 {
-		b.WriteString("No draft notes found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("draft notes")
 	}
-	b.WriteString("| ID | Author ID | Commit | Note (truncated) |\n")
-	b.WriteString("| -- | --------- | ------ | ---------------- |\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Draft Notes", len(out.DraftNotes), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Author ID", "Commit", "Note"))
 	for _, d := range out.DraftNotes {
-		note := toolutil.NormalizeText(d.Note)
-		if len(note) > 60 {
-			note = note[:57] + "..."
-		}
 		commit := d.CommitID
 		if len(commit) > 8 {
 			commit = commit[:8]
 		}
-		//gitlab:allow-unescaped commit: a commit SHA, hexadecimal by construction, truncated here.
-		fmt.Fprintf(&b, "| %d | %d | %s | %s |\n", d.ID, d.AuthorID, commit, toolutil.EscapeMdTableCell(note))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(d.ID, 10),
+			strconv.FormatInt(d.AuthorID, 10),
+			toolutil.MdCodeSpanCell(commit),
+			toolutil.EscapeMdTableCell(noteCell(d.Note)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'draft_note_get' with draft_note_id for full content",
-		"Use action 'draft_note_publish_all' to publish all drafts at once",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintActionDraftNoteGet, "read one draft note in full"),
+		toolutil.HintAction(hintActionDraftNotePublishAll, "publish every draft at once"),
 	)
 	return b.String()
 }

--- a/internal/tools/mrdraftnotes/mr_draft_notes_test.go
+++ b/internal/tools/mrdraftnotes/mr_draft_notes_test.go
@@ -759,7 +759,22 @@ const errExpectedAPI = "expected API error, got nil"
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown_Full verifies FormatOutputMarkdown when full.
+// draftCardHints is the guidance section a draft note card closes with, and
+// draftListHints the one a listing closes with.
+const (
+	draftCardHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.draft_note_publish' to publish this draft note\n" +
+		"- Use action 'mr_review.draft_note_update' to change it before publishing\n" +
+		"- Use action 'mr_review.draft_note_delete' to discard it\n"
+	draftListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'mr_review.draft_note_get' to read one draft note in full\n" +
+		"- Use action 'mr_review.draft_note_publish_all' to publish every draft at once\n"
+)
+
+// TestFormatOutputMarkdown_Full verifies the whole rendering of a draft note,
+// including the row this card used to label "MR ID": GitLab answers with the
+// merge request's global database id there, not the project-scoped IID every
+// draft note action takes, and a reader who passed it back got a 404.
 func TestFormatOutputMarkdown_Full(t *testing.T) {
 	out := Output{
 		ID:                10,
@@ -767,52 +782,60 @@ func TestFormatOutputMarkdown_Full(t *testing.T) {
 		MergeRequestID:    99,
 		Note:              "Draft review comment",
 		CommitID:          "abc123def456",
+		LineCode:          "a1b2c3_10_11",
 		DiscussionID:      "disc-001",
 		ResolveDiscussion: true,
+		Position:          &PositionOutput{NewPath: "main.go", NewLine: 42, PositionType: "text"},
 	}
-	md := FormatOutputMarkdown(out)
-
-	for _, want := range []string{
-		"## Draft Note #10",
-		"**Author ID**: 1",
-		"**MR ID**: 99",
-		"**Commit**: `abc123def456`",
-		"**Discussion**: disc-001",
-		"**Resolve Discussion**: true",
-		"### Body",
-		"Draft review comment",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Draft Note #10\n\n" +
+		"- **ID**: 10\n" +
+		"- **Author ID**: 1\n" +
+		"- **MR global ID (not the IID)**: 99\n" +
+		"- **Commit**: `abc123def456`\n" +
+		"- **Line Code**: `a1b2c3_10_11`\n" +
+		"- **Discussion**: `disc-001`\n" +
+		"- **Resolves the discussion**: ✅\n" +
+		"- **Position**: `main.go` line 42\n" +
+		"- **Note**: Draft review comment\n" + draftCardHints
+	if got := FormatOutputMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_Minimal verifies FormatOutputMarkdown when minimal.
+// TestFormatOutputMarkdown_Minimal verifies that a draft note GitLab sent
+// nothing optional for shows no label with nothing after it.
 func TestFormatOutputMarkdown_Minimal(t *testing.T) {
 	out := Output{
-		ID:                5,
-		AuthorID:          2,
-		MergeRequestID:    50,
-		Note:              "simple note",
-		ResolveDiscussion: false,
+		ID:             5,
+		AuthorID:       2,
+		MergeRequestID: 50,
+		Note:           "simple note",
 	}
-	md := FormatOutputMarkdown(out)
+	want := "## Draft Note #5\n\n" +
+		"- **ID**: 5\n" +
+		"- **Author ID**: 2\n" +
+		"- **MR global ID (not the IID)**: 50\n" +
+		"- **Resolves the discussion**: ❌\n" +
+		"- **Note**: simple note\n" + draftCardHints
+	if got := FormatOutputMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
+	}
+}
 
-	if !strings.Contains(md, "## Draft Note #5") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "**Resolve Discussion**: false") {
-		t.Errorf("should show resolve false:\n%s", md)
-	}
-	// CommitID and DiscussionID are empty, lines should not appear
-	if strings.Contains(md, "**Commit**") {
-		t.Errorf("should not contain Commit when empty:\n%s", md)
-	}
-	if strings.Contains(md, "**Discussion**") {
-		t.Errorf("should not contain Discussion when empty:\n%s", md)
+// TestFormatOutputMarkdown_PositionWithoutALine verifies that a note anchored
+// to a whole file names no line: GitLab sends none for one, and "line 0" read
+// as the top of the file.
+func TestFormatOutputMarkdown_PositionWithoutALine(t *testing.T) {
+	out := Output{ID: 6, AuthorID: 2, MergeRequestID: 50, Note: "on the file", Position: &PositionOutput{OldPath: "docs/img.png", PositionType: "image"}}
+	want := "## Draft Note #6\n\n" +
+		"- **ID**: 6\n" +
+		"- **Author ID**: 2\n" +
+		"- **MR global ID (not the IID)**: 50\n" +
+		"- **Resolves the discussion**: ❌\n" +
+		"- **Position**: `docs/img.png` (image)\n" +
+		"- **Note**: on the file\n" + draftCardHints
+	if got := FormatOutputMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
@@ -829,46 +852,37 @@ func TestFormatListMarkdown_WithDraftNotes(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Draft Notes (2)",
-		"| ID |",
-		"| -- |",
-		"| 1 |",
-		"| 2 |",
-		"abcdef12", // commit truncated to 8 chars
-		"Short note",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
-	}
-	// Full 16-char commit should not appear (truncated to 8)
-	if strings.Contains(md, "abcdef1234567890") {
-		t.Errorf("commit should be truncated to 8 chars:\n%s", md)
-	}
-	// Long note should be truncated to 60 chars with "..."
-	if strings.Contains(md, "properly here") {
-		t.Errorf("long note should be truncated:\n%s", md)
+	want := "## Draft Notes (2)\n\n" +
+		"| ID | Author ID | Commit | Note |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | 10 | `abcdef12` | Short note |\n" +
+		"| 2 | 20 | `abc` | Another note that is quite long and exceeds sixty characters… |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" + draftListHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
-func TestFormatListMarkdown_Empty(t *testing.T) {
-	out := ListOutput{
-		DraftNotes: []Output{},
-		Pagination: toolutil.PaginationOutput{},
+// TestFormatListMarkdown_TruncatesOnRuneBoundaries verifies that a note whose
+// sixtieth rune is multi-byte is cut between characters rather than through
+// one: the byte slice this replaced put half a character on the page.
+func TestFormatListMarkdown_TruncatesOnRuneBoundaries(t *testing.T) {
+	out := ListOutput{DraftNotes: []Output{{ID: 1, AuthorID: 10, Note: strings.Repeat("é", 70)}}}
+	want := "## Draft Notes (1)\n\n" +
+		"| ID | Author ID | Commit | Note |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | 10 |  | " + strings.Repeat("é", 60) + "… |\n" + draftListHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
-	md := FormatListMarkdown(out)
+}
 
-	if !strings.Contains(md, "No draft notes found.") {
-		t.Errorf("expected 'No draft notes found.' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+// TestFormatListMarkdown_Empty verifies that a merge request with no draft note
+// renders the one-sentence empty message and no table header.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	want := "No draft notes found.\n"
+	if got := FormatListMarkdown(ListOutput{DraftNotes: []Output{}}); got != want {
+		t.Errorf("rendered =\n%q\nwant\n%q", got, want)
 	}
 }
 

--- a/internal/tools/mrnotes/markdown.go
+++ b/internal/tools/mrnotes/markdown.go
@@ -2,6 +2,21 @@ package mrnotes
 
 import "github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 
+// Canonical action IDs the hints name, the one form every surface resolves:
+// the dynamic surface executes it and the meta and individual surfaces resolve
+// it to their own tool names, which the prose these replaced could not.
+//
+// The merge request note actions belong to the gitlab_mr_review catalog group,
+// so their IDs carry the mr_review domain. The action_specs.go constants of the
+// same shape spell that domain "merge_request" and are used for related-action
+// metadata only; a hint naming one would name an action no surface executes.
+const (
+	actionNoteGet    = "mr_review.note_get"
+	actionNoteCreate = "mr_review.note_create"
+	actionNoteUpdate = "mr_review.note_update"
+	actionNoteDelete = "mr_review.note_delete"
+)
+
 // FormatOutputMarkdown renders a single MR note as a Markdown summary.
 func FormatOutputMarkdown(n Output) string {
 	return toolutil.FormatNoteMarkdown(toNoteMarkdown(n), toolutil.NoteMarkdownOptions{
@@ -9,21 +24,28 @@ func FormatOutputMarkdown(n Output) string {
 		IncludeInternal:   true,
 		IncludeResolvable: true,
 		Hints: []string{
-			"Use the selected tool surface's merge-request note update action with the same project_id, merge_request_iid, and this note_id to edit this note",
-			"Use the selected tool surface's merge-request note delete action with the same project_id, merge_request_iid, this note_id, and explicit confirm=true to remove this note",
+			toolutil.HintAction(actionNoteUpdate, "edit this note"),
+			toolutil.HintAction(actionNoteDelete, "remove this note (it takes confirm=true)"),
 		},
 	})
 }
 
 // FormatListMarkdown renders a list of MR notes as a Markdown table.
+//
+// IncludeInternal matches issuenotes: a merge request carries internal notes
+// too, and without the column a reader could not tell one from a note everybody
+// can see. The table carries no link, so the hints carry no instruction to keep
+// them — [toolutil.FormatNoteListMarkdown] drops that one — and they name the
+// canonical action IDs every surface resolves rather than describing a tool.
 func FormatListMarkdown(out ListOutput) string {
 	return toolutil.FormatNoteListMarkdown(toolutil.NoteMarkdowns(out.Notes, toNoteMarkdown), out.Pagination, toolutil.NoteListMarkdownOptions{
-		Title:        "MR Notes",
-		EmptyMessage: "No merge request notes found.\n",
-		Hints: toolutil.ListHints(
-			"Use the selected tool surface's merge-request note get action with the same project_id, merge_request_iid, and note_id to read a specific note",
-			"Use the selected tool surface's merge-request note create action with the same project_id and merge_request_iid to add a new note to this MR",
-		),
+		Title:           "MR Notes",
+		EmptyMessage:    toolutil.EmptyMessage("merge request notes"),
+		IncludeInternal: true,
+		Hints: []string{
+			toolutil.HintAction(actionNoteGet, "read one of these notes in full"),
+			toolutil.HintAction(actionNoteCreate, "add a new note to this merge request"),
+		},
 	})
 }
 

--- a/internal/tools/packages/markdown.go
+++ b/internal/tools/packages/markdown.go
@@ -8,27 +8,27 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-const fmtSizeBytes = "- **Size**: %d bytes\n"
+// shortDigestLength is how much of a SHA-256 digest a table column shows
+// before the ellipsis; a digest of exactly this length is left whole, so the
+// ellipsis always means something was cut.
+const shortDigestLength = 12
 
-// FormatPublishMarkdown renders a published package file as Markdown.
+// FormatPublishMarkdown renders a published package file as the card of one
+// object.
 func FormatPublishMarkdown(out PublishOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Published\n\n")
-	fmt.Fprintf(&b, "- **Package File ID**: %d\n", out.PackageFileID)
-	fmt.Fprintf(&b, "- **Package ID**: %d\n", out.PackageID)
+	c := toolutil.NewCard(&b, "Package Published")
+	c.Int("Package File ID", out.PackageFileID)
+	c.Int("Package ID", out.PackageID)
 	// The only validation on a package file name refuses a space and a leading
 	// tilde or at-sign, so a pipe and a '<' both survive.
-	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(out.FileName))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	if out.SHA256 != "" {
-		//gitlab:allow-unescaped out.SHA256: a SHA-256 digest, computed by GitLab for a published file and by crypto/sha256 here for a downloaded one, so hexadecimal either way.
-		fmt.Fprintf(&b, "- **SHA256**: %s\n", out.SHA256)
-	}
-	if out.URL != "" {
-		toolutil.WriteMdURL(&b, out.URL)
-	}
-	toolutil.WriteHints(
-		&b,
+	c.Field("File Name", out.FileName)
+	c.Field("Size", fmt.Sprintf("%d bytes", out.Size))
+	// A digest is a value a reader compares character by character, so it is a
+	// code span sized to its content rather than a raw interpolation.
+	c.Code("SHA256", out.SHA256)
+	c.URL(out.URL)
+	c.End(
 		"Use action 'publish_and_link' to also create a release asset link in one step",
 		"Use action 'publish_directory' to batch-upload all files from a directory",
 		"Use action 'list' to see all packages in this project",
@@ -36,19 +36,17 @@ func FormatPublishMarkdown(out PublishOutput) string {
 	return b.String()
 }
 
-// FormatDownloadMarkdown renders a downloaded package file as Markdown.
+// FormatDownloadMarkdown renders a downloaded package file as the card of one
+// object.
 func FormatDownloadMarkdown(out DownloadOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Downloaded\n\n")
+	c := toolutil.NewCard(&b, "Package Downloaded")
 	// The output path is the caller's own argument echoed back, before any
 	// canonicalization.
-	fmt.Fprintf(&b, "- **Output Path**: %s\n", toolutil.EscapeMdTableCell(out.OutputPath))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Size)
-	if out.SHA256 != "" {
-		fmt.Fprintf(&b, "- **SHA256**: %s\n", out.SHA256)
-	}
-	toolutil.WriteHints(
-		&b,
+	c.Field("Output Path", out.OutputPath)
+	c.Field("Size", fmt.Sprintf("%d bytes", out.Size))
+	c.Code("SHA256", out.SHA256)
+	c.End(
 		"Use action 'file_list' to see all files in this package",
 		"Use action 'list' to browse other packages in the project",
 	)
@@ -57,22 +55,18 @@ func FormatDownloadMarkdown(out DownloadOutput) string {
 
 // FormatListMarkdown renders a paginated list of packages as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Packages (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Packages), out.Pagination)
 	if len(out.Packages) == 0 {
-		b.WriteString("No packages found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("packages")
 	}
-	b.WriteString("| ID | Name | Version | Type | Status | Creator | Pipeline |\n")
-	b.WriteString(toolutil.TblSep7Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Packages", len(out.Packages), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Version", "Type", "Status", "Creator", "Pipeline"))
 	for _, p := range out.Packages {
 		writePackageRow(&b, p, pipelineSummary(p))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
+	// The pipeline column carries a link, so the footer keeps the instruction
+	// to preserve it.
+	toolutil.WriteListFooter(&b, out.Pagination, true,
 		"Use action 'file_list' with a package_id to see individual files",
 		"Use action 'delete' to remove a package",
 		"Use action 'publish' or 'publish_directory' to upload new packages",
@@ -88,18 +82,15 @@ func FormatListMarkdown(out ListOutput) string {
 // cell escaper turns a finished link back into text, so each summary escapes
 // the GitLab-authored text it holds and this row writes the column as given.
 func writePackageRow(b *strings.Builder, p ListItem, lastColumn string) {
-	fmt.Fprintf(
-		b, "| %d | %s | %s | %s | %s | %s | %s |\n",
-		p.ID,
+	b.WriteString(toolutil.MarkdownTableRow(
+		strconv.FormatInt(p.ID, 10),
 		toolutil.EscapeMdTableCell(p.Name),
 		toolutil.EscapeMdTableCell(versionSummary(p)),
-		//gitlab:allow-unescaped p.PackageType: the registry format GitLab stores the package under, one of its own enum values (generic, maven, npm and the rest).
-		p.PackageType,
-		//gitlab:allow-unescaped p.Status: a GitLab package status enum value (default, hidden, processing, error).
-		p.Status,
+		toolutil.EscapeMdTableCell(p.PackageType),
+		toolutil.EscapeMdTableCell(p.Status),
 		creatorSummary(p),
 		lastColumn,
-	)
+	))
 }
 
 // versionSummary names the package's version and how many others GitLab sent
@@ -148,22 +139,19 @@ func pipelineItemSummary(pipeline PipelineItem) string {
 
 // FormatGroupListMarkdown renders a paginated list of group packages as a Markdown table.
 func FormatGroupListMarkdown(out GroupListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Group Packages (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Packages), out.Pagination)
 	if len(out.Packages) == 0 {
-		b.WriteString("No packages found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("packages")
 	}
-	b.WriteString("| ID | Name | Version | Type | Status | Creator | Project |\n")
-	b.WriteString(toolutil.TblSep7Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Group Packages", len(out.Packages), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Version", "Type", "Status", "Creator", "Project"))
 	for _, p := range out.Packages {
 		writePackageRow(&b, p.ListItem, groupProjectSummary(p))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
+	// Unlike the project list, this table's last column is the owning project's
+	// path rather than a pipeline link, so no column here carries one and the
+	// footer drops the instruction to preserve them.
+	toolutil.WriteListFooter(&b, out.Pagination, false,
 		"Use action 'list' to scope packages to a single project",
 		"Use action 'file_list' with a package_id to see individual files",
 		"Use action 'delete' to remove a package",
@@ -185,100 +173,110 @@ func groupProjectSummary(pkg GroupListItem) string {
 
 // FormatFileListMarkdown renders a paginated list of package files as a Markdown table.
 func FormatFileListMarkdown(out FileListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Files (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Files), out.Pagination)
 	if len(out.Files) == 0 {
-		b.WriteString("No package files found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("package files")
 	}
-	b.WriteString("| ID | File Name | Size | SHA256 |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Package Files", len(out.Files), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "File Name", "Size (bytes)", "SHA256"))
 	for _, f := range out.Files {
-		sha := f.SHA256
-		if len(sha) > 12 {
-			sha = sha[:12] + "..."
-		}
-		fmt.Fprintf(
-			&b, "| %d | %s | %d | %s |\n",
-			f.PackageFileID,
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(f.PackageFileID, 10),
 			toolutil.EscapeMdTableCell(f.FileName),
-			f.Size,
-			//gitlab:allow-unescaped sha: the leading characters of a SHA-256 digest, which is hexadecimal, so slicing it cannot split a rune.
-			sha,
-		)
+			strconv.FormatInt(f.Size, 10),
+			toolutil.MdCodeSpanCell(shortDigest(f.SHA256)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&b, out.Pagination, false,
 		"Use action 'download' to retrieve a specific file",
 		"Use action 'file_delete' to remove a single file",
 	)
 	return b.String()
 }
 
-// FormatPublishAndLinkMarkdown renders a publish-and-link result as Markdown.
+// shortDigest is the leading characters of a SHA-256 digest, with an ellipsis
+// when anything was cut. A digest is hexadecimal, so slicing it cannot split a
+// rune.
+func shortDigest(sha string) string {
+	if len(sha) <= shortDigestLength {
+		return sha
+	}
+	return sha[:shortDigestLength] + "..."
+}
+
+// FormatPublishAndLinkMarkdown renders a publish-and-link result as one card
+// with a section per object: the package file and the release link it now has.
 func FormatPublishAndLinkMarkdown(out PublishAndLinkOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Published & Linked\n\n")
-	fmt.Fprintf(&b, "### Package\n\n")
-	fmt.Fprintf(&b, "- **Package File ID**: %d\n", out.Package.PackageFileID)
-	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(out.Package.FileName))
-	fmt.Fprintf(&b, fmtSizeBytes, out.Package.Size)
-	if out.Package.URL != "" {
-		toolutil.WriteMdURL(&b, out.Package.URL)
-	}
-	fmt.Fprintf(&b, "\n### Release Link\n\n")
-	fmt.Fprintf(&b, toolutil.FmtMdID, out.ReleaseLink.ID)
-	fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(out.ReleaseLink.Name))
-	if out.ReleaseLink.URL != "" {
-		toolutil.WriteMdURL(&b, out.ReleaseLink.URL)
-	}
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, "Package Published & Linked")
+	pkg := c.Section("Package")
+	pkg.Int("Package File ID", out.Package.PackageFileID)
+	pkg.Field("File Name", out.Package.FileName)
+	pkg.Field("Size", fmt.Sprintf("%d bytes", out.Package.Size))
+	pkg.URL(out.Package.URL)
+	link := c.Section("Release Link")
+	link.Int("ID", out.ReleaseLink.ID)
+	link.Field("Name", out.ReleaseLink.Name)
+	link.URL(out.ReleaseLink.URL)
+	c.End(
 		"Repeat for more files, or use 'publish_directory' to batch-upload a directory",
 		"Use gitlab_release action 'get' to verify the release links",
 	)
 	return b.String()
 }
 
-// FormatPublishDirMarkdown renders a directory publish result as Markdown.
+// FormatPublishDirMarkdown renders a directory publish result as the card of
+// one object.
+//
+// The heading names the outcome rather than always claiming success: a run
+// where every file failed used to be headed "Directory Published" with an
+// errors section under it, which is the opposite of what happened. The count
+// is published out of the two lists too, because TotalFiles is the number of
+// files that succeeded and reads as the number attempted.
 func FormatPublishDirMarkdown(out PublishDirOutput) string {
+	published, failed := len(out.Published), len(out.Errors)
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Directory Published\n\n")
-	fmt.Fprintf(&b, "- **Total Files**: %d\n", out.TotalFiles)
-	fmt.Fprintf(&b, "- **Total Bytes**: %d\n", out.TotalBytes)
-	if len(out.Published) > 0 {
-		b.WriteString("\n| File | Size | SHA256 |\n")
-		b.WriteString(toolutil.TblSep3Col)
+	c := toolutil.NewCard(&b, publishDirHeading(published, failed))
+	c.Field("Published", fmt.Sprintf("%d of %d files", published, published+failed))
+	c.Field("Total Bytes", fmt.Sprintf("%d bytes", out.TotalBytes))
+	if published > 0 {
+		files := c.Table("Published Files", "File", "Size (bytes)", "SHA256")
 		for _, p := range out.Published {
-			sha := p.SHA256
-			if len(sha) > 12 {
-				sha = sha[:12] + "..."
-			}
-			fmt.Fprintf(
-				&b, "| %s | %d | %s |\n",
+			files.Row(
 				toolutil.EscapeMdTableCell(p.FileName),
-				p.Size,
-				sha,
+				strconv.FormatInt(p.Size, 10),
+				toolutil.MdCodeSpanCell(shortDigest(p.SHA256)),
 			)
 		}
 	}
-	if len(out.Errors) > 0 {
-		fmt.Fprintf(&b, "\n### Errors (%d)\n\n", len(out.Errors))
+	if failed > 0 {
+		errs := c.Table(fmt.Sprintf("Errors (%d)", failed), "Error")
 		for _, e := range out.Errors {
 			// Each is a local directory entry name plus a wrapped error whose
 			// text carries GitLab's own message.
-			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(e))
+			errs.Row(toolutil.EscapeMdTableCell(e))
 		}
 	}
-	toolutil.WriteHints(
-		&b,
+	c.End(
 		"Use 'publish_and_link' to also create release asset links for each file",
 		"Use gitlab_release to create/manage releases and link these packages",
 		"Use action 'list' to verify the uploaded packages",
 	)
 	return b.String()
+}
+
+// publishDirHeading names what the run actually did.
+func publishDirHeading(published, failed int) string {
+	switch {
+	case failed == 0:
+		return "Directory Published"
+	case published == 0:
+		return "Directory Publish Failed"
+	default:
+		return "Directory Partially Published"
+	}
 }
 
 func init() {

--- a/internal/tools/packages/markdown_test.go
+++ b/internal/tools/packages/markdown_test.go
@@ -16,60 +16,87 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// TestFormatPublishMarkdown_WithChecksumAndURL verifies publish markdown includes
-// file identifiers, checksum, URL, and follow-up hints for common workflows.
+// The guidance sections the package formatters close with. Each card and
+// list pins its whole response below, so these are named once rather than
+// repeated in every expectation.
+const (
+	publishHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'publish_and_link' to also create a release asset link in one step\n" +
+		"- Use action 'publish_directory' to batch-upload all files from a directory\n" +
+		"- Use action 'list' to see all packages in this project\n"
+	downloadHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'file_list' to see all files in this package\n" +
+		"- Use action 'list' to browse other packages in the project\n"
+	publishAndLinkHints = "\n---\n💡 **Next steps:**\n" +
+		"- Repeat for more files, or use 'publish_directory' to batch-upload a directory\n" +
+		"- Use gitlab_release action 'get' to verify the release links\n"
+	publishDirHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use 'publish_and_link' to also create release asset links for each file\n" +
+		"- Use gitlab_release to create/manage releases and link these packages\n" +
+		"- Use action 'list' to verify the uploaded packages\n"
+	listHints = "\n---\n💡 **Next steps:**\n" +
+		"- " + toolutil.HintPreserveLinks + "\n" +
+		"- Use action 'file_list' with a package_id to see individual files\n" +
+		"- Use action 'delete' to remove a package\n" +
+		"- Use action 'publish' or 'publish_directory' to upload new packages\n"
+	// The group table's last column is the owning project's path, not a link,
+	// so its guidance carries no instruction to preserve links.
+	groupListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'list' to scope packages to a single project\n" +
+		"- Use action 'file_list' with a package_id to see individual files\n" +
+		"- Use action 'delete' to remove a package\n"
+	fileListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use action 'download' to retrieve a specific file\n" +
+		"- Use action 'file_delete' to remove a single file\n"
+	packageTableHeader = "| ID | Name | Version | Type | Status | Creator | Pipeline |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- |\n"
+	groupTableHeader = "| ID | Name | Version | Type | Status | Creator | Project |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- |\n"
+)
+
+// TestFormatPublishMarkdown_WithChecksumAndURL verifies the whole publish card:
+// the identifiers, the size with its unit, the digest as a code span and the
+// URL linked to itself.
 func TestFormatPublishMarkdown_WithChecksumAndURL(t *testing.T) {
+	const url = "https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz"
 	out := PublishOutput{
 		PackageFileID: 10,
 		PackageID:     20,
 		FileName:      "app.tar.gz",
 		Size:          4096,
 		SHA256:        "0123456789abcdef",
-		URL:           "https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz",
+		URL:           url,
 	}
 
 	got := FormatPublishMarkdown(out)
-	for _, want := range []string{
-		"## Package Published",
-		"**Package File ID**: 10",
-		"**Package ID**: 20",
-		"**File Name**: app.tar.gz",
-		"**Size**: 4096 bytes",
-		"**SHA256**: 0123456789abcdef",
-		"**URL**: [https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz](https://gitlab.example.com/api/v4/projects/1/packages/generic/pkg/1.0.0/app.tar.gz)",
-		"publish_and_link",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(got, want) {
-				t.Fatalf("FormatPublishMarkdown() = %q, want %q", got, want)
-			}
-		})
+	want := "## Package Published\n\n" +
+		"- **Package File ID**: 10\n" +
+		"- **Package ID**: 20\n" +
+		"- **File Name**: app.tar.gz\n" +
+		"- **Size**: 4096 bytes\n" +
+		"- **SHA256**: `0123456789abcdef`\n" +
+		"- **URL**: [" + url + "](" + url + ")\n" +
+		publishHints
+	if got != want {
+		t.Errorf("FormatPublishMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatDownloadMarkdown_WithChecksum verifies download markdown reports the
-// local output path, byte count, checksum, and next actions.
+// TestFormatDownloadMarkdown_WithChecksum verifies the whole download card.
 func TestFormatDownloadMarkdown_WithChecksum(t *testing.T) {
-	out := DownloadOutput{OutputPath: "/tmp/app.tar.gz", Size: 2048, SHA256: "abcdef"}
-
-	got := FormatDownloadMarkdown(out)
-	for _, want := range []string{
-		"## Package Downloaded",
-		"**Output Path**: /tmp/app.tar.gz",
-		"**Size**: 2048 bytes",
-		"**SHA256**: abcdef",
-		"file_list",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(got, want) {
-				t.Fatalf("FormatDownloadMarkdown() = %q, want %q", got, want)
-			}
-		})
+	got := FormatDownloadMarkdown(DownloadOutput{OutputPath: "/tmp/app.tar.gz", Size: 2048, SHA256: "abcdef"})
+	want := "## Package Downloaded\n\n" +
+		"- **Output Path**: /tmp/app.tar.gz\n" +
+		"- **Size**: 2048 bytes\n" +
+		"- **SHA256**: `abcdef`\n" +
+		downloadHints
+	if got != want {
+		t.Errorf("FormatDownloadMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
 // TestFormatPublishAndLinkMarkdown_RendersBothSections verifies the composite
-// formatter keeps package and release-link details visible after a successful workflow.
+// card keeps both objects visible, each under a section of its own.
 func TestFormatPublishAndLinkMarkdown_RendersBothSections(t *testing.T) {
 	out := PublishAndLinkOutput{
 		Package: PublishOutput{
@@ -82,28 +109,25 @@ func TestFormatPublishAndLinkMarkdown_RendersBothSections(t *testing.T) {
 	}
 
 	got := FormatPublishAndLinkMarkdown(out)
-	for _, want := range []string{
-		"## Package Published & Linked",
-		"### Package",
-		"**Package File ID**: 11",
-		"**File Name**: app.tar.gz",
-		"**URL**: [https://gitlab.example.com/package/app.tar.gz](https://gitlab.example.com/package/app.tar.gz)",
-		"### Release Link",
-		"**ID**: 22",
-		"**Name**: app.tar.gz",
-		"**URL**: [https://gitlab.example.com/release/app.tar.gz](https://gitlab.example.com/release/app.tar.gz)",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(got, want) {
-				t.Fatalf("FormatPublishAndLinkMarkdown() = %q, want %q", got, want)
-			}
-		})
+	want := "## Package Published & Linked\n\n" +
+		"### Package\n\n" +
+		"- **Package File ID**: 11\n" +
+		"- **File Name**: app.tar.gz\n" +
+		"- **Size**: 1024 bytes\n" +
+		"- **URL**: [https://gitlab.example.com/package/app.tar.gz](https://gitlab.example.com/package/app.tar.gz)\n\n" +
+		"### Release Link\n\n" +
+		"- **ID**: 22\n" +
+		"- **Name**: app.tar.gz\n" +
+		"- **URL**: [https://gitlab.example.com/release/app.tar.gz](https://gitlab.example.com/release/app.tar.gz)\n" +
+		publishAndLinkHints
+	if got != want {
+		t.Errorf("FormatPublishAndLinkMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatPublishDirMarkdown_WithPublishedFiles verifies that
-// [FormatPublishDirMarkdown] renders a table of published files with SHA256
-// truncation when hashes exceed 12 characters.
+// TestFormatPublishDirMarkdown_WithPublishedFiles verifies a run where every
+// file succeeded: the heading claims success, the count names both halves, and
+// the files are a table under a heading of its own.
 func TestFormatPublishDirMarkdown_WithPublishedFiles(t *testing.T) {
 	out := PublishDirOutput{
 		TotalFiles: 2,
@@ -114,65 +138,97 @@ func TestFormatPublishDirMarkdown_WithPublishedFiles(t *testing.T) {
 		},
 	}
 	got := FormatPublishDirMarkdown(out)
-	if !strings.Contains(got, "## Directory Published") {
-		t.Error("missing header")
-	}
-	if !strings.Contains(got, "| file1.txt | 512 |") {
-		t.Error("missing file1.txt row")
-	}
-	if !strings.Contains(got, "abcdef123456...") {
-		t.Error("SHA256 should be truncated to 12 chars + ellipsis")
-	}
-	if !strings.Contains(got, "| file2.txt | 512 | short |") {
-		t.Error("short SHA256 should not be truncated")
+	want := "## Directory Published\n\n" +
+		"- **Published**: 2 of 2 files\n" +
+		"- **Total Bytes**: 1024 bytes\n\n" +
+		"### Published Files\n\n" +
+		"| File | Size (bytes) | SHA256 |\n" +
+		"| --- | --- | --- |\n" +
+		"| file1.txt | 512 | `abcdef123456...` |\n" +
+		"| file2.txt | 512 | `short` |\n" +
+		publishDirHints
+	if got != want {
+		t.Errorf("FormatPublishDirMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatPublishDirMarkdown_WithErrors verifies that
-// [FormatPublishDirMarkdown] includes error entries in the output.
+// TestFormatPublishDirMarkdown_WithErrors verifies that a run where every file
+// failed is headed by that outcome rather than by "Directory Published", which
+// is what it used to claim above the list of failures.
 func TestFormatPublishDirMarkdown_WithErrors(t *testing.T) {
 	out := PublishDirOutput{
-		TotalFiles: 1,
 		TotalBytes: 100,
 		Errors:     []string{"upload failed: timeout", "checksum mismatch"},
 	}
 	got := FormatPublishDirMarkdown(out)
-	if !strings.Contains(got, "### Errors (2)") {
-		t.Error("missing Errors section")
+	want := "## Directory Publish Failed\n\n" +
+		"- **Published**: 0 of 2 files\n" +
+		"- **Total Bytes**: 100 bytes\n\n" +
+		"### Errors (2)\n\n" +
+		"| Error |\n" +
+		"| --- |\n" +
+		"| upload failed: timeout |\n" +
+		"| checksum mismatch |\n" +
+		publishDirHints
+	if got != want {
+		t.Errorf("FormatPublishDirMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
-	if !strings.Contains(got, "- upload failed: timeout") {
-		t.Error("missing first error")
+}
+
+// TestFormatPublishDirMarkdown_PartialRun verifies a run where some files
+// failed is headed as partial, so the heading never contradicts the errors
+// under it.
+func TestFormatPublishDirMarkdown_PartialRun(t *testing.T) {
+	out := PublishDirOutput{
+		TotalFiles: 1,
+		TotalBytes: 512,
+		Published:  []PublishDirItem{{FileName: "ok.txt", Size: 512, SHA256: "short"}},
+		Errors:     []string{"bad.txt: upload failed"},
+	}
+	got := FormatPublishDirMarkdown(out)
+	want := "## Directory Partially Published\n\n" +
+		"- **Published**: 1 of 2 files\n" +
+		"- **Total Bytes**: 512 bytes\n\n" +
+		"### Published Files\n\n" +
+		"| File | Size (bytes) | SHA256 |\n" +
+		"| --- | --- | --- |\n" +
+		"| ok.txt | 512 | `short` |\n\n" +
+		"### Errors (1)\n\n" +
+		"| Error |\n" +
+		"| --- |\n" +
+		"| bad.txt: upload failed |\n" +
+		publishDirHints
+	if got != want {
+		t.Errorf("FormatPublishDirMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
 // TestFormatPublishDirMarkdown_Empty verifies that [FormatPublishDirMarkdown]
-// handles zero files and no errors gracefully.
+// handles zero files and no errors gracefully, opening no table.
 func TestFormatPublishDirMarkdown_Empty(t *testing.T) {
-	out := PublishDirOutput{}
-	got := FormatPublishDirMarkdown(out)
-	if !strings.Contains(got, "**Total Files**: 0") {
-		t.Error("missing total files")
-	}
-	if strings.Contains(got, "| File |") {
-		t.Error("should not contain table when no files published")
+	got := FormatPublishDirMarkdown(PublishDirOutput{})
+	want := "## Directory Published\n\n" +
+		"- **Published**: 0 of 0 files\n" +
+		"- **Total Bytes**: 0 bytes\n" +
+		publishDirHints
+	if got != want {
+		t.Errorf("FormatPublishDirMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_EmptyPackages verifies that [FormatListMarkdown]
-// renders "No packages found." when the list is empty.
+// TestFormatListMarkdown_EmptyPackages verifies an empty list is the one
+// sentence and nothing else: no heading counting zero above it.
 func TestFormatListMarkdown_EmptyPackages(t *testing.T) {
-	out := ListOutput{
-		Packages:   nil,
-		Pagination: toolutil.PaginationOutput{TotalItems: 0},
-	}
-	got := FormatListMarkdown(out)
-	if !strings.Contains(got, "No packages found.") {
-		t.Error("missing 'No packages found.' message")
+	got := FormatListMarkdown(ListOutput{Packages: nil, Pagination: toolutil.PaginationOutput{TotalItems: 0}})
+	want := "No packages found.\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() = %q, want %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_IncludesPreserveLinksHint verifies that package list
-// markdown links pipeline summaries and emits the preserve-links hint.
+// TestFormatListMarkdown_IncludesPreserveLinksHint verifies the whole table:
+// the pipeline cell is a link, and the preserve-links hint leads the guidance
+// because this table has one.
 func TestFormatListMarkdown_IncludesPreserveLinksHint(t *testing.T) {
 	out := ListOutput{
 		Packages: []ListItem{{
@@ -189,29 +245,42 @@ func TestFormatListMarkdown_IncludesPreserveLinksHint(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	}
 	got := FormatListMarkdown(out)
-	if !strings.Contains(got, "[7 success main](https://gitlab.example.com/project/-/pipelines/7)") {
-		t.Fatalf("FormatListMarkdown() = %q, want linked pipeline", got)
+	want := "## Packages (1)\n\n" + packageTableHeader +
+		"| 1 | pkg | 1.0.0 |  |  |  | [7 success main](https://gitlab.example.com/project/-/pipelines/7) |\n" +
+		"\n1 items total\n" + listHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
-	if !strings.Contains(got, toolutil.HintPreserveLinks) {
-		t.Fatalf("FormatListMarkdown() = %q, want preserve-links hint", got)
+}
+
+// TestFormatListMarkdown_KeysetPageCountsWhatItShows verifies a page GitLab
+// sent no total for is headed by what it shows and says more is available,
+// rather than by a zero above a table of rows.
+func TestFormatListMarkdown_KeysetPageCountsWhatItShows(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Packages:   []ListItem{{ID: 1, Name: "pkg", Version: "1.0.0"}},
+		Pagination: toolutil.PaginationOutput{HasMore: true},
+	})
+	want := "## Packages (1 shown, more available)\n\n" + packageTableHeader +
+		"| 1 | pkg | 1.0.0 |  |  |  |  |\n" + listHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
 // TestFormatGroupListMarkdown_EmptyPackages verifies the group package list
-// markdown renders the empty-state message.
+// renders the empty-state sentence alone.
 func TestFormatGroupListMarkdown_EmptyPackages(t *testing.T) {
-	got := FormatGroupListMarkdown(GroupListOutput{
-		Packages:   nil,
-		Pagination: toolutil.PaginationOutput{TotalItems: 0},
-	})
-	if !strings.Contains(got, "No packages found.") {
-		t.Error("missing 'No packages found.' message")
+	got := FormatGroupListMarkdown(GroupListOutput{Packages: nil, Pagination: toolutil.PaginationOutput{TotalItems: 0}})
+	want := "No packages found.\n"
+	if got != want {
+		t.Errorf("FormatGroupListMarkdown() = %q, want %q", got, want)
 	}
 }
 
-// TestFormatGroupListMarkdown_RendersProjectAndHint verifies the group package
-// list markdown renders the owning project path, the project id fallback, and
-// the preserve-links hint.
+// TestFormatGroupListMarkdown_RendersProjectAndHint verifies the whole table:
+// the owning project path, the project id fallback, and a guidance section
+// that does not tell the model to preserve links this table does not carry.
 func TestFormatGroupListMarkdown_RendersProjectAndHint(t *testing.T) {
 	got := FormatGroupListMarkdown(GroupListOutput{
 		Packages: []GroupListItem{
@@ -220,14 +289,12 @@ func TestFormatGroupListMarkdown_RendersProjectAndHint(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
-	if !strings.Contains(got, "grp/proj") {
-		t.Errorf("FormatGroupListMarkdown() = %q, want project path", got)
-	}
-	if !strings.Contains(got, "| 8 |") && !strings.Contains(got, " 8 |") {
-		t.Errorf("FormatGroupListMarkdown() = %q, want project id fallback 8", got)
-	}
-	if !strings.Contains(got, toolutil.HintPreserveLinks) {
-		t.Errorf("FormatGroupListMarkdown() = %q, want preserve-links hint", got)
+	want := "## Group Packages (2)\n\n" + groupTableHeader +
+		"| 1 | pkg-a | 1.0.0 | generic | default |  | grp/proj |\n" +
+		"| 2 | pkg-b | 2.0.0 | npm | default |  | 8 |\n" +
+		"\n2 items total\n" + groupListHints
+	if got != want {
+		t.Errorf("FormatGroupListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -321,18 +388,52 @@ func TestCreatorSummary_Variants(t *testing.T) {
 
 // TestFormatMarkdown_OmitTheChecksumsAndURLsGitLabDidNotSend verifies each
 // formatter that names a digest or a URL says nothing at all when the answer
-// carried neither, rather than printing an empty row.
+// carried neither, rather than printing an empty row. Each expectation is the
+// whole card, which is the only way to be sure the row is absent rather than
+// merely spelled differently.
 func TestFormatMarkdown_OmitTheChecksumsAndURLsGitLabDidNotSend(t *testing.T) {
-	for name, rendered := range map[string]string{
-		"publish":          FormatPublishMarkdown(PublishOutput{PackageFileID: 1, FileName: "app.bin"}),
-		"download":         FormatDownloadMarkdown(DownloadOutput{OutputPath: "/tmp/app.bin"}),
-		"publish and link": FormatPublishAndLinkMarkdown(PublishAndLinkOutput{}),
-	} {
-		t.Run(name, func(t *testing.T) {
-			for _, unwanted := range []string{"SHA256", "URL"} {
-				if strings.Contains(rendered, unwanted) {
-					t.Errorf("%s markdown names %q for an answer that carried none: %s", name, unwanted, rendered)
-				}
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "publish",
+			got:  FormatPublishMarkdown(PublishOutput{PackageFileID: 1, FileName: "app.bin"}),
+			want: "## Package Published\n\n" +
+				"- **Package File ID**: 1\n" +
+				"- **Package ID**: 0\n" +
+				"- **File Name**: app.bin\n" +
+				"- **Size**: 0 bytes\n" +
+				publishHints,
+		},
+		{
+			name: "download",
+			got:  FormatDownloadMarkdown(DownloadOutput{OutputPath: "/tmp/app.bin"}),
+			want: "## Package Downloaded\n\n" +
+				"- **Output Path**: /tmp/app.bin\n" +
+				"- **Size**: 0 bytes\n" +
+				downloadHints,
+		},
+		{
+			name: "publish and link",
+			got:  FormatPublishAndLinkMarkdown(PublishAndLinkOutput{}),
+			want: "## Package Published & Linked\n\n" +
+				"### Package\n\n" +
+				"- **Package File ID**: 0\n" +
+				"- **Size**: 0 bytes\n\n" +
+				"### Release Link\n\n" +
+				"- **ID**: 0\n" +
+				publishAndLinkHints,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s markdown =\n%q\nwant:\n%q", tt.name, tt.got, tt.want)
+			}
+			if strings.Contains(tt.got, "SHA256") || strings.Contains(tt.got, "**URL**") {
+				t.Errorf("%s markdown names a digest or URL for an answer that carried none: %s", tt.name, tt.got)
 			}
 		})
 	}
@@ -352,11 +453,14 @@ func TestFormatMarkdown_ShortensOnlyAChecksumLongerThanTheColumn(t *testing.T) {
 			},
 			Pagination: toolutil.PaginationOutput{TotalItems: 2},
 		})
-		if !strings.Contains(got, "| "+exactly12+" |") {
-			t.Errorf("FormatFileListMarkdown shortened a twelve-character digest: %s", got)
-		}
-		if !strings.Contains(got, "abcdef123456...") {
-			t.Errorf("FormatFileListMarkdown did not shorten a longer digest: %s", got)
+		want := "## Package Files (2)\n\n" +
+			"| ID | File Name | Size (bytes) | SHA256 |\n" +
+			"| --- | --- | --- | --- |\n" +
+			"| 1 | short.bin | 0 | `" + exactly12 + "` |\n" +
+			"| 2 | long.bin | 0 | `abcdef123456...` |\n" +
+			"\n2 items total\n" + fileListHints
+		if got != want {
+			t.Errorf("FormatFileListMarkdown() =\n%q\nwant:\n%q", got, want)
 		}
 	})
 	t.Run("directory publish", func(t *testing.T) {
@@ -367,14 +471,17 @@ func TestFormatMarkdown_ShortensOnlyAChecksumLongerThanTheColumn(t *testing.T) {
 				{FileName: "long.bin", SHA256: longer},
 			},
 		})
-		if !strings.Contains(got, "| "+exactly12+" |") {
-			t.Errorf("FormatPublishDirMarkdown shortened a twelve-character digest: %s", got)
-		}
-		if !strings.Contains(got, "abcdef123456...") {
-			t.Errorf("FormatPublishDirMarkdown did not shorten a longer digest: %s", got)
-		}
-		if strings.Contains(got, "Errors") {
-			t.Errorf("FormatPublishDirMarkdown shows an errors section for a run with none: %s", got)
+		want := "## Directory Published\n\n" +
+			"- **Published**: 2 of 2 files\n" +
+			"- **Total Bytes**: 0 bytes\n\n" +
+			"### Published Files\n\n" +
+			"| File | Size (bytes) | SHA256 |\n" +
+			"| --- | --- | --- |\n" +
+			"| short.bin | 0 | `" + exactly12 + "` |\n" +
+			"| long.bin | 0 | `abcdef123456...` |\n" +
+			publishDirHints
+		if got != want {
+			t.Errorf("FormatPublishDirMarkdown() =\n%q\nwant:\n%q", got, want)
 		}
 	})
 }
@@ -386,41 +493,50 @@ func TestFormatPackageListMarkdown_SentFields(t *testing.T) {
 		ID: 10, Name: "my-pkg", Version: "1.0.0", PackageType: "generic", Status: "default",
 		CreatorID: 57, Versions: []toolutil.PackageVersionOutput{{ID: 9, Version: "0.9.0"}},
 	}
-	for name, rendered := range map[string]string{
-		"project": FormatListMarkdown(ListOutput{
-			Packages:   []ListItem{item},
-			Pagination: toolutil.PaginationOutput{TotalItems: 1},
-		}),
-		"group": FormatGroupListMarkdown(GroupListOutput{
-			Packages:   []GroupListItem{{ListItem: item, ProjectID: 42, ProjectPath: "grp/proj"}},
-			Pagination: toolutil.PaginationOutput{TotalItems: 1},
-		}),
-	} {
-		t.Run(name, func(t *testing.T) {
-			for _, want := range []string{"Creator", "| 57 |", "1.0.0 (+1)"} {
-				if !strings.Contains(rendered, want) {
-					t.Errorf("%s markdown missing %q: %s", name, want, rendered)
-				}
+	const row = "| 10 | my-pkg | 1.0.0 (+1) | generic | default | 57 | "
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "project",
+			got: FormatListMarkdown(ListOutput{
+				Packages:   []ListItem{item},
+				Pagination: toolutil.PaginationOutput{TotalItems: 1},
+			}),
+			want: "## Packages (1)\n\n" + packageTableHeader + row + " |\n\n1 items total\n" + listHints,
+		},
+		{
+			name: "group",
+			got: FormatGroupListMarkdown(GroupListOutput{
+				Packages:   []GroupListItem{{ListItem: item, ProjectID: 42, ProjectPath: "grp/proj"}},
+				Pagination: toolutil.PaginationOutput{TotalItems: 1},
+			}),
+			want: "## Group Packages (1)\n\n" + groupTableHeader + row + "grp/proj |\n\n1 items total\n" + groupListHints,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s markdown =\n%q\nwant:\n%q", tt.name, tt.got, tt.want)
 			}
 		})
 	}
 }
 
-// TestFormatFileListMarkdown_EmptyFiles verifies that [FormatFileListMarkdown]
-// renders "No package files found." when the list is empty.
+// TestFormatFileListMarkdown_EmptyFiles verifies an empty list is the one
+// sentence and nothing else.
 func TestFormatFileListMarkdown_EmptyFiles(t *testing.T) {
-	out := FileListOutput{
-		Files:      nil,
-		Pagination: toolutil.PaginationOutput{TotalItems: 0},
-	}
-	got := FormatFileListMarkdown(out)
-	if !strings.Contains(got, "No package files found.") {
-		t.Error("missing 'No package files found.' message")
+	got := FormatFileListMarkdown(FileListOutput{Files: nil, Pagination: toolutil.PaginationOutput{TotalItems: 0}})
+	want := "No package files found.\n"
+	if got != want {
+		t.Errorf("FormatFileListMarkdown() = %q, want %q", got, want)
 	}
 }
 
-// TestFormatFileListMarkdown_LongSHA verifies that [FormatFileListMarkdown]
-// truncates SHA256 values longer than 12 characters.
+// TestFormatFileListMarkdown_LongSHA verifies the whole table for one file
+// whose digest is longer than the column.
 func TestFormatFileListMarkdown_LongSHA(t *testing.T) {
 	out := FileListOutput{
 		Files: []FileListItem{
@@ -429,8 +545,13 @@ func TestFormatFileListMarkdown_LongSHA(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 1},
 	}
 	got := FormatFileListMarkdown(out)
-	if !strings.Contains(got, "0123456789ab...") {
-		t.Error("SHA256 should be truncated to 12 chars + ellipsis")
+	want := "## Package Files (1)\n\n" +
+		"| ID | File Name | Size (bytes) | SHA256 |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 1 | pkg.tar.gz | 2048 | `0123456789ab...` |\n" +
+		"\n1 items total\n" + fileListHints
+	if got != want {
+		t.Errorf("FormatFileListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 

--- a/internal/tools/pipelines/markdown.go
+++ b/internal/tools/pipelines/markdown.go
@@ -2,11 +2,23 @@ package pipelines
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name, beside the ones action_specs.go
+// already declares. A hint names the ID every surface resolves, so it is never
+// a tool name the serving surface does not register.
+const (
+	actionPipelineVariables  = "pipeline.variables"
+	actionPipelineTestReport = "pipeline.test_report"
+	actionPipelineWait       = "pipeline.wait"
+	actionJobList            = "job.list"
+	actionJobTrace           = "job.trace"
 )
 
 type pipelineNotFoundOutput struct {
@@ -21,141 +33,182 @@ func formatPipelineNotFound(out pipelineNotFoundOutput) *mcp.CallToolResult {
 	)
 }
 
-// FormatListMarkdown renders a paginated list of pipelines as a Markdown table.
+// FormatListMarkdown renders a page of pipelines as a Markdown table: a
+// collection of objects that share columns.
+//
+// The heading counts what the response can vouch for rather than
+// Pagination.TotalItems alone, which keyset pagination never sends: "Pipelines
+// (0)" above a table of rows was what a reader saw on every keyset page.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Pipelines (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Pipelines), out.Pagination)
 	if len(out.Pipelines) == 0 {
-		b.WriteString("No pipelines found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("pipelines")
 	}
-	b.WriteString("| ID | Status | Source | Ref | SHA |\n")
-	b.WriteString(toolutil.TblSep5Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Pipelines", len(out.Pipelines), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Status", "Source", "Ref", "SHA"))
 	for _, p := range out.Pipelines {
-		sha := p.SHA
-		if len(sha) > 8 {
-			sha = sha[:8]
-		}
-		fmt.Fprintf(&b, "| %s | %s %s | %s | %s | %s |\n",
-			//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
-			//gitlab:allow-unescaped sha: the first characters of a commit SHA, which is hexadecimal.
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), toolutil.PipelineStatusEmoji(p.Status), p.Status, toolutil.EscapeMdTableCell(p.Source), toolutil.EscapeMdTableCell(p.Ref), sha)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL),
+			pipelineStatusCell(p.Status),
+			toolutil.EscapeMdTableCell(p.Source),
+			toolutil.EscapeMdTableCell(p.Ref),
+			toolutil.EscapeMdTableCell(shortSHA(p.SHA)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'get' with a pipeline_id for full details",
-		"Use gitlab_job action 'list' with pipeline_id to see jobs",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionPipelineGet, "see one pipeline in full"),
+		toolutil.HintAction(actionJobList, "see the jobs of a pipeline"),
 	)
 	return b.String()
 }
 
-// FormatDetailMarkdown renders a single pipeline detail as a Markdown summary.
+// pipelineStatusCell renders a pipeline status with its glyph, and nothing
+// when GitLab sent no status.
+func pipelineStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// shortSHA is the abbreviation a commit SHA is shown by in a table cell.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// FormatDetailMarkdown renders one pipeline as the card of a single object.
 func FormatDetailMarkdown(p DetailOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## %s Pipeline #%d: %s\n\n", toolutil.PipelineStatusEmoji(p.Status), p.ID, p.Status)
-	//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
-	fmt.Fprintf(&b, "- **IID**: %d\n", p.IID)
-	fmt.Fprintf(&b, "- **Source**: %s\n", p.Source)
+	c := toolutil.NewCard(&b, pipelineHeading(p))
+	writePipelineDetail(c, p)
+	c.End(
+		toolutil.HintAction(actionJobList, "see the jobs of this pipeline"),
+		toolutil.HintAction(actionPipelineVariables, "see the variables it ran with"),
+		toolutil.HintAction(actionPipelineTestReport, "see its test results"),
+	)
+	return b.String()
+}
+
+// pipelineHeading composes the card's heading: the status as a glyph, the
+// pipeline's ID and status, and the archived marker an archived pipeline
+// carries. Without that marker a reader cannot tell an archived pipeline from
+// a live one, and an archived pipeline can neither be retried nor cancelled.
+func pipelineHeading(p DetailOutput) string {
+	heading := fmt.Sprintf("%s Pipeline #%d: %s", toolutil.PipelineStatusEmoji(p.Status), p.ID, p.Status)
+	if p.Archived {
+		heading += " " + toolutil.EmojiArchived
+	}
+	return heading
+}
+
+// writePipelineDetail writes the pipeline's own rows onto the card it is
+// given, so the wait result can show the same fields under its own H3 instead
+// of embedding a second H2 and a second guidance section.
+func writePipelineDetail(c *toolutil.Card, p DetailOutput) {
+	c.Int("IID", p.IID)
+	c.Field("Source", p.Source)
 	// A ref is not an identifier: git check-ref-format permits '|', '<' and
-	// '>', so a pushable branch can end this line or open a tag in it.
-	fmt.Fprintf(&b, "- **Ref**: %s (tag: %v)\n", toolutil.EscapeMdTableCell(p.Ref), p.Tag)
-	//gitlab:allow-unescaped p.SHA: a commit SHA, hexadecimal digits only.
-	fmt.Fprintf(&b, "- **SHA**: %s\n", p.SHA)
-	if p.BeforeSHA != "" {
-		//gitlab:allow-unescaped p.BeforeSHA: the commit SHA the push started from, hexadecimal digits only.
-		fmt.Fprintf(&b, "- **Before SHA**: %s\n", p.BeforeSHA)
-	}
-	if p.Name != "" {
-		// The pipeline name comes from workflow:name in .gitlab-ci.yml, which
-		// is free text and interpolates CI variables besides.
-		fmt.Fprintf(&b, toolutil.FmtMdName, toolutil.EscapeMdTableCell(p.Name))
-	}
+	// '>', so a pushable branch could end this row or open a tag in it.
+	c.Field("Ref", p.Ref)
+	c.Bool("Tag", p.Tag)
+	c.Code("SHA", p.SHA)
+	c.Code("Before SHA", p.BeforeSHA)
+	// The pipeline name comes from workflow:name in .gitlab-ci.yml, which is
+	// free text and interpolates CI variables besides.
+	c.Field("Name", p.Name)
+	c.Field("Detailed Status", detailedStatusLabel(p))
+	c.Flag(toolutil.EmojiArchived, "Archived", p.Archived)
 	if p.Duration > 0 {
-		fmt.Fprintf(&b, "- **Duration**: %ds\n", p.Duration)
+		c.Field("Duration", fmt.Sprintf("%ds", p.Duration))
 	}
 	if p.QueuedDuration > 0 {
-		fmt.Fprintf(&b, "- **Queued**: %ds\n", p.QueuedDuration)
+		c.Field("Queued", fmt.Sprintf("%ds", p.QueuedDuration))
 	}
 	if p.Coverage != "" {
-		//gitlab:allow-unescaped p.Coverage: the average job coverage GitLab computes for the pipeline and serializes as a decimal number.
-		fmt.Fprintf(&b, "- **Coverage**: %s%%\n", p.Coverage)
+		c.Field("Coverage", p.Coverage+"%")
 	}
-	if p.YamlErrors != "" {
-		// GitLab quotes the user's own CI file back in this message, job and
-		// stage names included, and a Psych parse error carries "(<unknown>)".
-		fmt.Fprintf(&b, "- **YAML Errors**: %s\n", toolutil.EscapeMdTableCell(p.YamlErrors))
+	// GitLab quotes the user's own CI file back in this message, job and stage
+	// names included, and a Psych parse error carries "(<unknown>)".
+	c.Text("YAML Errors", p.YamlErrors)
+	if p.User != nil {
+		c.Markdown("User", toolutil.MdUserLink(p.User.Username, p.User.WebURL))
 	}
-	if p.User != nil && p.User.Username != "" {
-		fmt.Fprintf(&b, "- **User**: %s\n", toolutil.EscapeMdTableCell(p.User.Username))
-	}
-	if p.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(p.CreatedAt))
-	}
-	if p.StartedAt != "" {
-		fmt.Fprintf(&b, "- **Started**: %s\n", toolutil.FormatTime(p.StartedAt))
-	}
-	if p.FinishedAt != "" {
-		fmt.Fprintf(&b, "- **Finished**: %s\n", toolutil.FormatTime(p.FinishedAt))
-	}
-	toolutil.WriteMdURL(&b, p.WebURL)
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_job action 'list' with this pipeline_id to see all jobs",
-		"Use action 'variables' to see pipeline variables",
-		"Use action 'test_report' to see test results",
-	)
-	return b.String()
+	c.Time("Created", p.CreatedAt)
+	c.Time("Started", p.StartedAt)
+	c.Time("Finished", p.FinishedAt)
+	c.URL(p.WebURL)
 }
 
-// FormatVariablesMarkdown renders pipeline variables as a Markdown table.
+// detailedStatusLabel is the human label GitLab computes for a pipeline's
+// status, shown only when it says more than the status word already on the
+// card: GitLab sends "passed" for a successful pipeline and "failed (allowed
+// to fail)" for one whose only failures were allowed, which the bare status
+// cannot express.
+func detailedStatusLabel(p DetailOutput) string {
+	if p.DetailedStatus == nil {
+		return ""
+	}
+	label := strings.TrimSpace(p.DetailedStatus.Label)
+	if label == "" || strings.EqualFold(label, p.Status) {
+		return ""
+	}
+	return label
+}
+
+// FormatVariablesMarkdown renders a pipeline's variables as a Markdown table.
 func FormatVariablesMarkdown(out VariablesOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Pipeline Variables (%d)\n\n", len(out.Variables))
 	if len(out.Variables) == 0 {
-		b.WriteString("No pipeline variables found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("pipeline variables")
 	}
-	b.WriteString("| Key | Value | Type |\n")
-	b.WriteString(toolutil.TblSep3Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Pipeline Variables", len(out.Variables), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("Key", "Value", "Type"))
 	for _, v := range out.Variables {
-		fmt.Fprintf(&b, "| %s | %s | %s |\n",
-			//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
-			toolutil.EscapeMdTableCell(v.Key), toolutil.EscapeMdTableCell(v.Value), v.VariableType)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(v.Key),
+			toolutil.EscapeMdTableCell(v.Value),
+			toolutil.EscapeMdTableCell(v.VariableType),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_pipeline_get` to view pipeline details",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(actionPipelineGet, "see the pipeline these variables ran"),
 	)
 	return b.String()
 }
 
-// FormatTestReportMarkdown renders a pipeline test report as Markdown.
+// FormatTestReportMarkdown renders a pipeline's test report as the card of one
+// object: the totals as rows, the suites as the nested collection they are.
+//
+// The report carries no individual test case, so the hints name the jobs and
+// their logs rather than promising per-test detail this rendering cannot show.
 func FormatTestReportMarkdown(out TestReportOutput) string {
 	var b strings.Builder
-	b.WriteString("## Pipeline Test Report\n\n")
-	writeTestReportTotals(&b, out.TotalCount, out.TotalTime, out.SuccessCount, out.FailedCount, out.SkippedCount, out.ErrorCount)
-	writeTestSuites(&b, testSuiteOutputs(out.TestSuites))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_job_list` to see individual job results",
-		"Use `gitlab_job_trace` to view job logs for failures",
+	c := toolutil.NewCard(&b, "Pipeline Test Report")
+	writeTestReportTotals(c, out.TotalCount, out.TotalTime, out.SuccessCount, out.FailedCount, out.SkippedCount, out.ErrorCount)
+	writeTestSuites(c, testSuiteOutputs(out.TestSuites))
+	c.End(
+		toolutil.HintAction(actionJobList, "see the jobs these suites ran in"),
+		toolutil.HintAction(actionJobTrace, "read the log of a failing job"),
 	)
 	return b.String()
 }
 
-// FormatTestReportSummaryMarkdown renders a pipeline test report summary as Markdown.
+// FormatTestReportSummaryMarkdown renders a pipeline's test report summary as
+// the card of one object.
+//
+// The full report shows the same per-suite totals and no test cases, so the
+// hint says that rather than offering "full test details".
 func FormatTestReportSummaryMarkdown(out TestReportSummaryOutput) string {
 	var b strings.Builder
-	b.WriteString("## Pipeline Test Report Summary\n\n")
-	writeTestReportTotals(&b, out.TotalCount, out.TotalTime, out.SuccessCount, out.FailedCount, out.SkippedCount, out.ErrorCount)
-	writeTestSuites(&b, testSuiteSummaryOutputs(out.TestSuites))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_pipeline_test_report` for full test details",
-		"Use `gitlab_job_list` to investigate failures",
+	c := toolutil.NewCard(&b, "Pipeline Test Report Summary")
+	writeTestReportTotals(c, out.TotalCount, out.TotalTime, out.SuccessCount, out.FailedCount, out.SkippedCount, out.ErrorCount)
+	writeTestSuites(c, testSuiteSummaryOutputs(out.TestSuites))
+	c.End(
+		toolutil.HintAction(actionPipelineTestReport, "see the same per-suite totals in the full report"),
+		toolutil.HintAction(actionJobList, "investigate failures job by job"),
 	)
 	return b.String()
 }
@@ -170,22 +223,34 @@ type testSuiteMarkdown struct {
 	ErrorCount   int64
 }
 
-func writeTestReportTotals(b *strings.Builder, totalCount int64, totalTime float64, successCount, failedCount, skippedCount, errorCount int64) {
-	fmt.Fprintf(b, "- **Total**: %d tests (%.2fs)\n", totalCount, totalTime)
-	fmt.Fprintf(b, "- **Passed**: %d | **Failed**: %d | **Skipped**: %d | **Errors**: %d\n\n",
-		successCount, failedCount, skippedCount, errorCount)
+// writeTestReportTotals writes one row per count. The four counts used to
+// share a line separated by pipes, which is a table row anywhere a renderer
+// looks for one and four values a reader has to parse out of one item.
+func writeTestReportTotals(c *toolutil.Card, totalCount int64, totalTime float64, successCount, failedCount, skippedCount, errorCount int64) {
+	c.Int("Total", totalCount)
+	c.Field("Time", fmt.Sprintf("%.2fs", totalTime))
+	c.Int("Passed", successCount)
+	c.Int("Failed", failedCount)
+	c.Int("Skipped", skippedCount)
+	c.Int("Errors", errorCount)
 }
 
-func writeTestSuites(b *strings.Builder, suites []testSuiteMarkdown) {
+// writeTestSuites writes the suites as the nested collection of a card.
+func writeTestSuites(c *toolutil.Card, suites []testSuiteMarkdown) {
 	if len(suites) == 0 {
 		return
 	}
-	b.WriteString("### Test Suites\n\n")
-	b.WriteString("| Suite | Total | Passed | Failed | Skipped | Errors | Time |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- | --- |\n")
+	table := c.Table("Test Suites", "Suite", "Total", "Passed", "Failed", "Skipped", "Errors", "Time")
 	for _, suite := range suites {
-		fmt.Fprintf(b, "| %s | %d | %d | %d | %d | %d | %.2fs |\n",
-			toolutil.EscapeMdTableCell(suite.Name), suite.TotalCount, suite.SuccessCount, suite.FailedCount, suite.SkippedCount, suite.ErrorCount, suite.TotalTime)
+		table.Row(
+			toolutil.EscapeMdTableCell(suite.Name),
+			strconv.FormatInt(suite.TotalCount, 10),
+			strconv.FormatInt(suite.SuccessCount, 10),
+			strconv.FormatInt(suite.FailedCount, 10),
+			strconv.FormatInt(suite.SkippedCount, 10),
+			strconv.FormatInt(suite.ErrorCount, 10),
+			fmt.Sprintf("%.2fs", suite.TotalTime),
+		)
 	}
 }
 
@@ -213,39 +278,53 @@ func testSuiteSummaryOutputs(suites []TestSuiteSummaryOutput) []testSuiteMarkdow
 	return out
 }
 
-// FormatWaitMarkdown renders the wait result as a Markdown summary.
+// FormatWaitMarkdown renders the wait result as the card of the pipeline that
+// was waited for: the wait's own rows, then the pipeline's fields under one
+// H3, and one guidance section at the end.
 //
-//gitlab:allow-unescaped out.Pipeline.Status: the same pipeline status enum, reached through the pipeline the wait polled.
-//gitlab:allow-unescaped out.FinalStatus: the status the wait ended on, taken from that same pipeline.
-//gitlab:allow-unescaped out.WaitedFor: how long this server waited, rendered by time.Duration.String.
+// The pipeline used to be embedded by calling [FormatDetailMarkdown], which
+// wrote a second H2 under the H3 and a guidance section in the middle of the
+// response, where ExtractHints never looked.
 func FormatWaitMarkdown(out WaitOutput) string {
 	var b strings.Builder
-	if out.TimedOut {
-		fmt.Fprintf(&b, "## \u23F0 Pipeline #%d: Timed Out (current: %s)\n\n", out.Pipeline.ID, out.Pipeline.Status)
-	} else {
-		fmt.Fprintf(&b, "## %s Pipeline #%d: %s\n\n", toolutil.PipelineStatusEmoji(out.FinalStatus), out.Pipeline.ID, out.FinalStatus)
-	}
-	fmt.Fprintf(&b, "- **Waited**: %s (%d polls)\n", out.WaitedFor, out.PollCount)
-	fmt.Fprintf(&b, "- **Final Status**: %s\n", out.FinalStatus)
-	if out.TimedOut {
-		b.WriteString("- **Timed Out**: yes\n")
-	}
-	b.WriteString("\n### Pipeline Details\n\n")
-	b.WriteString(FormatDetailMarkdown(out.Pipeline))
-	if out.TimedOut {
-		toolutil.WriteHints(
-			&b,
-			"Pipeline is still running. Call gitlab_pipeline_wait again to continue waiting",
-			"Use gitlab_pipeline_cancel to abort the pipeline",
-		)
-	} else if out.FinalStatus == "failed" {
-		toolutil.WriteHints(
-			&b,
-			"Use gitlab_job action 'list' with scope 'failed' to find failed jobs",
-			"Use gitlab_pipeline_retry to retry failed jobs",
-		)
-	}
+	c := toolutil.NewCard(&b, waitHeading(out))
+	// The poller writes this duration itself, with time.Duration.String over
+	// time.Since, so it is the server's own text rather than GitLab's.
+	c.Field("Waited", out.WaitedFor)
+	c.Int("Polls", int64(out.PollCount))
+	c.Field("Final Status", out.FinalStatus)
+	c.Warn("Timed Out", out.TimedOut)
+	writePipelineDetail(c.Section("Pipeline Details"), out.Pipeline)
+	c.End(waitHints(out)...)
 	return b.String()
+}
+
+// waitHeading names the outcome: the timer glyph and the status still running
+// when the wait gave up, and the pipeline's own status glyph otherwise.
+func waitHeading(out WaitOutput) string {
+	if out.TimedOut {
+		return fmt.Sprintf("⏰ Pipeline #%d: Timed Out (current: %s)", out.Pipeline.ID, out.Pipeline.Status)
+	}
+	return fmt.Sprintf("%s Pipeline #%d: %s", toolutil.PipelineStatusEmoji(out.FinalStatus), out.Pipeline.ID, out.FinalStatus)
+}
+
+// waitHints names what a caller can do next with the outcome the wait
+// reached, and nothing when the pipeline simply succeeded.
+func waitHints(out WaitOutput) []string {
+	switch {
+	case out.TimedOut:
+		return []string{
+			toolutil.HintAction(actionPipelineWait, "keep waiting for this pipeline"),
+			toolutil.HintAction(actionPipelineCancel, "abort it instead"),
+		}
+	case out.FinalStatus == "failed":
+		return []string{
+			toolutil.HintAction(actionJobList, "find the jobs that failed"),
+			toolutil.HintAction(actionPipelineRetry, "retry the failed jobs"),
+		}
+	default:
+		return nil
+	}
 }
 
 func formatWaitResult(out WaitOutput) *mcp.CallToolResult {

--- a/internal/tools/pipelines/pipelines_test.go
+++ b/internal/tools/pipelines/pipelines_test.go
@@ -1404,7 +1404,16 @@ func TestGetLatest_WithRef(t *testing.T) {
 // FormatListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithPipelines verifies FormatListMarkdown when with pipelines.
+// listHints is the guidance section every pipeline list closes with.
+const listHints = "\n---\n💡 **Next steps:**\n" +
+	"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+	"- Use action 'pipeline.get' to see one pipeline in full\n" +
+	"- Use action 'job.list' to see the jobs of a pipeline\n"
+
+// TestFormatListMarkdown_WithPipelines checks the whole list rendering: the
+// heading counting the total GitLab reported, one linked row per pipeline with
+// its status glyph and abbreviated SHA, the pagination footer, and the
+// guidance section.
 func TestFormatListMarkdown_WithPipelines(t *testing.T) {
 	out := ListOutput{
 		Pipelines: []Output{
@@ -1413,54 +1422,49 @@ func TestFormatListMarkdown_WithPipelines(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Pipelines (2)",
-		"| ID |",
-		"[#1]",
-		"[#2]",
-		"abc123de", // SHA truncated to 8 chars
-		"short",    // SHA shorter than 8 kept as-is
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Pipelines (2)\n\n" +
+		"| ID | Status | Source | Ref | SHA |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [#1](https://gitlab.example.com/-/pipelines/1) | ✅ success | push | main | abc123de |\n" +
+		"| [#2](https://gitlab.example.com/-/pipelines/2) | ❌ failed | web | develop | short |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty checks that an empty page is the one sentence
+// and nothing else: no heading counting zero above it, and no table header.
 func TestFormatListMarkdown_Empty(t *testing.T) {
 	out := ListOutput{
 		Pipelines:  []Output{},
 		Pagination: toolutil.PaginationOutput{},
 	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "No pipelines found") {
-		t.Errorf("expected 'No pipelines found' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No pipelines found.\n"
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_ClickablePipelineLinks verifies that pipeline IDs
-// in the list are rendered as clickable Markdown links [#ID](weburl).
-func TestFormatListMarkdown_ClickablePipelineLinks(t *testing.T) {
+// TestFormatListMarkdown_KeysetPageCountsTheRowsShown checks the heading of a
+// keyset page, which carries no total: it counts the rows shown and says more
+// follow, rather than the "(0)" a missing total used to print above a table of
+// rows.
+func TestFormatListMarkdown_KeysetPageCountsTheRowsShown(t *testing.T) {
 	out := ListOutput{
 		Pipelines: []Output{
-			{
-				ID: 42, Status: "success", Source: "push", Ref: "main", SHA: "abc12345",
-				WebURL: "https://gitlab.example.com/-/pipelines/42",
-			},
+			{ID: 42, Status: "running", Source: "push", Ref: "main", SHA: "abc12345", WebURL: "https://gitlab.example.com/-/pipelines/42"},
 		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
+		Pagination: toolutil.PaginationOutput{HasMore: true},
 	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "[#42](https://gitlab.example.com/-/pipelines/42)") {
-		t.Errorf("expected clickable pipeline link, got:\n%s", md)
+	want := "## Pipelines (1 shown, more available)\n\n" +
+		"| ID | Status | Source | Ref | SHA |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [#42](https://gitlab.example.com/-/pipelines/42) | 🔵 running | push | main | abc12345 |\n" +
+		listHints
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown(keyset)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -1497,32 +1501,38 @@ func TestFormatDetailMarkdown_Full(t *testing.T) {
 		CommittedAt: "2026-02-28T09:00:00Z",
 		User:        &toolutil.BasicUserOutput{Username: "testuser"},
 	}
-	md := FormatDetailMarkdown(out)
-
-	for _, want := range []string{
-		"Pipeline #99",
-		"success",
-		"**Source**: push",
-		"**Ref**: main (tag: true)",
-		"**SHA**: abc123",
-		"**Before SHA**: 000",
-		"**Name**: Full Pipeline",
-		"**Duration**: 300s",
-		"**Queued**: 15s",
-		"**Coverage**: 92.5%",
-		"**YAML Errors**: some error",
-		"**User**: testuser",
-		"**URL**:",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## ✅ Pipeline #99: success\n\n" +
+		"- **IID**: 99\n" +
+		"- **Source**: push\n" +
+		"- **Ref**: main\n" +
+		"- **Tag**: ✅\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **Before SHA**: `000`\n" +
+		"- **Name**: Full Pipeline\n" +
+		"- **Detailed Status**: passed\n" +
+		"- **Duration**: 300s\n" +
+		"- **Queued**: 15s\n" +
+		"- **Coverage**: 92.5%\n" +
+		"- **YAML Errors**: some error\n" +
+		"- **User**: @testuser\n" +
+		"- **Created**: 1 Mar 2026 10:00 UTC\n" +
+		"- **Started**: 1 Mar 2026 10:00 UTC\n" +
+		"- **Finished**: 1 Mar 2026 10:05 UTC\n" +
+		"- **URL**: [https://gitlab.example.com/-/pipelines/99](https://gitlab.example.com/-/pipelines/99)\n" +
+		detailHints
+	if got := FormatDetailMarkdown(out); got != want {
+		t.Errorf("FormatDetailMarkdown(full)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatDetailMarkdown_Minimal verifies FormatDetailMarkdown when minimal.
+// detailHints is the guidance section the pipeline card closes with.
+const detailHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.list' to see the jobs of this pipeline\n" +
+	"- Use action 'pipeline.variables' to see the variables it ran with\n" +
+	"- Use action 'pipeline.test_report' to see its test results\n"
+
+// TestFormatDetailMarkdown_Minimal checks that a pipeline GitLab sent little
+// about renders only the rows it answered: no label stands without a value.
 func TestFormatDetailMarkdown_Minimal(t *testing.T) {
 	out := DetailOutput{
 		ID:     1,
@@ -1532,23 +1542,103 @@ func TestFormatDetailMarkdown_Minimal(t *testing.T) {
 		SHA:    "xyz",
 		WebURL: "https://gitlab.example.com/-/pipelines/1",
 	}
-	md := FormatDetailMarkdown(out)
-
-	if !strings.Contains(md, "Pipeline #1") {
-		t.Errorf("missing header:\n%s", md)
+	want := "## 🟡 Pipeline #1: pending\n\n" +
+		"- **IID**: 0\n" +
+		"- **Source**: web\n" +
+		"- **Ref**: dev\n" +
+		"- **Tag**: ❌\n" +
+		"- **SHA**: `xyz`\n" +
+		"- **URL**: [https://gitlab.example.com/-/pipelines/1](https://gitlab.example.com/-/pipelines/1)\n" +
+		detailHints
+	if got := FormatDetailMarkdown(out); got != want {
+		t.Errorf("FormatDetailMarkdown(minimal)\n got %q\nwant %q", got, want)
 	}
-	for _, absent := range []string{
-		"**Before SHA**",
-		"**Name**",
-		"**Duration**",
-		"**Queued**",
-		"**Coverage**",
-		"**YAML Errors**",
-		"**User**",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
+}
+
+// TestFormatDetailMarkdown_ArchivedIsMarked checks that an archived pipeline
+// says so twice over — in the heading and as a row — since an archived
+// pipeline can be neither retried nor cancelled and nothing else in the card
+// would tell a reader that.
+func TestFormatDetailMarkdown_ArchivedIsMarked(t *testing.T) {
+	out := DetailOutput{
+		ID:       7,
+		Status:   "success",
+		Ref:      "main",
+		SHA:      "abc",
+		Archived: true,
+		WebURL:   "https://gitlab.example.com/-/pipelines/7",
+	}
+	want := "## ✅ Pipeline #7: success 📦\n\n" +
+		"- **IID**: 0\n" +
+		"- **Ref**: main\n" +
+		"- **Tag**: ❌\n" +
+		"- **SHA**: `abc`\n" +
+		"- 📦 **Archived**\n" +
+		"- **URL**: [https://gitlab.example.com/-/pipelines/7](https://gitlab.example.com/-/pipelines/7)\n" +
+		detailHints
+	if got := FormatDetailMarkdown(out); got != want {
+		t.Errorf("FormatDetailMarkdown(archived)\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestFormatDetailMarkdown_HostileValuesStayInTheirRow checks what a value
+// GitLab could carry does to the card: a ref that ends a table cell, a name
+// that opens a heading and a SHA that spells an HTML anchor all stay inside
+// the row that shows them.
+//
+// The SHA is a code span, and a code span's content is literal: the anchor is
+// shown as the text it is, and MdCodeSpan sizes the fence so the value cannot
+// close the span it sits in. The runtime scan reports the anchor's bytes as a
+// raw tag because it reads the line rather than the span; the assertion below
+// is what the reader actually sees.
+func TestFormatDetailMarkdown_HostileValuesStayInTheirRow(t *testing.T) {
+	out := DetailOutput{
+		ID:     4,
+		Status: "success",
+		Ref:    "a|b",
+		SHA:    `<a href="http://attacker.invalid">click</a>`,
+		Name:   "x\r\n## injected heading",
+		WebURL: "https://gitlab.example.com/-/pipelines/4",
+	}
+	want := "## ✅ Pipeline #4: success\n\n" +
+		"- **IID**: 0\n" +
+		"- **Ref**: a&#124;b\n" +
+		"- **Tag**: ❌\n" +
+		"- **SHA**: `<a href=\"http://attacker.invalid\">click</a>`\n" +
+		"- **Name**: x ## injected heading\n" +
+		"- **URL**: [https://gitlab.example.com/-/pipelines/4](https://gitlab.example.com/-/pipelines/4)\n" +
+		detailHints
+	if got := FormatDetailMarkdown(out); got != want {
+		t.Errorf("FormatDetailMarkdown(hostile)\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestFormatDetailMarkdown_DetailedStatusOnlyWhenItSaysMore checks that the
+// detailed status is written only when it differs from the status word already
+// on the card: GitLab sends "success" as "passed" for every successful
+// pipeline, and a row repeating that says nothing.
+func TestFormatDetailMarkdown_DetailedStatusOnlyWhenItSaysMore(t *testing.T) {
+	base := DetailOutput{ID: 3, Status: "failed", Ref: "main", SHA: "abc", WebURL: "https://gitlab.example.com/-/pipelines/3"}
+	cases := []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{name: "same word", label: "Failed", want: ""},
+		{name: "says more", label: "failed (allowed to fail)", want: "- **Detailed Status**: failed (allowed to fail)\n"},
+		{name: "absent", label: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := base
+			out.DetailedStatus = &StatusOutput{Label: tc.label}
+			md := FormatDetailMarkdown(out)
+			row := "- **Detailed Status**: " + tc.label + "\n"
+			if tc.want == "" && strings.Contains(md, "**Detailed Status**") {
+				t.Errorf("detailed status row written for label %q:\n%s", tc.label, md)
+			}
+			if tc.want != "" && !strings.Contains(md, row) {
+				t.Errorf("missing %q:\n%s", row, md)
 			}
 		})
 	}
@@ -1566,37 +1656,25 @@ func TestFormatVariablesMarkdown_WithData(t *testing.T) {
 			{Key: "SECRET_FILE", Value: "/tmp/secret", VariableType: "file"},
 		},
 	}
-	md := FormatVariablesMarkdown(out)
-
-	for _, want := range []string{
-		"## Pipeline Variables (2)",
-		"| Key |",
-		"CI_VAR",
-		"SECRET_FILE",
-		"env_var",
-		"file",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Pipeline Variables (2)\n\n" +
+		"| Key | Value | Type |\n" +
+		"| --- | --- | --- |\n" +
+		"| CI_VAR | hello | env_var |\n" +
+		"| SECRET_FILE | /tmp/secret | file |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'pipeline.get' to see the pipeline these variables ran\n"
+	if got := FormatVariablesMarkdown(out); got != want {
+		t.Errorf("FormatVariablesMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatVariablesMarkdown_Empty verifies FormatVariablesMarkdown when empty.
+// TestFormatVariablesMarkdown_Empty checks that a pipeline with no variables
+// renders the one sentence: the heading counting zero above it said the same
+// thing twice.
 func TestFormatVariablesMarkdown_Empty(t *testing.T) {
-	out := VariablesOutput{Variables: nil}
-	md := FormatVariablesMarkdown(out)
-
-	if !strings.Contains(md, "## Pipeline Variables (0)") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "No pipeline variables found") {
-		t.Errorf("expected 'No pipeline variables found' in markdown:\n%s", md)
-	}
-	if strings.Contains(md, "| Key |") {
-		t.Error("should not contain table header when empty")
+	const want = "No pipeline variables found.\n"
+	if got := FormatVariablesMarkdown(VariablesOutput{Variables: nil}); got != want {
+		t.Errorf("FormatVariablesMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -1618,44 +1696,42 @@ func TestFormatTestReportMarkdown_WithSuites(t *testing.T) {
 			{Name: "Integration", TotalTime: 60.5, TotalCount: 5, SuccessCount: 4, FailedCount: 0, SkippedCount: 1, ErrorCount: 0},
 		},
 	}
-	md := FormatTestReportMarkdown(out)
-
-	for _, want := range []string{
-		"## Pipeline Test Report",
-		"**Total**: 10 tests",
-		"120.50s",
-		"**Passed**: 8",
-		"**Failed**: 1",
-		"**Skipped**: 1",
-		"**Errors**: 0",
-		"### Test Suites",
-		"| Suite |",
-		"Unit Tests",
-		"Integration",
-		"60.00s",
-		"60.50s",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Pipeline Test Report\n\n" +
+		"- **Total**: 10\n" +
+		"- **Time**: 120.50s\n" +
+		"- **Passed**: 8\n" +
+		"- **Failed**: 1\n" +
+		"- **Skipped**: 1\n" +
+		"- **Errors**: 0\n" +
+		"\n### Test Suites\n\n" +
+		"| Suite | Total | Passed | Failed | Skipped | Errors | Time |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| Unit Tests | 5 | 4 | 1 | 0 | 0 | 60.00s |\n" +
+		"| Integration | 5 | 4 | 0 | 1 | 0 | 60.50s |\n" +
+		reportHints
+	if got := FormatTestReportMarkdown(out); got != want {
+		t.Errorf("FormatTestReportMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatTestReportMarkdown_Empty verifies FormatTestReportMarkdown when empty.
-func TestFormatTestReportMarkdown_Empty(t *testing.T) {
-	out := TestReportOutput{}
-	md := FormatTestReportMarkdown(out)
+// reportHints is the guidance section the full test report closes with.
+const reportHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'job.list' to see the jobs these suites ran in\n" +
+	"- Use action 'job.trace' to read the log of a failing job\n"
 
-	if !strings.Contains(md, "## Pipeline Test Report") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "**Total**: 0 tests") {
-		t.Errorf("expected zero counts:\n%s", md)
-	}
-	if strings.Contains(md, "### Test Suites") {
-		t.Error("should not contain suites section when empty")
+// TestFormatTestReportMarkdown_Empty checks that a report of zeros keeps every
+// count row — a zero is an answer GitLab gave — and opens no suites section.
+func TestFormatTestReportMarkdown_Empty(t *testing.T) {
+	want := "## Pipeline Test Report\n\n" +
+		"- **Total**: 0\n" +
+		"- **Time**: 0.00s\n" +
+		"- **Passed**: 0\n" +
+		"- **Failed**: 0\n" +
+		"- **Skipped**: 0\n" +
+		"- **Errors**: 0\n" +
+		reportHints
+	if got := FormatTestReportMarkdown(TestReportOutput{}); got != want {
+		t.Errorf("FormatTestReportMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -1676,38 +1752,43 @@ func TestFormatTestReportSummaryMarkdown_WithSuites(t *testing.T) {
 			{Name: "Unit", TotalTime: 100.0, TotalCount: 10, SuccessCount: 9, FailedCount: 1, SkippedCount: 0, ErrorCount: 0, BuildIDs: []int64{101, 102}},
 		},
 	}
-	md := FormatTestReportSummaryMarkdown(out)
-
-	for _, want := range []string{
-		"## Pipeline Test Report Summary",
-		"**Total**: 20 tests",
-		"200.00s",
-		"**Passed**: 18",
-		"### Test Suites",
-		"Unit",
-		"100.00s",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Pipeline Test Report Summary\n\n" +
+		"- **Total**: 20\n" +
+		"- **Time**: 200.00s\n" +
+		"- **Passed**: 18\n" +
+		"- **Failed**: 1\n" +
+		"- **Skipped**: 1\n" +
+		"- **Errors**: 0\n" +
+		"\n### Test Suites\n\n" +
+		"| Suite | Total | Passed | Failed | Skipped | Errors | Time |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| Unit | 10 | 9 | 1 | 0 | 0 | 100.00s |\n" +
+		summaryHints
+	if got := FormatTestReportSummaryMarkdown(out); got != want {
+		t.Errorf("FormatTestReportSummaryMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatTestReportSummaryMarkdown_Empty verifies FormatTestReportSummaryMarkdown when empty.
-func TestFormatTestReportSummaryMarkdown_Empty(t *testing.T) {
-	out := TestReportSummaryOutput{}
-	md := FormatTestReportSummaryMarkdown(out)
+// summaryHints is the guidance section the summary closes with. It offers the
+// full report's per-suite totals rather than "full test details", which the
+// full report does not carry either.
+const summaryHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'pipeline.test_report' to see the same per-suite totals in the full report\n" +
+	"- Use action 'job.list' to investigate failures job by job\n"
 
-	if !strings.Contains(md, "## Pipeline Test Report Summary") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "**Total**: 0 tests") {
-		t.Errorf("expected zero counts:\n%s", md)
-	}
-	if strings.Contains(md, "### Test Suites") {
-		t.Error("should not contain suites section when empty")
+// TestFormatTestReportSummaryMarkdown_Empty checks the summary of a pipeline
+// that ran no tests: every count row stays and no suites section opens.
+func TestFormatTestReportSummaryMarkdown_Empty(t *testing.T) {
+	want := "## Pipeline Test Report Summary\n\n" +
+		"- **Total**: 0\n" +
+		"- **Time**: 0.00s\n" +
+		"- **Passed**: 0\n" +
+		"- **Failed**: 0\n" +
+		"- **Skipped**: 0\n" +
+		"- **Errors**: 0\n" +
+		summaryHints
+	if got := FormatTestReportSummaryMarkdown(TestReportSummaryOutput{}); got != want {
+		t.Errorf("FormatTestReportSummaryMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 

--- a/internal/tools/pipelines/wait_test.go
+++ b/internal/tools/pipelines/wait_test.go
@@ -375,89 +375,98 @@ func TestWait_ContextCanceledDuringPoll(t *testing.T) {
 	}
 }
 
-// TestFormatWaitMarkdown_Success verifies markdown rendering for a successfully completed pipeline.
+// waitPipelineRows is the pipeline the wait fixtures poll, rendered under the
+// wait's own H3. The detail is embedded without its heading so the response
+// carries one H2, one guidance section and no card nested inside another.
+const waitPipelineRows = "\n### Pipeline Details\n\n" +
+	"- **IID**: 0\n" +
+	"- **Tag**: ❌\n" +
+	"- **URL**: [https://gitlab.example.com/-/pipelines/10](https://gitlab.example.com/-/pipelines/10)\n"
+
+// TestFormatWaitMarkdown_Success checks the whole rendering of a wait that
+// ended well: the wait's own rows, the pipeline under one H3, and no guidance
+// section, since a pipeline that succeeded needs no next step.
 func TestFormatWaitMarkdown_Success(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ✅ Pipeline #10: success\n\n" +
+		"- **Waited**: 30s\n" +
+		"- **Polls**: 3\n" +
+		"- **Final Status**: success\n" +
+		waitPipelineRows
+	got := FormatWaitMarkdown(WaitOutput{
 		Pipeline:    DetailOutput{ID: 10, Status: "success", WebURL: "https://gitlab.example.com/-/pipelines/10"},
 		WaitedFor:   "30s",
 		PollCount:   3,
 		FinalStatus: "success",
 	})
-	if !strings.Contains(md, "Pipeline #10") {
-		t.Error("expected 'Pipeline #10' in markdown")
-	}
-	if !strings.Contains(md, "success") {
-		t.Error("expected 'success' in markdown")
-	}
-	if !strings.Contains(md, "30s") {
-		t.Error("expected waited duration in markdown")
-	}
-	if !strings.Contains(md, "3 polls") {
-		t.Error("expected poll count in markdown")
-	}
-	if strings.Contains(md, "Timed Out") {
-		t.Error("should not contain 'Timed Out' for success")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(success)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_Failed verifies markdown rendering for a failed pipeline with hints.
+// TestFormatWaitMarkdown_Failed checks that a failed wait names the two
+// actions that follow it, by the canonical IDs every surface resolves.
 func TestFormatWaitMarkdown_Failed(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ❌ Pipeline #10: failed\n\n" +
+		"- **Waited**: 45s\n" +
+		"- **Polls**: 5\n" +
+		"- **Final Status**: failed\n" +
+		waitPipelineRows +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.list' to find the jobs that failed\n" +
+		"- Use action 'pipeline.retry' to retry the failed jobs\n"
+	got := FormatWaitMarkdown(WaitOutput{
 		Pipeline:    DetailOutput{ID: 10, Status: "failed", WebURL: "https://gitlab.example.com/-/pipelines/10"},
 		WaitedFor:   "45s",
 		PollCount:   5,
 		FinalStatus: "failed",
 	})
-	if !strings.Contains(md, "Pipeline #10") {
-		t.Error("expected 'Pipeline #10' in markdown")
-	}
-	if !strings.Contains(md, "failed") {
-		t.Error("expected 'failed' in markdown")
-	}
-	if !strings.Contains(md, "gitlab_job") {
-		t.Error("expected hint about jobs in markdown for failed pipeline")
-	}
-	if !strings.Contains(md, "gitlab_pipeline_retry") {
-		t.Error("expected hint about retry in markdown for failed pipeline")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(failed)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_TimedOut verifies markdown rendering for a timed-out wait.
+// TestFormatWaitMarkdown_TimedOut checks that a timeout is marked with the
+// warning sign rather than a tick — a tick on "Timed Out" reads as success —
+// and that the heading names the status the pipeline is still in.
 func TestFormatWaitMarkdown_TimedOut(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ⏰ Pipeline #10: Timed Out (current: running)\n\n" +
+		"- **Waited**: 300s\n" +
+		"- **Polls**: 30\n" +
+		"- **Final Status**: running\n" +
+		"- ⚠️ **Timed Out**\n" +
+		waitPipelineRows +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'pipeline.wait' to keep waiting for this pipeline\n" +
+		"- Use action 'pipeline.cancel' to abort it instead\n"
+	got := FormatWaitMarkdown(WaitOutput{
 		Pipeline:    DetailOutput{ID: 10, Status: "running", WebURL: "https://gitlab.example.com/-/pipelines/10"},
 		WaitedFor:   "300s",
 		PollCount:   30,
 		FinalStatus: "running",
 		TimedOut:    true,
 	})
-	if !strings.Contains(md, "Timed Out") {
-		t.Error("expected 'Timed Out' in markdown")
-	}
-	if !strings.Contains(md, "Pipeline #10") {
-		t.Error("expected 'Pipeline #10' in markdown")
-	}
-	if !strings.Contains(md, "gitlab_pipeline_wait") {
-		t.Error("expected hint about calling wait again")
-	}
-	if !strings.Contains(md, "gitlab_pipeline_cancel") {
-		t.Error("expected hint about cancel")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(timed out)\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatWaitMarkdown_Canceled verifies markdown rendering for a canceled pipeline.
+// TestFormatWaitMarkdown_Canceled checks a wait that ended on a cancellation:
+// the outcome is neither a success nor a failure, so it carries the stop glyph
+// and no hints.
 func TestFormatWaitMarkdown_Canceled(t *testing.T) {
-	md := FormatWaitMarkdown(WaitOutput{
+	want := "## ⛔ Pipeline #10: canceled\n\n" +
+		"- **Waited**: 15s\n" +
+		"- **Polls**: 2\n" +
+		"- **Final Status**: canceled\n" +
+		waitPipelineRows
+	got := FormatWaitMarkdown(WaitOutput{
 		Pipeline:    DetailOutput{ID: 10, Status: "canceled", WebURL: "https://gitlab.example.com/-/pipelines/10"},
 		WaitedFor:   "15s",
 		PollCount:   2,
 		FinalStatus: "canceled",
 	})
-	if !strings.Contains(md, "Pipeline #10") {
-		t.Error("expected 'Pipeline #10' in markdown")
-	}
-	if !strings.Contains(md, "canceled") {
-		t.Error("expected 'canceled' in markdown")
+	if got != want {
+		t.Errorf("FormatWaitMarkdown(canceled)\n got %q\nwant %q", got, want)
 	}
 }
 

--- a/internal/tools/pipelineschedules/markdown.go
+++ b/internal/tools/pipelineschedules/markdown.go
@@ -2,123 +2,183 @@ package pipelineschedules
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single pipeline schedule as Markdown.
+// Canonical action IDs the hints name. Every surface resolves the ID: the
+// dynamic surface executes it and the meta and individual surfaces resolve it
+// to their own tool names, so a hint written this way never names something
+// the serving surface does not register — which "the selected tool surface's
+// pipeline-schedule update action" was a sentence-long way of avoiding.
+//
+// The ID is the catalog's: these actions are registered under the
+// gitlab_pipeline group, so their domain is "pipeline" and not
+// "pipeline_schedule", which is what the related-action constants beside
+// ActionSpecs still spell.
+const (
+	hintActionScheduleGet            = "pipeline.schedule_get"
+	hintActionScheduleList           = "pipeline.schedule_list"
+	hintActionScheduleCreate         = "pipeline.schedule_create"
+	hintActionScheduleUpdate         = "pipeline.schedule_update"
+	hintActionScheduleDelete         = "pipeline.schedule_delete"
+	hintActionScheduleRun            = "pipeline.schedule_run"
+	hintActionScheduleEditVariable   = "pipeline.schedule_edit_variable"
+	hintActionScheduleDeleteVariable = "pipeline.schedule_delete_variable"
+	hintActionPipelineGet            = "pipeline.get"
+)
+
+// FormatOutputMarkdown renders one pipeline schedule as the card of a single
+// object. A schedule with no ID is no schedule and renders nothing.
 func FormatOutputMarkdown(s Output) string {
 	if s.ID == 0 {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Pipeline Schedule #%d\n\n", s.ID)
-	b.WriteString("| Field | Value |\n")
-	b.WriteString(toolutil.TblSep2Col)
-	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(s.Description))
-	fmt.Fprintf(&b, "| Ref | %s |\n", toolutil.EscapeMdTableCell(s.Ref))
-	fmt.Fprintf(&b, "| Cron | `%s` |\n", toolutil.EscapeMdTableCell(s.Cron))
-	if s.CronTimezone != "" {
-		fmt.Fprintf(&b, "| Timezone | %s |\n", toolutil.EscapeMdTableCell(s.CronTimezone))
-	}
-	fmt.Fprintf(&b, "| Active | %s |\n", toolutil.BoolEmoji(s.Active))
-	if s.NextRunAt != "" {
-		fmt.Fprintf(&b, "| Next Run | %s |\n", toolutil.FormatTime(s.NextRunAt))
-	}
-	if s.Owner != nil && s.Owner.Username != "" {
-		fmt.Fprintf(&b, "| Owner | %s |\n", toolutil.EscapeMdTableCell(s.Owner.Username))
+	c := toolutil.NewCard(&b, fmt.Sprintf("Pipeline Schedule #%d", s.ID))
+	// The description, the ref and the cron are what a maintainer typed.
+	c.Field("Description", s.Description)
+	c.Field("Ref", s.Ref)
+	c.Code("Cron", s.Cron)
+	c.Field("Timezone", s.CronTimezone)
+	c.Bool("Active", s.Active)
+	c.Time("Next Run", s.NextRunAt)
+	if s.Owner != nil {
+		c.Markdown("Owner", toolutil.MdUserLink(s.Owner.Username, s.Owner.WebURL))
 	}
 	if s.LastPipeline != nil {
-		// The documented `last_pipeline` reference has no web_url, so render the
-		// title as plain text (MdTitleLink emits no link for an empty URL).
-		fmt.Fprintf(&b, "| Last Pipeline | %s |\n",
-			toolutil.MdTitleLink(fmt.Sprintf("#%d (%s)", s.LastPipeline.ID, s.LastPipeline.Status), ""))
+		// The documented last_pipeline reference carries no web_url, so this
+		// row names the pipeline rather than linking it.
+		c.Field("Last Pipeline", fmt.Sprintf("#%d (%s)", s.LastPipeline.ID, s.LastPipeline.Status))
 	}
-	if s.CreatedAt != "" {
-		fmt.Fprintf(&b, "| Created | %s |\n", toolutil.FormatTime(s.CreatedAt))
-	}
-	if s.UpdatedAt != "" {
-		fmt.Fprintf(&b, "| Updated | %s |\n", toolutil.FormatTime(s.UpdatedAt))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use the selected tool surface's pipeline-schedule update action with the same project_id and schedule_id to modify schedule settings",
-		"Use the selected tool surface's pipeline-schedule run action with the same project_id and schedule_id to trigger this schedule immediately",
-		"Use the selected tool surface's pipeline-schedule delete action with the same project_id, schedule_id, and explicit confirm=true to remove this schedule",
+	// A schedule runs with its variables and inputs, and a reader deciding
+	// whether to run one needs to know which are set. The values never appear:
+	// a schedule variable may be a secret, and GitLab shows one nowhere.
+	c.Field("Variables", variableKeySummary(s.Variables))
+	c.Field("Inputs", inputNameSummary(s.Inputs))
+	c.Time("Created", s.CreatedAt)
+	c.Time("Updated", s.UpdatedAt)
+	c.End(
+		toolutil.HintAction(hintActionScheduleUpdate, "change this schedule"),
+		toolutil.HintAction(hintActionScheduleRun, "trigger it now"),
+		toolutil.HintAction(hintActionScheduleDelete, "remove it"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of pipeline schedules as a Markdown table.
+// variableKeySummary names the keys a schedule carries and the type of each,
+// never a value.
+func variableKeySummary(variables []VariableObject) string {
+	if len(variables) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(variables))
+	for _, v := range variables {
+		if v.VariableType == "" {
+			parts = append(parts, v.Key)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", v.Key, v.VariableType))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// inputNameSummary names the pipeline inputs a schedule carries, without their
+// values, which are typed like the variables and shown on the same terms.
+func inputNameSummary(inputs []InputObject) string {
+	if len(inputs) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(inputs))
+	for _, in := range inputs {
+		names = append(names, in.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// FormatListMarkdown renders a page of pipeline schedules as a Markdown table.
+//
+// The table carries no link, so the footer carries no instruction to keep
+// them, and the heading counts what the response can vouch for rather than a
+// total keyset pagination never sends.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Schedules) == 0 {
-		return "No pipeline schedules found.\n"
+		return toolutil.EmptyMessage("pipeline schedules")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Pipeline Schedules (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Schedules), out.Pagination)
-	b.WriteString("| ID | Description | Ref | Cron | Active | Owner |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Pipeline Schedules", len(out.Schedules), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Description", "Ref", "Cron", "Active", "Owner"))
 	for _, s := range out.Schedules {
 		owner := ""
 		if s.Owner != nil {
-			owner = s.Owner.Username
+			owner = toolutil.MdUserHandle(s.Owner.Username)
 		}
-		fmt.Fprintf(&b, "| %d | %s | %s | `%s` | %t | %s |\n",
-			s.ID, toolutil.EscapeMdTableCell(s.Description), toolutil.EscapeMdTableCell(s.Ref), toolutil.EscapeMdTableCell(s.Cron), s.Active, toolutil.EscapeMdTableCell(owner))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.Itoa(s.ID),
+			toolutil.EscapeMdTableCell(s.Description),
+			toolutil.EscapeMdTableCell(s.Ref),
+			toolutil.MdCodeSpanCell(s.Cron),
+			toolutil.BoolEmoji(s.Active),
+			owner,
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use the selected tool surface's pipeline-schedule get action with the same project_id and schedule_id for full details",
-		"Use the selected tool surface's pipeline-schedule create action with project_id to add a new schedule",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(hintActionScheduleGet, "see one schedule in full"),
+		toolutil.HintAction(hintActionScheduleCreate, "add a schedule"),
 	)
 	return b.String()
 }
 
-// FormatVariableMarkdown renders a pipeline schedule variable as Markdown.
+// FormatVariableMarkdown renders one pipeline schedule variable as the card of
+// a single object.
 func FormatVariableMarkdown(v VariableOutput) string {
 	var b strings.Builder
-	b.WriteString("## Pipeline Schedule Variable\n\n")
-	fmt.Fprintf(&b, "- **Key**: %s\n", toolutil.EscapeMdTableCell(v.Key))
-	fmt.Fprintf(&b, "- **Value**: %s\n", toolutil.EscapeMdTableCell(v.Value))
-	if v.VariableType != "" {
-		//gitlab:allow-unescaped v.VariableType: a CI variable type GitLab picks from a fixed set (env_var, file).
-		fmt.Fprintf(&b, "- **Type**: %s\n", v.VariableType)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use the selected tool surface's pipeline-schedule variable edit action with the same project_id, schedule_id, and key to change this variable",
-		"Use the selected tool surface's pipeline-schedule variable delete action with the same project_id, schedule_id, key, and explicit confirm=true to remove it",
+	c := toolutil.NewCard(&b, "Pipeline Schedule Variable")
+	c.Field("Key", v.Key)
+	c.Field("Value", v.Value)
+	// A CI variable type is one of GitLab's fixed set (env_var, file).
+	c.Field("Type", v.VariableType)
+	c.End(
+		toolutil.HintAction(hintActionScheduleEditVariable, "change this variable"),
+		toolutil.HintAction(hintActionScheduleDeleteVariable, "remove it"),
 	)
 	return b.String()
 }
 
-// FormatTriggeredPipelinesMarkdown renders a list of triggered pipelines as Markdown.
+// FormatTriggeredPipelinesMarkdown renders the pipelines a schedule triggered
+// as a Markdown table.
 func FormatTriggeredPipelinesMarkdown(out TriggeredPipelinesListOutput) string {
 	if len(out.Pipelines) == 0 {
-		return "No triggered pipelines found.\n"
+		return toolutil.EmptyMessage("triggered pipelines")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Triggered Pipelines (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Pipelines), out.Pagination)
-	b.WriteString("| ID | IID | Ref | Status | Source |\n")
-	b.WriteString("| --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Triggered Pipelines", len(out.Pipelines), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "IID", "Ref", "Status", "Source"))
 	for _, p := range out.Pipelines {
-		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s |\n",
-			//gitlab:allow-unescaped p.Status: a pipeline status, one of GitLab's fixed set (created, running, success, failed and the rest).
-			//gitlab:allow-unescaped p.Source: a pipeline source, one of GitLab's fixed set (push, web, schedule, trigger and the rest).
-			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL), p.IID, toolutil.EscapeMdTableCell(p.Ref), p.Status, p.Source)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(fmt.Sprintf("#%d", p.ID), p.WebURL),
+			strconv.Itoa(p.IID),
+			toolutil.EscapeMdTableCell(p.Ref),
+			pipelineStatusCell(p.Status),
+			toolutil.EscapeMdTableCell(p.Source),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use the selected tool surface's pipeline get action with pipeline_id for full details",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionPipelineGet, "see one pipeline in full"),
+		toolutil.HintAction(hintActionScheduleList, "see the schedules of this project"),
 	)
 	return b.String()
+}
+
+// pipelineStatusCell renders a pipeline status with the glyph every pipeline
+// row in the tree shows, and nothing when GitLab sent no status.
+func pipelineStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
 }
 
 func init() {

--- a/internal/tools/pipelineschedules/pipeline_schedules_test.go
+++ b/internal/tools/pipelineschedules/pipeline_schedules_test.go
@@ -1509,7 +1509,10 @@ func TestListTriggeredPipelines_OrderByAndSort(t *testing.T) {
 // toOutput — all optional fields (owner, timestamps)
 // ---------------------------------------------------------------------------.
 
-// TestToOutput_AllOptionalFields verifies ToOutput when all optional fields.
+// TestToOutput_AllOptionalFields checks the whole card of a schedule GitLab
+// answered in full, the variables and inputs included: a reader deciding
+// whether to run a schedule needs to know which are set, and the card used to
+// show neither. The values never appear — a schedule variable may be a secret.
 func TestToOutput_AllOptionalFields(t *testing.T) {
 	out := FormatOutputMarkdown(Output{
 		ID:           1,
@@ -1518,34 +1521,41 @@ func TestToOutput_AllOptionalFields(t *testing.T) {
 		Cron:         "0 1 * * *",
 		CronTimezone: "UTC",
 		Active:       true,
-		Owner:        &OwnerOutput{Username: "admin"},
+		Owner:        &OwnerOutput{Username: "admin", WebURL: "https://gitlab.example.com/admin"},
 		LastPipeline: &LastPipelineOutput{ID: 99, Status: "success"},
+		Variables:    []VariableObject{{Key: "DEPLOY_TOKEN", Value: "s3cret", VariableType: "env_var"}, {Key: "CONFIG", Value: "x", VariableType: "file"}},
+		Inputs:       []InputObject{{Name: "environment", Value: "staging"}},
 		NextRunAt:    "2026-03-08T01:00:00Z",
 		CreatedAt:    "2026-01-01T00:00:00Z",
 		UpdatedAt:    "2026-03-07T12:00:00Z",
 	})
-
-	for _, want := range []string{
-		"## Pipeline Schedule #1",
-		"| Description | Nightly |",
-		"| Ref | main |",
-		"| Cron | `0 1 * * *` |",
-		"| Timezone | UTC |",
-		"| Active | ✅ |",
-		"| Next Run | 8 Mar 2026 01:00 UTC |",
-		"| Owner | admin |",
-		"| Last Pipeline |",
-		"#99 (success)",
-		"| Created | 1 Jan 2026 00:00 UTC |",
-		"| Updated | 7 Mar 2026 12:00 UTC |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(out, want) {
-				t.Errorf("markdown missing %q:\n%s", want, out)
-			}
-		})
+	want := "## Pipeline Schedule #1\n\n" +
+		"- **Description**: Nightly\n" +
+		"- **Ref**: main\n" +
+		"- **Cron**: `0 1 * * *`\n" +
+		"- **Timezone**: UTC\n" +
+		"- **Active**: ✅\n" +
+		"- **Next Run**: 8 Mar 2026 01:00 UTC\n" +
+		"- **Owner**: [@admin](https://gitlab.example.com/admin)\n" +
+		"- **Last Pipeline**: #99 (success)\n" +
+		"- **Variables**: DEPLOY_TOKEN (env_var), CONFIG (file)\n" +
+		"- **Inputs**: environment\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Updated**: 7 Mar 2026 12:00 UTC\n" +
+		scheduleCardHints
+	if out != want {
+		t.Errorf("FormatOutputMarkdown(all fields)\n got %q\nwant %q", out, want)
+	}
+	if strings.Contains(out, "s3cret") {
+		t.Errorf("a schedule variable's value reached the Markdown:\n%s", out)
 	}
 }
+
+// scheduleCardHints is the guidance section a schedule card closes with.
+const scheduleCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'pipeline.schedule_update' to change this schedule\n" +
+	"- Use action 'pipeline.schedule_run' to trigger it now\n" +
+	"- Use action 'pipeline.schedule_delete' to remove it\n"
 
 // ---------------------------------------------------------------------------
 // FormatOutputMarkdown
@@ -1559,7 +1569,9 @@ func TestFormatOutputMarkdown_ZeroID(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown_MinimalFields verifies FormatOutputMarkdown when minimal fields.
+// TestFormatOutputMarkdown_MinimalFields checks that a schedule GitLab said
+// little about renders only the rows it answered: no label stands without a
+// value.
 func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 	md := FormatOutputMarkdown(Output{
 		ID:          5,
@@ -1568,22 +1580,14 @@ func TestFormatOutputMarkdown_MinimalFields(t *testing.T) {
 		Cron:        "0 9 * * 1",
 		Active:      false,
 	})
-
-	if !strings.Contains(md, "## Pipeline Schedule #5") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	for _, absent := range []string{
-		"| Timezone |",
-		"| Next Run |",
-		"| Owner |",
-		"| Created |",
-		"| Updated |",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+	want := "## Pipeline Schedule #5\n\n" +
+		"- **Description**: Weekly\n" +
+		"- **Ref**: develop\n" +
+		"- **Cron**: `0 9 * * 1`\n" +
+		"- **Active**: ❌\n" +
+		scheduleCardHints
+	if md != want {
+		t.Errorf("FormatOutputMarkdown(minimal)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -1600,35 +1604,28 @@ func TestFormatListMarkdown_WithSchedules(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatListMarkdown(out)
-
-	for _, want := range []string{
-		"## Pipeline Schedules (2)",
-		"| ID |",
-		"| --- |",
-		"| 1 |",
-		"| 2 |",
-		"Nightly",
-		"Weekly",
-		"admin",
-		"user1",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	// The table carries no link, so the footer carries no instruction to keep
+	// links the reader cannot see.
+	want := "## Pipeline Schedules (2)\n\n" +
+		"| ID | Description | Ref | Cron | Active | Owner |\n" +
+		"| --- | --- | --- | --- | --- | --- |\n" +
+		"| 1 | Nightly | main | `0 1 * * *` | ✅ | @admin |\n" +
+		"| 2 | Weekly | develop | `0 9 * * 1` | ❌ | @user1 |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'pipeline.schedule_get' to see one schedule in full\n" +
+		"- Use action 'pipeline.schedule_create' to add a schedule\n"
+	if got := FormatListMarkdown(out); got != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty checks that an empty page is the one sentence
+// and nothing else.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No pipeline schedules found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No pipeline schedules found.\n"
+	if got := FormatListMarkdown(ListOutput{}); got != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 
@@ -1636,32 +1633,35 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 // FormatVariableMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatVariableMarkdown_WithType verifies FormatVariableMarkdown when with type.
+// variableCardHints is the guidance section a schedule variable closes with.
+const variableCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use action 'pipeline.schedule_edit_variable' to change this variable\n" +
+	"- Use action 'pipeline.schedule_delete_variable' to remove it\n"
+
+// TestFormatVariableMarkdown_WithType checks the whole card of one schedule
+// variable.
 func TestFormatVariableMarkdown_WithType(t *testing.T) {
 	md := FormatVariableMarkdown(VariableOutput{Key: "MY_VAR", Value: "hello", VariableType: "env_var"})
-
-	for _, want := range []string{
-		"## Pipeline Schedule Variable",
-		"**Key**: MY_VAR",
-		"**Value**: hello",
-		"**Type**: env_var",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Pipeline Schedule Variable\n\n" +
+		"- **Key**: MY_VAR\n" +
+		"- **Value**: hello\n" +
+		"- **Type**: env_var\n" +
+		variableCardHints
+	if md != want {
+		t.Errorf("FormatVariableMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
-// TestFormatVariableMarkdown_WithoutType verifies FormatVariableMarkdown when without type.
+// TestFormatVariableMarkdown_WithoutType checks that a variable GitLab sent no
+// type for shows no type row rather than a label with nothing after it.
 func TestFormatVariableMarkdown_WithoutType(t *testing.T) {
 	md := FormatVariableMarkdown(VariableOutput{Key: "K", Value: "V"})
-	if strings.Contains(md, "**Type**") {
-		t.Error("should not contain Type when empty")
-	}
-	if !strings.Contains(md, "**Key**: K") {
-		t.Errorf("missing key:\n%s", md)
+	want := "## Pipeline Schedule Variable\n\n" +
+		"- **Key**: K\n" +
+		"- **Value**: V\n" +
+		variableCardHints
+	if md != want {
+		t.Errorf("FormatVariableMarkdown(no type)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -1678,34 +1678,29 @@ func TestFormatTriggeredPipelinesMarkdown_WithData(t *testing.T) {
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	}
-	md := FormatTriggeredPipelinesMarkdown(out)
-
-	for _, want := range []string{
-		"## Triggered Pipelines (2)",
-		"| ID |",
-		"| --- |",
-		"| [#100](https://example.com/100) |",
-		"| [#101](https://example.com/101) |",
-		"success",
-		"failed",
-		"schedule",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	// The status carries the glyph every pipeline row in the tree shows, which
+	// this table was the one place not to.
+	want := "## Triggered Pipelines (2)\n\n" +
+		"| ID | IID | Ref | Status | Source |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| [#100](https://example.com/100) | 10 | main | ✅ success | schedule |\n" +
+		"| [#101](https://example.com/101) | 11 | main | ❌ failed | schedule |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- When presenting these results, always include the clickable [text](url) links from the table so the user can navigate to GitLab\n" +
+		"- Use action 'pipeline.get' to see one pipeline in full\n" +
+		"- Use action 'pipeline.schedule_list' to see the schedules of this project\n"
+	if got := FormatTriggeredPipelinesMarkdown(out); got != want {
+		t.Errorf("FormatTriggeredPipelinesMarkdown()\n got %q\nwant %q", got, want)
 	}
 }
 
-// TestFormatTriggeredPipelinesMarkdown_Empty verifies FormatTriggeredPipelinesMarkdown when empty.
+// TestFormatTriggeredPipelinesMarkdown_Empty checks that an empty page is the
+// one sentence and nothing else.
 func TestFormatTriggeredPipelinesMarkdown_Empty(t *testing.T) {
-	md := FormatTriggeredPipelinesMarkdown(TriggeredPipelinesListOutput{})
-	if !strings.Contains(md, "No triggered pipelines found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No triggered pipelines found.\n"
+	if got := FormatTriggeredPipelinesMarkdown(TriggeredPipelinesListOutput{}); got != want {
+		t.Errorf("FormatTriggeredPipelinesMarkdown(empty)\n got %q\nwant %q", got, want)
 	}
 }
 

--- a/internal/tools/protectedenvs/markdown.go
+++ b/internal/tools/protectedenvs/markdown.go
@@ -2,70 +2,134 @@ package protectedenvs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single protected environment as Markdown.
+// Canonical action IDs the hints name that the specs do not already spell.
+const (
+	actionEnvProtectedList    = "environment.protected_list"
+	actionEnvProtectedProtect = "environment.protected_protect"
+	actionEnvProtectedUpdate  = "environment.protected_update"
+)
+
+// FormatOutputMarkdown renders one protected environment as the card of a
+// single object: the approvals it needs, then the deploy access levels and the
+// approval rules as nested collections.
 func FormatOutputMarkdown(pe Output) string {
 	if pe.Name == "" {
 		return ""
 	}
 	var b strings.Builder
 	// An environment name is written in .gitlab-ci.yml or typed in the UI.
-	fmt.Fprintf(&b, "## Protected Environment: %s\n\n", toolutil.EscapeMdHeading(pe.Name))
-	fmt.Fprintf(&b, "- **Required Approvals**: %d\n\n", pe.RequiredApprovalCount)
-
-	if len(pe.DeployAccessLevels) > 0 {
-		b.WriteString("### Deploy Access Levels\n\n")
-		b.WriteString("| ID | Access Level | Description | User ID | Group ID |\n")
-		b.WriteString("| --- | --- | --- | --- | --- |\n")
-		for _, a := range pe.DeployAccessLevels {
-			fmt.Fprintf(&b, "| %d | %d | %s | %d | %d |\n",
-				a.ID, a.AccessLevel, toolutil.EscapeMdTableCell(a.AccessLevelDescription), a.UserID, a.GroupID)
-		}
-		b.WriteString("\n")
-	}
-
+	c := toolutil.NewCard(&b, "Protected Environment: "+pe.Name)
+	// An environment with approval rules of its own counts its approvals per
+	// rule, so the single number GitLab sends beside them is not what gates a
+	// deployment, and printing it alone said a deployment needed two approvals
+	// when it needed one from each of three rules.
 	if len(pe.ApprovalRules) > 0 {
-		b.WriteString("### Approval Rules\n\n")
-		b.WriteString("| ID | Access Level | Description | Required Approvals | User ID | Group ID |\n")
-		b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
-		for _, r := range pe.ApprovalRules {
-			fmt.Fprintf(&b, "| %d | %d | %s | %d | %d | %d |\n",
-				r.ID, r.AccessLevel, toolutil.EscapeMdTableCell(r.AccessLevelDescription), r.RequiredApprovalCount, r.UserID, r.GroupID)
-		}
-		b.WriteString("\n")
+		c.Field("Required Approvals", "per approval rule (see below)")
+	} else {
+		c.Int("Required Approvals", pe.RequiredApprovalCount)
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'protected_update' to modify protection rules",
-		"Use action 'protected_unprotect' to remove environment protection",
+	if len(pe.DeployAccessLevels) > 0 {
+		t := c.Table("Deploy Access Levels", "ID", "Level", "Grantee", "Description", "Inheritance")
+		for _, a := range pe.DeployAccessLevels {
+			t.Row(
+				strconv.FormatInt(a.ID, 10),
+				levelCell(a.AccessLevel, a.UserID, a.GroupID),
+				granteeCell(a.UserID, a.GroupID),
+				// GitLab's access-level description is a role name for a plain
+				// rule but a user's display name or a group's name for a
+				// granular one.
+				toolutil.EscapeMdTableCell(a.AccessLevelDescription),
+				inheritanceCell(a.GroupID, a.GroupInheritanceType),
+			)
+		}
+	}
+	if len(pe.ApprovalRules) > 0 {
+		t := c.Table("Approval Rules", "ID", "Level", "Grantee", "Description", "Required", "Inheritance")
+		for _, r := range pe.ApprovalRules {
+			t.Row(
+				strconv.FormatInt(r.ID, 10),
+				levelCell(r.AccessLevel, r.UserID, r.GroupID),
+				granteeCell(r.UserID, r.GroupID),
+				toolutil.EscapeMdTableCell(r.AccessLevelDescription),
+				strconv.FormatInt(r.RequiredApprovalCount, 10),
+				inheritanceCell(r.GroupID, r.GroupInheritanceType),
+			)
+		}
+	}
+	c.End(
+		toolutil.HintAction(actionEnvProtectedUpdate, "change the deploy access levels or approval rules"),
+		toolutil.HintAction(actionEnvProtectedUnprotect, "remove this environment's protection"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of protected environments as a Markdown table.
+// levelCell renders the role a rule grants, and "-" for a rule that names a
+// user or a group instead, whose access_level is not what decides.
+func levelCell(accessLevel int, userID, groupID int64) string {
+	if granteeCell(userID, groupID) != "" {
+		return "-"
+	}
+	return toolutil.AccessLevelDescription(gl.AccessLevelValue(accessLevel))
+}
+
+// granteeCell names who a granular rule is about, and nothing for a rule that
+// grants a role to everyone who holds it. GitLab sends zero for the id a rule
+// is not about, which used to be rendered as a numeric 0 in a column of its
+// own, so every role rule claimed to be about user 0 and group 0.
+func granteeCell(userID, groupID int64) string {
+	switch {
+	case userID != 0:
+		return fmt.Sprintf("user #%d", userID)
+	case groupID != 0:
+		return fmt.Sprintf("group #%d", groupID)
+	default:
+		return ""
+	}
+}
+
+// inheritanceCell says whether a group rule reaches the group's inherited
+// members or only its direct ones, and nothing at all for a rule that is not
+// about a group, where GitLab's zero means "not applicable" rather than
+// "direct".
+func inheritanceCell(groupID, inheritanceType int64) string {
+	if groupID == 0 {
+		return ""
+	}
+	if inheritanceType == 0 {
+		return "direct"
+	}
+	return "inherited"
+}
+
+// FormatListMarkdown renders a page of a project's protected environments as a
+// Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Environments) == 0 {
-		return "No protected environments found.\n"
+		return toolutil.EmptyMessage("protected environments")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Environments (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Environments), out.Pagination)
-	b.WriteString("| Name | Required Approvals | Deploy Access Levels | Approval Rules |\n")
-	b.WriteString("| --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Protected Environments", len(out.Environments), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Required Approvals", "Deploy Access Levels", "Approval Rules"))
 	for _, pe := range out.Environments {
-		fmt.Fprintf(&b, "| %s | %d | %d | %d |\n",
-			toolutil.EscapeMdTableCell(pe.Name), pe.RequiredApprovalCount,
-			len(pe.DeployAccessLevels), len(pe.ApprovalRules))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(pe.Name),
+			strconv.FormatInt(pe.RequiredApprovalCount, 10),
+			strconv.Itoa(len(pe.DeployAccessLevels)),
+			strconv.Itoa(len(pe.ApprovalRules)),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'protected_get' with environment name for full details",
-		"Use action 'protected_protect' to add environment protection",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionEnvProtectedGet, "see one environment's rules in full"),
+		toolutil.HintAction(actionEnvProtectedProtect, "protect another environment or wildcard"),
+		toolutil.HintAction(actionEnvProtectedList, "page through the rest of the project's protected environments"),
 	)
 	return b.String()
 }

--- a/internal/tools/protectedenvs/protected_envs_test.go
+++ b/internal/tools/protectedenvs/protected_envs_test.go
@@ -407,73 +407,126 @@ func TestUnprotect_MissingEnvironment(t *testing.T) {
 
 // ---------- Formatters ----------.
 
-// TestFormatOutputMarkdown verifies FormatOutputMarkdown.
-func TestFormatOutputMarkdown(t *testing.T) {
-	pe := Output{
+// cardHints is the guidance section every protected-environment card closes
+// with.
+const cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'environment.protected_update' to change the deploy access levels or approval rules\n" +
+	"- Use action 'environment.protected_unprotect' to remove this environment's protection\n"
+
+// listHints is the guidance section the listing closes with. The table carries
+// no link, so the preserve-links instruction is not written.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'environment.protected_get' to see one environment's rules in full\n" +
+	"- Use action 'environment.protected_protect' to protect another environment or wildcard\n" +
+	"- Use action 'environment.protected_list' to page through the rest of the project's protected environments\n"
+
+// TestFormatOutputMarkdown_WithRules pins the whole card of a protected
+// environment: the headline defers to the per-rule counts below it, and every
+// rule says which role it grants, to whom, and whether a group rule reaches
+// inherited members.
+func TestFormatOutputMarkdown_WithRules(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
 		Name:                  "production",
 		RequiredApprovalCount: 2,
 		DeployAccessLevels: []AccessLevelOutput{
 			{ID: 1, AccessLevel: 40, AccessLevelDescription: "Maintainers"},
+			{ID: 2, AccessLevelDescription: "Sam Bauch", UserID: 123},
 		},
 		ApprovalRules: []ApprovalRuleOutput{
 			{ID: 10, AccessLevel: 40, AccessLevelDescription: "Maintainers", RequiredApprovalCount: 1},
+			{ID: 11, AccessLevelDescription: "Release managers", GroupID: 55, GroupInheritanceType: 1, RequiredApprovalCount: 2},
 		},
-	}
-	md := FormatOutputMarkdown(pe)
-	if !strings.Contains(md, "production") {
-		t.Error("expected environment name in output")
-	}
-	if !strings.Contains(md, "Maintainers") {
-		t.Error("expected access level description in output")
-	}
-	if !strings.Contains(md, "Deploy Access Levels") {
-		t.Error("expected deploy access levels section")
-	}
-	if !strings.Contains(md, "Approval Rules") {
-		t.Error("expected approval rules section")
-	}
-	if !strings.Contains(md, "protected_update") || !strings.Contains(md, "protected_unprotect") {
-		t.Error("expected canonical protected action hints")
+	})
+
+	want := "## Protected Environment: production\n\n" +
+		"- **Required Approvals**: per approval rule (see below)\n" +
+		"\n### Deploy Access Levels\n\n" +
+		"| ID | Level | Grantee | Description | Inheritance |\n| --- | --- | --- | --- | --- |\n" +
+		"| 1 | Maintainer |  | Maintainers |  |\n" +
+		"| 2 | - | user #123 | Sam Bauch |  |\n" +
+		"\n### Approval Rules\n\n" +
+		"| ID | Level | Grantee | Description | Required | Inheritance |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 10 | Maintainer |  | Maintainers | 1 |  |\n" +
+		"| 11 | - | group #55 | Release managers | 2 | inherited |\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_Empty verifies FormatOutputMarkdown when empty.
+// TestFormatOutputMarkdown_NoRules pins the card of an environment on the
+// unified approval setting: the headline count GitLab sent, and no table.
+func TestFormatOutputMarkdown_NoRules(t *testing.T) {
+	got := FormatOutputMarkdown(Output{Name: "staging", RequiredApprovalCount: 1})
+
+	want := "## Protected Environment: staging\n\n" +
+		"- **Required Approvals**: 1\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_Empty verifies FormatOutputMarkdown renders nothing
+// at all for a value carrying no environment name.
 func TestFormatOutputMarkdown_Empty(t *testing.T) {
-	md := FormatOutputMarkdown(Output{})
-	if md != "" {
+	if md := FormatOutputMarkdown(Output{}); md != "" {
 		t.Errorf("FormatOutputMarkdown(empty) = %q, want empty", md)
 	}
 }
 
-// TestFormatListMarkdown verifies FormatListMarkdown.
+// TestFormatListMarkdown pins the whole listing: the heading counting what
+// GitLab reported, the table, the pagination line and one guidance section.
 func TestFormatListMarkdown(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Environments: []Output{
 			{Name: "production", RequiredApprovalCount: 2, DeployAccessLevels: []AccessLevelOutput{{ID: 1}}},
 			{Name: "staging", RequiredApprovalCount: 0},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, TotalPages: 1, Page: 1, PerPage: 20},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "production") {
-		t.Error("expected production in list output")
-	}
-	if !strings.Contains(md, "staging") {
-		t.Error("expected staging in list output")
-	}
-	if !strings.Contains(md, "Protected Environments (2)") {
-		t.Error("expected header with count")
-	}
-	if !strings.Contains(md, "protected_get") || !strings.Contains(md, "protected_protect") {
-		t.Error("expected canonical protected action hints")
+	})
+
+	want := "## Protected Environments (2)\n\n" +
+		"| Name | Required Approvals | Deploy Access Levels | Approval Rules |\n| --- | --- | --- | --- |\n" +
+		"| production | 2 | 1 | 0 |\n" +
+		"| staging | 0 | 0 | 0 |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_KeysetPage pins the heading of a page GitLab sent no
+// total for: it counts the rows shown and says more are available, rather than
+// claiming a total of zero above two rows.
+func TestFormatListMarkdown_KeysetPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Environments: []Output{{Name: "production"}, {Name: "staging"}},
+		Pagination:   toolutil.PaginationOutput{HasMore: true},
+	})
+
+	want := "## Protected Environments (2 shown, more available)\n\n" +
+		"| Name | Required Approvals | Deploy Access Levels | Approval Rules |\n| --- | --- | --- | --- |\n" +
+		"| production | 0 | 0 | 0 |\n" +
+		"| staging | 0 | 0 | 0 |\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Empty pins that a project with no protected
+// environments renders the one sentence and nothing else.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No protected environments found") {
-		t.Errorf("FormatListMarkdown(empty) = %q, want no-results message", md)
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No protected environments found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/protectedpackages/markdown.go
+++ b/internal/tools/protectedpackages/markdown.go
@@ -2,59 +2,56 @@ package protectedpackages
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single package protection rule as Markdown.
+// FormatOutputMarkdown renders a single package protection rule as the card
+// of one object: the pattern it matches and the access levels it demands.
 func FormatOutputMarkdown(r Output) string {
 	if r.ID == 0 {
 		return ""
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Protection Rule #%d\n\n", r.ID)
-	// The pattern is free text this server's own create action passes through.
-	fmt.Fprintf(&b, "- **Pattern**: `%s`\n", toolutil.EscapeMdTableCell(r.PackageNamePattern))
-	//gitlab:allow-unescaped r.PackageType: the registry format GitLab stores the rule for, one of its own enum values (npm, pypi, maven and the rest).
-	fmt.Fprintf(&b, "- **Package Type**: %s\n", r.PackageType)
-	if r.MinimumAccessLevelForPush != "" {
-		//gitlab:allow-unescaped r.MinimumAccessLevelForPush: a protection rule access level GitLab picks from a fixed set (maintainer, owner, admin).
-		fmt.Fprintf(&b, "- **Min Push Level**: %s\n", r.MinimumAccessLevelForPush)
-	}
-	if r.MinimumAccessLevelForDelete != "" {
-		//gitlab:allow-unescaped r.MinimumAccessLevelForDelete: a protection rule access level GitLab picks from a fixed set (maintainer, owner, admin).
-		fmt.Fprintf(&b, "- **Min Delete Level**: %s\n", r.MinimumAccessLevelForDelete)
-	}
-	toolutil.WriteHints(
-		&b,
+	c := toolutil.NewCard(&b, fmt.Sprintf("Package Protection Rule #%d", r.ID))
+	// The pattern is free text this server's own create action passes through,
+	// and a reader has to copy it exactly, so it is a code span rather than an
+	// escaped cell: an entity inside a span renders as its own characters.
+	c.Code("Pattern", r.PackageNamePattern)
+	c.Field("Package Type", r.PackageType)
+	c.Field("Min Push Level", r.MinimumAccessLevelForPush)
+	c.Field("Min Delete Level", r.MinimumAccessLevelForDelete)
+	c.End(
 		"Use `gitlab_update_package_protection_rule` to modify this rule",
 		"Use `gitlab_delete_package_protection_rule` to remove it",
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a paginated list of package protection rules as Markdown.
+// FormatListMarkdown renders a paginated list of package protection rules as
+// a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Rules) == 0 {
-		return "No package protection rules found."
+		return toolutil.EmptyMessage("package protection rules")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Package Protection Rules (%d)\n\n", len(out.Rules))
-	b.WriteString("| ID | Pattern | Type | Min Push | Min Delete |\n")
-	b.WriteString("| --: | ------- | ---- | -------- | ---------- |\n")
+	toolutil.WriteListHeading(&b, "Package Protection Rules", len(out.Rules), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Pattern", "Type", "Min Push", "Min Delete"))
 	for _, r := range out.Rules {
-		fmt.Fprintf(
-			&b, "| %d | `%s` | %s | %s | %s |\n",
-			r.ID,
-			toolutil.EscapeMdTableCell(r.PackageNamePattern),
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.MdCodeSpanCell(r.PackageNamePattern),
 			toolutil.EscapeMdTableCell(r.PackageType),
 			toolutil.EscapeMdTableCell(r.MinimumAccessLevelForPush),
 			toolutil.EscapeMdTableCell(r.MinimumAccessLevelForDelete),
-		)
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		"Use `gitlab_create_package_protection_rule` to add a new rule")
 	return b.String()
 }
 

--- a/internal/tools/protectedpackages/protected_packages_test.go
+++ b/internal/tools/protectedpackages/protected_packages_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
 const (
@@ -418,28 +419,30 @@ func TestDelete_CancelledContext(t *testing.T) {
 
 // Markdown tests.
 
-// TestFormatOutputMarkdown_Basic verifies FormatOutputMarkdown produces a
-// rule header, the package pattern, and the push access level for a fully
-// populated Output.
+// ruleCardHints is the guidance section a protection rule card closes with.
+const ruleCardHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use `gitlab_update_package_protection_rule` to modify this rule\n" +
+	"- Use `gitlab_delete_package_protection_rule` to remove it\n"
+
+// TestFormatOutputMarkdown_Basic verifies FormatOutputMarkdown renders a
+// fully populated rule as the whole card: the heading, the pattern as a code
+// span, the type and both access levels.
 func TestFormatOutputMarkdown_Basic(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:                          1,
 		PackageNamePattern:          "@scope/pkg*",
 		PackageType:                 "npm",
 		MinimumAccessLevelForPush:   "maintainer",
 		MinimumAccessLevelForDelete: "owner",
 	})
-	if !contains(md, "## Package Protection Rule #1") {
-		t.Error("missing header")
-	}
-	if !contains(md, "@scope/pkg*") {
-		t.Error("missing pattern")
-	}
-	if !contains(md, "MinimumAccessLevelForPush") || !contains(md, "Min Push Level") {
-		// check for at least one — implementation uses "Min Push Level"
-		if !contains(md, "Min Push Level") {
-			t.Error("missing push level")
-		}
+	want := "## Package Protection Rule #1\n\n" +
+		"- **Pattern**: `@scope/pkg*`\n" +
+		"- **Package Type**: npm\n" +
+		"- **Min Push Level**: maintainer\n" +
+		"- **Min Delete Level**: owner\n" +
+		ruleCardHints
+	if got != want {
+		t.Errorf("FormatOutputMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -453,50 +456,73 @@ func TestFormatOutputMarkdown_Empty(t *testing.T) {
 }
 
 // TestFormatOutputMarkdown_NoAccessLevels verifies FormatOutputMarkdown omits
-// the push/delete level rows when those fields are empty.
+// the push/delete level rows when those fields are empty: the card shows what
+// GitLab sent and never a label with nothing after it.
 func TestFormatOutputMarkdown_NoAccessLevels(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:                 2,
 		PackageNamePattern: "mylib*",
 		PackageType:        "pypi",
 	})
-	if !contains(md, "## Package Protection Rule #2") {
-		t.Error("missing header")
-	}
-	if contains(md, "Min Push Level") {
-		t.Error("should not contain push level when empty")
-	}
-	if contains(md, "Min Delete Level") {
-		t.Error("should not contain delete level when empty")
+	want := "## Package Protection Rule #2\n\n" +
+		"- **Pattern**: `mylib*`\n" +
+		"- **Package Type**: pypi\n" +
+		ruleCardHints
+	if got != want {
+		t.Errorf("FormatOutputMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown emits a
-// "No package protection rules found" message for an empty list.
+// TestFormatListMarkdown_Empty verifies an empty list is the one sentence and
+// nothing else: no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !contains(md, "No package protection rules found") {
-		t.Error("missing empty message")
+	got := FormatListMarkdown(ListOutput{})
+	want := "No package protection rules found.\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() = %q, want %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_WithRules verifies FormatListMarkdown produces a
-// table with one row per rule, including the package type column.
+// TestFormatListMarkdown_WithRules verifies FormatListMarkdown produces the
+// whole table: one row per rule, the pattern as a code span, and the guidance
+// after the rows rather than before them.
 func TestFormatListMarkdown_WithRules(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Rules: []Output{
 			{ID: 1, PackageNamePattern: "@scope/pkg*", PackageType: "npm", MinimumAccessLevelForPush: "maintainer"},
 			{ID: 2, PackageNamePattern: "mylib*", PackageType: "pypi"},
 		},
 	})
-	if !contains(md, "| 1 |") {
-		t.Error("missing rule 1 row")
+	want := "## Package Protection Rules (2)\n\n" +
+		"| ID | Pattern | Type | Min Push | Min Delete |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | `@scope/pkg*` | npm | maintainer |  |\n" +
+		"| 2 | `mylib*` | pypi |  |  |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use `gitlab_create_package_protection_rule` to add a new rule\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
-	if !contains(md, "| 2 |") {
-		t.Error("missing rule 2 row")
-	}
-	if !contains(md, "npm") {
-		t.Error("missing npm type")
+}
+
+// TestFormatListMarkdown_CountsTheTotalGitLabSent verifies the heading counts
+// what the response reports rather than the page length, which is what a
+// reader compares against the rows.
+func TestFormatListMarkdown_CountsTheTotalGitLabSent(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Rules:      []Output{{ID: 1, PackageNamePattern: "a*", PackageType: "npm"}},
+		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 1, TotalItems: 45, TotalPages: 45, HasMore: true, NextPage: 2},
+	})
+	want := "## Package Protection Rules (45)\n\n" +
+		"Showing 1 of 45 results (page 1 of 45)\n\n" +
+		"| ID | Pattern | Type | Min Push | Min Delete |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | `a*` | npm |  |  |\n" +
+		"\nPage 1 of 45 | 45 items total | 1 per page\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use `gitlab_create_package_protection_rule` to add a new rule\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -531,17 +557,4 @@ func TestDelete_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 500")
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) > 0 && len(substr) > 0 && containsSubstring(s, substr)
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/tools/releaselinks/markdown.go
+++ b/internal/tools/releaselinks/markdown.go
@@ -2,79 +2,129 @@ package releaselinks
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a single release asset link as Markdown.
+// The canonical catalog IDs the hints name that the specs do not already
+// spell. The asset-link actions are projected under the release domain, so the
+// ID every surface resolves is "release.link_list" and not the
+// "release_link.list" the cross-link constant in action_specs.go spells.
+const (
+	hintActionLinkList        = "release.link_list"
+	hintActionLinkGet         = "release.link_get"
+	hintActionLinkUpdate      = "release.link_update"
+	hintActionLinkDelete      = "release.link_delete"
+	hintActionLinkCreate      = "release.link_create"
+	hintActionLinkCreateBatch = "release.link_create_batch"
+)
+
+// linkColumns are the columns every collection of asset links shares, so the
+// batch result and the listing cannot drift apart.
+var linkColumns = []string{"ID", "Name", "Type", "URL"}
+
+// linkRow renders one asset link as a row of that collection. The URL column
+// is labeled with the URL rather than with the link's name, which the Name
+// column beside it already carries: a row whose last two cells read alike says
+// nothing about where the asset is.
+func linkRow(l Output) string {
+	return toolutil.MarkdownTableRow(
+		strconv.FormatInt(l.ID, 10),
+		toolutil.EscapeMdTableCell(l.Name),
+		toolutil.EscapeMdTableCell(l.LinkType),
+		toolutil.MdTitleLink(l.URL, l.URL),
+	)
+}
+
+// FormatOutputMarkdown renders one release asset link as the card of a single
+// object.
 func FormatOutputMarkdown(l Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Release Link: %s\n\n", toolutil.EscapeMdHeading(l.Name))
-	fmt.Fprintf(&b, toolutil.FmtMdID, l.ID)
-	toolutil.WriteMdURL(&b, l.URL)
-	//gitlab:allow-unescaped l.LinkType: a release link type GitLab picks from a fixed set (other, runbook, image, package).
-	fmt.Fprintf(&b, "- **Type**: %s\n", l.LinkType)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'link_update' to modify this link",
-		"Use action 'link_delete' to remove this link",
+	c := toolutil.NewCard(&b, "Release Link: "+l.Name)
+	c.Int("ID", l.ID)
+	// A release link type GitLab picks from a fixed set (other, runbook,
+	// image, package).
+	c.Field("Type", l.LinkType)
+	c.URL(l.URL)
+	c.Link("Direct Asset URL", l.DirectAssetURL, l.DirectAssetURL)
+	c.End(
+		toolutil.HintAction(hintActionLinkUpdate, "change this link's name, URL or type"),
+		toolutil.HintAction(hintActionLinkDelete, "remove this link from the release"),
 	)
 	return b.String()
 }
 
-// FormatBatchMarkdown renders the result of a batch link creation as Markdown.
+// FormatDeletedMarkdown renders the link GitLab removed. It is a card of its
+// own rather than the one above because the object it describes no longer
+// exists: rendered as an ordinary link card, a deletion answered with the
+// link's own heading and offered the reader an update and a delete of
+// something that had just gone.
+func FormatDeletedMarkdown(l DeletedOutput) string {
+	var b strings.Builder
+	c := toolutil.NewCard(&b, "Release Link Deleted: "+l.Name)
+	c.Int("ID", l.ID)
+	c.Field("Type", l.LinkType)
+	c.URL(l.URL)
+	c.Note("The link is removed from the release. The file or package it pointed at is untouched.")
+	c.End(
+		toolutil.HintAction(hintActionLinkList, "see the links the release still has"),
+		toolutil.HintAction(hintActionLinkCreate, "link another asset to the release"),
+	)
+	return b.String()
+}
+
+// FormatBatchMarkdown renders the result of a batch link creation: the links
+// created as a collection, then the ones GitLab refused.
 func FormatBatchMarkdown(out CreateBatchOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Release Links Created (%d)\n\n", len(out.Created))
+	toolutil.WriteListHeading(&b, "Release Links Created", len(out.Created), toolutil.PaginationOutput{})
 	if len(out.Created) > 0 {
-		b.WriteString("| ID | Name | Type | URL |\n")
-		b.WriteString(toolutil.TblSep4Col)
+		b.WriteString(toolutil.MarkdownTableHeader(linkColumns...))
 		for _, l := range out.Created {
-			fmt.Fprintf(&b, "| %d | %s | %s | %s |\n", l.ID, toolutil.EscapeMdTableCell(l.Name), toolutil.EscapeMdTableCell(l.LinkType), toolutil.MdTitleLink(l.Name, l.URL))
+			b.WriteString(linkRow(l))
 		}
 	}
 	if len(out.Failed) > 0 {
+		// The blank line is what separates the section from the table above it:
+		// a heading written straight after a row ends that row's table where
+		// the reader cannot see why.
 		fmt.Fprintf(&b, "\n### Failures (%d)\n\n", len(out.Failed))
 		for _, f := range out.Failed {
 			// Each failure carries the link's own name and GitLab's message.
 			fmt.Fprintf(&b, "- %s\n", toolutil.EscapeMdTableCell(f))
 		}
 	}
-	toolutil.WriteHints(
-		&b,
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, len(out.Created) > 0,
 		toolutil.HintPreserveLinks,
-		"Use action 'link_list' to view all links for this release",
+		toolutil.HintAction(hintActionLinkList, "see every link the release now has"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of release asset links as a Markdown table.
+// FormatListMarkdown renders a release's asset links as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Release Links (%d)\n\n", len(out.Links))
-	toolutil.WriteListSummary(&b, len(out.Links), out.Pagination)
 	if len(out.Links) == 0 {
-		b.WriteString("No release links found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("release links")
 	}
-	b.WriteString("| ID | Name | Type | URL |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Release Links", len(out.Links), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader(linkColumns...))
 	for _, l := range out.Links {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n", l.ID, toolutil.EscapeMdTableCell(l.Name), toolutil.EscapeMdTableCell(l.LinkType), toolutil.MdTitleLink(l.Name, l.URL))
+		b.WriteString(linkRow(l))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'link_create' to add a new release asset link",
-		"Use action 'link_create_batch' to add multiple asset links in one call",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(hintActionLinkGet, "see one link on its own"),
+		toolutil.HintAction(hintActionLinkCreate, "add a new release asset link"),
+		toolutil.HintAction(hintActionLinkCreateBatch, "add several asset links in one call"),
 	)
 	return b.String()
 }
 
 func init() {
 	toolutil.RegisterMarkdown(FormatOutputMarkdown)
+	toolutil.RegisterMarkdown(FormatDeletedMarkdown)
 	toolutil.RegisterMarkdown(FormatBatchMarkdown)
 	toolutil.RegisterMarkdown(FormatListMarkdown)
 }

--- a/internal/tools/releaselinks/release_links.go
+++ b/internal/tools/releaselinks/release_links.go
@@ -34,6 +34,15 @@ type Output struct {
 	DirectAssetURL string `json:"direct_asset_url,omitempty"`
 }
 
+// DeletedOutput is the link GitLab removed, carrying exactly the fields
+// [Output] carries and published under the same JSON keys, so the action's
+// schema is unchanged. It exists as a type of its own only so the Markdown
+// registry can render a deletion as a deletion: while the delete action
+// answered with [Output], its result rendered as an ordinary link card, under
+// the link's own heading and offering the reader an update and a delete of
+// something that had just gone.
+type DeletedOutput Output
+
 // DeleteInput defines parameters for deleting a release link.
 type DeleteInput struct {
 	ProjectID toolutil.StringOrInt `json:"project_id" jsonschema:"Project ID or URL-encoded path,required"`
@@ -207,22 +216,22 @@ func releaseLinkType(url, explicit string) gl.LinkTypeValue {
 
 // Delete removes an asset link from a release by its link ID.
 // Returns the deleted link details or an error if the link does not exist.
-func Delete(ctx context.Context, client *gitlabclient.Client, input DeleteInput) (Output, error) {
+func Delete(ctx context.Context, client *gitlabclient.Client, input DeleteInput) (DeletedOutput, error) {
 	if err := ctx.Err(); err != nil {
-		return Output{}, err
+		return DeletedOutput{}, err
 	}
 	if input.ProjectID == "" {
-		return Output{}, errors.New("Delete: project_id is required. Use gitlab_project_list to find the ID first, then pass it as project_id")
+		return DeletedOutput{}, errors.New("Delete: project_id is required. Use gitlab_project_list to find the ID first, then pass it as project_id")
 	}
 	if input.LinkID <= 0 {
-		return Output{}, toolutil.ErrRequiredInt64("Delete", "link_id")
+		return DeletedOutput{}, toolutil.ErrRequiredInt64("Delete", "link_id")
 	}
 	l, _, err := client.GL().ReleaseLinks.DeleteReleaseLink(string(input.ProjectID), input.TagName, input.LinkID, gl.WithContext(ctx))
 	if err != nil {
-		return Output{}, toolutil.WrapErrWithStatusHint("Delete", err, http.StatusNotFound,
+		return DeletedOutput{}, toolutil.WrapErrWithStatusHint("Delete", err, http.StatusNotFound,
 			"verify link_id with gitlab_release_link_list; deleting release links requires Developer role or higher")
 	}
-	return ToOutput(l), nil
+	return DeletedOutput(ToOutput(l)), nil
 }
 
 // Get retrieves a single release asset link by its ID.

--- a/internal/tools/releaselinks/release_links_test.go
+++ b/internal/tools/releaselinks/release_links_test.go
@@ -773,9 +773,33 @@ func TestList_EmptyResult(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown_WithData verifies FormatOutputMarkdown when with data.
+// cardHints is the guidance section a link card closes with, and deletedHints
+// the one the deletion card carries instead: a removed link can be neither
+// updated nor deleted again.
+const (
+	cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'release.link_update' to change this link's name, URL or type\n" +
+		"- Use action 'release.link_delete' to remove this link from the release\n"
+	deletedHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'release.link_list' to see the links the release still has\n" +
+		"- Use action 'release.link_create' to link another asset to the release\n"
+)
+
+// listHints is the guidance section the listing closes with, the preserve-links
+// instruction first because the URL column carries links.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- " + toolutil.HintPreserveLinks + "\n" +
+	"- Use action 'release.link_get' to see one link on its own\n" +
+	"- Use action 'release.link_create' to add a new release asset link\n" +
+	"- Use action 'release.link_create_batch' to add several asset links in one call\n"
+
+const linkHeader = "| ID | Name | Type | URL |\n| --- | --- | --- | --- |\n"
+
+// TestFormatOutputMarkdown_WithData pins the whole card of an asset link:
+// every field GitLab sends, both URLs as links, and the hints a link that
+// still exists allows.
 func TestFormatOutputMarkdown_WithData(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:             10,
 		Name:           "Binary amd64",
 		URL:            "https://example.com/bin/amd64",
@@ -783,43 +807,75 @@ func TestFormatOutputMarkdown_WithData(t *testing.T) {
 		DirectAssetURL: "https://direct.example.com",
 	})
 
-	for _, want := range []string{
-		"## Release Link: Binary amd64",
-		"- **ID**: 10",
-		"- **URL**: [https://example.com/bin/amd64](https://example.com/bin/amd64)",
-		"- **Type**: package",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Release Link: Binary amd64\n\n" +
+		"- **ID**: 10\n" +
+		"- **Type**: package\n" +
+		"- **URL**: [https://example.com/bin/amd64](https://example.com/bin/amd64)\n" +
+		"- **Direct Asset URL**: [https://direct.example.com](https://direct.example.com)\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_Empty verifies FormatOutputMarkdown when empty.
+// TestFormatOutputMarkdown_Empty pins the card of a zero value: the ID row,
+// which is an answer at zero, and no label with an empty value under it.
 func TestFormatOutputMarkdown_Empty(t *testing.T) {
-	md := FormatOutputMarkdown(Output{})
-	if !strings.Contains(md, "## Release Link:") {
-		t.Errorf("expected header in empty output:\n%s", md)
-	}
-	if !strings.Contains(md, "- **ID**: 0") {
-		t.Errorf("expected zero ID:\n%s", md)
+	got := FormatOutputMarkdown(Output{})
+
+	want := "## Release Link: \n\n" +
+		"- **ID**: 0\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_LinkType verifies FormatOutputMarkdown renders the
-// link type GitLab sends. It used to assert the `external` flag beside it,
-// which no Grape entity has exposed since 16.0.
+// TestFormatOutputMarkdown_LinkType pins the link type GitLab sends. It used to
+// assert the `external` flag beside it, which no Grape entity has exposed
+// since 16.0.
 func TestFormatOutputMarkdown_LinkType(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:       5,
 		Name:     "Runbook",
 		URL:      "https://example.com/runbook",
 		LinkType: "runbook",
 	})
-	if !strings.Contains(md, "- **Type**: runbook") {
-		t.Errorf("expected the runbook link type:\n%s", md)
+
+	want := "## Release Link: Runbook\n\n" +
+		"- **ID**: 5\n" +
+		"- **Type**: runbook\n" +
+		"- **URL**: [https://example.com/runbook](https://example.com/runbook)\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatDeletedMarkdown pins what the delete action now answers with: a
+// card that says the link is gone and offers the two actions that still make
+// sense. Rendered as an ordinary link card, the same response used to invite
+// the reader to update and delete a link that no longer existed.
+func TestFormatDeletedMarkdown(t *testing.T) {
+	got := FormatDeletedMarkdown(DeletedOutput{
+		ID:       10,
+		Name:     "Binary amd64",
+		URL:      "https://example.com/bin/amd64",
+		LinkType: "package",
+	})
+
+	want := "## Release Link Deleted: Binary amd64\n\n" +
+		"- **ID**: 10\n" +
+		"- **Type**: package\n" +
+		"- **URL**: [https://example.com/bin/amd64](https://example.com/bin/amd64)\n" +
+		"\nThe link is removed from the release. The file or package it pointed at is untouched.\n" +
+		deletedHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -827,80 +883,80 @@ func TestFormatOutputMarkdown_LinkType(t *testing.T) {
 // FormatListMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithLinks verifies FormatListMarkdown when with links.
+// TestFormatListMarkdown_WithLinks pins the whole listing: the heading
+// counting what GitLab reported, the URL column labeled with the URL rather
+// than repeating the name beside it, and one guidance section at the end.
 func TestFormatListMarkdown_WithLinks(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Links: []Output{
 			{ID: 10, Name: "Binary amd64", LinkType: "package", URL: "https://example.com/amd64"},
 			{ID: 11, Name: "Binary arm64", LinkType: "package", URL: "https://example.com/arm64"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
+	})
 
-	for _, want := range []string{
-		"## Release Links (2)",
-		"| ID |",
-		"| --- |",
-		"| 10 |",
-		"| 11 |",
-		"Binary amd64",
-		"Binary arm64",
-		"package",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Release Links (2)\n\n" +
+		linkHeader +
+		"| 10 | Binary amd64 | package | [https://example.com/amd64](https://example.com/amd64) |\n" +
+		"| 11 | Binary arm64 | package | [https://example.com/arm64](https://example.com/arm64) |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_HeadingCountsTheResponseTotal pins the count the
+// heading carries when a page is one of several: the total GitLab reported,
+// not the two rows shown, which is what the heading used to say.
+func TestFormatListMarkdown_HeadingCountsTheResponseTotal(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Links: []Output{
+			{ID: 10, Name: "Binary amd64", LinkType: "package", URL: "https://example.com/amd64"},
+			{ID: 11, Name: "Binary arm64", LinkType: "package", URL: "https://example.com/arm64"},
+		},
+		Pagination: toolutil.PaginationOutput{TotalItems: 45, Page: 1, PerPage: 2, TotalPages: 23},
+	})
+
+	want := "## Release Links (45)\n\n" +
+		"Showing 2 of 45 results (page 1 of 23)\n\n" +
+		linkHeader +
+		"| 10 | Binary amd64 | package | [https://example.com/amd64](https://example.com/amd64) |\n" +
+		"| 11 | Binary arm64 | package | [https://example.com/arm64](https://example.com/arm64) |\n" +
+		"\nPage 1 of 23 | 45 items total | 2 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Empty pins that a release with no links renders the
+// one sentence and nothing else.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No release links found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No release links found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_SingleLink verifies FormatListMarkdown when single link.
+// TestFormatListMarkdown_SingleLink pins the listing of a response GitLab sent
+// no pagination with: the heading counts the row shown and no pagination line
+// is written at all.
 func TestFormatListMarkdown_SingleLink(t *testing.T) {
-	out := ListOutput{
-		Links: []Output{
-			{ID: 1, Name: "Image", LinkType: "image", URL: "https://example.com/img"},
-		},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "## Release Links (1)") {
-		t.Errorf("expected count 1:\n%s", md)
-	}
-	if !strings.Contains(md, "| 1 |") {
-		t.Errorf("expected row with ID 1:\n%s", md)
-	}
-}
+	got := FormatListMarkdown(ListOutput{
+		Links: []Output{{ID: 1, Name: "Image", LinkType: "image", URL: "https://example.com/img"}},
+	})
 
-// TestFormatListMarkdown_ContainsHints verifies that FormatListMarkdown includes
-// next-step hints for both link_create (single) and link_create_batch (bulk).
-func TestFormatListMarkdown_ContainsHints(t *testing.T) {
-	out := ListOutput{
-		Links: []Output{
-			{ID: 1, Name: "Binary", LinkType: "package", URL: "https://example.com/bin"},
-		},
-	}
-	md := FormatListMarkdown(out)
-	for _, want := range []string{
-		"link_create'",
-		"link_create_batch'",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatListMarkdown missing hint containing %q:\n%s", want, md)
-			}
-		})
+	want := "## Release Links (1)\n\n" +
+		linkHeader +
+		"| 1 | Image | image | [https://example.com/img](https://example.com/img) |\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -908,60 +964,64 @@ func TestFormatListMarkdown_ContainsHints(t *testing.T) {
 // FormatBatchMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatBatchMarkdown_WithCreatedAndFailed verifies that FormatBatchMarkdown
-// renders both the created links table and the failures list when both are present.
+// TestFormatBatchMarkdown_WithCreatedAndFailed pins the whole batch result:
+// the links created as a table, the ones GitLab refused under a heading of
+// their own, and one guidance section closing the document.
 func TestFormatBatchMarkdown_WithCreatedAndFailed(t *testing.T) {
-	out := CreateBatchOutput{
+	got := FormatBatchMarkdown(CreateBatchOutput{
 		Created: []Output{
 			{ID: 1, Name: "Binary amd64", LinkType: "package", URL: "https://example.com/amd64"},
 			{ID: 2, Name: "Binary arm64", LinkType: "package", URL: "https://example.com/arm64"},
 		},
 		Failed: []string{"checksum.txt: 409 Conflict"},
-	}
-	md := FormatBatchMarkdown(out)
-	checks := []string{
-		"## Release Links Created (2)",
-		"| ID | Name | Type | URL |",
-		"| 1 |", "Binary amd64", "package",
-		"| 2 |", "Binary arm64",
-		"### Failures (1)",
-		"checksum.txt: 409 Conflict",
-	}
-	for _, c := range checks {
-		t.Run(c, func(t *testing.T) {
-			if !strings.Contains(md, c) {
-				t.Errorf("missing %q in:\n%s", c, md)
-			}
-		})
+	})
+
+	want := "## Release Links Created (2)\n\n" +
+		linkHeader +
+		"| 1 | Binary amd64 | package | [https://example.com/amd64](https://example.com/amd64) |\n" +
+		"| 2 | Binary arm64 | package | [https://example.com/arm64](https://example.com/arm64) |\n" +
+		"\n### Failures (1)\n\n" +
+		"- checksum.txt: 409 Conflict\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- " + toolutil.HintPreserveLinks + "\n" +
+		"- Use action 'release.link_list' to see every link the release now has\n"
+
+	if got != want {
+		t.Errorf("batch mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatBatchMarkdown_AllCreated verifies rendering when all links
-// are created successfully with no failures.
+// TestFormatBatchMarkdown_AllCreated pins the result of a batch GitLab
+// accepted whole: no failures heading under it.
 func TestFormatBatchMarkdown_AllCreated(t *testing.T) {
-	out := CreateBatchOutput{
-		Created: []Output{
-			{ID: 5, Name: "Source", LinkType: "other", URL: "https://example.com/src"},
-		},
-	}
-	md := FormatBatchMarkdown(out)
-	if !strings.Contains(md, "## Release Links Created (1)") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if strings.Contains(md, "Failures") {
-		t.Errorf("unexpected Failures section:\n%s", md)
+	got := FormatBatchMarkdown(CreateBatchOutput{
+		Created: []Output{{ID: 5, Name: "Source", LinkType: "other", URL: "https://example.com/src"}},
+	})
+
+	want := "## Release Links Created (1)\n\n" +
+		linkHeader +
+		"| 5 | Source | other | [https://example.com/src](https://example.com/src) |\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- " + toolutil.HintPreserveLinks + "\n" +
+		"- Use action 'release.link_list' to see every link the release now has\n"
+
+	if got != want {
+		t.Errorf("batch mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatBatchMarkdown_Empty verifies rendering when no links were created.
+// TestFormatBatchMarkdown_Empty pins the result of a batch that created
+// nothing: no table, and no instruction to preserve links a render with none
+// cannot have.
 func TestFormatBatchMarkdown_Empty(t *testing.T) {
-	out := CreateBatchOutput{Created: []Output{}}
-	md := FormatBatchMarkdown(out)
-	if !strings.Contains(md, "## Release Links Created (0)") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Errorf("unexpected table for empty output:\n%s", md)
+	got := FormatBatchMarkdown(CreateBatchOutput{Created: []Output{}})
+
+	want := "## Release Links Created (0)\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'release.link_list' to see every link the release now has\n"
+
+	if got != want {
+		t.Errorf("batch mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/releases/markdown.go
+++ b/internal/tools/releases/markdown.go
@@ -1,12 +1,25 @@
 package releases
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// The canonical catalog IDs the hints name that the specs do not already
+// spell. The asset-link actions are projected under the release domain, so the
+// ID every surface resolves is "release.link_list" and not the
+// "release_link.list" the cross-link constant in action_specs.go spells.
+const (
+	hintActionReleaseLinkList   = "release.link_list"
+	actionReleaseCreate         = "release.create"
+	actionReleaseUpdate         = "release.update"
+	actionReleaseLinkCreate     = "release.link_create"
+	actionReleaseLinkCreateBulk = "release.link_create_batch"
+	actionPackagePublishAndLink = "package.publish_and_link"
+	actionTagList               = "tag.list"
 )
 
 type releaseNotFoundOutput struct {
@@ -22,17 +35,27 @@ func formatReleaseNotFound(out releaseNotFoundOutput) *mcp.CallToolResult {
 	)
 }
 
-// releaseWebURL derives the release page URL from the _links.edit_url field by
-// trimming the trailing "/edit" segment, or returns "" when no links exist.
+// releaseWebURL derives the release page URL from the _links object, preferring
+// the self link GitLab sends for the page itself and falling back to the
+// edit_url with its trailing "/edit" segment trimmed. Returns "" when no links
+// are present.
 func releaseWebURL(r Output) string {
-	if r.Links == nil || r.Links.EditURL == "" {
+	if r.Links == nil {
+		return ""
+	}
+	if r.Links.Self != "" {
+		return r.Links.Self
+	}
+	if r.Links.EditURL == "" {
 		return ""
 	}
 	return strings.TrimSuffix(r.Links.EditURL, "/edit")
 }
 
 // milestoneTitles extracts the milestone titles from the nested milestone
-// objects for compact Markdown rendering.
+// objects, each escaped on its own: joining them first and escaping the join
+// let a title carrying a pipe split the row it landed in, since the escaper
+// cannot tell the separator this function wrote from one a title holds.
 func milestoneTitles(ms []*toolutil.MilestoneOutput) []string {
 	if len(ms) == 0 {
 		return nil
@@ -40,84 +63,107 @@ func milestoneTitles(ms []*toolutil.MilestoneOutput) []string {
 	titles := make([]string, 0, len(ms))
 	for _, m := range ms {
 		if m != nil && m.Title != "" {
-			titles = append(titles, m.Title)
+			titles = append(titles, toolutil.EscapeMdTableCell(m.Title))
 		}
 	}
 	return titles
 }
 
-// FormatMarkdown renders a single release as a Markdown summary.
+// releaseHeading names the release the way a reader asked for it: its title
+// when GitLab has one, and the tag it was cut from otherwise.
+func releaseHeading(r Output) string {
+	if strings.TrimSpace(r.Name) != "" {
+		return "Release: " + r.Name
+	}
+	return "Release: " + r.TagName
+}
+
+// releasedCell renders the date a release went out, falling back to when it was
+// created, and marks a release GitLab flagged as upcoming with the calendar
+// glyph: without it a date in the future read as one already past.
+func releasedCell(released, created string, upcoming bool) string {
+	if released == "" {
+		released = created
+	}
+	cell := toolutil.FormatTime(released)
+	if upcoming && cell != "" {
+		return toolutil.EmojiCalendar + " " + cell
+	}
+	return cell
+}
+
+// commitSHA is the commit a release points at, in the short form GitLab sends
+// beside the full one and in the full form when it sent no short one.
+func commitSHA(c toolutil.CommitOutput) string {
+	if c.ShortID != "" {
+		return c.ShortID
+	}
+	return c.ID
+}
+
+// FormatMarkdown renders one release as the card of a single object: its own
+// fields, then its notes as quoted prose under their label.
 func FormatMarkdown(r Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Release: %s\n\n", toolutil.EscapeMdHeading(r.Name))
+	c := toolutil.NewCard(&b, releaseHeading(r))
 	// A tag name is a git ref, and check-ref-format permits '|', '<' and '>'.
-	fmt.Fprintf(&b, "- **Tag**: %s\n", toolutil.EscapeMdTableCell(r.TagName))
-	if r.Author != nil && r.Author.Username != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdAuthorAt, toolutil.EscapeMdTableCell(r.Author.Username))
+	c.Field("Tag", r.TagName)
+	if r.Author != nil {
+		c.Markdown("Author", toolutil.MdUserLink(r.Author.Username, r.Author.WebURL))
 	}
-	if webURL := releaseWebURL(r); webURL != "" {
-		toolutil.WriteMdURL(&b, webURL)
+	c.Time("Created", r.CreatedAt)
+	c.Markdown("Released", releasedCell(r.ReleasedAt, "", r.UpcomingRelease))
+	c.Flag(toolutil.EmojiCalendar, "Upcoming release", r.UpcomingRelease)
+	if r.Commit != nil {
+		// A commit SHA, hexadecimal by construction, shown the short way GitLab
+		// shows it when it sent one and in full when it did not.
+		c.Code("Commit", commitSHA(*r.Commit))
+		c.Field("Commit Title", r.Commit.Title)
 	}
-	fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(r.CreatedAt))
-	if r.ReleasedAt != "" {
-		fmt.Fprintf(&b, "- **Released**: %s\n", toolutil.FormatTime(r.ReleasedAt))
+	// A milestone title is free text, escaped one title at a time.
+	c.Markdown("Milestones", strings.Join(milestoneTitles(r.Milestones), ", "))
+	if r.Assets != nil {
+		c.Count("Assets", r.Assets.Count)
 	}
-	if r.Commit != nil && r.Commit.ID != "" {
-		//gitlab:allow-unescaped r.Commit.ID: a commit SHA, hexadecimal by construction.
-		fmt.Fprintf(&b, "- **Commit**: %s\n", r.Commit.ID)
-	}
-	if r.UpcomingRelease {
-		b.WriteString("- " + toolutil.EmojiCalendar + " **Upcoming release**\n")
-	}
-	if titles := milestoneTitles(r.Milestones); len(titles) > 0 {
-		fmt.Fprintf(&b, "- **Milestones**: %s\n", toolutil.EscapeMdTableCell(strings.Join(titles, ", ")))
-	}
-	if r.Description != "" {
-		fmt.Fprintf(&b, "\n### Description\n\n%s\n", toolutil.WrapGFMBody(r.Description))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_release action 'link_list' to see release assets",
-		"Use gitlab_release action 'link_create' to add a single asset link",
-		"Use gitlab_release action 'link_create_batch' to add multiple asset links in one call",
-		"Use gitlab_package action 'publish_and_link' to upload and link binaries to this release",
-		"Use gitlab_release action 'update' to edit the release description",
+	c.URL(releaseWebURL(r))
+	c.Text("Description", r.Description)
+	c.End(
+		toolutil.HintAction(hintActionReleaseLinkList, "see the assets linked to this release"),
+		toolutil.HintAction(actionReleaseLinkCreate, "add a single asset link"),
+		toolutil.HintAction(actionReleaseLinkCreateBulk, "add several asset links in one call"),
+		toolutil.HintAction(actionPackagePublishAndLink, "upload a binary and link it to this release"),
+		toolutil.HintAction(actionReleaseUpdate, "edit the release notes"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of releases as a Markdown table.
+// FormatListMarkdown renders a page of a project's releases as a Markdown
+// table.
 func FormatListMarkdown(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Releases (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Releases), out.Pagination)
 	if len(out.Releases) == 0 {
-		b.WriteString("No releases found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("releases")
 	}
-	b.WriteString("| Tag | Name | Author | Released |\n")
-	b.WriteString(toolutil.TblSep4Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Releases", len(out.Releases), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Tag", "Name", "Author", "Released"))
 	for _, r := range out.Releases {
-		released := r.ReleasedAt
-		if released == "" {
-			released = r.CreatedAt
+		var author string
+		if r.Author != nil {
+			author = toolutil.MdUserLink(r.Author.Username, r.Author.WebURL)
 		}
 		// The cell escaper leaves ']' alone, so a hand-built link's label could
 		// be closed from inside it by a tag holding one.
-		tag := toolutil.MdTitleLink(r.TagName, releaseWebURL(r))
-		var author string
-		if r.Author != nil {
-			author = r.Author.Username
-		}
-		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", tag, toolutil.EscapeMdTableCell(r.Name), toolutil.EscapeMdTableCell(author), toolutil.FormatTime(released))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(r.TagName, releaseWebURL(r)),
+			toolutil.EscapeMdTableCell(r.Name),
+			author,
+			releasedCell(r.ReleasedAt, r.CreatedAt, r.UpcomingRelease),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'get' with a tag_name to see full release details",
-		"Use action 'create' to create a new release",
-		"Use gitlab_tag action 'list' to see available tags",
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionReleaseGet, "see one release in full, with its notes and assets"),
+		toolutil.HintAction(actionReleaseCreate, "create a new release"),
+		toolutil.HintAction(actionTagList, "see the tags a release can be cut from"),
 	)
 	return b.String()
 }

--- a/internal/tools/releases/releases_test.go
+++ b/internal/tools/releases/releases_test.go
@@ -648,34 +648,78 @@ func TestList_EmptyResult(t *testing.T) {
 // FormatMarkdown — all fields, minimal fields, upcoming release
 // ---------------------------------------------------------------------------.
 
-// TestFormatMarkdown_AllFields verifies FormatMarkdown when all fields.
+// cardHints is the guidance section every release card closes with.
+const cardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- Use action 'release.link_list' to see the assets linked to this release\n" +
+	"- Use action 'release.link_create' to add a single asset link\n" +
+	"- Use action 'release.link_create_batch' to add several asset links in one call\n" +
+	"- Use action 'package.publish_and_link' to upload a binary and link it to this release\n" +
+	"- Use action 'release.update' to edit the release notes\n"
+
+// listHints is the guidance section the listing closes with, the preserve-links
+// instruction first because the Tag column carries links.
+const listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+	"- " + toolutil.HintPreserveLinks + "\n" +
+	"- Use action 'release.get' to see one release in full, with its notes and assets\n" +
+	"- Use action 'release.create' to create a new release\n" +
+	"- Use action 'tag.list' to see the tags a release can be cut from\n"
+
+// TestFormatMarkdown_AllFields pins the whole card of a release with
+// everything GitLab sends: the author as a handle, the commit as a code span,
+// the milestones escaped one title at a time, and the notes as quoted prose
+// under their label, which no heading of the response can be forged from.
 func TestFormatMarkdown_AllFields(t *testing.T) {
-	md := FormatMarkdown(Output{
+	got := FormatMarkdown(Output{
 		TagName:         "v2.0.0",
 		Name:            "Release v2.0.0",
 		Description:     "## Changes\n- Feature X",
-		Author:          &toolutil.AuthorOutput{Username: "admin"},
+		Author:          &toolutil.AuthorOutput{Username: "admin", WebURL: "https://gitlab.example.com/admin"},
 		CreatedAt:       "2026-03-02T10:00:00Z",
 		ReleasedAt:      "2026-03-02T10:00:00Z",
-		Commit:          &toolutil.CommitOutput{ID: "abc123"},
+		Commit:          &toolutil.CommitOutput{ID: "abc123", ShortID: "abc123", Title: "Fix login"},
 		UpcomingRelease: true,
 		Milestones:      []*toolutil.MilestoneOutput{{Title: "m1"}, {Title: "m2"}},
+		Assets:          &toolutil.AssetsOutput{Count: 3},
 	})
-	for _, want := range []string{
-		"## Release: Release v2.0.0",
-		"**Tag**: v2.0.0",
-		"**Author**: @admin",
-		"**Commit**: abc123",
-		"**Upcoming release**",
-		"**Milestones**: m1, m2",
-		"### Description",
-		"Feature X",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+
+	want := "## Release: Release v2.0.0\n\n" +
+		"- **Tag**: v2.0.0\n" +
+		"- **Author**: [@admin](https://gitlab.example.com/admin)\n" +
+		"- **Created**: 2 Mar 2026 10:00 UTC\n" +
+		"- **Released**: \U0001F4C5 2 Mar 2026 10:00 UTC\n" +
+		"- \U0001F4C5 **Upcoming release**\n" +
+		"- **Commit**: `abc123`\n" +
+		"- **Commit Title**: Fix login\n" +
+		"- **Milestones**: m1, m2\n" +
+		"- **Assets**: 3\n" +
+		"- **Description**:\n" +
+		"  > ## Changes\n" +
+		"  > - Feature X\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatMarkdown_MilestoneTitlesAreEscapedOneAtATime pins the defect the
+// join hid: a milestone title carrying a pipe used to be escaped after the
+// join, which cannot tell the separator this formatter wrote from one the
+// title holds.
+func TestFormatMarkdown_MilestoneTitlesAreEscapedOneAtATime(t *testing.T) {
+	got := FormatMarkdown(Output{
+		TagName:    "v3.0.0",
+		Name:       "Escaping",
+		Milestones: []*toolutil.MilestoneOutput{{Title: "a|b"}, {Title: ""}, {Title: "[c](http://attacker.invalid/)"}},
+	})
+
+	want := "## Release: Escaping\n\n" +
+		"- **Tag**: v3.0.0\n" +
+		"- **Milestones**: a&#124;b, &#91;c](http://attacker.invalid/)\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -690,45 +734,59 @@ func TestFormatReleaseNotFound(t *testing.T) {
 	}
 }
 
-// TestFormatMarkdown_MinimalFields verifies FormatMarkdown when minimal fields.
+// TestFormatMarkdown_MinimalFields pins the whole card of a release GitLab
+// answered with nothing optional: three rows and no label with an empty value
+// under it.
 func TestFormatMarkdown_MinimalFields(t *testing.T) {
-	md := FormatMarkdown(Output{
+	got := FormatMarkdown(Output{
 		TagName:   "v0.1.0",
 		Name:      "Beta",
 		CreatedAt: "2026-01-01T00:00:00Z",
 	})
-	if !strings.Contains(md, "## Release: Beta") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	if !strings.Contains(md, "**Tag**: v0.1.0") {
-		t.Errorf("missing tag:\n%s", md)
-	}
-	for _, absent := range []string{
-		"**Author**",
-		"**Commit**",
-		"**Upcoming release**",
-		"**Milestones**",
-		"### Description",
-		"**Released**",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+
+	want := "## Release: Beta\n\n" +
+		"- **Tag**: v0.1.0\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMarkdown_WithReleasedAt verifies FormatMarkdown when with released at.
+// TestFormatMarkdown_UntitledRelease pins the heading of a release GitLab has
+// no title for: the tag names it, rather than a heading trailing a colon.
+func TestFormatMarkdown_UntitledRelease(t *testing.T) {
+	got := FormatMarkdown(Output{TagName: "v0.2.0"})
+
+	want := "## Release: v0.2.0\n\n" +
+		"- **Tag**: v0.2.0\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatMarkdown_WithReleasedAt pins the release date of a release already
+// out: the display form, and no calendar marker, which belongs to an upcoming
+// one.
 func TestFormatMarkdown_WithReleasedAt(t *testing.T) {
-	md := FormatMarkdown(Output{
+	got := FormatMarkdown(Output{
 		TagName:    "v1.5.0",
 		Name:       "Patch",
 		CreatedAt:  "2026-02-01T00:00:00Z",
 		ReleasedAt: "2026-02-15T00:00:00Z",
 	})
-	if !strings.Contains(md, "**Released**: 15 Feb 2026 00:00 UTC") {
-		t.Errorf("missing released_at:\n%s", md)
+
+	want := "## Release: Patch\n\n" +
+		"- **Tag**: v1.5.0\n" +
+		"- **Created**: 1 Feb 2026 00:00 UTC\n" +
+		"- **Released**: 15 Feb 2026 00:00 UTC\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -736,60 +794,82 @@ func TestFormatMarkdown_WithReleasedAt(t *testing.T) {
 // FormatListMarkdown — with data, empty, pagination
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithData verifies FormatListMarkdown when with data.
+// TestFormatListMarkdown_WithData pins the whole listing: the heading counting
+// what GitLab reported, the author as a handle, the pagination line and one
+// guidance section.
 func TestFormatListMarkdown_WithData(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Releases: []Output{
 			{TagName: "v2.0.0", Name: "Major", Author: &toolutil.AuthorOutput{Username: "admin"}, ReleasedAt: "2026-06-01T10:00:00Z"},
 			{TagName: "v1.0.0", Name: "First", Author: &toolutil.AuthorOutput{Username: "dev"}, CreatedAt: "2026-01-01T10:00:00Z"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
-	for _, want := range []string{
-		"## Releases (2)",
-		"| Tag | Name | Author | Released |",
-		"v2.0.0",
-		"Major",
-		"admin",
-		"v1.0.0",
-		"First",
-		"dev",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	})
+
+	want := "## Releases (2)\n\n" +
+		"| Tag | Name | Author | Released |\n| --- | --- | --- | --- |\n" +
+		"| v2.0.0 | Major | @admin | 1 Jun 2026 10:00 UTC |\n" +
+		"| v1.0.0 | First | @dev | 1 Jan 2026 10:00 UTC |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_UpcomingIsMarked pins what the Released column was
+// missing: a release GitLab flagged as upcoming carries the calendar glyph, so
+// a date in the future no longer reads as one already past.
+func TestFormatListMarkdown_UpcomingIsMarked(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Releases: []Output{
+			{TagName: "v9.0.0", Name: "Planned", ReleasedAt: "2027-01-01T00:00:00Z", UpcomingRelease: true},
+		},
+		Pagination: toolutil.PaginationOutput{TotalItems: 1, TotalPages: 1},
+	})
+
+	want := "## Releases (1)\n\n" +
+		"| Tag | Name | Author | Released |\n| --- | --- | --- | --- |\n" +
+		"| v9.0.0 | Planned |  | \U0001F4C5 1 Jan 2027 00:00 UTC |\n" +
+		"\n1 items total\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatListMarkdown_Empty pins that a project with no releases renders the
+// one sentence and nothing else: no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Releases:   []Output{},
 		Pagination: toolutil.PaginationOutput{TotalItems: 0},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "No releases found.") {
-		t.Errorf("expected 'No releases found.' in:\n%s", md)
-	}
-	if strings.Contains(md, "| Tag |") {
-		t.Errorf("should not contain table header for empty list:\n%s", md)
+	})
+
+	if want := "No releases found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_FallbackToCreatedAt verifies FormatListMarkdown when fallback to created at.
+// TestFormatListMarkdown_FallbackToCreatedAt pins the Released column of a
+// release GitLab sent no release date for: it falls back to when the release
+// was created rather than leaving the cell empty.
 func TestFormatListMarkdown_FallbackToCreatedAt(t *testing.T) {
-	out := ListOutput{
-		Releases: []Output{
-			{TagName: "v0.1.0", Name: "Alpha", CreatedAt: "2026-01-01T00:00:00Z"},
-		},
+	got := FormatListMarkdown(ListOutput{
+		Releases:   []Output{{TagName: "v0.1.0", Name: "Alpha", CreatedAt: "2026-01-01T00:00:00Z"}},
 		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "1 Jan 2026 00:00 UTC") {
-		t.Errorf("expected created_at fallback in Released column:\n%s", md)
+	})
+
+	want := "## Releases (1)\n\n" +
+		"| Tag | Name | Author | Released |\n| --- | --- | --- | --- |\n" +
+		"| v0.1.0 | Alpha |  | 1 Jan 2026 00:00 UTC |\n" +
+		"\nPage 1 of 1 | 1 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -880,86 +960,83 @@ func TestToOutput_WebURL_EmptyEditURL(t *testing.T) {
 	}
 }
 
-// TestFormatMarkdown_WithWebURL verifies that the detail Markdown includes
-// a clickable URL link when a web URL is derivable from _links.edit_url.
+// TestFormatMarkdown_WithWebURL pins the whole card of a release whose page
+// GitLab names through its self link: the card's address is its URL row, and a
+// release whose links carry only the edit form is linked to the page that form
+// edits.
 func TestFormatMarkdown_WithWebURL(t *testing.T) {
-	md := FormatMarkdown(Output{
+	selfCard := FormatMarkdown(Output{
+		TagName:   "v1.0.0",
+		Name:      "Release v1.0.0",
+		CreatedAt: "2026-03-01T10:00:00Z",
+		Links: &toolutil.LinksOutput{
+			Self:    "https://gitlab.example.com/-/releases/v1.0.0",
+			EditURL: "https://gitlab.example.com/-/releases/v1.0.0/edit",
+		},
+	})
+
+	want := "## Release: Release v1.0.0\n\n" +
+		"- **Tag**: v1.0.0\n" +
+		"- **Created**: 1 Mar 2026 10:00 UTC\n" +
+		"- **URL**: [https://gitlab.example.com/-/releases/v1.0.0](https://gitlab.example.com/-/releases/v1.0.0)\n" +
+		cardHints
+
+	if selfCard != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", selfCard, want)
+	}
+
+	editCard := FormatMarkdown(Output{
 		TagName:   "v1.0.0",
 		Name:      "Release v1.0.0",
 		CreatedAt: "2026-03-01T10:00:00Z",
 		Links:     &toolutil.LinksOutput{EditURL: "https://gitlab.example.com/-/releases/v1.0.0/edit"},
 	})
-	want := "[https://gitlab.example.com/-/releases/v1.0.0](https://gitlab.example.com/-/releases/v1.0.0)"
-	if !strings.Contains(md, want) {
-		t.Errorf("FormatMarkdown missing clickable URL link, got:\n%s", md)
+
+	if editCard != want {
+		t.Errorf("edit-url fallback mismatch:\ngot:\n%s\nwant:\n%s", editCard, want)
 	}
 }
 
-// TestFormatMarkdown_WithoutWebURL verifies that no URL line appears when
-// WebURL is empty.
+// TestFormatMarkdown_WithoutWebURL pins that a release GitLab sent no links
+// for carries no URL row at all, rather than a label with nothing after it.
 func TestFormatMarkdown_WithoutWebURL(t *testing.T) {
-	md := FormatMarkdown(Output{
+	got := FormatMarkdown(Output{
 		TagName:   "v0.1.0",
 		Name:      "Alpha",
 		CreatedAt: "2026-01-01T00:00:00Z",
 	})
-	if strings.Contains(md, "**URL**") {
-		t.Errorf("FormatMarkdown should not contain URL when empty, got:\n%s", md)
+
+	want := "## Release: Alpha\n\n" +
+		"- **Tag**: v0.1.0\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		cardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMarkdown_ContainsHints verifies that FormatMarkdown includes
-// next-step hints guiding the user to release link tools (single and batch)
-// and to publish_and_link for uploading binaries.
-func TestFormatMarkdown_ContainsHints(t *testing.T) {
-	md := FormatMarkdown(Output{
-		TagName:   "v1.0.0",
-		Name:      "Hints test",
-		CreatedAt: "2026-01-01T00:00:00Z",
-	})
-	for _, want := range []string{
-		"link_create'",
-		"link_create_batch'",
-		"publish_and_link'",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("FormatMarkdown missing hint containing %q:\n%s", want, md)
-			}
-		})
-	}
-}
-
-// TestFormatListMarkdown_ClickableTagLink verifies that the list table
-// renders tag names as clickable Markdown links when WebURL is present.
+// TestFormatListMarkdown_ClickableTagLink pins that the Tag column links to the
+// release page derived from the edit URL, and renders plain text when GitLab
+// sent no links at all.
 func TestFormatListMarkdown_ClickableTagLink(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Releases: []Output{
 			{TagName: "v2.0.0", Name: "Major", Author: &toolutil.AuthorOutput{Username: "admin"}, ReleasedAt: "2026-06-01T10:00:00Z", Links: &toolutil.LinksOutput{EditURL: "https://gitlab.example.com/-/releases/v2.0.0/edit"}},
+			{TagName: "v1.0.0", Name: "First", CreatedAt: "2026-01-01T10:00:00Z"},
 		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
-	if !strings.Contains(md, "[v2.0.0](https://gitlab.example.com/-/releases/v2.0.0)") {
-		t.Errorf("FormatListMarkdown missing clickable tag link, got:\n%s", md)
-	}
-}
+		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
+	})
 
-// TestFormatListMarkdown_NoLinkWithoutWebURL verifies that tag names appear
-// as plain text when WebURL is empty.
-func TestFormatListMarkdown_NoLinkWithoutWebURL(t *testing.T) {
-	out := ListOutput{
-		Releases: []Output{
-			{TagName: "v1.0.0", Name: "First", CreatedAt: "2026-01-01T00:00:00Z"},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1, Page: 1, PerPage: 20, TotalPages: 1},
-	}
-	md := FormatListMarkdown(out)
-	if strings.Contains(md, "[v1.0.0](") {
-		t.Errorf("FormatListMarkdown should not contain link when WebURL is empty, got:\n%s", md)
-	}
-	if !strings.Contains(md, "v1.0.0") {
-		t.Errorf("FormatListMarkdown should contain tag name as plain text, got:\n%s", md)
+	want := "## Releases (2)\n\n" +
+		"| Tag | Name | Author | Released |\n| --- | --- | --- | --- |\n" +
+		"| [v2.0.0](https://gitlab.example.com/-/releases/v2.0.0) | Major | @admin | 1 Jun 2026 10:00 UTC |\n" +
+		"| v1.0.0 | First |  | 1 Jan 2026 10:00 UTC |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/repository/markdown.go
+++ b/internal/tools/repository/markdown.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,225 +9,251 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatTreeMarkdown renders a paginated repository tree as a Markdown table.
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionTree              = "repository.tree"
+	actionCompare           = "repository.compare"
+	actionRawBlob           = "repository.raw_blob"
+	actionChangelogAdd      = "repository.changelog_add"
+	actionChangelogGenerate = "repository.changelog_generate"
+	actionFileGet           = "repository.file_get"
+	actionCommitGet         = "repository.commit_get"
+	actionCommitList        = "repository.commit_list"
+	actionReleaseCreate     = "release.create"
+)
+
+// imageNote is the sentence a card writes where the bytes themselves are
+// attached to the result rather than printed.
+const imageNote = "\U0001F5BC️ Image content is attached below as ImageContent for multimodal viewing."
+
+// treeNodeIcon marks what a tree entry is. A submodule is a commit object
+// pinned inside the tree, not a file, and marking it as one told a reader it
+// could be read with file_get.
+func treeNodeIcon(nodeType string) string {
+	switch nodeType {
+	case "tree":
+		return toolutil.EmojiFolder
+	case "commit":
+		return toolutil.EmojiLink
+	default:
+		return toolutil.EmojiFile
+	}
+}
+
+// FormatTreeMarkdown renders a page of a repository tree as a Markdown table.
 func FormatTreeMarkdown(out TreeOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Repository Tree (%d entries)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Tree), out.Pagination)
 	if len(out.Tree) == 0 {
-		b.WriteString("No files or directories found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("files or directories")
 	}
-	b.WriteString("| Type | Name | Path |\n")
-	b.WriteString(toolutil.TblSep3Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Repository Tree", len(out.Tree), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Type", "Name", "Path"))
 	for _, n := range out.Tree {
-		icon := toolutil.EmojiFile
-		if n.Type == "tree" {
-			icon = toolutil.EmojiFolder
-		}
-		fmt.Fprintf(&b, "| %s | %s | %s |\n", icon, toolutil.EscapeMdTableCell(n.Name), toolutil.EscapeMdTableCell(n.Path))
+		b.WriteString(toolutil.MarkdownTableRow(
+			treeNodeIcon(n.Type),
+			toolutil.EscapeMdTableCell(n.Name),
+			toolutil.MdCodeSpanCell(n.Path),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use gitlab_repository action 'file_get' with a file path to read file content",
-		"Use gitlab_repository action 'compare' to see differences between branches or commits",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionFileGet, "read one file's content"),
+		toolutil.HintAction(actionCompare, "see differences between branches or commits"),
 	)
 	return b.String()
 }
 
-// FormatCompareMarkdown renders a repository comparison result.
+// FormatCompareMarkdown renders a comparison of two refs as a card whose
+// commits and changed files are the nested collections they are.
 func FormatCompareMarkdown(out CompareOutput) string {
 	var b strings.Builder
 	if out.CompareSameRef {
-		b.WriteString("## Repository Compare: same ref\n\nBoth references point to the same commit.\n")
+		c := toolutil.NewCard(&b, "Repository Compare: same ref")
+		c.Note("Both references point to the same commit.")
+		c.End(toolutil.HintAction(actionCompare, "compare two different refs"))
 		return b.String()
 	}
 	if out.CompareTimeout {
-		b.WriteString("## Repository Compare: timeout\n\nThe comparison timed out. Try with a smaller range.\n")
+		c := toolutil.NewCard(&b, "Repository Compare: timeout")
+		c.Note("The comparison timed out. Try again with a smaller range.")
+		c.End(toolutil.HintAction(actionCompare, "compare a smaller range"))
 		return b.String()
 	}
-	fmt.Fprintf(&b, "## Repository Compare\n\n")
-	fmt.Fprintf(&b, "**Commits**: %d | **Diffs**: %d\n\n", len(out.Commits), len(out.Diffs))
+	c := toolutil.NewCard(&b, "Repository Compare")
+	c.Int("Commits", int64(len(out.Commits)))
+	c.Int("Changed Files", int64(len(out.Diffs)))
+	c.URL(out.WebURL)
 	if len(out.Commits) > 0 {
-		b.WriteString("### Commits\n\n")
-		b.WriteString("| Short ID | Title | Author |\n")
-		b.WriteString(toolutil.TblSep3Col)
-		for _, c := range out.Commits {
-			//gitlab:allow-unescaped c.ShortID: an abbreviated git object id, which GitLab derives from the commit hash and is hexadecimal.
-			fmt.Fprintf(&b, toolutil.FmtRow3Str, c.ShortID, toolutil.EscapeMdTableCell(c.Title), toolutil.EscapeMdTableCell(c.AuthorName))
+		t := c.Table("Commits", "Short ID", "Title", "Author")
+		for _, commit := range out.Commits {
+			t.Row(
+				toolutil.MdCodeSpanCell(commit.ShortID),
+				toolutil.EscapeMdTableCell(commit.Title),
+				toolutil.EscapeMdTableCell(commit.AuthorName),
+			)
 		}
 	}
 	if len(out.Diffs) > 0 {
-		b.WriteString("\n### Changed Files\n\n")
-		b.WriteString("| Status | Path |\n")
-		b.WriteString("| --- | --- |\n")
+		t := c.Table("Changed Files", "Status", "Path")
 		for _, d := range out.Diffs {
-			status := "modified"
-			switch {
-			case d.NewFile:
-				status = "added"
-			case d.DeletedFile:
-				status = "deleted"
-			case d.RenamedFile:
-				status = "renamed"
-			}
-			fmt.Fprintf(&b, "| %s | %s |\n", status, toolutil.EscapeMdTableCell(d.NewPath))
+			t.Row(diffStatus(d), toolutil.MdCodeSpanCell(d.NewPath))
 		}
 	}
-	if out.WebURL != "" {
-		toolutil.WriteMdURLNewline(&b, out.WebURL)
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_get` to view a specific commit",
-		"Use `gitlab_file_get` to read a changed file",
+	c.End(
+		toolutil.HintAction(actionCommitGet, "view one of these commits"),
+		toolutil.HintAction(actionFileGet, "read a changed file"),
 	)
 	return b.String()
 }
 
-// FormatContributorsMarkdown renders a list of contributors.
+// diffStatus names what happened to a file in a diff.
+func diffStatus(d DiffOutput) string {
+	switch {
+	case d.NewFile:
+		return "added"
+	case d.DeletedFile:
+		return "deleted"
+	case d.RenamedFile:
+		return "renamed"
+	default:
+		return "modified"
+	}
+}
+
+// FormatContributorsMarkdown renders a page of repository contributors as a
+// Markdown table.
 func FormatContributorsMarkdown(out ContributorsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Repository Contributors (%d)\n\n", len(out.Contributors))
-	toolutil.WriteListSummary(&b, len(out.Contributors), out.Pagination)
 	if len(out.Contributors) == 0 {
-		b.WriteString("No contributors found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("contributors")
 	}
-	b.WriteString("| Name | Email | Commits | Additions | Deletions |\n")
-	b.WriteString(toolutil.TblSep5Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Repository Contributors", len(out.Contributors), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Email", "Commits", "Additions", "Deletions"))
 	for _, c := range out.Contributors {
-		fmt.Fprintf(&b, "| %s | %s | %d | %d | %d |\n",
-			toolutil.EscapeMdTableCell(c.Name), toolutil.EscapeMdTableCell(c.Email),
-			c.Commits, c.Additions, c.Deletions)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(c.Name),
+			toolutil.EscapeMdTableCell(c.Email),
+			strconv.FormatInt(c.Commits, 10),
+			strconv.FormatInt(c.Additions, 10),
+			strconv.FormatInt(c.Deletions, 10),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_commit_list` to view commits by a contributor",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionCommitList, "view commits by one contributor"),
 	)
 	return b.String()
 }
 
-// FormatBlobMarkdown renders blob metadata.
+// FormatBlobMarkdown renders a blob's metadata as a card. The bytes are not
+// printed here: raw_blob is the action that decodes them.
 func FormatBlobMarkdown(out BlobOutput) string {
 	var b strings.Builder
-	b.WriteString("## Repository Blob\n\n")
+	c := toolutil.NewCard(&b, "Repository Blob")
 	// The blob SHA is not GitLab's echo of anything it validated: it is the
 	// caller's own argument, filtered only by a remote endpoint answering 200.
-	fmt.Fprintf(&b, "- **SHA**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
-	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
+	c.Code("SHA", out.SHA)
+	c.Int("Size (bytes)", int64(out.Size))
 	switch out.ContentCategory {
 	case "image":
-		//gitlab:allow-unescaped out.ImageMIMEType: sniffed by http.DetectContentType on a branch that only runs when the result already begins with image/, so it is one of that function's own constants.
-		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", out.ImageMIMEType)
-		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
+		c.Field("Content Type", "image ("+out.ImageMIMEType+")")
+		c.Note(imageNote)
 	case "binary":
-		b.WriteString("- **Content type**: binary (content omitted, not viewable as text)\n")
+		c.Field("Content Type", "binary (content omitted, not viewable as text)")
 	default:
-		fmt.Fprintf(&b, "- **Content**: text (%d chars)\n", len(out.Content))
+		c.Field("Content Type", "text")
+		c.Int("Characters", int64(len(out.Content)))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_repository_raw_blob` for decoded text content",
-	)
+	c.End(toolutil.HintAction(actionRawBlob, "read the decoded text content"))
 	return b.String()
 }
 
-// FormatRawBlobContentMarkdown renders raw blob content.
+// FormatRawBlobContentMarkdown renders a blob's decoded content as a card
+// whose body is fenced.
 func FormatRawBlobContentMarkdown(out RawBlobContentOutput) string {
 	var b strings.Builder
-	b.WriteString("## Repository Raw Blob Content\n\n")
+	c := toolutil.NewCard(&b, "Repository Raw Blob Content")
 	// The blob SHA is not GitLab's echo of anything it validated: it is the
 	// caller's own argument, filtered only by a remote endpoint answering 200.
-	fmt.Fprintf(&b, "- **SHA**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
-	fmt.Fprintf(&b, "- **Size**: %d bytes\n", out.Size)
+	c.Code("SHA", out.SHA)
+	c.Int("Size (bytes)", int64(out.Size))
 	switch out.ContentCategory {
 	case "image":
-		//gitlab:allow-unescaped out.ImageMIMEType: sniffed by http.DetectContentType on a branch that only runs when the result already begins with image/, so it is one of that function's own constants.
-		fmt.Fprintf(&b, "- **Content type**: image (%s)\n", out.ImageMIMEType)
-		b.WriteString("\n> \U0001F5BC\uFE0F Image content is attached below as ImageContent for multimodal viewing.\n")
+		c.Field("Content Type", "image ("+out.ImageMIMEType+")")
+		c.Note(imageNote)
 	case "binary":
-		b.WriteString("- **Content type**: binary (content omitted, not viewable as text)\n")
+		c.Field("Content Type", "binary (content omitted, not viewable as text)")
 	default:
 		// The blob is a file of the repository, so a fixed fence is closed by
 		// the first run of three backticks whoever pushed it wrote.
-		b.WriteString("\n")
-		b.WriteString(toolutil.MarkdownFencedBlock("", out.Content))
+		c.Fence("", "", out.Content)
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_file_get` to view file with metadata",
-	)
+	c.End(toolutil.HintAction(actionFileGet, "view the file with its metadata"))
 	return b.String()
 }
 
 func blobResult(out BlobOutput) *mcp.CallToolResult {
-	switch out.ContentCategory {
-	case "image":
+	if out.ContentCategory == "image" {
 		return toolutil.ToolResultWithImage(FormatBlobMarkdown(out), toolutil.ContentAssistant, out.ImageData, out.ImageMIMEType)
-	default:
-		return toolutil.ToolResultWithMarkdown(FormatBlobMarkdown(out))
 	}
+	return toolutil.ToolResultWithMarkdown(FormatBlobMarkdown(out))
 }
 
 func rawBlobResult(out RawBlobContentOutput) *mcp.CallToolResult {
-	switch out.ContentCategory {
-	case "image":
+	if out.ContentCategory == "image" {
 		return toolutil.ToolResultWithImage(FormatRawBlobContentMarkdown(out), toolutil.ContentAssistant, out.ImageData, out.ImageMIMEType)
-	default:
-		return toolutil.ToolResultWithMarkdown(FormatRawBlobContentMarkdown(out))
 	}
+	return toolutil.ToolResultWithMarkdown(FormatRawBlobContentMarkdown(out))
 }
 
-// FormatArchiveMarkdown renders archive download info.
+// FormatArchiveMarkdown renders the archive download address as a card.
 func FormatArchiveMarkdown(out ArchiveOutput) string {
 	var b strings.Builder
-	b.WriteString("## Repository Archive\n\n")
+	c := toolutil.NewCard(&b, "Repository Archive")
 	// Archive makes no API call at all, so all three are the caller's own
 	// arguments echoed back, format included: nothing checks it against the
 	// eight values its schema lists.
-	fmt.Fprintf(&b, "- **Project**: %s\n", toolutil.EscapeMdTableCell(out.ProjectID))
-	fmt.Fprintf(&b, "- **Format**: %s\n", toolutil.EscapeMdTableCell(out.Format))
-	if out.SHA != "" {
-		fmt.Fprintf(&b, "- **SHA/Ref**: %s\n", toolutil.EscapeMdTableCell(out.SHA))
-	}
-	toolutil.WriteMdURL(&b, out.URL)
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use `gitlab_repository_tree` to browse the repository instead",
-	)
+	c.Field("Project", out.ProjectID)
+	c.Field("Format", out.Format)
+	c.Field("SHA/Ref", out.SHA)
+	c.URL(out.URL)
+	c.End(toolutil.HintAction(actionTree, "browse the repository instead of downloading it"))
 	return b.String()
 }
 
-// FormatAddChangelogMarkdown renders changelog addition confirmation.
+// FormatAddChangelogMarkdown renders the outcome of committing changelog data.
 func FormatAddChangelogMarkdown(out AddChangelogOutput) string {
 	var b strings.Builder
-	if out.Success {
-		fmt.Fprintf(&b, "## Changelog Updated\n\nVersion **%s** changelog data committed successfully.\n", out.Version)
-	} else {
-		b.WriteString("## Changelog Update Failed\n")
+	if !out.Success {
+		c := toolutil.NewCard(&b, "Changelog Update Failed")
+		c.Field("Version", out.Version)
+		c.End(toolutil.HintAction(actionChangelogGenerate, "generate the notes without committing them"))
+		return b.String()
 	}
-	toolutil.WriteHints(&b, "Use gitlab_repository action 'get_changelog' to view the full changelog")
+	c := toolutil.NewCard(&b, "Changelog Updated")
+	// The version is the caller's own argument echoed back, so it is a row the
+	// card escapes rather than bold text interpolated into a sentence.
+	c.Field("Version", out.Version)
+	c.Note("The changelog data was committed successfully.")
+	c.End(toolutil.HintAction(actionChangelogGenerate, "generate the notes for another range"))
 	return b.String()
 }
 
 // FormatChangelogDataMarkdown renders generated changelog notes.
+//
+// The notes are fenced rather than written raw: they are release prose built
+// out of commit messages, so a commit title carrying a heading, a list item or
+// a guidance section used to become part of this response.
 func FormatChangelogDataMarkdown(out ChangelogDataOutput) string {
 	var b strings.Builder
-	b.WriteString("## Generated Changelog Data\n\n")
+	c := toolutil.NewCard(&b, "Generated Changelog Data")
 	if out.Notes == "" {
-		b.WriteString("No changelog entries found.\n")
+		c.Note("GitLab generated no changelog entries for this range.")
+		c.End(toolutil.HintAction(actionChangelogGenerate, "widen the range with from and to"))
 		return b.String()
 	}
-	b.WriteString(out.Notes)
-	b.WriteString("\n")
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_repository_changelog_add` to commit this changelog to the repository",
-		"Use `gitlab_release_create` to create a release with these notes",
+	c.Fence("", "markdown", out.Notes)
+	c.End(
+		toolutil.HintAction(actionChangelogAdd, "commit this changelog to the repository"),
+		toolutil.HintAction(actionReleaseCreate, "create a release with these notes"),
 	)
 	return b.String()
 }

--- a/internal/tools/repository/repository.go
+++ b/internal/tools/repository/repository.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	gl "gitlab.com/gitlab-org/api/client-go/v3"
@@ -432,9 +433,14 @@ func Archive(ctx context.Context, client *gitlabclient.Client, input ArchiveInpu
 	}
 	baseURL := client.GL().BaseURL().String()
 	pid := string(input.ProjectID)
-	archiveURL := fmt.Sprintf("%sprojects/%s/repository/archive.%s", baseURL, pid, format)
+	// The project id is a path segment and the ref is a query value, and both
+	// are the caller's own text: a full project path carries the separators
+	// that end a segment, and a ref may carry any of "?", "#", "&" or a space,
+	// each of which built a different address than the one asked for.
+	archiveURL := fmt.Sprintf("%sprojects/%s/repository/archive.%s",
+		baseURL, url.PathEscape(pid), url.PathEscape(format))
 	if input.SHA != "" {
-		archiveURL += "?sha=" + input.SHA
+		archiveURL += "?" + url.Values{"sha": {input.SHA}}.Encode()
 	}
 	return ArchiveOutput{
 		ProjectID: pid,

--- a/internal/tools/repository/repository_test.go
+++ b/internal/tools/repository/repository_test.go
@@ -549,6 +549,32 @@ func TestRepositoryArchive_DefaultFormat(t *testing.T) {
 	}
 }
 
+// TestRepositoryArchive_EscapesPathAndQuery pins that the address this action
+// hands back is built by escaping its two caller-supplied parts: a full
+// project path carries the separators that would end the segment early, and a
+// ref may carry any of "?", "#", "&" or a space, each of which built a
+// different address than the one asked for.
+func TestRepositoryArchive_EscapesPathAndQuery(t *testing.T) {
+	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		testutil.RespondJSON(w, http.StatusOK, `{}`)
+	}))
+
+	out, err := Archive(context.Background(), client, ArchiveInput{
+		ProjectID: "group/sub/project",
+		SHA:       "feature/a b?c",
+		Format:    "zip",
+	})
+	if err != nil {
+		t.Fatalf("Archive() unexpected error: %v", err)
+	}
+
+	base := client.GL().BaseURL().String()
+	want := base + "projects/group%2Fsub%2Fproject/repository/archive.zip?sha=feature%2Fa+b%3Fc"
+	if out.URL != want {
+		t.Errorf("Archive URL = %q, want %q", out.URL, want)
+	}
+}
+
 // TestRepositoryArchive_EmptyProjectID verifies RepositoryArchive when empty project ID.
 func TestRepositoryArchive_EmptyProjectID(t *testing.T) {
 	client := testutil.NewTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1031,163 +1057,235 @@ func TestRepositoryTree_WithPagination(t *testing.T) {
 // Format*Markdown Tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatTreeMarkdown verifies FormatTreeMarkdown.
+// The guidance sections the repository formatters close with, pinned once so
+// each whole-output expectation names them rather than restating them.
+const (
+	treeHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_get' to read one file's content\n" +
+		"- Use action 'repository.compare' to see differences between branches or commits\n"
+
+	compareHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_get' to view one of these commits\n" +
+		"- Use action 'repository.file_get' to read a changed file\n"
+
+	compareAgainHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.compare' to compare two different refs\n"
+
+	contributorsHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.commit_list' to view commits by one contributor\n"
+
+	blobHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.raw_blob' to read the decoded text content\n"
+
+	rawBlobHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.file_get' to view the file with its metadata\n"
+
+	archiveHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.tree' to browse the repository instead of downloading it\n"
+
+	changelogGenerateHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.changelog_generate' to generate the notes for another range\n"
+
+	changelogDataHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.changelog_add' to commit this changelog to the repository\n" +
+		"- Use action 'release.create' to create a release with these notes\n"
+)
+
+// TestFormatTreeMarkdown pins the whole tree listing. A submodule is a commit
+// object pinned inside the tree rather than a file, and it carries a marker of
+// its own: marking it as a file told a reader it could be read with file_get.
 func TestFormatTreeMarkdown(t *testing.T) {
-	out := TreeOutput{
+	got := FormatTreeMarkdown(TreeOutput{
 		Tree: []TreeNodeOutput{
 			{ID: "a", Name: "README.md", Type: "blob", Path: "README.md", Mode: "100644"},
 			{ID: "b", Name: "src", Type: "tree", Path: "src", Mode: "040000"},
+			{ID: "c", Name: "core", Type: "commit", Path: "libs/core", Mode: "160000"},
 		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 2},
-	}
-	md := FormatTreeMarkdown(out)
-	if !strings.Contains(md, "Repository Tree (2 entries)") {
-		t.Errorf("expected header with count, got:\n%s", md)
-	}
-	if !strings.Contains(md, "README.md") {
-		t.Error("expected README.md in output")
-	}
-	if !strings.Contains(md, "src") {
-		t.Error("expected src in output")
+		Pagination: toolutil.PaginationOutput{TotalItems: 3},
+	})
+
+	want := "## Repository Tree (3)\n\n" +
+		"| Type | Name | Path |\n" +
+		"| --- | --- | --- |\n" +
+		"| \U0001F4C4 | README.md | `README.md` |\n" +
+		"| \U0001F4C1 | src | `src` |\n" +
+		"| \U0001F517 | core | `libs/core` |\n" +
+		"\n3 items total\n" +
+		treeHints
+
+	if got != want {
+		t.Errorf("tree mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatTreeMarkdown_Empty verifies FormatTreeMarkdown when empty.
+// TestFormatTreeMarkdown_Empty pins the whole response of an empty tree.
 func TestFormatTreeMarkdown_Empty(t *testing.T) {
-	out := TreeOutput{
-		Tree:       nil,
-		Pagination: toolutil.PaginationOutput{TotalItems: 0},
-	}
-	md := FormatTreeMarkdown(out)
-	if !strings.Contains(md, "No files or directories found") {
-		t.Errorf("expected 'No files or directories found', got:\n%s", md)
+	got := FormatTreeMarkdown(TreeOutput{})
+
+	want := "No files or directories found.\n"
+
+	if got != want {
+		t.Errorf("empty tree mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCompareMarkdown verifies FormatCompareMarkdown.
+// TestFormatCompareMarkdown pins the whole comparison: the two counts as rows
+// of the card, then the commits and the changed files as the nested
+// collections they are.
 func TestFormatCompareMarkdown(t *testing.T) {
-	out := CompareOutput{
+	got := FormatCompareMarkdown(CompareOutput{
 		Commits: []commits.Output{
 			{ShortID: "abc1", Title: "feat: init", AuthorName: "Alice"},
 		},
 		Diffs: []DiffOutput{
-			{OldPath: "a.go", NewPath: "a.go", NewFile: false, DeletedFile: false, RenamedFile: false},
+			{OldPath: "a.go", NewPath: "a.go"},
 		},
 		WebURL: "https://gitlab.example.com/-/compare/main...develop",
-	}
-	md := FormatCompareMarkdown(out)
-	if !strings.Contains(md, "Repository Compare") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "abc1") {
-		t.Error("expected short_id in output")
-	}
-	if !strings.Contains(md, "a.go") {
-		t.Error("expected file path in output")
-	}
-	if !strings.Contains(md, "modified") {
-		t.Error("expected 'modified' status")
-	}
-	if !strings.Contains(md, "https://gitlab.example.com") {
-		t.Error("expected web URL")
+	})
+
+	want := "## Repository Compare\n\n" +
+		"- **Commits**: 1\n" +
+		"- **Changed Files**: 1\n" +
+		"- **URL**: [https://gitlab.example.com/-/compare/main...develop](https://gitlab.example.com/-/compare/main...develop)\n" +
+		"\n### Commits\n\n" +
+		"| Short ID | Title | Author |\n" +
+		"| --- | --- | --- |\n" +
+		"| `abc1` | feat: init | Alice |\n" +
+		"\n### Changed Files\n\n" +
+		"| Status | Path |\n" +
+		"| --- | --- |\n" +
+		"| modified | `a.go` |\n" +
+		compareHints
+
+	if got != want {
+		t.Errorf("compare mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCompareMarkdown_NewDeletedRenamed verifies FormatCompareMarkdown when new deleted renamed.
+// TestFormatCompareMarkdown_NewDeletedRenamed pins the three statuses a diff
+// carries beside "modified".
 func TestFormatCompareMarkdown_NewDeletedRenamed(t *testing.T) {
-	out := CompareOutput{
+	got := FormatCompareMarkdown(CompareOutput{
 		Diffs: []DiffOutput{
 			{NewPath: "new.go", NewFile: true},
 			{NewPath: "old.go", DeletedFile: true},
 			{NewPath: "moved.go", RenamedFile: true},
 		},
-	}
-	md := FormatCompareMarkdown(out)
-	if !strings.Contains(md, "added") {
-		t.Error("expected 'added' status for new file")
-	}
-	if !strings.Contains(md, "deleted") {
-		t.Error("expected 'deleted' status")
-	}
-	if !strings.Contains(md, "renamed") {
-		t.Error("expected 'renamed' status")
+	})
+
+	want := "## Repository Compare\n\n" +
+		"- **Commits**: 0\n" +
+		"- **Changed Files**: 3\n" +
+		"\n### Changed Files\n\n" +
+		"| Status | Path |\n" +
+		"| --- | --- |\n" +
+		"| added | `new.go` |\n" +
+		"| deleted | `old.go` |\n" +
+		"| renamed | `moved.go` |\n" +
+		compareHints
+
+	if got != want {
+		t.Errorf("compare mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCompareMarkdown_SameRef verifies FormatCompareMarkdown when same ref.
+// TestFormatCompareMarkdown_SameRef pins the whole answer to a comparison of a
+// ref with itself.
 func TestFormatCompareMarkdown_SameRef(t *testing.T) {
-	out := CompareOutput{CompareSameRef: true}
-	md := FormatCompareMarkdown(out)
-	if !strings.Contains(md, "same ref") {
-		t.Errorf("expected 'same ref' message, got:\n%s", md)
+	got := FormatCompareMarkdown(CompareOutput{CompareSameRef: true})
+
+	want := "## Repository Compare: same ref\n\n" +
+		"Both references point to the same commit.\n" +
+		compareAgainHints
+
+	if got != want {
+		t.Errorf("compare mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatCompareMarkdown_Timeout verifies FormatCompareMarkdown when timeout.
+// TestFormatCompareMarkdown_Timeout pins the whole answer to a comparison
+// GitLab gave up on.
 func TestFormatCompareMarkdown_Timeout(t *testing.T) {
-	out := CompareOutput{CompareTimeout: true}
-	md := FormatCompareMarkdown(out)
-	if !strings.Contains(md, "timeout") {
-		t.Errorf("expected 'timeout' message, got:\n%s", md)
+	got := FormatCompareMarkdown(CompareOutput{CompareTimeout: true})
+
+	want := "## Repository Compare: timeout\n\n" +
+		"The comparison timed out. Try again with a smaller range.\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.compare' to compare a smaller range\n"
+
+	if got != want {
+		t.Errorf("compare mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatContributorsMarkdown verifies FormatContributorsMarkdown.
+// TestFormatContributorsMarkdown pins the whole contributor listing, the
+// heading counting what the response vouches for.
 func TestFormatContributorsMarkdown(t *testing.T) {
-	out := ContributorsOutput{
+	got := FormatContributorsMarkdown(ContributorsOutput{
 		Contributors: []ContributorOutput{
 			{Name: "Alice", Email: "alice@test.com", Commits: 10, Additions: 500, Deletions: 100},
 			{Name: "Bob", Email: "bob@test.com", Commits: 5, Additions: 200, Deletions: 50},
 		},
-	}
-	md := FormatContributorsMarkdown(out)
-	if !strings.Contains(md, "Repository Contributors (2)") {
-		t.Errorf("expected header with count, got:\n%s", md)
-	}
-	if !strings.Contains(md, "Alice") {
-		t.Error("expected Alice in output")
-	}
-	if !strings.Contains(md, "Bob") {
-		t.Error("expected Bob in output")
+		Pagination: toolutil.PaginationOutput{TotalItems: 45, TotalPages: 3, Page: 1, PerPage: 20},
+	})
+
+	want := "## Repository Contributors (45)\n\n" +
+		"Showing 2 of 45 results (page 1 of 3)\n\n" +
+		"| Name | Email | Commits | Additions | Deletions |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| Alice | alice@test.com | 10 | 500 | 100 |\n" +
+		"| Bob | bob@test.com | 5 | 200 | 50 |\n" +
+		"\nPage 1 of 3 | 45 items total | 20 per page\n" +
+		contributorsHints
+
+	if got != want {
+		t.Errorf("contributors mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatContributorsMarkdown_Empty verifies FormatContributorsMarkdown when empty.
+// TestFormatContributorsMarkdown_Empty pins the whole response of a repository
+// with no contributors.
 func TestFormatContributorsMarkdown_Empty(t *testing.T) {
-	out := ContributorsOutput{Contributors: nil}
-	md := FormatContributorsMarkdown(out)
-	if !strings.Contains(md, "No contributors found") {
-		t.Errorf("expected 'No contributors found', got:\n%s", md)
+	got := FormatContributorsMarkdown(ContributorsOutput{})
+
+	want := "No contributors found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatBlobMarkdown verifies FormatBlobMarkdown.
+// TestFormatBlobMarkdown pins the whole blob card, which carries the metadata
+// and no body: raw_blob is the action that decodes the bytes.
 func TestFormatBlobMarkdown(t *testing.T) {
-	out := BlobOutput{SHA: "abc123", Size: 1024, Content: "base64data"}
-	md := FormatBlobMarkdown(out)
-	if !strings.Contains(md, "Repository Blob") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "abc123") {
-		t.Error("expected SHA in output")
-	}
-	if !strings.Contains(md, "1024 bytes") {
-		t.Error("expected size in output")
+	got := FormatBlobMarkdown(BlobOutput{SHA: "abc123", Size: 1024, Content: "base64data"})
+
+	want := "## Repository Blob\n\n" +
+		"- **SHA**: `abc123`\n" +
+		"- **Size (bytes)**: 1024\n" +
+		"- **Content Type**: text\n" +
+		"- **Characters**: 10\n" +
+		blobHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatRawBlobContentMarkdown verifies FormatRawBlobContentMarkdown.
+// TestFormatRawBlobContentMarkdown pins the whole raw blob card, the body
+// fenced: the blob is a file of the repository, so a fixed fence would be
+// closed by the first run of three backticks whoever pushed it wrote.
 func TestFormatRawBlobContentMarkdown(t *testing.T) {
-	out := RawBlobContentOutput{SHA: "def456", Size: 42, Content: "hello world"}
-	md := FormatRawBlobContentMarkdown(out)
-	if !strings.Contains(md, "Raw Blob Content") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "def456") {
-		t.Error("expected SHA in output")
-	}
-	if !strings.Contains(md, "hello world") {
-		t.Error("expected content in output")
+	got := FormatRawBlobContentMarkdown(RawBlobContentOutput{SHA: "def456", Size: 42, Content: "hello world"})
+
+	want := "## Repository Raw Blob Content\n\n" +
+		"- **SHA**: `def456`\n" +
+		"- **Size (bytes)**: 42\n" +
+		"\n```\nhello world\n```\n" +
+		rawBlobHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1203,7 +1301,7 @@ func TestMarkdownForResult_BlobContentCategories(t *testing.T) {
 		{
 			name:     "blob text",
 			result:   BlobOutput{SHA: "textsha", Size: 4, Content: "text", ContentCategory: "text"},
-			wantText: "Content**: text",
+			wantText: "Content Type**: text",
 		},
 		{
 			name:     "blob binary",
@@ -1312,72 +1410,101 @@ func TestClassifyBlobContent(t *testing.T) {
 	}
 }
 
-// TestFormatArchiveMarkdown verifies FormatArchiveMarkdown.
+// TestFormatArchiveMarkdown pins the whole archive card. All three values are
+// the caller's own arguments echoed back, so all three are rows the card
+// escapes.
 func TestFormatArchiveMarkdown(t *testing.T) {
-	out := ArchiveOutput{ProjectID: "42", SHA: "main", Format: "zip", URL: "https://example.com/archive.zip"}
-	md := FormatArchiveMarkdown(out)
-	if !strings.Contains(md, "Repository Archive") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "zip") {
-		t.Error("expected format in output")
-	}
-	if !strings.Contains(md, "main") {
-		t.Error("expected SHA/Ref in output")
-	}
-	if !strings.Contains(md, "https://example.com/archive.zip") {
-		t.Error("expected URL in output")
+	got := FormatArchiveMarkdown(ArchiveOutput{
+		ProjectID: "42", SHA: "main", Format: "zip", URL: "https://example.com/archive.zip",
+	})
+
+	want := "## Repository Archive\n\n" +
+		"- **Project**: 42\n" +
+		"- **Format**: zip\n" +
+		"- **SHA/Ref**: main\n" +
+		"- **URL**: [https://example.com/archive.zip](https://example.com/archive.zip)\n" +
+		archiveHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatArchiveMarkdown_NoSHA verifies FormatArchiveMarkdown when no SHA.
+// TestFormatArchiveMarkdown_NoSHA pins that an archive of the default branch,
+// which names no ref, writes no ref row.
 func TestFormatArchiveMarkdown_NoSHA(t *testing.T) {
-	out := ArchiveOutput{ProjectID: "42", Format: "tar.gz", URL: "https://example.com/archive.tar.gz"}
-	md := FormatArchiveMarkdown(out)
-	if strings.Contains(md, "SHA/Ref") {
-		t.Error("expected no SHA/Ref line when SHA is empty")
+	got := FormatArchiveMarkdown(ArchiveOutput{
+		ProjectID: "42", Format: "tar.gz", URL: "https://example.com/archive.tar.gz",
+	})
+
+	want := "## Repository Archive\n\n" +
+		"- **Project**: 42\n" +
+		"- **Format**: tar.gz\n" +
+		"- **URL**: [https://example.com/archive.tar.gz](https://example.com/archive.tar.gz)\n" +
+		archiveHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatAddChangelogMarkdown_Success verifies FormatAddChangelogMarkdown when success.
+// TestFormatAddChangelogMarkdown_Success pins the whole confirmation. The
+// version is the caller's own argument, so it is a row the card escapes rather
+// than bold text interpolated into a sentence.
 func TestFormatAddChangelogMarkdown_Success(t *testing.T) {
-	out := AddChangelogOutput{Success: true, Version: "1.0.0"}
-	md := FormatAddChangelogMarkdown(out)
-	if !strings.Contains(md, "Changelog Updated") {
-		t.Error("expected success header")
-	}
-	if !strings.Contains(md, "1.0.0") {
-		t.Error("expected version in output")
+	got := FormatAddChangelogMarkdown(AddChangelogOutput{Success: true, Version: "1.0.0"})
+
+	want := "## Changelog Updated\n\n" +
+		"- **Version**: 1.0.0\n\n" +
+		"The changelog data was committed successfully.\n" +
+		changelogGenerateHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatAddChangelogMarkdown_Failure verifies FormatAddChangelogMarkdown when failure.
+// TestFormatAddChangelogMarkdown_Failure pins the whole failure answer.
 func TestFormatAddChangelogMarkdown_Failure(t *testing.T) {
-	out := AddChangelogOutput{Success: false}
-	md := FormatAddChangelogMarkdown(out)
-	if !strings.Contains(md, "Failed") {
-		t.Error("expected failure header")
+	got := FormatAddChangelogMarkdown(AddChangelogOutput{Success: false})
+
+	want := "## Changelog Update Failed\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.changelog_generate' to generate the notes without committing them\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatChangelogDataMarkdown verifies FormatChangelogDataMarkdown.
+// TestFormatChangelogDataMarkdown pins the whole generated-changelog render.
+// The notes are release prose built out of commit messages, so they are fenced
+// rather than written raw, where a commit title carrying a heading used to
+// become part of this response.
 func TestFormatChangelogDataMarkdown(t *testing.T) {
-	out := ChangelogDataOutput{Notes: "## 1.0.0\n\n- feat: initial release\n"}
-	md := FormatChangelogDataMarkdown(out)
-	if !strings.Contains(md, "Generated Changelog Data") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(md, "1.0.0") {
-		t.Error("expected notes content")
+	got := FormatChangelogDataMarkdown(ChangelogDataOutput{Notes: "## 1.0.0\n\n- feat: initial release\n"})
+
+	want := "## Generated Changelog Data\n\n" +
+		"```markdown\n## 1.0.0\n\n- feat: initial release\n```\n" +
+		changelogDataHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatChangelogDataMarkdown_Empty verifies FormatChangelogDataMarkdown when empty.
+// TestFormatChangelogDataMarkdown_Empty pins the whole answer for a range with
+// no changelog entries.
 func TestFormatChangelogDataMarkdown_Empty(t *testing.T) {
-	out := ChangelogDataOutput{Notes: ""}
-	md := FormatChangelogDataMarkdown(out)
-	if !strings.Contains(md, "No changelog entries found") {
-		t.Errorf("expected 'No changelog entries found', got:\n%s", md)
+	got := FormatChangelogDataMarkdown(ChangelogDataOutput{})
+
+	want := "## Generated Changelog Data\n\n" +
+		"GitLab generated no changelog entries for this range.\n" +
+		"\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.changelog_generate' to widen the range with from and to\n"
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/repositorysubmodules/list_test.go
+++ b/internal/tools/repositorysubmodules/list_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 )
 
@@ -208,33 +206,37 @@ func TestParseGitmodules_RemoteWithCredentials_PublishesNeither(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown_RemoteWithCredentials_RendersNoPassword verifies that
-// the rendered submodule table, which is the text a model reads, carries no
-// part of a credentialed remote.
+// TestFormatListMarkdown_RemoteWithCredentials_RendersNoPassword pins the
+// whole rendered submodule table for a .gitmodules remote carrying a user name
+// and a password, which is the text a model reads: neither half of the
+// credential appears anywhere in it.
+//
+// The expectation is the whole render rather than two "does not contain"
+// checks, because an absence assertion passes just as happily over a table
+// that stopped rendering: this one fails if any byte of the row moves.
 func TestFormatListMarkdown_RemoteWithCredentials_RendersNoPassword(t *testing.T) {
 	entries := parseGitmodules("[submodule \"lib\"]\n\tpath = lib\n\turl = https://ciuser:s3cretpw@gitlab.example.com/group/project.git\n")
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-	result := FormatListMarkdown(ListOutput{Submodules: entries, Count: len(entries)})
-	if len(result.Content) == 0 {
-		t.Fatal("expected rendered content")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected text content, got %T", result.Content[0])
-	}
-	md := text.Text
 
+	got := renderedText(t, FormatListMarkdown(ListOutput{Submodules: entries, Count: len(entries)}))
+
+	want := "## Repository Submodules (1)\n\n" +
+		"| Name | Path | Commit SHA | Resolved Project |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| lib | `lib` |  | group/project |\n" +
+		submoduleListHints
+
+	if got != want {
+		t.Errorf("table mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
 	for _, secret := range []string{"s3cretpw", "ciuser"} {
 		t.Run("withholds "+secret, func(t *testing.T) {
-			if strings.Contains(md, secret) {
-				t.Errorf("submodule table leaked %q:\n%s", secret, md)
+			if strings.Contains(got, secret) {
+				t.Errorf("submodule table leaked %q:\n%s", secret, got)
 			}
 		})
-	}
-	if !strings.Contains(md, "group/project") {
-		t.Errorf("submodule table missing the resolved project:\n%s", md)
 	}
 }
 
@@ -374,42 +376,39 @@ func TestList_CancelledContext(t *testing.T) {
 
 // FormatListMarkdown tests.
 
-// TestFormatListMarkdown_WithEntries verifies FormatListMarkdown when with entries.
+// TestFormatListMarkdown_WithEntries pins the whole submodule table: the path
+// and the abbreviated commit are code spans a reader copies, and a pipe typed
+// into a .gitmodules name stays inside its own cell.
 func TestFormatListMarkdown_WithEntries(t *testing.T) {
-	out := ListOutput{
+	got := renderedText(t, FormatListMarkdown(ListOutput{
 		Submodules: []SubmoduleEntry{
 			{Name: "lib", Path: "lib", CommitSHA: "abc123def456", ResolvedProject: "group/lib"},
+			{Name: "a | b", Path: "vendor/x", CommitSHA: "0123456", ResolvedProject: "group/x"},
 		},
-		Count: 1,
-	}
-	r := FormatListMarkdown(out)
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(tc.Text, "abc123de") {
-		t.Error("expected truncated SHA in output")
-	}
-	if !strings.Contains(tc.Text, "group/lib") {
-		t.Error("expected resolved project in output")
+		Count: 2,
+	}))
+
+	want := "## Repository Submodules (2)\n\n" +
+		"| Name | Path | Commit SHA | Resolved Project |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| lib | `lib` | `abc123de` | group/lib |\n" +
+		"| a &#124; b | `vendor/x` | `0123456` | group/x |\n" +
+		submoduleListHints
+
+	if got != want {
+		t.Errorf("table mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty pins the whole response of a repository with no
+// submodules: one sentence, and no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	r := FormatListMarkdown(ListOutput{Submodules: []SubmoduleEntry{}, Count: 0})
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(tc.Text, "No submodules found") {
-		t.Error("expected empty message")
+	got := renderedText(t, FormatListMarkdown(ListOutput{Submodules: []SubmoduleEntry{}, Count: 0}))
+
+	want := "No submodules found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/repositorysubmodules/markdown.go
+++ b/internal/tools/repositorysubmodules/markdown.go
@@ -1,7 +1,6 @@
 package repositorysubmodules
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -9,75 +8,100 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown renders the submodule list as a Markdown table.
+// Canonical action IDs the hints name, the one form every surface resolves.
+// These actions are routes on the gitlab_repository catalog group, so each ID
+// carries that domain.
+const (
+	hintListSubmodules    = "repository.list_submodules"
+	hintReadSubmoduleFile = "repository.read_submodule_file"
+	hintUpdateSubmodule   = "repository.update_submodule"
+)
+
+// shortSHA is a git object id abbreviated to the eight characters a reader
+// compares by, or the whole id when it is shorter.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// FormatListMarkdown renders the submodules of a repository as a Markdown
+// table.
 func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	if out.Count == 0 {
-		return toolutil.ToolResultWithMarkdown("## Repository Submodules\n\nNo submodules found.")
+		return toolutil.ToolResultWithMarkdown(toolutil.EmptyMessage("submodules"))
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Repository Submodules (%d)\n\n", out.Count)
-	b.WriteString("| Name | Path | Commit SHA | Resolved Project |\n")
-	b.WriteString("|------|------|------------|------------------|\n")
+	toolutil.WriteListHeading(&b, "Repository Submodules", out.Count, toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Path", "Commit SHA", "Resolved Project"))
 	for _, s := range out.Submodules {
-		sha := s.CommitSHA
-		if len(sha) > 8 {
-			sha = sha[:8]
-		}
 		// The name, the path and the resolved project all come out of the
-		// repository's own .gitmodules, so all three are text somebody typed:
-		// resolveProjectPath returns the substring after the colon of an
-		// SCP-style remote verbatim.
-		//gitlab:allow-unescaped sha: the object id of a submodule tree entry, hexadecimal by construction.
-		fmt.Fprintf(&b, "| %s | `%s` | `%s` | %s |\n",
-			toolutil.EscapeMdTableCell(s.Name), toolutil.EscapeMdTableCell(s.Path), sha,
-			toolutil.EscapeMdTableCell(s.ResolvedProject))
+		// repository's own .gitmodules, so all three are text somebody typed;
+		// the path and the SHA are code spans a reader copies, and a code span
+		// sized by the helper cannot be closed from inside the value.
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(s.Name),
+			toolutil.MdCodeSpanCell(s.Path),
+			toolutil.MdCodeSpanCell(shortSHA(s.CommitSHA)),
+			toolutil.EscapeMdTableCell(s.ResolvedProject),
+		))
 	}
-	toolutil.WriteHints(&b, "Use `gitlab_read_repository_submodule_file` to view submodule content details")
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(hintReadSubmoduleFile, "read a file out of one submodule"),
+		toolutil.HintAction(hintUpdateSubmodule, "move a submodule to another commit"),
+	)
 	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
-// FormatReadMarkdown renders the submodule file read result as Markdown.
+// FormatReadMarkdown renders a file read out of a submodule as the card of the
+// file, with the body fenced under a section of its own.
 func FormatReadMarkdown(out ReadOutput) *mcp.CallToolResult {
 	ext := ""
 	if idx := strings.LastIndex(out.FileName, "."); idx >= 0 {
 		ext = out.FileName[idx+1:]
 	}
-	sha := out.CommitSHA
-	if len(sha) > 8 {
-		sha = sha[:8]
-	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "## File from Submodule\n\n")
-	fmt.Fprintf(&b, "- **Submodule**: `%s`\n", toolutil.EscapeMdTableCell(out.SubmodulePath))
-	fmt.Fprintf(&b, "- **Resolved Project**: %s\n", toolutil.EscapeMdTableCell(out.ResolvedProject))
-	fmt.Fprintf(&b, "- **Commit**: `%s`\n", sha)
-	fmt.Fprintf(&b, "- **File**: `%s` (%d bytes)\n\n", toolutil.EscapeMdTableCell(out.FilePath), out.Size)
+	c := toolutil.NewCard(&b, "File from Submodule")
+	c.Code("Submodule", out.SubmodulePath)
+	c.Field("Resolved Project", out.ResolvedProject)
+	c.Code("Commit", shortSHA(out.CommitSHA))
+	c.Code("File", out.FilePath)
+	c.Int("Size (bytes)", out.Size)
+	c.Field("Encoding", out.Encoding)
 	// The body is a file of the submodule's own repository, so whoever can push
 	// there chooses it: a three-backtick fence would be closed by the first run
 	// of three the file contains, and everything after it would render as
 	// Markdown of this response. The extension is read off the file name and is
 	// as much the pusher's choice, which is why the info string goes through the
 	// same helper rather than into the fence line by hand.
-	b.WriteString(toolutil.MarkdownFencedBlock(ext, out.Content))
-	toolutil.WriteHints(&b, "Use `gitlab_update_repository_submodule` to change the commit SHA reference")
+	c.Fence("Content", ext, out.Content)
+	c.End(toolutil.HintAction(hintUpdateSubmodule, "change the commit SHA this submodule is pinned to"))
 	return toolutil.ToolResultWithMarkdown(b.String())
 }
 
-// FormatUpdateMarkdown formats the submodule update result as markdown.
+// FormatUpdateMarkdown renders the commit a submodule update created as the
+// card of that commit.
 func FormatUpdateMarkdown(out UpdateOutput) *mcp.CallToolResult {
 	var b strings.Builder
+	c := toolutil.NewCard(&b, "Submodule Updated")
+	c.Code("Commit", out.ShortID)
+	c.Code("Full SHA", out.ID)
 	// The title, the ident and the message are what a person wrote in the
-	// commit, and this package's own update action supplies the message.
-	//gitlab:allow-unescaped out.ShortID: an abbreviated commit SHA, hexadecimal by construction.
-	//gitlab:allow-unescaped out.ID: the commit SHA GitLab returned for the commit the update created, hexadecimal by construction.
-	fmt.Fprintf(&b, "## Submodule Updated\n\n- **Commit**: %s (%s)\n- **Title**: %s\n- **Author**: %s <%s>\n- **Message**: %s",
-		out.ShortID, out.ID, toolutil.EscapeMdTableCell(out.Title), toolutil.EscapeMdTableCell(out.AuthorName),
-		toolutil.EscapeMdTableCell(out.AuthorEmail), toolutil.EscapeMdTableCell(out.Message))
-	if out.Status != "" {
-		//gitlab:allow-unescaped out.Status: a client-go BuildStateValue, one of a closed set of lowercase words.
-		fmt.Fprintf(&b, "\n- **Status**: %s", out.Status)
-	}
+	// commit, and this package's own update action supplies the message. The
+	// email is a plain row rather than an angle-bracketed ident, which GFM
+	// turns into a mailto autolink.
+	c.Field("Title", out.Title)
+	c.Field("Author", out.AuthorName)
+	c.Field("Author Email", out.AuthorEmail)
+	c.Time("Committed", out.CommittedDate)
+	c.Text("Message", out.Message)
+	c.Field("Status", out.Status)
+	c.End(
+		toolutil.HintAction(hintListSubmodules, "see every submodule of this repository"),
+		toolutil.HintAction(hintReadSubmoduleFile, "read a file at the new commit"),
+	)
 	return toolutil.ToolResultWithMarkdown(b.String())
 }
 

--- a/internal/tools/repositorysubmodules/markdown_test.go
+++ b/internal/tools/repositorysubmodules/markdown_test.go
@@ -12,6 +12,34 @@ import (
 // it is a heading of the server's response rather than a line of a file.
 const injectedLine = "## Injected heading"
 
+// The guidance sections the three submodule formatters close with, pinned
+// once so each whole-output expectation names them rather than restating them.
+const (
+	submoduleListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.read_submodule_file' to read a file out of one submodule\n" +
+		"- Use action 'repository.update_submodule' to move a submodule to another commit\n"
+
+	submoduleReadHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.update_submodule' to change the commit SHA this submodule is pinned to\n"
+
+	submoduleUpdateHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'repository.list_submodules' to see every submodule of this repository\n" +
+		"- Use action 'repository.read_submodule_file' to read a file at the new commit\n"
+)
+
+// renderedText returns the Markdown a formatter's result carries.
+func renderedText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("the formatter returned no content")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content is %T, want text", result.Content[0])
+	}
+	return text.Text
+}
+
 // TestFormatReadMarkdown_FenceOutlivesBacktickRunsInTheContent checks that the
 // block wrapping a submodule's file is closed by nothing the file contains.
 //

--- a/internal/tools/repositorysubmodules/read_test.go
+++ b/internal/tools/repositorysubmodules/read_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 )
 
@@ -229,9 +227,11 @@ func TestRead_Base64Content(t *testing.T) {
 
 // FormatReadMarkdown tests.
 
-// TestFormatReadMarkdown verifies FormatReadMarkdown.
+// TestFormatReadMarkdown pins the whole card of a file read out of a
+// submodule: the paths and the abbreviated commit as code spans, and the body
+// fenced with the language the file's own extension names.
 func TestFormatReadMarkdown(t *testing.T) {
-	out := ReadOutput{
+	got := renderedText(t, FormatReadMarkdown(ReadOutput{
 		FileName:        "main.c",
 		FilePath:        "src/main.c",
 		SubmodulePath:   "libs/core-module",
@@ -239,29 +239,22 @@ func TestFormatReadMarkdown(t *testing.T) {
 		CommitSHA:       "abc123def456789",
 		Size:            42,
 		Content:         "int main() {}",
-	}
-	r := FormatReadMarkdown(out)
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(tc.Text, "libs/core-module") {
-		t.Error("expected submodule path")
-	}
-	if !strings.Contains(tc.Text, "org/project") {
-		t.Error("expected resolved project")
-	}
-	if !strings.Contains(tc.Text, "abc123de") {
-		t.Error("expected truncated commit SHA")
-	}
-	if !strings.Contains(tc.Text, "int main() {}") {
-		t.Error("expected file content")
-	}
-	if !strings.Contains(tc.Text, "```c") {
-		t.Error("expected code block with extension")
+		Encoding:        "text",
+	}))
+
+	want := "## File from Submodule\n\n" +
+		"- **Submodule**: `libs/core-module`\n" +
+		"- **Resolved Project**: org/project\n" +
+		"- **Commit**: `abc123de`\n" +
+		"- **File**: `src/main.c`\n" +
+		"- **Size (bytes)**: 42\n" +
+		"- **Encoding**: text\n" +
+		"\n### Content\n\n" +
+		"```c\nint main() {}\n```\n" +
+		submoduleReadHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/repositorysubmodules/repository_submodules_test.go
+++ b/internal/tools/repositorysubmodules/repository_submodules_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/testutil"
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
@@ -119,60 +117,77 @@ func TestUpdate_Error(t *testing.T) {
 	}
 }
 
-// TestFormatUpdateMarkdown verifies FormatUpdateMarkdown.
+// TestFormatUpdateMarkdown pins the card of the commit a submodule update
+// created when GitLab answered with little more than the identity.
 func TestFormatUpdateMarkdown(t *testing.T) {
-	r := FormatUpdateMarkdown(UpdateOutput{
+	got := renderedText(t, FormatUpdateMarkdown(UpdateOutput{
 		ID:         "abc123",
 		ShortID:    "abc",
 		Title:      "Update submodule",
 		AuthorName: "Dev",
-	})
-	if r == nil {
-		t.Fatal("expected non-nil result")
+	}))
+
+	want := "## Submodule Updated\n\n" +
+		"- **Commit**: `abc`\n" +
+		"- **Full SHA**: `abc123`\n" +
+		"- **Title**: Update submodule\n" +
+		"- **Author**: Dev\n" +
+		submoduleUpdateHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatUpdateMarkdown_Content verifies FormatUpdateMarkdown when content.
+// TestFormatUpdateMarkdown_Content pins the whole card of a fully populated
+// update. The address is a row of its own rather than an angle-bracketed
+// ident, which GFM turns into a mailto autolink to an address nobody chose to
+// publish.
 func TestFormatUpdateMarkdown_Content(t *testing.T) {
-	out := UpdateOutput{
-		ID:          "abc123def456",
-		ShortID:     "abc123d",
-		Title:       "Update lib",
-		AuthorName:  "Alice",
-		AuthorEmail: "alice@example.com",
-		Message:     "Bump lib to v2",
-	}
-	r := FormatUpdateMarkdown(out)
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(tc.Text, "abc123d") {
-		t.Error("expected short ID")
-	}
-	if !strings.Contains(tc.Text, "Alice") {
-		t.Error("expected author")
+	got := renderedText(t, FormatUpdateMarkdown(UpdateOutput{
+		ID:            "abc123def456",
+		ShortID:       "abc123d",
+		Title:         "Update lib",
+		AuthorName:    "Alice",
+		AuthorEmail:   "alice@example.com",
+		CommittedDate: "2026-03-20T15:45:00Z",
+		Message:       "Bump lib to v2",
+	}))
+
+	want := "## Submodule Updated\n\n" +
+		"- **Commit**: `abc123d`\n" +
+		"- **Full SHA**: `abc123def456`\n" +
+		"- **Title**: Update lib\n" +
+		"- **Author**: Alice\n" +
+		"- **Author Email**: alice@example.com\n" +
+		"- **Committed**: 20 Mar 2026 15:45 UTC\n" +
+		"- **Message**: Bump lib to v2\n" +
+		submoduleUpdateHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatUpdateMarkdown_WithStatus verifies the Status line renders when status is set.
+// TestFormatUpdateMarkdown_WithStatus pins that the build state GitLab
+// reported is a row of the card.
 func TestFormatUpdateMarkdown_WithStatus(t *testing.T) {
-	out := UpdateOutput{
+	got := renderedText(t, FormatUpdateMarkdown(UpdateOutput{
 		ID:      "abc123def456",
 		ShortID: "abc123d",
 		Title:   "Update lib",
 		Status:  "success",
-	}
-	r := FormatUpdateMarkdown(out)
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(tc.Text, "**Status**") || !strings.Contains(tc.Text, "success") {
-		t.Errorf("expected Status line, got %q", tc.Text)
+	}))
+
+	want := "## Submodule Updated\n\n" +
+		"- **Commit**: `abc123d`\n" +
+		"- **Full SHA**: `abc123def456`\n" +
+		"- **Title**: Update lib\n" +
+		"- **Status**: success\n" +
+		submoduleUpdateHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/resourceevents/action_specs_test.go
+++ b/internal/tools/resourceevents/action_specs_test.go
@@ -155,51 +155,114 @@ func resourceEventSpecsByTool(t *testing.T, specs []toolutil.ActionSpec) map[str
 	return byTool
 }
 
-// TestFormatIterationEventsMarkdown_NonEmpty verifies the iteration events formatter.
+// The guidance sections the iteration and weight event results end with, so
+// each expectation below can pin the whole rendered document.
+const (
+	iterationListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use filters to narrow down iteration events by date or action\n"
+	iterationCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_issue_iteration_event_list` to see all iteration changes\n"
+	weightListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use filters to narrow down weight events by date\n"
+)
+
+// TestFormatIterationEventsMarkdown_NonEmpty pins the whole list document of
+// iteration events.
 func TestFormatIterationEventsMarkdown_NonEmpty(t *testing.T) {
-	md := FormatIterationEventsMarkdown(ListIterationEventsOutput{
+	got := FormatIterationEventsMarkdown(ListIterationEventsOutput{
 		Events: []IterationEventOutput{
 			{ID: 1, Action: "add", Iteration: &IterationOutput{ID: 5, Title: "Sprint 1"}, User: &EventUserOutput{Username: "user"}, CreatedAt: "2026-01-01T00:00:00Z"},
 		},
 	})
-	if md == "" || !strings.Contains(md, "Sprint 1") {
-		t.Fatalf("unexpected markdown: %q", md)
+
+	want := "## Iteration Events (1)\n\n" +
+		"| ID | Action | Iteration | User | Date |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | add | Sprint 1 | user | 1 Jan 2026 00:00 UTC |\n" +
+		iterationListHints
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatIterationEventMarkdown_NonEmpty verifies the single iteration event formatter.
+// TestFormatIterationEventMarkdown_NonEmpty pins the whole card of one
+// iteration event.
 func TestFormatIterationEventMarkdown_NonEmpty(t *testing.T) {
-	md := FormatIterationEventMarkdown(IterationEventOutput{
+	got := FormatIterationEventMarkdown(IterationEventOutput{
 		ID: 1, Action: "add", Iteration: &IterationOutput{ID: 5, Title: "Sprint 1"},
 		User: &EventUserOutput{Username: "user"}, ResourceType: "Issue", ResourceID: 10, CreatedAt: "2026-01-01T00:00:00Z",
 	})
-	if md == "" || !strings.Contains(md, "Sprint 1") {
-		t.Fatalf("unexpected markdown: %q", md)
+
+	want := "## Iteration Event #1\n\n" +
+		"- **Action**: add\n" +
+		"- **Iteration**: Sprint 1\n" +
+		"- **Iteration ID**: 5\n" +
+		"- **User**: user\n" +
+		"- **Resource Type**: Issue\n" +
+		"- **Resource ID**: 10\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		iterationCardHints
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatWeightEventsMarkdown_NonEmpty verifies the weight events formatter.
+// TestFormatIterationEventMarkdown_DeletedIteration pins the card of an event
+// whose iteration GitLab no longer sends: neither the title nor the ID is
+// written, where the card used to read "(ID: 0)".
+func TestFormatIterationEventMarkdown_DeletedIteration(t *testing.T) {
+	got := FormatIterationEventMarkdown(IterationEventOutput{ID: 2, Action: "remove", User: &EventUserOutput{Username: "user"}})
+
+	want := "## Iteration Event #2\n\n" +
+		"- **Action**: remove\n" +
+		"- **User**: user\n" +
+		iterationCardHints
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatWeightEventsMarkdown_NonEmpty pins the whole list document of
+// weight events.
+//
+// The column this table used to render came from resource_type and resource_id,
+// which the weight entity does not expose, so every row read as an empty type
+// followed by #0; the issue the entity does name is rendered as the database ID
+// it is, with no "#" in front of it to read as a per-project number.
 func TestFormatWeightEventsMarkdown_NonEmpty(t *testing.T) {
-	md := FormatWeightEventsMarkdown(ListWeightEventsOutput{
+	got := FormatWeightEventsMarkdown(ListWeightEventsOutput{
 		Events: []WeightEventOutput{
 			{ID: 2, Weight: 5, User: &EventUserOutput{Username: "user"}, IssueID: 10, CreatedAt: "2026-01-01T00:00:00Z"},
 		},
 	})
-	if md == "" || !strings.Contains(md, "5") {
-		t.Fatalf("unexpected markdown: %q", md)
+
+	want := "## Weight Events (1)\n\n" +
+		"| ID | Weight | User | Issue ID | Date |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 2 | 5 | user | 10 | 1 Jan 2026 00:00 UTC |\n" +
+		weightListHints
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	// The column this table used to render came from resource_type and
-	// resource_id, which the weight entity does not expose, so every row read
-	// as an empty type followed by #0. Asserting the weight alone would pass a
-	// renderer that still did that, or one that dropped the column.
-	if !strings.Contains(md, "| Issue |") {
-		t.Errorf("the header names no Issue column: %q", md)
+}
+
+// TestFormatWeightEventsMarkdown_Empty pins the whole response of an issue with
+// no weight events.
+func TestFormatWeightEventsMarkdown_Empty(t *testing.T) {
+	got := FormatWeightEventsMarkdown(ListWeightEventsOutput{})
+
+	if want := "No weight events found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
-	if !strings.Contains(md, "#10") {
-		t.Errorf("the row does not render the issue the entity names: %q", md)
-	}
-	if strings.Contains(md, "#0") {
-		t.Errorf("the row still renders a zero identifier: %q", md)
+}
+
+// TestFormatIterationEventsMarkdown_Empty pins the whole response of an issue
+// with no iteration events.
+func TestFormatIterationEventsMarkdown_Empty(t *testing.T) {
+	got := FormatIterationEventsMarkdown(ListIterationEventsOutput{})
+
+	if want := "No iteration events found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 

--- a/internal/tools/resourceevents/markdown.go
+++ b/internal/tools/resourceevents/markdown.go
@@ -2,158 +2,222 @@ package resourceevents
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// The values below reach a cell in this file with no escaper on them, because
-// each is a word GitLab picked from a fixed set rather than text anybody typed.
-// The five event kinds share them, so one declaration covers every table here.
-//
-//gitlab:allow-unescaped e.Action: a resource event action GitLab writes, either add or remove.
-//gitlab:allow-unescaped out.Action: a resource event action GitLab writes, either add or remove.
-//gitlab:allow-unescaped e.State: the state a state event recorded, one of GitLab's own set (closed, opened, merged).
-//gitlab:allow-unescaped out.State: the state a state event recorded, one of GitLab's own set (closed, opened, merged).
-//gitlab:allow-unescaped e.ResourceType: the kind of thing the event hangs on, which GitLab names Issue, MergeRequest or Epic.
-//gitlab:allow-unescaped out.ResourceType: the kind of thing the event hangs on, which GitLab names Issue, MergeRequest or Epic.
+// Every value GitLab sends here reaches the page through an escaper: the card
+// rows through [toolutil.Card], which escapes what it writes, and the table
+// cells through [toolutil.EscapeMdTableCell] at the row. The five event kinds
+// used to interpolate the action, the state and the resource type raw, under
+// declarations saying each was a word from a fixed set, and a word from a fixed
+// set survives the escaper unchanged, so the declarations bought nothing and
+// are gone.
 
 // FormatLabelEventsMarkdown formats a list of label events.
 func FormatLabelEventsMarkdown(out ListLabelEventsOutput) string {
 	if len(out.Events) == 0 {
-		return "No label events found.\n"
+		return toolutil.EmptyMessage("label events")
 	}
-	var sb strings.Builder
-	sb.WriteString("## Label Events\n\n| ID | Action | Label | User | Date |\n|---|---|---|---|---|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Label Events", len(out.Events), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Action", "Label", "User", "Date"))
 	for _, e := range out.Events {
-		fmt.Fprintf(&sb, fmtEventTableRow, e.ID, e.Action, labelName(e.Label), eventUsername(e.User), toolutil.FormatTime(e.CreatedAt))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			toolutil.EscapeMdTableCell(e.Action),
+			labelName(e.Label),
+			eventUsername(e.User),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use filters to narrow down label events by date or action")
-	return sb.String()
+	toolutil.WriteListFooter(&b, out.Pagination, false, "Use filters to narrow down label events by date or action")
+	return b.String()
 }
 
-// FormatLabelEventMarkdown formats a single label event.
+// FormatLabelEventMarkdown formats a single label event as a card.
 func FormatLabelEventMarkdown(out LabelEventOutput) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Label Event #%d\n\n", out.ID)
-	sb.WriteString(fmtPropertyValueTableHeader)
-	fmt.Fprintf(&sb, fmtActionRow, out.Action)
-	fmt.Fprintf(&sb, "| Label | %s |\n", labelName(out.Label))
-	fmt.Fprintf(&sb, fmtUserRow, eventUsername(out.User))
-	fmt.Fprintf(&sb, fmtResourceRow, out.ResourceType, out.ResourceID)
-	fmt.Fprintf(&sb, fmtCreatedRow, toolutil.FormatTime(out.CreatedAt))
-	toolutil.WriteHints(&sb, "Use `gitlab_issue_label_event_list` or `gitlab_mr_label_event_list` to see all label changes")
-	return sb.String()
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("Label Event #%d", out.ID))
+	c.Field("Action", out.Action)
+	c.Field("Label", labelName(out.Label))
+	c.Field("User", eventUsername(out.User))
+	writeEventResource(c, out.ResourceType, out.ResourceID)
+	c.Time("Created", out.CreatedAt)
+	c.End("Use `gitlab_issue_label_event_list` or `gitlab_mr_label_event_list` to see all label changes")
+	return b.String()
 }
 
 // FormatMilestoneEventsMarkdown formats a list of milestone events.
 func FormatMilestoneEventsMarkdown(out ListMilestoneEventsOutput) string {
 	if len(out.Events) == 0 {
-		return "No milestone events found.\n"
+		return toolutil.EmptyMessage("milestone events")
 	}
-	var sb strings.Builder
-	sb.WriteString("## Milestone Events\n\n| ID | Action | Milestone | User | Date |\n|---|---|---|---|---|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Milestone Events", len(out.Events), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Action", "Milestone", "User", "Date"))
 	for _, e := range out.Events {
-		fmt.Fprintf(&sb, fmtEventTableRow, e.ID, e.Action, milestoneTitle(e.Milestone), eventUsername(e.User), toolutil.FormatTime(e.CreatedAt))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			toolutil.EscapeMdTableCell(e.Action),
+			milestoneTitle(e.Milestone),
+			eventUsername(e.User),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use filters to narrow down milestone events by date or action")
-	return sb.String()
+	toolutil.WriteListFooter(&b, out.Pagination, false, "Use filters to narrow down milestone events by date or action")
+	return b.String()
 }
 
-// FormatMilestoneEventMarkdown formats a single milestone event.
+// FormatMilestoneEventMarkdown formats a single milestone event as a card. The
+// milestone's own ID is a row of its own and is written only when GitLab sent
+// one: an event whose milestone has been deleted used to read "(ID: 0)".
 func FormatMilestoneEventMarkdown(out MilestoneEventOutput) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Milestone Event #%d\n\n", out.ID)
-	sb.WriteString(fmtPropertyValueTableHeader)
-	fmt.Fprintf(&sb, fmtActionRow, out.Action)
-	fmt.Fprintf(&sb, "| Milestone | %s (ID: %d) |\n", milestoneTitle(out.Milestone), milestoneID(out.Milestone))
-	fmt.Fprintf(&sb, fmtUserRow, eventUsername(out.User))
-	fmt.Fprintf(&sb, fmtResourceRow, out.ResourceType, out.ResourceID)
-	fmt.Fprintf(&sb, fmtCreatedRow, toolutil.FormatTime(out.CreatedAt))
-	toolutil.WriteHints(&sb, "Use `gitlab_issue_milestone_event_list` or `gitlab_mr_milestone_event_list` to see all milestone changes")
-	return sb.String()
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("Milestone Event #%d", out.ID))
+	c.Field("Action", out.Action)
+	c.Field("Milestone", milestoneTitle(out.Milestone))
+	c.Count("Milestone ID", milestoneID(out.Milestone))
+	c.Field("User", eventUsername(out.User))
+	writeEventResource(c, out.ResourceType, out.ResourceID)
+	c.Time("Created", out.CreatedAt)
+	c.End("Use `gitlab_issue_milestone_event_list` or `gitlab_mr_milestone_event_list` to see all milestone changes")
+	return b.String()
 }
 
 // FormatStateEventsMarkdown formats a list of state events.
 func FormatStateEventsMarkdown(out ListStateEventsOutput) string {
 	if len(out.Events) == 0 {
-		return "No state events found.\n"
+		return toolutil.EmptyMessage("state events")
 	}
-	var sb strings.Builder
-	sb.WriteString("## State Events\n\n| ID | State | User | Resource | Date |\n|---|---|---|---|---|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "State Events", len(out.Events), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "State", "User", "Resource", "Date"))
 	for _, e := range out.Events {
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s #%d | %s |\n", e.ID, e.State, eventUsername(e.User), e.ResourceType, e.ResourceID, toolutil.FormatTime(e.CreatedAt))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			toolutil.EscapeMdTableCell(e.State),
+			eventUsername(e.User),
+			resourceReference(e.ResourceType, e.ResourceID),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use filters to narrow down state events by date or action")
-	return sb.String()
+	toolutil.WriteListFooter(&b, out.Pagination, false, "Use filters to narrow down state events by date or action")
+	return b.String()
 }
 
-// FormatStateEventMarkdown formats a single state event.
+// FormatStateEventMarkdown formats a single state event as a card.
 func FormatStateEventMarkdown(out StateEventOutput) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## State Event #%d\n\n", out.ID)
-	sb.WriteString(fmtPropertyValueTableHeader)
-	fmt.Fprintf(&sb, "| State | %s |\n", out.State)
-	fmt.Fprintf(&sb, fmtUserRow, eventUsername(out.User))
-	fmt.Fprintf(&sb, fmtResourceRow, out.ResourceType, out.ResourceID)
-	fmt.Fprintf(&sb, fmtCreatedRow, toolutil.FormatTime(out.CreatedAt))
-	toolutil.WriteHints(&sb, "Use `gitlab_issue_state_event_list` or `gitlab_mr_state_event_list` to see all state changes")
-	return sb.String()
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("State Event #%d", out.ID))
+	c.Field("State", out.State)
+	c.Field("User", eventUsername(out.User))
+	writeEventResource(c, out.ResourceType, out.ResourceID)
+	c.Time("Created", out.CreatedAt)
+	c.End("Use `gitlab_issue_state_event_list` or `gitlab_mr_state_event_list` to see all state changes")
+	return b.String()
 }
 
 // FormatIterationEventsMarkdown formats a list of iteration events.
 func FormatIterationEventsMarkdown(out ListIterationEventsOutput) string {
 	if len(out.Events) == 0 {
-		return "No iteration events found.\n"
+		return toolutil.EmptyMessage("iteration events")
 	}
-	var sb strings.Builder
-	sb.WriteString("## Iteration Events\n\n| ID | Action | Iteration | User | Date |\n|---|---|---|---|---|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Iteration Events", len(out.Events), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Action", "Iteration", "User", "Date"))
 	for _, e := range out.Events {
-		fmt.Fprintf(&sb, fmtEventTableRow, e.ID, e.Action, iterationTitle(e.Iteration), eventUsername(e.User), toolutil.FormatTime(e.CreatedAt))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			toolutil.EscapeMdTableCell(e.Action),
+			iterationTitle(e.Iteration),
+			eventUsername(e.User),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use filters to narrow down iteration events by date or action")
-	return sb.String()
+	toolutil.WriteListFooter(&b, out.Pagination, false, "Use filters to narrow down iteration events by date or action")
+	return b.String()
 }
 
-// FormatIterationEventMarkdown formats a single iteration event.
+// FormatIterationEventMarkdown formats a single iteration event as a card. The
+// iteration's own ID is written only when GitLab sent one, on the same terms as
+// the milestone's.
 func FormatIterationEventMarkdown(out IterationEventOutput) string {
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "## Iteration Event #%d\n\n", out.ID)
-	sb.WriteString(fmtPropertyValueTableHeader)
-	fmt.Fprintf(&sb, fmtActionRow, out.Action)
-	fmt.Fprintf(&sb, "| Iteration | %s (ID: %d) |\n", iterationTitle(out.Iteration), iterationID(out.Iteration))
-	fmt.Fprintf(&sb, fmtUserRow, eventUsername(out.User))
-	fmt.Fprintf(&sb, fmtResourceRow, out.ResourceType, out.ResourceID)
-	fmt.Fprintf(&sb, fmtCreatedRow, toolutil.FormatTime(out.CreatedAt))
-	toolutil.WriteHints(&sb, "Use `gitlab_issue_iteration_event_list` to see all iteration changes")
-	return sb.String()
+	var b strings.Builder
+	c := toolutil.NewCard(&b, fmt.Sprintf("Iteration Event #%d", out.ID))
+	c.Field("Action", out.Action)
+	c.Field("Iteration", iterationTitle(out.Iteration))
+	c.Count("Iteration ID", iterationID(out.Iteration))
+	c.Field("User", eventUsername(out.User))
+	writeEventResource(c, out.ResourceType, out.ResourceID)
+	c.Time("Created", out.CreatedAt)
+	c.End("Use `gitlab_issue_iteration_event_list` to see all iteration changes")
+	return b.String()
 }
 
 // FormatWeightEventsMarkdown formats a list of weight events.
 func FormatWeightEventsMarkdown(out ListWeightEventsOutput) string {
 	if len(out.Events) == 0 {
-		return "No weight events found.\n"
+		return toolutil.EmptyMessage("weight events")
 	}
-	var sb strings.Builder
-	// Issue rather than the Resource column its siblings render: the weight
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Weight Events", len(out.Events), out.Pagination)
+	// Issue ID rather than the Resource column its siblings render: the weight
 	// entity exposes issue_id and no resource_type or resource_id, so that
-	// column read " #0" on every row.
-	sb.WriteString("## Weight Events\n\n| ID | Weight | User | Issue | Date |\n|---|---|---|---|---|\n")
+	// column read " #0" on every row. The number is written plainly, since the
+	// issue_id of a weight event is the issue's database ID and a "#42" reads
+	// as the per-project number a reader could look up.
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Weight", "User", "Issue ID", "Date"))
 	for _, e := range out.Events {
-		fmt.Fprintf(&sb, "| %d | %d | %s | #%d | %s |\n", e.ID, e.Weight, eventUsername(e.User), e.IssueID, toolutil.FormatTime(e.CreatedAt))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(e.ID, 10),
+			strconv.FormatInt(e.Weight, 10),
+			eventUsername(e.User),
+			strconv.FormatInt(e.IssueID, 10),
+			toolutil.FormatTime(e.CreatedAt),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use filters to narrow down weight events by date")
-	return sb.String()
+	toolutil.WriteListFooter(&b, out.Pagination, false, "Use filters to narrow down weight events by date")
+	return b.String()
+}
+
+// writeEventResource writes the object an event hangs on as two rows: the kind
+// GitLab names it with, and its database ID when GitLab sent one. The pair used
+// to be one "Issue #42" line, whose sigil reads as the per-project number a
+// reader could look up while the value is the database ID, and whose zero read
+// as a resource that does not exist.
+func writeEventResource(c *toolutil.Card, resourceType string, resourceID int64) {
+	c.Field("Resource Type", resourceType)
+	c.Count("Resource ID", resourceID)
+}
+
+// resourceReference renders the same pair as one table cell, "Issue (ID 42)",
+// and nothing at all when GitLab named neither.
+func resourceReference(resourceType string, resourceID int64) string {
+	kind := toolutil.EscapeMdTableCell(resourceType)
+	switch {
+	case kind == "" && resourceID == 0:
+		return ""
+	case kind == "":
+		return "ID " + strconv.FormatInt(resourceID, 10)
+	case resourceID == 0:
+		return kind
+	default:
+		return fmt.Sprintf("%s (ID %d)", kind, resourceID)
+	}
 }
 
 // eventUsername returns the username of an event's user as a table cell, or ""
 // when absent.
 //
 // This accessor and the three below exist only to fill the cells of this
-// file's tables, so each escapes what it returns rather than leaving the
-// question to a dozen call sites. A label name and the two titles are text a
-// person typed, and GitLab's only rule on a label name is that it holds no
-// comma.
+// file's tables and the rows of its cards, so each escapes what it returns
+// rather than leaving the question to a dozen call sites; the card escaper is
+// idempotent, so a value reaching a row through one of them renders unchanged.
+// A label name and the two titles are text a person typed, and GitLab's only
+// rule on a label name is that it holds no comma.
 func eventUsername(u *EventUserOutput) string {
 	if u == nil {
 		return ""

--- a/internal/tools/resourceevents/resource_events.go
+++ b/internal/tools/resourceevents/resource_events.go
@@ -10,15 +10,6 @@ import (
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-const (
-	fmtPropertyValueTableHeader = "| Property | Value |\n|---|---|\n"
-	fmtUserRow                  = "| User | %s |\n"
-	fmtResourceRow              = "| Resource | %s #%d |\n"
-	fmtCreatedRow               = "| Created | %s |\n"
-	fmtEventTableRow            = "| %d | %s | %s | %s | %s |\n"
-	fmtActionRow                = "| Action | %s |\n"
-)
-
 // ---------------------------------------------------------------------------
 // Input types
 // ---------------------------------------------------------------------------.

--- a/internal/tools/resourceevents/resource_events_test.go
+++ b/internal/tools/resourceevents/resource_events_test.go
@@ -843,87 +843,203 @@ func TestCovtoStateEventOutput_NilUser(t *testing.T) {
 
 // ======================== Formatters ========================.
 
-// TestFormatLabelEventsMarkdown_Empty verifies FormatLabelEventsMarkdown when empty.
+// The guidance sections the label, milestone and state event results end with,
+// so each expectation below can pin the whole rendered document.
+const (
+	labelListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use filters to narrow down label events by date or action\n"
+	labelCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_issue_label_event_list` or `gitlab_mr_label_event_list` to see all label changes\n"
+	milestoneListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use filters to narrow down milestone events by date or action\n"
+	milestoneCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_issue_milestone_event_list` or `gitlab_mr_milestone_event_list` to see all milestone changes\n"
+	stateListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use filters to narrow down state events by date or action\n"
+	stateCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_issue_state_event_list` or `gitlab_mr_state_event_list` to see all state changes\n"
+)
+
+// TestFormatLabelEventsMarkdown_Empty pins the whole response of an issue with
+// no label events.
 func TestFormatLabelEventsMarkdown_Empty(t *testing.T) {
-	md := FormatLabelEventsMarkdown(ListLabelEventsOutput{})
-	if !strings.Contains(md, "No label events found") {
-		t.Error("expected empty label events message")
+	got := FormatLabelEventsMarkdown(ListLabelEventsOutput{})
+
+	if want := "No label events found.\n"; got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatLabelEventsMarkdown_WithEvents verifies FormatLabelEventsMarkdown when with events.
+// TestFormatLabelEventsMarkdown_WithEvents pins the whole list document: the
+// heading counts the total GitLab reported, and the pagination footer opens a
+// block of its own after the last row, where the list used to end at the row and
+// say nothing about the pages that follow.
 func TestFormatLabelEventsMarkdown_WithEvents(t *testing.T) {
 	out := ListLabelEventsOutput{
-		Events: []LabelEventOutput{{ID: 1, Action: "add", Label: &LabelEventLabelOutput{Name: "bug"}, User: &EventUserOutput{Username: "alice"}}},
+		Events:     []LabelEventOutput{{ID: 1, Action: "add", Label: &LabelEventLabelOutput{Name: "bug"}, User: &EventUserOutput{Username: "alice"}, CreatedAt: "2026-01-01T00:00:00Z"}},
+		Pagination: toolutil.PaginationOutput{Page: 1, PerPage: 20, TotalItems: 45, TotalPages: 3, NextPage: 2, HasMore: true},
 	}
-	md := FormatLabelEventsMarkdown(out)
-	if !strings.Contains(md, "bug") || !strings.Contains(md, "alice") {
-		t.Error("expected label and user in markdown")
+
+	got := FormatLabelEventsMarkdown(out)
+
+	want := "## Label Events (45)\n\n" +
+		"Showing 1 of 45 results (page 1 of 3)\n\n" +
+		"| ID | Action | Label | User | Date |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | add | bug | alice | 1 Jan 2026 00:00 UTC |\n\n" +
+		"Page 1 of 3 | 45 items total | 20 per page\n" +
+		labelListHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatLabelEventMarkdown verifies FormatLabelEventMarkdown.
+// TestFormatLabelEventMarkdown pins the whole card of one label event, the
+// object it hangs on as two rows rather than one "Issue #1" whose sigil reads as
+// the per-project number while the value is the database ID.
 func TestFormatLabelEventMarkdown(t *testing.T) {
-	out := LabelEventOutput{ID: 10, Action: "add", Label: &LabelEventLabelOutput{Name: "bug"}, User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1}
-	md := FormatLabelEventMarkdown(out)
-	if !strings.Contains(md, "Label Event #10") || !strings.Contains(md, "bug") {
-		t.Error("expected label event details")
+	out := LabelEventOutput{ID: 10, Action: "add", Label: &LabelEventLabelOutput{Name: "bug"}, User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1, CreatedAt: "2026-01-01T00:00:00Z"}
+
+	got := FormatLabelEventMarkdown(out)
+
+	want := "## Label Event #10\n\n" +
+		"- **Action**: add\n" +
+		"- **Label**: bug\n" +
+		"- **User**: alice\n" +
+		"- **Resource Type**: Issue\n" +
+		"- **Resource ID**: 1\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		labelCardHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatMilestoneEventsMarkdown_Empty verifies FormatMilestoneEventsMarkdown when empty.
+// TestFormatLabelEventMarkdown_DeletedActors pins the card of an event whose
+// user and label GitLab no longer sends: each row is absent rather than empty,
+// where the card used to print a label with nothing after it.
+func TestFormatLabelEventMarkdown_DeletedActors(t *testing.T) {
+	got := FormatLabelEventMarkdown(LabelEventOutput{ID: 11, Action: "remove"})
+
+	want := "## Label Event #11\n\n" +
+		"- **Action**: remove\n" +
+		labelCardHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
+	}
+}
+
+// TestFormatMilestoneEventsMarkdown_Empty pins the whole response of an issue
+// with no milestone events.
 func TestFormatMilestoneEventsMarkdown_Empty(t *testing.T) {
-	md := FormatMilestoneEventsMarkdown(ListMilestoneEventsOutput{})
-	if !strings.Contains(md, "No milestone events found") {
-		t.Error("expected empty milestone events message")
+	got := FormatMilestoneEventsMarkdown(ListMilestoneEventsOutput{})
+
+	if want := "No milestone events found.\n"; got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatMilestoneEventsMarkdown_WithEvents verifies FormatMilestoneEventsMarkdown when with events.
+// TestFormatMilestoneEventsMarkdown_WithEvents pins the whole list document of
+// a single page: no summary line and no pagination footer, since there is
+// nothing to page through.
 func TestFormatMilestoneEventsMarkdown_WithEvents(t *testing.T) {
 	out := ListMilestoneEventsOutput{
-		Events: []MilestoneEventOutput{{ID: 1, Action: "add", Milestone: &MilestoneOutput{Title: "v1.0"}, User: &EventUserOutput{Username: "alice"}}},
+		Events: []MilestoneEventOutput{{ID: 1, Action: "add", Milestone: &MilestoneOutput{Title: "v1.0"}, User: &EventUserOutput{Username: "alice"}, CreatedAt: "2026-01-01T00:00:00Z"}},
 	}
-	md := FormatMilestoneEventsMarkdown(out)
-	if !strings.Contains(md, "v1.0") || !strings.Contains(md, "alice") {
-		t.Error("expected milestone and user in markdown")
+
+	got := FormatMilestoneEventsMarkdown(out)
+
+	want := "## Milestone Events (1)\n\n" +
+		"| ID | Action | Milestone | User | Date |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | add | v1.0 | alice | 1 Jan 2026 00:00 UTC |\n" +
+		milestoneListHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatMilestoneEventMarkdown verifies FormatMilestoneEventMarkdown.
+// TestFormatMilestoneEventMarkdown pins the whole card of one milestone event,
+// the milestone's own ID a row of its own.
 func TestFormatMilestoneEventMarkdown(t *testing.T) {
-	out := MilestoneEventOutput{ID: 30, Action: "add", Milestone: &MilestoneOutput{ID: 200, Title: "v1.0"}, User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1}
-	md := FormatMilestoneEventMarkdown(out)
-	if !strings.Contains(md, "Milestone Event #30") || !strings.Contains(md, "v1.0") {
-		t.Error("expected milestone event details")
+	out := MilestoneEventOutput{ID: 30, Action: "add", Milestone: &MilestoneOutput{ID: 200, Title: "v1.0"}, User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1, CreatedAt: "2026-01-01T00:00:00Z"}
+
+	got := FormatMilestoneEventMarkdown(out)
+
+	want := "## Milestone Event #30\n\n" +
+		"- **Action**: add\n" +
+		"- **Milestone**: v1.0\n" +
+		"- **Milestone ID**: 200\n" +
+		"- **User**: alice\n" +
+		"- **Resource Type**: Issue\n" +
+		"- **Resource ID**: 1\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		milestoneCardHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatStateEventsMarkdown_Empty verifies FormatStateEventsMarkdown when empty.
+// TestFormatMilestoneEventMarkdown_DeletedMilestone pins the card of an event
+// whose milestone has since been deleted: neither the title nor the ID is
+// written, where the card used to read "(ID: 0)" for a milestone that is not
+// there.
+func TestFormatMilestoneEventMarkdown_DeletedMilestone(t *testing.T) {
+	got := FormatMilestoneEventMarkdown(MilestoneEventOutput{ID: 31, Action: "remove", User: &EventUserOutput{Username: "alice"}})
+
+	want := "## Milestone Event #31\n\n" +
+		"- **Action**: remove\n" +
+		"- **User**: alice\n" +
+		milestoneCardHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
+	}
+}
+
+// TestFormatStateEventsMarkdown_Empty pins the whole response of an issue with
+// no state events.
 func TestFormatStateEventsMarkdown_Empty(t *testing.T) {
-	md := FormatStateEventsMarkdown(ListStateEventsOutput{})
-	if !strings.Contains(md, "No state events found") {
-		t.Error("expected empty state events message")
+	got := FormatStateEventsMarkdown(ListStateEventsOutput{})
+
+	if want := "No state events found.\n"; got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatStateEventsMarkdown_WithEvents verifies FormatStateEventsMarkdown when with events.
+// TestFormatStateEventsMarkdown_WithEvents pins the whole list document, the
+// resource cell naming the kind and the ID rather than a "#" reference.
 func TestFormatStateEventsMarkdown_WithEvents(t *testing.T) {
 	out := ListStateEventsOutput{
-		Events: []StateEventOutput{{ID: 1, State: "closed", User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1}},
+		Events: []StateEventOutput{{ID: 1, State: "closed", User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1, CreatedAt: "2026-01-01T00:00:00Z"}},
 	}
-	md := FormatStateEventsMarkdown(out)
-	if !strings.Contains(md, "closed") || !strings.Contains(md, "alice") {
-		t.Error("expected state and user in markdown")
+
+	got := FormatStateEventsMarkdown(out)
+
+	want := "## State Events (1)\n\n" +
+		"| ID | State | User | Resource | Date |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | closed | alice | Issue (ID 1) | 1 Jan 2026 00:00 UTC |\n" +
+		stateListHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 
-// TestFormatStateEventMarkdown verifies FormatStateEventMarkdown.
+// TestFormatStateEventMarkdown pins the whole card of one state event.
 func TestFormatStateEventMarkdown(t *testing.T) {
-	out := StateEventOutput{ID: 40, State: "closed", User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1}
-	md := FormatStateEventMarkdown(out)
-	if !strings.Contains(md, "State Event #40") || !strings.Contains(md, "closed") {
-		t.Error("expected state event details")
+	out := StateEventOutput{ID: 40, State: "closed", User: &EventUserOutput{Username: "alice"}, ResourceType: "Issue", ResourceID: 1, CreatedAt: "2026-01-01T00:00:00Z"}
+
+	got := FormatStateEventMarkdown(out)
+
+	want := "## State Event #40\n\n" +
+		"- **State**: closed\n" +
+		"- **User**: alice\n" +
+		"- **Resource Type**: Issue\n" +
+		"- **Resource ID**: 1\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		stateCardHints
+	if got != want {
+		t.Errorf(fmtGotWant, got, want)
 	}
 }
 

--- a/internal/tools/resourcegroups/markdown.go
+++ b/internal/tools/resourcegroups/markdown.go
@@ -1,54 +1,98 @@
 package resourcegroups
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatListMarkdown renders resource groups as a compact Markdown table.
-func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	sb.WriteString("## Resource Groups\n\n")
-	if len(out.Groups) == 0 {
-		sb.WriteString("No resource groups found.\n")
-		return sb.String()
-	}
-	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Key", "Process Mode"))
-	for _, g := range out.Groups {
-		//gitlab:allow-unescaped g.ProcessMode: a resource group process mode GitLab picks from a fixed set (unordered, oldest_first, newest_first).
-		fmt.Fprintf(&sb, "| %d | %s | %s |\n", g.ID, toolutil.EscapeMdTableCell(g.Key), g.ProcessMode)
-	}
-	toolutil.WriteHints(&sb, "Use `gitlab_get_resource_group` to view details or edit process mode")
-	return sb.String()
-}
+// Canonical action IDs the hints name. They are the IDs the catalog builds
+// from the group that owns these actions, gitlab_pipeline, so a hint names
+// what every surface resolves.
+const (
+	hintActionResourceGroupGet          = "pipeline.resource_group_get"
+	hintActionResourceGroupEdit         = "pipeline.resource_group_edit"
+	hintActionResourceGroupList         = "pipeline.resource_group_list"
+	hintActionResourceGroupUpcomingJobs = "pipeline.resource_group_upcoming_jobs"
+	hintActionJobGet                    = "job.get"
+	hintActionJobTrace                  = "job.trace"
+)
 
-// FormatGroupMarkdown renders a single resource group summary.
-func FormatGroupMarkdown(g ResourceGroupItem) string {
+// FormatListMarkdown renders a project's resource groups as a Markdown table.
+//
+// The two next steps are named separately: reading one group and changing its
+// process mode are different actions, and one hint offering both named a tool
+// that only reads.
+func FormatListMarkdown(out ListOutput) string {
+	if len(out.Groups) == 0 {
+		return toolutil.EmptyMessage("resource groups")
+	}
 	var b strings.Builder
-	// The key is the resource_group name written in .gitlab-ci.yml.
-	fmt.Fprintf(&b, "## Resource Group\n\n- **ID**: %d\n- **Key**: %s\n- **Process Mode**: %s\n",
-		g.ID, toolutil.EscapeMdTableCell(g.Key), g.ProcessMode)
-	toolutil.WriteHints(&b, "Use `gitlab_list_resource_group_upcoming_jobs` to see upcoming jobs for this group")
+	toolutil.WriteListHeading(&b, "Resource Groups", len(out.Groups), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Key", "Process Mode"))
+	for _, g := range out.Groups {
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(g.ID, 10),
+			toolutil.EscapeMdTableCell(g.Key),
+			toolutil.EscapeMdTableCell(g.ProcessMode),
+		))
+	}
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(hintActionResourceGroupGet, "see one resource group in full"),
+		toolutil.HintAction(hintActionResourceGroupEdit, "change a group's process mode"),
+	)
 	return b.String()
 }
 
-// FormatJobsMarkdown renders upcoming resource-group jobs as a Markdown table.
+// FormatGroupMarkdown renders one resource group as the card of a single
+// object.
+func FormatGroupMarkdown(g ResourceGroupItem) string {
+	var b strings.Builder
+	c := toolutil.NewCard(&b, "Resource Group: "+g.Key)
+	c.Int("ID", g.ID)
+	// The key is the resource_group name written in .gitlab-ci.yml.
+	c.Field("Key", g.Key)
+	c.Field("Process Mode", g.ProcessMode)
+	c.End(
+		toolutil.HintAction(hintActionResourceGroupUpcomingJobs, "see the jobs waiting on this group"),
+		toolutil.HintAction(hintActionResourceGroupEdit, "change its process mode"),
+	)
+	return b.String()
+}
+
+// FormatJobsMarkdown renders the jobs waiting on a resource group as a
+// Markdown table.
 func FormatJobsMarkdown(out ListUpcomingJobsOutput) string {
-	var sb strings.Builder
-	sb.WriteString("## Upcoming Jobs\n\n")
 	if len(out.Jobs) == 0 {
-		sb.WriteString("No upcoming jobs.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("upcoming jobs")
 	}
-	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Status", "Stage"))
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Upcoming Jobs", len(out.Jobs), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Status", "Stage"))
 	for _, j := range out.Jobs {
-		//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, toolutil.EscapeMdTableCell(j.Stage))
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(j.ID, 10),
+			toolutil.EscapeMdTableCell(j.Name),
+			jobStatusCell(j.Status),
+			toolutil.EscapeMdTableCell(j.Stage),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use job tools to view logs or retry specific jobs")
-	return sb.String()
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(hintActionJobGet, "see one of these jobs in full"),
+		toolutil.HintAction(hintActionJobTrace, "read a job's log"),
+		toolutil.HintAction(hintActionResourceGroupList, "see the other resource groups of this project"),
+	)
+	return b.String()
+}
+
+// jobStatusCell renders a job status with the glyph every job row in the tree
+// shows, and nothing when GitLab sent no status.
+func jobStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
 }
 
 func init() {

--- a/internal/tools/resourcegroups/resource_groups_test.go
+++ b/internal/tools/resourcegroups/resource_groups_test.go
@@ -134,11 +134,20 @@ func TestListUpcomingJobs_Error(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown verifies FormatListMarkdown.
+// TestFormatListMarkdown checks the whole list rendering. The two next steps
+// are named separately: reading one group and changing its process mode are
+// different actions, and one hint offering both named a tool that only reads.
 func TestFormatListMarkdown(t *testing.T) {
+	want := "## Resource Groups (1)\n\n" +
+		"| ID | Key | Process Mode |\n" +
+		"| --- | --- | --- |\n" +
+		"| 1 | prod | unordered |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'pipeline.resource_group_get' to see one resource group in full\n" +
+		"- Use action 'pipeline.resource_group_edit' to change a group's process mode\n"
 	md := FormatListMarkdown(ListOutput{Groups: []ResourceGroupItem{{ID: 1, Key: "prod", ProcessMode: "unordered"}}})
-	if md == "" {
-		t.Error("expected non-empty markdown")
+	if md != want {
+		t.Errorf("FormatListMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -150,12 +159,9 @@ func TestFormatListMarkdown(t *testing.T) {
 
 // TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{Groups: nil})
-	if !strings.Contains(md, "No resource groups found") {
-		t.Errorf("expected empty message, got:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No resource groups found.\n"
+	if md := FormatListMarkdown(ListOutput{Groups: nil}); md != want {
+		t.Errorf("FormatListMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -166,17 +172,15 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 // TestFormatGroupMarkdown verifies FormatGroupMarkdown.
 func TestFormatGroupMarkdown(t *testing.T) {
 	md := FormatGroupMarkdown(ResourceGroupItem{ID: 42, Key: "staging", ProcessMode: "oldest_first"})
-	for _, want := range []string{
-		"## Resource Group",
-		"**ID**: 42",
-		"**Key**: staging",
-		"**Process Mode**: oldest_first",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Resource Group: staging\n\n" +
+		"- **ID**: 42\n" +
+		"- **Key**: staging\n" +
+		"- **Process Mode**: oldest_first\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'pipeline.resource_group_upcoming_jobs' to see the jobs waiting on this group\n" +
+		"- Use action 'pipeline.resource_group_edit' to change its process mode\n"
+	if md != want {
+		t.Errorf("FormatGroupMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
@@ -192,32 +196,27 @@ func TestFormatJobsMarkdown_WithData(t *testing.T) {
 			{ID: 11, Name: "build", Status: "created", Stage: "build"},
 		},
 	})
-	for _, want := range []string{
-		"## Upcoming Jobs",
-		"| ID |",
-		"| 10 |",
-		"| 11 |",
-		"deploy",
-		"build",
-		"pending",
-		"created",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	// The status carries the glyph every job row in the tree shows, which this
+	// table was the one place not to.
+	want := "## Upcoming Jobs (2)\n\n" +
+		"| ID | Name | Status | Stage |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 10 | deploy | 🟡 pending | deploy |\n" +
+		"| 11 | build | 🆕 created | build |\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- Use action 'job.get' to see one of these jobs in full\n" +
+		"- Use action 'job.trace' to read a job's log\n" +
+		"- Use action 'pipeline.resource_group_list' to see the other resource groups of this project\n"
+	if md != want {
+		t.Errorf("FormatJobsMarkdown()\n got %q\nwant %q", md, want)
 	}
 }
 
 // TestFormatJobsMarkdown_Empty verifies FormatJobsMarkdown when empty.
 func TestFormatJobsMarkdown_Empty(t *testing.T) {
-	md := FormatJobsMarkdown(ListUpcomingJobsOutput{Jobs: nil})
-	if !strings.Contains(md, "No upcoming jobs") {
-		t.Errorf("expected empty message, got:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	const want = "No upcoming jobs found.\n"
+	if md := FormatJobsMarkdown(ListUpcomingJobsOutput{Jobs: nil}); md != want {
+		t.Errorf("FormatJobsMarkdown(empty)\n got %q\nwant %q", md, want)
 	}
 }
 

--- a/internal/tools/runnercontrollers/markdown.go
+++ b/internal/tools/runnercontrollers/markdown.go
@@ -2,72 +2,82 @@ package runnercontrollers
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a runner controller as Markdown.
+// Canonical action IDs the hints name, the one form every surface resolves: a
+// controller action is projected under the runner domain.
+const (
+	actionControllerGet       = "runner.controller_get"
+	actionControllerList      = "runner.controller_list"
+	actionControllerUpdate    = "runner.controller_update"
+	actionControllerTokenList = "runner.controller_token_list"
+	actionControllerScopeList = "runner.controller_scope_list"
+)
+
+// writeController writes the fields every runner controller carries, so the
+// summary and the detail card cannot drift apart.
+func writeController(c *toolutil.Card, out Output) {
+	c.Int("ID", out.ID)
+	c.Text("Description", out.Description)
+	// A runner controller state, a typed enum client-go renders from GitLab's
+	// own fixed set.
+	c.Field("State", out.State)
+	c.Time("Created", out.CreatedAt)
+	c.Time("Updated", out.UpdatedAt)
+}
+
+// FormatOutputMarkdown renders one runner controller as the card of a single
+// object.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Controller #%d\n\n", out.ID)
-	toolutil.WriteDescription(&b, out.Description)
-	//gitlab:allow-unescaped out.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
-	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	if out.UpdatedAt != "" {
-		fmt.Fprintf(&b, "- **Updated At**: %s\n", toolutil.FormatTime(out.UpdatedAt))
-	}
-	toolutil.WriteHints(&b, "Use `gitlab_runner_controller_token_list` to manage authentication")
+	c := toolutil.NewCard(&b, fmt.Sprintf("Runner Controller #%d", out.ID))
+	writeController(c, out)
+	c.End(
+		toolutil.HintAction(actionControllerGet, "see this controller's full details"),
+		toolutil.HintAction(actionControllerTokenList, "manage the tokens it authenticates with"),
+	)
 	return b.String()
 }
 
-// FormatDetailsMarkdown renders detailed runner controller info as Markdown.
+// FormatDetailsMarkdown renders one runner controller in full: the same fields
+// with whether it is connected right now.
 func FormatDetailsMarkdown(out DetailsOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Controller #%d: Details\n\n", out.ID)
-	toolutil.WriteDescription(&b, out.Description)
-	//gitlab:allow-unescaped out.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
-	fmt.Fprintf(&b, toolutil.FmtMdState, out.State)
-	fmt.Fprintf(&b, "- **Connected**: %t\n", out.Connected)
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	if out.UpdatedAt != "" {
-		fmt.Fprintf(&b, "- **Updated At**: %s\n", toolutil.FormatTime(out.UpdatedAt))
-	}
-	toolutil.WriteHints(&b, "Use `gitlab_runner_controller_scope_list` to view scopes")
+	c := toolutil.NewCard(&b, fmt.Sprintf("Runner Controller #%d: Details", out.ID))
+	writeController(c, out.Output)
+	c.Bool("Connected", out.Connected)
+	c.End(
+		toolutil.HintAction(actionControllerScopeList, "see the runners this controller is scoped to"),
+		toolutil.HintAction(actionControllerUpdate, "change its description or state"),
+	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of runner controllers as Markdown.
+// FormatListMarkdown renders a page of runner controllers as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Controllers) == 0 {
-		return "No runner controllers found.\n"
+		return toolutil.EmptyMessage("runner controllers")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Controllers (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Controllers), out.Pagination)
-	b.WriteString("| ID | Description | State | Created At |\n")
-	b.WriteString("| --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Runner Controllers", len(out.Controllers), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Description", "State", "Created"))
 	for _, rc := range out.Controllers {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s |\n",
-			//gitlab:allow-unescaped rc.State: a runner controller state, a typed enum client-go renders from GitLab's own fixed set.
-			//gitlab:allow-unescaped rc.CreatedAt: a timestamp this package formatted itself, with time.Time.Format as RFC 3339.
-			rc.ID, toolutil.EscapeMdTableCell(rc.Description), rc.State, rc.CreatedAt)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(rc.ID, 10),
+			toolutil.EscapeMdTableCell(rc.Description),
+			toolutil.EscapeMdTableCell(rc.State),
+			toolutil.FormatTime(rc.CreatedAt),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, "Use `gitlab_runner_controller_get` to view details of a specific controller")
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionControllerGet, "see one controller in full"),
+		toolutil.HintAction(actionControllerList, "page through the rest of the controllers"),
+	)
 	return b.String()
-}
-
-// FormatGetMarkdown formats Get output as an MCP tool result.
-func FormatGetMarkdown(out DetailsOutput) *mcp.CallToolResult {
-	return toolutil.ToolResultWithMarkdown(FormatDetailsMarkdown(out))
 }
 
 func init() {

--- a/internal/tools/runnercontrollers/runner_controllers_test.go
+++ b/internal/tools/runnercontrollers/runner_controllers_test.go
@@ -409,90 +409,115 @@ func TestDelete_ContextCancelled(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown verifies Markdown formatting with and without timestamps.
+// summaryHints, detailHints and listHints are the guidance sections the three
+// controller renderings close with.
+const (
+	summaryHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_get' to see this controller's full details\n" +
+		"- Use action 'runner.controller_token_list' to manage the tokens it authenticates with\n"
+	detailHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_scope_list' to see the runners this controller is scoped to\n" +
+		"- Use action 'runner.controller_update' to change its description or state\n"
+	listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_get' to see one controller in full\n" +
+		"- Use action 'runner.controller_list' to page through the rest of the controllers\n"
+)
+
+// TestFormatOutputMarkdown pins the whole card of a runner controller, with
+// and without the timestamps GitLab may omit.
 func TestFormatOutputMarkdown(t *testing.T) {
-	out := Output{
+	got := FormatOutputMarkdown(Output{
 		ID: 1, Description: "ctrl-1", State: "enabled",
 		CreatedAt: "2026-01-15T10:00:00Z", UpdatedAt: "2026-01-15T12:00:00Z",
+	})
+
+	want := "## Runner Controller #1\n\n" +
+		"- **ID**: 1\n" +
+		"- **Description**: ctrl-1\n" +
+		"- **State**: enabled\n" +
+		"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+		"- **Updated**: 15 Jan 2026 12:00 UTC\n" +
+		summaryHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	md := FormatOutputMarkdown(out)
-	for _, want := range []string{"ctrl-1", "enabled", "Created At", "Updated At"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q: %s", want, md)
-			}
-		})
-	}
+	bare := FormatOutputMarkdown(Output{ID: 1, Description: "ctrl-1", State: "enabled"})
 
-	// Without timestamps
-	out.CreatedAt = ""
-	out.UpdatedAt = ""
-	md = FormatOutputMarkdown(out)
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At when empty")
+	wantBare := "## Runner Controller #1\n\n" +
+		"- **ID**: 1\n" +
+		"- **Description**: ctrl-1\n" +
+		"- **State**: enabled\n" +
+		summaryHints
+
+	if bare != wantBare {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", bare, wantBare)
 	}
 }
 
-// TestFormatDetailsMarkdown verifies detailed Markdown formatting.
+// TestFormatDetailsMarkdown pins the whole detail card: the same fields with
+// the connection flag as a glyph rather than as the word "true".
 func TestFormatDetailsMarkdown(t *testing.T) {
-	out := DetailsOutput{
-		ID: 1, Description: "ctrl-1", State: "enabled", CreatedAt: "2026-01-15T10:00:00Z", UpdatedAt: "2026-01-15T12:00:00Z",
+	got := FormatDetailsMarkdown(DetailsOutput{
+		ID: 1, Description: "ctrl-1", State: "enabled",
+		CreatedAt: "2026-01-15T10:00:00Z", UpdatedAt: "2026-01-15T12:00:00Z",
 		Connected: true,
+	})
+
+	want := "## Runner Controller #1: Details\n\n" +
+		"- **ID**: 1\n" +
+		"- **Description**: ctrl-1\n" +
+		"- **State**: enabled\n" +
+		"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+		"- **Updated**: 15 Jan 2026 12:00 UTC\n" +
+		"- **Connected**: ✅\n" +
+		detailHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	md := FormatDetailsMarkdown(out)
-	for _, want := range []string{"ctrl-1", "Details", "true", "Created At"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q: %s", want, md)
-			}
-		})
-	}
+	disconnected := FormatDetailsMarkdown(DetailsOutput{
+		ID: 2, Description: "ctrl-2", State: "disabled",
+	})
 
-	// Without timestamps
-	out.CreatedAt = ""
-	out.UpdatedAt = ""
-	md = FormatDetailsMarkdown(out)
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At when empty")
+	wantDisconnected := "## Runner Controller #2: Details\n\n" +
+		"- **ID**: 2\n" +
+		"- **Description**: ctrl-2\n" +
+		"- **State**: disabled\n" +
+		"- **Connected**: ❌\n" +
+		detailHints
+
+	if disconnected != wantDisconnected {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", disconnected, wantDisconnected)
 	}
 }
 
-// TestFormatListMarkdown verifies list Markdown with data and empty.
+// TestFormatListMarkdown pins the whole listing: the heading counting what
+// GitLab reported, the created column in the display form rather than the wire
+// one, and the empty answer as one sentence.
 func TestFormatListMarkdown(t *testing.T) {
-	out := ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Controllers: []Output{
-			{ID: 1, Description: "ctrl-1", State: "enabled"},
+			{ID: 1, Description: "ctrl-1", State: "enabled", CreatedAt: "2026-01-15T10:00:00Z"},
 			{ID: 2, Description: "ctrl-2", State: "disabled"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
+	})
+
+	want := "## Runner Controllers (2)\n\n" +
+		"| ID | Description | State | Created |\n| --- | --- | --- | --- |\n" +
+		"| 1 | ctrl-1 | enabled | 15 Jan 2026 10:00 UTC |\n" +
+		"| 2 | ctrl-2 | disabled |  |\n" +
+		"\n2 items total\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	md := FormatListMarkdown(out)
-	for _, want := range []string{"ctrl-1", "ctrl-2", "enabled", "disabled"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q: %s", want, md)
-			}
-		})
-	}
-
-	// Empty
-	md = FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No runner controllers found") {
-		t.Errorf("expected empty message, got: %s", md)
-	}
-}
-
-// TestFormatGetMarkdown verifies FormatGetMarkdown returns a non-nil result.
-func TestFormatGetMarkdown(t *testing.T) {
-	out := DetailsOutput{
-		ID: 1, Description: "ctrl-1", State: "enabled",
-		Connected: true,
-	}
-	result := FormatGetMarkdown(out)
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if empty := FormatListMarkdown(ListOutput{}); empty != "No runner controllers found.\n" {
+		t.Errorf("empty list mismatch:\ngot:\n%s", empty)
 	}
 }

--- a/internal/tools/runnercontrollerscopes/markdown.go
+++ b/internal/tools/runnercontrollerscopes/markdown.go
@@ -2,65 +2,80 @@ package runnercontrollerscopes
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatScopesMarkdown renders scopes as Markdown.
+// The canonical catalog IDs the hints name. A scope action is projected under
+// the runner domain, so the ID every surface resolves carries that prefix,
+// which the bare action names in action_specs.go do not.
+const (
+	hintActionScopeList           = "runner." + actionScopeList
+	hintActionScopeAddInstance    = "runner." + actionScopeAddInstance
+	hintActionScopeAddRunner      = "runner." + actionScopeAddRunner
+	hintActionScopeRemoveInstance = "runner." + actionScopeRemoveInstance
+	hintActionScopeRemoveRunner   = "runner." + actionScopeRemoveRunner
+)
+
+// FormatScopesMarkdown renders every scope a runner controller holds: the card
+// of one controller's scoping, with each kind of scope as a nested collection
+// under a heading of its own.
 func FormatScopesMarkdown(out ScopesOutput) string {
 	var b strings.Builder
-	b.WriteString("## Runner Controller Scopes\n\n")
-	fmt.Fprintf(&b, "### Instance-Level Scopes (%d)\n\n", len(out.InstanceLevelScopings))
+	c := toolutil.NewCard(&b, "Runner Controller Scopes")
 	if len(out.InstanceLevelScopings) == 0 {
-		b.WriteString("No instance-level scopes configured.\n")
+		c.Section(fmt.Sprintf("Instance-Level Scopes (%d)", 0)).
+			Note("No instance-level scopes configured.")
 	} else {
-		b.WriteString("| Created At | Updated At |\n")
-		b.WriteString("| --- | --- |\n")
+		t := c.Table(fmt.Sprintf("Instance-Level Scopes (%d)", len(out.InstanceLevelScopings)), "Created", "Updated")
 		for _, is := range out.InstanceLevelScopings {
-			fmt.Fprintf(&b, "| %s | %s |\n", toolutil.FormatTime(is.CreatedAt), toolutil.FormatTime(is.UpdatedAt))
+			t.Row(toolutil.FormatTime(is.CreatedAt), toolutil.FormatTime(is.UpdatedAt))
 		}
-		b.WriteString("\n")
 	}
-	fmt.Fprintf(&b, "### Runner-Level Scopes (%d)\n\n", len(out.RunnerLevelScopings))
 	if len(out.RunnerLevelScopings) == 0 {
-		b.WriteString("No runner-level scopes configured.\n")
+		c.Section(fmt.Sprintf("Runner-Level Scopes (%d)", 0)).
+			Note("No runner-level scopes configured.")
 	} else {
-		b.WriteString("| Runner ID | Created At | Updated At |\n")
-		b.WriteString("| --- | --- | --- |\n")
+		t := c.Table(fmt.Sprintf("Runner-Level Scopes (%d)", len(out.RunnerLevelScopings)), "Runner ID", "Created", "Updated")
 		for _, rs := range out.RunnerLevelScopings {
-			fmt.Fprintf(&b, "| %d | %s | %s |\n", rs.RunnerID, toolutil.FormatTime(rs.CreatedAt), toolutil.FormatTime(rs.UpdatedAt))
+			t.Row(strconv.FormatInt(rs.RunnerID, 10), toolutil.FormatTime(rs.CreatedAt), toolutil.FormatTime(rs.UpdatedAt))
 		}
 	}
-	toolutil.WriteHints(&b, "Use `gitlab_runner_controller_scope_add_instance` to add a new scope")
+	c.End(
+		toolutil.HintAction(hintActionScopeAddInstance, "grant this controller the instance-level scope"),
+		toolutil.HintAction(hintActionScopeAddRunner, "scope this controller to one more runner"),
+	)
 	return b.String()
 }
 
-// FormatInstanceScopeMarkdown renders an instance scope result as Markdown.
+// FormatInstanceScopeMarkdown renders the instance-level scope a controller was
+// granted as the card of one object.
 func FormatInstanceScopeMarkdown(out InstanceScopeOutput) string {
 	var b strings.Builder
-	b.WriteString("## Instance-Level Scope\n\n")
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	if out.UpdatedAt != "" {
-		fmt.Fprintf(&b, "- **Updated At**: %s\n", toolutil.FormatTime(out.UpdatedAt))
-	}
-	toolutil.WriteHints(&b, "Use scope tools to manage this controller's scopes")
+	c := toolutil.NewCard(&b, "Instance-Level Scope")
+	c.Time("Created", out.CreatedAt)
+	c.Time("Updated", out.UpdatedAt)
+	c.End(
+		toolutil.HintAction(hintActionScopeList, "see every scope this controller holds"),
+		toolutil.HintAction(hintActionScopeRemoveInstance, "revoke the instance-level scope"),
+	)
 	return b.String()
 }
 
-// FormatRunnerScopeMarkdown renders a runner scope result as Markdown.
+// FormatRunnerScopeMarkdown renders the scope tying a controller to one runner
+// as the card of one object.
 func FormatRunnerScopeMarkdown(out RunnerScopeOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Scope (Runner #%d)\n\n", out.RunnerID)
-	if out.CreatedAt != "" {
-		fmt.Fprintf(&b, "- **Created At**: %s\n", toolutil.FormatTime(out.CreatedAt))
-	}
-	if out.UpdatedAt != "" {
-		fmt.Fprintf(&b, "- **Updated At**: %s\n", toolutil.FormatTime(out.UpdatedAt))
-	}
-	toolutil.WriteHints(&b, "Use scope tools to manage this controller's scopes")
+	c := toolutil.NewCard(&b, fmt.Sprintf("Runner Scope (Runner #%d)", out.RunnerID))
+	c.Int("Runner ID", out.RunnerID)
+	c.Time("Created", out.CreatedAt)
+	c.Time("Updated", out.UpdatedAt)
+	c.End(
+		toolutil.HintAction(hintActionScopeList, "see every scope this controller holds"),
+		toolutil.HintAction(hintActionScopeRemoveRunner, "remove this runner from the controller's scope"),
+	)
 	return b.String()
 }
 

--- a/internal/tools/runnercontrollerscopes/runner_controller_scopes_test.go
+++ b/internal/tools/runnercontrollerscopes/runner_controller_scopes_test.go
@@ -363,81 +363,132 @@ func TestRemoveRunnerScope_ContextCancelled(t *testing.T) {
 	}
 }
 
-// TestFormatScopesMarkdown verifies Markdown for scopes with various combinations.
-func TestFormatScopesMarkdown(t *testing.T) {
-	// Both instance and runner scopes
-	out := ScopesOutput{
+// scopesHints, instanceHints and runnerHints are the guidance sections the
+// three scope renderings close with.
+const (
+	scopesHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_scope_add_instance' to grant this controller the instance-level scope\n" +
+		"- Use action 'runner.controller_scope_add_runner' to scope this controller to one more runner\n"
+	instanceHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_scope_list' to see every scope this controller holds\n" +
+		"- Use action 'runner.controller_scope_remove_instance' to revoke the instance-level scope\n"
+	runnerHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.controller_scope_list' to see every scope this controller holds\n" +
+		"- Use action 'runner.controller_scope_remove_runner' to remove this runner from the controller's scope\n"
+)
+
+// TestFormatScopesMarkdown_BothKinds pins the whole card of a controller that
+// holds both kinds of scope: each collection as a table of its own, under a
+// heading that counts it.
+func TestFormatScopesMarkdown_BothKinds(t *testing.T) {
+	got := FormatScopesMarkdown(ScopesOutput{
 		InstanceLevelScopings: []InstanceScopeItem{
 			{CreatedAt: "2026-01-15T10:00:00Z", UpdatedAt: "2026-01-15T12:00:00Z"},
 		},
 		RunnerLevelScopings: []RunnerScopeItem{
 			{RunnerID: 42, CreatedAt: "2026-01-15T10:00:00Z", UpdatedAt: "2026-01-15T12:00:00Z"},
 		},
-	}
+	})
 
-	md := FormatScopesMarkdown(out)
-	for _, want := range []string{"Instance-Level", "Runner-Level", "42"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q: %s", want, md)
-			}
-		})
-	}
+	want := "## Runner Controller Scopes\n\n" +
+		"### Instance-Level Scopes (1)\n\n" +
+		"| Created | Updated |\n| --- | --- |\n" +
+		"| 15 Jan 2026 10:00 UTC | 15 Jan 2026 12:00 UTC |\n" +
+		"\n### Runner-Level Scopes (1)\n\n" +
+		"| Runner ID | Created | Updated |\n| --- | --- | --- |\n" +
+		"| 42 | 15 Jan 2026 10:00 UTC | 15 Jan 2026 12:00 UTC |\n" +
+		scopesHints
 
-	// Empty instance scopes
-	out.InstanceLevelScopings = nil
-	md = FormatScopesMarkdown(out)
-	if !strings.Contains(md, "No instance-level scopes") {
-		t.Errorf("expected empty instance message: %s", md)
-	}
-
-	// Empty runner scopes
-	out.RunnerLevelScopings = nil
-	out.InstanceLevelScopings = []InstanceScopeItem{{CreatedAt: "2026-01-15T10:00:00Z"}}
-	md = FormatScopesMarkdown(out)
-	if !strings.Contains(md, "No runner-level scopes") {
-		t.Errorf("expected empty runner message: %s", md)
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatInstanceScopeMarkdown verifies instance scope Markdown formatting.
+// TestFormatScopesMarkdown_EmptyKinds pins the card of a controller with no
+// scope of one kind or of either: the section says so in a sentence instead of
+// opening an empty table.
+func TestFormatScopesMarkdown_EmptyKinds(t *testing.T) {
+	noInstance := FormatScopesMarkdown(ScopesOutput{
+		RunnerLevelScopings: []RunnerScopeItem{{RunnerID: 42, CreatedAt: "2026-01-15T10:00:00Z"}},
+	})
+
+	wantNoInstance := "## Runner Controller Scopes\n\n" +
+		"### Instance-Level Scopes (0)\n\n" +
+		"No instance-level scopes configured.\n" +
+		"\n### Runner-Level Scopes (1)\n\n" +
+		"| Runner ID | Created | Updated |\n| --- | --- | --- |\n" +
+		"| 42 | 15 Jan 2026 10:00 UTC |  |\n" +
+		scopesHints
+
+	if noInstance != wantNoInstance {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", noInstance, wantNoInstance)
+	}
+
+	neither := FormatScopesMarkdown(ScopesOutput{})
+
+	wantNeither := "## Runner Controller Scopes\n\n" +
+		"### Instance-Level Scopes (0)\n\n" +
+		"No instance-level scopes configured.\n" +
+		"\n### Runner-Level Scopes (0)\n\n" +
+		"No runner-level scopes configured.\n" +
+		scopesHints
+
+	if neither != wantNeither {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", neither, wantNeither)
+	}
+}
+
+// TestFormatInstanceScopeMarkdown pins the whole card of an instance-level
+// scope, with and without the timestamps GitLab may omit.
 func TestFormatInstanceScopeMarkdown(t *testing.T) {
-	out := InstanceScopeOutput{
+	got := FormatInstanceScopeMarkdown(InstanceScopeOutput{
 		CreatedAt: "2026-01-15T10:00:00Z",
 		UpdatedAt: "2026-01-15T12:00:00Z",
+	})
+
+	want := "## Instance-Level Scope\n\n" +
+		"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+		"- **Updated**: 15 Jan 2026 12:00 UTC\n" +
+		instanceHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	md := FormatInstanceScopeMarkdown(out)
-	if !strings.Contains(md, "Created At") || !strings.Contains(md, "Updated At") {
-		t.Errorf("markdown missing timestamps: %s", md)
-	}
+	bare := FormatInstanceScopeMarkdown(InstanceScopeOutput{})
 
-	// Without timestamps
-	md = FormatInstanceScopeMarkdown(InstanceScopeOutput{})
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At when empty")
+	if wantBare := "## Instance-Level Scope\n" + instanceHints; bare != wantBare {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", bare, wantBare)
 	}
 }
 
-// TestFormatRunnerScopeMarkdown verifies runner scope Markdown formatting.
+// TestFormatRunnerScopeMarkdown pins the whole card of a runner-level scope,
+// with and without the timestamps GitLab may omit.
 func TestFormatRunnerScopeMarkdown(t *testing.T) {
-	out := RunnerScopeOutput{
+	got := FormatRunnerScopeMarkdown(RunnerScopeOutput{
 		RunnerID:  42,
 		CreatedAt: "2026-01-15T10:00:00Z",
 		UpdatedAt: "2026-01-15T12:00:00Z",
+	})
+
+	want := "## Runner Scope (Runner #42)\n\n" +
+		"- **Runner ID**: 42\n" +
+		"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+		"- **Updated**: 15 Jan 2026 12:00 UTC\n" +
+		runnerHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 
-	md := FormatRunnerScopeMarkdown(out)
-	if !strings.Contains(md, "42") || !strings.Contains(md, "Created At") {
-		t.Errorf("markdown missing data: %s", md)
-	}
+	bare := FormatRunnerScopeMarkdown(RunnerScopeOutput{RunnerID: 42})
 
-	// Without timestamps
-	out.CreatedAt = ""
-	out.UpdatedAt = ""
-	md = FormatRunnerScopeMarkdown(out)
-	if strings.Contains(md, "Created At") {
-		t.Error("should not contain Created At when empty")
+	wantBare := "## Runner Scope (Runner #42)\n\n" +
+		"- **Runner ID**: 42\n" +
+		runnerHints
+
+	if bare != wantBare {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", bare, wantBare)
 	}
 }
 

--- a/internal/tools/runners/markdown.go
+++ b/internal/tools/runners/markdown.go
@@ -2,179 +2,261 @@ package runners
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatOutputMarkdown renders a runner output as Markdown.
+// Canonical action IDs the hints name, the one form every surface resolves.
+const (
+	actionRunnerGet          = "runner.get"
+	actionRunnerJobs         = "runner.jobs"
+	actionRunnerList         = "runner.list"
+	actionRunnerUpdate       = "runner.update"
+	actionRunnerRemove       = "runner.remove"
+	actionRunnerRegister     = "runner.register"
+	actionRunnerVerify       = "runner.verify"
+	actionRunnerListManagers = "runner.list_managers"
+	actionJobGet             = "job.get"
+)
+
+// writeRunnerSummary writes the fields a runner carries wherever it is
+// rendered, so the summary and the detail card cannot drift apart.
+func writeRunnerSummary(c *toolutil.Card, name, description, runnerType, status, jobStatus string, shared, online, paused bool) {
+	c.Field("Name", name)
+	c.Field("Description", description)
+	// A runner type GitLab picks from a fixed set (instance_type, group_type,
+	// project_type) and a status it derives from when the runner last
+	// contacted it (online, offline, stale, never_contacted).
+	c.Field("Type", runnerType)
+	c.Field("Status", status)
+	c.Field("Job Execution Status", jobStatus)
+	c.Bool("Shared", shared)
+	c.Bool("Online", online)
+	// Paused is the one negative-polarity flag here: a tick against "Paused"
+	// reads as a runner in good order, which is the opposite of what it means.
+	c.Warn("Paused", paused)
+}
+
+// FormatOutputMarkdown renders one runner as the card of a single object.
+//
+// A runner GitLab has just created or registered answers with the
+// authentication token it minted, once and nowhere else, so the card shows it
+// as a secret and [toolutil.Card.End] adds the sentence saying it cannot be
+// read back. The table this replaced published every other field and dropped
+// the token on the floor, which made the register action unusable: the value
+// it exists to return was not in its answer.
 func FormatOutputMarkdown(out Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner #%d\n\n", out.ID)
-	b.WriteString("| Field | Value |\n")
-	b.WriteString(toolutil.TblSep2Col)
-	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
-	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
-	//gitlab:allow-unescaped out.RunnerType: a runner type GitLab picks from a fixed set (instance_type, group_type, project_type).
-	//gitlab:allow-unescaped out.Status: a runner status GitLab derives from when the runner last contacted it (online, offline, stale, never_contacted).
-	fmt.Fprintf(&b, "| Type | %s |\n", out.RunnerType)
-	fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
-	fmt.Fprintf(&b, "| Paused | %s |\n", toolutil.BoolEmoji(out.Paused))
-	fmt.Fprintf(&b, "| Shared | %s |\n", toolutil.BoolEmoji(out.IsShared))
-	fmt.Fprintf(&b, "| Online | %s |\n", toolutil.BoolEmoji(out.Online))
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' for full runner configuration",
-		"Use action 'jobs' to see jobs executed by this runner",
+	c := toolutil.NewCard(&b, fmt.Sprintf("Runner #%d", out.ID))
+	c.Int("ID", out.ID)
+	writeRunnerSummary(c, out.Name, out.Description, out.RunnerType, out.Status, out.JobExecutionStatus,
+		out.IsShared, out.Online, out.Paused)
+	c.Code("IP Address", out.IPAddress)
+	c.Time("Created", out.CreatedAt)
+	if out.CreatedBy != nil {
+		c.Markdown("Created By", toolutil.MdUserLink(out.CreatedBy.Username, out.CreatedBy.WebURL))
+	}
+	c.Secret("Token", out.Token)
+	c.Time("Token Expires", out.TokenExpiresAt)
+	c.End(
+		toolutil.HintAction(actionRunnerGet, "see this runner's full configuration"),
+		toolutil.HintAction(actionRunnerJobs, "list the jobs it has run"),
 	)
 	return b.String()
 }
 
-// FormatDetailsMarkdown renders detailed runner information as Markdown.
+// FormatDetailsMarkdown renders one runner in full: its configuration, then
+// the projects and groups it serves as nested collections.
 func FormatDetailsMarkdown(out DetailsOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner #%d: Details\n\n", out.ID)
-	b.WriteString("| Field | Value |\n")
-	b.WriteString(toolutil.TblSep2Col)
-	fmt.Fprintf(&b, "| Name | %s |\n", toolutil.EscapeMdTableCell(out.Name))
-	fmt.Fprintf(&b, "| Description | %s |\n", toolutil.EscapeMdTableCell(out.Description))
-	//gitlab:allow-unescaped out.RunnerType: a runner type GitLab picks from a fixed set (instance_type, group_type, project_type).
-	//gitlab:allow-unescaped out.Status: a runner status GitLab derives from when the runner last contacted it (online, offline, stale, never_contacted).
-	fmt.Fprintf(&b, "| Type | %s |\n", out.RunnerType)
-	fmt.Fprintf(&b, "| Status | %s |\n", out.Status)
-	fmt.Fprintf(&b, "| Paused | %s |\n", toolutil.BoolEmoji(out.Paused))
-	fmt.Fprintf(&b, "| Shared | %s |\n", toolutil.BoolEmoji(out.IsShared))
-	fmt.Fprintf(&b, "| Online | %s |\n", toolutil.BoolEmoji(out.Online))
-	fmt.Fprintf(&b, "| Locked | %s |\n", toolutil.BoolEmoji(out.Locked))
-	//gitlab:allow-unescaped out.AccessLevel: a runner access level GitLab picks from a fixed set (not_protected, ref_protected), and refuses any other value on register and update.
-	fmt.Fprintf(&b, "| Access Level | %s |\n", out.AccessLevel)
-	fmt.Fprintf(&b, "| Run Untagged | %s |\n", toolutil.BoolEmoji(out.RunUntagged))
-	if len(out.TagList) > 0 {
-		fmt.Fprintf(&b, "| Tags | %s |\n", toolutil.EscapeMdTableCell(strings.Join(out.TagList, ", ")))
-	}
+	c := toolutil.NewCard(&b, fmt.Sprintf("Runner #%d: Details", out.ID))
+	c.Int("ID", out.ID)
+	writeRunnerSummary(c, out.Name, out.Description, out.RunnerType, out.Status, out.JobExecutionStatus,
+		out.IsShared, out.Online, out.Paused)
+	c.Bool("Locked", out.Locked)
+	// A runner access level GitLab picks from a fixed set (not_protected,
+	// ref_protected), and refuses any other value on register and update.
+	c.Field("Access Level", out.AccessLevel)
+	c.Bool("Run Untagged", out.RunUntagged)
+	// A tag is free text the runner's owner typed.
+	c.Field("Tags", strings.Join(out.TagList, ", "))
 	if out.MaximumTimeout > 0 {
-		fmt.Fprintf(&b, "| Max Timeout | %ds |\n", out.MaximumTimeout)
+		c.Field("Max Timeout", fmt.Sprintf("%ds", out.MaximumTimeout))
 	}
-	if out.MaintenanceNote != "" {
-		fmt.Fprintf(&b, "| Maintenance Note | %s |\n", toolutil.EscapeMdTableCell(out.MaintenanceNote))
+	c.Text("Maintenance Note", out.MaintenanceNote)
+	c.Field("Version", out.Version)
+	c.Field("Platform", out.Platform)
+	c.Field("Architecture", out.Architecture)
+	c.Code("Revision", out.Revision)
+	c.Code("IP Address", out.IPAddress)
+	c.Time("Last Contact", out.ContactedAt)
+	c.Time("Created", out.CreatedAt)
+	if out.CreatedBy != nil {
+		c.Markdown("Created By", toolutil.MdUserLink(out.CreatedBy.Username, out.CreatedBy.WebURL))
 	}
-	if out.ContactedAt != "" {
-		fmt.Fprintf(&b, "| Last Contact | %s |\n", toolutil.FormatTime(out.ContactedAt))
-	}
-	if len(out.Projects) > 0 {
-		fmt.Fprintf(&b, "| Projects | %d |\n", len(out.Projects))
-	}
-	if len(out.Groups) > 0 {
-		fmt.Fprintf(&b, "| Groups | %d |\n", len(out.Groups))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'update' to change runner settings",
-		"Use action 'update' with paused=true to pause or resume this runner",
-		"Use action 'jobs' to list jobs for this runner",
+	writeProjects(c, out.Projects)
+	writeGroups(c, out.Groups)
+	c.End(
+		toolutil.HintAction(actionRunnerUpdate, "change this runner's settings, paused state included"),
+		toolutil.HintAction(actionRunnerJobs, "list the jobs it has run"),
+		toolutil.HintAction(actionRunnerListManagers, "see the machines running it"),
 	)
 	return b.String()
 }
 
-// FormatListMarkdown renders a list of runners as Markdown.
+// writeProjects writes the projects a runner is assigned to. The card used to
+// say only how many there were, which answered none of the questions a reader
+// opens a runner's details to ask.
+func writeProjects(c *toolutil.Card, projects []RunnerDetailsProjectOutput) {
+	if len(projects) == 0 {
+		return
+	}
+	t := c.Table(fmt.Sprintf("Projects (%d)", len(projects)), "ID", "Name", "Path")
+	for _, p := range projects {
+		t.Row(
+			strconv.FormatInt(p.ID, 10),
+			toolutil.EscapeMdTableCell(p.Name),
+			toolutil.EscapeMdTableCell(p.PathWithNamespace),
+		)
+	}
+}
+
+// writeGroups writes the groups a runner serves, each linked to its page.
+func writeGroups(c *toolutil.Card, groups []RunnerDetailsGroupOutput) {
+	if len(groups) == 0 {
+		return
+	}
+	t := c.Table(fmt.Sprintf("Groups (%d)", len(groups)), "ID", "Name")
+	for _, g := range groups {
+		t.Row(
+			strconv.FormatInt(g.ID, 10),
+			toolutil.MdTitleLink(g.Name, g.WebURL),
+		)
+	}
+}
+
+// FormatListMarkdown renders a page of runners as a Markdown table.
 func FormatListMarkdown(out ListOutput) string {
 	if len(out.Runners) == 0 {
-		return "No runners found.\n"
+		return toolutil.EmptyMessage("runners")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runners (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Runners), out.Pagination)
-	b.WriteString("| ID | Name | Type | Status | Paused | Shared |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Runners", len(out.Runners), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Type", "Status", "Paused", "Shared"))
 	for _, r := range out.Runners {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %t | %t |\n",
-			//gitlab:allow-unescaped r.RunnerType: the list rows carry the same runner type enum the single-runner table writes.
-			//gitlab:allow-unescaped r.Status: the list rows carry the same status enum the single-runner table writes.
-			r.ID, toolutil.EscapeMdTableCell(r.Name), r.RunnerType, r.Status, r.Paused, r.IsShared)
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(r.ID, 10),
+			toolutil.EscapeMdTableCell(r.Name),
+			toolutil.EscapeMdTableCell(r.RunnerType),
+			toolutil.EscapeMdTableCell(r.Status),
+			toolutil.BoolEmoji(r.Paused),
+			toolutil.BoolEmoji(r.IsShared),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' with runner_id for full configuration",
-		"Use action 'remove' to unregister a runner",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionRunnerGet, "see one runner's full configuration"),
+		toolutil.HintAction(actionRunnerList, "page through the rest of the runners"),
+		toolutil.HintAction(actionRunnerRemove, "unregister a runner"),
 	)
 	return b.String()
 }
 
-// FormatJobListMarkdown renders a list of runner jobs as Markdown.
+// FormatJobListMarkdown renders the jobs a runner has processed as a Markdown
+// table.
 func FormatJobListMarkdown(out JobListOutput) string {
 	if len(out.Jobs) == 0 {
-		return "No jobs found.\n"
+		return toolutil.EmptyMessage("jobs")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Jobs (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Jobs), out.Pagination)
-	b.WriteString("| ID | Name | Status | Stage | Ref | Duration |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Runner Jobs", len(out.Jobs), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Status", "Stage", "Ref", "Duration"))
 	for _, j := range out.Jobs {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %.1fs |\n",
-			//gitlab:allow-unescaped j.Status: a job status, GitLab's own build state (created, running, success, failed and the rest).
-			// The stage name is written in .gitlab-ci.yml, and the jobs package
-			// escapes the same field in both of its tables.
-			j.ID, toolutil.EscapeMdTableCell(j.Name), j.Status, toolutil.EscapeMdTableCell(j.Stage), toolutil.EscapeMdTableCell(j.Ref), j.Duration)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.MdTitleLink(strconv.FormatInt(j.ID, 10), j.WebURL),
+			toolutil.EscapeMdTableCell(j.Name),
+			jobStatusCell(j.Status),
+			// The stage name is written in .gitlab-ci.yml.
+			toolutil.EscapeMdTableCell(j.Stage),
+			toolutil.EscapeMdTableCell(j.Ref),
+			fmt.Sprintf("%.1fs", j.Duration),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(&b, "Use gitlab_job action 'get' with job_id for full job details")
+	toolutil.WriteListFooter(&b, out.Pagination, true,
+		toolutil.HintAction(actionJobGet, "see one job in full, with its log"),
+		toolutil.HintAction(actionRunnerJobs, "page through the rest of this runner's jobs"),
+	)
 	return b.String()
 }
 
-// FormatAuthTokenMarkdown renders an auth token as Markdown.
+// jobStatusCell renders a job status with the glyph every pipeline-shaped
+// status in the tree carries, and nothing when GitLab sent none.
+func jobStatusCell(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return ""
+	}
+	// A job status, GitLab's own build state (created, running, success,
+	// failed and the rest).
+	return toolutil.PipelineStatusEmoji(status) + " " + toolutil.EscapeMdTableCell(status)
+}
+
+// FormatAuthTokenMarkdown renders the authentication token a runner reset
+// answered with: the secret GitLab shows once, and when it expires.
 func FormatAuthTokenMarkdown(out AuthTokenOutput) string {
 	var b strings.Builder
-	b.WriteString("## Runner Authentication Token\n\n")
-	if out.Token != "" {
-		//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, inside a code span so the reader can copy it back verbatim.
-		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
-	}
-	if out.ExpiresAt != "" {
-		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
-	}
-	toolutil.WriteHints(&b, "Use action 'register' with this token to register a new runner")
+	c := toolutil.NewCard(&b, "Runner Authentication Token")
+	c.Secret("Token", out.Token)
+	c.Time("Expires At", out.ExpiresAt)
+	c.End(
+		toolutil.HintAction(actionRunnerVerify, "check the new token authenticates"),
+		toolutil.HintAction(actionRunnerGet, "read the runner back"),
+	)
 	return b.String()
 }
 
-// FormatRegTokenMarkdown renders a registration token as Markdown.
-func FormatRegTokenMarkdown(out AuthTokenOutput) string {
+// FormatRegTokenMarkdown renders a registration token reset. It is a formatter
+// of its own because the two tokens are different secrets used in different
+// places: a registration token registers new runners, an authentication token
+// is what one runner authenticates with.
+func FormatRegTokenMarkdown(out RegTokenOutput) string {
 	var b strings.Builder
-	b.WriteString("## Runner Registration Token\n\n")
-	if out.Token != "" {
-		//gitlab:allow-unescaped out.Token: a token GitLab minted, a fixed prefix and URL-safe characters, inside a code span so the reader can copy it back verbatim.
-		fmt.Fprintf(&b, "- **Token**: `%s`\n", out.Token)
-	}
-	if out.ExpiresAt != "" {
-		fmt.Fprintf(&b, "- **Expires At**: %s\n", toolutil.FormatTime(out.ExpiresAt))
-	}
-	toolutil.WriteHints(&b, "Use action 'register' with this token to register a new runner")
+	c := toolutil.NewCard(&b, "Runner Registration Token")
+	c.Secret("Token", out.Token)
+	c.Time("Expires At", out.ExpiresAt)
+	c.Note("Every runner registered with the previous token keeps working; the old token registers no new ones.")
+	c.End(toolutil.HintAction(actionRunnerRegister, "register a new runner with this token"))
 	return b.String()
 }
 
-// FormatManagerListMarkdown renders a list of runner managers as Markdown.
+// FormatManagerListMarkdown renders the managers of one runner as a Markdown
+// table.
 func FormatManagerListMarkdown(out ManagerListOutput) string {
 	if len(out.Managers) == 0 {
-		return "No runner managers found.\n"
+		return toolutil.EmptyMessage("runner managers")
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Runner Managers (%d)\n\n", len(out.Managers))
-	b.WriteString("| ID | System ID | Version | Platform | Arch | Status | Job Status | IP |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Runner Managers", len(out.Managers), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "System ID", "Version", "Platform", "Arch", "Status", "Job Status", "IP", "Last Contact"))
 	for _, m := range out.Managers {
-		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %s | %s | %s |\n",
-			// The version, platform and architecture come out of the info
-			// payload the runner process posts, which GitLab length-checks and
-			// nothing else, and this server's own runner.register writes them.
-			//gitlab:allow-unescaped m.Status: a manager status GitLab derives from when the manager last contacted it (online, offline, stale, never_contacted).
-			//gitlab:allow-unescaped m.JobExecutionStatus: a job execution status GitLab derives from the manager's running builds (active, idle).
-			//gitlab:allow-unescaped m.IPAddress: GitLab fills this from the address the manager connected from, never from the info payload beside it.
-			m.ID, toolutil.EscapeMdTableCell(m.SystemID), toolutil.EscapeMdTableCell(m.Version),
-			toolutil.EscapeMdTableCell(m.Platform), toolutil.EscapeMdTableCell(m.Architecture), m.Status,
-			m.JobExecutionStatus, m.IPAddress)
+		// The version, platform and architecture come out of the info payload
+		// the runner process posts, which GitLab length-checks and nothing
+		// else, and this server's own runner.register writes them.
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(m.ID, 10),
+			toolutil.EscapeMdTableCell(m.SystemID),
+			toolutil.EscapeMdTableCell(m.Version),
+			toolutil.EscapeMdTableCell(m.Platform),
+			toolutil.EscapeMdTableCell(m.Architecture),
+			toolutil.EscapeMdTableCell(m.Status),
+			toolutil.EscapeMdTableCell(m.JobExecutionStatus),
+			toolutil.EscapeMdTableCell(m.IPAddress),
+			toolutil.FormatTime(m.ContactedAt),
+		))
 	}
-	toolutil.WriteHints(&b, "Use action 'get' with runner_id for full runner information")
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(actionRunnerGet, "see the runner these managers belong to"),
+	)
 	return b.String()
 }
 

--- a/internal/tools/runners/runners.go
+++ b/internal/tools/runners/runners.go
@@ -149,6 +149,23 @@ type AuthTokenOutput struct {
 	ExpiresAt string `json:"token_expires_at,omitempty"`
 }
 
+// RegTokenOutput represents a runner *registration* token, carrying exactly
+// the fields [AuthTokenOutput] carries and published under the same JSON keys,
+// so the actions' schemas are unchanged.
+//
+// It is a type of its own because the Markdown registry is keyed by type: the
+// two tokens are different secrets used in different places, and while the
+// three registration resets answered with AuthTokenOutput the registry could
+// hold one formatter for the pair. The first registration won, so every
+// registration-token reset rendered under the heading "Runner Authentication
+// Token" and the auth-token reset was the one that never reached its own
+// formatter at all.
+type RegTokenOutput struct {
+	toolutil.HintableOutput
+	Token     string `json:"token"`
+	ExpiresAt string `json:"token_expires_at,omitempty"`
+}
+
 // ---------------------------------------------------------------------------
 // Converters
 // ---------------------------------------------------------------------------.
@@ -983,14 +1000,14 @@ type ResetInstanceRegTokenInput struct{}
 // ResetInstanceRegToken resets the instance-level runner registration token.
 //
 // Deprecated: Scheduled for removal in GitLab 20.0.
-func ResetInstanceRegToken(ctx context.Context, client *gitlabclient.Client, _ ResetInstanceRegTokenInput) (AuthTokenOutput, error) {
+func ResetInstanceRegToken(ctx context.Context, client *gitlabclient.Client, _ ResetInstanceRegTokenInput) (RegTokenOutput, error) {
 	if err := ctx.Err(); err != nil {
-		return AuthTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
+		return RegTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
 	}
 
 	t, _, err := client.GL().Runners.ResetInstanceRunnerRegistrationToken(gl.WithContext(ctx))
 	if err != nil {
-		return AuthTokenOutput{}, toolutil.WrapErrWithStatusHint("reset instance runner registration token", err, http.StatusForbidden,
+		return RegTokenOutput{}, toolutil.WrapErrWithStatusHint("reset instance runner registration token", err, http.StatusForbidden,
 			"resetting the instance-level registration token requires an admin token. For group/project scopes use gitlab_runner_reset_group_reg_token / gitlab_runner_reset_project_reg_token")
 	}
 	return toRegTokenOutput(t), nil
@@ -1008,21 +1025,21 @@ type ResetGroupRegTokenInput struct {
 // ResetGroupRegToken resets a group's runner registration token.
 //
 // Deprecated: Scheduled for removal in GitLab 20.0.
-func ResetGroupRegToken(ctx context.Context, client *gitlabclient.Client, input ResetGroupRegTokenInput) (AuthTokenOutput, error) {
+func ResetGroupRegToken(ctx context.Context, client *gitlabclient.Client, input ResetGroupRegTokenInput) (RegTokenOutput, error) {
 	if input.GroupID == "" {
-		return AuthTokenOutput{}, toolutil.ErrFieldRequired("group_id")
+		return RegTokenOutput{}, toolutil.ErrFieldRequired("group_id")
 	}
 	if err := ctx.Err(); err != nil {
-		return AuthTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
+		return RegTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
 	}
 
 	t, _, err := client.GL().Runners.ResetGroupRunnerRegistrationToken(string(input.GroupID), gl.WithContext(ctx))
 	if err != nil {
 		if toolutil.IsHTTPStatus(err, http.StatusForbidden) {
-			return AuthTokenOutput{}, toolutil.WrapErrWithHint("reset group runner registration token", err,
+			return RegTokenOutput{}, toolutil.WrapErrWithHint("reset group runner registration token", err,
 				"resetting a group runner registration token requires Owner role on the group")
 		}
-		return AuthTokenOutput{}, toolutil.WrapErrWithStatusHint("reset group runner registration token", err, http.StatusNotFound,
+		return RegTokenOutput{}, toolutil.WrapErrWithStatusHint("reset group runner registration token", err, http.StatusNotFound,
 			"verify the group exists with gitlab_group_get")
 	}
 	return toRegTokenOutput(t), nil
@@ -1040,29 +1057,29 @@ type ResetProjectRegTokenInput struct {
 // ResetProjectRegToken resets a project's runner registration token.
 //
 // Deprecated: Scheduled for removal in GitLab 20.0.
-func ResetProjectRegToken(ctx context.Context, client *gitlabclient.Client, input ResetProjectRegTokenInput) (AuthTokenOutput, error) {
+func ResetProjectRegToken(ctx context.Context, client *gitlabclient.Client, input ResetProjectRegTokenInput) (RegTokenOutput, error) {
 	if input.ProjectID == "" {
-		return AuthTokenOutput{}, toolutil.ErrFieldRequired("project_id")
+		return RegTokenOutput{}, toolutil.ErrFieldRequired("project_id")
 	}
 	if err := ctx.Err(); err != nil {
-		return AuthTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
+		return RegTokenOutput{}, toolutil.WrapErrWithMessage(toolutil.ErrMsgContextCanceled, err)
 	}
 
 	t, _, err := client.GL().Runners.ResetProjectRunnerRegistrationToken(string(input.ProjectID), gl.WithContext(ctx))
 	if err != nil {
 		if toolutil.IsHTTPStatus(err, http.StatusForbidden) {
-			return AuthTokenOutput{}, toolutil.WrapErrWithHint("reset project runner registration token", err,
+			return RegTokenOutput{}, toolutil.WrapErrWithHint("reset project runner registration token", err,
 				"resetting a project runner registration token requires Maintainer or Owner role on the project")
 		}
-		return AuthTokenOutput{}, toolutil.WrapErrWithStatusHint("reset project runner registration token", err, http.StatusNotFound,
+		return RegTokenOutput{}, toolutil.WrapErrWithStatusHint("reset project runner registration token", err, http.StatusNotFound,
 			"verify the project exists with gitlab_project_get")
 	}
 	return toRegTokenOutput(t), nil
 }
 
-// toRegTokenOutput converts a RunnerRegistrationToken to AuthTokenOutput.
-func toRegTokenOutput(t *gl.RunnerRegistrationToken) AuthTokenOutput {
-	out := AuthTokenOutput{}
+// toRegTokenOutput converts a RunnerRegistrationToken to RegTokenOutput.
+func toRegTokenOutput(t *gl.RunnerRegistrationToken) RegTokenOutput {
+	out := RegTokenOutput{}
 	if t.Token != nil {
 		out.Token = *t.Token
 	}

--- a/internal/tools/runners/runners_test.go
+++ b/internal/tools/runners/runners_test.go
@@ -1765,9 +1765,43 @@ func TestResetProjectRegToken_CancelledContext(t *testing.T) {
 // FormatOutputMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdown verifies FormatOutputMarkdown.
+// The guidance sections the runner renderings close with.
+const (
+	summaryHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.get' to see this runner's full configuration\n" +
+		"- Use action 'runner.jobs' to list the jobs it has run\n"
+	secretSummaryHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Store the token securely. It cannot be retrieved later\n" +
+		"- Use action 'runner.get' to see this runner's full configuration\n" +
+		"- Use action 'runner.jobs' to list the jobs it has run\n"
+	detailHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.update' to change this runner's settings, paused state included\n" +
+		"- Use action 'runner.jobs' to list the jobs it has run\n" +
+		"- Use action 'runner.list_managers' to see the machines running it\n"
+	listHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.get' to see one runner's full configuration\n" +
+		"- Use action 'runner.list' to page through the rest of the runners\n" +
+		"- Use action 'runner.remove' to unregister a runner\n"
+	jobListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- " + toolutil.HintPreserveLinks + "\n" +
+		"- Use action 'job.get' to see one job in full, with its log\n" +
+		"- Use action 'runner.jobs' to page through the rest of this runner's jobs\n"
+	authTokenHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Store the token securely. It cannot be retrieved later\n" +
+		"- Use action 'runner.verify' to check the new token authenticates\n" +
+		"- Use action 'runner.get' to read the runner back\n"
+	regTokenHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Store the token securely. It cannot be retrieved later\n" +
+		"- Use action 'runner.register' to register a new runner with this token\n"
+	managerHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'runner.get' to see the runner these managers belong to\n"
+)
+
+// TestFormatOutputMarkdown pins the whole card of a runner: the flags as
+// glyphs, the paused condition marked rather than ticked, and no token row for
+// a runner GitLab answered without one.
 func TestFormatOutputMarkdown(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:          5,
 		Name:        "my-runner",
 		Description: "test runner",
@@ -1778,21 +1812,58 @@ func TestFormatOutputMarkdown(t *testing.T) {
 		Online:      true,
 	})
 
-	for _, want := range []string{
-		"## Runner #5",
-		"| Name | my-runner |",
-		"| Description | test runner |",
-		"| Type | project_type |",
-		"| Status | online |",
-		"| Paused | ❌ |",
-		"| Shared | ✅ |",
-		"| Online | ✅ |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runner #5\n\n" +
+		"- **ID**: 5\n" +
+		"- **Name**: my-runner\n" +
+		"- **Description**: test runner\n" +
+		"- **Type**: project_type\n" +
+		"- **Status**: online\n" +
+		"- **Shared**: ✅\n" +
+		"- **Online**: ✅\n" +
+		summaryHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdown_RegisteredRunner pins what the table this card
+// replaced dropped: the authentication token GitLab mints once when a runner
+// is created or registered, with the sentence saying it cannot be read back,
+// and the fields the captured response adds beside it.
+func TestFormatOutputMarkdown_RegisteredRunner(t *testing.T) {
+	got := FormatOutputMarkdown(Output{
+		ID:                 7,
+		Name:               "new-runner",
+		RunnerType:         "instance_type",
+		Status:             "never_contacted",
+		JobExecutionStatus: "idle",
+		Paused:             true,
+		IPAddress:          "10.0.0.1",
+		CreatedAt:          "2026-01-15T10:00:00Z",
+		CreatedBy:          &toolutil.UserBasicOutput{Username: "dana", WebURL: "https://gitlab.example.com/dana"},
+		Token:              "glrt-a_b_c",
+		TokenExpiresAt:     "2026-12-31T23:59:59Z",
+	})
+
+	want := "## Runner #7\n\n" +
+		"- **ID**: 7\n" +
+		"- **Name**: new-runner\n" +
+		"- **Type**: instance_type\n" +
+		"- **Status**: never_contacted\n" +
+		"- **Job Execution Status**: idle\n" +
+		"- **Shared**: ❌\n" +
+		"- **Online**: ❌\n" +
+		"- ⚠️ **Paused**\n" +
+		"- **IP Address**: `10.0.0.1`\n" +
+		"- **Created**: 15 Jan 2026 10:00 UTC\n" +
+		"- **Created By**: [@dana](https://gitlab.example.com/dana)\n" +
+		"- **Token**: `glrt-a_b_c`\n" +
+		"- **Token Expires**: 31 Dec 2026 23:59 UTC\n" +
+		secretSummaryHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1800,9 +1871,11 @@ func TestFormatOutputMarkdown(t *testing.T) {
 // FormatDetailsMarkdown — all optional fields present and absent
 // ---------------------------------------------------------------------------.
 
-// TestFormatDetailsMarkdown_Full verifies FormatDetailsMarkdown when full.
+// TestFormatDetailsMarkdown_Full pins the whole detail card, the projects and
+// groups a runner serves included: the card used to say only how many there
+// were, which answered none of the questions its details are opened for.
 func TestFormatDetailsMarkdown_Full(t *testing.T) {
-	md := FormatDetailsMarkdown(DetailsOutput{
+	got := FormatDetailsMarkdown(DetailsOutput{
 		ID:              10,
 		Name:            "detail-runner",
 		Description:     "detailed",
@@ -1818,58 +1891,70 @@ func TestFormatDetailsMarkdown_Full(t *testing.T) {
 		MaximumTimeout:  7200,
 		MaintenanceNote: "under repair",
 		ContactedAt:     "2026-01-15T10:00:00Z",
-		Projects:        []RunnerDetailsProjectOutput{{ID: 1}, {ID: 2}},
-		Groups:          []RunnerDetailsGroupOutput{{ID: 5}},
+		Version:         "16.0.0",
+		Platform:        "linux",
+		Architecture:    "amd64",
+		Revision:        "abc123",
+		IPAddress:       "10.0.0.1",
+		Projects: []RunnerDetailsProjectOutput{
+			{ID: 1, Name: "web", PathWithNamespace: "acme/web"},
+			{ID: 2, Name: "api", PathWithNamespace: "acme/api"},
+		},
+		Groups: []RunnerDetailsGroupOutput{{ID: 5, Name: "acme", WebURL: "https://gitlab.example.com/acme"}},
 	})
 
-	for _, want := range []string{
-		"## Runner #10: Details",
-		"| Name | detail-runner |",
-		"| Description | detailed |",
-		"| Type | group_type |",
-		"| Status | offline |",
-		"| Paused | ✅ |",
-		"| Shared | ❌ |",
-		"| Online | ❌ |",
-		"| Locked | ✅ |",
-		"| Access Level | ref_protected |",
-		"| Run Untagged | ❌ |",
-		"| Tags | docker, linux |",
-		"| Max Timeout | 7200s |",
-		"| Maintenance Note | under repair |",
-		"| Last Contact | 15 Jan 2026 10:00 UTC |",
-		"| Projects | 2 |",
-		"| Groups | 1 |",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runner #10: Details\n\n" +
+		"- **ID**: 10\n" +
+		"- **Name**: detail-runner\n" +
+		"- **Description**: detailed\n" +
+		"- **Type**: group_type\n" +
+		"- **Status**: offline\n" +
+		"- **Shared**: ❌\n" +
+		"- **Online**: ❌\n" +
+		"- ⚠️ **Paused**\n" +
+		"- **Locked**: ✅\n" +
+		"- **Access Level**: ref_protected\n" +
+		"- **Run Untagged**: ❌\n" +
+		"- **Tags**: docker, linux\n" +
+		"- **Max Timeout**: 7200s\n" +
+		"- **Maintenance Note**: under repair\n" +
+		"- **Version**: 16.0.0\n" +
+		"- **Platform**: linux\n" +
+		"- **Architecture**: amd64\n" +
+		"- **Revision**: `abc123`\n" +
+		"- **IP Address**: `10.0.0.1`\n" +
+		"- **Last Contact**: 15 Jan 2026 10:00 UTC\n" +
+		"\n### Projects (2)\n\n" +
+		"| ID | Name | Path |\n| --- | --- | --- |\n" +
+		"| 1 | web | acme/web |\n" +
+		"| 2 | api | acme/api |\n" +
+		"\n### Groups (1)\n\n" +
+		"| ID | Name |\n| --- | --- |\n" +
+		"| 5 | [acme](https://gitlab.example.com/acme) |\n" +
+		detailHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatDetailsMarkdown_Minimal verifies FormatDetailsMarkdown when minimal.
+// TestFormatDetailsMarkdown_Minimal pins the whole card of a runner GitLab
+// answered with nothing optional: no label with an empty value under it, and
+// no heading for a collection it sent none of.
 func TestFormatDetailsMarkdown_Minimal(t *testing.T) {
-	md := FormatDetailsMarkdown(DetailsOutput{
-		ID:   1,
-		Name: "min",
-	})
+	got := FormatDetailsMarkdown(DetailsOutput{ID: 1, Name: "min"})
 
-	if !strings.Contains(md, "## Runner #1: Details") {
-		t.Errorf("missing header:\n%s", md)
-	}
-	for _, absent := range []string{
-		"| Tags |",
-		"| Max Timeout |",
-		"| Maintenance Note |",
-		"| Last Contact |",
-	} {
-		t.Run(absent, func(t *testing.T) {
-			if strings.Contains(md, absent) {
-				t.Errorf("should not contain %q for minimal output:\n%s", absent, md)
-			}
-		})
+	want := "## Runner #1: Details\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: min\n" +
+		"- **Shared**: ❌\n" +
+		"- **Online**: ❌\n" +
+		"- **Locked**: ❌\n" +
+		"- **Run Untagged**: ❌\n" +
+		detailHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1877,9 +1962,11 @@ func TestFormatDetailsMarkdown_Minimal(t *testing.T) {
 // FormatListMarkdown — with data and empty
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithData verifies FormatListMarkdown when with data.
+// TestFormatListMarkdown_WithData pins the whole listing: the heading counting
+// what GitLab reported, the flags as glyphs rather than as "true", the
+// pagination line and one guidance section.
 func TestFormatListMarkdown_WithData(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Runners: []Output{
 			{ID: 1, Name: "r1", RunnerType: "instance_type", Status: "online", Paused: false, IsShared: true},
 			{ID: 2, Name: "r2", RunnerType: "project_type", Status: "offline", Paused: true, IsShared: false},
@@ -1887,33 +1974,44 @@ func TestFormatListMarkdown_WithData(t *testing.T) {
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	})
 
-	for _, want := range []string{
-		"## Runners (2)",
-		"| ID |",
-		"| --- |",
-		"| 1 |",
-		"| 2 |",
-		"r1",
-		"r2",
-		"instance_type",
-		"project_type",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runners (2)\n\n" +
+		"| ID | Name | Type | Status | Paused | Shared |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 1 | r1 | instance_type | online | ❌ | ✅ |\n" +
+		"| 2 | r2 | project_type | offline | ✅ | ❌ |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
-func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No runners found") {
-		t.Errorf("expected empty message:\n%s", md)
+// TestFormatListMarkdown_KeysetPage pins the heading of a page GitLab sent no
+// total for: it counts the rows shown rather than claiming a total of zero
+// above them.
+func TestFormatListMarkdown_KeysetPage(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{
+		Runners:    []Output{{ID: 1, Name: "r1", RunnerType: "instance_type", Status: "online"}},
+		Pagination: toolutil.PaginationOutput{HasMore: true},
+	})
+
+	want := "## Runners (1 shown, more available)\n\n" +
+		"| ID | Name | Type | Status | Paused | Shared |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| 1 | r1 | instance_type | online | ❌ | ❌ |\n" +
+		listHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+}
+
+// TestFormatListMarkdown_Empty pins that a listing with no runners renders the
+// one sentence and nothing else.
+func TestFormatListMarkdown_Empty(t *testing.T) {
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No runners found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1921,44 +2019,37 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 // FormatJobListMarkdown — with data and empty
 // ---------------------------------------------------------------------------.
 
-// TestFormatJobListMarkdown_WithData verifies FormatJobListMarkdown when with data.
+// TestFormatJobListMarkdown_WithData pins the whole listing of a runner's
+// jobs: each ID linked to the job's page, the status with its glyph, and one
+// guidance section.
 func TestFormatJobListMarkdown_WithData(t *testing.T) {
-	md := FormatJobListMarkdown(JobListOutput{
+	got := FormatJobListMarkdown(JobListOutput{
 		Jobs: []jobs.Output{
-			{ID: 100, Name: "build", Status: "success", Stage: "build", Ref: "main", Duration: 12.5},
+			{ID: 100, Name: "build", Status: "success", Stage: "build", Ref: "main", Duration: 12.5, WebURL: "https://gitlab.example.com/acme/web/-/jobs/100"},
 			{ID: 101, Name: "test", Status: "running", Stage: "test", Ref: "develop", Duration: 0.0},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2, Page: 1, PerPage: 20, TotalPages: 1},
 	})
 
-	for _, want := range []string{
-		"## Runner Jobs (2)",
-		"| ID |",
-		"| --- |",
-		"| 100 |",
-		"| 101 |",
-		"build",
-		"test",
-		"success",
-		"running",
-		"12.5s",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runner Jobs (2)\n\n" +
+		"| ID | Name | Status | Stage | Ref | Duration |\n| --- | --- | --- | --- | --- | --- |\n" +
+		"| [100](https://gitlab.example.com/acme/web/-/jobs/100) | build | ✅ success | build | main | 12.5s |\n" +
+		"| 101 | test | \U0001F535 running | test | develop | 0.0s |\n" +
+		"\nPage 1 of 1 | 2 items total | 20 per page\n" +
+		jobListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatJobListMarkdown_Empty verifies FormatJobListMarkdown when empty.
+// TestFormatJobListMarkdown_Empty pins that a runner that has run nothing
+// renders the one sentence and nothing else.
 func TestFormatJobListMarkdown_Empty(t *testing.T) {
-	md := FormatJobListMarkdown(JobListOutput{})
-	if !strings.Contains(md, "No jobs found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table header when empty")
+	got := FormatJobListMarkdown(JobListOutput{})
+
+	if want := "No jobs found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -1966,106 +2057,135 @@ func TestFormatJobListMarkdown_Empty(t *testing.T) {
 // FormatAuthTokenMarkdown — with and without ExpiresAt
 // ---------------------------------------------------------------------------.
 
-// TestFormatAuthTokenMarkdown_Full verifies FormatAuthTokenMarkdown when full.
+// TestFormatAuthTokenMarkdown_Full pins the whole card of an authentication
+// token reset: the secret in a code span, when it expires, and the sentence
+// saying it cannot be read back.
 func TestFormatAuthTokenMarkdown_Full(t *testing.T) {
-	md := FormatAuthTokenMarkdown(AuthTokenOutput{
+	got := FormatAuthTokenMarkdown(AuthTokenOutput{
 		Token:     "glrt-abc123",
 		ExpiresAt: "2026-12-31T23:59:59Z",
 	})
 
-	for _, want := range []string{
-		"## Runner Authentication Token",
-		"**Token**: `glrt-abc123`",
-		"**Expires At**: 31 Dec 2026 23:59 UTC",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runner Authentication Token\n\n" +
+		"- **Token**: `glrt-abc123`\n" +
+		"- **Expires At**: 31 Dec 2026 23:59 UTC\n" +
+		authTokenHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatAuthTokenMarkdown_NoExpiry verifies FormatAuthTokenMarkdown when no expiry.
+// TestFormatAuthTokenMarkdown_NoExpiry pins the card of a token GitLab set no
+// expiry on: no label with nothing after it.
 func TestFormatAuthTokenMarkdown_NoExpiry(t *testing.T) {
-	md := FormatAuthTokenMarkdown(AuthTokenOutput{Token: "tok"})
-	if strings.Contains(md, "Expires At") {
-		t.Errorf("should not contain Expires At when empty:\n%s", md)
+	got := FormatAuthTokenMarkdown(AuthTokenOutput{Token: "tok"})
+
+	want := "## Runner Authentication Token\n\n" +
+		"- **Token**: `tok`\n" +
+		authTokenHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatAuthTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded verifies
-// that a runner authentication token is written inside a code span and that an
-// empty one writes no token line at all.
+// TestFormatAuthTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded pins that a
+// runner authentication token is written inside a code span and that an empty
+// one writes no token line, and no store-it hint, at all.
 //
 // It matters for two reasons. A token written as bare Markdown is read as
 // Markdown, so an underscore pair in it is eaten as emphasis and what the
 // reader copies back is not what GitLab minted. And a card that announces a
 // **Token** with nothing after it tells a reader a credential was issued when
-// none was, which is how the shared form at accesstokens/markdown.go already
-// reads.
+// none was.
 func TestFormatAuthTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded(t *testing.T) {
 	t.Run("token is inside a code span", func(t *testing.T) {
-		md := FormatAuthTokenMarkdown(AuthTokenOutput{Token: "glrt-a_b_c"})
-		if !strings.Contains(md, "- **Token**: `glrt-a_b_c`\n") {
-			t.Errorf("token not written inside a code span:\n%s", md)
+		want := "## Runner Authentication Token\n\n" +
+			"- **Token**: `glrt-a_b_c`\n" +
+			authTokenHints
+		if got := FormatAuthTokenMarkdown(AuthTokenOutput{Token: "glrt-a_b_c"}); got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 	t.Run("empty token writes no line", func(t *testing.T) {
-		md := FormatAuthTokenMarkdown(AuthTokenOutput{ExpiresAt: "2026-12-31T23:59:59Z"})
-		if strings.Contains(md, "**Token**") {
-			t.Errorf("empty token still announced:\n%s", md)
+		want := "## Runner Authentication Token\n\n" +
+			"- **Expires At**: 31 Dec 2026 23:59 UTC\n" +
+			"\n---\n\U0001F4A1 **Next steps:**\n" +
+			"- Use action 'runner.verify' to check the new token authenticates\n" +
+			"- Use action 'runner.get' to read the runner back\n"
+		if got := FormatAuthTokenMarkdown(AuthTokenOutput{ExpiresAt: "2026-12-31T23:59:59Z"}); got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
 
-// TestFormatRegTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded verifies the
-// same two properties for the registration token card, which is a second copy
-// of the same renderer and carried the same two defects.
+// TestFormatRegTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded pins the same
+// two properties for the registration token card, which is a renderer of its
+// own since the split: while the two shared an output type the registry served
+// one formatter for both, and every registration reset rendered under the
+// authentication token's heading.
 func TestFormatRegTokenMarkdown_TokenShapes_AreCodeSpannedAndGuarded(t *testing.T) {
 	t.Run("token is inside a code span", func(t *testing.T) {
-		md := FormatRegTokenMarkdown(AuthTokenOutput{Token: "reg-a_b_c"})
-		if !strings.Contains(md, "- **Token**: `reg-a_b_c`\n") {
-			t.Errorf("token not written inside a code span:\n%s", md)
+		want := "## Runner Registration Token\n\n" +
+			"- **Token**: `reg-a_b_c`\n" +
+			regTokenNote +
+			regTokenHints
+		if got := FormatRegTokenMarkdown(RegTokenOutput{Token: "reg-a_b_c"}); got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 	t.Run("empty token writes no line", func(t *testing.T) {
-		md := FormatRegTokenMarkdown(AuthTokenOutput{ExpiresAt: "2026-06-01T00:00:00Z"})
-		if strings.Contains(md, "**Token**") {
-			t.Errorf("empty token still announced:\n%s", md)
+		want := "## Runner Registration Token\n\n" +
+			"- **Expires At**: 1 Jun 2026 00:00 UTC\n" +
+			regTokenNote +
+			"\n---\n\U0001F4A1 **Next steps:**\n" +
+			"- Use action 'runner.register' to register a new runner with this token\n"
+		if got := FormatRegTokenMarkdown(RegTokenOutput{ExpiresAt: "2026-06-01T00:00:00Z"}); got != want {
+			t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 		}
 	})
 }
+
+// regTokenNote is the sentence the registration card closes its rows with.
+const regTokenNote = "\nEvery runner registered with the previous token keeps working; the old token registers no new ones.\n"
 
 // ---------------------------------------------------------------------------
 // FormatRegTokenMarkdown — with and without ExpiresAt
 // ---------------------------------------------------------------------------.
 
-// TestFormatRegTokenMarkdown_Full verifies FormatRegTokenMarkdown when full.
+// TestFormatRegTokenMarkdown_Full pins the whole card of a registration token
+// reset: its own heading, the secret, when it expires, and what the reset did
+// to the runners already registered.
 func TestFormatRegTokenMarkdown_Full(t *testing.T) {
-	md := FormatRegTokenMarkdown(AuthTokenOutput{
+	got := FormatRegTokenMarkdown(RegTokenOutput{
 		Token:     "reg-tok-123",
 		ExpiresAt: "2026-06-01T00:00:00Z",
 	})
 
-	for _, want := range []string{
-		"## Runner Registration Token",
-		"**Token**: `reg-tok-123`",
-		"**Expires At**: 1 Jun 2026 00:00 UTC",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Runner Registration Token\n\n" +
+		"- **Token**: `reg-tok-123`\n" +
+		"- **Expires At**: 1 Jun 2026 00:00 UTC\n" +
+		regTokenNote +
+		regTokenHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatRegTokenMarkdown_NoExpiry verifies FormatRegTokenMarkdown when no expiry.
+// TestFormatRegTokenMarkdown_NoExpiry pins the card of a registration token
+// GitLab set no expiry on.
 func TestFormatRegTokenMarkdown_NoExpiry(t *testing.T) {
-	md := FormatRegTokenMarkdown(AuthTokenOutput{Token: "tok"})
-	if strings.Contains(md, "Expires At") {
-		t.Errorf("should not contain Expires At when empty:\n%s", md)
+	got := FormatRegTokenMarkdown(RegTokenOutput{Token: "tok"})
+
+	want := "## Runner Registration Token\n\n" +
+		"- **Token**: `tok`\n" +
+		regTokenNote +
+		regTokenHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -2215,29 +2335,36 @@ func TestListManagers_APIError(t *testing.T) {
 	}
 }
 
-// TestFormatManagerListMarkdown_WithManagers verifies markdown output for
-// a non-empty list of runner managers.
+// TestFormatManagerListMarkdown_WithManagers pins the whole listing of a
+// runner's managers, the last-contact column included: a manager list is read
+// to find out which machine has gone quiet.
 func TestFormatManagerListMarkdown_WithManagers(t *testing.T) {
-	out := ManagerListOutput{
-		Managers: []ManagerOutput{
-			{ID: 10, SystemID: "sys-01", Version: "16.0", Platform: "linux", Architecture: "amd64", Status: "online", IPAddress: "10.0.0.1"},
-		},
-	}
-	md := FormatManagerListMarkdown(out)
-	if !strings.Contains(md, "sys-01") {
-		t.Error("expected sys-01 in markdown output")
-	}
-	if !strings.Contains(md, "Runner Managers") {
-		t.Error("expected header in markdown output")
+	got := FormatManagerListMarkdown(ManagerListOutput{
+		Managers: []ManagerOutput{{
+			ID: 10, SystemID: "sys-01", Version: "16.0", Platform: "linux", Architecture: "amd64",
+			Status: "online", JobExecutionStatus: "idle", IPAddress: "10.0.0.1",
+			ContactedAt: "2026-01-15T10:00:00Z",
+		}},
+	})
+
+	want := "## Runner Managers (1)\n\n" +
+		"| ID | System ID | Version | Platform | Arch | Status | Job Status | IP | Last Contact |\n" +
+		"| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n" +
+		"| 10 | sys-01 | 16.0 | linux | amd64 | online | idle | 10.0.0.1 | 15 Jan 2026 10:00 UTC |\n" +
+		managerHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatManagerListMarkdown_Empty verifies markdown output for
-// an empty managers list.
+// TestFormatManagerListMarkdown_Empty pins that a runner with no manager
+// renders the one sentence and nothing else.
 func TestFormatManagerListMarkdown_Empty(t *testing.T) {
-	md := FormatManagerListMarkdown(ManagerListOutput{})
-	if !strings.Contains(md, "No runner managers found") {
-		t.Error("expected empty message")
+	got := FormatManagerListMarkdown(ManagerListOutput{})
+
+	if want := "No runner managers found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/securefiles/markdown.go
+++ b/internal/tools/securefiles/markdown.go
@@ -1,62 +1,130 @@
 package securefiles
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// expiryOrDash formats an optional expiry timestamp as RFC 3339, or "-" when nil.
-// The dash is used in table cells to signal "no expiry set" rather than an empty cell.
+// expiryOrDash formats an optional expiry timestamp in the display form every
+// other table in this server shows, or "-" when GitLab sent none. The dash is
+// used in table cells to signal "no expiry set" rather than an empty cell.
 func expiryOrDash(t *time.Time) string {
 	if t == nil {
 		return "-"
 	}
-	return toolutil.FormatTimePtr(t)
+	if shown := toolutil.FormatTimeValue(*t); shown != "" {
+		return shown
+	}
+	return "-"
 }
 
 // FormatListMarkdown formats secure files as markdown.
 func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	sb.WriteString("## Secure Files\n\n")
-	toolutil.WriteListSummary(&sb, len(out.Files), out.Pagination)
 	if len(out.Files) == 0 {
-		sb.WriteString("No secure files found.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("secure files")
 	}
-	sb.WriteString("| ID | Name | Checksum Algorithm | Expires At |\n|----|------|-----------|-----------|\n")
+	var sb strings.Builder
+	toolutil.WriteListHeading(&sb, "Secure Files", len(out.Files), out.Pagination)
+	sb.WriteString(toolutil.MarkdownTableHeader("ID", "Name", "Checksum Algorithm", "Expires At"))
 	for _, f := range out.Files {
-		//gitlab:allow-unescaped f.ChecksumAlgorithm: a digest algorithm name GitLab picks from a fixed set (sha256).
-		fmt.Fprintf(&sb, "| %d | %s | %s | %s |\n", f.ID, toolutil.EscapeMdTableCell(f.Name), f.ChecksumAlgorithm, expiryOrDash(f.ExpiresAt))
+		sb.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(f.ID, 10),
+			toolutil.EscapeMdTableCell(f.Name),
+			toolutil.EscapeMdTableCell(f.ChecksumAlgorithm),
+			expiryOrDash(f.ExpiresAt),
+		))
 	}
-	toolutil.WritePagination(&sb, out.Pagination)
-	toolutil.WriteHints(&sb, "Use `gitlab_show_secure_file` to view details of a specific file")
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&sb, out.Pagination, false,
+		"Use `gitlab_show_secure_file` to view details of a specific file")
 	return sb.String()
 }
 
-// FormatShowMarkdown formats a secure file as markdown.
+// FormatShowMarkdown renders one secure file as the card of one object: the
+// identity, the digest, the two timestamps, and the parsed certificate or
+// provisioning-profile metadata as a section of its own.
+//
+// The download hint this card used to carry named `gitlab_show_secure_file`,
+// which is the action that produced the card and downloads nothing: GitLab
+// serves a secure file's contents only to a CI job, and this server exposes
+// no such route. A hint pointing at a route nobody implements is worse than
+// no hint, so it is gone.
 func FormatShowMarkdown(f SecureFileItem) string {
 	var b strings.Builder
-	//gitlab:allow-unescaped f.Checksum: a file digest GitLab computed, hexadecimal digits only.
-	//gitlab:allow-unescaped f.ChecksumAlgorithm: a digest algorithm name GitLab picks from a fixed set (sha256).
-	fmt.Fprintf(&b, "## Secure File\n\n- **ID**: %d\n- **Name**: %s\n- **Checksum**: %s\n- **Algorithm**: %s\n- **Created At**: %s\n- **Expires At**: %s\n",
-		f.ID, toolutil.EscapeMdTableCell(f.Name), f.Checksum, f.ChecksumAlgorithm, toolutil.FormatTimePtr(f.CreatedAt), toolutil.FormatTimePtr(f.ExpiresAt))
+	c := toolutil.NewCard(&b, showHeading(f.Name))
+	c.Int("ID", f.ID)
+	c.Field("Name", f.Name)
+	// The digest and the algorithm name are GitLab's own; the digest is a code
+	// span because a reader compares it character by character.
+	c.Code("Checksum", f.Checksum)
+	c.Field("Algorithm", f.ChecksumAlgorithm)
+	c.Time("Created At", toolutil.RFC3339Ptr(f.CreatedAt))
+	c.Time("Expires At", toolutil.RFC3339Ptr(f.ExpiresAt))
 	if f.FileExtension != "" {
 		// GitLab derives the extension from the uploaded file's name.
-		fmt.Fprintf(&b, "- **File Extension**: %s\n", toolutil.EscapeMdTableCell(f.FileExtension))
+		c.Field("File Extension", f.FileExtension)
 	}
-	if f.Metadata != nil {
-		m := f.Metadata
-		// Everything below is read out of the certificate whoever uploaded the
-		// file supplied, so its common names are whatever they put in it.
-		fmt.Fprintf(&b, "\n### Certificate Metadata\n\n- **ID**: %s\n- **Expires At**: %s\n- **Issuer CN**: %s\n- **Subject CN**: %s\n",
-			toolutil.EscapeMdTableCell(m.ID), toolutil.FormatTimePtr(m.ExpiresAt),
-			toolutil.EscapeMdTableCell(m.Issuer.CN), toolutil.EscapeMdTableCell(m.Subject.CN))
-	}
-	toolutil.WriteHints(&b, "Use `gitlab_show_secure_file` to download this file")
+	writeMetadataSection(c, f)
+	c.End(
+		"Use `gitlab_list_secure_files` to see the other secure files in this project",
+		"Use `gitlab_remove_secure_file` to delete it",
+	)
 	return b.String()
+}
+
+// writeMetadataSection writes the parsed metadata GitLab extracts from a
+// recognized certificate or provisioning profile, and writes nothing at all
+// when the object carries no value a reader would see: the section used to be
+// opened whenever the key was present, which printed a heading over four
+// labels with nothing after them.
+func writeMetadataSection(c *toolutil.Card, f SecureFileItem) {
+	m := f.Metadata
+	if m == nil || !metadataHasContent(m) {
+		return
+	}
+	// Everything below is read out of the certificate whoever uploaded the
+	// file supplied, so its common names are whatever they put in it.
+	s := c.Section(metadataSectionTitle(f.FileExtension))
+	s.Field("ID", m.ID)
+	s.Time("Expires At", toolutil.RFC3339Ptr(m.ExpiresAt))
+	s.Field("Issuer CN", m.Issuer.CN)
+	s.Field("Subject CN", m.Subject.CN)
+}
+
+// metadataHasContent reports whether the parsed metadata holds anything the
+// card would render.
+func metadataHasContent(m *SecureFileMetadata) bool {
+	return strings.TrimSpace(m.ID) != "" ||
+		m.ExpiresAt != nil ||
+		strings.TrimSpace(m.Issuer.CN) != "" ||
+		strings.TrimSpace(m.Subject.CN) != ""
+}
+
+// metadataSectionTitle names the section after the kind of file the metadata
+// was parsed out of. GitLab parses two, and the extension is what says which:
+// calling a provisioning profile's metadata a certificate's misnames every
+// field under the heading.
+func metadataSectionTitle(fileExtension string) string {
+	switch strings.ToLower(strings.TrimPrefix(fileExtension, ".")) {
+	case "mobileprovision", "provisionprofile":
+		return "Provisioning Profile Metadata"
+	default:
+		return "Certificate Metadata"
+	}
+}
+
+// showHeading names the card after the file when GitLab sent a name, and
+// after the resource alone when it did not, so the heading never ends in a
+// colon with nothing behind it.
+func showHeading(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "Secure File"
+	}
+	return "Secure File: " + name
 }
 
 func init() {

--- a/internal/tools/securefiles/secure_files_test.go
+++ b/internal/tools/securefiles/secure_files_test.go
@@ -238,19 +238,41 @@ func TestRemove_Error(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown verifies FormatListMarkdown.
+// secureFileListHints is the guidance a secure file list closes with, and
+// secureFileCardHints the guidance the detail card closes with. Neither names
+// a download route: GitLab serves a secure file's contents only to a CI job
+// and this server exposes no such action.
+const (
+	secureFileListHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use `gitlab_show_secure_file` to view details of a specific file\n"
+	secureFileCardHints = "\n---\n💡 **Next steps:**\n" +
+		"- Use `gitlab_list_secure_files` to see the other secure files in this project\n" +
+		"- Use `gitlab_remove_secure_file` to delete it\n"
+	secureFileTableHeader = "| ID | Name | Checksum Algorithm | Expires At |\n| --- | --- | --- | --- |\n"
+)
+
+// TestFormatListMarkdown verifies the list renders as a whole: the heading
+// counting what GitLab reported, the table, and the guidance after the rows.
 func TestFormatListMarkdown(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{Files: []SecureFileItem{{ID: 1, Name: testFileName}}})
-	if md == "" {
-		t.Error("expected non-empty markdown")
+	got := FormatListMarkdown(ListOutput{Files: []SecureFileItem{{ID: 1, Name: testFileName}}})
+	want := "## Secure Files (1)\n\n" + secureFileTableHeader +
+		"| 1 | " + testFileName + " |  | - |\n" + secureFileListHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatShowMarkdown verifies FormatShowMarkdown.
+// TestFormatShowMarkdown verifies the detail card of a file GitLab sent
+// nothing but an id and a name for: no metadata section, and no label with
+// nothing after it.
 func TestFormatShowMarkdown(t *testing.T) {
-	md := FormatShowMarkdown(SecureFileItem{ID: 1, Name: testFileName})
-	if md == "" {
-		t.Error("expected non-empty markdown")
+	got := FormatShowMarkdown(SecureFileItem{ID: 1, Name: testFileName})
+	want := "## Secure File: " + testFileName + "\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: " + testFileName + "\n" +
+		secureFileCardHints
+	if got != want {
+		t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -292,14 +314,13 @@ func TestList_WithPagination(t *testing.T) {
 // FormatListMarkdown — empty list
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty verifies an empty list is the one sentence and
+// nothing else: no heading counting zero above it and no table header.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "No secure files found") {
-		t.Errorf("expected empty message:\n%s", md)
-	}
-	if strings.Contains(md, "| ID |") {
-		t.Error("should not contain table when empty")
+	got := FormatListMarkdown(ListOutput{})
+	want := "No secure files found.\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() = %q, want %q", got, want)
 	}
 }
 
@@ -307,21 +328,24 @@ func TestFormatListMarkdown_Empty(t *testing.T) {
 // FormatListMarkdown — with pagination
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithPagination verifies FormatListMarkdown when with pagination.
+// TestFormatListMarkdown_WithPagination verifies the heading counts the total
+// GitLab reported rather than the page length, and that the pagination footer
+// follows the rows.
 func TestFormatListMarkdown_WithPagination(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Files: []SecureFileItem{
 			{ID: 1, Name: "key.pem", ChecksumAlgorithm: "sha256"},
 			{ID: 2, Name: "cert.pem", ChecksumAlgorithm: "sha256"},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 5, Page: 1, PerPage: 2, TotalPages: 3},
 	})
-	for _, want := range []string{"| ID |", "| 1 |", "| 2 |", "key.pem", "cert.pem"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Secure Files (5)\n\n" +
+		"Showing 2 of 5 results (page 1 of 3)\n\n" + secureFileTableHeader +
+		"| 1 | key.pem | sha256 | - |\n" +
+		"| 2 | cert.pem | sha256 | - |\n" +
+		"\nPage 1 of 3 | 5 items total | 2 per page\n" + secureFileListHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -411,19 +435,21 @@ func TestList_KeysetPagination(t *testing.T) {
 	}
 }
 
-// TestFormatShowMarkdown_FullMetadata verifies the detail markdown renders the
-// timestamps (non-nil branch) and the certificate metadata section.
+// TestFormatShowMarkdown_FullMetadata verifies the detail card renders the
+// timestamps in the display form (non-nil branch) and the parsed metadata as a
+// section of its own, whole.
 func TestFormatShowMarkdown_FullMetadata(t *testing.T) {
 	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	expires := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	mdExpires := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	md := FormatShowMarkdown(SecureFileItem{
+	got := FormatShowMarkdown(SecureFileItem{
 		ID:                7,
 		Name:              "cert.cer",
 		Checksum:          "deadbeef",
 		ChecksumAlgorithm: "sha256",
 		CreatedAt:         &created,
 		ExpiresAt:         &expires,
+		FileExtension:     "cer",
 		Metadata: &SecureFileMetadata{
 			ID:        "00:11:22",
 			Issuer:    SecureFileIssuer{CN: "Acme Root CA"},
@@ -431,16 +457,57 @@ func TestFormatShowMarkdown_FullMetadata(t *testing.T) {
 			ExpiresAt: &mdExpires,
 		},
 	})
-	for _, want := range []string{
-		"2024-01-02T03:04:05Z", "2025-01-02T03:04:05Z", "Certificate Metadata",
-		"00:11:22", "Acme Root CA", "service.example.com", "2026-06-01T00:00:00Z",
-	} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("markdown missing %q:\n%s", want, md)
-			}
-		})
+	want := "## Secure File: cert.cer\n\n" +
+		"- **ID**: 7\n" +
+		"- **Name**: cert.cer\n" +
+		"- **Checksum**: `deadbeef`\n" +
+		"- **Algorithm**: sha256\n" +
+		"- **Created At**: 2 Jan 2024 03:04 UTC\n" +
+		"- **Expires At**: 2 Jan 2025 03:04 UTC\n" +
+		"- **File Extension**: cer\n\n" +
+		"### Certificate Metadata\n\n" +
+		"- **ID**: 00:11:22\n" +
+		"- **Expires At**: 1 Jun 2026 00:00 UTC\n" +
+		"- **Issuer CN**: Acme Root CA\n" +
+		"- **Subject CN**: service.example.com\n" +
+		secureFileCardHints
+	if got != want {
+		t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
+}
+
+// TestFormatShowMarkdown_MetadataSectionNamesTheFileKind verifies a
+// provisioning profile's metadata is not headed "Certificate Metadata", and
+// that metadata carrying nothing a reader would see opens no section at all:
+// a heading over four empty labels is what the old renderer printed.
+func TestFormatShowMarkdown_MetadataSectionNamesTheFileKind(t *testing.T) {
+	t.Run("provisioning profile", func(t *testing.T) {
+		got := FormatShowMarkdown(SecureFileItem{
+			ID: 3, Name: "app.mobileprovision", FileExtension: "mobileprovision",
+			Metadata: &SecureFileMetadata{ID: "aa-bb"},
+		})
+		want := "## Secure File: app.mobileprovision\n\n" +
+			"- **ID**: 3\n" +
+			"- **Name**: app.mobileprovision\n" +
+			"- **File Extension**: mobileprovision\n\n" +
+			"### Provisioning Profile Metadata\n\n" +
+			"- **ID**: aa-bb\n" +
+			secureFileCardHints
+		if got != want {
+			t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", got, want)
+		}
+	})
+
+	t.Run("empty metadata opens no section", func(t *testing.T) {
+		got := FormatShowMarkdown(SecureFileItem{ID: 4, Name: "blob.bin", Metadata: &SecureFileMetadata{}})
+		want := "## Secure File: blob.bin\n\n" +
+			"- **ID**: 4\n" +
+			"- **Name**: blob.bin\n" +
+			secureFileCardHints
+		if got != want {
+			t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", got, want)
+		}
+	})
 }
 
 // TestFormatShowMarkdown_FileExtension verifies the file extension reaches the
@@ -449,12 +516,21 @@ func TestFormatShowMarkdown_FullMetadata(t *testing.T) {
 // nothing to show for itself.
 func TestFormatShowMarkdown_FileExtension(t *testing.T) {
 	withExt := FormatShowMarkdown(SecureFileItem{ID: 1, Name: "keystore.jks", FileExtension: "jks"})
-	if !strings.Contains(withExt, "- **File Extension**: jks") {
-		t.Errorf("markdown missing the file extension line:\n%s", withExt)
+	wantWith := "## Secure File: keystore.jks\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: keystore.jks\n" +
+		"- **File Extension**: jks\n" +
+		secureFileCardHints
+	if withExt != wantWith {
+		t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", withExt, wantWith)
 	}
 	without := FormatShowMarkdown(SecureFileItem{ID: 1, Name: "keystore"})
-	if strings.Contains(without, "**File Extension**") {
-		t.Errorf("markdown shows an extension GitLab did not send:\n%s", without)
+	wantWithout := "## Secure File: keystore\n\n" +
+		"- **ID**: 1\n" +
+		"- **Name**: keystore\n" +
+		secureFileCardHints
+	if without != wantWithout {
+		t.Errorf("FormatShowMarkdown() =\n%q\nwant:\n%q", without, wantWithout)
 	}
 }
 
@@ -491,20 +567,18 @@ func TestSecureFiles_UnreadableCapturedFileExtension(t *testing.T) {
 }
 
 // TestFormatListMarkdown_ExpiresColumn verifies the list table renders the
-// Expires At column, including the "-" placeholder for files without expiry.
+// Expires At column in the display form every other table in this server
+// shows, and the "-" placeholder for a file with no expiry.
 func TestFormatListMarkdown_ExpiresColumn(t *testing.T) {
 	expires := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
-	md := FormatListMarkdown(ListOutput{Files: []SecureFileItem{
+	got := FormatListMarkdown(ListOutput{Files: []SecureFileItem{
 		{ID: 1, Name: "a.pem", ChecksumAlgorithm: "sha256", ExpiresAt: &expires},
 		{ID: 2, Name: "b.pem", ChecksumAlgorithm: "sha256"},
 	}})
-	if !strings.Contains(md, "Expires At") {
-		t.Errorf("missing Expires At header:\n%s", md)
-	}
-	if !strings.Contains(md, "2025-01-02T03:04:05Z") {
-		t.Errorf("missing rendered expiry:\n%s", md)
-	}
-	if !strings.Contains(md, "| - |") {
-		t.Errorf("missing placeholder for absent expiry:\n%s", md)
+	want := "## Secure Files (2)\n\n" + secureFileTableHeader +
+		"| 1 | a.pem | sha256 | 2 Jan 2025 03:04 UTC |\n" +
+		"| 2 | b.pem | sha256 | - |\n" + secureFileListHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }

--- a/internal/tools/snippetdiscussions/snippet_discussions_test.go
+++ b/internal/tools/snippetdiscussions/snippet_discussions_test.go
@@ -564,7 +564,26 @@ func TestList_Empty(t *testing.T) {
 // Formatter coverage
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_WithData verifies FormatListMarkdown when with data.
+// The three guidance sections this package's shared renderers end with, so each
+// expectation below can pin the whole rendered document.
+//
+// These three formatters are registered for [toolutil.DiscussionThreadOutput]
+// and [toolutil.DiscussionThreadNoteOutput], which every REST discussion domain
+// aliases, and the registry keeps the first registration of a type, so what a
+// snippet discussion actually renders as is the commitdiscussions card. They
+// are tested here for what they write, which is what this package would serve
+// once each domain has a shape of its own.
+const (
+	listHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_get_snippet_discussion` to view full discussion details\n"
+	threadHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_add_snippet_discussion_note` to reply to this discussion\n"
+	noteHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use `gitlab_update_snippet_discussion_note` to edit this note\n"
+)
+
+// TestFormatListMarkdown_WithData pins the whole list document of a page of
+// snippet discussion threads.
 func TestFormatListMarkdown_WithData(t *testing.T) {
 	out := ListOutput{
 		Discussions: []Output{
@@ -576,24 +595,30 @@ func TestFormatListMarkdown_WithData(t *testing.T) {
 			},
 		},
 	}
-	s := FormatListMarkdownString(out)
-	if !strings.Contains(s, "Snippet Discussions") {
-		t.Error("expected header")
-	}
-	if !strings.Contains(s, "alice") {
-		t.Error("expected author")
+
+	got := FormatListMarkdownString(out)
+
+	want := "## Snippet Discussions (1)\n\n" +
+		"### Discussion d1\n" +
+		"- **@alice** (1 Jan 2026 00:00 UTC, note 1):\n" +
+		"  > note body\n" +
+		listHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty pins the whole response of a snippet with no
+// discussions.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	s := FormatListMarkdownString(ListOutput{})
-	if !strings.Contains(s, "No snippet discussions found") {
-		t.Error("expected empty message")
+	got := FormatListMarkdownString(ListOutput{})
+
+	if want := "No snippet discussions found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatMarkdown_WithNotes verifies FormatMarkdown when with notes.
+// TestFormatMarkdown_WithNotes pins the whole card of a thread with one note.
 func TestFormatMarkdown_WithNotes(t *testing.T) {
 	out := Output{
 		ID: "d1",
@@ -601,40 +626,53 @@ func TestFormatMarkdown_WithNotes(t *testing.T) {
 			{ID: 1, Author: &toolutil.NoteUserOutput{Username: "bob"}, CreatedAt: "2026-01-01T00:00:00Z", Body: "hello"},
 		},
 	}
-	s := FormatMarkdownString(out)
-	if !strings.Contains(s, "Discussion d1") {
-		t.Error("expected discussion ID")
-	}
-	if !strings.Contains(s, "@bob") {
-		t.Error("expected author")
+
+	got := FormatMarkdownString(out)
+
+	want := "## Discussion d1\n\n" +
+		"- **@bob** (1 Jan 2026 00:00 UTC, note 1):\n" +
+		"  > hello\n" +
+		threadHintsBlock
+	if got != want {
+		t.Errorf("thread card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatNoteMarkdown_AllFields verifies FormatNoteMarkdown when all fields.
+// TestFormatNoteMarkdown_AllFields pins the whole note card.
 func TestFormatNoteMarkdown_AllFields(t *testing.T) {
 	out := NoteOutput{
-		ID:        1,
-		Author:    &toolutil.NoteUserOutput{Username: "carol"},
-		Body:      "test body",
-		CreatedAt: "2026-01-01T00:00:00Z",
+		ID:         1,
+		Author:     &toolutil.NoteUserOutput{Username: "carol"},
+		Body:       "test body",
+		CreatedAt:  "2026-01-01T00:00:00Z",
+		Resolvable: true,
 	}
-	s := FormatNoteMarkdownString(out)
-	if !strings.Contains(s, "Note") {
-		t.Error("expected Note header")
-	}
-	if !strings.Contains(s, "@carol") {
-		t.Error("expected author")
-	}
-	if !strings.Contains(s, "Created") {
-		t.Error("expected Created")
+
+	got := FormatNoteMarkdownString(out)
+
+	want := "## Discussion Note #1\n\n" +
+		"- **Author**: @carol\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Resolvable**: unresolved\n" +
+		"- **Body**: test body\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatNoteMarkdown_NoCreatedAt verifies FormatNoteMarkdown when no created at.
+// TestFormatNoteMarkdown_NoCreatedAt pins the card of a note with no time on
+// it: the row is absent rather than empty, and a note that cannot be resolved
+// shows no resolution state.
 func TestFormatNoteMarkdown_NoCreatedAt(t *testing.T) {
-	s := FormatNoteMarkdownString(NoteOutput{ID: 1, Author: &toolutil.NoteUserOutput{Username: "x"}, Body: "y"})
-	if strings.Contains(s, "Created") {
-		t.Error("should not include Created when empty")
+	got := FormatNoteMarkdownString(NoteOutput{ID: 1, Author: &toolutil.NoteUserOutput{Username: "x"}, Body: "y"})
+
+	want := "## Discussion Note #1\n\n" +
+		"- **Author**: @x\n" +
+		"- **Body**: y\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/tools/snippetnotes/snippet_notes_test.go
+++ b/internal/tools/snippetnotes/snippet_notes_test.go
@@ -490,65 +490,95 @@ func TestDelete_CancelledContext(t *testing.T) {
 
 // Markdown tests.
 
-// TestFormatOutputMarkdown_Basic verifies the OutputMarkdown_Basic markdown formatter output.
+// The two guidance sections a snippet note result ends with, so each
+// expectation below can pin the whole rendered document.
+const (
+	noteHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'note_update' with note_id to edit this note\n" +
+		"- Use action 'note_delete' with note_id to remove this note\n"
+	listHintsBlock = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'note_get' with note_id to read a specific note\n" +
+		"- Use action 'note_create' to add a new note to this snippet\n"
+)
+
+// TestFormatOutputMarkdown_Basic pins the whole card of a note somebody wrote.
 func TestFormatOutputMarkdown_Basic(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:     100,
 		Body:   "Great snippet",
 		Author: &toolutil.NoteUserOutput{Username: "alice"},
 		System: false,
 	})
-	if !contains(md, "## Snippet Note #100") {
-		t.Error("missing header")
-	}
-	if !contains(md, "alice") {
-		t.Error("missing author")
+
+	want := "## Snippet Note #100\n\n" +
+		"- **Author**: @alice\n" +
+		"- **Body**: Great snippet\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_NilAuthor verifies the markdown formatter renders
-// without panicking when the author object is nil.
+// TestFormatOutputMarkdown_NilAuthor pins the card of a note GitLab answered
+// with no author object: the author row is absent rather than a bare handle.
 func TestFormatOutputMarkdown_NilAuthor(t *testing.T) {
-	md := FormatOutputMarkdown(Output{ID: 100, Body: "no author"})
-	if !contains(md, "## Snippet Note #100") {
-		t.Error("missing header")
+	got := FormatOutputMarkdown(Output{ID: 100, Body: "no author"})
+
+	want := "## Snippet Note #100\n\n" +
+		"- **Body**: no author\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdown_SystemNote verifies the OutputMarkdown_SystemNote markdown formatter output.
+// TestFormatOutputMarkdown_SystemNote pins the card of a system note.
 func TestFormatOutputMarkdown_SystemNote(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:     101,
 		Body:   "changed the title",
 		Author: &toolutil.NoteUserOutput{Username: "admin"},
 		System: true,
 	})
-	if !contains(md, "System note") {
-		t.Error("missing system note indicator")
+
+	want := "## Snippet Note #101\n\n" +
+		"- **Author**: @admin\n" +
+		"- **System note**\n" +
+		"- **Body**: changed the title\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the ListMarkdown_Empty markdown formatter output.
+// TestFormatListMarkdown_Empty pins the whole response of a snippet with no
+// notes.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !contains(md, "No snippet notes found") {
-		t.Error("missing empty message")
+	got := FormatListMarkdown(ListOutput{})
+
+	if want := "No snippet notes found.\n"; got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_WithNotes verifies the ListMarkdown_WithNotes markdown formatter output.
+// TestFormatListMarkdown_WithNotes pins the whole list document: the table the
+// shared note list renderer writes, with the system flag as a glyph.
 func TestFormatListMarkdown_WithNotes(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Notes: []Output{
 			{ID: 100, Author: &toolutil.NoteUserOutput{Username: "alice"}, System: false},
 			{ID: 101, Author: &toolutil.NoteUserOutput{Username: "admin"}, System: true},
 		},
 	})
-	if !contains(md, "| 100 |") {
-		t.Error("missing note 100 row")
-	}
-	if !contains(md, "| 101 |") {
-		t.Error("missing note 101 row")
+
+	want := "## Snippet Notes (2)\n\n" +
+		"| ID | Author | Created | System |\n" +
+		"| --- | --- | --- | --- |\n" +
+		"| 100 | alice |  | ❌ |\n" +
+		"| 101 | admin |  | ✅ |\n" +
+		listHintsBlock
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -853,19 +883,24 @@ func TestList_EmptyResult(t *testing.T) {
 	}
 }
 
-// TestFormatOutputMarkdown_WithUpdatedAt verifies the OutputMarkdown_WithUpdatedAt markdown formatter output.
+// TestFormatOutputMarkdown_WithUpdatedAt pins the whole card of a note that has
+// been edited: the shared note card shows the time it was written, and the time
+// of the edit is carried by the JSON rather than the card.
 func TestFormatOutputMarkdown_WithUpdatedAt(t *testing.T) {
-	md := FormatOutputMarkdown(Output{
+	got := FormatOutputMarkdown(Output{
 		ID:        100,
 		Body:      "test note",
 		Author:    &toolutil.NoteUserOutput{Username: "bob"},
 		CreatedAt: "2026-03-10T09:00:00Z",
 		UpdatedAt: "2026-03-10T10:00:00Z",
 	})
-	if !contains(md, "bob") {
-		t.Error("missing author")
-	}
-	if !contains(md, "## Snippet Note #100") {
-		t.Error("missing header")
+
+	want := "## Snippet Note #100\n\n" +
+		"- **Author**: @bob\n" +
+		"- **Created**: 10 Mar 2026 09:00 UTC\n" +
+		"- **Body**: test note\n" +
+		noteHintsBlock
+	if got != want {
+		t.Errorf("note card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/internal/tools/tags/markdown.go
+++ b/internal/tools/tags/markdown.go
@@ -1,12 +1,21 @@
 package tags
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name that the action specs do not already
+// spell, the one form every surface resolves.
+const (
+	actionTagCreate       = "tag.create"
+	actionTagDelete       = "tag.delete"
+	actionTagGetProtected = "tag.get_protected"
+	actionReleaseCreate   = "release.create"
 )
 
 type tagNotFoundOutput struct {
@@ -21,37 +30,38 @@ func formatTagNotFound(out tagNotFoundOutput) *mcp.CallToolResult {
 	)
 }
 
-// FormatOutputMarkdownString renders a single tag as a Markdown summary.
+// FormatOutputMarkdownString renders one tag as a card: the tag's own fields,
+// then the commit it points at as a nested object.
+//
+// The tag object's own id ("target") is shown only when it differs from the
+// commit's: for a lightweight tag the two are the same string, and printing it
+// twice under two labels invited a reader to treat the tag object as a second
+// commit.
 func FormatOutputMarkdownString(t Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Tag: %s\n\n", toolutil.EscapeMdHeading(t.Name))
-	//gitlab:allow-unescaped t.Target: the object id the tag resolves to, which GitLab reports as a hexadecimal SHA.
-	fmt.Fprintf(&b, toolutil.FmtMdTarget, t.Target)
-	fmt.Fprintf(&b, "- **Protected**: %v\n", t.Protected)
-	if t.Message != "" {
-		// The annotated tag message is what whoever tagged typed, and this
-		// server's own tag.create writes it.
-		fmt.Fprintf(&b, "- **Message**: %s\n", toolutil.EscapeMdTableCell(t.Message))
+	c := toolutil.NewCard(&b, "Tag: "+t.Name)
+	c.Bool("Protected", t.Protected)
+	if t.Commit == nil || t.Target != t.Commit.ID {
+		c.Code("Tag Object", t.Target)
 	}
+	// The annotated tag message is what whoever tagged typed, and this server's
+	// own tag.create writes it: a message of several lines is quoted rather than
+	// flattened onto the row.
+	c.Text("Message", t.Message)
+	c.Time("Created", t.CreatedAt)
 	if t.Commit != nil {
-		if t.Commit.ID != "" {
-			//gitlab:allow-unescaped t.Commit.ID: a commit SHA, hexadecimal by construction.
-			fmt.Fprintf(&b, "- **Commit SHA**: %s\n", t.Commit.ID)
-		}
-		if t.Commit.Message != "" {
-			fmt.Fprintf(&b, "- **Commit Message**: %s\n", toolutil.EscapeMdTableCell(t.Commit.Message))
-		}
+		commit := c.Sub("Commit")
+		commit.Code("SHA", t.Commit.ID)
+		commit.Field("Title", t.Commit.Title)
+		commit.Field("Author", t.Commit.AuthorName)
+		commit.Time("Committed", t.Commit.CommittedDate)
 	}
-	if t.Release != nil && t.Release.Description != "" {
-		fmt.Fprintf(&b, "- **Release**: %s\n", toolutil.EscapeMdTableCell(t.Release.Description))
+	if t.Release != nil {
+		c.Text("Release", t.Release.Description)
 	}
-	if t.CreatedAt != "" {
-		fmt.Fprintf(&b, toolutil.FmtMdCreated, toolutil.FormatTime(t.CreatedAt))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'delete' to remove this tag",
-		"Use gitlab_release action 'create' with this tag to create a release",
+	c.End(
+		toolutil.HintAction(actionTagDelete, "remove this tag"),
+		toolutil.HintAction(actionReleaseCreate, "create a release from this tag"),
 	)
 	return b.String()
 }
@@ -61,27 +71,39 @@ func FormatOutputMarkdown(t Output) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatOutputMarkdownString(t))
 }
 
-// FormatListMarkdownString renders a list of tags as a Markdown table.
+// FormatListMarkdownString renders a page of tags as a Markdown table.
+//
+// The commit column is the commit the tag resolves to, not the tag object's
+// own id: for an annotated tag those differ, and the column that named the tag
+// object was a SHA no other action accepts.
 func FormatListMarkdownString(out ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Tags (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Tags), out.Pagination)
 	if len(out.Tags) == 0 {
-		b.WriteString("No tags found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("tags")
 	}
-	b.WriteString("| Name | Target | Protected |\n")
-	b.WriteString(toolutil.TblSep3Col)
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Tags", len(out.Tags), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Commit", "Protected"))
 	for _, t := range out.Tags {
-		fmt.Fprintf(&b, "| %s | %s | %v |\n", toolutil.EscapeMdTableCell(t.Name), toolutil.EscapeMdTableCell(t.Target), t.Protected)
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(t.Name),
+			toolutil.MdCodeSpanCell(tagCommitSHA(t)),
+			toolutil.BoolEmoji(t.Protected),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' with a tag_name to see tag details",
-		"Use action 'create' to create a new tag",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionTagGet, "see one tag in full"),
+		toolutil.HintAction(actionTagCreate, "create a new tag"),
 	)
 	return b.String()
+}
+
+// tagCommitSHA is the commit a tag resolves to: the commit object's id when
+// GitLab sent one, and the tag object's target otherwise.
+func tagCommitSHA(t Output) string {
+	if t.Commit != nil && t.Commit.ID != "" {
+		return t.Commit.ID
+	}
+	return t.Target
 }
 
 // FormatListMarkdown renders a list of tags as an MCP CallToolResult.
@@ -89,36 +111,33 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
 }
 
-// FormatSignatureMarkdownString renders a tag signature as a Markdown summary.
+// FormatSignatureMarkdownString renders a tag's X.509 signature as a card with
+// the certificate and its issuer as sections of their own.
 func FormatSignatureMarkdownString(out SignatureOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Tag Signature\n\n")
-	//gitlab:allow-unescaped out.SignatureType: a signing scheme GitLab names, one of PGP, SSH or X509.
-	fmt.Fprintf(&b, "- **Signature Type**: %s\n", out.SignatureType)
-	//gitlab:allow-unescaped out.VerificationStatus: a verification verdict GitLab computes, not text it stored.
-	fmt.Fprintf(&b, "- **Verification Status**: %s\n", out.VerificationStatus)
+	c := toolutil.NewCard(&b, "Tag Signature")
+	c.Field("Signature Type", out.SignatureType)
+	c.Field("Verification Status", out.VerificationStatus)
 	cert := out.X509Certificate
-	fmt.Fprintf(&b, "\n### X.509 Certificate\n\n")
-	// The subject and the email are read out of the signer's own certificate,
-	// which GitLab stores as parsed rather than validating.
-	fmt.Fprintf(&b, "- **Subject**: %s\n", toolutil.EscapeMdTableCell(cert.Subject))
-	fmt.Fprintf(&b, toolutil.FmtMdEmail, toolutil.EscapeMdTableCell(cert.Email))
-	//gitlab:allow-unescaped cert.CertificateStatus: a GitLab certificate status, either good or revoked.
-	fmt.Fprintf(&b, toolutil.FmtMdStatus, cert.CertificateStatus)
-	if cert.SerialNumber != "" {
-		//gitlab:allow-unescaped cert.SerialNumber: GetSignature fills it from big.Int.String, so it holds decimal digits.
-		fmt.Fprintf(&b, "- **Serial Number**: %s\n", cert.SerialNumber)
+	// A section is opened only where GitLab sent something to put under it: a
+	// heading with nothing beneath reads as content that failed to render.
+	if cert != (X509CertificateOutput{}) {
+		certificate := c.Section("X.509 Certificate")
+		// The subject and the email are read out of the signer's own
+		// certificate, which GitLab stores as parsed rather than validating.
+		certificate.Field("Subject", cert.Subject)
+		certificate.Field("Email", cert.Email)
+		certificate.Field("Status", cert.CertificateStatus)
+		certificate.Code("Serial Number", cert.SerialNumber)
 	}
-	issuer := cert.X509Issuer
-	fmt.Fprintf(&b, "\n### Issuer\n\n")
-	fmt.Fprintf(&b, "- **Subject**: %s\n", toolutil.EscapeMdTableCell(issuer.Subject))
-	if issuer.CrlURL != "" {
-		fmt.Fprintf(&b, "- **CRL URL**: %s\n", toolutil.EscapeMdTableCell(issuer.CrlURL))
+	if cert.X509Issuer != (X509IssuerOutput{}) {
+		issuer := c.Section("Issuer")
+		issuer.Field("Subject", cert.X509Issuer.Subject)
+		issuer.Link("CRL URL", cert.X509Issuer.CrlURL, cert.X509Issuer.CrlURL)
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' to see full tag details",
-		"Use action 'list' to browse all tags",
+	c.End(
+		toolutil.HintAction(actionTagGet, "see the tag this signature belongs to"),
+		toolutil.HintAction(actionTagList, "browse all tags"),
 	)
 	return b.String()
 }
@@ -128,26 +147,33 @@ func FormatSignatureMarkdown(out SignatureOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatSignatureMarkdownString(out))
 }
 
-// FormatProtectedTagMarkdownString renders a protected tag as Markdown.
+// FormatProtectedTagMarkdownString renders one protected tag rule as a card
+// whose create access levels are the nested collection they are.
 func FormatProtectedTagMarkdownString(out ProtectedTagOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Tag: %s\n\n", toolutil.EscapeMdHeading(out.Name))
-	if len(out.CreateAccessLevels) > 0 {
-		b.WriteString("### Create Access Levels\n\n")
-		b.WriteString("| ID | Access Level | Description | User ID | Group ID | Deploy Key ID |\n")
-		b.WriteString("|----|-------------|-------------|---------|----------|---------------|\n")
-		for _, al := range out.CreateAccessLevels {
-			fmt.Fprintf(&b, "| %d | %d | %s | %s | %s | %s |\n",
-				al.ID, al.AccessLevel, toolutil.EscapeMdTableCell(al.AccessLevelDescription),
-				formatIDCell(al.UserID), formatIDCell(al.GroupID), formatIDCell(al.DeployKeyID))
-		}
+	c := toolutil.NewCard(&b, "Protected Tag: "+out.Name)
+	if len(out.CreateAccessLevels) == 0 {
+		c.Note("No create access levels are defined, so no one may create this tag.")
 	} else {
-		b.WriteString("No create access levels defined.\n")
+		t := c.Table("Create Access Levels", "ID", "Access Level", "Description", "User ID", "Group ID", "Deploy Key ID")
+		for _, al := range out.CreateAccessLevels {
+			t.Row(
+				formatIDCell(al.ID),
+				// The role the number stands for: the number alone was a lookup
+				// table a reader does not have.
+				toolutil.EscapeMdTableCell(toolutil.AccessLevelDescription(gl.AccessLevelValue(al.AccessLevel))),
+				// GitLab's own description, which names a role for a plain rule
+				// and a person, group or deploy key for a granular one.
+				toolutil.EscapeMdTableCell(al.AccessLevelDescription),
+				formatIDCell(al.UserID),
+				formatIDCell(al.GroupID),
+				formatIDCell(al.DeployKeyID),
+			)
+		}
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'list_protected' to see all protected tags",
-		"Use action 'unprotect' to remove tag protection",
+	c.End(
+		toolutil.HintAction(actionTagListProtected, "see all protected tags"),
+		toolutil.HintAction(actionTagUnprotect, "remove tag protection"),
 	)
 	return b.String()
 }
@@ -157,33 +183,28 @@ func FormatProtectedTagMarkdown(out ProtectedTagOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatProtectedTagMarkdownString(out))
 }
 
-// FormatListProtectedTagsMarkdownString renders a list of protected tags as Markdown.
+// FormatListProtectedTagsMarkdownString renders a page of protected tags as a
+// Markdown table.
 func FormatListProtectedTagsMarkdownString(out ListProtectedTagsOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Protected Tags (%d)\n\n", out.Pagination.TotalItems)
-	toolutil.WriteListSummary(&b, len(out.Tags), out.Pagination)
 	if len(out.Tags) == 0 {
-		b.WriteString("No protected tags found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("protected tags")
 	}
-	b.WriteString("| Name | Create Access Levels |\n")
-	b.WriteString("|------|---------------------|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Protected Tags", len(out.Tags), out.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("Name", "Create Access Levels"))
 	for _, t := range out.Tags {
 		levels := make([]string, len(t.CreateAccessLevels))
 		for i, al := range t.CreateAccessLevels {
 			levels[i] = formatAccessLevelSummary(al)
 		}
-		// GitLab's access-level description is a role name for a plain rule but
-		// a user's display name, a group's name or a deploy key's title for a
-		// granular one, and this file's detail formatter escapes the same field.
-		fmt.Fprintf(&b, "| %s | %s |\n", toolutil.EscapeMdTableCell(t.Name),
-			toolutil.EscapeMdTableCell(strings.Join(levels, ", ")))
+		b.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(t.Name),
+			toolutil.EscapeMdTableCell(strings.Join(levels, ", ")),
+		))
 	}
-	toolutil.WritePagination(&b, out.Pagination)
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get_protected' with tag name for full details",
-		"Use action 'protect' to add a new protected tag",
+	toolutil.WriteListFooter(&b, out.Pagination, false,
+		toolutil.HintAction(actionTagGetProtected, "see one rule in full"),
+		toolutil.HintAction(actionTagProtect, "add a new protected tag"),
 	)
 	return b.String()
 }

--- a/internal/tools/tags/tags_test.go
+++ b/internal/tools/tags/tags_test.go
@@ -1044,9 +1044,35 @@ func TestProtectedTagOutput_FromGLEmptyLevels(t *testing.T) {
 // Markdown formatters
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdownString verifies FormatOutputMarkdownString.
+// The guidance sections the five tag formatters close with, pinned once so
+// each whole-output expectation names them rather than restating them.
+const (
+	tagCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.delete' to remove this tag\n" +
+		"- Use action 'release.create' to create a release from this tag\n"
+
+	tagListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.get' to see one tag in full\n" +
+		"- Use action 'tag.create' to create a new tag\n"
+
+	tagSignatureHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.get' to see the tag this signature belongs to\n" +
+		"- Use action 'tag.list' to browse all tags\n"
+
+	protectedTagCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.list_protected' to see all protected tags\n" +
+		"- Use action 'tag.unprotect' to remove tag protection\n"
+
+	protectedTagListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'tag.get_protected' to see one rule in full\n" +
+		"- Use action 'tag.protect' to add a new protected tag\n"
+)
+
+// TestFormatOutputMarkdownString pins the whole card of an annotated tag: the
+// tag object's own id, which differs from the commit's here, then the commit
+// as a nested object.
 func TestFormatOutputMarkdownString(t *testing.T) {
-	md := FormatOutputMarkdownString(Output{
+	got := FormatOutputMarkdownString(Output{
 		Name:      testTagV100,
 		Target:    "abc123",
 		Protected: true,
@@ -1055,65 +1081,127 @@ func TestFormatOutputMarkdownString(t *testing.T) {
 		Release:   &ReleaseNoteOutput{TagName: testTagV100, Description: "Initial release"},
 		CreatedAt: "2026-01-01T00:00:00Z",
 	})
-	if !strings.Contains(md, "## Tag: v1.0.0") {
-		t.Error("expected heading with tag name")
-	}
-	if !strings.Contains(md, "abc123def456") {
-		t.Error("expected commit SHA")
-	}
-	if !strings.Contains(md, "feat: init") {
-		t.Error("expected commit message")
-	}
-	if !strings.Contains(md, "Initial release") {
-		t.Error("expected release description")
-	}
-	if !strings.Contains(md, testReleaseName) {
-		t.Error("expected message")
-	}
-	if !strings.Contains(md, "1 Jan 2026") {
-		t.Error("expected created at")
+
+	want := "## Tag: v1.0.0\n\n" +
+		"- **Protected**: ✅\n" +
+		"- **Tag Object**: `abc123`\n" +
+		"- **Message**: Release v1.0.0\n" +
+		"- **Created**: 1 Jan 2026 00:00 UTC\n" +
+		"- **Commit**:\n" +
+		"  - **SHA**: `abc123def456`\n" +
+		"- **Release**: Initial release\n" +
+		tagCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdownString_Minimal verifies FormatOutputMarkdownString when minimal.
+// TestFormatOutputMarkdownString_LightweightTag pins that a tag whose target
+// is its commit shows the id once: printing it twice under two labels invited
+// a reader to treat the tag object as a second commit.
+func TestFormatOutputMarkdownString_LightweightTag(t *testing.T) {
+	got := FormatOutputMarkdownString(Output{
+		Name:   testTagV100,
+		Target: "abc123def456",
+		Commit: &CommitOutput{ID: "abc123def456", Title: "Fix login", AuthorName: "Alice", CommittedDate: "2026-03-20T15:45:00Z"},
+	})
+
+	want := "## Tag: v1.0.0\n\n" +
+		"- **Protected**: ❌\n" +
+		"- **Commit**:\n" +
+		"  - **SHA**: `abc123def456`\n" +
+		"  - **Title**: Fix login\n" +
+		"  - **Author**: Alice\n" +
+		"  - **Committed**: 20 Mar 2026 15:45 UTC\n" +
+		tagCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdownString_MultiLineMessage pins that an annotated tag
+// message of several lines is quoted under its label rather than flattened
+// onto the row, where its second paragraph used to become a line of the card.
+func TestFormatOutputMarkdownString_MultiLineMessage(t *testing.T) {
+	got := FormatOutputMarkdownString(Output{
+		Name:    "v2",
+		Target:  "abc",
+		Message: "Release notes\n\n- one\n- two",
+	})
+
+	want := "## Tag: v2\n\n" +
+		"- **Protected**: ❌\n" +
+		"- **Tag Object**: `abc`\n" +
+		"- **Message**:\n" +
+		"  > Release notes\n" +
+		"  >\n" +
+		"  > - one\n" +
+		"  > - two\n" +
+		tagCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestFormatOutputMarkdownString_Minimal pins the card of a tag GitLab
+// answered with nothing but a name and a target.
 func TestFormatOutputMarkdownString_Minimal(t *testing.T) {
-	md := FormatOutputMarkdownString(Output{Name: "v0", Target: "x"})
-	if !strings.Contains(md, "## Tag: v0") {
-		t.Error("expected heading")
-	}
-	if strings.Contains(md, "Message") {
-		t.Error("should not contain Message when empty")
+	got := FormatOutputMarkdownString(Output{Name: "v0", Target: "x"})
+
+	want := "## Tag: v0\n\n" +
+		"- **Protected**: ❌\n" +
+		"- **Tag Object**: `x`\n" +
+		tagCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdownString verifies FormatListMarkdownString.
+// TestFormatListMarkdownString pins the whole tag listing. The commit column
+// is the commit a tag resolves to rather than the tag object's own id, which
+// for an annotated tag is a SHA no other action accepts.
 func TestFormatListMarkdownString(t *testing.T) {
-	md := FormatListMarkdownString(ListOutput{
+	got := FormatListMarkdownString(ListOutput{
 		Tags: []Output{
-			{Name: testTagV100, Target: "abc", Protected: true},
+			{Name: testTagV100, Target: "abc", Protected: true, Commit: &CommitOutput{ID: "c0ffee1"}},
 			{Name: "v0.9.0", Target: "def", Protected: false},
 		},
 		Pagination: toolutil.PaginationOutput{TotalItems: 2},
 	})
-	if !strings.Contains(md, "## Tags (2)") {
-		t.Error("expected heading with count")
-	}
-	if !strings.Contains(md, "| v1.0.0 |") {
-		t.Error("expected v1.0.0 row")
+
+	want := "## Tags (2)\n\n" +
+		"| Name | Commit | Protected |\n" +
+		"| --- | --- | --- |\n" +
+		"| v1.0.0 | `c0ffee1` | ✅ |\n" +
+		"| v0.9.0 | `def` | ❌ |\n" +
+		"\n2 items total\n" +
+		tagListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdownString_Empty verifies FormatListMarkdownString when empty.
+// TestFormatListMarkdownString_Empty pins the whole response of a project with
+// no tags.
 func TestFormatListMarkdownString_Empty(t *testing.T) {
-	md := FormatListMarkdownString(ListOutput{})
-	if !strings.Contains(md, "No tags found") {
-		t.Error("expected 'No tags found' message")
+	got := FormatListMarkdownString(ListOutput{})
+
+	want := "No tags found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatSignatureMarkdownString verifies FormatSignatureMarkdownString.
+// TestFormatSignatureMarkdownString pins the whole card of a signed tag: the
+// certificate and its issuer as sections of their own.
 func TestFormatSignatureMarkdownString(t *testing.T) {
-	md := FormatSignatureMarkdownString(SignatureOutput{
+	got := FormatSignatureMarkdownString(SignatureOutput{
 		SignatureType:      "X509",
 		VerificationStatus: "verified",
 		X509Certificate: X509CertificateOutput{
@@ -1127,167 +1215,163 @@ func TestFormatSignatureMarkdownString(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "## Tag Signature") {
-		t.Error("expected signature heading")
-	}
-	if !strings.Contains(md, "X509") {
-		t.Error("expected signature type")
-	}
-	if !strings.Contains(md, testEmailAddr) {
-		t.Error("expected email")
-	}
-	if !strings.Contains(md, "12345") {
-		t.Error("expected serial number")
-	}
-	if !strings.Contains(md, testCRLURL) {
-		t.Error("expected CRL URL")
+
+	want := "## Tag Signature\n\n" +
+		"- **Signature Type**: X509\n" +
+		"- **Verification Status**: verified\n" +
+		"\n### X.509 Certificate\n\n" +
+		"- **Subject**: CN=Test\n" +
+		"- **Email**: test@example.com\n" +
+		"- **Status**: good\n" +
+		"- **Serial Number**: `12345`\n" +
+		"\n### Issuer\n\n" +
+		"- **Subject**: CN=Issuer\n" +
+		"- **CRL URL**: [https://example.com/crl](https://example.com/crl)\n" +
+		tagSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatSignatureMarkdownString_Minimal verifies FormatSignatureMarkdownString when minimal.
+// TestFormatSignatureMarkdownString_Minimal pins that a signature GitLab sent
+// no certificate for opens neither section: a heading with nothing beneath it
+// reads as content that failed to render.
 func TestFormatSignatureMarkdownString_Minimal(t *testing.T) {
-	md := FormatSignatureMarkdownString(SignatureOutput{
+	got := FormatSignatureMarkdownString(SignatureOutput{
 		SignatureType:      "X509",
 		VerificationStatus: "unverified",
 	})
-	if !strings.Contains(md, "unverified") {
-		t.Error("expected verification status")
-	}
-	if strings.Contains(md, "Serial Number") {
-		t.Error("should not contain serial number when empty")
+
+	want := "## Tag Signature\n\n" +
+		"- **Signature Type**: X509\n" +
+		"- **Verification Status**: unverified\n" +
+		tagSignatureHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatProtectedTagMarkdownString verifies FormatProtectedTagMarkdownString.
+// TestFormatProtectedTagMarkdownString pins the whole card of a protection
+// rule: its create access levels as the nested collection they are, the role
+// the number stands for beside GitLab's own description.
 func TestFormatProtectedTagMarkdownString(t *testing.T) {
-	md := FormatProtectedTagMarkdownString(ProtectedTagOutput{
-		Name: "v*",
-		CreateAccessLevels: []TagAccessLevelOutput{
-			{ID: 1, AccessLevel: 40, AccessLevelDescription: descMaintainers},
+	cases := []struct {
+		name  string
+		input ProtectedTagOutput
+		want  string
+	}{
+		{
+			name: "a role rule",
+			input: ProtectedTagOutput{
+				Name:               "v*",
+				CreateAccessLevels: []TagAccessLevelOutput{{ID: 1, AccessLevel: 40, AccessLevelDescription: descMaintainers}},
+			},
+			want: "## Protected Tag: v*\n\n" +
+				"### Create Access Levels\n\n" +
+				"| ID | Access Level | Description | User ID | Group ID | Deploy Key ID |\n" +
+				"| --- | --- | --- | --- | --- | --- |\n" +
+				"| 1 | Maintainer | Maintainers | - | - | - |\n" +
+				protectedTagCardHints,
 		},
-	})
-	if !strings.Contains(md, "## Protected Tag: v*") {
-		t.Error("expected heading")
+		{
+			name: "one user",
+			input: ProtectedTagOutput{
+				Name:               "v*",
+				CreateAccessLevels: []TagAccessLevelOutput{{ID: 1, AccessLevel: 40, AccessLevelDescription: descMaintainers, UserID: 5}},
+			},
+			want: "## Protected Tag: v*\n\n" +
+				"### Create Access Levels\n\n" +
+				"| ID | Access Level | Description | User ID | Group ID | Deploy Key ID |\n" +
+				"| --- | --- | --- | --- | --- | --- |\n" +
+				"| 1 | Maintainer | Maintainers | 5 | - | - |\n" +
+				protectedTagCardHints,
+		},
+		{
+			name: "one group",
+			input: ProtectedTagOutput{
+				Name:               "release-*",
+				CreateAccessLevels: []TagAccessLevelOutput{{ID: 2, AccessLevel: 30, AccessLevelDescription: "Developers", GroupID: 10}},
+			},
+			want: "## Protected Tag: release-*\n\n" +
+				"### Create Access Levels\n\n" +
+				"| ID | Access Level | Description | User ID | Group ID | Deploy Key ID |\n" +
+				"| --- | --- | --- | --- | --- | --- |\n" +
+				"| 2 | Developer | Developers | - | 10 | - |\n" +
+				protectedTagCardHints,
+		},
+		{
+			name: "one deploy key",
+			input: ProtectedTagOutput{
+				Name:               "deploy-*",
+				CreateAccessLevels: []TagAccessLevelOutput{{ID: 3, AccessLevel: 40, AccessLevelDescription: "Deploy Key", DeployKeyID: 7}},
+			},
+			want: "## Protected Tag: deploy-*\n\n" +
+				"### Create Access Levels\n\n" +
+				"| ID | Access Level | Description | User ID | Group ID | Deploy Key ID |\n" +
+				"| --- | --- | --- | --- | --- | --- |\n" +
+				"| 3 | Maintainer | Deploy Key | - | - | 7 |\n" +
+				protectedTagCardHints,
+		},
 	}
-	if !strings.Contains(md, descMaintainers) {
-		t.Error("expected access level description")
-	}
-	if !strings.Contains(md, "Deploy Key ID") {
-		t.Error("expected Deploy Key ID column header")
-	}
-	if !strings.Contains(md, "| - | - | - |") {
-		t.Error("expected '-' for zero UserID, GroupID, and DeployKeyID")
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FormatProtectedTagMarkdownString(c.input); got != c.want {
+				t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, c.want)
+			}
+		})
 	}
 }
 
-// TestFormatProtectedTagMarkdownString_Empty verifies FormatProtectedTagMarkdownString when empty.
+// TestFormatProtectedTagMarkdownString_Empty pins the whole card of a rule
+// with no create access levels, which is a rule nobody may create the tag
+// under.
 func TestFormatProtectedTagMarkdownString_Empty(t *testing.T) {
-	md := FormatProtectedTagMarkdownString(ProtectedTagOutput{Name: "release-*"})
-	if !strings.Contains(md, "No create access levels") {
-		t.Error("expected no access levels message")
+	got := FormatProtectedTagMarkdownString(ProtectedTagOutput{Name: "release-*"})
+
+	want := "## Protected Tag: release-*\n\n" +
+		"No create access levels are defined, so no one may create this tag.\n" +
+		protectedTagCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListProtectedTagsMarkdownString verifies FormatListProtectedTagsMarkdownString.
+// TestFormatListProtectedTagsMarkdownString pins the whole protected-tag
+// listing, each entry naming the principal it grants when it grants one.
 func TestFormatListProtectedTagsMarkdownString(t *testing.T) {
-	md := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{
-		Tags: []ProtectedTagOutput{
-			{Name: "v*", CreateAccessLevels: []TagAccessLevelOutput{{AccessLevelDescription: descMaintainers}}},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	})
-	if !strings.Contains(md, "## Protected Tags (1)") {
-		t.Error("expected heading with count")
+	cases := []struct {
+		name   string
+		levels []TagAccessLevelOutput
+		cell   string
+	}{
+		{"a role", []TagAccessLevelOutput{{AccessLevelDescription: descMaintainers}}, "Maintainers"},
+		{"one user", []TagAccessLevelOutput{{AccessLevelDescription: "Developer", UserID: 5}}, "Developer (User #5)"},
+		{"one group", []TagAccessLevelOutput{{AccessLevelDescription: descMaintainers, GroupID: 10}}, "Maintainers (Group #10)"},
+		{"one deploy key", []TagAccessLevelOutput{{AccessLevelDescription: "Deploy Key", DeployKeyID: 7}}, "Deploy Key (Deploy Key #7)"},
 	}
-	if !strings.Contains(md, descMaintainers) {
-		t.Error("expected access level description")
-	}
-}
 
-// TestFormatProtectedTagMarkdownString_WithUserID verifies FormatProtectedTagMarkdownString when with user ID.
-func TestFormatProtectedTagMarkdownString_WithUserID(t *testing.T) {
-	md := FormatProtectedTagMarkdownString(ProtectedTagOutput{
-		Name: "v*",
-		CreateAccessLevels: []TagAccessLevelOutput{
-			{ID: 1, AccessLevel: 40, AccessLevelDescription: descMaintainers, UserID: 5},
-		},
-	})
-	if !strings.Contains(md, "| 5 |") {
-		t.Error("expected User ID 5 in table")
-	}
-	if !strings.Contains(md, "| - | - |") {
-		t.Error("expected '-' for zero GroupID and DeployKeyID")
-	}
-}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{
+				Tags:       []ProtectedTagOutput{{Name: "v*", CreateAccessLevels: c.levels}},
+				Pagination: toolutil.PaginationOutput{TotalItems: 1},
+			})
 
-// TestFormatProtectedTagMarkdownString_WithGroupID verifies FormatProtectedTagMarkdownString when with group ID.
-func TestFormatProtectedTagMarkdownString_WithGroupID(t *testing.T) {
-	md := FormatProtectedTagMarkdownString(ProtectedTagOutput{
-		Name: "release-*",
-		CreateAccessLevels: []TagAccessLevelOutput{
-			{ID: 2, AccessLevel: 30, AccessLevelDescription: "Developers", GroupID: 10},
-		},
-	})
-	if !strings.Contains(md, "| 10 |") {
-		t.Error("expected Group ID 10 in table")
-	}
-}
+			want := "## Protected Tags (1)\n\n" +
+				"| Name | Create Access Levels |\n" +
+				"| --- | --- |\n" +
+				"| v* | " + c.cell + " |\n" +
+				"\n1 items total\n" +
+				protectedTagListHints
 
-// TestFormatProtectedTagMarkdownString_WithDeployKeyID verifies FormatProtectedTagMarkdownString when with deploy key ID.
-func TestFormatProtectedTagMarkdownString_WithDeployKeyID(t *testing.T) {
-	md := FormatProtectedTagMarkdownString(ProtectedTagOutput{
-		Name: "deploy-*",
-		CreateAccessLevels: []TagAccessLevelOutput{
-			{ID: 3, AccessLevel: 40, AccessLevelDescription: "Deploy Key", DeployKeyID: 7},
-		},
-	})
-	if !strings.Contains(md, "| 7 |") {
-		t.Error("expected Deploy Key ID 7 in table")
-	}
-}
-
-// TestFormatListProtectedTags_WithUserContext verifies FormatListProtectedTags when with user context.
-func TestFormatListProtectedTags_WithUserContext(t *testing.T) {
-	md := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{
-		Tags: []ProtectedTagOutput{
-			{Name: "v*", CreateAccessLevels: []TagAccessLevelOutput{
-				{AccessLevelDescription: "Developer", UserID: 5},
-			}},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	})
-	if !strings.Contains(md, "Developer (User #5)") {
-		t.Error("expected 'Developer (User #5)' context in list view")
-	}
-}
-
-// TestFormatListProtectedTags_WithGroupContext verifies FormatListProtectedTags when with group context.
-func TestFormatListProtectedTags_WithGroupContext(t *testing.T) {
-	md := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{
-		Tags: []ProtectedTagOutput{
-			{Name: "v*", CreateAccessLevels: []TagAccessLevelOutput{
-				{AccessLevelDescription: descMaintainers, GroupID: 10},
-			}},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	})
-	if !strings.Contains(md, "Maintainers (Group #10)") {
-		t.Error("expected 'Maintainers (Group #10)' context in list view")
-	}
-}
-
-// TestFormatListProtectedTags_WithDeployKeyContext verifies FormatListProtectedTags when with deploy key context.
-func TestFormatListProtectedTags_WithDeployKeyContext(t *testing.T) {
-	md := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{
-		Tags: []ProtectedTagOutput{
-			{Name: "v*", CreateAccessLevels: []TagAccessLevelOutput{
-				{AccessLevelDescription: "Deploy Key", DeployKeyID: 7},
-			}},
-		},
-		Pagination: toolutil.PaginationOutput{TotalItems: 1},
-	})
-	if !strings.Contains(md, "Deploy Key (Deploy Key #7)") {
-		t.Error("expected 'Deploy Key (Deploy Key #7)' context in list view")
+			if got != want {
+				t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+			}
+		})
 	}
 }
 
@@ -1322,27 +1406,38 @@ func TestFormatAccessLevelSummary(t *testing.T) {
 	}
 }
 
-// TestFormatListProtectedTagsMarkdownString_Empty verifies FormatListProtectedTagsMarkdownString when empty.
+// TestFormatListProtectedTagsMarkdownString_Empty pins the whole response of a
+// project with no protected tags.
 func TestFormatListProtectedTagsMarkdownString_Empty(t *testing.T) {
-	md := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{})
-	if !strings.Contains(md, "No protected tags found") {
-		t.Error("expected 'No protected tags found' message")
+	got := FormatListProtectedTagsMarkdownString(ListProtectedTagsOutput{})
+
+	want := "No protected tags found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatMarkdownWrappers verifies the MCP CallToolResult wrappers preserve
-// the Markdown content produced by the tag string formatters.
+// TestFormatMarkdownWrappers verifies the MCP CallToolResult wrappers carry
+// exactly the Markdown the tag string formatters produce, which is what makes
+// the whole-output expectations above cover the wrapped surfaces too.
 func TestFormatMarkdownWrappers(t *testing.T) {
+	tagOut := Output{Name: testTagV100, Target: "abc"}
+	listOut := ListOutput{Tags: []Output{tagOut}, Pagination: toolutil.PaginationOutput{TotalItems: 1}}
+	signatureOut := SignatureOutput{SignatureType: "X509", VerificationStatus: "verified"}
+	protectedOut := ProtectedTagOutput{Name: "v*"}
+	protectedListOut := ListProtectedTagsOutput{Tags: []ProtectedTagOutput{protectedOut}, Pagination: toolutil.PaginationOutput{TotalItems: 1}}
+
 	tests := []struct {
 		name   string
 		result *mcp.CallToolResult
 		want   string
 	}{
-		{name: "tag", result: FormatOutputMarkdown(Output{Name: testTagV100, Target: "abc"}), want: "## Tag: v1.0.0"},
-		{name: "list", result: FormatListMarkdown(ListOutput{Tags: []Output{{Name: testTagV100, Target: "abc"}}, Pagination: toolutil.PaginationOutput{TotalItems: 1}}), want: "## Tags (1)"},
-		{name: "signature", result: FormatSignatureMarkdown(SignatureOutput{SignatureType: "X509", VerificationStatus: "verified"}), want: "## Tag Signature"},
-		{name: "protected", result: FormatProtectedTagMarkdown(ProtectedTagOutput{Name: "v*"}), want: "## Protected Tag: v*"},
-		{name: "protected list", result: FormatListProtectedTagsMarkdown(ListProtectedTagsOutput{Tags: []ProtectedTagOutput{{Name: "v*"}}, Pagination: toolutil.PaginationOutput{TotalItems: 1}}), want: "## Protected Tags (1)"},
+		{name: "tag", result: FormatOutputMarkdown(tagOut), want: FormatOutputMarkdownString(tagOut)},
+		{name: "list", result: FormatListMarkdown(listOut), want: FormatListMarkdownString(listOut)},
+		{name: "signature", result: FormatSignatureMarkdown(signatureOut), want: FormatSignatureMarkdownString(signatureOut)},
+		{name: "protected", result: FormatProtectedTagMarkdown(protectedOut), want: FormatProtectedTagMarkdownString(protectedOut)},
+		{name: "protected list", result: FormatListProtectedTagsMarkdown(protectedListOut), want: FormatListProtectedTagsMarkdownString(protectedListOut)},
 	}
 
 	for _, tt := range tests {
@@ -1354,8 +1449,8 @@ func TestFormatMarkdownWrappers(t *testing.T) {
 			if !ok {
 				t.Fatalf("content type = %T, want TextContent", tt.result.Content[0])
 			}
-			if !strings.Contains(content.Text, tt.want) {
-				t.Fatalf("markdown missing %q:\n%s", tt.want, content.Text)
+			if content.Text != tt.want {
+				t.Fatalf("wrapper mismatch:\ngot:\n%s\nwant:\n%s", content.Text, tt.want)
 			}
 		})
 	}

--- a/internal/tools/terraformstates/markdown.go
+++ b/internal/tools/terraformstates/markdown.go
@@ -1,49 +1,103 @@
 package terraformstates
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
+// hintLockNeedsCLI is what a reader has to know about locking a state through
+// this server: `gitlab_lock_terraform_state` cannot work, because client-go
+// sends no Terraform lock-info body and GitLab rejects the call with 400.
+// Saying so where the lock is mentioned is the point; pointing at the tool
+// instead sent a reader to a call that always fails.
+const (
+	hintLockNeedsCLI = "Locking a state needs the terraform CLI against the GitLab HTTP backend: " +
+		"`gitlab_lock_terraform_state` sends no lock-info body, which GitLab refuses"
+	hintUnlockStaleLock = "Use `gitlab_unlock_terraform_state` to clear a stale lock"
+)
+
 // FormatListMarkdown formats Terraform states as markdown.
+//
+// The endpoint sends no pagination headers, so the heading counts what is
+// shown; the empty pagination is what says so rather than a zero total.
 func FormatListMarkdown(out ListOutput) string {
-	var sb strings.Builder
-	sb.WriteString("## Terraform States\n\n")
 	if len(out.States) == 0 {
-		sb.WriteString("No Terraform states found.\n")
-		return sb.String()
+		return toolutil.EmptyMessage("Terraform states")
 	}
-	sb.WriteString("| Name | Latest Serial |\n|------|---------------|\n")
+	var sb strings.Builder
+	toolutil.WriteListHeading(&sb, "Terraform States", len(out.States), toolutil.PaginationOutput{})
+	sb.WriteString(toolutil.MarkdownTableHeader("Name", "Latest Serial"))
 	for _, s := range out.States {
-		fmt.Fprintf(&sb, "| %s | %d |\n", toolutil.EscapeMdTableCell(s.Name), s.LatestSerial)
+		sb.WriteString(toolutil.MarkdownTableRow(
+			toolutil.EscapeMdTableCell(s.Name),
+			serialCell(s.LatestSerial),
+		))
 	}
-	toolutil.WriteHints(&sb, "Use `gitlab_get_terraform_state` to view details of a specific state")
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&sb, toolutil.PaginationOutput{}, false,
+		"Use `gitlab_get_terraform_state` to view details of a specific state")
 	return sb.String()
 }
 
-// FormatStateMarkdown formats a single Terraform state as markdown.
+// serialCell renders a state's latest serial, and says "no versions" for a
+// zero: GitLab omits the serial for a state nothing has written yet, and a
+// bare 0 reads as a version numbered zero.
+func serialCell(serial uint64) string {
+	if serial == 0 {
+		return "no versions"
+	}
+	return strconv.FormatUint(serial, 10)
+}
+
+// FormatStateMarkdown formats a single Terraform state as the card of one
+// object. A state nothing has written to yet carries neither a serial nor a
+// download path, and says so once instead of showing two labels with nothing
+// after them.
 func FormatStateMarkdown(s StateItem) string {
 	var b strings.Builder
 	// The state's name is chosen by whoever ran terraform against it, and the
 	// download path is built around that name.
-	fmt.Fprintf(&b, "## Terraform State: %s\n\n- **Latest Serial**: %d\n- **Download Path**: %s\n",
-		toolutil.EscapeMdHeading(s.Name), s.LatestSerial, toolutil.EscapeMdTableCell(s.DownloadPath))
-	toolutil.WriteHints(
-		&b,
-		"Use `gitlab_lock_terraform_state` to lock this state",
+	c := toolutil.NewCard(&b, stateHeading(s.Name))
+	// The serial is a uint64, so it is written through its own formatter
+	// rather than through Card.Count, which takes an int64 and would need a
+	// conversion that can misrepresent a large value. Zero is skipped for the
+	// reason Count skips it: GitLab omits the serial for a state nothing has
+	// written yet.
+	if s.LatestSerial != 0 {
+		c.Field("Latest Serial", strconv.FormatUint(s.LatestSerial, 10))
+	}
+	c.Code("Download Path", s.DownloadPath)
+	if s.LatestSerial == 0 && strings.TrimSpace(s.DownloadPath) == "" {
+		c.Note("GitLab has recorded no versions of this state.")
+	}
+	c.End(
+		hintLockNeedsCLI,
+		hintUnlockStaleLock,
 		"Use `gitlab_delete_terraform_state` to remove it",
 	)
 	return b.String()
 }
 
-// FormatLockMarkdown formats a lock/unlock result as markdown.
+// stateHeading names the card after the state when GitLab sent a name, and
+// after the resource alone when it did not, so the heading never ends in a
+// colon with nothing behind it.
+func stateHeading(name string) string {
+	if strings.TrimSpace(name) == "" {
+		return "Terraform State"
+	}
+	return "Terraform State: " + name
+}
+
+// FormatLockMarkdown formats a lock/unlock result as the card of one object.
 func FormatLockMarkdown(out LockOutput) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Terraform State Lock\n\n- **Success**: %v\n- **Message**: %s\n",
-		out.Success, toolutil.EscapeMdTableCell(out.Message))
-	toolutil.WriteHints(&b, "Use `gitlab_get_terraform_state` to verify lock status")
+	c := toolutil.NewCard(&b, "Terraform State Lock")
+	c.Bool("Success", out.Success)
+	c.Field("Message", out.Message)
+	c.End(hintLockNeedsCLI, hintUnlockStaleLock)
 	return b.String()
 }
 

--- a/internal/tools/terraformstates/terraform_states_test.go
+++ b/internal/tools/terraformstates/terraform_states_test.go
@@ -191,11 +191,26 @@ func TestUnlock_Error(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown verifies FormatListMarkdown.
+// listHints is the guidance a Terraform state list closes with.
+const listHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use `gitlab_get_terraform_state` to view details of a specific state\n"
+
+// TestFormatListMarkdown verifies FormatListMarkdown renders the whole table:
+// a heading counting the states, one row each, and a state nothing has
+// written to yet saying so rather than showing a serial of zero.
 func TestFormatListMarkdown(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{States: []StateItem{{Name: "state1", LatestSerial: 3}}})
-	if md == "" {
-		t.Error("expected non-empty markdown")
+	got := FormatListMarkdown(ListOutput{States: []StateItem{
+		{Name: "state1", LatestSerial: 3},
+		{Name: "fresh"},
+	}})
+	want := "## Terraform States (2)\n\n" +
+		"| Name | Latest Serial |\n" +
+		"| --- | --- |\n" +
+		"| state1 | 3 |\n" +
+		"| fresh | no versions |\n" +
+		listHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -220,15 +235,37 @@ func TestDeleteVersion_Error(t *testing.T) {
 // FormatStateMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatStateMarkdown_Coverage verifies FormatStateMarkdown when coverage.
+// stateHints is the guidance a Terraform state card closes with: what
+// locking really needs, how to clear a stale lock, and how to delete.
+const stateHints = "\n---\n💡 **Next steps:**\n" +
+	"- " + hintLockNeedsCLI + "\n" +
+	"- " + hintUnlockStaleLock + "\n" +
+	"- Use `gitlab_delete_terraform_state` to remove it\n"
+
+// TestFormatStateMarkdown_Coverage verifies FormatStateMarkdown renders the
+// whole card for a written state, and that the guidance no longer sends a
+// reader to gitlab_lock_terraform_state, which GitLab refuses on every call.
 func TestFormatStateMarkdown_Coverage(t *testing.T) {
-	md := FormatStateMarkdown(StateItem{Name: "prod-state", LatestSerial: 42, DownloadPath: "/dl/path"})
-	for _, want := range []string{"prod-state", "42", "/dl/path"} {
-		t.Run(want, func(t *testing.T) {
-			if !strings.Contains(md, want) {
-				t.Errorf("missing %q in markdown", want)
-			}
-		})
+	got := FormatStateMarkdown(StateItem{Name: "prod-state", LatestSerial: 42, DownloadPath: "/dl/path"})
+	want := "## Terraform State: prod-state\n\n" +
+		"- **Latest Serial**: 42\n" +
+		"- **Download Path**: `/dl/path`\n" +
+		stateHints
+	if got != want {
+		t.Errorf("FormatStateMarkdown() =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestFormatStateMarkdown_UnwrittenState verifies a state with no serial and
+// no download path renders neither row and says why, rather than printing two
+// labels with nothing after them.
+func TestFormatStateMarkdown_UnwrittenState(t *testing.T) {
+	got := FormatStateMarkdown(StateItem{Name: "fresh"})
+	want := "## Terraform State: fresh\n\n" +
+		"GitLab has recorded no versions of this state.\n" +
+		stateHints
+	if got != want {
+		t.Errorf("FormatStateMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -236,14 +273,18 @@ func TestFormatStateMarkdown_Coverage(t *testing.T) {
 // FormatLockMarkdown
 // ---------------------------------------------------------------------------.
 
-// TestFormatLockMarkdown_Coverage verifies FormatLockMarkdown when coverage.
+// TestFormatLockMarkdown_Coverage verifies FormatLockMarkdown renders the
+// whole card, with the outcome as the flag glyph rather than the word "true".
 func TestFormatLockMarkdown_Coverage(t *testing.T) {
-	md := FormatLockMarkdown(LockOutput{Success: true, Message: "State 'x' locked"})
-	if !strings.Contains(md, "true") {
-		t.Error("missing success in markdown")
-	}
-	if !strings.Contains(md, "locked") {
-		t.Error("missing lock message in markdown")
+	got := FormatLockMarkdown(LockOutput{Success: true, Message: "State 'x' locked"})
+	want := "## Terraform State Lock\n\n" +
+		"- **Success**: " + toolutil.BoolEmoji(true) + "\n" +
+		"- **Message**: State 'x' locked\n" +
+		"\n---\n💡 **Next steps:**\n" +
+		"- " + hintLockNeedsCLI + "\n" +
+		"- " + hintUnlockStaleLock + "\n"
+	if got != want {
+		t.Errorf("FormatLockMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
@@ -251,11 +292,13 @@ func TestFormatLockMarkdown_Coverage(t *testing.T) {
 // FormatListMarkdown — empty
 // ---------------------------------------------------------------------------.
 
-// TestFormatListMarkdown_Empty verifies FormatListMarkdown when empty.
+// TestFormatListMarkdown_Empty verifies an empty list is the one sentence and
+// nothing else: no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{States: nil})
-	if !strings.Contains(md, "No Terraform states found") {
-		t.Error("missing empty message")
+	got := FormatListMarkdown(ListOutput{States: nil})
+	want := "No Terraform states found.\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/tools/uploads/markdown.go
+++ b/internal/tools/uploads/markdown.go
@@ -2,50 +2,72 @@ package uploads
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
 )
 
-// FormatUploadMarkdown renders an uploaded file result as Markdown.
+// uploadHint is the one next step an upload result offers.
+const uploadHint = "Use the Markdown reference in issue or MR descriptions to embed this file"
+
+// FormatUploadMarkdown renders an uploaded file result as the card of one
+// object.
 func FormatUploadMarkdown(u UploadOutput) string {
 	var b strings.Builder
-	b.WriteString("## File Uploaded\n\n")
-	fmt.Fprintf(&b, "- **Alt**: %s\n", toolutil.EscapeMdTableCell(u.Alt))
-	fmt.Fprintf(&b, "- **URL**: %s\n", toolutil.EscapeMdTableCell(u.URL))
-	if u.FullURL != "" {
-		toolutil.WriteMdURL(&b, u.FullURL)
-	}
-	// GitLab builds this snippet around the file name whoever uploaded it chose.
-	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", toolutil.EscapeMdTableCell(u.Markdown))
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use the Markdown reference in issue or MR descriptions to embed this file",
-	)
+	writeUploadCard(&b, u, "")
 	return b.String()
+}
+
+// writeUploadCard writes the upload card into b, with an optional embed
+// between the rows and the guidance section.
+//
+// The embed goes here rather than after the formatter returns because
+// [toolutil.WriteHints] closes the response: anything appended after the
+// guidance section leaves it neither leading nor trailing, which is the one
+// position [toolutil.ExtractHints] refuses to read, so the hint stopped
+// reaching next_steps the moment the embed was appended behind it.
+func writeUploadCard(b *strings.Builder, u UploadOutput, embed string) {
+	c := toolutil.NewCard(b, "File Uploaded")
+	c.Count("ID", u.ID)
+	c.Field("Alt", u.Alt)
+	// The relative form is the /uploads/<secret>/<name> reference the Markdown
+	// snippet is built around, so it is labeled Path; the URL row is the
+	// address a reader can open.
+	c.Field("Path", u.URL)
+	c.URL(u.FullURL)
+	// GitLab builds this snippet around the file name whoever uploaded it
+	// chose, and a reader copies it verbatim, so it is a code span sized to
+	// its content rather than a fixed pair of backticks around an escaped
+	// value: an entity inside a span renders as its own characters.
+	c.Code("Markdown", u.Markdown)
+	if embed != "" {
+		c.Note(embed)
+	}
+	c.End(uploadHint)
 }
 
 // FormatListMarkdown renders a list of project markdown uploads as Markdown.
 func FormatListMarkdown(o ListOutput) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Project Markdown Uploads (%d)\n\n", len(o.Uploads))
-	toolutil.WriteListSummary(&b, len(o.Uploads), o.Pagination)
 	if len(o.Uploads) == 0 {
-		b.WriteString("No uploads found.\n")
-		return b.String()
+		return toolutil.EmptyMessage("uploads")
 	}
-	toolutil.WriteHints(&b, toolutil.HintPreserveLinks)
-	b.WriteString("| ID | Filename | Size | Created | Uploaded By |\n")
-	b.WriteString("|---|---|---|---|---|\n")
+	var b strings.Builder
+	toolutil.WriteListHeading(&b, "Project Markdown Uploads", len(o.Uploads), o.Pagination)
+	b.WriteString(toolutil.MarkdownTableHeader("ID", "Filename", "Size (bytes)", "Created", "Uploaded By"))
 	for _, u := range o.Uploads {
-		fmt.Fprintf(&b, "| %d | %s | %d | %s | %s |\n",
-			u.ID,
+		b.WriteString(toolutil.MarkdownTableRow(
+			strconv.FormatInt(u.ID, 10),
 			toolutil.EscapeMdTableCell(u.Filename),
-			u.Size,
-			toolutil.EscapeMdTableCell(u.CreatedAt),
-			toolutil.EscapeMdTableCell(uploadedByLabel(u.UploadedBy)))
+			strconv.FormatInt(u.Size, 10),
+			toolutil.FormatTime(u.CreatedAt),
+			toolutil.EscapeMdTableCell(uploadedByLabel(u.UploadedBy)),
+		))
 	}
+	// The table carries no link, so the footer carries no instruction to keep
+	// the links of a table that has none.
+	toolutil.WriteListFooter(&b, o.Pagination, false,
+		"Use `gitlab_project_upload_delete` with an ID from the table to remove one")
 	return b.String()
 }
 

--- a/internal/tools/uploads/uploads.go
+++ b/internal/tools/uploads/uploads.go
@@ -278,20 +278,32 @@ func DeleteBySecret(ctx context.Context, client *gitlabclient.Client, input Dele
 }
 
 // UploadToolResult builds a CallToolResult for upload operations. For image
-// files it appends a Markdown image embed with the full URL so capable MCP
-// clients can render the image inline. Non-image uploads return text only.
+// files the card carries a Markdown image embed with the full URL so capable
+// MCP clients can render the image inline. Non-image uploads return text only.
+//
+// Two things the hand-built literal this replaced got wrong. The embed was
+// appended after the card, which put it below the guidance section and left
+// that section neither leading nor trailing, the one position
+// [toolutil.ExtractHints] refuses to read, so the upload's hint never reached
+// next_steps; it is now written between the rows and the guidance. And the
+// result was assembled as a literal with no annotations and no normalization,
+// which skipped the control-byte strip every other response passes through;
+// it now goes through [toolutil.ToolResultAnnotated], carrying
+// [toolutil.ContentUser] when an image embed is present, since that block is
+// for a person to look at, and the assistant default otherwise.
 func UploadToolResult(u UploadOutput) *mcp.CallToolResult {
-	md := FormatUploadMarkdown(u)
+	embed := ""
 	if toolutil.IsImageFile(u.Alt) && u.FullURL != "" {
 		// An image embed is a link with a '!' in front, so both halves want the
 		// same escaping MdTitleLink gives a link, applied here because the
 		// helper writes no '!'.
-		md += fmt.Sprintf("\n![%s](%s)\n",
+		embed = fmt.Sprintf("![%s](%s)",
 			toolutil.EscapeMdLinkLabel(u.Alt), toolutil.EscapeMdLinkDestination(u.FullURL))
 	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: md},
-		},
+	var b strings.Builder
+	writeUploadCard(&b, u, embed)
+	if embed == "" {
+		return toolutil.ToolResultWithMarkdown(b.String())
 	}
+	return toolutil.ToolResultAnnotated(b.String(), toolutil.ContentUser)
 }

--- a/internal/tools/uploads/uploads_test.go
+++ b/internal/tools/uploads/uploads_test.go
@@ -696,44 +696,57 @@ func TestProjectUploadDelete_Success(t *testing.T) {
 	}
 }
 
-// TestFormatUploadMarkdown verifies the Markdown output includes alt, URL,
-// full_url, and markdown fields.
+// uploadCardHints is the guidance an upload card closes with.
+const uploadCardHints = "\n---\n💡 **Next steps:**\n- " + uploadHint + "\n"
+
+// TestFormatUploadMarkdown verifies the whole card: the relative reference is
+// labeled Path, the absolute one is the linked URL row, and the Markdown
+// snippet is a code span sized to its content.
 func TestFormatUploadMarkdown(t *testing.T) {
 	out := UploadOutput{
+		ID:       12,
 		Alt:      "screenshot.png",
 		URL:      "/uploads/a1b2/screenshot.png",
 		FullURL:  "https://gitlab.example.com/uploads/a1b2/screenshot.png",
 		Markdown: "![screenshot.png](/uploads/a1b2/screenshot.png)",
 	}
-	md := FormatUploadMarkdown(out)
-	if !strings.Contains(md, "## File Uploaded") {
-		t.Error("expected header in markdown")
-	}
-	if !strings.Contains(md, "screenshot.png") {
-		t.Error("expected alt in markdown")
-	}
-	if !strings.Contains(md, "- **URL**: [") {
-		t.Error("expected full URL in markdown")
-	}
-	if !strings.Contains(md, "Markdown") {
-		t.Error("expected markdown field")
+	got := FormatUploadMarkdown(out)
+	want := "## File Uploaded\n\n" +
+		"- **ID**: 12\n" +
+		"- **Alt**: screenshot.png\n" +
+		"- **Path**: /uploads/a1b2/screenshot.png\n" +
+		"- **URL**: [https://gitlab.example.com/uploads/a1b2/screenshot.png](https://gitlab.example.com/uploads/a1b2/screenshot.png)\n" +
+		"- **Markdown**: `![screenshot.png](/uploads/a1b2/screenshot.png)`\n" +
+		uploadCardHints
+	if got != want {
+		t.Errorf("FormatUploadMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestFormatUploadMarkdown_NoFullURL verifies the output omits Full URL when empty.
+// TestFormatUploadMarkdown_NoFullURL verifies the output omits the URL row
+// when GitLab sent no absolute address, and the ID row when it sent none:
+// the card shows what GitLab sent and never a label with nothing after it.
 func TestFormatUploadMarkdown_NoFullURL(t *testing.T) {
 	out := UploadOutput{
 		Alt:      "file.txt",
 		URL:      "/uploads/a1b2/file.txt",
 		Markdown: "![file.txt](/uploads/a1b2/file.txt)",
 	}
-	md := FormatUploadMarkdown(out)
-	if strings.Contains(md, "Full URL") {
-		t.Error("should not contain Full URL when empty")
+	got := FormatUploadMarkdown(out)
+	want := "## File Uploaded\n\n" +
+		"- **Alt**: file.txt\n" +
+		"- **Path**: /uploads/a1b2/file.txt\n" +
+		"- **Markdown**: `![file.txt](/uploads/a1b2/file.txt)`\n" +
+		uploadCardHints
+	if got != want {
+		t.Errorf("FormatUploadMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 
-// TestUploadToolResult_Image verifies that image files get an inline embed.
+// TestUploadToolResult_Image verifies that an image upload carries the inline
+// embed between the rows and the guidance, that the guidance still closes the
+// response so ExtractHints can read it, and that the block states the
+// audience the embed implies.
 func TestUploadToolResult_Image(t *testing.T) {
 	out := UploadOutput{
 		Alt:      "screenshot.png",
@@ -742,19 +755,33 @@ func TestUploadToolResult_Image(t *testing.T) {
 		Markdown: "![screenshot.png](/uploads/a1b2/screenshot.png)",
 	}
 	result := UploadToolResult(out)
-	if result == nil || len(result.Content) == 0 {
-		t.Fatal("expected non-empty result")
+	if result == nil || len(result.Content) != 1 {
+		t.Fatalf("UploadToolResult() = %#v, want one content block", result)
 	}
 	tc, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
-		t.Fatal("expected TextContent")
+		t.Fatalf("content block is %T, want *mcp.TextContent", result.Content[0])
 	}
-	if !strings.Contains(tc.Text, "![screenshot.png]") {
-		t.Error("expected inline image embed for image file")
+	want := "## File Uploaded\n\n" +
+		"- **Alt**: screenshot.png\n" +
+		"- **Path**: /uploads/a1b2/screenshot.png\n" +
+		"- **URL**: [https://gitlab.example.com/uploads/a1b2/screenshot.png](https://gitlab.example.com/uploads/a1b2/screenshot.png)\n" +
+		"- **Markdown**: `![screenshot.png](/uploads/a1b2/screenshot.png)`\n\n" +
+		"![screenshot.png](https://gitlab.example.com/uploads/a1b2/screenshot.png)\n" +
+		uploadCardHints
+	if tc.Text != want {
+		t.Errorf("UploadToolResult() text =\n%q\nwant:\n%q", tc.Text, want)
+	}
+	if tc.Annotations != toolutil.ContentUser {
+		t.Errorf("annotations = %#v, want toolutil.ContentUser", tc.Annotations)
+	}
+	if hints := toolutil.ExtractHints(tc.Text); len(hints) != 1 || hints[0] != uploadHint {
+		t.Errorf("ExtractHints() = %#v, want the upload hint", hints)
 	}
 }
 
-// TestUploadToolResult_NonImage verifies that non-image files don't get an inline embed.
+// TestUploadToolResult_NonImage verifies that a non-image upload carries no
+// embed and stays annotated for the assistant.
 func TestUploadToolResult_NonImage(t *testing.T) {
 	out := UploadOutput{
 		Alt:      "report.pdf",
@@ -763,16 +790,24 @@ func TestUploadToolResult_NonImage(t *testing.T) {
 		Markdown: "![report.pdf](/uploads/a1b2/report.pdf)",
 	}
 	result := UploadToolResult(out)
-	if result == nil || len(result.Content) == 0 {
-		t.Fatal("expected non-empty result")
+	if result == nil || len(result.Content) != 1 {
+		t.Fatalf("UploadToolResult() = %#v, want one content block", result)
 	}
 	tc, ok := result.Content[0].(*mcp.TextContent)
 	if !ok {
-		t.Fatal("expected TextContent")
+		t.Fatalf("content block is %T, want *mcp.TextContent", result.Content[0])
 	}
-	// The embed pattern adds ![alt](full_url) with the full URL, not the relative URL
-	if strings.Contains(tc.Text, "![report.pdf](https://") {
-		t.Error("non-image should not have inline image embed with full URL")
+	want := "## File Uploaded\n\n" +
+		"- **Alt**: report.pdf\n" +
+		"- **Path**: /uploads/a1b2/report.pdf\n" +
+		"- **URL**: [https://gitlab.example.com/uploads/a1b2/report.pdf](https://gitlab.example.com/uploads/a1b2/report.pdf)\n" +
+		"- **Markdown**: `![report.pdf](/uploads/a1b2/report.pdf)`\n" +
+		uploadCardHints
+	if tc.Text != want {
+		t.Errorf("UploadToolResult() text =\n%q\nwant:\n%q", tc.Text, want)
+	}
+	if tc.Annotations != toolutil.ContentAssistant {
+		t.Errorf("annotations = %#v, want toolutil.ContentAssistant", tc.Annotations)
 	}
 }
 
@@ -1065,22 +1100,25 @@ func TestList_KeysetPaginationParams(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdown_Empty verifies the list formatter renders a header and
-// an explicit no-uploads line for an empty result set.
+// uploadListHints is the guidance the upload list closes with.
+const uploadListHints = "\n---\n💡 **Next steps:**\n" +
+	"- Use `gitlab_project_upload_delete` with an ID from the table to remove one\n"
+
+// TestFormatListMarkdown_Empty verifies an empty list is the one sentence and
+// nothing else: no heading counting zero above it.
 func TestFormatListMarkdown_Empty(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{})
-	if !strings.Contains(md, "Project Markdown Uploads (0)") {
-		t.Errorf("missing header: %q", md)
-	}
-	if !strings.Contains(md, "No uploads found.") {
-		t.Errorf("missing empty marker: %q", md)
+	got := FormatListMarkdown(ListOutput{})
+	want := "No uploads found.\n"
+	if got != want {
+		t.Errorf("FormatListMarkdown() = %q, want %q", got, want)
 	}
 }
 
-// TestFormatListMarkdown_Populated verifies the list formatter emits a table row
-// with the uploader label and a pagination/hints block.
+// TestFormatListMarkdown_Populated verifies the whole table: the guidance sits
+// after the rows rather than between the heading and the header row, where it
+// used to swallow the table entirely, and the date renders in the display form.
 func TestFormatListMarkdown_Populated(t *testing.T) {
-	md := FormatListMarkdown(ListOutput{
+	got := FormatListMarkdown(ListOutput{
 		Uploads: []ListItem{
 			{
 				ID: 1, Size: 1024, Filename: "a.png", CreatedAt: "2026-01-01",
@@ -1088,14 +1126,13 @@ func TestFormatListMarkdown_Populated(t *testing.T) {
 			},
 		},
 	})
-	if !strings.Contains(md, "Project Markdown Uploads (1)") {
-		t.Errorf("missing header: %q", md)
-	}
-	if !strings.Contains(md, "Admin User (@admin)") {
-		t.Errorf("missing uploader label: %q", md)
-	}
-	if !strings.Contains(md, "a.png") {
-		t.Errorf("missing filename: %q", md)
+	want := "## Project Markdown Uploads (1)\n\n" +
+		"| ID | Filename | Size (bytes) | Created | Uploaded By |\n" +
+		"| --- | --- | --- | --- | --- |\n" +
+		"| 1 | a.png | 1024 | 1 Jan 2026 | Admin User (@admin) |\n" +
+		uploadListHints
+	if got != want {
+		t.Errorf("FormatListMarkdown() =\n%q\nwant:\n%q", got, want)
 	}
 }
 

--- a/internal/tools/wikis/markdown.go
+++ b/internal/tools/wikis/markdown.go
@@ -1,12 +1,18 @@
 package wikis
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/gitlab-mcp-server/v3/internal/toolutil"
+)
+
+// Canonical action IDs the hints name that the action specs do not already
+// spell, the one form every surface resolves.
+const (
+	actionWikiCreate = "wiki.create"
+	actionWikiDelete = "wiki.delete"
 )
 
 type wikiNotFoundOutput struct {
@@ -21,25 +27,46 @@ func formatWikiNotFound(out wikiNotFoundOutput) *mcp.CallToolResult {
 	)
 }
 
-// FormatOutputMarkdownString formats a single wiki page as Markdown.
+// FormatOutputMarkdownString renders one wiki page as a card: the page's own
+// fields, then its body under a label of its own.
 func FormatOutputMarkdownString(w Output) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "## Wiki: %s\n\n", toolutil.EscapeMdHeading(w.Title))
-	fmt.Fprintf(&b, "- **Slug**: %s\n", toolutil.EscapeMdTableCell(w.Slug))
-	//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
-	fmt.Fprintf(&b, "- **Format**: %s\n", w.Format)
-	if w.Encoding != "" {
-		fmt.Fprintf(&b, "- **Encoding**: %s\n", toolutil.EscapeMdTableCell(w.Encoding))
-	}
-	if w.Content != "" {
-		fmt.Fprintf(&b, "\n### Content\n\n%s\n", toolutil.WrapGFMBody(w.Content))
-	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'update' to edit this wiki page",
-		"Use action 'delete' to remove this wiki page",
+	c := toolutil.NewCard(&b, wikiHeading(w.Title))
+	c.Field("Slug", w.Slug)
+	c.Field("Format", w.Format)
+	c.Field("Encoding", w.Encoding)
+	c.Count("Page Metadata ID", w.WikiPageMetaID)
+	writeWikiContent(c, w.Format, w.Content)
+	c.End(
+		toolutil.HintAction(actionWikiUpdate, "edit this wiki page"),
+		toolutil.HintAction(actionWikiDelete, "remove this wiki page"),
 	)
 	return b.String()
+}
+
+// wikiHeading names the card: the page's title, and the bare word when GitLab
+// sent none, so the heading never ends in a colon with nothing after it.
+func wikiHeading(title string) string {
+	if strings.TrimSpace(title) == "" {
+		return "Wiki"
+	}
+	return "Wiki: " + title
+}
+
+// writeWikiContent writes the page body under its own label. A Markdown page
+// is quoted, so nothing a page author wrote can add a heading, a row or a
+// guidance section to the card; a page in any other format is fenced with that
+// format as the info string, since quoting rdoc or asciidoc would render it as
+// the Markdown it is not.
+func writeWikiContent(c *toolutil.Card, format, content string) {
+	if content == "" {
+		return
+	}
+	if format == "" || strings.EqualFold(format, "markdown") {
+		c.Text("Content", content)
+		return
+	}
+	c.Fence("Content", format, content)
 }
 
 // FormatOutputMarkdown returns an MCP tool result for a single wiki page.
@@ -47,27 +74,24 @@ func FormatOutputMarkdown(w Output) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatOutputMarkdownString(w))
 }
 
-// FormatListMarkdownString formats a list of wiki pages as a Markdown table.
+// FormatListMarkdownString renders a page of wiki pages as a Markdown table.
 func FormatListMarkdownString(out ListOutput) string {
 	if len(out.WikiPages) == 0 {
-		return "No wiki pages found.\n"
+		return toolutil.EmptyMessage("wiki pages")
 	}
 	var b strings.Builder
-	b.WriteString("| Title | Slug | Format |\n")
-	b.WriteString("| --- | --- | --- |\n")
+	toolutil.WriteListHeading(&b, "Wiki Pages", len(out.WikiPages), toolutil.PaginationOutput{})
+	b.WriteString(toolutil.MarkdownTableHeader("Title", "Slug", "Format"))
 	for _, w := range out.WikiPages {
-		fmt.Fprintf(
-			&b, "| %s | %s | %s |\n",
+		b.WriteString(toolutil.MarkdownTableRow(
 			toolutil.EscapeMdTableCell(w.Title),
 			toolutil.EscapeMdTableCell(w.Slug),
-			//gitlab:allow-unescaped w.Format: a wiki format, a gl.WikiFormatValue GitLab picks from a fixed set (markdown, rdoc, asciidoc, org).
-			w.Format,
-		)
+			toolutil.EscapeMdTableCell(w.Format),
+		))
 	}
-	toolutil.WriteHints(
-		&b,
-		"Use action 'get' with a slug to read a wiki page",
-		"Use action 'create' to add a new wiki page",
+	toolutil.WriteListFooter(&b, toolutil.PaginationOutput{}, false,
+		toolutil.HintAction(actionWikiGet, "read one wiki page"),
+		toolutil.HintAction(actionWikiCreate, "add a new wiki page"),
 	)
 	return b.String()
 }
@@ -77,23 +101,21 @@ func FormatListMarkdown(out ListOutput) *mcp.CallToolResult {
 	return toolutil.ToolResultWithMarkdown(FormatListMarkdownString(out))
 }
 
-// FormatAttachmentMarkdownString renders a wiki attachment upload result as Markdown.
+// FormatAttachmentMarkdownString renders a wiki attachment upload as the card
+// of the object it created.
 func FormatAttachmentMarkdownString(o AttachmentOutput) string {
 	var b strings.Builder
-	b.WriteString("## Wiki Attachment Uploaded\n\n")
-	fmt.Fprintf(&b, "- **File Name**: %s\n", toolutil.EscapeMdTableCell(o.FileName))
-	fmt.Fprintf(&b, "- **File Path**: %s\n", toolutil.EscapeMdTableCell(o.FilePath))
-	if o.Branch != "" {
-		fmt.Fprintf(&b, "- **Branch**: %s\n", toolutil.EscapeMdTableCell(o.Branch))
-	}
-	toolutil.WriteMdURL(&b, o.URL)
-	// GitLab builds this snippet around the file name whoever uploaded it chose.
-	fmt.Fprintf(&b, "- **Markdown**: `%s`\n", toolutil.EscapeMdTableCell(o.Markdown))
-	toolutil.WriteHints(
-		&b,
-		toolutil.HintPreserveLinks,
-		"Use action 'get' to view the wiki page where this attachment is used",
-		"Use action 'list' to see all wiki pages",
+	c := toolutil.NewCard(&b, "Wiki Attachment Uploaded")
+	c.Field("File Name", o.FileName)
+	c.Field("File Path", o.FilePath)
+	c.Field("Branch", o.Branch)
+	c.URL(o.URL)
+	// GitLab builds this snippet around the file name whoever uploaded it chose,
+	// and it is meant to be copied into a page verbatim, so it is a code span.
+	c.Code("Markdown", o.Markdown)
+	c.End(
+		toolutil.HintAction(actionWikiGet, "view the wiki page where this attachment is used"),
+		toolutil.HintAction(actionWikiList, "see all wiki pages"),
 	)
 	return b.String()
 }

--- a/internal/tools/wikis/wikis_test.go
+++ b/internal/tools/wikis/wikis_test.go
@@ -665,24 +665,43 @@ func TestUploadAttachment_APIError(t *testing.T) {
 	}
 }
 
-// TestFormatAttachmentMarkdownString verifies FormatAttachmentMarkdownString.
+// The guidance sections the three wiki formatters close with.
+const (
+	wikiCardHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'wiki.update' to edit this wiki page\n" +
+		"- Use action 'wiki.delete' to remove this wiki page\n"
+
+	wikiListHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'wiki.get' to read one wiki page\n" +
+		"- Use action 'wiki.create' to add a new wiki page\n"
+
+	wikiAttachmentHints = "\n---\n\U0001F4A1 **Next steps:**\n" +
+		"- Use action 'wiki.get' to view the wiki page where this attachment is used\n" +
+		"- Use action 'wiki.list' to see all wiki pages\n"
+)
+
+// TestFormatAttachmentMarkdownString pins the whole card of an uploaded
+// attachment, the snippet GitLab built for it included: it is meant to be
+// copied into a page verbatim, so it is a code span rather than a live image.
 func TestFormatAttachmentMarkdownString(t *testing.T) {
-	out := AttachmentOutput{
+	got := FormatAttachmentMarkdownString(AttachmentOutput{
 		FileName: "diagram.png",
 		FilePath: "uploads/abc/diagram.png",
 		Branch:   "main",
 		URL:      "/uploads/abc/diagram.png",
 		Markdown: "![diagram](uploads/abc/diagram.png)",
-	}
-	md := FormatAttachmentMarkdownString(out)
-	if md == "" {
-		t.Fatal("FormatAttachmentMarkdownString() returned empty string")
-	}
-	if !strings.Contains(md, "diagram.png") {
-		t.Errorf("markdown should contain filename")
-	}
-	if !strings.Contains(md, "main") {
-		t.Errorf("markdown should contain branch")
+	})
+
+	want := "## Wiki Attachment Uploaded\n\n" +
+		"- **File Name**: diagram.png\n" +
+		"- **File Path**: uploads/abc/diagram.png\n" +
+		"- **Branch**: main\n" +
+		"- **URL**: [/uploads/abc/diagram.png](/uploads/abc/diagram.png)\n" +
+		"- **Markdown**: `![diagram](uploads/abc/diagram.png)`\n" +
+		wikiAttachmentHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -825,28 +844,63 @@ func TestUploadAttachment_NoBranch(t *testing.T) {
 // Formatter tests
 // ---------------------------------------------------------------------------.
 
-// TestFormatOutputMarkdownString_WithEncodingAndContent verifies FormatOutputMarkdownString when with encoding and content.
+// TestFormatOutputMarkdownString_WithEncodingAndContent pins the whole card of
+// a Markdown page: the body is quoted under its label, so a heading a page
+// author typed stays text instead of becoming a heading of the response.
 func TestFormatOutputMarkdownString_WithEncodingAndContent(t *testing.T) {
-	s := FormatOutputMarkdownString(Output{
+	got := FormatOutputMarkdownString(Output{
 		Title: "Test", Slug: "test", Format: "markdown",
-		Content: "# Hello", Encoding: "UTF-8",
+		Content: "# Hello\n\nSecond paragraph.", Encoding: "UTF-8",
 	})
-	if !strings.Contains(s, "Encoding") {
-		t.Error("expected Encoding field")
-	}
-	if !strings.Contains(s, "# Hello") {
-		t.Error("expected content")
+
+	want := "## Wiki: Test\n\n" +
+		"- **Slug**: test\n" +
+		"- **Format**: markdown\n" +
+		"- **Encoding**: UTF-8\n" +
+		"- **Content**:\n" +
+		"  > # Hello\n" +
+		"  >\n" +
+		"  > Second paragraph.\n" +
+		wikiCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatOutputMarkdownString_Minimal verifies FormatOutputMarkdownString when minimal.
-func TestFormatOutputMarkdownString_Minimal(t *testing.T) {
-	s := FormatOutputMarkdownString(Output{Title: "T", Slug: "t", Format: "markdown"})
-	if strings.Contains(s, "Encoding") {
-		t.Error("should not include Encoding")
+// TestFormatOutputMarkdownString_NonMarkdownFormat pins that a page in a
+// format other than Markdown is fenced with that format rather than quoted,
+// since quoting it would render it as the Markdown it is not.
+func TestFormatOutputMarkdownString_NonMarkdownFormat(t *testing.T) {
+	got := FormatOutputMarkdownString(Output{
+		Title: "Setup", Slug: "setup", Format: "rdoc", Content: "= Setup",
+	})
+
+	want := "## Wiki: Setup\n\n" +
+		"- **Slug**: setup\n" +
+		"- **Format**: rdoc\n" +
+		"\n### Content\n\n" +
+		"```rdoc\n= Setup\n```\n" +
+		wikiCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
-	if strings.Contains(s, "Content") {
-		t.Error("should not include Content section")
+}
+
+// TestFormatOutputMarkdownString_Minimal pins the card of a page read without
+// its content: neither the encoding nor the body is written as a label with
+// nothing after it.
+func TestFormatOutputMarkdownString_Minimal(t *testing.T) {
+	got := FormatOutputMarkdownString(Output{Title: "T", Slug: "t", Format: "markdown"})
+
+	want := "## Wiki: T\n\n" +
+		"- **Slug**: t\n" +
+		"- **Format**: markdown\n" +
+		wikiCardHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -858,25 +912,36 @@ func TestFormatOutputMarkdown_NonNil(t *testing.T) {
 	}
 }
 
-// TestFormatListMarkdownString_WithPages verifies FormatListMarkdownString when with pages.
+// TestFormatListMarkdownString_WithPages pins the whole wiki listing, heading
+// included: the list used to open straight into a table header with no
+// heading above it at all.
 func TestFormatListMarkdownString_WithPages(t *testing.T) {
-	s := FormatListMarkdownString(ListOutput{WikiPages: []Output{
+	got := FormatListMarkdownString(ListOutput{WikiPages: []Output{
 		{Title: "Home", Slug: "home", Format: "markdown"},
 		{Title: "FAQ", Slug: "faq", Format: "rdoc"},
 	}})
-	if !strings.Contains(s, "Home") {
-		t.Error("expected Home")
-	}
-	if !strings.Contains(s, "FAQ") {
-		t.Error("expected FAQ")
+
+	want := "## Wiki Pages (2)\n\n" +
+		"| Title | Slug | Format |\n" +
+		"| --- | --- | --- |\n" +
+		"| Home | home | markdown |\n" +
+		"| FAQ | faq | rdoc |\n" +
+		wikiListHints
+
+	if got != want {
+		t.Errorf("list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
-// TestFormatListMarkdownString_Empty verifies FormatListMarkdownString when empty.
+// TestFormatListMarkdownString_Empty pins the whole response of a project with
+// no wiki pages.
 func TestFormatListMarkdownString_Empty(t *testing.T) {
-	s := FormatListMarkdownString(ListOutput{})
-	if !strings.Contains(s, "No wiki pages found") {
-		t.Error("expected empty message")
+	got := FormatListMarkdownString(ListOutput{})
+
+	want := "No wiki pages found.\n"
+
+	if got != want {
+		t.Errorf("empty list mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -888,11 +953,20 @@ func TestFormatListMarkdown_NonNil(t *testing.T) {
 	}
 }
 
-// TestFormatAttachmentMarkdownString_NoBranch verifies FormatAttachmentMarkdownString when no branch.
+// TestFormatAttachmentMarkdownString_NoBranch pins that an upload GitLab
+// answered with no branch writes no branch row at all.
 func TestFormatAttachmentMarkdownString_NoBranch(t *testing.T) {
-	s := FormatAttachmentMarkdownString(AttachmentOutput{FileName: "f", FilePath: "p", URL: "u", Markdown: "m"})
-	if strings.Contains(s, "Branch") {
-		t.Error("should not include Branch")
+	got := FormatAttachmentMarkdownString(AttachmentOutput{FileName: "f", FilePath: "p", URL: "u", Markdown: "m"})
+
+	want := "## Wiki Attachment Uploaded\n\n" +
+		"- **File Name**: f\n" +
+		"- **File Path**: p\n" +
+		"- **URL**: [u](u)\n" +
+		"- **Markdown**: `m`\n" +
+		wikiAttachmentHints
+
+	if got != want {
+		t.Errorf("card mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 


### PR DESCRIPTION
The second migration wave: the domains a model reaches through a pipeline rather than through a person. Merge requests and their notes, discussions, award emoji and resource events; the CI/CD family; repository content; runners, environments, deployments and releases; packages, the registry, dependencies, secure files and uploads.

The rule is the layer's rule, unchanged: one object is a card written by `toolutil.Card`, a collection of objects sharing columns is a table, and nothing else writes a card row by hand. A value the reader must copy exactly goes in a code span, an access level goes through `AccessLevelDescription`, an empty list through `EmptyMessage`, and a time through the shared formatter rather than as GitLab sent it.

The served surface does not move, and the golden snapshots say so.
