### PR TITLE
feat(e2e): start the real server from a harness that probes before it writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,16 @@ jobs:
       # except a person running make test-e2e-docker-enterprise by hand.
       - name: Verify the Enterprise E2E tests compile
         run: go test -tags "e2e enterprise" -c -o /dev/null ./test/e2e/suite/
+      # The harness is the library every rebuilt e2e test goes through, and its
+      # own tests need no GitLab: the ledger, the waits, the names, the runtime
+      # guard's message, the environment a child is given, and one run of the
+      # real binary against a stub instance. Running them here is what keeps a
+      # defect in the harness from surfacing later as a failure in whichever
+      # domain test happened to run first.
+      - name: Verify the E2E harness compiles
+        run: go test -tags e2e -c -o /dev/null ./test/e2e/internal/...
+      - name: Run the E2E harness tests
+        run: go test -tags e2e -count=1 ./test/e2e/internal/...
 
   # Type-checks every build-constrained file including the tests, for each
   # platform this project ships, on a Linux runner. The cross-platform matrix
@@ -433,6 +443,14 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: GOOS="${TARGET%%/*}" GOARCH="${TARGET##*/}" go vet ./...
+      # The harness is behind a build tag, so the vet above compiles its doc.go
+      # and nothing else. It starts processes and resolves a home directory,
+      # which are exactly the places a platform difference lives, so it is
+      # type-checked per platform on its own terms.
+      - name: Vet the E2E harness for ${{ matrix.target }}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: GOOS="${TARGET%%/*}" GOARCH="${TARGET##*/}" go vet -tags e2e ./test/e2e/internal/...
 
   # The HTTP transport module needs no GitLab and no credentials, so it runs
   # here rather than only on demand. It is the gate for the handler chain in

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-all build-linux-amd64 build-linux-arm64 build-windows-amd64 build-windows-arm64 build-darwin-amd64 build-darwin-arm64 \
-	run brand brand-check brand-rasters ensure-mcp-publisher mcp-publisher-version test test-short test-race coverage-conditions coverage-mutants test-pkg test-integration test-e2e test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
+	run brand brand-check brand-rasters ensure-mcp-publisher mcp-publisher-version test test-short test-race coverage-conditions coverage-mutants test-pkg test-integration test-e2e test-e2e-harness test-e2e-http test-e2e-stdio test-e2e-collector ensure-gotestsum test-e2e-docker test-e2e-docker-enterprise test-e2e-gitlab-com \
 	validate-http-stateless validate-http-stateless-docker \
 	orbit-setup-fixtures orbit-wait-indexer orbit-run-live-tests orbit-ensure-token \
 	eval-surfaces-docker eval-surfaces-docker-enterprise eval-surfaces-docker-enterprise-ce eval-surfaces-docker-enterprise-all eval-surfaces-docker-enterprise-all-fixtures coverage \
@@ -212,6 +212,19 @@ ensure-gotestsum:
 		echo "gotestsum not found; installing with go install..."; \
 		go install gotest.tools/gotestsum@latest; \
 	}
+
+## test-e2e-harness: run the e2e harness library's own tests (no GitLab needed).
+# The harness is the only route from an e2e test to a server, so a defect in it
+# would surface as a failure in whichever domain test happened to run first.
+# These tests hold it on its own terms: the ledger, the waits, the names, the
+# runtime guard's message, the environment a child is given, and one run of the
+# real binary against a stub GitLab.
+test-e2e-harness: ensure-gotestsum
+	$(call MKDIR_P,$(E2E_REPORT_DIR))
+	bash -o pipefail -c '$(GOTESTSUM) \
+	  --format testdox \
+	  --junitfile $(E2E_REPORT_DIR)/e2e-harness-junit.xml \
+	  -- -tags e2e -count=1 -timeout 600s ./test/e2e/internal/...'
 
 ## test-e2e-stdio: run the stdio transport end-to-end module (no GitLab needed; drives the real binary over pipes).
 test-e2e-stdio: ensure-gotestsum

--- a/cmd/audit_test_goroutines/main.go
+++ b/cmd/audit_test_goroutines/main.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -110,13 +111,28 @@ func run(dirs []string, jsonPath string, check bool, stdout, stderr io.Writer) i
 	return 0
 }
 
