### PR TITLE
feat(e2e): declare the call record the rebuilt suite writes and the audit reads

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -10799,14 +10799,18 @@ func TestServerCardSubscriptions_PublishesTheEndingVocabulary(t *testing.T) {
 // is imported only from _test.go files. internal/freshness reads the harness
 // setting that defers a committed-artifact comparison and imports testing for
 // the skip it performs, which belongs in a test binary and nowhere else.
+// internal/testutil/e2ecalls is the record the end-to-end harness writes and
+// cmd/audit_e2e_coverage reads; it is named here in its own right because this
+// list matches exact import paths, so internal/testutil does not cover a
+// subpackage of it.
 //
-// Today all three stay out by accident, because nothing in the server's import
+// Today all four stay out by accident, because nothing in the server's import
 // graph happens to reach them. This makes it hold on purpose: the day somebody
 // imports test support from production code, this is the check that says so,
 // and it says so before the binary grows.
 func TestDependencies_TestSupport_NeverReachesTheServerBinary(t *testing.T) {
 	const modulePrefix = "github.com/jmrplens/gitlab-mcp-server/v3/"
-	forbidden := []string{"internal/testutil", "internal/graphqlschema", "internal/freshness"}
+	forbidden := []string{"internal/testutil", "internal/testutil/e2ecalls", "internal/graphqlschema", "internal/freshness"}
 
 	// The package list is asked of the toolchain rather than derived from the
 	// source, because an indirect import through any of the 250 packages in

--- a/internal/testutil/e2ecalls/doc.go
+++ b/internal/testutil/e2ecalls/doc.go
@@ -1,0 +1,40 @@
+// Package e2ecalls declares the record the end-to-end suite writes down while
+// it runs, and the coverage audit reads back afterwards: what a test asked the
+// server to do, what the server dispatched, and on which runtime, surface and
+// mode.
+//
+// # Why the record exists
+//
+// Coverage used to be credited by mentions in the source: cmd/audit_e2e_gaps
+// globs the suite's test files and credits any catalog action whose ID appears
+// on a code line. That counts an action nothing runs, and it counted eighteen
+// of them that neither Docker target can reach. A call counts here only when
+// the server dispatched it, in a test that passed, on a named runtime, surface
+// and mode, which is what these lines carry.
+//
+// # Why it is a package of its own
+//
+// Two programs read and write it: the e2e harness, which is built with the e2e
+// tag, and cmd/audit_e2e_coverage, which is an ordinary command. A shared Go
+// type is what keeps the two halves from drifting, and it can only be shared
+// from a package both may import. internal/testutil cannot be that package: it
+// embeds the pinned GraphQL schema and net/http/httptest, which a command has
+// no use for and would carry anyway. So this package is untagged, imports only
+// the standard library, and holds nothing else.
+//
+// Being untagged means it is compiled by an ordinary build, enters make test,
+// the coverage job and Sonar, and is held to the same bar as production code.
+// It must still never reach the server binary: cmd/server's
+// TestDependencies_TestSupport_NeverReachesTheServerBinary names it, because
+// that test matches exact import paths and internal/testutil alone does not
+// cover a subpackage of it.
+//
+// # What a shard is
+//
+// One test process writes one shard, named [ShardPattern], into the directory
+// [DirEnv] names. Nothing is written when that variable is unset. Each line is
+// one JSON [Record]: a schema version, a line type, and exactly one payload of
+// [Run], [Session], [Call], [Dispatch] or [Skip]. [Read] merges a directory of
+// them, subdirectories included, so one run per Docker target can be compared
+// against another without moving files around.
+package e2ecalls

--- a/internal/testutil/e2ecalls/reader.go
+++ b/internal/testutil/e2ecalls/reader.go
@@ -1,0 +1,112 @@
+// The reading half: every shard of a directory tree, merged in one pass, with
+// a line nobody can read reported rather than dropped.
+
+package e2ecalls
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxShardLine bounds one recorded line.
+//
+// The longest today is a session line carrying a thousand tool names, which is
+// tens of kilobytes, and the scanner's default 64 KiB limit would nearly cover
+// it. The cap is a megabyte because a line silently dropped for being long
+// would look exactly like a call nobody made, which is the one thing this
+// record exists to be believed about.
+const maxShardLine = 1 << 20
+
+// Read merges every shard under dir, subdirectories included, in the order the
+// directory tree walks.
+//
+// Subdirectories are read because one run per Docker target writes into a
+// directory of its own, and the coverage audit compares the runtimes against
+// each other: making a reader out of two of them would otherwise mean copying
+// files around before anything could be compared.
+//
+// A directory holding no shard is an error rather than an empty result. These
+// shards are written by a suite run, so nothing there means the suite did not
+// run with recording on, and reporting that as zero coverage would be a claim
+// about the server made from a claim about the harness.
+func Read(dir string) ([]Record, error) {
+	var (
+		records     []Record
+		readFailure error
+		shards      int
+	)
+	walkErr := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, entryErr error) error {
+		if entryErr != nil {
+			return entryErr
+		}
+		if entry.IsDir() || !isShard(entry.Name()) {
+			return nil
+		}
+		shards++
+		read, err := readShard(path)
+		if err != nil {
+			readFailure = err
+			return fs.SkipAll
+		}
+		records = append(records, read...)
+		return nil
+	})
+	if readFailure != nil {
+		return nil, readFailure
+	}
+	if walkErr != nil {
+		return nil, fmt.Errorf("read shard directory %s: %w", dir, walkErr)
+	}
+	if shards == 0 {
+		return nil, fmt.Errorf("no %s shard under %s: the suite records only when %s is set to an absolute directory", ShardPattern, dir, DirEnv)
+	}
+	return records, nil
+}
+
+// isShard reports whether a file name is one of this package's shards.
+//
+// It matches the two halves of [ShardPattern] rather than calling
+// [path/filepath.Match] on it, which would hand back a pattern error this
+// package owns the pattern for and could only discard.
+func isShard(name string) bool {
+	return strings.HasPrefix(name, shardPrefix) && strings.HasSuffix(name, shardExt)
+}
+
+// readShard reads one shard file.
+func readShard(path string) ([]Record, error) {
+	// #nosec G304 -- the path comes from a walk of the directory the caller named.
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("open shard: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	var records []Record
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxShardLine)
+	line := 0
+	for scanner.Scan() {
+		line++
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		var record Record
+		if unmarshalErr := json.Unmarshal([]byte(text), &record); unmarshalErr != nil {
+			return nil, fmt.Errorf("parse %s line %d: %w", path, line, unmarshalErr)
+		}
+		if validateErr := record.validate(); validateErr != nil {
+			return nil, fmt.Errorf("%s line %d: %w", path, line, validateErr)
+		}
+		records = append(records, record)
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, fmt.Errorf("read %s: %w", path, scanErr)
+	}
+	return records, nil
+}