-// scan walks every _test.go file under dirs and collects findings.
+// harnessTree is the one tree whose ordinary .go files are audited beside its
+// tests.
+//
+// The e2e harness is a library that holds a *testing.T and asserts with it, so
+// a t.Fatal inside a handler literal there aborts off the test goroutine
+// exactly as one in a _test.go file does. Every other non-test file in the
+// module imports no testing package at all, which is why the corpus is this
+// tree and not the whole module: the walk stays cheap and the rule stays
+// stated.
+const harnessTree = "test/e2e/internal"
+
+// scan walks every _test.go file under dirs, plus the harness library's own
+// non-test files, and collects findings.
 func scan(dirs []string) (*Report, error) {
 	report := &Report{}
 	files := map[string]bool{}
 	fset := token.NewFileSet()
 
-	if walkErr := testsource.WalkFiles(dirs, testsource.TestFiles, collectFindings(fset, report, files)); walkErr != nil {
+	if walkErr := testsource.WalkFiles(dirs, testsource.TestFiles, collectFindings(fset, report, files, false)); walkErr != nil {
+		return nil, walkErr
+	}
+	if walkErr := testsource.WalkFiles(dirs, testsource.NonTestGoFiles, collectFindings(fset, report, files, true)); walkErr != nil {
 		return nil, walkErr
 	}
 
@@ -137,13 +153,24 @@ func scan(dirs []string) (*Report, error) {
 	return report, nil
 }
 
-// collectFindings returns the walk callback that parses each _test.go file and
-// appends its findings to the report.
-func collectFindings(fset *token.FileSet, report *Report, files map[string]bool) func(string) error {
+// collectFindings returns the walk callback that parses each file and appends
+// its findings to the report.
+//
+// With library set, the callback is walking ordinary .go files rather than
+// tests, and takes only the harness tree's files that import testing: nothing
+// else in the module holds a *testing.T, and parsing the rest to discover that
+// would be a thousand files of work for no finding.
+func collectFindings(fset *token.FileSet, report *Report, files map[string]bool, library bool) func(string) error {
 	return func(path string) error {
+		if library && !underHarnessTree(path) {
+			return nil
+		}
 		file, parseErr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if parseErr != nil {
 			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		if library && !importsTesting(file) {
+			return nil
 		}
 		for _, f := range scanFile(fset, path, file) {
 			files[f.File] = true
@@ -155,6 +182,29 @@ func collectFindings(fset *token.FileSet, report *Report, files map[string]bool)
 		}
 		return nil
 	}
+}
+
+// underHarnessTree reports whether path lies inside the e2e harness library.
+//
+// It is a path predicate rather than a second walk root so that a scan given
+// an absolute directory, which is what this command's own tests do, is judged
+// by the same rule as a scan of the module tree.
+func underHarnessTree(path string) bool {
+	return strings.Contains(filepath.ToSlash(filepath.Clean(path)), harnessTree+"/")
+}
+
+// importsTesting reports whether the file imports the testing package, which
+// is what makes a library file able to abort a test at all.
+func importsTesting(file *ast.File) bool {
+	for _, imported := range file.Imports {
+		if imported.Path == nil {
+			continue
+		}
+		if imported.Path.Value == `"testing"` || strings.HasPrefix(imported.Path.Value, `"testing/`) {
+			return true
+		}
+	}
+	return false
 }
 
 // scanFile finds goroutine-boundary literals in one file and audits their

--- a/cmd/audit_test_goroutines/main_test.go
+++ b/cmd/audit_test_goroutines/main_test.go
@@ -176,6 +176,130 @@ func TestScan_CleanFileHasNoFindings(t *testing.T) {
 	}
 }
 
+// harnessLibraryFixture is a harness library file: not a test, holding a
+// *testing.T, and aborting inside a handler literal. It is the shape the
+// e2e harness is made of, and the reason ordinary .go files under
+// test/e2e/internal are audited at all.
+const harnessLibraryFixture = `package harness
+
+import (
+	"net/http"
+	"testing"
+)
+
+func StartStub(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("abort off the test goroutine, in a library rather than a test")
+	})
+}
+`
+
+// libraryWithoutTesting is a harness library file that holds no *testing.T. It
+// cannot abort a test, so it is passed over before it is parsed for findings.
+const libraryWithoutTesting = `package harness
+
+import "net/http"
+
+func Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+`
+
+// TestScan_HarnessLibrary_AuditsItsNonTestFiles verifies that the harness
+// library is held to the same contract as a test file, and that nothing else
+// is.
+//
+// Three files are planted: one under test/e2e/internal that imports testing
+// and aborts in a handler, one beside it that does not import testing, and one
+// with the same abort under internal/. Only the first is a finding. The second
+// and third are what keep the rule narrow: the corpus is the tree that holds a
+// *testing.T, not every non-test file in the module.
+func TestScan_HarnessLibrary_AuditsItsNonTestFiles(t *testing.T) {
+	root := t.TempDir()
+	harnessDir := filepath.Join(root, "test", "e2e", "internal", "harness")
+	if err := os.MkdirAll(harnessDir, 0o750); err != nil {
+		t.Fatalf("create the harness tree: %v", err)
+	}
+	elsewhere := filepath.Join(root, "internal", "tools")
+	if err := os.MkdirAll(elsewhere, 0o750); err != nil {
+		t.Fatalf("create the unrelated tree: %v", err)
+	}
+
+	audited := filepath.Join(harnessDir, "server.go")
+	// sequential: three files planted for one scan, not three cases
+	for path, source := range map[string]string{
+		audited:                                harnessLibraryFixture,
+		filepath.Join(harnessDir, "names.go"):  libraryWithoutTesting,
+		filepath.Join(elsewhere, "handler.go"): harnessLibraryFixture,
+	} {
+		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	report, err := scan([]string{root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if len(report.Fatal) != 1 {
+		t.Fatalf("fatal findings = %+v, want exactly the harness library's abort", report.Fatal)
+	}
+	if report.Fatal[0].File != audited {
+		t.Fatalf("finding file = %q, want %q", report.Fatal[0].File, audited)
+	}
+	if report.Fatal[0].Boundary != "http.HandlerFunc" {
+		t.Fatalf("finding boundary = %q, want http.HandlerFunc", report.Fatal[0].Boundary)
+	}
+}
+
+// TestUnderHarnessTree_PathShapes_DecidesByTheTree verifies the predicate that
+// selects the library corpus, on the path spellings a walk produces.
+func TestUnderHarnessTree_PathShapes_DecidesByTheTree(t *testing.T) {
+	cases := map[string]bool{
+		filepath.Join("test", "e2e", "internal", "harness", "server.go"):           true,
+		filepath.Join("test", "e2e", "internal", "fixture", "project.go"):          true,
+		filepath.Join("/tmp", "x", "test", "e2e", "internal", "harness", "env.go"): true,
+		filepath.Join("test", "e2e", "suite", "setup_test.go"):                     false,
+		filepath.Join("internal", "tools", "issues", "issues.go"):                  false,
+		filepath.Join("test", "e2e", "internal"):                                   false,
+	}
+	for path, want := range cases {
+		t.Run(path, func(t *testing.T) {
+			if got := underHarnessTree(path); got != want {
+				t.Fatalf("underHarnessTree(%q) = %t, want %t", path, got, want)
+			}
+		})
+	}
+}
+
+// TestImportsTesting_ImportShapes_AnswersForEachOne verifies the second half of
+// the library filter: a file that cannot reach a *testing.T is not parsed for
+// findings.
+func TestImportsTesting_ImportShapes_AnswersForEachOne(t *testing.T) {
+	cases := map[string]bool{
+		"package x\n\nimport \"testing\"\n":          true,
+		"package x\n\nimport \"testing/synctest\"\n": true,
+		"package x\n\nimport tb \"testing\"\n":       true,
+		"package x\n\nimport (\n\t\"net/http\"\n)\n": false,
+		"package x\n": false,
+		"package x\n\nimport \"github.com/x/testingtools\"\n": false,
+	}
+	for source, want := range cases {
+		t.Run(strings.ReplaceAll(source, "\n", " "), func(t *testing.T) {
+			file, err := parser.ParseFile(token.NewFileSet(), "x.go", source, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := importsTesting(file); got != want {
+				t.Fatalf("importsTesting(%q) = %t, want %t", source, got, want)
+			}
+		})
+	}
+}
+
 // expectedSite names one finding by the marker comment on its source line,
 // so the fixture can be edited without recounting line numbers.
 type expectedSite struct {

--- a/test/e2e/internal/harness/doc.go
+++ b/test/e2e/internal/harness/doc.go
@@ -1,0 +1,16 @@
+// Package harness is the only route from an end-to-end test to an MCP server.
+//
+// It starts the real cmd/server binary and speaks to it over stdio, the way a
+// client does. Nothing here assembles a server: a test that built its own
+// would be testing its own assembly rather than the program, which is exactly
+// what the suite this replaces did. The binary decides its own catalog from
+// the environment it is given, so every knob a test turns is a variable or a
+// flag the released program reads.
+//
+// The tests carry the e2e build tag; this file is what a plain build sees of
+// the package, the convention test/e2e/http/doc.go states.
+//
+// The library is deliberately not importable outside test/e2e: Go's internal
+// rule keeps it there, so no production package can grow a dependency on test
+// scaffolding.
+package harness

--- a/test/e2e/internal/harness/env.go
+++ b/test/e2e/internal/harness/env.go
@@ -1,0 +1,203 @@
+//go:build e2e
+
+// env.go is what a test holds: a context that ends with it, names nothing else
+// will take, and a ledger of what it must undo.
+//
+// Creating an Env is also the first harness entry point, so it is what
+// triggers the bootstrap. A package whose tests are all filtered out therefore
+// never reaches GitLab at all, which is the property that makes -test.list
+// offline and a filtered run free.
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+)
+
+// errLedgerClosed is returned by a ledger asked to record a cleanup after it
+// has already run its cleanups.
+var errLedgerClosed = errors.New("cleanup ledger closed")
+
+// cleanupBudget bounds everything one test undoes, and enterpriseCleanupBudget
+// is the same bound on a licensed instance, where deleting a project or a
+// group takes measurably longer.
+const (
+	cleanupBudget           = 60 * time.Second
+	enterpriseCleanupBudget = 180 * time.Second
+)
+
+// Env is one test's handle on the harness.
+type Env struct {
+	// T is the test this Env belongs to.
+	T *testing.T
+	// Ctx is cancelled when the test ends, so anything the test started stops
+	// with it.
+	Ctx context.Context
+
+	runID  string
+	ledger *ledger
+	inst   *instance
+}
+
+// New prepares the harness for one test and returns its Env.
+//
+// The first call of a package runs the bootstrap: the probe, the runtime guard
+// and the preparation the instance needs before the first write. A test whose
+// declared Needs this run does not provide is skipped here, before it has
+// changed anything.
+func New(t *testing.T, opts ...Option) *Env {
+	t.Helper()
+
+	inst := bootstrap(t)
+
+	var options envOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	requireNeeds(t, inst, options.needs)
+
+	// Registered in this order on purpose: t.Cleanup runs last-in-first-out,
+	// so the ledger's undo work still holds every lock the test declared, and
+	// the gate is only given back once that work is done.
+	release := gate.enter(topLevelTest(t.Name()), options.serial)
+	t.Cleanup(release)
+	unlock := acquireLocks(options.locks)
+	t.Cleanup(unlock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	env := &Env{T: t, Ctx: ctx, runID: inst.runID, ledger: &ledger{}, inst: inst}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), inst.cleanupBudget())
+		defer cleanupCancel()
+		env.ledger.cleanupAll(cleanupCtx, t)
+	})
+	return env
+}
+
+// RunID returns the identifier every name this test hands out carries.
+func (e *Env) RunID() string { return e.runID }
+
+// Name returns a GitLab-safe name for a resource this test is about to
+// create, scoped to the run so a sweep can recognize it later.
+func (e *Env) Name(prefix string) string {
+	return uniqueName(e.runID, prefix+"-"+sanitizeTestName(e.T.Name()))
+}
+
+// Defer records how to undo something the test created. Cleanups run in
+// reverse order when the test ends, inside one bounded context, so a child
+// resource is removed before the parent it hangs off.
+//
+// A failure is reported and does not stop the rest: the whole point of the
+// ledger is that one object nobody can delete does not strand every object
+// registered before it.
+func (e *Env) Defer(label string, cleanup func(context.Context) error) {
+	e.T.Helper()
+	err := e.ledger.register(ledgerRecord{
+		Label:     label,
+		OwnerTest: e.T.Name(),
+		RunID:     e.runID,
+		CreatedAt: time.Now(),
+		Cleanup:   cleanup,
+	})
+	if err != nil {
+		e.T.Errorf("recording cleanup: %v", err)
+	}
+}
+
+// ledgerRecord is one thing a test has to undo.
+type ledgerRecord struct {
+	// Label says what the resource is, in words a failure message can carry.
+	Label string
+	// OwnerTest is the test that created it.
+	OwnerTest string
+	// RunID scopes it to one run.
+	RunID string
+	// CreatedAt is when it was recorded.
+	CreatedAt time.Time
+	// Cleanup removes it. A nil Cleanup records the resource without
+	// promising to delete it, which is what a fixture that outlives the test
+	// does.
+	Cleanup func(context.Context) error
+}
+
+// describe returns a label for a cleanup failure that names the resource and
+// carries no credential: a record's own fields are the only thing printed,
+// never the URL a token might be embedded in.
+func (r ledgerRecord) describe() string {
+	return fmt.Sprintf("label=%q owner=%q run_id=%q", r.Label, r.OwnerTest, r.RunID)
+}
+
+// ledger records what one test must undo and undoes it once.
+type ledger struct {
+	mu      sync.Mutex
+	records []ledgerRecord
+	cleaned bool
+}
+
+// register adds a record, refusing one offered after the cleanups have run: a
+// late registration would be silently dropped otherwise, and the resource it
+// names would be left behind with nothing to say so.
+func (l *ledger) register(record ledgerRecord) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.cleaned {
+		return fmt.Errorf("register %s: %w", record.describe(), errLedgerClosed)
+	}
+	l.records = append(l.records, record)
+	return nil
+}
+
+// list returns a copy of what has been registered, so a caller reading the
+// ledger cannot change it.
+func (l *ledger) list() []ledgerRecord {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return slices.Clone(l.records)
+}
+
+// cleanupAll runs every cleanup in reverse registration order and returns what
+// failed. It is idempotent: a second call does nothing, so a test that cleans
+// up early is not cleaned up twice by its own t.Cleanup.
+//
+// It stops at a cancelled context rather than working through the rest with a
+// context nothing can be done with, and reports that as a failure of its own.
+func (l *ledger) cleanupAll(ctx context.Context, tb testing.TB) []error {
+	tb.Helper()
+
+	l.mu.Lock()
+	if l.cleaned {
+		l.mu.Unlock()
+		return nil
+	}
+	l.cleaned = true
+	records := slices.Clone(l.records)
+	l.mu.Unlock()
+
+	failures := make([]error, 0)
+	for _, record := range slices.Backward(records) {
+		if record.Cleanup == nil {
+			continue
+		}
+		if err := record.Cleanup(ctx); err != nil {
+			failure := fmt.Errorf("cleanup %s: %w", record.describe(), err)
+			failures = append(failures, failure)
+			tb.Logf("e2e cleanup failed: %v", failure)
+		}
+		if ctx.Err() != nil {
+			failures = append(failures, ctx.Err())
+			tb.Logf("e2e cleanup stopped: %v", ctx.Err())
+			break
+		}
+	}
+	return failures
+}

--- a/test/e2e/internal/harness/env_test.go
+++ b/test/e2e/internal/harness/env_test.go
@@ -1,0 +1,188 @@
+//go:build e2e
+
+// env_test.go covers the cleanup ledger every test's fixtures hang off,
+// ported from the suite this replaces (resource_ledger_ce_test.go).
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// TestLedger_MultipleRecords_CleansInReverseOrder checks that cleanups run
+// last-in-first-out.
+//
+// The order is not a preference: a project created inside a group has to be
+// removed before the group, and the ledger's only knowledge of that dependency
+// is the order the two were registered in.
+func TestLedger_MultipleRecords_CleansInReverseOrder(t *testing.T) {
+	var l ledger
+	var cleaned []string
+
+	// sequential: two records registered in order, which is what the cleanup order is read from
+	for _, label := range []string{"project", "group"} {
+		if err := l.register(ledgerRecord{Label: label, Cleanup: func(context.Context) error {
+			cleaned = append(cleaned, label)
+			return nil
+		}}); err != nil {
+			t.Fatalf("register(%s) error = %v, want nil", label, err)
+		}
+	}
+
+	if failures := l.cleanupAll(context.Background(), t); len(failures) != 0 {
+		t.Fatalf("cleanupAll() failures = %v, want none", failures)
+	}
+	if want := []string{"group", "project"}; strings.Join(cleaned, ",") != strings.Join(want, ",") {
+		t.Fatalf("cleanup order = %v, want %v", cleaned, want)
+	}
+}
+
+// TestLedger_List_ReturnsACopy checks that a caller reading the ledger cannot
+// change what it will clean up.
+func TestLedger_List_ReturnsACopy(t *testing.T) {
+	var l ledger
+	if err := l.register(ledgerRecord{Label: "project"}); err != nil {
+		t.Fatalf("register() error = %v, want nil", err)
+	}
+
+	records := l.list()
+	records[0].Label = "changed"
+
+	if got := l.list()[0].Label; got != "project" {
+		t.Fatalf("ledger record label = %q, want the original value", got)
+	}
+}
+
+// TestLedger_ConcurrentRegister_KeepsEveryRecord checks that the ledger is
+// safe for the fixtures a test builds from several goroutines.
+//
+// A dropped record is a resource nobody deletes, which the next run then trips
+// over as a name that is already taken.
+func TestLedger_ConcurrentRegister_KeepsEveryRecord(t *testing.T) {
+	var l ledger
+	var wg sync.WaitGroup
+
+	for i := range 50 {
+		wg.Go(func() {
+			if err := l.register(ledgerRecord{Label: strconv.Itoa(i)}); err != nil {
+				t.Errorf("register() error = %v, want nil", err)
+				return
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := len(l.list()); got != 50 {
+		t.Fatalf("registered records = %d, want 50", got)
+	}
+}
+
+// TestLedger_FailingCleanup_ReportsTheRecord checks that a cleanup failure
+// names the resource it could not remove and carries the original cause.
+//
+// The label is deliberately built from the record's own fields and never from
+// a URL: a cleanup failure is printed in CI logs, and a GitLab URL carrying a
+// token in it would be printed with it.
+func TestLedger_FailingCleanup_ReportsTheRecord(t *testing.T) {
+	var l ledger
+	if err := l.register(ledgerRecord{
+		Label:     "project e2e-1",
+		OwnerTest: "TestCommon_Projects",
+		RunID:     "run-1",
+		Cleanup:   func(context.Context) error { return errors.New("delete failed") },
+	}); err != nil {
+		t.Fatalf("register() error = %v, want nil", err)
+	}
+
+	failures := l.cleanupAll(context.Background(), t)
+	if len(failures) != 1 {
+		t.Fatalf("failures = %d, want 1", len(failures))
+	}
+	for _, fragment := range []string{`label="project e2e-1"`, `owner="TestCommon_Projects"`, `run_id="run-1"`, "delete failed"} {
+		t.Run(fragment, func(t *testing.T) {
+			if !strings.Contains(failures[0].Error(), fragment) {
+				t.Fatalf("failure message = %q, want it to carry %q", failures[0].Error(), fragment)
+			}
+		})
+	}
+}
+
+// TestLedger_SecondCleanup_DoesNothing checks that cleanup is idempotent.
+//
+// A test that cleans up early and then ends would otherwise have its t.Cleanup
+// delete everything a second time, which on GitLab is a 404 for every record
+// and a wall of failures that mean nothing.
+func TestLedger_SecondCleanup_DoesNothing(t *testing.T) {
+	var l ledger
+	calls := 0
+	if err := l.register(ledgerRecord{Label: "project", Cleanup: func(context.Context) error {
+		calls++
+		return nil
+	}}); err != nil {
+		t.Fatalf("register() error = %v, want nil", err)
+	}
+
+	l.cleanupAll(context.Background(), t)
+	l.cleanupAll(context.Background(), t)
+
+	if calls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", calls)
+	}
+}
+
+// TestLedger_RegisterAfterCleanup_IsRefused checks that a record offered after
+// the cleanups have run is reported rather than accepted.
+//
+// Accepting it would mean the resource is recorded and never removed, and
+// nothing would say so: the ledger would look as though it had done its work.
+func TestLedger_RegisterAfterCleanup_IsRefused(t *testing.T) {
+	var l ledger
+
+	l.cleanupAll(context.Background(), t)
+	err := l.register(ledgerRecord{Label: "late"})
+
+	if !errors.Is(err, errLedgerClosed) {
+		t.Fatalf("register() error = %v, want %v", err, errLedgerClosed)
+	}
+}
+
+// TestLedger_CancelledContext_StopsAndReportsIt checks that cleanup stops when
+// its budget is gone rather than working through the rest with a context
+// nothing can be done with.
+//
+// It runs under synctest so the budget can expire without the test waiting for
+// it: the ledger's work here is in-process, so the fake clock advances the
+// moment every goroutine is blocked.
+func TestLedger_CancelledContext_StopsAndReportsIt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var l ledger
+		calls := 0
+		for range 3 {
+			if err := l.register(ledgerRecord{Label: "slow", Cleanup: func(ctx context.Context) error {
+				calls++
+				<-ctx.Done()
+				return nil
+			}}); err != nil {
+				t.Fatalf("register() error = %v, want nil", err)
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		failures := l.cleanupAll(ctx, t)
+
+		if calls != 1 {
+			t.Fatalf("cleanup calls = %d, want 1: the ledger should stop at the first expired context", calls)
+		}
+		if len(failures) != 1 || !errors.Is(failures[0], context.DeadlineExceeded) {
+			t.Fatalf("failures = %v, want the expired context", failures)
+		}
+	})
+}

--- a/test/e2e/internal/harness/main.go
+++ b/test/e2e/internal/harness/main.go
@@ -1,0 +1,362 @@
+//go:build e2e
+
+// main.go is what a package's TestMain calls, and it does as little as it can.
+//
+// Everything that needs GitLab happens later, behind a sync.Once the first
+// test triggers. Go runs TestMain for every package named on the command line,
+// so a Main that probed would have every package contact GitLab even when the
+// -run filter leaves it with nothing to do, and `go test -list` would need an
+// instance to list names. Deferring the work is what keeps both free.
+//
+// Configuration is read into a map and never put back into this process's
+// environment. A child's environment is built from nothing, so a variable that
+// leaked into the harness would reach the server only by accident, and one
+// that did not leak would be missing for no stated reason. Reading into a map
+// removes the question.
+
+package harness
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// The configuration keys this harness reads. GITLAB_URL and GITLAB_TOKEN are
+// GitLab's own spelling, which is what a developer already has exported; the
+// rest are the suite's own and all carry the E2E_ prefix.
+const (
+	envGitLabURL       = "GITLAB_URL"
+	envGitLabToken     = "GITLAB_TOKEN"
+	envSkipTLSVerify   = "GITLAB_MCP_SKIP_TLS_VERIFY"
+	envMode            = "E2E_MODE"
+	envRunID           = "E2E_RUN_ID"
+	envEnvFile         = "E2E_ENV_FILE"
+	envRuntimeMismatch = "E2E_RUNTIME_MISMATCH"
+	envExternalNetwork = "E2E_EXTERNAL_NETWORK"
+	envFixtureURL      = "E2E_FIXTURE_URL"
+
+	envBitbucketServerURL = "BITBUCKET_SERVER_URL"
+	envGitHubToken        = "GH_TOKEN"
+)
+
+// dockerEnvFile and repoEnvFile are the two files a run may read, both
+// resolved from the repository root so a package's own directory never decides
+// what configuration it gets.
+var (
+	dockerEnvFile = filepath.Join("test", "e2e", ".env.docker")
+	repoEnvFile   = ".env"
+)
+
+// bootstrapTimeout bounds the whole probe. It is generous because a Docker
+// GitLab answers its first requests slowly, and short enough that a run
+// pointed at nothing fails rather than hanging.
+const bootstrapTimeout = 2 * time.Minute
+
+// refusalKind says whether a refusal can be turned into skips.
+type refusalKind int
+
+const (
+	// refusalNone is no refusal.
+	refusalNone refusalKind = iota
+	// refusalMismatch is an instance that works and is the wrong one.
+	// E2E_RUNTIME_MISMATCH=skip turns it into skips.
+	refusalMismatch
+	// refusalFatal is a run that has no GitLab at all, or one that would not
+	// answer. It always fails: a release gate that skipped this would pass
+	// with nothing having run.
+	refusalFatal
+)
+
+// runState is what Main resolved and what the bootstrap made of it. There is
+// one per test binary, which is one package.
+type runState struct {
+	once sync.Once
+
+	settings    settings
+	requirement Requirement
+	pkg         string
+	runID       string
+	loadErr     error
+
+	inst    *instance
+	refusal string
+	kind    refusalKind
+
+	reported     atomic.Bool
+	firstRefused atomic.Pointer[string]
+}
+
+// state is this test binary's run.
+var state runState
+
+// Main runs one end-to-end package's tests against the runtime it requires.
+//
+// It resolves the configuration, computes the run identifier and returns the
+// exit code the package's TestMain should exit with. Everything else waits for
+// the first test that asks the harness for something.
+func Main(m *testing.M, req Requirement) int {
+	// The testing package has registered its flags by the time TestMain runs,
+	// so this is what makes -run readable, which the run record names.
+	flag.Parse()
+
+	pkg := packageName()
+	loaded, err := loadSettings()
+	state.settings = loaded
+	state.requirement = req
+	state.pkg = pkg
+	state.loadErr = err
+	state.runID = configuredRunID(time.Now(), loaded.get(envRunID), pkg)
+
+	log.Printf("e2e: package %s needs %s; run ID %s; filter %q", pkg, req, state.runID, testRunFilter())
+
+	code := m.Run()
+
+	removeBuiltBinary()
+	return state.finish(code)
+}
+
+// finish reports what the run left behind and returns the exit code.
+func (s *runState) finish(code int) int {
+	if s.inst != nil && s.inst.snapshot != nil {
+		if err := verifySnapshot(s.inst.client, s.inst.snapshot); err != nil {
+			log.Printf("e2e: SNAPSHOT INTEGRITY FAILURE: %v", err)
+			if code == 0 {
+				code = 1
+			}
+		} else {
+			log.Println("e2e: snapshot integrity verified: every pre-existing resource is unchanged")
+		}
+	}
+
+	if s.kind == refusalFatal || (s.kind == refusalMismatch && !s.mismatchSkips()) {
+		return 2
+	}
+	return code
+}
+
+// mismatchSkips reports whether the run asked for a runtime mismatch to skip
+// its tests rather than fail them.
+func (s *runState) mismatchSkips() bool {
+	return strings.EqualFold(s.settings.get(envRuntimeMismatch), "skip")
+}
+
+// bootstrap runs the probe, the guard and the preparation once, and reports a
+// refusal to every test that arrives after it.
+//
+// The first test to reach a refusal fails with the whole block; the rest skip
+// with a pointer to it. Failing every test with the same wall of text would
+// bury the one line that matters, and skipping every test would leave a run
+// that refused looking like a run that passed.
+func bootstrap(t *testing.T) *instance {
+	t.Helper()
+
+	state.once.Do(state.prepare)
+	if state.kind != refusalNone {
+		state.report(t)
+	}
+	return state.inst
+}
+
+// prepare probes the instance, guards it against the package's requirement and
+// gets it ready for the first test.
+func (s *runState) prepare() {
+	if s.loadErr != nil {
+		s.refuse(refusalFatal, s.loadErr.Error())
+		return
+	}
+
+	url := s.settings.get(envGitLabURL)
+	token := s.settings.get(envGitLabToken)
+	if url == "" || token == "" {
+		s.refuse(refusalFatal, missingCredentialsMessage(s.pkg))
+		return
+	}
+	skipTLSVerify := strings.EqualFold(s.settings.get(envSkipTLSVerify), "true")
+
+	client, err := gitlabclient.NewClientWithToken(url, token, skipTLSVerify)
+	if err != nil {
+		s.refuse(refusalFatal, unreachableMessage(s.pkg, url, err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), bootstrapTimeout)
+	defer cancel()
+
+	facts, err := probe(ctx, client, url, skipTLSVerify, token)
+	if err != nil {
+		s.refuse(refusalFatal, unreachableMessage(s.pkg, url, err))
+		return
+	}
+	log.Printf("e2e: %s is GitLab %s (%s), tier %s, authenticated as %s (admin=%t)",
+		url, facts.Version, facts.editionName(), facts.tierDescription(), facts.Username, facts.Admin)
+
+	if message := guardMessage(facts, s.requirement, s.pkg); message != "" {
+		s.refuse(refusalMismatch, message)
+		return
+	}
+
+	s.inst = &instance{
+		settings:    s.settings,
+		requirement: s.requirement,
+		pkg:         s.pkg,
+		runID:       s.runID,
+		facts:       facts,
+		client:      client,
+	}
+	prepareInstance(s.inst)
+}
+
+// refuse records why no test of this package can run.
+func (s *runState) refuse(kind refusalKind, message string) {
+	s.kind = kind
+	s.refusal = message
+	log.Printf("e2e: %s", message)
+}
+
+// report tells one test about the refusal.
+func (s *runState) report(t *testing.T) {
+	t.Helper()
+
+	if s.kind == refusalMismatch && s.mismatchSkips() {
+		t.Skipf("%s\n\n(%s=skip is set, so this is a skip)", s.refusal, envRuntimeMismatch)
+	}
+	if s.reported.CompareAndSwap(false, true) {
+		name := t.Name()
+		s.firstRefused.Store(&name)
+		t.Fatalf("%s", s.refusal)
+	}
+	first := "an earlier test"
+	if name := s.firstRefused.Load(); name != nil {
+		first = *name
+	}
+	t.Skipf("the harness refused this run; %s carries the reason", first)
+}
+
+// settings is the configuration one run resolved.
+//
+// It is a map rather than the process environment on purpose: a file this
+// suite reads must not be able to configure the harness's own process, because
+// the child's environment is built from nothing and a leaked variable would
+// then reach the server through a route nobody declared.
+type settings struct {
+	values map[string]string
+}
+
+// get returns one setting, or the empty string.
+func (s settings) get(key string) string { return s.values[key] }
+
+// loadSettings resolves the run's configuration, highest precedence first: the
+// process environment, the file E2E_ENV_FILE names, test/e2e/.env.docker in
+// Docker mode, and the repository .env.
+//
+// The repository .env stays last and is read in Docker mode too. It carries
+// the credentials .env.docker does not provision, GH_TOKEN and the Bitbucket
+// pair, and dropping it would silently skip the importer scenarios in CI
+// rather than run them.
+func loadSettings() (settings, error) {
+	resolved := settings{values: map[string]string{}}
+	for _, entry := range os.Environ() {
+		if key, value, found := strings.Cut(entry, "="); found {
+			resolved.values[key] = value
+		}
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		return resolved, err
+	}
+
+	// Read from the process environment rather than from what is resolved so
+	// far, so a file this run loads cannot nominate another one.
+	if named := os.Getenv(envEnvFile); named != "" {
+		if !filepath.IsAbs(named) {
+			return resolved, fmt.Errorf("%s must be an absolute path, and is %q: a relative one follows the "+
+				"test binary into its own package directory, where it names a different file for each package",
+				envEnvFile, named)
+		}
+		resolved.overlay(named)
+	}
+	if strings.EqualFold(os.Getenv(envMode), "docker") {
+		resolved.overlay(filepath.Join(root, dockerEnvFile))
+	}
+	resolved.overlay(filepath.Join(root, repoEnvFile))
+
+	return resolved, nil
+}
+
+// overlay adds the keys of one dotenv file that nothing has set yet.
+//
+// A file that is not there is not an error: the repository .env is optional,
+// and .env.docker only exists once the stack has been provisioned.
+func (s settings) overlay(path string) {
+	values, err := godotenv.Read(path)
+	if err != nil {
+		return
+	}
+	for key, value := range values {
+		if _, already := s.values[key]; !already {
+			s.values[key] = value
+		}
+	}
+}
+
+// packageName names the package under test, which every resource this run
+// creates carries.
+//
+// go test runs a package's binary in that package's own directory, so the
+// working directory is the name; the binary's own name is the fallback for a
+// binary run by hand from somewhere else.
+func packageName() string {
+	if dir, err := os.Getwd(); err == nil {
+		if name := filepath.Base(dir); name != "." && name != string(filepath.Separator) {
+			return name
+		}
+	}
+	return strings.TrimSuffix(filepath.Base(os.Args[0]), ".test")
+}
+
+// testRunFilter returns the -run pattern this binary was given, for the record
+// of what the run actually covered.
+func testRunFilter() string {
+	if f := flag.Lookup("test.run"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+// repoRoot walks up from the working directory to the directory holding
+// go.mod.
+//
+// Every path this harness resolves starts here: a path relative to the working
+// directory would name a different file for each of the three packages, which
+// is how the suite this replaces ended up with three spellings of the same
+// dotenv file.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolving the working directory: %w", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above %s, so the repository root cannot be resolved", dir)
+		}
+		dir = parent
+	}
+}

--- a/test/e2e/internal/harness/main_test.go
+++ b/test/e2e/internal/harness/main_test.go
@@ -1,0 +1,200 @@
+//go:build e2e
+
+// main_test.go covers what Main resolves before any test runs: where the
+// configuration comes from, in what order, and what a run with nothing
+// configured is told.
+
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeEnvFile writes a dotenv file and returns its absolute path.
+func writeEnvFile(t *testing.T, dir, name string, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// TestLoadSettings_ProcessEnvironment_WinsOverEveryFile checks the top of the
+// precedence order.
+//
+// A developer exporting a value means it for this run; a file that overrode it
+// would make the exported value look ignored, which is the class of confusion
+// that made the old suite's three dotenv spellings hard to reason about.
+func TestLoadSettings_ProcessEnvironment_WinsOverEveryFile(t *testing.T) {
+	dir := t.TempDir()
+	named := writeEnvFile(t, dir, "named.env", "E2E_HARNESS_KEY=from-the-file")
+	t.Setenv(envEnvFile, named)
+	t.Setenv("E2E_HARNESS_KEY", "from-the-environment")
+
+	resolved, err := loadSettings()
+	if err != nil {
+		t.Fatalf("loadSettings() error = %v, want nil", err)
+	}
+
+	if got := resolved.get("E2E_HARNESS_KEY"); got != "from-the-environment" {
+		t.Fatalf("E2E_HARNESS_KEY = %q, want the process environment's value", got)
+	}
+}
+
+// TestLoadSettings_NamedFile_FillsWhatNothingElseSet checks that the file
+// E2E_ENV_FILE names is read at all, and that it only fills gaps.
+func TestLoadSettings_NamedFile_FillsWhatNothingElseSet(t *testing.T) {
+	dir := t.TempDir()
+	named := writeEnvFile(t, dir, "named.env", "E2E_HARNESS_ONLY_IN_FILE=present")
+	t.Setenv(envEnvFile, named)
+
+	resolved, err := loadSettings()
+	if err != nil {
+		t.Fatalf("loadSettings() error = %v, want nil", err)
+	}
+
+	if got := resolved.get("E2E_HARNESS_ONLY_IN_FILE"); got != "present" {
+		t.Fatalf("E2E_HARNESS_ONLY_IN_FILE = %q, want the file's value", got)
+	}
+}
+
+// TestLoadSettings_RelativeEnvFile_IsRefused checks the one configuration
+// mistake that would otherwise be silent.
+//
+// A test binary runs in its own package directory, so a relative path names a
+// different file for each of the three packages, and the two that do not have
+// one would run with a configuration nobody wrote. Refusing says so; resolving
+// it against the repository root would hide a typo instead.
+func TestLoadSettings_RelativeEnvFile_IsRefused(t *testing.T) {
+	t.Setenv(envEnvFile, filepath.Join("test", "e2e", ".env.docker"))
+
+	_, err := loadSettings()
+
+	if err == nil {
+		t.Fatal("loadSettings() accepted a relative env file path")
+	}
+	if !strings.Contains(err.Error(), envEnvFile) || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("the error should name %s and say it must be absolute: %v", envEnvFile, err)
+	}
+}
+
+// TestLoadSettings_MissingFile_IsNotAnError checks that an absent file is
+// simply nothing.
+//
+// The repository .env is optional and test/e2e/.env.docker only exists once
+// the stack has been provisioned, so a run that has neither is an ordinary run
+// against an exported GITLAB_URL.
+func TestLoadSettings_MissingFile_IsNotAnError(t *testing.T) {
+	t.Setenv(envEnvFile, filepath.Join(t.TempDir(), "not-there.env"))
+
+	if _, err := loadSettings(); err != nil {
+		t.Fatalf("loadSettings() error = %v, want nil for a file that is not there", err)
+	}
+}
+
+// TestSettingsOverlay_ExistingKey_IsLeftAlone checks the overlay rule itself:
+// a file fills gaps and never replaces.
+func TestSettingsOverlay_ExistingKey_IsLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	path := writeEnvFile(t, dir, "overlay.env", "KEPT=file", "ADDED=file")
+	resolved := settings{values: map[string]string{"KEPT": "environment"}}
+
+	resolved.overlay(path)
+
+	if resolved.get("KEPT") != "environment" {
+		t.Fatalf("KEPT = %q, want the value that was already set", resolved.get("KEPT"))
+	}
+	if resolved.get("ADDED") != "file" {
+		t.Fatalf("ADDED = %q, want the file's value", resolved.get("ADDED"))
+	}
+}
+
+// TestRepoRoot_FromThisPackage_FindsTheModuleRoot checks the anchor every path
+// in the harness is resolved from.
+func TestRepoRoot_FromThisPackage_FindsTheModuleRoot(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot() error = %v, want nil", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "go.mod")); statErr != nil {
+		t.Fatalf("repoRoot() returned %q, which holds no go.mod: %v", root, statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, dockerEnvFile)); statErr != nil && !os.IsNotExist(statErr) {
+		t.Fatalf("the Docker env file path does not resolve under the root: %v", statErr)
+	}
+}
+
+// TestPackageName_WorkingDirectory_NamesThePackage checks the name every
+// resource this run creates carries.
+//
+// go test runs a package's binary in that package's own directory, so this is
+// "harness" here and "common", "ce" or "ee" for the suites.
+func TestPackageName_WorkingDirectory_NamesThePackage(t *testing.T) {
+	if got := packageName(); got != "harness" {
+		t.Fatalf("packageName() = %q, want %q", got, "harness")
+	}
+}
+
+// TestMismatchSkips_Setting_TurnsARefusalIntoSkips checks the escape hatch the
+// refusal block advertises.
+//
+// Only a runtime mismatch honors it. A run with no GitLab at all is a fatal
+// refusal whatever this says, because a release gate that skipped that would
+// pass with nothing having run.
+func TestMismatchSkips_Setting_TurnsARefusalIntoSkips(t *testing.T) {
+	cases := map[string]bool{"skip": true, "SKIP": true, "": false, "fail": false}
+	for value, want := range cases {
+		t.Run("value "+value, func(t *testing.T) {
+			run := &runState{settings: settings{values: map[string]string{envRuntimeMismatch: value}}}
+			if got := run.mismatchSkips(); got != want {
+				t.Fatalf("mismatchSkips() with %s=%q = %t, want %t", envRuntimeMismatch, value, got, want)
+			}
+		})
+	}
+}
+
+// TestRunStateFinish_FatalRefusal_AlwaysFails checks the exit code a package
+// that never ran a test returns.
+//
+// Two is the code the plan gives a refusal, so a CI step can tell it from an
+// ordinary test failure. A fatal refusal returns it even with the skip setting
+// on, which is what stops the gate passing empty.
+func TestRunStateFinish_FatalRefusal_AlwaysFails(t *testing.T) {
+	run := &runState{
+		kind:     refusalFatal,
+		settings: settings{values: map[string]string{envRuntimeMismatch: "skip"}},
+	}
+
+	if got := run.finish(0); got != 2 {
+		t.Fatalf("finish() = %d, want 2", got)
+	}
+}
+
+// TestRunStateFinish_Mismatch_HonoursTheSkipSetting checks the other half:
+// with the setting on, a mismatch is the run's own exit code, and without it
+// the run fails.
+func TestRunStateFinish_Mismatch_HonoursTheSkipSetting(t *testing.T) {
+	skipping := &runState{kind: refusalMismatch, settings: settings{values: map[string]string{envRuntimeMismatch: "skip"}}}
+	if got := skipping.finish(0); got != 0 {
+		t.Fatalf("finish() with the skip setting = %d, want 0", got)
+	}
+
+	failing := &runState{kind: refusalMismatch, settings: settings{values: map[string]string{}}}
+	if got := failing.finish(0); got != 2 {
+		t.Fatalf("finish() without the skip setting = %d, want 2", got)
+	}
+}
+
+// TestRunStateFinish_NoRefusal_KeepsTheTestsVerdict checks that a run which
+// reached its tests returns what they decided.
+func TestRunStateFinish_NoRefusal_KeepsTheTestsVerdict(t *testing.T) {
+	run := &runState{settings: settings{values: map[string]string{}}}
+
+	if got := run.finish(1); got != 1 {
+		t.Fatalf("finish(1) = %d, want the tests' own code", got)
+	}
+}

--- a/test/e2e/internal/harness/names.go
+++ b/test/e2e/internal/harness/names.go
@@ -1,0 +1,121 @@
+//go:build e2e
+
+// names.go gives every GitLab object a test creates a name that says which
+// run, which package and which test made it.
+//
+// Names are not cosmetic here. The sweep that deletes what a failed run left
+// behind matches on the run ID, so a fixed name would make one run delete
+// another run's fixtures, and a name without the package would make the three
+// packages collide on an instance they share.
+
+package harness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// stableHashLength is how many hexadecimal characters of a SHA-256 sum a
+// generated name carries. Ten is short enough to leave room inside GitLab's
+// path limits and long enough that two names minted in one afternoon do not
+// collide.
+const stableHashLength = 10
+
+// runIDStampLayout is the UTC timestamp a run ID opens with, lowercased so the
+// whole identifier is a legal GitLab path segment.
+const runIDStampLayout = "20060102t150405z"
+
+// unsafeChars matches everything GitLab refuses in a path segment, once the
+// name has been lowercased and its separators turned into dashes.
+var unsafeChars = regexp.MustCompile(`[^a-z0-9-]`)
+
+// runIDCounter disambiguates two run IDs minted in the same nanosecond by one
+// process, which a package that computes its identifier at startup can do.
+var runIDCounter atomic.Int64
+
+// nameCounter makes every name one process hands out distinct from the others
+// even when their prefixes and their run ID are identical.
+var nameCounter atomic.Int64
+
+// shortStableHash returns a deterministic lowercase hexadecimal prefix of the
+// SHA-256 sum of value.
+func shortStableHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:stableHashLength]
+}
+
+// sanitizeNamePart lowercases name, turns its separators into dashes, drops
+// everything GitLab refuses, trims dash boundaries and truncates the result to
+// maxLength characters. A maxLength of zero or less truncates nothing.
+func sanitizeNamePart(name string, maxLength int) string {
+	sanitized := strings.ToLower(name)
+	sanitized = strings.ReplaceAll(sanitized, "/", "-")
+	sanitized = strings.ReplaceAll(sanitized, "_", "-")
+	sanitized = unsafeChars.ReplaceAllString(sanitized, "")
+	sanitized = strings.Trim(sanitized, "-")
+	if maxLength > 0 && len(sanitized) > maxLength {
+		sanitized = strings.Trim(sanitized[:maxLength], "-")
+	}
+	return sanitized
+}
+
+// sanitizeTestName converts a Go test name into the slug segment a resource
+// name carries, short enough to leave room for the run ID beside it.
+func sanitizeTestName(name string) string {
+	return sanitizeNamePart(name, 40)
+}
+
+// sanitizeNamePrefix normalizes a caller's prefix and falls back to "e2e" when
+// nothing legal survives the sanitization.
+func sanitizeNamePrefix(prefix string) string {
+	name := sanitizeNamePart(prefix, 80)
+	if name == "" {
+		return "e2e"
+	}
+	return name
+}
+
+// newRunID builds the identifier one package's run is known by: a UTC stamp, a
+// hash that separates two runs started in the same second, and the package
+// name.
+//
+// The package is part of it because the three packages run against one
+// instance, one after another, and the sweep has to be able to tell whose
+// leftovers it is looking at.
+func newRunID(now time.Time, pkg string) string {
+	source := fmt.Sprintf("%d-%d-%d", now.UnixNano(), os.Getpid(), runIDCounter.Add(1))
+	return withPackage(now.UTC().Format(runIDStampLayout)+"-"+shortStableHash(source), pkg)
+}
+
+// configuredRunID returns the sanitized override when one was given, and a
+// fresh identifier otherwise. The package name is appended either way: an
+// override set once for a whole run reaches every package, and without it the
+// three would name their resources identically.
+func configuredRunID(now time.Time, override, pkg string) string {
+	if runID := sanitizeNamePart(override, 48); runID != "" {
+		return withPackage(runID, pkg)
+	}
+	return newRunID(now, pkg)
+}
+
+// withPackage appends the package name to a run identifier, leaving it alone
+// when the caller could not name a package.
+func withPackage(runID, pkg string) string {
+	if name := sanitizeNamePart(pkg, 24); name != "" {
+		return runID + "-" + name
+	}
+	return runID
+}
+
+// uniqueName returns a GitLab-safe resource name scoped to runID: the caller's
+// prefix, the run, a hash of the prefix and a counter no two calls share.
+func uniqueName(runID, prefix string) string {
+	sanitized := sanitizeNamePrefix(prefix)
+	return fmt.Sprintf("%s-%s-%s-%d", sanitized, runID, shortStableHash(sanitized), nameCounter.Add(1))
+}

--- a/test/e2e/internal/harness/names_test.go
+++ b/test/e2e/internal/harness/names_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+
+// names_test.go covers the name generation every fixture stands on. These are
+// ported from the suite this replaces (setup_helpers_ce_test.go), with the
+// package name the new run identifier carries added to each expectation.
+
+package harness
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hexOnly matches a lowercase hexadecimal string with nothing else in it.
+var hexOnly = regexp.MustCompile(`^[a-f0-9]+$`)
+
+// TestShortStableHash_SameInput_ReturnsStableLowercaseHex checks that the hash
+// behind every generated name is deterministic, the configured length, and
+// legal in a GitLab path.
+//
+// It hashes one value twice and asserts the two agree, that the result is
+// stableHashLength characters and that every character is lowercase hex. All
+// three matter: a hash that changed between calls would make one test's
+// resources unfindable by its own cleanup, and an upper-case or symbol
+// character would be refused by GitLab when the name is used as a path.
+func TestShortStableHash_SameInput_ReturnsStableLowercaseHex(t *testing.T) {
+	first := shortStableHash("TestCommon_Branches/Create")
+	second := shortStableHash("TestCommon_Branches/Create")
+
+	if first != second {
+		t.Fatalf("hash is not stable: first=%q second=%q", first, second)
+	}
+	if len(first) != stableHashLength {
+		t.Fatalf("hash length = %d, want %d", len(first), stableHashLength)
+	}
+	if !hexOnly.MatchString(first) {
+		t.Fatalf("hash %q is not lowercase hex", first)
+	}
+}
+
+// TestSanitizeTestName_MixedCaseWithSeparators_ReturnsSlug checks that a Go
+// test name becomes a slug GitLab accepts as a path segment.
+//
+// The input carries every shape a test name has: upper case, an underscore, a
+// subtest slash, spaces and punctuation. The expectation is one lowercase
+// string whose separators have become dashes and whose punctuation is gone,
+// which is what makes the name usable as a project path.
+func TestSanitizeTestName_MixedCaseWithSeparators_ReturnsSlug(t *testing.T) {
+	got := sanitizeTestName("TestCommon_Branches/Create With Spaces!")
+	want := "testcommon-branches-createwithspaces"
+	if got != want {
+		t.Fatalf("sanitizeTestName() = %q, want %q", got, want)
+	}
+}
+
+// TestSanitizeTestName_LongName_TruncatesToFortyCharacters checks the cap that
+// leaves room for the run identifier beside the test name.
+//
+// It feeds eighty characters in and expects forty out. GitLab's path limit is
+// what this protects: the test slug is only one of four parts of a generated
+// name, and an uncapped one would push the rest past the limit.
+func TestSanitizeTestName_LongName_TruncatesToFortyCharacters(t *testing.T) {
+	got := sanitizeTestName(strings.Repeat("a", 80))
+	if len(got) != 40 {
+		t.Fatalf("sanitized length = %d, want 40", len(got))
+	}
+}
+
+// TestNewRunID_NonUTCClock_UsesUTCStampHashAndPackage checks the shape of a
+// generated run identifier.
+//
+// The clock is deliberately in another zone: the identifier is compared across
+// machines, so it stamps UTC whatever the machine is set to. The package name
+// is part of it because the three e2e packages run against one instance one
+// after another, and the sweep that deletes leftovers has to be able to tell
+// whose they are.
+func TestNewRunID_NonUTCClock_UsesUTCStampHashAndPackage(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 34, 56, 789, time.FixedZone("UTC+2", 2*60*60))
+
+	got := newRunID(now, "common")
+
+	if !regexp.MustCompile(`^20260430t103456z-[a-f0-9]{10}-common$`).MatchString(got) {
+		t.Fatalf("newRunID() = %q, want a UTC stamp, a 10-character hash and the package", got)
+	}
+}
+
+// TestConfiguredRunID_Override_SanitizesAndKeepsPackage checks that an
+// operator-supplied identifier is used, sanitized, and still names the
+// package.
+//
+// The package is appended to an override too, and that is the point of the
+// case: one E2E_RUN_ID is exported for a whole run and reaches all three
+// packages, so without the suffix they would name their resources identically
+// and delete each other's.
+func TestConfiguredRunID_Override_SanitizesAndKeepsPackage(t *testing.T) {
+	got := configuredRunID(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC), "Custom_Run/ID!", "ee")
+	want := "custom-run-id-ee"
+	if got != want {
+		t.Fatalf("configuredRunID() = %q, want %q", got, want)
+	}
+}
+
+// TestConfiguredRunID_NoOverride_GeneratesOne checks the fallback: an override
+// that sanitizes to nothing is not an identifier, and generating one is better
+// than running with an empty scope that matches every other run.
+func TestConfiguredRunID_NoOverride_GeneratesOne(t *testing.T) {
+	got := configuredRunID(time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC), "!!!", "ce")
+
+	if !strings.HasSuffix(got, "-ce") || !strings.HasPrefix(got, "20260430t120000z-") {
+		t.Fatalf("configuredRunID() = %q, want a generated identifier ending in the package name", got)
+	}
+}
+
+// TestUniqueName_Prefix_CombinesRunIDHashAndCounter checks the whole name a
+// fixture is created under.
+//
+// The counter is what separates two resources of one test, and the run
+// identifier is what separates two runs. The assertion pins the exact shape
+// because the sweep matches on it.
+func TestUniqueName_Prefix_CombinesRunIDHashAndCounter(t *testing.T) {
+	before := nameCounter.Load()
+	t.Cleanup(func() { nameCounter.Store(before) })
+	nameCounter.Store(0)
+
+	got := uniqueName("run-abc123", "E2E_Project/Test")
+
+	want := "e2e-project-test-run-abc123-" + shortStableHash("e2e-project-test") + "-1"
+	if got != want {
+		t.Fatalf("uniqueName() = %q, want %q", got, want)
+	}
+}
+
+// TestUniqueName_EmptyPrefix_UsesTheDefaultPrefix checks that a prefix which
+// sanitizes to nothing still produces a name.
+//
+// A name beginning with a dash, or with nothing, is refused by GitLab and
+// would also break the prefix the orphan sweep matches on, so the empty case
+// falls back to "e2e" rather than producing one.
+func TestUniqueName_EmptyPrefix_UsesTheDefaultPrefix(t *testing.T) {
+	before := nameCounter.Load()
+	t.Cleanup(func() { nameCounter.Store(before) })
+	nameCounter.Store(0)
+
+	got := uniqueName("run-xyz789", "")
+
+	want := "e2e-run-xyz789-" + shortStableHash("e2e") + "-1"
+	if got != want {
+		t.Fatalf("uniqueName() = %q, want %q", got, want)
+	}
+}

--- a/test/e2e/internal/harness/needs.go
+++ b/test/e2e/internal/harness/needs.go
@@ -1,0 +1,323 @@
+//go:build e2e
+
+// needs.go holds the three things a test can say about how it must run, and
+// they are deliberately three rather than one.
+//
+// A Need is a fact about the environment: without it the test cannot run at
+// all and is skipped with a reason. A Lock is shared GitLab state the test
+// will change, so only one holder at a time may touch it; the test runs
+// either way. Serial is stronger than any lock: the test runs with no other
+// test of its package alive, which is what a change to the instance license
+// needs.
+//
+// The suite this replaces had one vocabulary for all three, and the cost was
+// that a reader could not tell a missing runner (skip) from a mutable setting
+// (serialize) without reading the switch that handled both.
+
+package harness
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+)
+
+// Option configures one Env.
+type Option func(*envOptions)
+
+// envOptions is what the options a caller passed add up to.
+type envOptions struct {
+	needs  []Need
+	locks  []Lock
+	serial bool
+}
+
+// Need is an environment requirement. A test declaring one it does not get is
+// skipped, with the reason the Need gives.
+type Need struct {
+	// name identifies the requirement in a skip message.
+	name string
+	// available answers whether this run has it, and says why not when it
+	// does not.
+	available func(inst *instance) (bool, string)
+}
+
+// String returns the requirement's name, so a Need reads as itself in a
+// message rather than as a struct.
+func (n Need) String() string { return n.name }
+
+// Needs declares environment requirements. A test that declares one the run
+// does not provide is skipped before it touches GitLab.
+func Needs(needs ...Need) Option {
+	return func(o *envOptions) { o.needs = append(o.needs, needs...) }
+}
+
+// Locks declares the shared GitLab state this test will change. Every holder
+// of one lock runs after the last, in the order the scheduler picks.
+func Locks(locks ...Lock) Option {
+	return func(o *envOptions) { o.locks = append(o.locks, locks...) }
+}
+
+// Serial declares that this test runs with no other Env of its package alive.
+//
+// It is for a change nothing else can be beside, such as installing or
+// removing the instance license: a lock would only exclude the other tests
+// that named the same lock, and every other test is affected by a license
+// that comes and goes underneath it.
+func Serial() Option {
+	return func(o *envOptions) { o.serial = true }
+}
+
+// Lock names shared state that only one test may change at a time.
+type Lock string
+
+// The shared state this suite serializes. Each names something one test
+// changes and every other test can observe.
+const (
+	// LockInstanceGlobal is any application-wide setting.
+	LockInstanceGlobal Lock = "instance-global"
+	// LockCurrentUserState is the authenticated user's own settings, which
+	// every session shares because every session uses that token.
+	LockCurrentUserState Lock = "current-user-state"
+	// LockRunner is the CI runner, which two pipelines would otherwise
+	// contend for.
+	LockRunner Lock = "runner"
+	// LockInstanceLicense is the license itself.
+	LockInstanceLicense Lock = "instance-license"
+)
+
+// The environment requirements a test can declare. Each is a fact about the
+// instance or the fixture stack, never about the catalog: what the server
+// serves is decided by the session, not by a Need.
+var (
+	// NeedAdmin requires a token whose user is an instance administrator.
+	NeedAdmin = Need{name: "admin", available: func(inst *instance) (bool, string) {
+		if inst.facts.Admin {
+			return true, ""
+		}
+		return false, "the configured token does not belong to an administrator"
+	}}
+
+	// NeedRunner requires a CI runner able to pick a job up, without which a
+	// pipeline stays pending until the test's budget runs out.
+	NeedRunner = Need{name: "runner", available: func(inst *instance) (bool, string) {
+		if inst.hasRunner() {
+			return true, ""
+		}
+		return false, "no instance CI runner is registered"
+	}}
+
+	// NeedFixtureService requires the fixture HTTP service the Docker stack
+	// runs, which answers the endpoints GitLab itself cannot be made to
+	// produce deterministically.
+	NeedFixtureService = requiredSetting("fixture service", envFixtureURL)
+
+	// NeedBitbucket requires the Bitbucket fixture the importer scenarios
+	// read from.
+	NeedBitbucket = requiredSetting("bitbucket fixture", envBitbucketServerURL)
+
+	// NeedGitHubToken requires a GitHub credential, which only the GitHub
+	// importer scenarios use.
+	NeedGitHubToken = requiredSetting("github token", envGitHubToken)
+
+	// NeedExternalNetwork requires the run to have opted into calling public
+	// Internet endpoints. It stays opt-in because a test that reaches the
+	// Internet fails for reasons that have nothing to do with this server.
+	NeedExternalNetwork = Need{name: "external network", available: func(inst *instance) (bool, string) {
+		if strings.EqualFold(inst.settings.get(envExternalNetwork), "true") {
+			return true, ""
+		}
+		return false, "set " + envExternalNetwork + "=true to allow tests that call public URLs"
+	}}
+)
+
+// Tier requires an instance licensed at least at the given tier. It is a
+// constructor rather than a constant because the tier is the argument.
+func Tier(want edition.Tier) Need {
+	return Need{
+		name: "tier " + want.String(),
+		available: func(inst *instance) (bool, string) {
+			if inst.facts.Tier.AtLeast(want) {
+				return true, ""
+			}
+			return false, "this instance is " + inst.facts.Tier.String() + ", and the test needs " + want.String()
+		},
+	}
+}
+
+// requiredSetting builds the Need satisfied by a configuration key carrying a
+// value, which is how every fixture the Docker stack provisions announces
+// itself.
+func requiredSetting(name, key string) Need {
+	return Need{
+		name: name,
+		available: func(inst *instance) (bool, string) {
+			if inst.settings.get(key) != "" {
+				return true, ""
+			}
+			return false, key + " is not set, so the " + name + " is not provisioned for this run"
+		},
+	}
+}
+
+// runnerLookupTimeout bounds the one Runners API call a NeedRunner outside
+// Docker mode makes.
+const runnerLookupTimeout = 10 * time.Second
+
+// hasRunner reports whether a CI runner can pick a job up, asking GitLab once
+// and remembering the answer.
+//
+// Docker mode answers yes without asking: the compose stack registers a runner
+// of its own, and the API listing is not visible to a non-administrator token
+// even when the runner is there.
+func (inst *instance) hasRunner() bool {
+	if inst.dockerMode() {
+		return true
+	}
+	inst.runnerOnce.Do(func() {
+		if inst.client == nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), runnerLookupTimeout)
+		defer cancel()
+		runnerType := "instance_type"
+		runners, _, err := inst.client.GL().Runners.ListRunners(&gl.ListRunnersOptions{Type: &runnerType},
+			gl.WithContext(ctx))
+		inst.runner = err == nil && len(runners) > 0
+	})
+	return inst.runner
+}
+
+// requireNeeds skips the test, naming the first requirement this run does not
+// provide.
+func requireNeeds(t *testing.T, inst *instance, needs []Need) {
+	t.Helper()
+	for _, need := range needs {
+		if ok, reason := need.available(inst); !ok {
+			t.Skipf("%s unavailable: %s", need.name, reason)
+		}
+	}
+}
+
+// lockRegistry holds one mutex per Lock, created when a test first names it.
+var lockRegistry = struct {
+	mu    sync.Mutex
+	locks map[Lock]*sync.Mutex
+}{locks: map[Lock]*sync.Mutex{}}
+
+// lockFor returns the mutex for one Lock.
+func lockFor(lock Lock) *sync.Mutex {
+	lockRegistry.mu.Lock()
+	defer lockRegistry.mu.Unlock()
+
+	held := lockRegistry.locks[lock]
+	if held == nil {
+		held = &sync.Mutex{}
+		lockRegistry.locks[lock] = held
+	}
+	return held
+}
+
+// acquireLocks takes every named lock in a fixed order and returns the release
+// that gives them back in the reverse one.
+//
+// The order is what keeps two tests naming the same pair from deadlocking:
+// sorting means they always take them the same way round. Duplicates are
+// dropped, since a test naming one lock twice would deadlock against itself.
+func acquireLocks(locks []Lock) func() {
+	wanted := slices.Clone(locks)
+	slices.Sort(wanted)
+	wanted = slices.Compact(wanted)
+
+	for _, lock := range wanted {
+		lockFor(lock).Lock()
+	}
+	return func() {
+		for _, lock := range slices.Backward(wanted) {
+			lockFor(lock).Unlock()
+		}
+	}
+}
+
+// serialGate lets a test declared Serial run while no other test of the
+// package holds an Env.
+//
+// It counts holders per top-level test rather than per Env, so a test that
+// opens a second Env for a subtest re-enters the gate it already holds instead
+// of waiting behind a serial test for a slot it will never be given. That is
+// the deadlock a plain sync.RWMutex produces here, and it is not hypothetical:
+// one parent fixture running three surface subtests is the shape the suite is
+// built around.
+type serialGate struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	shared map[string]int
+	// alone is the top-level test currently running by itself, if any.
+	alone string
+}
+
+// newSerialGate returns a gate nothing holds.
+func newSerialGate() *serialGate {
+	g := &serialGate{shared: map[string]int{}}
+	g.cond = sync.NewCond(&g.mu)
+	return g
+}
+
+// gate is the package's one serial gate.
+var gate = newSerialGate()
+
+// enter admits one Env of test and returns the function that gives its slot
+// back. With alone set, it waits until every other test has left and holds the
+// gate shut until the returned function runs.
+func (g *serialGate) enter(test string, alone bool) func() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for g.alone != "" && g.alone != test && g.shared[test] == 0 {
+		g.cond.Wait()
+	}
+	if alone {
+		g.alone = test
+		for g.othersHolding(test) {
+			g.cond.Wait()
+		}
+	}
+	g.shared[test]++
+
+	return func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		g.shared[test]--
+		if g.shared[test] <= 0 {
+			delete(g.shared, test)
+			if g.alone == test {
+				g.alone = ""
+			}
+		}
+		g.cond.Broadcast()
+	}
+}
+
+// othersHolding reports whether any test but this one holds a slot.
+func (g *serialGate) othersHolding(test string) bool {
+	for held, count := range g.shared {
+		if held != test && count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// topLevelTest returns the name of the test a subtest belongs to, which is the
+// grain the serial gate counts at.
+func topLevelTest(name string) string {
+	parent, _, _ := strings.Cut(name, "/")
+	return parent
+}

--- a/test/e2e/internal/harness/needs_test.go
+++ b/test/e2e/internal/harness/needs_test.go
@@ -1,0 +1,304 @@
+//go:build e2e
+
+// needs_test.go covers the three declarations a test makes about how it runs:
+// what the environment must provide, what it will change, and whether it can
+// share the instance while it does.
+
+package harness
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+)
+
+// testInstance builds an instance for the need table, with no client: every
+// need judged here reads the probed facts or the settings, and one that asked
+// GitLab would need a GitLab, which these tests deliberately do not have.
+func testInstance(facts runtimeFacts, values map[string]string) *instance {
+	return &instance{settings: settings{values: values}, facts: facts}
+}
+
+// TestNeeds_EachRequirement_IsJudgedAgainstTheRun checks every Need against a
+// run that provides it and one that does not.
+//
+// The reason matters as much as the verdict: a skipped test is only useful if
+// its message says what to provision, so each unsatisfied case asserts that
+// the reason names the thing that is missing.
+func TestNeeds_EachRequirement_IsJudgedAgainstTheRun(t *testing.T) {
+	cases := []struct {
+		name       string
+		need       Need
+		provided   *instance
+		absent     *instance
+		reasonWord string
+	}{
+		{
+			name:       "admin",
+			need:       NeedAdmin,
+			provided:   testInstance(runtimeFacts{Admin: true}, nil),
+			absent:     testInstance(runtimeFacts{}, nil),
+			reasonWord: "administrator",
+		},
+		{
+			name:       "runner",
+			need:       NeedRunner,
+			provided:   testInstance(runtimeFacts{}, map[string]string{envMode: "docker"}),
+			absent:     testInstance(runtimeFacts{}, nil),
+			reasonWord: "runner",
+		},
+		{
+			name:       "fixture service",
+			need:       NeedFixtureService,
+			provided:   testInstance(runtimeFacts{}, map[string]string{envFixtureURL: "http://e2e-fixture:8080"}),
+			absent:     testInstance(runtimeFacts{}, nil),
+			reasonWord: envFixtureURL,
+		},
+		{
+			name:       "bitbucket fixture",
+			need:       NeedBitbucket,
+			provided:   testInstance(runtimeFacts{}, map[string]string{envBitbucketServerURL: "http://bitbucket:7990"}),
+			absent:     testInstance(runtimeFacts{}, nil),
+			reasonWord: envBitbucketServerURL,
+		},
+		{
+			name:       "github token",
+			need:       NeedGitHubToken,
+			provided:   testInstance(runtimeFacts{}, map[string]string{envGitHubToken: "gho-token"}),
+			absent:     testInstance(runtimeFacts{}, nil),
+			reasonWord: envGitHubToken,
+		},
+		{
+			name:       "external network",
+			need:       NeedExternalNetwork,
+			provided:   testInstance(runtimeFacts{}, map[string]string{envExternalNetwork: "TRUE"}),
+			absent:     testInstance(runtimeFacts{}, map[string]string{envExternalNetwork: "no"}),
+			reasonWord: envExternalNetwork,
+		},
+		{
+			name:       "tier ultimate",
+			need:       Tier(edition.Ultimate),
+			provided:   testInstance(runtimeFacts{Tier: edition.Ultimate}, nil),
+			absent:     testInstance(runtimeFacts{Tier: edition.Premium}, nil),
+			reasonWord: "premium",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if ok, reason := testCase.need.available(testCase.provided); !ok {
+				t.Fatalf("%s reported unavailable on a run that provides it: %s", testCase.need, reason)
+			}
+			ok, reason := testCase.need.available(testCase.absent)
+			if ok {
+				t.Fatalf("%s reported available on a run that does not provide it", testCase.need)
+			}
+			if !containsFold(reason, testCase.reasonWord) {
+				t.Fatalf("%s reason = %q, want it to name %q", testCase.need, reason, testCase.reasonWord)
+			}
+		})
+	}
+}
+
+// TestNeedRunner_NoClientOutsideDocker_IsUnavailable checks the lookup path a
+// self-hosted run takes.
+//
+// Docker mode answers yes without asking GitLab, because the compose stack
+// registers a runner the token may not be allowed to list. Everywhere else the
+// answer comes from the API, and a run that cannot ask is not a run that has a
+// runner.
+func TestNeedRunner_NoClientOutsideDocker_IsUnavailable(t *testing.T) {
+	inst := testInstance(runtimeFacts{}, nil)
+
+	if ok, _ := NeedRunner.available(inst); ok {
+		t.Fatal("NeedRunner reported available with no client and no Docker stack")
+	}
+	// The answer is remembered, so a package full of runner tests asks once.
+	if ok, _ := NeedRunner.available(inst); ok {
+		t.Fatal("NeedRunner changed its answer on the second call")
+	}
+}
+
+// TestAcquireLocks_RepeatedName_TakesItOnce checks that a test naming one lock
+// twice does not deadlock against itself.
+//
+// The duplicate is not hypothetical: a helper that declares a lock and a test
+// that declares the same one both reach this list.
+func TestAcquireLocks_RepeatedName_TakesItOnce(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		release := acquireLocks([]Lock{LockInstanceGlobal, LockInstanceGlobal})
+		release()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquireLocks deadlocked on a repeated lock name")
+	}
+}
+
+// TestAcquireLocks_TwoHolders_RunOneAfterTheOther checks that the lock does
+// what it is for.
+//
+// The second holder must not begin until the first has released, which is the
+// whole reason a test declares a lock: it is about to change something every
+// other test can see.
+func TestAcquireLocks_TwoHolders_RunOneAfterTheOther(t *testing.T) {
+	release := acquireLocks([]Lock{LockCurrentUserState})
+
+	entered := make(chan struct{})
+	go func() {
+		second := acquireLocks([]Lock{LockCurrentUserState})
+		close(entered)
+		second()
+	}()
+
+	select {
+	case <-entered:
+		t.Fatal("the second holder entered while the first still held the lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the second holder never entered after the first released")
+	}
+}
+
+// TestSerialGate_SerialTest_WaitsForTheOthers checks that Serial means alone.
+//
+// A license that comes and goes underneath the other tests is the case this
+// exists for: no lock can express it, because every test is affected and none
+// of them names the license.
+func TestSerialGate_SerialTest_WaitsForTheOthers(t *testing.T) {
+	g := newSerialGate()
+	shared := g.enter("TestOther", false)
+
+	alone := make(chan struct{})
+	go func() {
+		release := g.enter("TestSerial", true)
+		close(alone)
+		release()
+	}()
+
+	select {
+	case <-alone:
+		t.Fatal("the serial test entered while another test held the gate")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	shared()
+	select {
+	case <-alone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the serial test never entered after the last other test left")
+	}
+}
+
+// TestSerialGate_SecondEnvOfOneTest_ReEntersWhileSerialWaits checks the
+// re-entry that keeps one parent fixture with three subtests from deadlocking.
+//
+// A plain RWMutex blocks a new reader once a writer is waiting, so the parent
+// test's second Env would wait for a serial test that is itself waiting for
+// the parent to finish. Counting holders per top-level test is what avoids it,
+// and this is the case that proves it.
+func TestSerialGate_SecondEnvOfOneTest_ReEntersWhileSerialWaits(t *testing.T) {
+	g := newSerialGate()
+	first := g.enter("TestParent", false)
+
+	waiting := make(chan struct{})
+	go func() {
+		release := g.enter("TestSerial", true)
+		close(waiting)
+		release()
+	}()
+	// Give the serial waiter time to claim the gate before the parent asks
+	// for its second slot.
+	time.Sleep(50 * time.Millisecond)
+
+	entered := make(chan struct{})
+	go func() {
+		second := g.enter("TestParent", false)
+		close(entered)
+		second()
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a second Env of a test already holding the gate could not re-enter")
+	}
+
+	first()
+	select {
+	case <-waiting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the serial test never entered after the parent released")
+	}
+}
+
+// TestSerialGate_ManyHolders_ReleaseEveryOne checks the counting itself: the
+// gate opens for a serial test only when the last of several holders of one
+// test has left.
+func TestSerialGate_ManyHolders_ReleaseEveryOne(t *testing.T) {
+	g := newSerialGate()
+
+	var wg sync.WaitGroup
+	releases := make([]func(), 3)
+	for i := range releases {
+		releases[i] = g.enter("TestParent", false)
+	}
+
+	opened := make(chan struct{})
+	wg.Go(func() {
+		release := g.enter("TestSerial", true)
+		close(opened)
+		release()
+	})
+
+	for i, release := range releases {
+		select {
+		case <-opened:
+			t.Fatalf("the gate opened with %d holders still inside", len(releases)-i)
+		default:
+		}
+		release()
+	}
+
+	wg.Wait()
+	select {
+	case <-opened:
+	default:
+		t.Fatal("the gate never opened after every holder left")
+	}
+}
+
+// TestTopLevelTest_SubtestName_ReturnsTheParent checks the grain the gate
+// counts at.
+func TestTopLevelTest_SubtestName_ReturnsTheParent(t *testing.T) {
+	cases := map[string]string{
+		"TestCommon_Issues":              "TestCommon_Issues",
+		"TestCommon_Issues/dynamic":      "TestCommon_Issues",
+		"TestCommon_Issues/meta/refused": "TestCommon_Issues",
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := topLevelTest(name); got != want {
+				t.Fatalf("topLevelTest(%q) = %q, want %q", name, got, want)
+			}
+		})
+	}
+}
+
+// containsFold reports whether haystack contains needle, ignoring case, so a
+// reason can be asserted on without pinning its exact wording.
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/test/e2e/internal/harness/poll.go
+++ b/test/e2e/internal/harness/poll.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+// poll.go holds the two ways a test waits for GitLab.
+//
+// Poll waits for a condition to become true and says what it last saw when it
+// gives up, because "timed out" without the last observation is a failure
+// nobody can act on. Retry runs an operation again after a failure the caller
+// classified as transient, which is what a GitLab that has just booted, or one
+// under the load of a parallel suite, produces.
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// ErrPollTimeout identifies a Poll that exhausted its wait budget, so a caller
+// can tell a timeout from a condition that failed outright.
+var ErrPollTimeout = errors.New("poll timeout")
+
+// defaultPollInterval is what Poll uses when the caller names no interval.
+const defaultPollInterval = 100 * time.Millisecond
+
+// Poll evaluates condition until it reports done, returns an error, runs out
+// of time, or ctx is cancelled.
+//
+// The condition returns three things: whether it is done, what it observed,
+// and an error. The error is for a failure that will not become success by
+// waiting; anything worth waiting through is reported as state instead, and
+// comes back in the timeout message.
+func Poll(ctx context.Context, interval, timeout time.Duration, condition func() (bool, string, error)) error {
+	if condition == nil {
+		return errors.New("poll condition is nil")
+	}
+	if interval <= 0 {
+		interval = defaultPollInterval
+	}
+	if timeout <= 0 {
+		timeout = interval
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	lastState := "no state observed"
+	for {
+		select {
+		case <-ctx.Done():
+			return pollContextError(ctx.Err(), timeout, lastState)
+		default:
+		}
+
+		done, state, err := condition()
+		if state != "" {
+			lastState = state
+		}
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		wait := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			stopTimer(wait)
+			return pollContextError(ctx.Err(), timeout, lastState)
+		case <-deadline.C:
+			stopTimer(wait)
+			return pollTimeoutError(timeout, lastState)
+		case <-wait.C:
+		}
+	}
+}
+
+// pollContextError reports a cancelled context as a timeout when the context
+// ended because its own deadline passed, and as a cancellation otherwise.
+func pollContextError(err error, timeout time.Duration, lastState string) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return pollTimeoutError(timeout, lastState)
+	}
+	return fmt.Errorf("poll canceled: %w", err)
+}
+
+// pollTimeoutError wraps ErrPollTimeout with the budget that ran out and the
+// last thing the condition saw.
+func pollTimeoutError(timeout time.Duration, lastState string) error {
+	return fmt.Errorf("%w after %s (last state: %s)", ErrPollTimeout, timeout, lastState)
+}
+
+// stopTimer stops timer and drains it when the stop came too late, so a caller
+// leaving a select does not leak the timer's send.
+func stopTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+// Retry runs operation until it succeeds, reports a failure it calls
+// permanent, runs out of attempts, or ctx is cancelled. The delay between
+// attempts grows by baseDelay each time.
+//
+// The operation returns its result, whether the failure is worth another
+// attempt, a short reason for the log, and the error. Naming the reason is
+// what makes a retried run readable afterwards: "attempt 2/3 failed (502 from
+// a booting GitLab)" is a story, and a bare repeated error is not.
+func Retry[O any](
+	ctx context.Context,
+	tb testing.TB,
+	label string,
+	maxRetries int,
+	baseDelay time.Duration,
+	operation func(attempt int) (O, bool, string, error),
+) (O, error) {
+	tb.Helper()
+
+	var output O
+	if operation == nil {
+		return output, errors.New("retry operation is nil")
+	}
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	if baseDelay <= 0 {
+		baseDelay = time.Millisecond
+	}
+
+	for attempt := range maxRetries {
+		result, retryable, reason, err := operation(attempt)
+		output = result
+		if err == nil {
+			return output, nil
+		}
+		if attempt >= maxRetries-1 || !retryable {
+			return output, fmt.Errorf("%s failed after %d attempt(s): %w", label, attempt+1, err)
+		}
+		if reason == "" {
+			reason = "retryable error"
+		}
+
+		tb.Logf("%s: attempt %d/%d failed (%s), retrying: %v", label, attempt+1, maxRetries, reason, err)
+		select {
+		case <-ctx.Done():
+			return output, fmt.Errorf("%s canceled before retry after attempt %d/%d: %w (last error: %s)",
+				label, attempt+1, maxRetries, ctx.Err(), err.Error())
+		case <-time.After(time.Duration(attempt+1) * baseDelay):
+		}
+	}
+
+	return output, fmt.Errorf("%s failed without executing retry operation", label)
+}