--- a/internal/testutil/e2ecalls/reader.go
+++ b/internal/testutil/e2ecalls/reader.go
@@ -62,7 +62,10 @@ func Read(dir string) ([]Record, error) {
 	if walkErr != nil {
 		return nil, fmt.Errorf("read shard directory %s: %w", dir, walkErr)
 	}
-	if shards == 0 {
+	// Asked as "did the walk reach at least one shard" rather than "is the
+	// count exactly zero": the question is whether anything was read, and a
+	// guard that only recognizes one value answers it for one value.
+	if shards <= 0 {
 		return nil, fmt.Errorf("no %s shard under %s: the suite records only when %s is set to an absolute directory", ShardPattern, dir, DirEnv)
 	}
 	return records, nil

--- a/internal/testutil/e2ecalls/reader_test.go
+++ b/internal/testutil/e2ecalls/reader_test.go
@@ -157,6 +157,70 @@ func TestRead_ReportsALineItCannotRead(t *testing.T) {
 	}
 }
 
+// TestRead_NamesTheLineTheBadRecordIsOn verifies that the error counts lines
+// from one and names the line the bad record is actually on, with a good
+// record and a blank line ahead of it.
+//
+// The number is the whole value of the message: a shard is one line per call
+// and can hold thousands, so an error that names the file and not the line
+// says only that the run is unreadable. A blank line is skipped rather than
+// counted, because the writer ends every line with a newline and the last one
+// therefore reads as empty.
+func TestRead_NamesTheLineTheBadRecordIsOn(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "calls-numbered.jsonl",
+		`{"schema":1,"type":"skip","skip":{"test":"a","reason":"b"}}`,
+		"",
+		`{"schema":1,"type":"skip"}`,
+	)
+
+	_, err := Read(dir)
+
+	if err == nil {
+		t.Fatal("Read error = nil, want one naming the third line")
+	}
+	if !strings.Contains(err.Error(), "line 3") {
+		t.Errorf("Read error = %v, want it to name line 3", err)
+	}
+}
+
+// TestShardPattern_MatchesWhatTheWriterNames verifies that the pattern a
+// reader is told to look for is the one a writer's own file name satisfies,
+// and that isShard agrees with filepath.Match on it.
+//
+// The two are spelled apart on purpose, the pattern from its prefix and
+// extension and the predicate from the same two constants, so nothing but a
+// test holds them to each other.
+func TestShardPattern_MatchesWhatTheWriterNames(t *testing.T) {
+	if ShardPattern != "calls-*.jsonl" {
+		t.Errorf("ShardPattern = %q, want calls-*.jsonl", ShardPattern)
+	}
+
+	dir := t.TempDir()
+	Release()
+	t.Cleanup(Release)
+	OpenDir(dir).Write(&recordingReporter{}, &Skip{Test: "a", Reason: "b"})
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("the writer left %d file(s) in its directory, want exactly one shard", len(entries))
+	}
+	name := entries[0].Name()
+	matched, matchErr := filepath.Match(ShardPattern, name)
+	if matchErr != nil {
+		t.Fatalf("Match error = %v", matchErr)
+	}
+	if !matched {
+		t.Errorf("the shard the writer named, %q, does not match ShardPattern %q", name, ShardPattern)
+	}
+	if !isShard(name) {
+		t.Errorf("isShard(%q) = false, want true: it must agree with ShardPattern", name)
+	}
+}
+
 // TestReadShard_ReportsAFileItCannotOpen verifies that a shard that cannot be
 // opened is reported.
 //

--- a/internal/testutil/e2ecalls/reader_test.go
+++ b/internal/testutil/e2ecalls/reader_test.go
@@ -1,0 +1,194 @@
+package e2ecalls
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeShard writes one shard file holding the given raw lines and returns its
+// path.
+func writeShard(t *testing.T, dir, name string, lines ...string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("MkdirAll error = %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+	return path
+}
+
+// TestRead_MergesEveryShardUnderTheDirectory verifies that Read returns what
+// the writer wrote, from the directory and from its subdirectories, and
+// ignores everything that is not a shard.
+//
+// Subdirectories are read because one Docker target records into a directory
+// of its own and the audit compares the runtimes against each other. Files
+// that are not shards are ignored because the same directory carries the
+// gotestsum JSON and the junit report of the run.
+func TestRead_MergesEveryShardUnderTheDirectory(t *testing.T) {
+	root := t.TempDir()
+	t.Cleanup(Release)
+
+	reporter := &recordingReporter{}
+	OpenDir(root).Write(reporter,
+		&Run{Package: "common", Requirement: "any", Status: RunStarted},
+		&Call{Test: "TestCommon_Issues", Action: "issue.list", Outcome: OutcomeOK, TestStatus: StatusPassed},
+	)
+	if len(reporter.messages) != 0 {
+		t.Fatalf("reported %v, want nothing", reporter.messages)
+	}
+	nested := filepath.Join(root, "ee")
+	writeShard(t, nested, "calls-ee.jsonl",
+		`{"schema":1,"type":"skip","skip":{"test":"TestEE_Epics","reason":"no license"}}`,
+		"",
+	)
+	writeShard(t, root, "notes.txt", "not a shard")
+	writeShard(t, root, "calls-report.txt", "not a shard either")
+
+	records, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read error = %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("records = %d, want 3: %+v", len(records), records)
+	}
+	byType := map[string]int{}
+	for _, record := range records {
+		byType[record.Type]++
+	}
+	for _, lineType := range []string{TypeRun, TypeCall, TypeSkip} {
+		t.Run(lineType, func(t *testing.T) {
+			if byType[lineType] != 1 {
+				t.Errorf("%s lines = %d, want 1", lineType, byType[lineType])
+			}
+		})
+	}
+	for _, record := range records {
+		if record.Call != nil && record.Call.Action != "issue.list" {
+			t.Errorf("call action = %q, want the one the writer wrote", record.Call.Action)
+		}
+	}
+}
+
+// TestRead_RefusesADirectoryHoldingNoShard verifies that an empty directory is
+// an error naming the switch, rather than an empty result.
+//
+// An empty result would be read as a suite that covered nothing, which is a
+// claim about the server made from a fact about the harness: nothing was
+// recorded because nothing asked for recording.
+func TestRead_RefusesADirectoryHoldingNoShard(t *testing.T) {
+	records, err := Read(t.TempDir())
+
+	if err == nil {
+		t.Fatalf("Read = %d record(s), want an error", len(records))
+	}
+	if !strings.Contains(err.Error(), DirEnv) {
+		t.Errorf("Read error = %v, want it to name %s", err, DirEnv)
+	}
+}
+
+// TestRead_ReportsADirectoryItCannotWalk verifies that a directory that is not
+// there is reported with its path.
+func TestRead_ReportsADirectoryItCannotWalk(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "never-created")
+
+	_, err := Read(missing)
+
+	if err == nil {
+		t.Fatal("Read error = nil, want an error for a missing directory")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("Read error = %v, want it to name %s", err, missing)
+	}
+}
+
+// TestRead_ReportsALineItCannotRead verifies that a shard line which is not
+// JSON, or which is JSON the record does not hold together, is reported with
+// the file and the line number.
+//
+// A shard is machine-written, so either means the artifact is stale or
+// truncated. The line number is what makes that diagnosable at all, since a
+// shard has no other landmarks.
+func TestRead_ReportsALineItCannotRead(t *testing.T) {
+	cases := []struct {
+		name    string
+		lines   []string
+		wantErr string
+	}{
+		{
+			name:    "not json",
+			lines:   []string{`{"schema":1,"type":"skip","skip":{"test":"a","reason":"b"}}`, "{"},
+			wantErr: "parse",
+		},
+		{
+			name:    "type without its payload",
+			lines:   []string{`{"schema":1,"type":"call"}`},
+			wantErr: "carries no payload",
+		},
+		{
+			name:    "another schema",
+			lines:   []string{`{"schema":99,"type":"skip","skip":{"test":"a","reason":"b"}}`},
+			wantErr: "schema",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeShard(t, dir, "calls-broken.jsonl", testCase.lines...)
+
+			_, err := Read(dir)
+
+			if err == nil {
+				t.Fatalf("Read error = nil, want one mentioning %q", testCase.wantErr)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Errorf("Read error = %v, want it to mention %q", err, testCase.wantErr)
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("Read error = %v, want it to name %s", err, path)
+			}
+		})
+	}
+}
+
+// TestReadShard_ReportsAFileItCannotOpen verifies that a shard that cannot be
+// opened is reported.
+//
+// It is called directly because a walk only offers files it has just listed,
+// so this branch is unreachable through Read on any tree a test can build.
+func TestReadShard_ReportsAFileItCannotOpen(t *testing.T) {
+	_, err := readShard(filepath.Join(t.TempDir(), "calls-missing.jsonl"))
+
+	if err == nil {
+		t.Fatal("readShard error = nil, want an error for a file that is not there")
+	}
+	if !strings.Contains(err.Error(), "open shard") {
+		t.Errorf("readShard error = %v, want it to say the shard could not be opened", err)
+	}
+}
+
+// TestRead_RefusesALineBeyondTheCap verifies that a line longer than the cap is
+// reported rather than skipped.
+//
+// A line silently dropped for being long looks exactly like a call nobody
+// made, and a coverage record that can lose calls quietly is not one anybody
+// should act on.
+func TestRead_RefusesALineBeyondTheCap(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "calls-long.jsonl", strings.Repeat("x", maxShardLine+1))
+
+	_, err := Read(dir)
+
+	if err == nil {
+		t.Fatal("Read error = nil, want an error for a line beyond the cap")
+	}
+	if !strings.Contains(err.Error(), "calls-long.jsonl") {
+		t.Errorf("Read error = %v, want it to name the shard", err)
+	}
+}