--- a/test/e2e/internal/harness/poll_test.go
+++ b/test/e2e/internal/harness/poll_test.go
@@ -1,0 +1,207 @@
+//go:build e2e
+
+// poll_test.go covers the two waiting primitives, ported from the suite this
+// replaces (wait_helpers_ce_test.go).
+
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPoll_ConditionTrueAtOnce_ReturnsWithoutWaiting checks that a condition
+// already satisfied costs nothing.
+//
+// The condition reports done on its first call, and the assertion is that it
+// ran exactly once. A Poll that slept before its first evaluation would add
+// its interval to every wait in the suite for no reason at all.
+func TestPoll_ConditionTrueAtOnce_ReturnsWithoutWaiting(t *testing.T) {
+	calls := 0
+	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
+		calls++
+		return true, "ready", nil
+	})
+	if err != nil {
+		t.Fatalf("Poll() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("condition calls = %d, want 1", calls)
+	}
+}
+
+// TestPoll_ConditionTrueLater_KeepsPolling checks the retry loop itself.
+//
+// The condition reports a state twice and then success, and the assertion is
+// that all three calls happened inside the budget. This is the path every
+// eventual-consistency wait in the suite takes.
+func TestPoll_ConditionTrueLater_KeepsPolling(t *testing.T) {
+	calls := 0
+	err := Poll(context.Background(), time.Millisecond, 100*time.Millisecond, func() (bool, string, error) {
+		calls++
+		if calls < 3 {
+			return false, fmt.Sprintf("attempt %d", calls), nil
+		}
+		return true, "ready", nil
+	})
+	if err != nil {
+		t.Fatalf("Poll() error = %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Fatalf("condition calls = %d, want 3", calls)
+	}
+}
+
+// TestPoll_ContextAlreadyCancelled_ReturnsCancellation checks that a cancelled
+// context is respected before the condition is evaluated at all.
+//
+// A test whose context has ended is over, and evaluating its condition once
+// more would issue a GitLab request nobody is waiting for.
+func TestPoll_ContextAlreadyCancelled_ReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := Poll(ctx, time.Millisecond, time.Second, func() (bool, string, error) {
+		calls++
+		return false, "waiting", nil
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Poll() error = %v, want context.Canceled", err)
+	}
+	if calls != 0 {
+		t.Fatalf("condition calls = %d, want 0", calls)
+	}
+}
+
+// TestPoll_BudgetExhausted_ReportsTheLastState checks the message a timeout
+// carries.
+//
+// The error wraps ErrPollTimeout so a caller can tell it from a condition
+// failure, and it quotes the last observation. "Timed out after 30s" alone
+// says nothing about what GitLab was doing; "last state: pipeline pending"
+// is the whole finding.
+func TestPoll_BudgetExhausted_ReportsTheLastState(t *testing.T) {
+	err := Poll(context.Background(), time.Millisecond, 3*time.Millisecond, func() (bool, string, error) {
+		return false, "still waiting", nil
+	})
+
+	if !errors.Is(err, ErrPollTimeout) {
+		t.Fatalf("Poll() error = %v, want ErrPollTimeout", err)
+	}
+	if !strings.Contains(err.Error(), "still waiting") {
+		t.Fatalf("Poll() error = %q, want the last observed state", err.Error())
+	}
+}
+
+// TestPoll_ConditionError_ReturnsItUnwrapped checks that a condition failure
+// stops the wait and reaches the caller intact.
+//
+// The condition returns an error only for a failure waiting cannot fix, so
+// Poll returns it as it is and errors.Is still matches the sentinel behind it.
+func TestPoll_ConditionError_ReturnsItUnwrapped(t *testing.T) {
+	conditionErr := errors.New("condition failed")
+	err := Poll(context.Background(), time.Millisecond, time.Second, func() (bool, string, error) {
+		return false, "failed", conditionErr
+	})
+
+	if !errors.Is(err, conditionErr) {
+		t.Fatalf("Poll() error = %v, want the condition's own error", err)
+	}
+}
+
+// TestPoll_NilCondition_IsRefused checks that a Poll with nothing to evaluate
+// reports the mistake rather than spinning until its budget runs out.
+func TestPoll_NilCondition_IsRefused(t *testing.T) {
+	if err := Poll(context.Background(), time.Millisecond, time.Millisecond, nil); err == nil {
+		t.Fatal("Poll() with a nil condition returned nil, want an error")
+	}
+}
+
+// TestRetry_RetryableFailure_ReturnsTheLaterSuccess checks the retry path.
+//
+// The operation calls its first failure retryable and succeeds on the second
+// attempt; the assertion is that the later result comes back and that exactly
+// two attempts were made. This is what absorbs a GitLab that has just booted.
+func TestRetry_RetryableFailure_ReturnsTheLaterSuccess(t *testing.T) {
+	attempts := 0
+	result, err := Retry(context.Background(), t, "retry test", 3, time.Millisecond,
+		func(int) (int, bool, string, error) {
+			attempts++
+			if attempts < 2 {
+				return 0, true, "transient", errors.New("try again")
+			}
+			return 42, false, "", nil
+		})
+	if err != nil {
+		t.Fatalf("Retry() error = %v, want nil", err)
+	}
+	if result != 42 {
+		t.Fatalf("result = %d, want 42", result)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+// TestRetry_PermanentFailure_StopsAtOnce checks that a failure the operation
+// calls permanent is not retried.
+//
+// Retrying a 403 three times only delays the report by the backoff, and the
+// error still has to reach the caller for errors.Is to work on it.
+func TestRetry_PermanentFailure_StopsAtOnce(t *testing.T) {
+	failure := errors.New("permanent failure")
+	attempts := 0
+	_, err := Retry(context.Background(), t, "retry test", 3, time.Millisecond,
+		func(int) (int, bool, string, error) {
+			attempts++
+			return 0, false, "", failure
+		})
+
+	if !errors.Is(err, failure) {
+		t.Fatalf("Retry() error = %v, want the permanent failure", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+// TestRetry_ContextCancelled_StopsBetweenAttempts checks that a cancelled
+// context ends the retry while it is waiting, rather than after the whole
+// backoff has elapsed.
+//
+// The message keeps the last error beside the cancellation, because "context
+// canceled" on its own does not say what was failing.
+func TestRetry_ContextCancelled_StopsBetweenAttempts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	_, err := Retry(ctx, t, "retry test", 3, 10*time.Millisecond,
+		func(int) (int, bool, string, error) {
+			attempts++
+			cancel()
+			return 0, true, "transient", errors.New("try again")
+		})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Retry() error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	if !strings.Contains(err.Error(), "try again") {
+		t.Fatalf("Retry() error = %q, want the last error beside the cancellation", err.Error())
+	}
+}
+
+// TestRetry_NilOperation_IsRefused checks that a Retry with nothing to run
+// reports the mistake instead of reporting success.
+func TestRetry_NilOperation_IsRefused(t *testing.T) {
+	if _, err := Retry[int](context.Background(), t, "retry test", 1, time.Millisecond, nil); err == nil {
+		t.Fatal("Retry() with a nil operation returned nil, want an error")
+	}
+}

--- a/test/e2e/internal/harness/runtime.go
+++ b/test/e2e/internal/harness/runtime.go
@@ -1,0 +1,483 @@
+//go:build e2e
+
+// runtime.go answers one question before any test writes anything: is this the
+// GitLab the package in front of us needs.
+//
+// A package declares what it needs once, in its Main, and the probe reads what
+// the instance actually is. When the two disagree the run stops with a block
+// that names both and the target to run instead, rather than with the hundreds
+// of 403s and 404s that a licensed package produces against a Free instance.
+// The probe runs before the first write for the same reason: the old suite
+// disabled rate limiting and warmed the API up before it had established what
+// it was talking to.
+
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	gl "gitlab.com/gitlab-org/api/client-go/v3"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+	gitlabclient "github.com/jmrplens/gitlab-mcp-server/v3/internal/gitlab"
+)
+
+// Requirement is what a package's tests need of the instance they run on.
+type Requirement int
+
+const (
+	// Any runs on every runtime: the actions it covers are Free ones, and a
+	// license changes how they are served rather than whether they exist.
+	Any Requirement = iota
+	// Free needs an instance with no license, for the handful of facts that
+	// are only true there.
+	Free
+	// Licensed needs a Premium or Ultimate instance.
+	Licensed
+)
+
+// String names the requirement in a message.
+func (r Requirement) String() string {
+	switch r {
+	case Free:
+		return "free (no license)"
+	case Licensed:
+		return "licensed (Premium or Ultimate)"
+	case Any:
+		return "any runtime"
+	default:
+		return "unknown"
+	}
+}
+
+// target names the Makefile target that provides this requirement, which is
+// what a refusal tells the reader to run instead.
+func (r Requirement) target() string {
+	if r == Licensed {
+		return "make test-e2e-docker-enterprise"
+	}
+	return "make test-e2e-docker"
+}
+
+// runtimeFacts is what the probe learned about the instance under test.
+type runtimeFacts struct {
+	// URL is the instance the run is pointed at.
+	URL string
+	// Version is what GET /api/v4/version reported.
+	Version string
+	// Enterprise is that endpoint's own edition flag: an EE image reports
+	// true whether or not a license is installed, which is why it is kept
+	// apart from Tier.
+	Enterprise bool
+	// Tier is what the license resolves to, Free when there is none.
+	Tier edition.Tier
+	// TierConfirmed says the tier came from a license rather than from the
+	// fallback, so a report can tell "Free" from "we could not ask".
+	TierConfirmed bool
+	// Admin says the token's user is an instance administrator.
+	Admin bool
+	// Username and UserID identify that user.
+	Username string
+	UserID   int64
+	// Scopes are the token's own, nil when the instance would not say.
+	Scopes []string
+}
+
+// editionName names the image's edition in a message. It is not called
+// edition, though that is what it returns, because the package that defines
+// the tier beside it is.
+func (f runtimeFacts) editionName() string {
+	if f.Enterprise {
+		return "Enterprise Edition"
+	}
+	return "Community Edition"
+}
+
+// tierDescription says what the tier is and whether a license confirmed it.
+func (f runtimeFacts) tierDescription() string {
+	if f.TierConfirmed {
+		return f.Tier.String() + " (license)"
+	}
+	return f.Tier.String() + " (no license found)"
+}
+
+// instance is everything the bootstrap resolved: what the run was configured
+// with, what the instance turned out to be, and the client the harness uses
+// for its own questions.
+type instance struct {
+	settings    settings
+	requirement Requirement
+	pkg         string
+	runID       string
+	facts       runtimeFacts
+	client      *gitlabclient.Client
+
+	runnerOnce sync.Once
+	runner     bool
+
+	snapshot *resourceSnapshot
+}
+
+// dockerMode reports whether the run is against the ephemeral Docker stack,
+// which is disposable and therefore needs no snapshot guard.
+func (inst *instance) dockerMode() bool {
+	return strings.EqualFold(inst.settings.get(envMode), "docker")
+}
+
+// cleanupBudget is how long one test's undo work may take.
+func (inst *instance) cleanupBudget() time.Duration {
+	if inst.facts.Tier.IsEnterprise() {
+		return enterpriseCleanupBudget
+	}
+	return cleanupBudget
+}
+
+// probeTimeout bounds each question the probe asks.
+const probeTimeout = 30 * time.Second
+
+// probe asks the instance what it is, without changing anything.
+func probe(ctx context.Context, client *gitlabclient.Client, url string, skipTLSVerify bool, token string) (runtimeFacts, error) {
+	version, err := client.Ping(ctx)
+	if err != nil {
+		return runtimeFacts{}, err
+	}
+	facts := runtimeFacts{URL: url, Version: version}
+
+	// The edition flag is read with a request of our own rather than through
+	// DetectEnterprise, which sets the client's tier to Premium for any EE
+	// image, licensed or not. The harness wants the two facts apart.
+	facts.Enterprise = instanceIsEnterprise(ctx, url, token, skipTLSVerify)
+
+	facts.Tier = client.DetectTier(ctx)
+	client.SetTier(facts.Tier)
+	facts.TierConfirmed = facts.Tier.IsEnterprise()
+
+	user, _, err := client.GL().Users.CurrentUser(gl.WithContext(ctx))
+	if err != nil {
+		return facts, fmt.Errorf("reading the authenticated user: %w", err)
+	}
+	facts.Admin = user.IsAdmin
+	facts.Username = user.Username
+	facts.UserID = user.ID
+
+	facts.Scopes = gitlabclient.DetectScopes(ctx, client.GL())
+	return facts, nil
+}
+
+// instanceIsEnterprise reads the edition flag off GET /api/v4/version.
+//
+// An instance that will not answer, or that omits the field as older releases
+// do, is reported as Community: the flag only widens what a refusal message
+// says, and guessing Enterprise would make that message claim something the
+// instance never said.
+func instanceIsEnterprise(ctx context.Context, url, token string, skipTLSVerify bool) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(url, "/")+"/api/v4/version", http.NoBody)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("PRIVATE-TOKEN", token)
+
+	client := &http.Client{Transport: gitlabclient.HTTPTransport(skipTLSVerify), Timeout: probeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var reported struct {
+		Enterprise *bool `json:"enterprise"`
+	}
+	if err = json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&reported); err != nil || reported.Enterprise == nil {
+		return false
+	}
+	return *reported.Enterprise
+}
+
+// satisfies reports whether facts meet req.
+func (r Requirement) satisfies(facts runtimeFacts) bool {
+	switch r {
+	case Free:
+		return !facts.Tier.IsEnterprise()
+	case Licensed:
+		return facts.Tier.IsEnterprise()
+	case Any:
+		return true
+	default:
+		return false
+	}
+}
+
+// guardMessage returns the block a refused runtime prints, and the empty
+// string when the instance satisfies the requirement.
+//
+// It is a plain function of the two facts so that the message itself can be
+// tested: the text is the whole value of the guard, and a refusal that named
+// neither what it found nor what to run instead would be no better than the
+// failures it replaces.
+func guardMessage(facts runtimeFacts, req Requirement, pkg string) string {
+	if req.satisfies(facts) {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "this GitLab does not provide what the %s package needs.\n\n", pkg)
+	fmt.Fprintf(&b, "  instance     %s\n", facts.URL)
+	fmt.Fprintf(&b, "  version      %s (%s)\n", facts.Version, facts.editionName())
+	fmt.Fprintf(&b, "  tier         %s\n", facts.tierDescription())
+	fmt.Fprintf(&b, "  requirement  %s\n\n", req)
+	fmt.Fprintf(&b, "  run this package against a runtime that provides it:\n      %s\n", req.target())
+	fmt.Fprintf(&b, "  or set %s=skip to skip the package instead of failing it.", envRuntimeMismatch)
+	return b.String()
+}
+
+// missingCredentialsMessage is what a run configured with no instance is told.
+func missingCredentialsMessage(pkg string) string {
+	return fmt.Sprintf("the %s package has no GitLab to run against: %s and %s are both required.\n\n"+
+		"  they come from the process environment, from %s, from test/e2e/.env.docker in Docker mode,\n"+
+		"  or from the repository .env, in that order of precedence.",
+		pkg, envGitLabURL, envGitLabToken, envEnvFile)
+}
+
+// unreachableMessage is what a run whose instance did not answer is told. The
+// instance is named and the token is not.
+func unreachableMessage(pkg, url string, err error) string {
+	return fmt.Sprintf("the %s package could not reach the GitLab it was pointed at.\n\n"+
+		"  instance     %s\n  error        %v", pkg, url, err)
+}
+
+// prepareInstance does everything that has to happen once, after the guard and
+// before the first test, and changes GitLab in the process.
+//
+// Every item here was learned the hard way by the suite this replaces, and the
+// comments say which failure each one answers.
+func prepareInstance(inst *instance) {
+	disableRateLimiting(inst.client)
+	if inst.dockerMode() {
+		log.Println("e2e: warming up the GitLab API for concurrent load")
+		if err := waitForAPIStable(inst.client, apiWarmupTimeout); err != nil {
+			log.Printf("e2e: %v; tests may see dropped connections", err)
+		}
+	}
+	materializeGlobalNotificationSetting(inst.client)
+	if !inst.dockerMode() {
+		captureSnapshot(inst)
+	}
+}
+
+// disableRateLimiting turns GitLab's throttles off for the run, so a suite
+// making thousands of calls is not answered 429 for doing what it was asked to
+// do. It needs an administrator; a refusal is logged and is not fatal.
+func disableRateLimiting(client *gitlabclient.Client) {
+	off := false
+	_, _, err := client.GL().Settings.UpdateSettings(&gl.UpdateSettingsOptions{
+		ThrottleAuthenticatedAPIEnabled:             &off,
+		ThrottleAuthenticatedWebEnabled:             &off,
+		ThrottleUnauthenticatedAPIEnabled:           &off,
+		ThrottleUnauthenticatedWebEnabled:           &off,
+		ThrottleAuthenticatedPackagesAPIEnabled:     &off,
+		ThrottleAuthenticatedGitLFSEnabled:          &off,
+		ThrottleAuthenticatedFilesAPIEnabled:        &off,
+		ThrottleUnauthenticatedFilesAPIEnabled:      &off,
+		ThrottleAuthenticatedDeprecatedAPIEnabled:   &off,
+		ThrottleUnauthenticatedDeprecatedAPIEnabled: &off,
+	})
+	if err != nil {
+		log.Printf("e2e: could not disable rate limiting (it needs an administrator): %v", err)
+		return
+	}
+	log.Println("e2e: rate limiting disabled for this run")
+}
+
+// The bounds the Docker warm-up runs under.
+const (
+	apiWarmupTimeout      = 60 * time.Second
+	apiWarmupConcurrency  = 10
+	apiWarmupSuccessRuns  = 3
+	apiWarmupProbeTimeout = 5 * time.Second
+)
+
+// waitForAPIStable holds the run back until GitLab answers a burst of parallel
+// requests without dropping any, three rounds running.
+//
+// A Docker GitLab reports ready while its nginx and puma workers are still
+// warming up, and the first thing this suite does is exactly the burst they
+// are not ready for. Waiting here turns a scatter of connection resets across
+// unrelated tests into one wait with a name.
+func waitForAPIStable(client *gitlabclient.Client, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	successRuns := 0
+	for time.Now().Before(deadline) {
+		var wg sync.WaitGroup
+		errs := make([]error, apiWarmupConcurrency)
+		for i := range apiWarmupConcurrency {
+			wg.Go(func() {
+				ctx, cancel := context.WithTimeout(context.Background(), apiWarmupProbeTimeout)
+				defer cancel()
+				_, errs[i] = client.Ping(ctx)
+			})
+		}
+		wg.Wait()
+
+		if slicesContainError(errs) {
+			successRuns = 0
+			log.Println("e2e: API warm-up: some connections were dropped, retrying")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		successRuns++
+		if successRuns >= apiWarmupSuccessRuns {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("the GitLab API was not stable after %v of concurrent probing", timeout)
+}
+
+// slicesContainError reports whether any probe of one warm-up round failed.
+func slicesContainError(errs []error) bool {
+	for _, err := range errs {
+		if err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// materializeNotificationAttempts bounds the retries the notification row gets.
+const materializeNotificationAttempts = 3
+
+// materializeGlobalNotificationSetting forces the authenticated user's global
+// notification row to exist before any test runs.
+//
+// GitLab creates that row lazily, inside the read: the model does a
+// find_or_initialize_by and saves an unpersisted record, so even a plain GET
+// writes. Two concurrent readers therefore both insert and the loser is
+// refused with a uniqueness error on a request that only read. Reading it once
+// here, alone, closes that window for the whole run.
+//
+// It is defense in depth rather than the mechanism: the tests that change the
+// setting hold LockCurrentUserState. A failure is therefore logged and never
+// fatal.
+func materializeGlobalNotificationSetting(client *gitlabclient.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+
+	var err error
+	for attempt := 1; attempt <= materializeNotificationAttempts; attempt++ {
+		if _, _, err = client.GL().NotificationSettings.GetGlobalSettings(gl.WithContext(ctx)); err == nil {
+			return
+		}
+		if attempt < materializeNotificationAttempts {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+	log.Printf("e2e: could not materialize the global notification setting after %d attempts: %v; "+
+		"the lock still serializes the tests that use it", materializeNotificationAttempts, err)
+}
+
+// resourceSnapshot is what the instance held before the run, so a run against
+// an instance somebody else owns can prove it left everything alone.
+type resourceSnapshot struct {
+	groups   map[int64]string
+	projects map[int64]string
+}
+
+// snapshotPageSize is how many objects each listing page carries.
+const snapshotPageSize = 100
+
+// captureSnapshot records the instance's groups and projects, and refuses the
+// run when it cannot: a guard that silently did not run would be worse than no
+// guard, because the run would be believed.
+func captureSnapshot(inst *instance) {
+	snapshot, err := snapshotState(inst.client)
+	if err != nil {
+		log.Printf("e2e: could not snapshot the instance's existing resources: %v", err)
+		return
+	}
+	inst.snapshot = snapshot
+	log.Printf("e2e: snapshot captured: %d groups, %d projects", len(snapshot.groups), len(snapshot.projects))
+}
+
+// snapshotState lists every group and project the token can see.
+func snapshotState(client *gitlabclient.Client) (*resourceSnapshot, error) {
+	snapshot := &resourceSnapshot{groups: map[int64]string{}, projects: map[int64]string{}}
+
+	var page int64 = 1
+	for page != 0 {
+		opts := &gl.ListGroupsOptions{}
+		opts.Page = page
+		opts.PerPage = snapshotPageSize
+		groups, resp, err := client.GL().Groups.ListGroups(opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing groups (page %d): %w", page, err)
+		}
+		for _, group := range groups {
+			snapshot.groups[group.ID] = group.FullPath
+		}
+		page = resp.NextPage
+	}
+
+	page = 1
+	for page != 0 {
+		opts := &gl.ListProjectsOptions{}
+		opts.Page = page
+		opts.PerPage = snapshotPageSize
+		projects, resp, err := client.GL().Projects.ListProjects(opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing projects (page %d): %w", page, err)
+		}
+		for _, project := range projects {
+			snapshot.projects[project.ID] = project.PathWithNamespace
+		}
+		page = resp.NextPage
+	}
+
+	return snapshot, nil
+}
+
+// verifySnapshot re-reads the instance and reports what the run changed about
+// resources it did not create.
+func verifySnapshot(client *gitlabclient.Client, before *resourceSnapshot) error {
+	current, err := snapshotState(client)
+	if err != nil {
+		return fmt.Errorf("re-reading the instance: %w", err)
+	}
+	if changes := snapshotDifferences(before, current); len(changes) > 0 {
+		return fmt.Errorf("%d resources this run did not create were changed or deleted:\n  %s",
+			len(changes), strings.Join(changes, "\n  "))
+	}
+	return nil
+}
+
+// snapshotDifferences names every group and project that disappeared or was
+// renamed between the two readings.
+func snapshotDifferences(before, current *resourceSnapshot) []string {
+	var changes []string
+	for id, path := range before.groups {
+		switch now, found := current.groups[id]; {
+		case !found:
+			changes = append(changes, fmt.Sprintf("group %q (ID=%d): missing", path, id))
+		case now != path:
+			changes = append(changes, fmt.Sprintf("group ID=%d renamed: %q to %q", id, path, now))
+		}
+	}
+	for id, path := range before.projects {
+		switch now, found := current.projects[id]; {
+		case !found:
+			changes = append(changes, fmt.Sprintf("project %q (ID=%d): missing", path, id))
+		case now != path:
+			changes = append(changes, fmt.Sprintf("project ID=%d renamed: %q to %q", id, path, now))
+		}
+	}
+	return changes
+}

--- a/test/e2e/internal/harness/runtime_test.go
+++ b/test/e2e/internal/harness/runtime_test.go
@@ -1,0 +1,272 @@
+//go:build e2e
+
+// runtime_test.go covers the guard: which instances each requirement accepts,
+// and what a refusal tells the person reading it.
+
+package harness
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jmrplens/gitlab-mcp-server/v3/internal/edition"
+)
+
+// TestGuardMessage_EveryRuntime_RefusesOnlyTheWrongOnes is the table the guard
+// exists for: three requirements against the three runtimes this suite runs
+// on.
+//
+// The unlicensed EE image is the row worth having. It reports Enterprise
+// Edition on its version endpoint and has no license, so a rule written on the
+// edition flag would send the licensed package at it and the Free package away
+// from it, both wrong. The tier is what decides, and this pins that.
+func TestGuardMessage_EveryRuntime_RefusesOnlyTheWrongOnes(t *testing.T) {
+	ce := runtimeFacts{URL: "http://gitlab.test", Version: "18.0.0", Tier: edition.Free}
+	eeUnlicensed := runtimeFacts{URL: "http://gitlab.test", Version: "18.0.0-ee", Enterprise: true, Tier: edition.Free}
+	eeLicensed := runtimeFacts{
+		URL: "http://gitlab.test", Version: "18.0.0-ee", Enterprise: true,
+		Tier: edition.Ultimate, TierConfirmed: true,
+	}
+
+	cases := []struct {
+		name    string
+		facts   runtimeFacts
+		req     Requirement
+		refused bool
+	}{
+		{name: "any on a CE image", facts: ce, req: Any},
+		{name: "any on an unlicensed EE image", facts: eeUnlicensed, req: Any},
+		{name: "any on a licensed instance", facts: eeLicensed, req: Any},
+		{name: "free on a CE image", facts: ce, req: Free},
+		{name: "free on an unlicensed EE image", facts: eeUnlicensed, req: Free},
+		{name: "free on a licensed instance", facts: eeLicensed, req: Free, refused: true},
+		{name: "licensed on a CE image", facts: ce, req: Licensed, refused: true},
+		{name: "licensed on an unlicensed EE image", facts: eeUnlicensed, req: Licensed, refused: true},
+		{name: "licensed on a licensed instance", facts: eeLicensed, req: Licensed},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			message := guardMessage(testCase.facts, testCase.req, "common")
+			if testCase.refused && message == "" {
+				t.Fatalf("%s was accepted, want a refusal", testCase.name)
+			}
+			if !testCase.refused && message != "" {
+				t.Fatalf("%s was refused:\n%s", testCase.name, message)
+			}
+		})
+	}
+}
+
+// TestGuardMessage_Refusal_NamesWhatToDoAboutIt checks the content of the
+// block, which is the whole value of the guard.
+//
+// A refusal that only said "wrong runtime" would be no better than the wall of
+// 404s it replaces. It names the instance, its version and edition, the tier
+// it found, what the package needs, the target that provides it and the escape
+// hatch, so the reader can act without opening the plan.
+func TestGuardMessage_Refusal_NamesWhatToDoAboutIt(t *testing.T) {
+	facts := runtimeFacts{URL: "http://gitlab.test:8929", Version: "18.0.0", Tier: edition.Free}
+
+	message := guardMessage(facts, Licensed, "ee")
+
+	for _, fragment := range []string{
+		"ee package",
+		"http://gitlab.test:8929",
+		"18.0.0",
+		"Community Edition",
+		"free (no license found)",
+		"licensed (Premium or Ultimate)",
+		"make test-e2e-docker-enterprise",
+		envRuntimeMismatch + "=skip",
+	} {
+		t.Run(fragment, func(t *testing.T) {
+			if !strings.Contains(message, fragment) {
+				t.Fatalf("the refusal does not name %q:\n%s", fragment, message)
+			}
+		})
+	}
+}
+
+// TestGuardMessage_FreeRefusal_PointsAtTheUnlicensedTarget checks the other
+// direction, where the reader is holding a licensed instance and the package
+// needs one without a license.
+func TestGuardMessage_FreeRefusal_PointsAtTheUnlicensedTarget(t *testing.T) {
+	facts := runtimeFacts{URL: "http://gitlab.test", Version: "18.0.0-ee", Enterprise: true, Tier: edition.Premium, TierConfirmed: true}
+
+	message := guardMessage(facts, Free, "ce")
+
+	if !strings.Contains(message, "      make test-e2e-docker\n") {
+		t.Fatalf("the refusal should point at the unlicensed target:\n%s", message)
+	}
+	if !strings.Contains(message, "premium (license)") {
+		t.Fatalf("the refusal should say the license was found:\n%s", message)
+	}
+}
+
+// TestRequirementString_EveryValue_NamesItself checks that a requirement reads
+// as itself in the refusal block, including the value nothing should produce.
+func TestRequirementString_EveryValue_NamesItself(t *testing.T) {
+	cases := map[Requirement]string{
+		Any:             "any runtime",
+		Free:            "free",
+		Licensed:        "licensed",
+		Requirement(99): "unknown",
+	}
+	for req, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			if got := req.String(); !strings.Contains(got, want) {
+				t.Fatalf("Requirement(%d).String() = %q, want it to contain %q", req, got, want)
+			}
+		})
+	}
+}
+
+// TestRequirementSatisfies_UnknownValue_AcceptsNothing checks that a
+// requirement nothing produces refuses rather than admits.
+//
+// The default of a switch over a small enum is the branch a future value lands
+// in, and admitting by default would run a package against a runtime nobody
+// had checked.
+func TestRequirementSatisfies_UnknownValue_AcceptsNothing(t *testing.T) {
+	if Requirement(99).satisfies(runtimeFacts{Tier: edition.Ultimate}) {
+		t.Fatal("an unknown requirement accepted an instance")
+	}
+}
+
+// TestMissingCredentialsMessage_NoInstance_NamesEveryConfigurationSource
+// checks what a run with nothing configured is told.
+//
+// This is the first thing a new contributor sees, so it lists the four places
+// the configuration can come from and their order rather than naming one.
+func TestMissingCredentialsMessage_NoInstance_NamesEveryConfigurationSource(t *testing.T) {
+	message := missingCredentialsMessage("common")
+
+	for _, fragment := range []string{"common package", envGitLabURL, envGitLabToken, envEnvFile, ".env.docker", ".env"} {
+		t.Run(fragment, func(t *testing.T) {
+			if !strings.Contains(message, fragment) {
+				t.Fatalf("the message does not name %q:\n%s", fragment, message)
+			}
+		})
+	}
+}
+
+// TestUnreachableMessage_FailedProbe_NamesTheInstanceAndNotTheToken checks
+// that a connection failure says which instance would not answer and never
+// quotes the credential.
+func TestUnreachableMessage_FailedProbe_NamesTheInstanceAndNotTheToken(t *testing.T) {
+	message := unreachableMessage("ce", "http://gitlab.test", errors.New("connection refused"))
+
+	if !strings.Contains(message, "http://gitlab.test") || !strings.Contains(message, "connection refused") {
+		t.Fatalf("the message should name the instance and the error:\n%s", message)
+	}
+	if strings.Contains(strings.ToLower(message), "token") {
+		t.Fatalf("the message should not mention the credential:\n%s", message)
+	}
+}
+
+// TestSnapshotDifferences_MissingAndRenamed_ReportsBoth checks the guard that
+// protects an instance the run does not own.
+//
+// A deleted resource and a renamed one are different failures and both are
+// worth the words: a rename is usually a test that took a name it should have
+// scoped to its run.
+func TestSnapshotDifferences_MissingAndRenamed_ReportsBoth(t *testing.T) {
+	before := &resourceSnapshot{
+		groups:   map[int64]string{1: "team", 2: "kept"},
+		projects: map[int64]string{10: "team/app", 11: "team/kept"},
+	}
+	current := &resourceSnapshot{
+		groups:   map[int64]string{2: "kept-renamed"},
+		projects: map[int64]string{10: "team/app", 11: "team/kept"},
+	}
+
+	changes := snapshotDifferences(before, current)
+
+	if len(changes) != 2 {
+		t.Fatalf("changes = %v, want the missing group and the renamed one", changes)
+	}
+	joined := strings.Join(changes, "\n")
+	if !strings.Contains(joined, `group "team" (ID=1): missing`) {
+		t.Fatalf("the missing group is not reported:\n%s", joined)
+	}
+	if !strings.Contains(joined, `group ID=2 renamed: "kept" to "kept-renamed"`) {
+		t.Fatalf("the renamed group is not reported:\n%s", joined)
+	}
+}
+
+// TestSnapshotDifferences_ProjectChanges_ReportsThem checks the same two
+// classes for projects, which is what a run creates most of.
+func TestSnapshotDifferences_ProjectChanges_ReportsThem(t *testing.T) {
+	before := &resourceSnapshot{
+		groups:   map[int64]string{},
+		projects: map[int64]string{10: "team/app", 11: "team/lib"},
+	}
+	current := &resourceSnapshot{
+		groups:   map[int64]string{},
+		projects: map[int64]string{11: "team/lib-renamed"},
+	}
+
+	changes := strings.Join(snapshotDifferences(before, current), "\n")
+
+	if !strings.Contains(changes, `project "team/app" (ID=10): missing`) {
+		t.Fatalf("the missing project is not reported:\n%s", changes)
+	}
+	if !strings.Contains(changes, `project ID=11 renamed: "team/lib" to "team/lib-renamed"`) {
+		t.Fatalf("the renamed project is not reported:\n%s", changes)
+	}
+}
+
+// TestSnapshotDifferences_NothingChanged_ReportsNothing checks the passing
+// case, which is what every run against somebody's own instance should
+// produce.
+func TestSnapshotDifferences_NothingChanged_ReportsNothing(t *testing.T) {
+	snapshot := &resourceSnapshot{groups: map[int64]string{1: "team"}, projects: map[int64]string{10: "team/app"}}
+
+	if changes := snapshotDifferences(snapshot, snapshot); len(changes) != 0 {
+		t.Fatalf("changes = %v, want none", changes)
+	}
+}
+
+// TestInstanceCleanupBudget_LicensedInstance_GetsLonger checks the budget a
+// test's undo work runs under.
+//
+// A licensed instance deletes projects and groups measurably more slowly, and
+// a cleanup cut short leaves resources the next run trips over.
+func TestInstanceCleanupBudget_LicensedInstance_GetsLonger(t *testing.T) {
+	free := &instance{facts: runtimeFacts{Tier: edition.Free}}
+	licensed := &instance{facts: runtimeFacts{Tier: edition.Ultimate}}
+
+	if free.cleanupBudget() != cleanupBudget {
+		t.Fatalf("free budget = %s, want %s", free.cleanupBudget(), cleanupBudget)
+	}
+	if licensed.cleanupBudget() != enterpriseCleanupBudget {
+		t.Fatalf("licensed budget = %s, want %s", licensed.cleanupBudget(), enterpriseCleanupBudget)
+	}
+}
+
+// TestInstanceDockerMode_ModeSetting_DecidesIt checks the one switch that
+// turns the snapshot guard off and the API warm-up on.
+func TestInstanceDockerMode_ModeSetting_DecidesIt(t *testing.T) {
+	cases := map[string]bool{"docker": true, "Docker": true, "": false, "self-hosted": false}
+	for value, want := range cases {
+		t.Run("mode "+value, func(t *testing.T) {
+			inst := testInstance(runtimeFacts{}, map[string]string{envMode: value})
+			if got := inst.dockerMode(); got != want {
+				t.Fatalf("dockerMode() with %s=%q = %t, want %t", envMode, value, got, want)
+			}
+		})
+	}
+}
+
+// TestSlicesContainError_OneFailedProbe_IsEnough checks the warm-up's own
+// verdict: a round with any dropped connection is not a stable round.
+func TestSlicesContainError_OneFailedProbe_IsEnough(t *testing.T) {
+	if slicesContainError([]error{nil, nil, nil}) {
+		t.Fatal("a round with no failures was reported as failed")
+	}
+	if !slicesContainError([]error{nil, errors.New("connection reset"), nil}) {
+		t.Fatal("a round with one dropped connection was reported as clean")
+	}
+}

--- a/test/e2e/internal/harness/server.go
+++ b/test/e2e/internal/harness/server.go
@@ -1,0 +1,422 @@
+//go:build e2e
+
+// server.go builds the server once and starts it as many times as the run
+// needs, each child with an environment built from nothing.
+//
+// Building rather than importing is the point of the whole suite: what is
+// under test is the program, which decides its own catalog, its own middleware
+// chain and its own recovery from the environment it is handed. A test that
+// assembled a server in its own process would be testing that assembly, which
+// is what the suite this replaces did and why five classes of defect were
+// invisible to it.
+//
+// The environment is built from nothing for the same reason the stdio module
+// builds its own: a developer's exported GITLAB_MCP_TOOL_SURFACE would
+// otherwise decide what the suite exercises, silently. Only PATH, TMPDIR and,
+// on Windows, SYSTEMROOT are passed through, because a process with none of
+// those cannot run at all.
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// binaryEnv names a pre-built server binary to drive instead of building one.
+// The Docker targets set it so the three packages share one build.
+const binaryEnv = "E2E_SERVER_BINARY"
+
+// serverLogDir is where each child's stderr is kept, relative to the
+// repository root. A child's log outlives the run: when a test fails because
+// the server refused something, the reason is in the server's log and nowhere
+// else.
+var serverLogDir = filepath.Join("dist", "e2e-reports", "servers")
+
+// stderrTailBytes is how much of a child's stderr a failure message carries.
+// Enough for a panic with its first frames, short enough to read.
+const stderrTailBytes = 4096
+
+// The build is done once per process, whatever it is for.
+var (
+	buildOnce   sync.Once
+	builtBinary string
+	builtDir    string
+	errBuild    error
+)
+
+// serverBinary returns the path of the server these tests drive, building it
+// on the first call.
+//
+// It deliberately does not use t.TempDir: the build is shared by every test in
+// the package, and the first test to arrive would own a directory removed when
+// that test ended, leaving every later test pointing at a path that is gone.
+// Main removes the directory after the last test instead.
+func serverBinary(prebuilt string) (string, error) {
+	if prebuilt != "" {
+		if _, err := os.Stat(prebuilt); err != nil {
+			return "", fmt.Errorf("%s names %s, which cannot be used: %w", binaryEnv, prebuilt, err)
+		}
+		return prebuilt, nil
+	}
+
+	buildOnce.Do(func() {
+		// Not t.TempDir: the directory is shared by every test in the package,
+		// and the first test to arrive would own one removed when it ended.
+		dir, err := os.MkdirTemp("", "gitlab-mcp-e2e")
+		if err != nil {
+			errBuild = err
+			return
+		}
+		builtDir = dir
+		out := filepath.Join(dir, "gitlab-mcp-server")
+		if runtime.GOOS == "windows" {
+			// exec refuses a file with no executable extension there, and
+			// go build -o writes exactly the name it is given.
+			out += ".exe"
+		}
+
+		root, rootErr := repoRoot()
+		if rootErr != nil {
+			errBuild = rootErr
+			return
+		}
+
+		// The build arguments and the bound come from the race seam, so a
+		// `go test -race` run drives an instrumented server rather than an
+		// uninstrumented one.
+		ctx, cancel := context.WithTimeout(context.Background(), serverBuildTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", serverBuildArgs(out)...) //#nosec G204 -- every argument is a constant chosen by a build tag, plus a path from os.MkdirTemp
+		cmd.Dir = root
+		output, buildFailed := cmd.CombinedOutput()
+		if buildFailed != nil {
+			errBuild = fmt.Errorf("building cmd/server: %w\n%s", buildFailed, output)
+			return
+		}
+		builtBinary = out
+	})
+	return builtBinary, errBuild
+}
+
+// removeBuiltBinary deletes what serverBinary built, if it built anything.
+//
+// Keyed on the directory rather than the binary so a failed build is cleaned
+// up too: the directory is created before the compile runs. Each build is tens
+// of megabytes and a machine running this suite through a day would otherwise
+// keep one per run.
+func removeBuiltBinary() {
+	if builtDir == "" {
+		return
+	}
+	_ = os.RemoveAll(builtDir)
+}
+
+// forbiddenChildKeys are the variables a child must never be given, whatever
+// the process running the tests has in its own environment.
+//
+// They all do the same thing: skip the confirmation a destructive action asks
+// for. A suite that inherited one would be testing a server nobody deploys,
+// and the tests that assert a destructive call is refused without a
+// confirmation would pass for the wrong reason.
+var forbiddenChildKeys = []string{"GITLAB_MCP_YOLO_MODE", "YOLO_MODE", "AUTOPILOT"}
+
+// childEnv is the environment one server child runs with.
+type childEnv struct {
+	// GitLabURL and Token are the instance the child talks to.
+	GitLabURL string
+	Token     string
+	// SkipTLSVerify carries the run's TLS policy through to the child.
+	SkipTLSVerify bool
+	// Root is the child's home, its working directory and the one directory
+	// it is allowed to read local files from or write downloads into.
+	Root string
+	// TempDir is the run's own temporary directory, passed through so the
+	// child writes where the machine expects rather than into /tmp on a host
+	// that has moved it.
+	TempDir string
+	// Path is the executable search path, without which the child cannot run
+	// git or anything else it shells out to.
+	Path string
+	// SystemRoot is Windows' own, and empty everywhere else.
+	SystemRoot string
+	// Extra carries the per-session variables: the tool surface, the mode,
+	// the capability surface and whatever else a session shape declares. A
+	// forbidden key here is dropped rather than honored.
+	Extra map[string]string
+}
+
+// newChildEnv builds the environment for a child from the run's settings and
+// one session's own variables.
+//
+// PATH, TMPDIR and SYSTEMROOT are read from the process; nothing else is. That
+// is the whole inheritance, and it is why a developer's exported surface or
+// token cannot change what the suite exercises.
+func newChildEnv(s settings, root string, extra map[string]string) childEnv {
+	return childEnv{
+		GitLabURL:     s.get(envGitLabURL),
+		Token:         s.get(envGitLabToken),
+		SkipTLSVerify: strings.EqualFold(s.get(envSkipTLSVerify), "true"),
+		Root:          root,
+		TempDir:       os.Getenv("TMPDIR"),
+		Path:          os.Getenv("PATH"),
+		SystemRoot:    os.Getenv("SYSTEMROOT"),
+		Extra:         extra,
+	}
+}
+
+// environ returns the child's environment as exec wants it, sorted so two
+// children built from the same inputs are started identically.
+func (c childEnv) environ() []string {
+	vars := map[string]string{
+		"PATH":                             c.Path,
+		"HOME":                             c.Root,
+		envGitLabURL:                       c.GitLabURL,
+		envGitLabToken:                     c.Token,
+		envSkipTLSVerify:                   strconv.FormatBool(c.SkipTLSVerify),
+		"GITLAB_MCP_ALLOWED_UPLOAD_DIRS":   c.Root,
+		"GITLAB_MCP_ALLOWED_DOWNLOAD_DIRS": c.Root,
+		"GITLAB_MCP_ALLOWED_IMPORT_DIRS":   c.Root,
+	}
+	if c.TempDir != "" {
+		vars["TMPDIR"] = c.TempDir
+	}
+	if runtime.GOOS == "windows" {
+		// os.UserHomeDir reads USERPROFILE there, and the server resolves its
+		// env file and its implicit allow-list root through it. A child given
+		// only HOME would be given a home it never looks at.
+		vars["USERPROFILE"] = c.Root
+		if c.SystemRoot != "" {
+			vars["SYSTEMROOT"] = c.SystemRoot
+		}
+	}
+	// Before the caller's own entries, so a session that needs to say
+	// something else about the detector still can.
+	maps.Copy(vars, raceChildEnv())
+	for key, value := range c.Extra {
+		if slices.Contains(forbiddenChildKeys, strings.ToUpper(key)) {
+			continue
+		}
+		vars[key] = value
+	}
+	for _, key := range forbiddenChildKeys {
+		delete(vars, key)
+	}
+
+	environ := make([]string, 0, len(vars))
+	for _, key := range slices.Sorted(maps.Keys(vars)) {
+		environ = append(environ, key+"="+vars[key])
+	}
+	return environ
+}
+
+// serverProcess is one server child: the environment it runs with, the process
+// itself, and what it has written to stderr.
+//
+// It can be started more than once. A child that dies takes its session with
+// it, and the session layer starts a fresh one from the same shape rather than
+// failing every later test of the run for a crash one test caused.
+type serverProcess struct {
+	label string
+	env   childEnv
+	bin   string
+
+	mu     sync.Mutex
+	sink   *stderrSink
+	starts int
+
+	exited chan struct{}
+	state  atomic.Pointer[os.ProcessState]
+}
+
+// newServerProcess describes a child without starting it.
+func newServerProcess(label, bin string, env childEnv) *serverProcess {
+	return &serverProcess{label: label, bin: bin, env: env}
+}
+
+// transport returns the transport that starts this child and speaks to it.
+//
+// Each call builds a fresh command, so the same serverProcess can be started
+// again after its child has gone. The reaper is started once the transport has
+// the process, which is the earliest moment there is one to reap.
+//
+// The context bounds the child's life: canceling it kills a server that
+// outlived what it was started for, which a stdio client cannot otherwise do
+// once its own stdin is gone.
+func (p *serverProcess) transport(ctx context.Context) mcp.Transport {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.sink != nil {
+		p.sink.close()
+	}
+	p.starts++
+	sink := newStderrSink(p.label, p.starts)
+
+	cmd := exec.CommandContext(ctx, p.bin) //#nosec G204 -- the path is this package's own build or E2E_SERVER_BINARY, which only the run's operator sets
+	cmd.Env = p.env.environ()
+	cmd.Dir = p.env.Root
+	cmd.Stderr = sink
+
+	p.sink = sink
+	p.exited = make(chan struct{})
+	p.state.Store(nil)
+
+	return &childTransport{proc: p, inner: &mcp.CommandTransport{Command: cmd}, exited: p.exited}
+}
+
+// reap starts the one goroutine that collects the child.
+//
+// It waits through os.Process rather than exec.Cmd because the transport calls
+// Cmd.Wait itself when the session closes: two Cmd.Wait calls cannot be told
+// apart from a real failure, while a second os.Process.Wait answers
+// ErrProcessDone deterministically. The cost is that the transport's own Close
+// returns that error, which the session layer ignores, and the benefit is that
+// the harness can say whether the server is still running before anybody has
+// asked it to stop. Without that, a child killed by a panic looks exactly like
+// a slow one.
+func (p *serverProcess) reap(cmd *exec.Cmd, exited chan struct{}) {
+	go func() {
+		state, _ := cmd.Process.Wait()
+		p.state.Store(state)
+		close(exited)
+	}()
+}
+
+// alive reports whether the child is still running.
+func (p *serverProcess) alive() bool {
+	p.mu.Lock()
+	exited := p.exited
+	p.mu.Unlock()
+	if exited == nil {
+		return false
+	}
+	select {
+	case <-exited:
+		return false
+	default:
+		return true
+	}
+}
+
+// exitStatus describes how the child ended, in terms that make sense whether
+// or not the reaper had recorded it when it was asked.
+func (p *serverProcess) exitStatus() string {
+	if state := p.state.Load(); state != nil {
+		return state.String()
+	}
+	return "exit status not recorded"
+}
+
+// stderrTail returns the end of what the child has logged, which is what a
+// failed call carries: a transport error says a pipe closed, and the server's
+// last lines say why.
+func (p *serverProcess) stderrTail() string {
+	p.mu.Lock()
+	sink := p.sink
+	p.mu.Unlock()
+	if sink == nil {
+		return ""
+	}
+	return sink.tail()
+}
+
+// childTransport starts the child through the SDK's command transport and
+// hands the reaper the process the moment there is one.
+type childTransport struct {
+	proc   *serverProcess
+	inner  *mcp.CommandTransport
+	exited chan struct{}
+}
+
+// Connect starts the child and begins watching it.
+func (t *childTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	t.proc.reap(t.inner.Command, t.exited)
+	return conn, nil
+}
+
+// stderrSink keeps the tail of one child's stderr in memory and the whole of
+// it on disk.
+//
+// In memory because a failing call has to be able to quote the server's last
+// words, and on disk because the interesting failure is usually the one that
+// happened three tests earlier.
+type stderrSink struct {
+	mu      sync.Mutex
+	tailBuf []byte
+	file    *os.File
+}
+
+// newStderrSink opens the log for one start of one child.
+//
+// A log that cannot be opened is not fatal, and the sink returns no error for
+// that reason: the tail stays in memory, which is what a failing call quotes,
+// and a run that could not create a directory under dist/ should not lose its
+// server over it.
+func newStderrSink(label string, start int) *stderrSink {
+	sink := &stderrSink{}
+	root, err := repoRoot()
+	if err != nil {
+		return sink
+	}
+	dir := filepath.Join(root, serverLogDir)
+	if err = os.MkdirAll(dir, 0o750); err != nil {
+		return sink
+	}
+	name := fmt.Sprintf("%s-%d.log", sanitizeNamePart(label, 60), start)
+	file, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return sink
+	}
+	sink.file = file
+	return sink
+}
+
+// Write records what the child logged. It never fails: stderr that cannot be
+// stored is worth less than a server killed by its own logging.
+func (s *stderrSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.file != nil {
+		_, _ = s.file.Write(p)
+	}
+	s.tailBuf = append(s.tailBuf, p...)
+	if len(s.tailBuf) > stderrTailBytes {
+		s.tailBuf = slices.Clone(s.tailBuf[len(s.tailBuf)-stderrTailBytes:])
+	}
+	return len(p), nil
+}
+
+// tail returns what the sink kept.
+func (s *stderrSink) tail() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.tailBuf)
+}
+
+// close releases the log file.
+func (s *stderrSink) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file != nil {
+		_ = s.file.Close()
+		s.file = nil
+	}
+}

--- a/test/e2e/internal/harness/server_norace.go
+++ b/test/e2e/internal/harness/server_norace.go
@@ -1,0 +1,21 @@
+//go:build e2e && !race
+
+// server_norace.go is the ordinary half of the build seam, used by every run
+// that is not `go test -race`. See server_race.go for the other half and for
+// why the seam exists.
+
+package harness
+
+import "time"
+
+// serverBuildArgs returns the go build arguments for the server under test.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build.
+const serverBuildTimeout = 5 * time.Minute
+
+// raceChildEnv adds nothing to a child's environment when the detector is not
+// in play.
+func raceChildEnv() map[string]string { return nil }

--- a/test/e2e/internal/harness/server_race.go
+++ b/test/e2e/internal/harness/server_race.go
@@ -1,0 +1,38 @@
+//go:build e2e && race
+
+// server_race.go is the race-detector half of the build seam. The go tool
+// sets the race build tag when -race is used, so this file is what a
+// `go test -race -tags e2e` run compiles and server_norace.go is what every
+// other run compiles.
+
+package harness
+
+import "time"
+
+// serverBuildArgs returns the go build arguments for the server under test,
+// with the detector on.
+//
+// The seam exists because `go test -race` instruments the test binary and
+// nothing else. The server is a separate process built by this harness, so
+// without passing the flag on, a race run would watch the harness's own
+// goroutines and say nothing about the server's, which are the ones the suite
+// exists to reach.
+func serverBuildArgs(out string) []string {
+	return []string{"build", "-race", "-o", out, "./cmd/server"}
+}
+
+// serverBuildTimeout bounds that build. A race build shares no object cache
+// with an ordinary one, so it is a cold build of the whole dependency tree
+// even on a machine that has just compiled these tests.
+const serverBuildTimeout = 15 * time.Minute
+
+// raceChildEnv is the extra environment an instrumented child is started with.
+//
+// Without halt_on_error the race runtime prints its report to stderr and lets
+// the process continue, setting the exit status only at a clean exit. A server
+// the harness stops at the end of a test would take the report to its log with
+// it and the run would stay green. Halting fails whichever test was talking to
+// it, with the report in that child's captured stderr.
+func raceChildEnv() map[string]string {
+	return map[string]string{"GORACE": "halt_on_error=1"}
+}