--- a/internal/testutil/e2ecalls/record.go
+++ b/internal/testutil/e2ecalls/record.go
@@ -200,6 +200,20 @@ func (r Record) validate() error {
 	if !present(r) {
 		return fmt.Errorf("line type %q carries no payload", r.Type)
 	}
+	// Exactly one payload is the envelope's contract, and the type naming one
+	// says nothing about the other four: a line carrying a call and a
+	// dispatch together is two claims under one type, and a reader that took
+	// the named half would compute coverage over a record it had only half
+	// read. Machine-written or not, that is a shard to refuse.
+	carried := 0
+	for _, has := range payloadPresent {
+		if has(r) {
+			carried++
+		}
+	}
+	if carried != 1 {
+		return fmt.Errorf("line type %q carries %d payloads, want exactly one", r.Type, carried)
+	}
 	return nil
 }
 

--- a/internal/testutil/e2ecalls/record.go
+++ b/internal/testutil/e2ecalls/record.go
@@ -1,0 +1,409 @@
+// The line shapes a shard holds, and the one envelope they are written in.
+// Every field name here is the contract between the harness that writes a
+// shard and cmd/audit_e2e_coverage that reads it.
+
+package e2ecalls
+
+import "fmt"
+
+const (
+	// DirEnv names the directory the end-to-end harness records its calls
+	// into. Recording is off unless it is set, so an ordinary suite run pays
+	// nothing for it.
+	//
+	// The path must be absolute. A test binary runs with its own package
+	// directory as the working directory, so a relative path would drop one
+	// shard under each of the suite's package directories and the merge would
+	// find none of them. A relative value is refused rather than resolved,
+	// because resolving it would produce exactly that scattering silently. The
+	// sibling GITLAB_MCP_TEST_INVENTORY_DIR is refused on the same terms.
+	//
+	// It carries the project's prefix and is not one of the settings
+	// internal/config resolves: it configures the test harness, cmd/server
+	// never reads it, and there is no legacy spelling of it to warn anybody
+	// about. That is the standing the developer-only EVAL_SURFACE_* variables
+	// have.
+	DirEnv = "GITLAB_MCP_TEST_E2E_CALLS_DIR"
+
+	// SchemaVersion is the version every line carries. A reader refuses a line
+	// written under another one rather than guessing which fields it holds:
+	// these shards are read by a command in the same tree, so a mismatch means
+	// a stale artifact and not an old peer to be tolerated.
+	SchemaVersion = 1
+
+	// ShardPattern is the [os.CreateTemp] pattern a shard file is named with.
+	// One process writes one shard, so package binaries running side by side
+	// never write to the same file and no cross-process locking is needed.
+	ShardPattern = shardPrefix + "*" + shardExt
+
+	// shardPrefix and shardExt bracket the name of a shard. [Read] matches
+	// them directly instead of calling [path/filepath.Match] on ShardPattern,
+	// so it has no pattern error to discard.
+	shardPrefix = "calls-"
+	shardExt    = ".jsonl"
+)
+
+// The five line types. Every [Record] carries exactly one of them, and the
+// reader refuses a record whose payload is not the one its type names.
+const (
+	// TypeRun names the line a test package writes once: which runtime it
+	// found, what it required, and whether it went on to run.
+	TypeRun = "run"
+	// TypeSession names the line one server configuration writes when it
+	// starts, holding what that session serves.
+	TypeSession = "session"
+	// TypeCall names the line one MCP call writes: what a test asked for and
+	// what came back.
+	TypeCall = "call"
+	// TypeDispatch names the line the server's own span writes: what it
+	// decided to run for a call the harness made.
+	TypeDispatch = "dispatch"
+	// TypeSkip names the line a skipped test writes, with its reason.
+	TypeSkip = "skip"
+)
+
+// What a call was made for. A call made to build or tear down fixture state is
+// worth less as coverage than one a test asserted on, so the purpose is
+// recorded rather than inferred from the test name.
+const (
+	// PurposeTest is a call the test body made and asserted on.
+	PurposeTest = "test"
+	// PurposeCleanup is a call made from a cleanup, after the test body.
+	PurposeCleanup = "cleanup"
+	// PurposeSweep is a call made by a sweep over what a session serves.
+	PurposeSweep = "sweep"
+	// PurposeRaw is a call made through the harness's raw escape hatch, where
+	// the protocol rather than the action is what the test is about.
+	PurposeRaw = "raw"
+)
+
+// What the caller expected. Anything other than these two names a harness
+// failure class, which is why the field is a string here: the classes belong
+// to the harness, and this package is the record rather than the vocabulary.
+const (
+	// ExpectationOK is a call the test expected to succeed.
+	ExpectationOK = "ok"
+	// ExpectationAny is a call whose outcome the test did not constrain.
+	ExpectationAny = "any"
+)
+
+// What came back. A refusal carries its reason, which is why it is a prefix
+// and not a value: [RefusedOutcome] spells one.
+const (
+	// OutcomeOK is a call the server answered without an error.
+	OutcomeOK = "ok"
+	// OutcomeToolError is a call answered with a tool error result.
+	OutcomeToolError = "tool_error"
+	// OutcomeProtocolError is a call answered with a JSON-RPC error.
+	OutcomeProtocolError = "protocol_error"
+	// OutcomeTransportError is a call that never got an answer.
+	OutcomeTransportError = "transport_error"
+	// OutcomePreview is a safe-mode preview: the server answered the call with
+	// the preview of a mutation it did not make.
+	OutcomePreview = "preview"
+	// OutcomeRefusedPrefix starts the outcome of a call the server refused.
+	// The refusal reason follows it.
+	OutcomeRefusedPrefix = "refused:"
+)
+
+// Whether a package ran at all. A refused run is recorded rather than left
+// silent, because a missing run line and a run that refused to start are
+// different answers to "was this runtime exercised".
+const (
+	// RunStarted is a package whose runtime met its requirement.
+	RunStarted = "started"
+	// RunRefused is a package that found a runtime it cannot run on.
+	RunRefused = "refused"
+)
+
+// How the test a call belongs to ended. Records are buffered per test and
+// written from its first-registered cleanup, so every call knows this by the
+// time it is written.
+const (
+	// StatusPassed is a test that ended without a failure.
+	StatusPassed = "passed"
+	// StatusFailed is a test that failed.
+	StatusFailed = "failed"
+	// StatusSkipped is a test that skipped.
+	StatusSkipped = "skipped"
+)
+
+// RefusedOutcome spells the outcome of a call the server refused for the given
+// reason, as [OutcomeRefusedPrefix] followed by that reason.
+//
+// It exists so the writer and the reader agree on one spelling: the coverage
+// audit classifies a refusal by this prefix, and a second hand-written
+// concatenation is how the two would come to disagree.
+func RefusedOutcome(reason string) string {
+	return OutcomeRefusedPrefix + reason
+}
+
+// Line is one thing a shard can hold. The set is closed on purpose: [Run],
+// [Session], [Call], [Dispatch] and [Skip] are the only implementations,
+// because the reader dispatches on [Record.Type] and a sixth shape it has
+// never heard of would be dropped or guessed at.
+type Line interface {
+	// record wraps the line in the envelope it is written as.
+	record() Record
+}
+
+// Record is one line of a shard: the schema it was written under, which line
+// it is, and exactly one payload.
+//
+// It is an envelope rather than one flat struct because the five lines share
+// almost no fields, and a flat struct would answer "which of these fields
+// apply" with a convention instead of with the type.
+type Record struct {
+	// Schema is [SchemaVersion] as of the run that wrote the line.
+	Schema int `json:"schema"`
+	// Type names which payload is set: one of the Type* constants.
+	Type string `json:"type"`
+	// Run is set when Type is [TypeRun].
+	Run *Run `json:"run,omitempty"`
+	// Session is set when Type is [TypeSession].
+	Session *Session `json:"session,omitempty"`
+	// Call is set when Type is [TypeCall].
+	Call *Call `json:"call,omitempty"`
+	// Dispatch is set when Type is [TypeDispatch].
+	Dispatch *Dispatch `json:"dispatch,omitempty"`
+	// Skip is set when Type is [TypeSkip].
+	Skip *Skip `json:"skip,omitempty"`
+}
+
+// payloadPresent answers, per line type, whether the record carries the
+// payload that type names.
+//
+// It is a table rather than a switch so that adding a line type is one entry
+// in one place: the reader asks it both questions it has, whether the type is
+// known and whether its payload is there.
+var payloadPresent = map[string]func(Record) bool{
+	TypeRun:      func(r Record) bool { return r.Run != nil },
+	TypeSession:  func(r Record) bool { return r.Session != nil },
+	TypeCall:     func(r Record) bool { return r.Call != nil },
+	TypeDispatch: func(r Record) bool { return r.Dispatch != nil },
+	TypeSkip:     func(r Record) bool { return r.Skip != nil },
+}
+
+// validate reports what is wrong with a record read back from a shard.
+//
+// A shard is machine-written, so every one of these means the artifact is
+// stale or truncated rather than that a caller made a mistake. Reporting it is
+// what keeps a coverage figure from being computed over lines nobody can read.
+func (r Record) validate() error {
+	if r.Schema != SchemaVersion {
+		return fmt.Errorf("schema %d is not %d: the shard was written by another version of this package", r.Schema, SchemaVersion)
+	}
+	present, known := payloadPresent[r.Type]
+	if !known {
+		return fmt.Errorf("unknown line type %q", r.Type)
+	}
+	if !present(r) {
+		return fmt.Errorf("line type %q carries no payload", r.Type)
+	}
+	return nil
+}
+
+// FixtureProfile is what a runtime had available to the test package that ran
+// on it.
+//
+// It travels with the run line because a scenario that needs a CI runner is
+// absent rather than failing when there is none, and a coverage figure that
+// cannot tell those apart is not worth reading.
+type FixtureProfile struct {
+	// Runner is whether a CI runner was registered.
+	Runner bool `json:"runner"`
+	// FixtureService is whether the compose fixture service was up.
+	FixtureService bool `json:"fixture_service"`
+	// Bitbucket is whether the Bitbucket import source was up.
+	Bitbucket bool `json:"bitbucket"`
+	// GHToken is whether a GitHub token was configured for import scenarios.
+	GHToken bool `json:"gh_token"`
+	// Seeds names the per-consumer seeds the setup script created.
+	Seeds []string `json:"seeds,omitempty"`
+}
+
+// Run is what one test package found when it started, written once per
+// package.
+//
+// It is the denominator of everything else in the shard: a call means nothing
+// without the runtime it was made against, since the served catalog, the
+// pruned schemas and the actions that exist at all follow from the edition and
+// the tier.
+type Run struct {
+	// Package is the test package that wrote the line.
+	Package string `json:"package"`
+	// Requirement is the runtime the package asked for.
+	Requirement string `json:"requirement"`
+	// Edition is what the instance reported: a community or enterprise build.
+	Edition string `json:"edition"`
+	// Tier is the licensing tier the catalog was built at.
+	Tier string `json:"tier"`
+	// TierConfirmed is whether the tier came from the instance license rather
+	// than from a setting. An unconfirmed tier means the catalog may hold
+	// actions the instance will refuse.
+	TierConfirmed bool `json:"tier_confirmed"`
+	// GitLabVersion is the version the instance reported.
+	GitLabVersion string `json:"gitlab_version"`
+	// RunID is the identifier every name this run created is scoped to, which
+	// is also what the orphan sweep deletes by.
+	RunID string `json:"run_id"`
+	// Commit is the revision under test, from E2E_COMMIT.
+	Commit string `json:"commit,omitempty"`
+	// Filter is the -run expression the binary was given, empty when it ran
+	// everything. A partial run is not a coverage claim about the rest.
+	Filter string `json:"filter,omitempty"`
+	// Fixtures is what the runtime had available.
+	Fixtures FixtureProfile `json:"fixtures"`
+	// Status is [RunStarted] or [RunRefused].
+	Status string `json:"status"`
+	// Reason says why a refused run refused. It is empty on a started run.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Session is one server configuration, written when that session starts.
+//
+// What a session serves is the denominator the coverage audit divides by: an
+// action no session served is absent rather than untested, and the two are
+// different findings.
+type Session struct {
+	// Label names the session in the call lines that reference it.
+	Label string `json:"label"`
+	// Surface is dynamic, meta or individual.
+	Surface string `json:"surface"`
+	// Mode is default, read-only or safe.
+	Mode string `json:"mode"`
+	// Capabilities is the resource and prompt surface: full or minimal.
+	Capabilities string `json:"capabilities"`
+	// Transport is how the harness reached the binary.
+	Transport string `json:"transport"`
+	// Tools are the tool names the session listed.
+	Tools []string `json:"tools,omitempty"`
+	// Resources are the static resource URIs the session listed.
+	Resources []string `json:"resources,omitempty"`
+	// ResourceTemplates are the URI templates the session listed.
+	ResourceTemplates []string `json:"resource_templates,omitempty"`
+	// Prompts are the prompt names the session listed.
+	Prompts []string `json:"prompts,omitempty"`
+	// Completions are the completion references the session offers.
+	Completions []string `json:"completions,omitempty"`
+	// SubscribableKinds are the resource kinds the session accepts a
+	// subscription for.
+	SubscribableKinds []string `json:"subscribable_kinds,omitempty"`
+	// DispatchObserved is whether the harness ever saw a span from this
+	// session. When it is false every call of the session is a claim about
+	// what was asked for and not about what ran.
+	DispatchObserved bool `json:"dispatch_observed"`
+}
+
+// Call is one MCP call a test made.
+//
+// It holds both halves of the question coverage asks: what the test requested,
+// which the client knows, and what the server dispatched, which only the
+// server's own span can say. The two differ wherever an alias is rewritten,
+// and crediting the requested one would credit an action that never ran.
+type Call struct {
+	// Test names the top-level test the call is attributed to.
+	Test string `json:"test"`
+	// Purpose is one of the Purpose* constants.
+	Purpose string `json:"purpose"`
+	// Expectation is [ExpectationOK], [ExpectationAny] or a harness failure
+	// class the test declared.
+	Expectation string `json:"expectation"`
+	// Session is the label of the session the call went to.
+	Session string `json:"session"`
+	// Surface repeats the session's surface, as Mode and Capabilities repeat
+	// the rest of its shape, so one call line can be classified on its own
+	// rather than only after a join back to the session that served it.
+	Surface string `json:"surface"`
+	// Mode is the protective mode the session runs in.
+	Mode string `json:"mode"`
+	// Capabilities is the resource and prompt surface of the session.
+	Capabilities string `json:"capabilities"`
+	// Requirement is the runtime requirement of the package that made the
+	// call.
+	Requirement string `json:"requirement"`
+	// Method is the MCP method, so the non-tool verbs are recorded on the same
+	// terms as tools/call.
+	Method string `json:"method"`
+	// Tool is the tool name the call named, empty for a method that names
+	// none.
+	Tool string `json:"tool,omitempty"`
+	// Action is the canonical catalog ID the test asked for.
+	Action string `json:"action,omitempty"`
+	// Dispatched is the canonical ID the server reported running, joined from
+	// the span on [Call.TraceID]. It is empty when no span arrived.
+	Dispatched string `json:"dispatched,omitempty"`
+	// Target names what a non-tool call addressed: a resource URI, a prompt or
+	// a completion reference.
+	Target string `json:"target,omitempty"`
+	// Arguments are the argument names the call carried, sorted. The values
+	// are left out: a value is a fixture, a name is part of the call.
+	Arguments []string `json:"arguments,omitempty"`
+	// Outcome is one of the Outcome* constants, or [RefusedOutcome] of the
+	// reason the server gave.
+	Outcome string `json:"outcome"`
+	// DurationMS is how long the call took, in milliseconds.
+	DurationMS float64 `json:"duration_ms,omitempty"`
+	// TraceID is the W3C trace the harness stamped into the call, which is
+	// what a [Dispatch] line joins on.
+	TraceID string `json:"trace_id,omitempty"`
+	// TestStatus is how the test ended: one of the Status* constants. A call
+	// made by a test that failed is not coverage.
+	TestStatus string `json:"test_status"`
+}
+
+// Dispatch is what the server said it ran, read from its own OTLP span.
+//
+// It is a line of its own rather than only a field of [Call] because the span
+// arrives over the network after the answer does. A call flushed before its
+// span lands carries no dispatched action, and this line is what the audit
+// joins to it afterwards.
+type Dispatch struct {
+	// TraceID is the trace the harness stamped into the call this describes.
+	TraceID string `json:"trace_id"`
+	// Tool is the span's gen_ai.tool.name.
+	Tool string `json:"tool,omitempty"`
+	// Action is the span's gitlab_mcp.action, which names the route that ran
+	// rather than the one the call asked for.
+	Action string `json:"action,omitempty"`
+	// Domain is the span's gitlab_mcp.domain.
+	Domain string `json:"domain,omitempty"`
+	// RefusalReason is the span's gitlab_mcp.refusal_reason, set when the
+	// server declined to run the action.
+	RefusalReason string `json:"refusal_reason,omitempty"`
+	// ErrorType is the span's error.type.
+	ErrorType string `json:"error_type,omitempty"`
+	// Status is the span status.
+	Status string `json:"status,omitempty"`
+}
+
+// Skip is a test that did not run, with the reason it gave.
+//
+// A skip is recorded because it is the honest third answer beside covered and
+// absent: an action whose only scenario skips for want of a runner is not
+// covered, and saying so is more useful than leaving the cell empty.
+type Skip struct {
+	// Test names the test that skipped.
+	Test string `json:"test"`
+	// Reason is what it said when it skipped.
+	Reason string `json:"reason"`
+}
+
+// record wraps the run line in its envelope.
+func (r *Run) record() Record { return Record{Schema: SchemaVersion, Type: TypeRun, Run: r} }
+
+// record wraps the session line in its envelope.
+func (s *Session) record() Record {
+	return Record{Schema: SchemaVersion, Type: TypeSession, Session: s}
+}
+
+// record wraps the call line in its envelope.
+func (c *Call) record() Record { return Record{Schema: SchemaVersion, Type: TypeCall, Call: c} }
+
+// record wraps the dispatch line in its envelope.
+func (d *Dispatch) record() Record {
+	return Record{Schema: SchemaVersion, Type: TypeDispatch, Dispatch: d}
+}
+
+// record wraps the skip line in its envelope.
+func (s *Skip) record() Record { return Record{Schema: SchemaVersion, Type: TypeSkip, Skip: s} }

--- a/internal/testutil/e2ecalls/record_test.go
+++ b/internal/testutil/e2ecalls/record_test.go
@@ -1,0 +1,172 @@
+package e2ecalls
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRefusedOutcome_CarriesThePrefixAndTheReason verifies that a refusal is
+// spelled as the prefix the reader classifies on followed by the reason the
+// server gave.
+//
+// It matters because the coverage audit tells a refused call from a served one
+// by that prefix alone. A second hand-written concatenation anywhere would be
+// how the writer and the reader come to disagree about what a refusal looks
+// like, so there is one function and this test pins what it produces.
+func TestRefusedOutcome_CarriesThePrefixAndTheReason(t *testing.T) {
+	got := RefusedOutcome("read_only")
+
+	if want := "refused:read_only"; got != want {
+		t.Errorf("RefusedOutcome = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, OutcomeRefusedPrefix) {
+		t.Errorf("RefusedOutcome = %q, want it to start with %q", got, OutcomeRefusedPrefix)
+	}
+}
+
+// TestLineRecord_WrapsEachLineInItsOwnEnvelope verifies that every line type
+// declares the schema version, names its own type, and sets its own payload
+// and no other.
+//
+// The envelope is the whole contract with the reader: it dispatches on the
+// type and reads the payload that type names. A line wrapping itself as the
+// wrong type, or leaving its payload unset, would be dropped by a reader that
+// is right to refuse it, so each of the five is checked here rather than only
+// through whichever ones a round-trip test happens to use.
+func TestLineRecord_WrapsEachLineInItsOwnEnvelope(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     Line
+		wantType string
+	}{
+		{name: "run", line: &Run{Package: "common", Status: RunStarted}, wantType: TypeRun},
+		{name: "session", line: &Session{Label: "dynamic"}, wantType: TypeSession},
+		{name: "call", line: &Call{Test: "TestCommon_Issues"}, wantType: TypeCall},
+		{name: "dispatch", line: &Dispatch{TraceID: "abc"}, wantType: TypeDispatch},
+		{name: "skip", line: &Skip{Test: "TestCommon_Issues", Reason: "no runner"}, wantType: TypeSkip},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			record := testCase.line.record()
+
+			if record.Schema != SchemaVersion {
+				t.Errorf("Schema = %d, want %d", record.Schema, SchemaVersion)
+			}
+			if record.Type != testCase.wantType {
+				t.Errorf("Type = %q, want %q", record.Type, testCase.wantType)
+			}
+			// validate is what the reader applies, and it is the check that
+			// the payload named by the type is the one that was set.
+			if err := record.validate(); err != nil {
+				t.Errorf("validate() = %v, want nil for a line wrapping itself", err)
+			}
+		})
+	}
+}
+
+// TestRecordValidate_RefusesALineItCannotRead verifies that a record whose
+// schema, type or payload does not hold together is reported rather than
+// accepted.
+//
+// A shard is machine-written, so each of these means the artifact is stale or
+// truncated. Accepting one would let the coverage audit compute a figure over
+// lines it did not understand, which is worse than refusing to compute one.
+func TestRecordValidate_RefusesALineItCannotRead(t *testing.T) {
+	cases := []struct {
+		name    string
+		record  Record
+		wantErr string
+	}{
+		{
+			name:    "another schema",
+			record:  Record{Schema: SchemaVersion + 1, Type: TypeCall, Call: &Call{}},
+			wantErr: "schema",
+		},
+		{
+			name:    "unknown type",
+			record:  Record{Schema: SchemaVersion, Type: "elicitation", Skip: &Skip{}},
+			wantErr: "unknown line type",
+		},
+		{
+			name:    "run without a payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeRun},
+			wantErr: "carries no payload",
+		},
+		{
+			name:    "session without a payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeSession},
+			wantErr: "carries no payload",
+		},
+		{
+			name:    "call without a payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeCall},
+			wantErr: "carries no payload",
+		},
+		{
+			name:    "dispatch without a payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeDispatch},
+			wantErr: "carries no payload",
+		},
+		{
+			name:    "skip without a payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeSkip},
+			wantErr: "carries no payload",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.record.validate()
+
+			if err == nil {
+				t.Fatalf("validate() = nil, want an error mentioning %q", testCase.wantErr)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Errorf("validate() = %v, want it to mention %q", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+// TestRecord_KeepsTheFieldNamesTheReaderJoinsOn verifies that the JSON of a
+// call line spells the fields cmd/audit_e2e_coverage reads by name.
+//
+// The Go type is shared, so a renamed field would move both halves together
+// and compile. What would not move with it is a shard written by an older run,
+// or a report someone reads by hand, and the trace ID is what the server's own
+// span is joined on. Pinning the spelling makes the rename visible here rather
+// than as an empty coverage column.
+func TestRecord_KeepsTheFieldNamesTheReaderJoinsOn(t *testing.T) {
+	line := &Call{
+		Test:       "TestCommon_Issues",
+		Purpose:    PurposeTest,
+		Action:     "issue.list",
+		Dispatched: "issue.list",
+		Outcome:    OutcomeOK,
+		TraceID:    "4bf92f3577b34da6a3ce929d0e0e4736",
+		TestStatus: StatusPassed,
+	}
+
+	encoded, err := json.Marshal(line.record())
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+
+	var decoded map[string]any
+	if unmarshalErr := json.Unmarshal(encoded, &decoded); unmarshalErr != nil {
+		t.Fatalf("Unmarshal error = %v", unmarshalErr)
+	}
+	call, ok := decoded["call"].(map[string]any)
+	if !ok {
+		t.Fatalf("encoded record = %s, want a call object under \"call\"", encoded)
+	}
+	for _, field := range []string{"test", "purpose", "action", "dispatched", "outcome", "trace_id", "test_status"} {
+		t.Run(field, func(t *testing.T) {
+			if _, present := call[field]; !present {
+				t.Errorf("call object = %v, want a %q field", call, field)
+			}
+		})
+	}
+}

--- a/internal/testutil/e2ecalls/record_test.go
+++ b/internal/testutil/e2ecalls/record_test.go
@@ -114,6 +114,25 @@ func TestRecordValidate_RefusesALineItCannotRead(t *testing.T) {
 			record:  Record{Schema: SchemaVersion, Type: TypeSkip},
 			wantErr: "carries no payload",
 		},
+		// The named payload is there and so is another: the envelope holds
+		// exactly one, and a reader that took the named half would have read
+		// half a record. The three shapes below are the ones a stale or
+		// hand-edited shard could plausibly hold.
+		{
+			name:    "call carrying a dispatch as well",
+			record:  Record{Schema: SchemaVersion, Type: TypeCall, Call: &Call{}, Dispatch: &Dispatch{}},
+			wantErr: "carries 2 payloads, want exactly one",
+		},
+		{
+			name:    "run carrying a session as well",
+			record:  Record{Schema: SchemaVersion, Type: TypeRun, Run: &Run{}, Session: &Session{}},
+			wantErr: "carries 2 payloads, want exactly one",
+		},
+		{
+			name:    "skip carrying every payload",
+			record:  Record{Schema: SchemaVersion, Type: TypeSkip, Run: &Run{}, Session: &Session{}, Call: &Call{}, Dispatch: &Dispatch{}, Skip: &Skip{}},
+			wantErr: "carries 5 payloads, want exactly one",
+		},
 	}
 
 	for _, testCase := range cases {

--- a/internal/testutil/e2ecalls/writer.go
+++ b/internal/testutil/e2ecalls/writer.go
@@ -1,0 +1,186 @@
+// The writing half: one shard per test process, opened when the first line is
+// written and never closed, because there is no shutdown hook to close it in.
+
+package e2ecalls
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// shardDirPerm is the mode the shard directory is created with. It holds
+// nothing secret, and nothing reads it except the merge that runs as the same
+// user.
+const shardDirPerm = 0o750
+
+// Reporter is the part of [testing.TB] the writer reports a broken shard
+// through.
+//
+// It is an interface rather than the concrete type for two reasons. This
+// package must not import testing: it is compiled into an ordinary build and
+// linked by cmd/audit_e2e_coverage, and a library that drags the testing
+// package into a command is a library nobody can use from one. And a reporter
+// is taken per call rather than held, because one shard is shared by every
+// test in the process while a failure belongs to whichever test was writing
+// when it happened.
+type Reporter interface {
+	// Errorf reports a failure without ending the test, the way
+	// [testing.T.Errorf] does.
+	Errorf(format string, args ...any)
+}
+
+// writers holds one writer per directory, so the many sessions and tests of
+// one process share one shard file and one seen set.
+//
+// Keying on the directory rather than caching the first lookup keeps
+// [testing.T.Setenv] meaningful in this package's own tests.
+var (
+	writersMu sync.Mutex
+	writers   = map[string]*Writer{}
+)
+
+// Writer appends lines to this process's shard of the call record.
+//
+// The zero value is not usable: [Open] and [OpenDir] make one. A nil *Writer
+// is usable and does nothing, which is what recording being off looks like to
+// a caller, so the harness has no branch of its own to get wrong.
+type Writer struct {
+	dir string
+
+	mu   sync.Mutex
+	file *os.File
+	// seen holds the lines already written, so a line repeated by a retry or
+	// by two sessions of one shape costs a map lookup and no write.
+	seen map[string]bool
+	// stopped is set once something has gone wrong and been reported, so a
+	// broken directory produces one failure and not one per line.
+	stopped bool
+}
+
+// Open returns the writer for the directory [DirEnv] names, or nil when
+// recording is off.
+func Open() *Writer {
+	return OpenDir(os.Getenv(DirEnv))
+}
+
+// OpenDir returns the writer recording into dir, or nil when dir is empty.
+//
+// Nothing is created here: the shard is opened when the first line is written,
+// so a process that records nothing leaves no empty file behind for the reader
+// to count as a run.
+func OpenDir(dir string) *Writer {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	writersMu.Lock()
+	defer writersMu.Unlock()
+	if existing, ok := writers[dir]; ok {
+		return existing
+	}
+	created := &Writer{dir: dir, seen: map[string]bool{}}
+	writers[dir] = created
+	return created
+}
+
+// Release closes every open shard and forgets it, so a later [Open] of the
+// same directory starts a new one.
+//
+// Nothing in a real run needs this: one shard belongs to one test process and
+// the operating system closes it at exit. Windows needs it in a test, where a
+// directory holding an open file cannot be removed and a test recording into
+// t.TempDir() would fail in cleanup after every one of its own assertions
+// passed.
+func Release() {
+	writersMu.Lock()
+	defer writersMu.Unlock()
+	for dir, writer := range writers {
+		writer.release()
+		delete(writers, dir)
+	}
+}
+
+// Write appends each line to the shard, reporting through reporter if the
+// shard cannot be written.
+//
+// A line already written is dropped. A nil writer writes nothing, and neither
+// does a writer that has already reported a failure.
+func (w *Writer) Write(reporter Reporter, lines ...Line) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, line := range lines {
+		w.writeLine(reporter, line)
+	}
+}
+
+// writeLine appends one line. The caller holds w.mu.
+func (w *Writer) writeLine(reporter Reporter, line Line) {
+	if w.stopped {
+		return
+	}
+	encoded, err := json.Marshal(line.record())
+	if err != nil {
+		w.stopf(reporter, "could not encode an e2e call line: %v", err)
+		return
+	}
+	text := string(encoded)
+	if w.seen[text] {
+		return
+	}
+	if w.file == nil {
+		if !filepath.IsAbs(w.dir) {
+			w.stopf(reporter, "%s must be an absolute path, got %q: a test binary runs in its own package directory, so a relative one writes a shard nothing will find", DirEnv, w.dir)
+			return
+		}
+		file, openErr := createShard(w.dir)
+		if openErr != nil {
+			w.stopf(reporter, "could not open an e2e call shard in %s: %v", w.dir, openErr)
+			return
+		}
+		w.file = file
+	}
+	// The write is deliberately unbuffered, and that is what makes the shard
+	// safe to never close: the writer is process-global with no shutdown hook
+	// to hang a Close on, so a buffer would lose whatever its tail held when
+	// the test binary exits. One syscall per new line is cheap because a line
+	// is written once however many times it is offered.
+	if _, writeErr := w.file.WriteString(text + "\n"); writeErr != nil {
+		w.stopf(reporter, "could not write an e2e call shard: %v", writeErr)
+		return
+	}
+	w.seen[text] = true
+}
+
+// stopf reports one failure and silences the writer for the rest of the run.
+// The caller holds w.mu.
+func (w *Writer) stopf(reporter Reporter, format string, args ...any) {
+	w.stopped = true
+	reporter.Errorf(format, args...)
+}
+
+// release closes this writer's shard, if it opened one.
+func (w *Writer) release() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file != nil {
+		_ = w.file.Close()
+		w.file = nil
+	}
+}
+
+// createShard opens this process's shard file.
+//
+// It is a variable so the failure branch is reachable from a test: the suite
+// runs as root often enough that a directory made read-only is not read-only.
+var createShard = func(dir string) (*os.File, error) {
+	if err := os.MkdirAll(dir, shardDirPerm); err != nil {
+		return nil, err
+	}
+	return os.CreateTemp(dir, ShardPattern)
+}

--- a/internal/testutil/e2ecalls/writer_test.go
+++ b/internal/testutil/e2ecalls/writer_test.go
@@ -1,0 +1,334 @@
+package e2ecalls
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordingReporter stands in for *testing.T so the writer's failure paths can
+// be exercised without failing the test that asked for them.
+type recordingReporter struct {
+	messages []string
+}
+
+// Errorf records one reported failure.
+func (r *recordingReporter) Errorf(format string, args ...any) {
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+}
+
+// joined returns every message as one string, for a substring assertion.
+func (r *recordingReporter) joined() string {
+	return strings.Join(r.messages, "\n")
+}
+
+// shardLines returns the non-empty lines of the one shard written into dir,
+// failing when the number of shards is not one.
+func shardLines(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir error = %v", err)
+	}
+	var shards []string
+	for _, entry := range entries {
+		if !entry.IsDir() && isShard(entry.Name()) {
+			shards = append(shards, filepath.Join(dir, entry.Name()))
+		}
+	}
+	if len(shards) != 1 {
+		t.Fatalf("shards in %s = %d, want 1", dir, len(shards))
+	}
+	content, err := os.ReadFile(shards[0])
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	var lines []string
+	for line := range strings.SplitSeq(string(content), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// TestOpen_RecordsOnlyWhenTheDirectoryIsNamed verifies that recording is off
+// unless DirEnv names a directory, and that Open and OpenDir reach the same
+// writer for one directory.
+//
+// Off by default is what lets an ordinary suite run pay nothing for this
+// record, and a nil writer is how the harness learns that without a branch of
+// its own.
+func TestOpen_RecordsOnlyWhenTheDirectoryIsNamed(t *testing.T) {
+	// The temporary directory is made first, so its removal is registered
+	// before Release and therefore runs after it. A shard left open is a
+	// directory Windows refuses to remove.
+	dir := t.TempDir()
+	t.Cleanup(Release)
+
+	t.Setenv(DirEnv, "")
+	if writer := Open(); writer != nil {
+		t.Errorf("Open() = %v with %s unset, want nil", writer, DirEnv)
+	}
+
+	t.Setenv(DirEnv, dir)
+	writer := Open()
+	if writer == nil {
+		t.Fatalf("Open() = nil with %s = %q, want a writer", DirEnv, dir)
+	}
+	if again := OpenDir(dir); again != writer {
+		t.Errorf("OpenDir(%q) = %p, want the writer Open returned (%p)", dir, again, writer)
+	}
+}
+
+// TestOpenDir_ReturnsOneWriterPerDirectory verifies that two directories get
+// two writers, one directory gets one, and a blank name gets none.
+//
+// One writer per directory is what makes the seen set and the shard shared by
+// every session and test of a process: a writer per caller would write one
+// shard per call site and duplicate every line across them.
+func TestOpenDir_ReturnsOneWriterPerDirectory(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Cleanup(Release)
+
+	if writer := OpenDir("   "); writer != nil {
+		t.Errorf("OpenDir(blank) = %v, want nil", writer)
+	}
+	one := OpenDir(first)
+	if one == nil {
+		t.Fatal("OpenDir(first) = nil, want a writer")
+	}
+	if OpenDir(first) != one {
+		t.Error("OpenDir(first) returned a second writer for one directory")
+	}
+	if OpenDir(second) == one {
+		t.Error("OpenDir(second) returned the writer of the first directory")
+	}
+}
+
+// TestWriterWrite_NilWriterWritesNothing verifies that writing to the nil
+// writer is a no-op rather than a panic.
+//
+// That is the whole point of returning nil when recording is off: the harness
+// records unconditionally and pays a nil check, instead of guarding every call
+// site and eventually missing one.
+func TestWriterWrite_NilWriterWritesNothing(t *testing.T) {
+	var writer *Writer
+	reporter := &recordingReporter{}
+
+	writer.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+
+	if len(reporter.messages) != 0 {
+		t.Errorf("reported %v, want nothing from a nil writer", reporter.messages)
+	}
+}
+
+// TestWriterWrite_WritesEachLineOnceAndDropsRepeats verifies that lines reach
+// the shard in order, one per line, and that an identical line offered twice
+// is written once.
+//
+// Repeats are ordinary: a session line is offered by every test that uses the
+// session, and a retried call offers the same line again. Writing them all
+// would inflate nothing in the audit, which counts distinct cells, and would
+// make the shard several times larger than the run it describes.
+func TestWriterWrite_WritesEachLineOnceAndDropsRepeats(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(Release)
+
+	writer := OpenDir(dir)
+	reporter := &recordingReporter{}
+	call := &Call{Test: "TestCommon_Issues", Action: "issue.list", Outcome: OutcomeOK, TestStatus: StatusPassed}
+
+	writer.Write(reporter, &Run{Package: "common", Status: RunStarted}, call)
+	writer.Write(reporter, call)
+
+	if len(reporter.messages) != 0 {
+		t.Fatalf("reported %v, want nothing", reporter.messages)
+	}
+	lines := shardLines(t, dir)
+	if len(lines) != 2 {
+		t.Fatalf("shard lines = %d, want 2: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], `"type":"run"`) {
+		t.Errorf("first line = %s, want the run line", lines[0])
+	}
+	if !strings.Contains(lines[1], `"action":"issue.list"`) {
+		t.Errorf("second line = %s, want the call line", lines[1])
+	}
+}
+
+// TestWriterWrite_RefusesARelativeDirectory verifies that a relative directory
+// is reported once and nothing is written.
+//
+// A test binary runs in its own package directory, so a relative directory
+// would leave one shard under each package and the merge would find none of
+// them. Resolving it would produce that scattering silently, which is why it
+// is refused instead.
+func TestWriterWrite_RefusesARelativeDirectory(t *testing.T) {
+	t.Cleanup(Release)
+
+	writer := OpenDir(filepath.Join("dist", "e2e-calls"))
+	reporter := &recordingReporter{}
+
+	writer.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+	writer.Write(reporter, &Skip{Test: "TestCommon_Labels", Reason: "no runner"})
+
+	if len(reporter.messages) != 1 {
+		t.Fatalf("reported %d time(s), want 1: %v", len(reporter.messages), reporter.messages)
+	}
+	if !strings.Contains(reporter.joined(), DirEnv) || !strings.Contains(reporter.joined(), "absolute") {
+		t.Errorf("report = %q, want it to name %s and say the path must be absolute", reporter.joined(), DirEnv)
+	}
+}
+
+// TestWriterWrite_ReportsAnUnopenableShardOnce verifies that a directory the
+// writer cannot open a shard in fails loudly and exactly once.
+//
+// The constructor is stubbed rather than the filesystem made hostile because
+// this suite is often run as root, where a directory stripped of write
+// permission is still writable.
+func TestWriterWrite_ReportsAnUnopenableShardOnce(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(Release)
+
+	original := createShard
+	createShard = func(string) (*os.File, error) { return nil, errors.New("no room") }
+	t.Cleanup(func() { createShard = original })
+
+	writer := OpenDir(dir)
+	reporter := &recordingReporter{}
+
+	writer.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+	writer.Write(reporter, &Skip{Test: "TestCommon_Labels", Reason: "no runner"})
+
+	if len(reporter.messages) != 1 {
+		t.Fatalf("reported %d time(s), want 1: %v", len(reporter.messages), reporter.messages)
+	}
+	if !strings.Contains(reporter.joined(), "no room") {
+		t.Errorf("report = %q, want it to carry the cause", reporter.joined())
+	}
+}
+
+// TestWriterWrite_ReportsAShardThatStopsAccepting verifies that a shard which
+// no longer accepts writes is reported rather than silently dropping lines.
+//
+// A dropped line is indistinguishable from a call nobody made, which is the
+// one reading of this record that must never be wrong.
+func TestWriterWrite_ReportsAShardThatStopsAccepting(t *testing.T) {
+	stubDir, dir := t.TempDir(), t.TempDir()
+	t.Cleanup(Release)
+
+	closed, err := os.CreateTemp(stubDir, ShardPattern)
+	if err != nil {
+		t.Fatalf("CreateTemp error = %v", err)
+	}
+	if closeErr := closed.Close(); closeErr != nil {
+		t.Fatalf("Close error = %v", closeErr)
+	}
+	original := createShard
+	createShard = func(string) (*os.File, error) { return closed, nil }
+	t.Cleanup(func() { createShard = original })
+
+	writer := OpenDir(dir)
+	reporter := &recordingReporter{}
+
+	writer.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+
+	if len(reporter.messages) != 1 {
+		t.Fatalf("reported %d time(s), want 1: %v", len(reporter.messages), reporter.messages)
+	}
+	if !strings.Contains(reporter.joined(), "could not write") {
+		t.Errorf("report = %q, want it to say the shard could not be written", reporter.joined())
+	}
+}
+
+// TestWriterWrite_ReportsALineItCannotEncode verifies that a line JSON cannot
+// hold is reported once and stops the writer.
+//
+// A duration of NaN is the reachable case: every other field is a string, a
+// bool or a string slice. It is reported rather than skipped because a writer
+// that drops what it cannot encode would produce a shard that is missing calls
+// and says so nowhere.
+func TestWriterWrite_ReportsALineItCannotEncode(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(Release)
+
+	writer := OpenDir(dir)
+	reporter := &recordingReporter{}
+
+	writer.Write(reporter, &Call{Test: "TestCommon_Issues", DurationMS: math.NaN()})
+	writer.Write(reporter, &Skip{Test: "TestCommon_Labels", Reason: "no runner"})
+
+	if len(reporter.messages) != 1 {
+		t.Fatalf("reported %d time(s), want 1: %v", len(reporter.messages), reporter.messages)
+	}
+	if !strings.Contains(reporter.joined(), "could not encode") {
+		t.Errorf("report = %q, want it to say the line could not be encoded", reporter.joined())
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("directory holds %d entr(ies), want none: a stopped writer opens no shard", len(entries))
+	}
+}
+
+// TestRelease_ClosesTheShardAndForgetsTheWriter verifies that Release lets a
+// later Open of the same directory start a new shard.
+//
+// Windows is why it exists: a directory holding an open file cannot be
+// removed, so a test recording into t.TempDir() would fail in cleanup after
+// every one of its own assertions had passed.
+func TestRelease_ClosesTheShardAndForgetsTheWriter(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(Release)
+
+	reporter := &recordingReporter{}
+	first := OpenDir(dir)
+	first.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+
+	Release()
+
+	second := OpenDir(dir)
+	if second == first {
+		t.Fatal("OpenDir returned the released writer, want a new one")
+	}
+	second.Write(reporter, &Skip{Test: "TestCommon_Labels", Reason: "no runner"})
+
+	if len(reporter.messages) != 0 {
+		t.Fatalf("reported %v, want nothing", reporter.messages)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("shards = %d, want 2: a released writer writes a shard of its own", len(entries))
+	}
+}
+
+// TestCreateShard_ReportsADirectoryItCannotMake verifies that the shard
+// constructor fails when the directory cannot be created.
+//
+// It is called directly because the writer stubs it everywhere else, so this
+// is the only place the real one's failure branch is reached.
+func TestCreateShard_ReportsADirectoryItCannotMake(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocked, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	file, err := createShard(filepath.Join(blocked, "shards"))
+
+	if err == nil {
+		_ = file.Close()
+		t.Error("createShard succeeded under a regular file, want an error")
+	}
+}

--- a/internal/testutil/e2ecalls/writer_test.go
+++ b/internal/testutil/e2ecalls/writer_test.go
@@ -314,6 +314,43 @@ func TestRelease_ClosesTheShardAndForgetsTheWriter(t *testing.T) {
 	}
 }
 
+// TestRelease_LetsTheSameWriterStartAnotherShard verifies that release lets go
+// of the file rather than only of the registry entry: a writer that kept
+// writing after Release opens a shard of its own instead of appending to the
+// one it was told to let go of.
+//
+// The sibling above releases and then opens the directory again, which gets a
+// new writer from the registry and would pass whether or not the old file was
+// ever closed. Writing through the same handle is what asks the question,
+// because only a closed file makes the writer open another.
+func TestRelease_LetsTheSameWriterStartAnotherShard(t *testing.T) {
+	dir := t.TempDir()
+	Release()
+	t.Cleanup(Release)
+
+	reporter := &recordingReporter{}
+	writer := OpenDir(dir)
+	// The second shard below belongs to a writer the registry has already let
+	// go of, so the package-level Release cannot close it; this test closes it
+	// itself, or Windows refuses to remove the directory holding it.
+	t.Cleanup(writer.release)
+	writer.Write(reporter, &Skip{Test: "TestCommon_Issues", Reason: "no runner"})
+
+	Release()
+	writer.Write(reporter, &Skip{Test: "TestCommon_Labels", Reason: "no runner"})
+
+	if len(reporter.messages) != 0 {
+		t.Fatalf("reported %v, want nothing", reporter.messages)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("shards = %d, want 2: a released writer holds no file and opens another", len(entries))
+	}
+}
+
 // TestCreateShard_ReportsADirectoryItCannotMake verifies that the shard
 // constructor fails when the directory cannot be created.
 //


### PR DESCRIPTION
Step S03 of the e2e rebuild (issue 704): the record both halves of the new suite share, the harness that writes it and the coverage audit that reads it.

`internal/testutil/e2ecalls` is untagged and standard-library only. It declares `DirEnv` (`GITLAB_MCP_TEST_E2E_CALLS_DIR`), `ShardPattern` (`calls-*.jsonl`), `SchemaVersion`, and five line types, run, session, call, dispatch and skip, each wrapped in one `Record` envelope carrying the schema, the type and exactly one payload. A run line says which package ran, what it required, the edition and tier and whether the tier was confirmed from a license, the GitLab version, the run id and commit, the fixture profile, and whether the run started or was refused and why. A session line says which surface, mode and capabilities were served and whether dispatch was observed. A call line carries the test, its purpose and expectation, the method, the tool, the requested and dispatched action, the target, the argument names, the outcome, the duration, the trace id and the test's final status. Constants spell every purpose, expectation, outcome and status, so the writer and the reader cannot drift.

The writer opens its shard lazily, writes unbuffered so a test binary exiting loses nothing, drops a line already written, refuses a relative directory rather than scattering shards under 178 package directories, reports a broken directory once and then stops, and is a no-op on a nil pointer so the harness records without a branch of its own. The reader walks subdirectories, since one run per Docker target merges, caps a line at 1 MiB rather than dropping a long one silently, validates every line, and refuses a directory holding no shard: nothing there means the suite did not record, and reporting that as zero coverage would be a claim about the server made from a claim about the harness.

Two fields the plan's list did not name are carried on purpose: `Target`, because the compare step classifies resources by template and prompts by name and a line holding only a method could not; and `TestStatus`, because the recorder flushes from the first-registered cleanup so each line carries the test's final verdict. Failures are reported through a one-method `Reporter` rather than `testing.TB`, because the audit command links this package and `testing` must not reach it. The package is named by exact path in `TestDependencies_TestSupport_NeverReachesTheServerBinary`.

The second commit closes the mutation and condition gate the step could not run: 31 mutants killed, 0 lived, 70 of 70 conditions. It found four holes 100% statement coverage had hidden, two counters nobody read back, the shard pattern asserted nowhere, and a release that might never have closed the file, and one of them was a code change: the shard guard asked whether the count was exactly zero rather than whether the walk reached a shard.