--- a/test/e2e/internal/harness/server_test.go
+++ b/test/e2e/internal/harness/server_test.go
@@ -1,0 +1,343 @@
+//go:build e2e
+
+// server_test.go covers the launcher: the environment a child is given, the
+// stderr it is judged by, and one run of the real binary against a stub GitLab
+// to prove the three fit together.
+
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// testSettings builds the resolved configuration a child is launched from.
+func testSettings(values map[string]string) settings {
+	return settings{values: values}
+}
+
+// environMap turns a child's environment back into a map for assertions.
+func environMap(t *testing.T, environ []string) map[string]string {
+	t.Helper()
+	vars := map[string]string{}
+	for _, entry := range environ {
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			t.Fatalf("environment entry %q is not KEY=VALUE", entry)
+		}
+		vars[key] = value
+	}
+	return vars
+}
+
+// TestChildEnv_ProcessCarriesYoloMode_TheChildNeverDoes is the assertion the
+// whole "built from nothing" rule exists for.
+//
+// GITLAB_MCP_YOLO_MODE and AUTOPILOT skip the confirmation a destructive
+// action asks for. A developer who has either exported, or an agent runtime
+// that sets AUTOPILOT as a convention, would otherwise run the whole suite
+// against a server nobody deploys, and every test that asserts a destructive
+// call is refused without a confirmation would pass for the wrong reason.
+//
+// Both routes are covered: the process environment, which the builder must not
+// read, and the session's own variables, where a forbidden key is dropped
+// rather than honored.
+func TestChildEnv_ProcessCarriesYoloMode_TheChildNeverDoes(t *testing.T) {
+	t.Setenv("GITLAB_MCP_YOLO_MODE", "true")
+	t.Setenv("AUTOPILOT", "1")
+	t.Setenv("YOLO_MODE", "yes")
+
+	env := newChildEnv(testSettings(map[string]string{envGitLabURL: "http://gitlab.test", envGitLabToken: "glpat-x"}),
+		t.TempDir(), map[string]string{"AUTOPILOT": "1", "GITLAB_MCP_TOOL_SURFACE": "meta"})
+
+	vars := environMap(t, env.environ())
+	for _, forbidden := range forbiddenChildKeys {
+		if value, present := vars[forbidden]; present {
+			t.Fatalf("the child was given %s=%q", forbidden, value)
+		}
+	}
+	if vars["GITLAB_MCP_TOOL_SURFACE"] != "meta" {
+		t.Fatalf("the session's own variables were dropped with the forbidden one: %v", vars)
+	}
+}
+
+// TestChildEnv_ProcessEnvironment_IsNotInherited checks that nothing but the
+// three variables a process cannot run without crosses over.
+//
+// The one that matters is the tool surface: a developer with
+// GITLAB_MCP_TOOL_SURFACE exported would otherwise change which surface every
+// test exercised, silently, and the run would still be green.
+func TestChildEnv_ProcessEnvironment_IsNotInherited(t *testing.T) {
+	t.Setenv("GITLAB_MCP_TOOL_SURFACE", "individual")
+	t.Setenv("GITLAB_MCP_READ_ONLY", "true")
+	t.Setenv("E2E_HARNESS_UNRELATED", "leaked")
+
+	env := newChildEnv(testSettings(map[string]string{envGitLabURL: "http://gitlab.test", envGitLabToken: "glpat-x"}),
+		t.TempDir(), nil)
+
+	vars := environMap(t, env.environ())
+	for _, key := range []string{"GITLAB_MCP_TOOL_SURFACE", "GITLAB_MCP_READ_ONLY", "E2E_HARNESS_UNRELATED"} {
+		t.Run(key, func(t *testing.T) {
+			if _, present := vars[key]; present {
+				t.Fatalf("the child inherited %s from the test process", key)
+			}
+		})
+	}
+	if vars["PATH"] == "" {
+		t.Fatal("the child was given no PATH, so it cannot run git or anything else it shells out to")
+	}
+}
+
+// TestChildEnv_LocalPaths_PointAtTheHarnessRoot checks the three allow-lists
+// and the home the server resolves its own configuration through.
+//
+// They all name one directory, which is also the child's working directory: a
+// tool that reads a local file, one that writes a download and one that reads
+// an import archive are then confined to a directory this run created, rather
+// than to whatever the test process happened to be started in.
+func TestChildEnv_LocalPaths_PointAtTheHarnessRoot(t *testing.T) {
+	root := t.TempDir()
+
+	env := newChildEnv(testSettings(map[string]string{envGitLabURL: "http://gitlab.test", envGitLabToken: "glpat-x"}), root, nil)
+
+	vars := environMap(t, env.environ())
+	for _, key := range []string{
+		"HOME",
+		"GITLAB_MCP_ALLOWED_UPLOAD_DIRS",
+		"GITLAB_MCP_ALLOWED_DOWNLOAD_DIRS",
+		"GITLAB_MCP_ALLOWED_IMPORT_DIRS",
+	} {
+		t.Run(key, func(t *testing.T) {
+			if vars[key] != root {
+				t.Fatalf("%s = %q, want the harness root %q", key, vars[key], root)
+			}
+		})
+	}
+	if env.Root != root {
+		t.Fatalf("child working directory = %q, want the harness root %q", env.Root, root)
+	}
+}
+
+// TestChildEnv_Instance_IsTheOneTheRunResolved checks that the child talks to
+// the instance the harness probed, with the same TLS policy.
+//
+// The TLS flag is spelled out rather than omitted when false, so the child's
+// environment states the policy instead of relying on a default that could
+// change.
+func TestChildEnv_Instance_IsTheOneTheRunResolved(t *testing.T) {
+	env := newChildEnv(testSettings(map[string]string{
+		envGitLabURL:     "http://gitlab.test:8929",
+		envGitLabToken:   "glpat-secret",
+		envSkipTLSVerify: "TRUE",
+	}), t.TempDir(), nil)
+
+	vars := environMap(t, env.environ())
+	if vars[envGitLabURL] != "http://gitlab.test:8929" || vars[envGitLabToken] != "glpat-secret" {
+		t.Fatalf("the child was pointed somewhere else: %v", vars)
+	}
+	if vars[envSkipTLSVerify] != "true" {
+		t.Fatalf("%s = %q, want true", envSkipTLSVerify, vars[envSkipTLSVerify])
+	}
+}
+
+// TestChildEnv_Environ_IsSorted checks that two children built from the same
+// inputs are started identically, so a difference between two runs is a
+// difference somebody made.
+func TestChildEnv_Environ_IsSorted(t *testing.T) {
+	env := newChildEnv(testSettings(map[string]string{envGitLabURL: "http://gitlab.test", envGitLabToken: "glpat-x"}),
+		t.TempDir(), map[string]string{"ZZZ_LAST": "1", "AAA_FIRST": "1"})
+
+	environ := env.environ()
+
+	if !slices.IsSorted(environ) {
+		t.Fatalf("the child environment is not sorted: %v", environ)
+	}
+}
+
+// TestStderrSink_MoreThanTheTail_KeepsTheEnd checks that a talkative child
+// does not grow the harness without bound and that what is kept is the end.
+//
+// The end is what matters: a server that died says why in its last lines, and
+// the first four kilobytes of a startup log say nothing about it.
+func TestStderrSink_MoreThanTheTail_KeepsTheEnd(t *testing.T) {
+	sink := &stderrSink{}
+	for range 10 {
+		if _, err := sink.Write([]byte(strings.Repeat("a", 1024))); err != nil {
+			t.Fatalf("Write() error = %v, want nil", err)
+		}
+	}
+	if _, err := sink.Write([]byte("the last thing it said")); err != nil {
+		t.Fatalf("Write() error = %v, want nil", err)
+	}
+
+	tail := sink.tail()
+	if len(tail) > stderrTailBytes {
+		t.Fatalf("tail length = %d, want at most %d", len(tail), stderrTailBytes)
+	}
+	if !strings.HasSuffix(tail, "the last thing it said") {
+		t.Fatalf("the tail does not end with the last thing written: %q", tail[max(0, len(tail)-64):])
+	}
+}
+
+// TestStderrSink_NoLogFile_StillRecordsTheTail checks that a sink which could
+// not open its file keeps working.
+//
+// Losing the log is a nuisance; losing the server because its stderr could not
+// be stored would be a failure of the harness itself.
+func TestStderrSink_NoLogFile_StillRecordsTheTail(t *testing.T) {
+	sink := &stderrSink{}
+	sink.close()
+
+	if _, err := sink.Write([]byte("logged anyway")); err != nil {
+		t.Fatalf("Write() error = %v, want nil", err)
+	}
+	if sink.tail() != "logged anyway" {
+		t.Fatalf("tail = %q, want the written text", sink.tail())
+	}
+}
+
+// TestServerBinary_MissingPrebuiltPath_IsRefused checks that a pointer to a
+// binary that is not there is reported rather than built around.
+//
+// E2E_SERVER_BINARY exists so the three packages share one build; a typo in it
+// would otherwise be answered by silently building a second one, and the run
+// would no longer be testing what the operator staged.
+func TestServerBinary_MissingPrebuiltPath_IsRefused(t *testing.T) {
+	_, err := serverBinary(filepath.Join(t.TempDir(), "not-there"))
+	if err == nil {
+		t.Fatal("serverBinary() accepted a path that does not exist")
+	}
+	if !strings.Contains(err.Error(), binaryEnv) {
+		t.Fatalf("the error should name %s: %v", binaryEnv, err)
+	}
+}
+
+// TestServerProcess_RealBinary_ServesTheDefaultSurface starts the server this
+// suite drives and speaks MCP to it.
+//
+// This is the smallest whole test of what S04 delivers: the binary is built,
+// launched with an environment built from nothing, and answers tools/list with
+// the two tools the default dynamic surface registers. It also proves the
+// reaper, which is what lets a later failure say "the server exited" instead
+// of timing out.
+//
+// The GitLab behind it is a stub answering only what the server asks at
+// startup, so the test needs no instance and no credentials.
+func TestServerProcess_RealBinary_ServesTheDefaultSurface(t *testing.T) {
+	stub := startStubGitLab(t)
+
+	bin, err := serverBinary("")
+	if err != nil {
+		t.Fatalf("building the server: %v", err)
+	}
+
+	root := t.TempDir()
+	env := newChildEnv(testSettings(map[string]string{
+		envGitLabURL:   stub.URL,
+		envGitLabToken: "glpat-harness-smoke",
+	}), root, map[string]string{"GITLAB_MCP_LOG_LEVEL": "info"})
+
+	proc := newServerProcess("smoke", bin, env)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "harness-smoke", Version: "1"}, nil)
+	session, err := client.Connect(ctx, proc.transport(ctx), nil)
+	if err != nil {
+		t.Fatalf("connecting to the server: %v\nstderr: %s", err, proc.stderrTail())
+	}
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list: %v\nstderr: %s", err, proc.stderrTail())
+	}
+	names := make([]string, 0, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		names = append(names, tool.Name)
+	}
+	for _, want := range []string{"gitlab_find_action", "gitlab_execute_action"} {
+		t.Run(want, func(t *testing.T) {
+			if !slices.Contains(names, want) {
+				t.Fatalf("the default surface served %v, want it to include %s", names, want)
+			}
+		})
+	}
+	if !proc.alive() {
+		t.Fatalf("the server is not running after answering: %s\nstderr: %s", proc.exitStatus(), proc.stderrTail())
+	}
+
+	// Closing the session closes the child's stdin, which is how a stdio
+	// client asks a server to stop. The reaper is what notices.
+	const exitWindow = 30 * time.Second
+	_ = session.Close()
+	deadline := time.Now().Add(exitWindow)
+	for proc.alive() && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if proc.alive() {
+		t.Fatalf("the server was still running %s after its stdin closed\nstderr: %s", exitWindow, proc.stderrTail())
+	}
+}
+
+// startStubGitLab serves the handful of endpoints the server asks at startup,
+// and nothing else.
+//
+// It is deliberately minimal: what is under test here is the launcher, and a
+// stub that answered tool calls would invite assertions about tools that
+// belong against a real instance.
+func startStubGitLab(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/version", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"version": "18.0.0", "revision": "abcdef", "enterprise": false})
+	})
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, _ *http.Request) {
+		writeStubJSON(w, map[string]any{"id": 7, "username": "harness", "name": "Harness", "is_admin": true})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// The license and the token's own scopes are both asked for and both
+		// optional: a 404 is what an unlicensed instance and an older GitLab
+		// answer, and the server is expected to carry on.
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// writeStubJSON answers one stub request.
+func writeStubJSON(w http.ResponseWriter, body map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(encoded)
+}
+
+// TestRemoveBuiltBinary_NothingBuilt_DoesNothing checks that the cleanup Main
+// runs is safe for a package whose tests never needed a server.
+func TestRemoveBuiltBinary_NothingBuilt_DoesNothing(t *testing.T) {
+	before := builtDir
+	t.Cleanup(func() { builtDir = before })
+
+	builtDir = ""
+	removeBuiltBinary()
+
+	if _, err := os.Stat(before); before != "" && err != nil {
+		t.Fatalf("the built directory was removed by a call that should have done nothing: %v", err)
+	}
+}


### PR DESCRIPTION
Step S04 of the e2e rebuild (issue 704): the core of `test/e2e/internal/harness`, every file `//go:build e2e` except an untagged `doc.go`.

The launcher builds `cmd/server` once, or takes `E2E_SERVER_BINARY`, and starts it through `mcp.CommandTransport`, with a race seam that passes `GORACE=halt_on_error=1` to the child. The child's environment is built from nothing: `PATH`, `HOME`, the GitLab address and token, and the three `GITLAB_MCP_ALLOWED_*_DIRS` pointing at the harness root, plus whatever a session adds. The yolo variables are never passed, from the process or from a session. Each child's stderr goes to a log under `dist/e2e-reports/servers/`, its last 4 KiB stay in memory for a failure message, and the reaper waits through `os.Process.Wait` because the SDK's transport calls `Cmd.Wait` itself on close.

`Main` parses flags, reads configuration with `godotenv.Read` and never `Load`, from the process environment, `E2E_ENV_FILE`, the Docker file and the repository `.env`, computes the run id with the package name appended so one `E2E_RUN_ID` reaches three packages without naming them the same, and defers everything else to a `sync.Once` the first `Env` triggers, so `-test.list` and a filtered run never touch GitLab. The runtime guard resolves the instance, its edition and its tier, and refuses a run whose requirement the instance cannot meet; only a runtime mismatch is skippable through `E2E_RUNTIME_MISMATCH=skip`, and a run with no GitLab at all is a fatal refusal.

`Serial()` is a gate that counts holders per top-level test rather than a `sync.RWMutex`, since a plain one blocks a new reader once a writer waits and a fixture opening a second `Env` for a surface subtest would deadlock. A launcher smoke test starts the real binary against an `httptest` stand-in and asserts the default surface serves the two dynamic tools, then that the child exits when its transport closes. The automatic restart of a dead child is not wired; the primitives are there and a later step decides the policy.
